### PR TITLE
docs: fix building pieces guide broken link

### DIFF
--- a/docs/pieces/custom-pieces.mdx
+++ b/docs/pieces/custom-pieces.mdx
@@ -23,6 +23,6 @@ You can request a new piece by:
 
 **3. Make the piece**
 
-If you are a developer and don't wish to wait until the piece is built by the community, we've put up a [guide to building a new piece](/building-pieces/overview).
+If you are a developer and don't wish to wait until the piece is built by the community, we've put up a [guide to building a new piece](../contributing/building-pieces/quickstart).
 
 You can follow the structure and steps in the guide to build your piece for your own use or to contribute with it to Activepieces.


### PR DESCRIPTION
Fix building pieces guide broken link in custom pieces page.