### PR TITLE
fix: fixed frontend eslint

### DIFF
--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -4,6 +4,9 @@
   "overrides": [
     {
       "files": ["*.ts"],
+      "parserOptions": {
+        "project":["packages/frontend/tsconfig.*?.json"]
+      },
       "rules": {
         "rxjs/no-async-subscribe": "error",
         "rxjs/no-nested-subscribe": "error",


### PR DESCRIPTION
## What does this PR do?

Eslint wasn't working on the frontend package ever since we switched to nx, I had to have a local copy of tsconfig.json in the root of the repo.

Fixes # (issue)

After leading https://nx.dev/recipes/other/eslint  I found out I had to set parserOptions.project in eslint.json of the package, to be packages/frontend/tsconfig.*?.json which solves the issue and enables eslint.

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
run nx lint frontend


