### PR TITLE
Piece/i 68 add google calendar piece

### DIFF
--- a/docs/pieces/apps/google_calendar.mdx
+++ b/docs/pieces/apps/google_calendar.mdx
@@ -1,0 +1,36 @@
+---
+title: "Google Calendar"
+description: ""
+---
+
+## Set up and run an app that calls a Google calendar API.
+
+1. In the Google Cloud console, enable the Google Calendar API.
+2. Click In the Google Cloud console, and go to Menu menu > APIs & Services > Credentials.
+3. Click Create Credentials > OAuth client ID.
+4. In the Name field, type a name for the credential. This name is only shown in the Google Cloud console.
+5. Click Create. The OAuth client created screen appears, showing your new Client ID and Client secret.
+6. Click OK. The newly created credential appears under OAuth 2.0 Client IDs.
+---
+
+
+## Triggers
+
+
+    <CardGroup cols={2}>
+      <Card title="New or Updated or Deleted Event">
+        Triggers when there is a new or updated or deleted Event for selected calendar.
+      </Card>
+    </CardGroup>
+
+
+---
+
+## Actions
+
+
+    <CardGroup cols={2}>
+      <Card title="Add Quick Event">
+        Add a Quick Event to a Google calendar
+      </Card>
+    </CardGroup>

