### PR TITLE
[DOCS]: Fix incorrect CD command on 'Create First Piece' Page

### DIFF
--- a/docs/contributing/building-pieces/quickstart.mdx
+++ b/docs/contributing/building-pieces/quickstart.mdx
@@ -15,7 +15,7 @@ Hacker News is a social news website that allows users to submit and vote on sto
 To get started, let's create a new folder for Hacker News and add the piece definition inside.
 
 ```bash
-mkdir packages/pieces/framework/src/lib/apps/hackernews && cd packages/src/lib/pieces/apps/hackernews
+mkdir packages/pieces/framework/src/lib/apps/hackernews && cd packages/pieces/framework/src/lib/apps/hackernews
 ```
 
 Next, let's create the definition file:


### PR DESCRIPTION
## What does this PR do?

Fixed an incorrect command found when attempting to `cd` into the hackernews example directory

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

You can test this by navigating to the create first piece page and viewing the Piece Definition commands and seeing if the && cd... is updated with the new uri