### PR TITLE
Fix mint.json issues

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -9,8 +9,6 @@
     "primary": "#5155D7",
     "dark": "#3033A6",
     "light": "#6D72F6",
-    "ultraLight": "#BCBCEF",
-    "ultraDark": "##070963",
     "background": {
       "dark": "#0C1322",
       "light": "#ffffff"
@@ -105,6 +103,7 @@
       ]
     },
     {
+      "group": "",
       "pages": ["license"]
     }
   ]


### PR DESCRIPTION
Error messages fixed: There is an extra # in one of the colors and a group name is missing.

Mintlify doesn't use ultralight and ultradark any more so those are safe to delete instead of just removing the extra #