### PR TITLE
issue 332

### DIFF
--- a/packages/frontend/src/app/modules/common/components/configs-form/configs-form.component.ts
+++ b/packages/frontend/src/app/modules/common/components/configs-form/configs-form.component.ts
@@ -33,7 +33,7 @@ import {
 	USE_CLOUD_CREDENTIALS,
 } from 'packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/edit-step-sidebar/edit-step-accordion/input-forms/component-input-forms/new-authentication-modal/new-authentication-modal.component';
 import { MatDialog } from '@angular/material/dialog';
-import { AppConnection, AppConnectionType, CloudAuth2Connection, OAuth2AppConnection } from '@activepieces/shared';
+import { AppConnection, AppConnectionType,  OAuth2AppConnection } from '@activepieces/shared';
 import { DropdownItem } from '../../model/dropdown-item.interface';
 import {
 	NewCloudAuthenticationModalComponent,
@@ -325,6 +325,7 @@ export class ConfigsFormComponent implements ControlValueAccessor {
 			}),
 			tap(connection => {
 				if (connection) {
+					debugger;
 					if (connection.value.type === AppConnectionType.OAUTH2) {
 						this.updateOrAddConfigModalClosed$ = this.dialogService
 							.open(NewAuthenticationModalComponent, {
@@ -336,12 +337,6 @@ export class ConfigsFormComponent implements ControlValueAccessor {
 							})
 							.afterClosed()
 							.pipe(
-								tap((newOAuth2Connection: OAuth2AppConnection) => {
-									if (newOAuth2Connection) {
-										const connectionValue = newOAuth2Connection.value;
-										this.form.get(authConfigKey)!.setValue(connectionValue);
-									}
-								}),
 								map(() => void 0)
 							);
 					} else {
@@ -364,12 +359,6 @@ export class ConfigsFormComponent implements ControlValueAccessor {
 										})
 										.afterClosed()
 										.pipe(
-											tap((cloudOAuth2Connection: CloudAuth2Connection) => {
-												if (cloudOAuth2Connection) {
-													const authConfigOptionValue = cloudOAuth2Connection.value;
-													this.form.get(authConfigKey)!.setValue(authConfigOptionValue);
-												}
-											}),
 											map(() => void 0)
 										);
 								})

--- a/packages/frontend/src/app/modules/common/components/form-controls/interpolating-text-form-control/utils.ts
+++ b/packages/frontend/src/app/modules/common/components/form-controls/interpolating-text-form-control/utils.ts
@@ -27,7 +27,7 @@ export const QuillMaterialBase = mixinErrorState(
 
 export class CustomErrorMatcher implements ErrorStateMatcher {
 	isErrorState(control: FormControl): boolean {
-		return control.dirty && control.invalid;
+		return control.touched && control.invalid;
 	}
 }
 

--- a/packages/frontend/src/app/modules/common/components/form-controls/o-auth2-cloud-connect-control/o-auth2-cloud-connect-control.component.html
+++ b/packages/frontend/src/app/modules/common/components/form-controls/o-auth2-cloud-connect-control/o-auth2-cloud-connect-control.component.html
@@ -3,7 +3,7 @@
 <app-button *ngIf="responseData" btnColor="warn" class="ap-w-full" (buttonClicked)="clearControlValue()"
   [fullWidthOfContainer]="true" type="button" [disabled]="isDisabled">Disconnect</app-button>
 <p *ngIf="popUpError" class="ap-typography-caption ap-text-danger" @fadeInUp>
-  Please make sure this config's credentials are correct.
+  Please make sure this connections's credentials are correct.
 </p>
 
 <ng-container *ngIf="popupOpened$ | async"></ng-container>

--- a/packages/frontend/src/app/modules/common/components/form-controls/o-auth2-cloud-connect-control/o-auth2-cloud-connect-control.component.ts
+++ b/packages/frontend/src/app/modules/common/components/form-controls/o-auth2-cloud-connect-control/o-auth2-cloud-connect-control.component.ts
@@ -1,3 +1,4 @@
+import { AppConnectionType } from '@activepieces/shared';
 import { Component, Input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { catchError, Observable, tap, throwError } from 'rxjs';
@@ -51,8 +52,9 @@ export class OAuth2CloudConnectControlComponent implements ControlValueAccessor 
 	openPopup(): void {
 		this.popupOpened$ = this.oauth2Service.openCloudAuthPopup(this.cloudConnectionPopupSettings).pipe(
 			tap(value => {
+				this.popUpError=false;
 				this.responseData = value;
-				this.onChange(value);
+				this.onChange({...value, type:AppConnectionType.CLOUD_OAUTH2});
 			}),
 			catchError(err => {
 				this.responseData = null;

--- a/packages/frontend/src/app/modules/common/components/form-controls/o-auth2-connect-control/o-auth2-connect-control.component.html
+++ b/packages/frontend/src/app/modules/common/components/form-controls/o-auth2-connect-control/o-auth2-connect-control.component.html
@@ -3,7 +3,7 @@
 <app-button *ngIf="responseData" btnColor="warn" class="ap-w-full" (buttonClicked)="clearControlValue()"
   [fullWidthOfContainer]="true" type="button" [disabled]="isDisabled">Disconnect</app-button>
 <p *ngIf="popUpError" class="ap-typography-caption ap-text-danger" @fadeInUp>
-  Please make sure this config's credentials are correct.
+  Please make sure this connections's credentials are correct.
 </p>
 
 <ng-container *ngIf="popupOpened$ | async"></ng-container>

--- a/packages/frontend/src/app/modules/common/components/form-controls/o-auth2-connect-control/o-auth2-connect-control.component.ts
+++ b/packages/frontend/src/app/modules/common/components/form-controls/o-auth2-connect-control/o-auth2-connect-control.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { catchError, Observable, tap, throwError } from 'rxjs';
-import { OAuth2AppDetails } from '@activepieces/shared';
+import { AppConnectionType, OAuth2AppDetails } from '@activepieces/shared';
 import { fadeInUp400ms } from '../../../animation/fade-in-up.animation';
 import { Oauth2Service } from '../../../service/oauth2.service';
 
@@ -43,11 +43,13 @@ export class OAuth2ConnectControlComponent implements ControlValueAccessor {
 	popUpError = false;
 
 	openPopup(): void {
+	
 		const configSettings = this.configSettings as (OAuth2AppDetails & { extraParams: Record<string, unknown>, auth_url: string, scope: string });
 		this.popupOpened$ = this.oauth2Service.openPopup(configSettings).pipe(
 			tap(value => {
+				this.popUpError=false;
 				this.responseData = value;
-				this.onChange(value);
+				this.onChange({...value, type:AppConnectionType.OAUTH2});
 			}),
 			catchError(err => {
 				this.responseData = null;

--- a/packages/frontend/src/app/modules/common/service/oauth2.service.ts
+++ b/packages/frontend/src/app/modules/common/service/oauth2.service.ts
@@ -47,18 +47,20 @@ export class Oauth2Service {
 		const popup = window.open(url, winTarget, winFeatures);
 		this.currentlyOpenPopUp = popup;
 		const codeObs$ = new Observable<any>(observer => {
-			window.addEventListener('message', function (event) {
+			window.addEventListener('message', function handler (event) {
 				if (redirect_uri.startsWith(event.origin)) {
 					if (event.data != undefined) {
 						event.data.code = decodeURIComponent(event.data.code);
 						observer.next(event.data);
 						popup?.close();
 						observer.complete();
+						
 					} else {
 						observer.error('No code returned');
 						popup?.close();
 						observer.complete();
 					}
+					window.removeEventListener('message',handler);
 				}
 			});
 		});
@@ -74,6 +76,7 @@ export class Oauth2Service {
 						tokenUrl: request.token_url,
 					}).pipe(
 						map(value => {
+							debugger;
 							if (value['error']) {
 								throw Error(value['error']);
 							}
@@ -124,7 +127,7 @@ export class Oauth2Service {
 		const popup = window.open(url, winTarget, winFeatures);
 		this.currentlyOpenPopUp = popup;
 		const codeObs$ = new Observable<any>(observer => {
-			window.addEventListener('message', function (event) {
+			window.addEventListener('message', function handler (event) {
 				if (redirect_uri.startsWith(event.origin)) {
 					if (event.data != undefined) {
 						event.data.code = decodeURIComponent(event.data.code);
@@ -136,6 +139,7 @@ export class Oauth2Service {
 						popup?.close();
 						observer.complete();
 					}
+					window.removeEventListener('message',handler);
 				}
 			});
 		});

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/edit-step-sidebar/edit-step-accordion/input-forms/component-input-forms/new-authentication-modal/new-authentication-modal.component.ts
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/edit-step-sidebar/edit-step-accordion/input-forms/component-input-forms/new-authentication-modal/new-authentication-modal.component.ts
@@ -4,7 +4,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Store } from '@ngrx/store';
 import { catchError, map, Observable, of, take, tap } from 'rxjs';
-import { AppConnection, AppConnectionType, OAuth2AppConnection, Project, UpsertOAuth2Request } from '@activepieces/shared';
+import { AppConnection, OAuth2AppConnection, OAuth2ConnectionValueWithApp, Project, UpsertOAuth2Request } from '@activepieces/shared';
 import { fadeInUp400ms } from 'packages/frontend/src/app/modules/common/animation/fade-in-up.animation';
 import { PieceConfig } from 'packages/frontend/src/app/modules/common/components/configs-form/connector-action-or-config';
 import { AppConnectionsService } from 'packages/frontend/src/app/modules/common/service/app-connections.service';
@@ -23,7 +23,7 @@ interface AuthConfigSettings {
 	token_url: FormControl<string>;
 	scope: FormControl<string>;
 	name: FormControl<string>;
-	value: FormControl<any>;
+	value: FormControl<OAuth2ConnectionValueWithApp>;
 	refresh_url: FormControl<string>;
 	extraParams: FormControl<Record<string, unknown>>;
 }
@@ -76,6 +76,7 @@ export class NewAuthenticationModalComponent implements OnInit {
 	}
 
 	ngOnInit(): void {
+		debugger;
 		this.hasCloudAuthCred$ = this.cloudAuthConfigsService.getAppsAndTheirClientIds().pipe(
 			map(res => {
 				return !!res[this.pieceName];
@@ -120,10 +121,11 @@ export class NewAuthenticationModalComponent implements OnInit {
 		});
 
 		if (this.connectionToUpdate) {
-			this.settingsForm.patchValue({
-				value: this.connectionToUpdate.value,
-			});
+			this.settingsForm.controls.value.setValue(this.connectionToUpdate.value);			
 			this.settingsForm.controls.name.setValue(this.connectionToUpdate.name);
+			this.settingsForm.controls.client_id.setValue(this.connectionToUpdate.value.client_id);
+			this.settingsForm.controls.client_secret.setValue(this.connectionToUpdate.value.client_secret);
+			this.settingsForm.controls.redirect_url.setValue(this.connectionToUpdate.value.redirect_url);
 			this.settingsForm.controls.name.disable();
 		}
 	}
@@ -140,24 +142,31 @@ export class NewAuthenticationModalComponent implements OnInit {
 			? this.connectionToUpdate.name
 			: this.settingsForm.controls.name.value;
 		const settingsFormValue = { ...this.settingsForm.getRawValue() };
-		const connectionValue = settingsFormValue['value'];
-		delete settingsFormValue['value'];
+		const connectionValue = settingsFormValue.value;
+		
 		delete connectionValue['name'];
 		delete connectionValue['appName'];
-		const newConfig: UpsertOAuth2Request = {
+		const newConnection: UpsertOAuth2Request = {
 			name: connectionName,
 			appName: this.pieceName,
-			value: { ...settingsFormValue, type: AppConnectionType.OAUTH2, ...connectionValue },
+			value: { ...connectionValue,
+				client_id:this.settingsForm.controls.client_id.value, 
+				client_secret:this.settingsForm.controls.client_secret.value,
+				redirect_url:this.settingsForm.controls.redirect_url.value,
+				scope:this.settingsForm.controls.scope.value,
+				token_url:this.settingsForm.controls.token_url.value,				
+			},
 			projectId: projectId,
 		};
-		return newConfig;
+		return newConnection;
 	}
 
-	saveConnection(connection: UpsertOAuth2Request): void {
+	saveConnection(connection: UpsertOAuth2Request): void { 
+		debugger;
 		this.upsert$ = this.appConnectionsService.upsert(connection).pipe(
 			catchError(err => {
 				console.error(err);
-				this.snackbar.open('Connection operation failed please check your console.', '', { panelClass: 'error' });
+				this.snackbar.open('Connection operation failed please check your console.', 'Close', { panelClass: 'error',duration:5000 });
 				return of(null);
 			}),
 			tap(connection => {

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/edit-step-sidebar/edit-step-accordion/input-forms/component-input-forms/new-cloud-authentication-modal/new-cloud-authentication-modal.component.ts
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/edit-step-sidebar/edit-step-accordion/input-forms/component-input-forms/new-cloud-authentication-modal/new-cloud-authentication-modal.component.ts
@@ -4,7 +4,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Store } from '@ngrx/store';
 import { catchError, Observable, of, take, tap } from 'rxjs';
-import { AppConnection, AppConnectionType, UpsertCloudOAuth2Request, Project } from '@activepieces/shared';
+import { AppConnection,  UpsertCloudOAuth2Request, Project,  CloudOAuth2ConnectionValue, CloudAuth2Connection } from '@activepieces/shared';
 import { fadeInUp400ms } from 'packages/frontend/src/app/modules/common/animation/fade-in-up.animation';
 import { PieceConfig } from 'packages/frontend/src/app/modules/common/components/configs-form/connector-action-or-config';
 import { CloudConnectionPopupSettings } from 'packages/frontend/src/app/modules/common/components/form-controls/o-auth2-cloud-connect-control/o-auth2-cloud-connect-control.component';
@@ -17,7 +17,7 @@ import { BuilderSelectors } from 'packages/frontend/src/app/modules/flow-builder
 interface AuthConfigSettings {
 	appName: FormControl<string | null>;
 	name: FormControl<string>;
-	value: FormControl<any>;
+	value: FormControl<CloudOAuth2ConnectionValue>;
 }
 export const USE_MY_OWN_CREDENTIALS = 'USE_MY_OWN_CREDENTIALS';
 @Component({
@@ -29,7 +29,7 @@ export const USE_MY_OWN_CREDENTIALS = 'USE_MY_OWN_CREDENTIALS';
 export class NewCloudAuthenticationModalComponent implements OnInit {
 	@Input() pieceAuthConfig: PieceConfig;
 	@Input() pieceName: string;
-	@Input() connectionToUpdate: AppConnection | undefined;
+	@Input() connectionToUpdate: CloudAuth2Connection | undefined;
 	cloudConnectionPopupSettings: CloudConnectionPopupSettings;
 	settingsForm: FormGroup<AuthConfigSettings>;
 	project$: Observable<Project>;
@@ -48,7 +48,7 @@ export class NewCloudAuthenticationModalComponent implements OnInit {
 		dialogData: {
 			pieceAuthConfig: PieceConfig;
 			pieceName: string;
-			connectionToUpdate: AppConnection | undefined;
+			connectionToUpdate: CloudAuth2Connection | undefined;
 			clientId: string;
 		}
 	) {
@@ -98,26 +98,25 @@ export class NewCloudAuthenticationModalComponent implements OnInit {
 		const connectionName = this.connectionToUpdate
 			? this.connectionToUpdate.name
 			: this.settingsForm.controls.name.value;
-		const settingsFormValue: any = { ...this.settingsForm.getRawValue() };
-		const connectionValue = settingsFormValue['value'];
-		delete settingsFormValue['value'];
-		delete settingsFormValue.key;
-		const newConfig: UpsertCloudOAuth2Request = {
+		const settingsFormValue = { ...this.settingsForm.getRawValue() };
+		const connectionValue = settingsFormValue.value;
+		
+		const newConnection: UpsertCloudOAuth2Request = {
 			appName: this.pieceName,
-			value: { type: AppConnectionType.CLOUD_OAUTH2, ...connectionValue },
+			value: {...connectionValue },
 			name: connectionName,
 			projectId: projectId,
 		};
-		return newConfig;
+		return newConnection;
 	}
 
 	saveConnection(connection: UpsertCloudOAuth2Request): void {
 		this.upsert$ = this.appConnectionsService.upsert(connection).pipe(
 			catchError(err => {
 				console.error(err);
-				this.snackbar.open('Connection operation failed please check your console.', '', {
+				this.snackbar.open('Connection operation failed please check your console.', 'Close', {
 					panelClass: 'error',
-					duration: 50000000,
+					duration: 5000,
 				});
 				return of(null);
 			}),

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/edit-step-sidebar/edit-step-sidebar.component.html
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/edit-step-sidebar/edit-step-sidebar.component.html
@@ -10,15 +10,14 @@
 </div>
 <ng-container *ngIf="selectedStepAndFlowId$ | async as selectedStepAndFlowId; else loading">
   <ng-container *ngIf="selectedFlowItemDetails$  | async; else loading"> <app-edit-step-accodion
-      [selectedStep]="selectedStepAndFlowId.step!"
-      [displayNameChanged$]="displayNameChanged$"></app-edit-step-accodion>
+      [selectedStep]="selectedStepAndFlowId.step!" [displayNameChanged$]="displayNameChanged$"></app-edit-step-accodion>
   </ng-container>
 
 </ng-container>
 
 
 <ng-template #loading>
-  <div class="d-column ap-flex-grow ap-justify-center ap-items-center">
+  <div class="ap-flex ap-flex-grow ap-justify-center ap-items-center ap-h-[500px]">
     <app-loading-icon> </app-loading-icon>
   </div>
 </ng-template>

--- a/packages/shared/src/lib/app-connection/dto/upsert-app-connection-request.ts
+++ b/packages/shared/src/lib/app-connection/dto/upsert-app-connection-request.ts
@@ -46,7 +46,7 @@ export const UpsertOAuth2Request = Type.Object({
 });
 
 export type UpsertCloudOAuth2Request = Static<typeof UpsertCloudOAuth2Request>;
-export type UpsertOAuth2Request = Static<typeof UpsertCloudOAuth2Request>;
+export type UpsertOAuth2Request = Static<typeof UpsertOAuth2Request>;
 export type UpsertSecretTextRequest = Static<typeof UpsertSecretTextRequest>;
 
 export const UpsertConnectionRequest = Type.Union([UpsertSecretTextRequest, UpsertOAuth2Request, UpsertCloudOAuth2Request]);


### PR DESCRIPTION
1)Fixed editing connection for oAuth2 apps bug where controls were not being set with their values.
2)Fixed a bug where editing a connection resulted in it being unselected in dropdown.
3)Fixed a bug where the connection control error message was going away after being fixed.
4)Fixed a bug where UpsertOAuth2Request was referring to  UpsertCloudOAuth2Request.
5)Connection name is now being marked dirty on create so users can know that it is name is used in the case of having a duplicated name.
6)Removed event listener "message" after authentication pop up is closed.