### PR TITLE
feat: add figma piece with new comment trigger and get file, get file…

### DIFF
--- a/packages/pieces/apps/src/index.ts
+++ b/packages/pieces/apps/src/index.ts
@@ -9,6 +9,7 @@ import { clickup } from './lib/clickup';
 import { discord } from './lib/discord';
 import { drip } from './lib/drip';
 import { dropbox } from './lib/dropbox';
+import { figma } from './lib/figma';
 import { github } from './lib/github';
 import { gmail } from './lib/gmail';
 import { googleCalendar } from './lib/google-calendar';
@@ -40,6 +41,7 @@ export const pieces: Piece[] = [
     discord,
     drip,
     dropbox,
+    figma,
     github,
     gmail,
     googleCalendar,

--- a/packages/pieces/apps/src/lib/figma/actions/get-comments-action.ts
+++ b/packages/pieces/apps/src/lib/figma/actions/get-comments-action.ts
@@ -1,0 +1,56 @@
+import { createAction, Property, assertNotNullOrUndefined } from "@activepieces/framework";
+import { figmaAuth } from '../common/props';
+import { figmaCommon } from "../common";
+import { figmaGetRequest } from '../common/utils';
+
+export const getCommentsAction = createAction({
+  name: 'get_comments',
+  displayName: 'Get file comments',
+  description: 'Get file comments',
+  sampleData: {
+    "success": true,
+    "response_body": {
+      "comments": [
+        {
+          "id": "123456789",
+          "uuid": null,
+          "file_key": "abc123DEF456ghi789JKLm",
+          "parent_id": "",
+          "user": {
+            "handle": "User Name",
+            "img_url": "https://s3-alpha.figma.com/profile/profile-id",
+            "id": "123456789123"
+          },
+          "created_at": "2023-02-13T00:00:00.000Z",
+          "resolved_at": null,
+          "message": "New comment",
+          "reactions": [],
+          "client_meta": {
+            "x": 0,
+            "y": 0
+          },
+          "order_id": "1"
+        }
+      ]
+    }
+  },
+  props: {
+    authentication: figmaAuth,
+    file_key: Property.ShortText({
+      displayName: 'File Key',
+      description: 'The Figma file key (copy from Figma file URL)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const token = context.propsValue.authentication?.access_token;
+    const fileKey = context.propsValue.file_key;
+
+    assertNotNullOrUndefined(token, 'token');
+    assertNotNullOrUndefined(fileKey, 'file_key');
+    
+    const url = `${figmaCommon.baseUrl}/${figmaCommon.comments}`.replace(':file_key', fileKey);
+
+    return figmaGetRequest({ token, url });
+  },
+});

--- a/packages/pieces/apps/src/lib/figma/actions/get-file-action.ts
+++ b/packages/pieces/apps/src/lib/figma/actions/get-file-action.ts
@@ -1,0 +1,32 @@
+import { createAction, Property, assertNotNullOrUndefined } from "@activepieces/framework";
+import { figmaAuth } from '../common/props';
+import { figmaCommon } from "../common";
+import { figmaGetRequest } from '../common/utils';
+
+export const getFileAction = createAction({
+  name: 'get_file',
+  displayName: 'Get file',
+  description: 'Get file',
+  sampleData: {
+    success: true,
+  },
+  props: {
+    authentication: figmaAuth,
+    file_key: Property.ShortText({
+      displayName: 'File Key',
+      description: 'The Figma file key (copy from Figma file URL)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const token = context.propsValue.authentication?.access_token;
+    const fileKey = context.propsValue.file_key;
+
+    assertNotNullOrUndefined(token, 'token');
+    assertNotNullOrUndefined(fileKey, 'file_key');
+    
+    const url = `${figmaCommon.baseUrl}/${figmaCommon.files}`.replace(':file_key', fileKey);
+
+    return figmaGetRequest({ token, url });
+  },
+});

--- a/packages/pieces/apps/src/lib/figma/actions/post-comment-action.ts
+++ b/packages/pieces/apps/src/lib/figma/actions/post-comment-action.ts
@@ -1,0 +1,38 @@
+import { createAction, Property, assertNotNullOrUndefined } from "@activepieces/framework";
+import { figmaAuth } from '../common/props';
+import { figmaCommon } from "../common";
+import { figmaPostRequestWithMessage } from '../common/utils';
+
+export const postCommentAction = createAction({
+  name: 'post_comment',
+  displayName: 'Post file comment',
+  description: 'Post file comment',
+  sampleData: {
+    success: true,
+  },
+  props: {
+    authentication: figmaAuth,
+    fileKey: Property.ShortText({
+      displayName: 'File Key',
+      description: 'The Figma file key (copy from Figma file URL)',
+      required: true,
+    }),
+    message: Property.LongText({
+      displayName: 'Comment',
+      description: 'Your comment',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const token = context.propsValue.authentication?.access_token;
+    const { fileKey, message } = context.propsValue;
+
+    assertNotNullOrUndefined(token, 'token');
+    assertNotNullOrUndefined(fileKey, 'fileKey');
+    assertNotNullOrUndefined(message, 'comment');
+    
+    const url = `${figmaCommon.baseUrl}/${figmaCommon.comments}`.replace(':file_key', fileKey);
+
+    return figmaPostRequestWithMessage({ token, url, message });
+  },
+});

--- a/packages/pieces/apps/src/lib/figma/actions/post-comment-action.ts
+++ b/packages/pieces/apps/src/lib/figma/actions/post-comment-action.ts
@@ -12,7 +12,7 @@ export const postCommentAction = createAction({
   },
   props: {
     authentication: figmaAuth,
-    fileKey: Property.ShortText({
+    file_key: Property.ShortText({
       displayName: 'File Key',
       description: 'The Figma file key (copy from Figma file URL)',
       required: true,
@@ -25,13 +25,13 @@ export const postCommentAction = createAction({
   },
   async run(context) {
     const token = context.propsValue.authentication?.access_token;
-    const { fileKey, message } = context.propsValue;
+    const { file_key, message } = context.propsValue;
 
     assertNotNullOrUndefined(token, 'token');
-    assertNotNullOrUndefined(fileKey, 'fileKey');
+    assertNotNullOrUndefined(file_key, 'file_key');
     assertNotNullOrUndefined(message, 'comment');
     
-    const url = `${figmaCommon.baseUrl}/${figmaCommon.comments}`.replace(':file_key', fileKey);
+    const url = `${figmaCommon.baseUrl}/${figmaCommon.comments}`.replace(':file_key', file_key);
 
     return figmaPostRequestWithMessage({ token, url, message });
   },

--- a/packages/pieces/apps/src/lib/figma/common/index.ts
+++ b/packages/pieces/apps/src/lib/figma/common/index.ts
@@ -1,0 +1,5 @@
+export const figmaCommon = {
+    baseUrl: "https://api.figma.com/v1",
+    files: "files/:file_key",
+    comments: "files/:file_key/comments",
+}

--- a/packages/pieces/apps/src/lib/figma/common/index.ts
+++ b/packages/pieces/apps/src/lib/figma/common/index.ts
@@ -1,5 +1,7 @@
 export const figmaCommon = {
-    baseUrl: "https://api.figma.com/v1",
-    files: "files/:file_key",
-    comments: "files/:file_key/comments",
+    baseUrl: 'https://api.figma.com',
+    files: 'v1/files/:file_key',
+    comments: 'v1/files/:file_key/comments',
+    webhooks: 'v2/webhooks',
+    webhook: 'v2/webhooks/:webhook_id',
 }

--- a/packages/pieces/apps/src/lib/figma/common/models.ts
+++ b/packages/pieces/apps/src/lib/figma/common/models.ts
@@ -1,0 +1,24 @@
+type User = {
+  handle: string;
+  img_url: string;
+  id: string;
+}
+
+type Pos = {
+  x: number;
+  y: number;
+}
+
+export type Comment = {
+  id: string;
+  uuid: string;
+  file_key: string;
+  parent_id: string;
+  user: User;
+  created_at: string;
+  resolved_at: string;
+  message: string;
+  reactions: unknown;
+  client_meta: Pos;
+  order_id: number;
+};

--- a/packages/pieces/apps/src/lib/figma/common/props.ts
+++ b/packages/pieces/apps/src/lib/figma/common/props.ts
@@ -1,0 +1,12 @@
+import { Property } from "@activepieces/framework";
+
+export const figmaAuth = Property.OAuth2({
+  description: '',
+  displayName: 'Authentication',
+  authUrl: 'https://www.figma.com/oauth',
+  tokenUrl: 'https://www.figma.com/api/oauth/token',
+  required: true,
+  scope: [
+    'file_read',
+  ],
+});

--- a/packages/pieces/apps/src/lib/figma/common/utils.ts
+++ b/packages/pieces/apps/src/lib/figma/common/utils.ts
@@ -19,7 +19,7 @@ export const figmaGetRequest = async ( { token, url }: FigmaGetRequestParams ) =
       };
   };
 
-  export const figmaPostRequestWithMessage = async ( { token, url, message }: FigmaPostRequestWithMessageParams ) => {
+export const figmaPostRequestWithMessage = async ( { token, url, message }: FigmaPostRequestWithMessageParams ) => {
     const request: HttpRequest<FigmaPostRequestWithMessageBody> = {
         method: HttpMethod.POST,
         url: url,
@@ -39,19 +39,79 @@ export const figmaGetRequest = async ( { token, url }: FigmaGetRequestParams ) =
         request_body: request.body,
         response_body: response.body,
       };
-  };
+};
 
-  type FigmaGetRequestParams = {
+export const figmaWebhookPostRequest = async ( { token, url, eventType, teamId, endpoint, passcode }: FigmaWebhookPostRequestParams ) => {
+  const request: HttpRequest<FigmaWebhookPostRequestBody> = {
+      method: HttpMethod.POST,
+      url: url,
+      body: {
+        event_type: eventType,
+        team_id: teamId,
+        endpoint: endpoint,
+        passcode: passcode,
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token,
+      },
+    };
+  
+    const response = await httpClient.sendRequest(request);
+  
+    return {
+      success: true,
+      request_body: request.body,
+      response_body: response.body,
+    };
+};
+
+export const figmaDeleteRequest = async ( { token, url }: FigmaGetRequestParams ) => {
+  const request: HttpRequest = {
+      method: HttpMethod.DELETE,
+      url: url,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token,
+      },
+    };
+  
+    const response = await httpClient.sendRequest(request);
+  
+    return {
+      success: true,
+      request_body: request.body,
+      response_body: response.body,
+    };
+};
+
+type FigmaGetRequestParams = {
     token: string;
     url: string;
-  }
+}
 
-  type FigmaPostRequestWithMessageParams = {
+type FigmaPostRequestWithMessageParams = {
     token: string;
     url: string;
     message: string;
-  }
+}
 
-  type FigmaPostRequestWithMessageBody = {
+type FigmaPostRequestWithMessageBody = {
     message: string;
-  }
+}
+
+type FigmaWebhookPostRequestParams = {
+    token: string;
+    url: string;
+    eventType: string;
+    teamId: string;
+    endpoint: string;
+    passcode: string;
+}
+
+type FigmaWebhookPostRequestBody = {
+  event_type: string;
+  team_id: string;
+  endpoint: string;
+  passcode: string;
+}

--- a/packages/pieces/apps/src/lib/figma/common/utils.ts
+++ b/packages/pieces/apps/src/lib/figma/common/utils.ts
@@ -1,0 +1,57 @@
+import { httpClient, HttpMethod, HttpRequest, AuthenticationType } from "@activepieces/framework";
+
+export const figmaGetRequest = async ( { token, url }: FigmaGetRequestParams ) => {
+    const request: HttpRequest = {
+        method: HttpMethod.GET,
+        url: url,
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token,
+        },
+      };
+    
+      const response = await httpClient.sendRequest(request);
+    
+      return {
+        success: true,
+        request_body: request.body,
+        response_body: response.body,
+      };
+  };
+
+  export const figmaPostRequestWithMessage = async ( { token, url, message }: FigmaPostRequestWithMessageParams ) => {
+    const request: HttpRequest<FigmaPostRequestWithMessageBody> = {
+        method: HttpMethod.POST,
+        url: url,
+        body: {
+            message: message,
+        },
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token,
+        },
+      };
+    
+      const response = await httpClient.sendRequest(request);
+    
+      return {
+        success: true,
+        request_body: request.body,
+        response_body: response.body,
+      };
+  };
+
+  type FigmaGetRequestParams = {
+    token: string;
+    url: string;
+  }
+
+  type FigmaPostRequestWithMessageParams = {
+    token: string;
+    url: string;
+    message: string;
+  }
+
+  type FigmaPostRequestWithMessageBody = {
+    message: string;
+  }

--- a/packages/pieces/apps/src/lib/figma/index.ts
+++ b/packages/pieces/apps/src/lib/figma/index.ts
@@ -1,6 +1,6 @@
 import { getFileAction } from './actions/get-file-action';
 import { getCommentsAction } from './actions/get-comments-action';
-import { createPiece } from "../../framework/piece";
+import { createPiece } from "@activepieces/framework";
 import { postCommentAction } from './actions/post-comment-action';
 import { newCommentTrigger } from './trigger/new-comment';
 

--- a/packages/pieces/apps/src/lib/figma/index.ts
+++ b/packages/pieces/apps/src/lib/figma/index.ts
@@ -1,0 +1,19 @@
+import { getFileAction } from './actions/get-file-action';
+import { getCommentsAction } from './actions/get-comments-action';
+import { createPiece } from "../../framework/piece";
+import { postCommentAction } from './actions/post-comment-action';
+import { newCommentTrigger } from './trigger/new-comment';
+
+export const figma = createPiece({
+	name: 'figma',
+	displayName: "Figma",
+	logoUrl: 'https://cdn.activepieces.com/pieces/figma.png',
+	actions: [
+		getFileAction,
+		getCommentsAction,
+		postCommentAction,
+  ],
+	triggers: [
+		newCommentTrigger,
+	]
+});

--- a/packages/pieces/apps/src/lib/figma/trigger/new-comment.ts
+++ b/packages/pieces/apps/src/lib/figma/trigger/new-comment.ts
@@ -1,0 +1,105 @@
+import { createTrigger, TriggerStrategy, Property, assertNotNullOrUndefined } from "@activepieces/framework";
+import { figmaAuth } from '../common/props';
+import { Comment } from '../common/models';
+import { figmaCommon } from "../common";
+import { figmaGetRequest } from '../common/utils';
+
+type TriggerData = {
+  lastCommentCreatedAt: string;
+}
+
+const TRIGGER_DATA_STORE_KEY = 'figma_new_comment_trigger_data'
+
+export const newCommentTrigger = createTrigger({
+  name: 'new_comment',
+  displayName: 'New comment',
+  description: 'Triggers when a new comment is posted',
+  // Update: There's a new Figma API v2 in open beta that supports webhooks!
+  // https://www.figma.com/developers/api#webhooks_v2
+  type: TriggerStrategy.POLLING,
+  sampleData: [{
+    "id": "123456789",
+    "uuid": null,
+    "file_key": "abc123DEF456ghi789JKLm",
+    "parent_id": "",
+    "user": {
+      "handle": "User Name",
+      "img_url": "https://s3-alpha.figma.com/profile/profile-id",
+      "id": "123456789123"
+    },
+    "created_at": "2023-02-13T00:00:00.000Z",
+    "resolved_at": null,
+    "message": "New comment",
+    "reactions": [],
+    "client_meta": {
+      "x": 0,
+      "y": 0
+    },
+    "order_id": "1"
+  }],
+  props: {
+    authentication: figmaAuth,
+    file_key: Property.ShortText({
+      displayName: 'File Key',
+      description: 'The Figma file key (copy from Figma file URL)',
+      required: true,
+    }),
+  },
+
+  async onEnable({ store }): Promise<void> {
+    // trigger only for comments later than now
+    await store.put<TriggerData>(TRIGGER_DATA_STORE_KEY, {
+      lastCommentCreatedAt: new Date().toISOString(),
+    });
+  },
+
+  async onDisable({ store }): Promise<void> {
+    await store.put(TRIGGER_DATA_STORE_KEY, null);
+  },
+
+  async run({ propsValue, store }): Promise<Comment[][]> {
+    const token = propsValue.authentication?.access_token
+    const fileKey = propsValue.file_key;
+    const newComments: Comment[] = [];
+
+    assertNotNullOrUndefined(token, 'token');
+    assertNotNullOrUndefined(fileKey, 'file_key');
+    
+    const url = `${figmaCommon.baseUrl}/${figmaCommon.comments}`.replace(':file_key', fileKey);
+
+    const lastTriggerData = await store.get<TriggerData>(TRIGGER_DATA_STORE_KEY);
+    const lastCommentCreatedAt = Date.parse(`${lastTriggerData?.lastCommentCreatedAt}`);
+    if (isNaN(lastCommentCreatedAt)) return [];
+
+    const response = await figmaGetRequest({ token, url });
+    const comments = response.response_body['comments'];
+
+    let latestCommentCreatedAt = 0;
+    let latestCommentCreatedAtString = "";
+
+    if (!comments || comments.length < 1) return [];
+    
+    // find all new comments and store the created_at value of the latest comment
+    for (let i = 0; i < comments.length; i++) {
+      const commentCreatedAtString = `${comments[i].created_at}`
+      const commentCreatedAt = Date.parse(commentCreatedAtString);
+      if (isNaN(commentCreatedAt)) continue;
+      if (commentCreatedAt > lastCommentCreatedAt) {
+        newComments.push(comments[i]);
+        if (commentCreatedAt > latestCommentCreatedAt) {
+          latestCommentCreatedAt = commentCreatedAt;
+          latestCommentCreatedAtString = commentCreatedAtString;
+        }
+      }
+    }
+
+    if (newComments.length < 1) return [];
+
+    await store.put<TriggerData>(TRIGGER_DATA_STORE_KEY, {
+      lastCommentCreatedAt: latestCommentCreatedAtString,
+    });
+
+    // trigger one run with all new comments
+    return [newComments];
+  },
+})


### PR DESCRIPTION
Add Figma piece with new comment trigger and get file, get file comments, and post file comment actions

## What does this PR do?

Figma piece. New file comment trigger. Get file, get file comments, and post file comment actions.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How should this be tested?

Connect to Figma [https://www.figma.com/developers/api#register-oauth2](https://www.figma.com/developers/api#register-oauth2) and copy a Figma file id from the "share url" of that file for testing.

Test Figma new comment trigger by creating new comments on that file. Test the actions to get file data, comments, etc.