### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!-- ## Which branch should I use for my PR?
+
+Assuming that:
+
+a = current major release
+b = current minor release
+c = future major release
+
+* a.x for any features and enhancements (e.g. 5.x)
+* a.b for any bug fixes (e.g. 4.4, 5.1)
+* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->
+
+| Q                                      | A
+| -------------------------------------- | ---
+| Bug fix? (use the a.b branch)          | [ ]
+| New feature/enhancement? (use the a.x branch)      | [ ]
+| Deprecations?                          | [ ]
+| BC breaks? (use the c.x branch)        | [ ]
+| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
+| Related user documentation PR URL      |  <!-- required for new features -->
+| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
+| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->
+
+<!--
+Additionally (see LINK TO CONTRIBUTOR MANUAL SHOULD BE ADDED HERE):
+ - Always add tests and ensure they pass.
+ - Bug fixes must be submitted against the lowest maintained branch where they apply
+   (lowest branches are regularly merged to upper ones so they get the fixes too.)
+ - Features and deprecations must be submitted against the "4.x" branch.
+-->
+
+#### Description:
+
+<!--
+Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
+-->
+
+#### Steps to test this PR:
+
+<!--
+This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
+-->
+1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://LINK-TO-HOW-TO-TEST))
+2. 
+
+<!--
+If you have any deprecations, list them here along with the new alternative.
+If you have any backwards compatibility breaks, list them here.
+-->


### PR DESCRIPTION
This PR will be the template to be used in new PRs, so when someone creates a new PR the content of this PR will be rendered for the PR issuer. 

The content of this document is to be agreed on, as it will affect the versioning system of the product