--- a/packages/pieces/src/lib/apps/google-calendar/actions/create-quick-event.ts
+++ b/packages/pieces/src/lib/apps/google-calendar/actions/create-quick-event.ts
@@ -12,13 +12,13 @@ export const createQuickCalendarEvent = createAction({
   displayName: 'Quick Event',
   props: {
     authentication: googleCalendarCommon.authentication,
-    calendarId: googleCalendarCommon.calendarDropdown,
+    calendar_id: googleCalendarCommon.calendarDropdown,
     text: Property.LongText({
       displayName: 'Summary',
       description: 'The text describing the event to be created',
       required: true,
     }),
-    sendUpdates: Property.Dropdown<string>({
+    send_updates: Property.Dropdown<string>({
       displayName: "Send Updates",
       description: "Guests who should receive notifications about the creation of the new event.",
       refreshers: [],
@@ -46,11 +46,11 @@ export const createQuickCalendarEvent = createAction({
   },
   async run(configValue) {
     // docs: https://developers.google.com/calendar/api/v3/reference/events/quickAdd
-    const calendarId = configValue.propsValue['calendarId'];
+    const calendarId = configValue.propsValue['calendar_id'];
     const url = `${googleCalendarCommon.baseUrl}/calendars/${calendarId}/events/quickAdd`;
     const qParams: Record<string, string> = {
       text: configValue.propsValue['text']!,
-      sendUpdates: configValue.propsValue['sendUpdates'] || "none",
+      sendUpdates: configValue.propsValue['send_updates'] || "none",
     };
     const request: HttpRequest<Record<string, unknown>> = {
       method: HttpMethod.POST,

--- a/packages/pieces/src/lib/apps/google-calendar/actions/create-quick-event.ts
+++ b/packages/pieces/src/lib/apps/google-calendar/actions/create-quick-event.ts
@@ -1,0 +1,67 @@
+import { createAction } from '../../../framework/action/action';
+import type { HttpRequest } from '../../../common/http/core/http-request';
+import { HttpMethod } from '../../../common/http/core/http-method';
+import { AuthenticationType } from '../../../common/authentication/core/authentication-type';
+import { httpClient } from '../../../common/http/core/http-client';
+import { Property } from '../../../framework/property';
+import { googleCalendarCommon } from '../common';
+
+export const createQuickCalendarEvent = createAction({
+  name: 'create_quick_event',
+  description: 'Add Quick Calendar Event',
+  displayName: 'Quick Event',
+  props: {
+    authentication: googleCalendarCommon.authentication,
+    calendarId: googleCalendarCommon.calendarDropdown,
+    text: Property.LongText({
+      displayName: 'Summary',
+      description: 'The text describing the event to be created',
+      required: true,
+    }),
+    sendUpdates: Property.Dropdown<string>({
+      displayName: "Send Updates",
+      description: "Guests who should receive notifications about the creation of the new event.",
+      refreshers: [],
+      required: false,
+      options: async () => {
+        return {
+          disabled: false,
+          options: [
+            {
+              label: "All",
+              value: "all",
+            },
+            {
+              label: "External Only",
+              value: "externalOnly",
+            },
+            {
+              label: "none",
+              value: "none",
+            }
+          ]
+        };
+      }
+    }),
+  },
+  async run(configValue) {
+    // docs: https://developers.google.com/calendar/api/v3/reference/events/quickAdd
+    const calendarId = configValue.propsValue['calendarId'];
+    const url = `${googleCalendarCommon.baseUrl}/calendars/${calendarId}/events/quickAdd`;
+    const qParams: Record<string, string> = {
+      text: configValue.propsValue['text']!,
+      sendUpdates: configValue.propsValue['sendUpdates'] || "none",
+    };
+    const request: HttpRequest<Record<string, unknown>> = {
+      method: HttpMethod.POST,
+      url,
+      body: {},
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: configValue.propsValue['authentication']!['access_token'],
+      },
+      queryParams: qParams,
+    };
+    return await httpClient.sendRequest(request);
+  },
+});

--- a/packages/pieces/src/lib/apps/google-calendar/common/helper.ts
+++ b/packages/pieces/src/lib/apps/google-calendar/common/helper.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from 'crypto';
+import { googleCalendarCommon } from './index';
+import { HttpMethod } from '../../../common/http/core/http-method';
+import { HttpRequest } from '../../../common/http/core/http-request';
+import { OAuth2PropertyValue } from '../../../framework/property';
+import {
+  CalendarList,
+  CalendarObject,
+  GoogleCalendarEvent,
+  GoogleCalendarEventList,
+  GoogleWatchResponse,
+  GoogleWatchType,
+} from './types';
+import { AuthenticationType } from '../../../common/authentication/core/authentication-type';
+import { httpClient } from '../../../common/http/core/http-client';
+
+export async function stopWatchEvent(
+  body: GoogleWatchResponse,
+  authProp: OAuth2PropertyValue
+) {
+  const request: HttpRequest<any> = {
+    method: HttpMethod.POST,
+    url: `${googleCalendarCommon.baseUrl}/channels/stop`,
+    body: {
+      id: body?.id,
+      resourceId: body?.resourceId,
+    },
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: authProp.access_token,
+    },
+  };
+  await httpClient.sendRequest<any>(request);
+}
+
+export async function watchEvent(
+  calendarId: string,
+  webhookUrl: string,
+  authProp: OAuth2PropertyValue
+): Promise<GoogleWatchResponse> {
+  const request: HttpRequest<any> = {
+    method: HttpMethod.POST,
+    url: `${googleCalendarCommon.baseUrl}/calendars/${calendarId}/events/watch`,
+    body: {
+      id: randomUUID(),
+      type: GoogleWatchType.WEBHOOK,
+      address: webhookUrl,
+    },
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: authProp.access_token,
+    },
+  };
+  const { body: webhook } = await httpClient.sendRequest<GoogleWatchResponse>(
+    request
+  );
+  return webhook;
+}
+
+export async function getCalendars(
+  authProp: OAuth2PropertyValue
+): Promise<CalendarObject[]> {
+  // docs: https://developers.google.com/calendar/api/v3/reference/calendarList/list
+  const request: HttpRequest<never> = {
+    method: HttpMethod.GET,
+    url: `${googleCalendarCommon.baseUrl}/users/me/calendarList`,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: authProp.access_token,
+    },
+  };
+  const response = await httpClient.sendRequest<CalendarList>(request);
+  return response.body.items;
+}
+
+export async function getLatestEvent(
+  calendarId: string,
+  authProp: OAuth2PropertyValue
+): Promise<GoogleCalendarEvent> {
+  // docs: https://developers.google.com/calendar/api/v3/reference/events/list
+  const now = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(now.getDate() - 1);
+
+  const qParams: Record<string, string> = {
+    updatedMin: yesterday.toISOString(),
+    maxResults: '2500', // Modified
+    orderBy: 'updated',
+    singleEvents: 'true',
+    showDeleted: 'true',
+  };
+
+  const request: HttpRequest<never> = {
+    method: HttpMethod.GET,
+    url: `${googleCalendarCommon.baseUrl}/calendars/${calendarId}/events`,
+    queryParams: qParams,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: authProp.access_token,
+    },
+  };
+
+  let eventList: GoogleCalendarEvent[] = [];
+  let pageToken = '';
+  do {
+    qParams['pageToken'] = pageToken;
+    const { body: res } = await httpClient.sendRequest<GoogleCalendarEventList>(
+      request
+    );
+    if (res.items.length > 0) {
+      eventList = [...eventList, ...res.items];
+    }
+    pageToken = res.nextPageToken;
+  } while (pageToken);
+  const lastUpdatedEvent = eventList.pop()!; // You can retrieve the last updated event.
+  return lastUpdatedEvent;
+}

--- a/packages/pieces/src/lib/apps/google-calendar/common/index.ts
+++ b/packages/pieces/src/lib/apps/google-calendar/common/index.ts
@@ -1,0 +1,40 @@
+import { OAuth2PropertyValue, Property } from '../../../framework/property';
+import { getCalendars } from './helper';
+
+export const googleCalendarCommon = {
+  baseUrl: 'https://www.googleapis.com/calendar/v3',
+  authentication: Property.OAuth2({
+    description: '',
+    displayName: 'Authentication',
+    authUrl: 'https://accounts.google.com/o/oauth2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    required: true,
+    scope: ['https://www.googleapis.com/auth/calendar'],
+  }),
+  calendarDropdown: Property.Dropdown<string>({
+    displayName: 'Calendar',
+    refreshers: ['authentication'],
+    required: true,
+    options: async (propsValue) => {
+      if (propsValue['authentication'] === undefined) {
+        return {
+          disabled: true,
+          options: [],
+        };
+      }
+      const authProp: OAuth2PropertyValue = propsValue[
+        'authentication'
+      ] as OAuth2PropertyValue;
+      const calendars = await getCalendars(authProp);
+      return {
+        disabled: false,
+        options: calendars.map((calendar) => {
+          return {
+            label: calendar.summary,
+            value: calendar.id,
+          };
+        }),
+      };
+    },
+  }),
+};

--- a/packages/pieces/src/lib/apps/google-calendar/common/types.ts
+++ b/packages/pieces/src/lib/apps/google-calendar/common/types.ts
@@ -1,0 +1,229 @@
+export enum GoogleWatchType {
+  WEBHOOK = 'web_hook',
+}
+
+export enum GoogleCalendarKind {
+  CALENDAR_LIST = 'calendar#calendarList',
+  CALENDAR_ENTRY = 'calendar#calendarListEntry',
+  CALENDAR_EVENT = 'calendar#event',
+  CALENDAR_EVENT_LIST = 'calendar#events',
+  EVENT_WATCH = 'api#channel',
+}
+
+export interface CalendarList {
+  kind: GoogleCalendarKind.CALENDAR_LIST;
+  etag: string;
+  nextPageToken: string;
+  nextSyncToken: string;
+  items: CalendarObject[];
+}
+
+export interface CalendarObject {
+  kind: GoogleCalendarKind.CALENDAR_ENTRY;
+  etag: string;
+  id: string;
+  summary: string;
+  description: string;
+  location: string;
+  timeZone: string;
+  summaryOverride: string;
+  colorId: string;
+  backgroundColor: string;
+  foregroundColor: string;
+  hidden: boolean;
+  selected: boolean;
+  accessRole: string;
+  defaultReminders: [
+    {
+      method: string;
+      minutes: number;
+    }
+  ];
+  notificationSettings: {
+    notifications: [
+      {
+        type: string;
+        method: string;
+      }
+    ];
+  };
+  primary: boolean;
+  deleted: boolean;
+  conferenceProperties: {
+    allowedConferenceSolutionTypes: string[];
+  };
+}
+
+export interface GoogleWatchResponse {
+  kind: GoogleCalendarKind.EVENT_WATCH;
+  id: string;
+  resourceId: string;
+  resourceUri: string;
+  token: string;
+  expiration: number;
+}
+
+interface Attendee {
+  id: string;
+  email: string;
+  displayName: string;
+  organizer: boolean;
+  self: boolean;
+  resource: boolean;
+  optional: boolean;
+  responseStatus: string;
+  comment: string;
+  additionalGuests: BigInteger;
+}
+
+export interface GoogleCalendarEvent {
+  kind: GoogleCalendarKind.CALENDAR_EVENT;
+  etag: string;
+  id: string;
+  status: string;
+  htmlLink: string;
+  created: Date;
+  updated: Date;
+  summary: string;
+  description: string;
+  location: string;
+  colorId: string;
+  creator: {
+    id: string;
+    email: string;
+    displayName: string;
+    self: boolean;
+  };
+  organizer: {
+    id: string;
+    email: string;
+    displayName: string;
+    self: boolean;
+  };
+  start: {
+    date: Date;
+    dateTime: Date;
+    timeZone: string;
+  };
+  end: {
+    date: Date;
+    dateTime: Date;
+    timeZone: string;
+  };
+  endTimeUnspecified: boolean;
+  recurrence: [string];
+  recurringEventId: string;
+  originalStartTime: {
+    date: Date;
+    dateTime: Date;
+    timeZone: string;
+  };
+  transparency: string;
+  visibility: string;
+  iCalUID: string;
+  sequence: BigInteger;
+  attendees: Attendee[];
+  attendeesOmitted: boolean;
+  extendedProperties: {
+    private: {
+      key: string;
+    };
+    shared: {
+      key: string;
+    };
+  };
+  hangoutLink: string;
+  conferenceData: {
+    createRequest: {
+      requestId: string;
+      conferenceSolutionKey: {
+        type: string;
+      };
+      status: {
+        statusCode: string;
+      };
+    };
+    entryPoints: [
+      {
+        entryPointType: string;
+        uri: string;
+        label: string;
+        pin: string;
+        accessCode: string;
+        meetingCode: string;
+        passcode: string;
+        password: string;
+      }
+    ];
+    conferenceSolution: {
+      key: {
+        type: string;
+      };
+      name: string;
+      iconUri: string;
+    };
+    conferenceId: string;
+    signature: string;
+    notes: string;
+  };
+  gadget: {
+    type: string;
+    title: string;
+    link: string;
+    iconLink: string;
+    width: BigInteger;
+    height: BigInteger;
+    display: string;
+    preferences: {
+      key: string;
+    };
+  };
+  anyoneCanAddSelf: boolean;
+  guestsCanInviteOthers: boolean;
+  guestsCanModify: boolean;
+  guestsCanSeeOtherGuests: boolean;
+  privateCopy: boolean;
+  locked: boolean;
+  reminders: {
+    useDefault: boolean;
+    overrides: [
+      {
+        method: string;
+        minutes: BigInteger;
+      }
+    ];
+  };
+  source: {
+    url: string;
+    title: string;
+  };
+  attachments: [
+    {
+      fileUrl: string;
+      title: string;
+      mimeType: string;
+      iconLink: string;
+      fileId: string;
+    }
+  ];
+  eventType: string;
+}
+
+export interface GoogleCalendarEventList {
+  kind: GoogleCalendarKind.CALENDAR_EVENT_LIST;
+  etag: string;
+  summary: string;
+  description: string;
+  updated: number;
+  timeZone: string;
+  accessRole: string;
+  defaultReminders: [
+    {
+      method: string;
+      minutes: BigInteger;
+    }
+  ];
+  nextPageToken: string;
+  nextSyncToken: string;
+  items: GoogleCalendarEvent[];
+}

--- a/packages/pieces/src/lib/apps/google-calendar/google-calendar.mdx
+++ b/packages/pieces/src/lib/apps/google-calendar/google-calendar.mdx
@@ -13,24 +13,12 @@ description: ""
 6. Click OK. The newly created credential appears under OAuth 2.0 Client IDs.
 ---
 
-
 ## Triggers
 
-
-    <CardGroup cols={2}>
-      <Card title="New or Updated or Deleted Event">
-        Triggers when there is a new or updated or deleted Event for selected calendar.
-      </Card>
-    </CardGroup>
-
+TRIGGERS
 
 ---
 
 ## Actions
 
-
-    <CardGroup cols={2}>
-      <Card title="Add Quick Event">
-        Add a Quick Event to a Google calendar
-      </Card>
-    </CardGroup>
+ACTIONS

--- a/packages/pieces/src/lib/apps/google-calendar/index.ts
+++ b/packages/pieces/src/lib/apps/google-calendar/index.ts
@@ -1,0 +1,12 @@
+import { createPiece } from '../../framework/piece';
+import { createQuickCalendarEvent } from './actions/create-quick-event';
+import { calendarEventUpdatedOrCreatedOrDeleted } from './triggers/calendar-event';
+
+
+export const googleCalendar = createPiece({
+	name: 'google_calendar',
+	logoUrl: 'https://cdn.activepieces.com/pieces/google_calendar.png',
+	displayName: "Google Calendar",
+	actions: [createQuickCalendarEvent],
+	triggers: [calendarEventUpdatedOrCreatedOrDeleted],
+});

--- a/packages/pieces/src/lib/apps/google-calendar/index.ts
+++ b/packages/pieces/src/lib/apps/google-calendar/index.ts
@@ -1,6 +1,6 @@
 import { createPiece } from '../../framework/piece';
 import { createQuickCalendarEvent } from './actions/create-quick-event';
-import { calendarEventUpdatedOrCreatedOrDeleted } from './triggers/calendar-event';
+import { calendarEventChanged } from './triggers/calendar-event';
 
 
 export const googleCalendar = createPiece({
@@ -8,5 +8,5 @@ export const googleCalendar = createPiece({
 	logoUrl: 'https://cdn.activepieces.com/pieces/google_calendar.png',
 	displayName: "Google Calendar",
 	actions: [createQuickCalendarEvent],
-	triggers: [calendarEventUpdatedOrCreatedOrDeleted],
+	triggers: [calendarEventChanged],
 });

--- a/packages/pieces/src/lib/apps/google-calendar/triggers/calendar-event.ts
+++ b/packages/pieces/src/lib/apps/google-calendar/triggers/calendar-event.ts
@@ -1,0 +1,71 @@
+import { OAuth2PropertyValue } from '../../../framework/property';
+import {
+  createTrigger,
+  TriggerStrategy,
+} from '../../../framework/trigger/trigger';
+import { googleCalendarCommon } from '../common';
+import { getLatestEvent, stopWatchEvent, watchEvent } from '../common/helper';
+import { GoogleWatchResponse } from '../common/types';
+
+export const calendarEventUpdatedOrCreatedOrDeleted = createTrigger({
+  // docs: https://developers.google.com/calendar/api/guides/push
+  name: 'new_event_added',
+  displayName: 'New Event',
+  description: 'Triggers when there is a new event added',
+  props: {
+    authentication: googleCalendarCommon.authentication,
+    calendarId: googleCalendarCommon.calendarDropdown,
+  },
+  sampleData: {
+    kind: 'calendar#event',
+    htmlLink: 'https://www.google.com/calendar/event?eid=kgjb90uioj4klrgfmdsnjsjvlgkm',
+    summary: 'ap-event-test',
+    organizer: {
+      email: 'test@test.com',
+    },
+    start: {
+      dateTime: '2023-02-02T22:30:00+03:00',
+      timeZone: 'Asia/Amman',
+    },
+    end: {
+      dateTime: '2023-02-02T23:30:00+03:00',
+      timeZone: 'Asia/Amman',
+    },
+    eventType: 'default',
+  },
+  type: TriggerStrategy.WEBHOOK,
+  async onEnable(context) {
+    const authProp: OAuth2PropertyValue = context.propsValue[
+      'authentication'
+    ] as OAuth2PropertyValue;
+
+    const currentChannel = await context.store?.get<GoogleWatchResponse>('_trigger');
+    if (currentChannel?.id) {
+      await stopWatchEvent(currentChannel, authProp); // to avoid creating multiple watchers
+    }
+    const calendarId = context.propsValue['calendarId']!;
+
+    const channel = await watchEvent(calendarId, context.webhookUrl!, authProp);
+
+    await context.store?.put<GoogleWatchResponse>('_trigger', channel);
+  },
+  async onDisable(context) {
+    const authProp: OAuth2PropertyValue = context.propsValue[
+      'authentication'
+    ] as OAuth2PropertyValue;
+
+    const googleChannel = await context.store?.get<GoogleWatchResponse>('_trigger');
+    if (googleChannel?.id) await stopWatchEvent(googleChannel, authProp);
+    await context.store?.put<GoogleWatchResponse | object>('_trigger', {});
+  },
+  async run(context) {
+    const authProp: OAuth2PropertyValue = context.propsValue[
+      'authentication'
+    ] as OAuth2PropertyValue;
+    const event = await getLatestEvent(
+      context.propsValue['calendarId']!,
+      authProp,
+    );
+    return [event];
+  },
+});

--- a/packages/pieces/src/lib/apps/google-calendar/triggers/calendar-event.ts
+++ b/packages/pieces/src/lib/apps/google-calendar/triggers/calendar-event.ts
@@ -7,19 +7,24 @@ import { googleCalendarCommon } from '../common';
 import { getLatestEvent, stopWatchEvent, watchEvent } from '../common/helper';
 import { GoogleWatchResponse } from '../common/types';
 
-export const calendarEventUpdatedOrCreatedOrDeleted = createTrigger({
+export const calendarEventChanged = createTrigger({
   // docs: https://developers.google.com/calendar/api/guides/push
-  name: 'new_event_added',
-  displayName: 'New Event',
-  description: 'Triggers when there is a new event added',
+  name: 'new_or_updated_event',
+  displayName: 'New Or updated Event',
+  description: 'Triggers when there is an event added or updated',
   props: {
     authentication: googleCalendarCommon.authentication,
-    calendarId: googleCalendarCommon.calendarDropdown,
+    calendar_id: googleCalendarCommon.calendarDropdown,
   },
   sampleData: {
     kind: 'calendar#event',
+    etag: "3350849506974000",
+    id: "0nsfi5ttd2b17ac76ma2f37oi9",
     htmlLink: 'https://www.google.com/calendar/event?eid=kgjb90uioj4klrgfmdsnjsjvlgkm',
     summary: 'ap-event-test',
+    created: "2023-02-03T11:36:36.000Z",
+    updated: "2023-02-03T11:45:53.487Z",
+    status: 'canceled',
     organizer: {
       email: 'test@test.com',
     },
@@ -30,6 +35,11 @@ export const calendarEventUpdatedOrCreatedOrDeleted = createTrigger({
     end: {
       dateTime: '2023-02-02T23:30:00+03:00',
       timeZone: 'Asia/Amman',
+    },
+    iCalUID: "0nsfi5ttd2b17ac76ma2f37oi9@google.com",
+    sequence: 1,
+    reminders: {
+      useDefault: true
     },
     eventType: 'default',
   },
@@ -43,7 +53,7 @@ export const calendarEventUpdatedOrCreatedOrDeleted = createTrigger({
     if (currentChannel?.id) {
       await stopWatchEvent(currentChannel, authProp); // to avoid creating multiple watchers
     }
-    const calendarId = context.propsValue['calendarId']!;
+    const calendarId = context.propsValue['calendar_id']!;
 
     const channel = await watchEvent(calendarId, context.webhookUrl!, authProp);
 
@@ -63,7 +73,7 @@ export const calendarEventUpdatedOrCreatedOrDeleted = createTrigger({
       'authentication'
     ] as OAuth2PropertyValue;
     const event = await getLatestEvent(
-      context.propsValue['calendarId']!,
+      context.propsValue['calendar_id']!,
       authProp,
     );
     return [event];

--- a/packages/pieces/src/lib/apps/index.ts
+++ b/packages/pieces/src/lib/apps/index.ts
@@ -21,6 +21,7 @@ import { drip } from './drip';
 import { calendly } from './calendly';
 import { http } from './http';
 import { todoist } from './todoist';
+import { googleCalendar } from './google-calendar';
 
 export const pieces: Piece[] = [
 	slack,
@@ -45,6 +46,7 @@ export const pieces: Piece[] = [
 	telegramBot,
   http,
   todoist,
+  googleCalendar,
 ].sort((a, b) => a.displayName > b.displayName ? 1 : -1);
 
 export const getPiece = (name: string): Piece | undefined => {


### PR DESCRIPTION
## What does this PR do?

# Issue:  https://github.com/activepieces/activepieces/issues/68

A new piece has been added:
- Name: google calendar
- Actions: Quick add event
- triggers: Event updated or created or  deleted
- Trigger type is webhook
- on-enable: a watch request to google resource is sent
notes: with each publish, a new channel is generated to watch the event so to avoid having multiple watchers at the same time, we stop the old channel and then create a new watcher
-run: Google APIs don't return the events in descending order so the only way was for me to get the last event modified to do multiple requests till getting to the last page and then get the last element


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. In the Google Cloud console, enable the Google Calendar API.
2. Click In the Google Cloud console, and go to Menu menu > APIs & Services > Credentials.
3. Click Create Credentials > OAuth client ID.
4. In the Name field, type a name for the credential. This name is only shown in the Google Cloud console.
5. Click Create. The OAuth client created screen appears, showing your new Client ID and Client secret.
6. Click OK. The newly created credential appears under OAuth 2.0 Client IDs.
7. ngrok http 300
8. setup new google calendar trigger/action 
9. publish


## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->