### PR TITLE
chore: fix engine webpack config

### DIFF
--- a/.github/workflows/build-everything.yml
+++ b/.github/workflows/build-everything.yml
@@ -13,8 +13,5 @@ jobs:
       - name: install npm deps
         run: npm ci
 
-      - name: check for engine compilation errors
-        run: npx tsc -p packages/engine/tsconfig.lib.json --noEmit
-
       - name: build everything
         run: npx nx run-many --target=build

--- a/packages/engine/webpack.config.js
+++ b/packages/engine/webpack.config.js
@@ -1,13 +1,8 @@
-const path = require('path');
-const IgnoreDynamicRequire = require('webpack-ignore-dynamic-require');
 const { composePlugins, withNx } = require('@nrwl/webpack');
+const IgnoreDynamicRequire = require('webpack-ignore-dynamic-require');
 
-// Nx plugins for webpack.
 module.exports = composePlugins(withNx(), (config) => {
-  config = {
-    ...config,
-    plugins: [new IgnoreDynamicRequire()],
-    externals: [],
-  }
+  config.plugins.push(new IgnoreDynamicRequire())
+  config.externals = [];
   return config;
 });


### PR DESCRIPTION
## What does this PR do?

- Push `IgnoreDynamicRequire` to `plugins` array instead of overriding it.
- The webpack compilation fails on ts errors now so removed redundant engine compilation step from the pipeline

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)