### PR TITLE
fix: run instance side effect on flow deletion

### DIFF
--- a/packages/backend/src/app/flows/flow-service.ts
+++ b/packages/backend/src/app/flows/flow-service.ts
@@ -20,6 +20,7 @@ import { paginationHelper } from "../helper/pagination/pagination-utils";
 import { buildPaginator } from "../helper/pagination/build-paginator";
 import { createRedisLock } from "../database/redis-connection";
 import { ActivepiecesError, ErrorCode } from "@activepieces/shared";
+import { instanceSideEffects } from "../instance/instance-side-effects";
 
 const flowRepo = databaseConnection.getRepository(FlowEntity);
 
@@ -110,6 +111,7 @@ export const flowService = {
     return await this.getOne(flowId, undefined);
   },
   async delete(flowId: FlowId): Promise<void> {
+    await instanceSideEffects.onFlowDelete(flowId);
     await flowRepo.delete({ id: flowId });
   },
 };

--- a/packages/backend/src/app/helper/trigger-utils.ts
+++ b/packages/backend/src/app/helper/trigger-utils.ts
@@ -175,7 +175,7 @@ const getPieceTrigger = (trigger: PieceTrigger): Trigger => {
 
 const getWebhookUrl = async (flowId: FlowId): Promise<string> => {
   const webhookPath = `v1/webhooks?flowId=${flowId}`;
-  let serverUrl = await getBackendUrl();
+  const serverUrl = await getBackendUrl();
   return `${serverUrl}/${webhookPath}`;
 };
 


### PR DESCRIPTION
## What does this PR do?

If the flow is deleted, the published flow side effects will not run for their triggers, the expected behavior to run the side effects on deleted flow.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [X] Create Flow with Schedule -> Publish -> Delete the Flow -> Schedule should be deleted.
