### PR TITLE
fix(build): release flow should be triggered manually

### DIFF
--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -1,9 +1,6 @@
 name: Release Backend
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-frontend.yml
+++ b/.github/workflows/release-frontend.yml
@@ -1,9 +1,6 @@
 name: Release Frontend
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Opening PR against main can be an accident as it's default branch, It should be trigger manually to avoid trigger build flows.