### PR TITLE
chore: remove Drip url from Airtable commmon

### DIFF
--- a/packages/pieces/apps/src/lib/airtable/common/index.ts
+++ b/packages/pieces/apps/src/lib/airtable/common/index.ts
@@ -15,7 +15,6 @@ export interface AirtableRecord {
 }
 
 export const airtableCommon = {
-    baseUrl: (accountId: string) => { return `https://api.getdrip.com/v2/${accountId}` },
     authentication: Property.SecretText({
         displayName: "Personal Token",
         required: true,


### PR DESCRIPTION
## What does this PR do?

Removes unused function from Airtable common, addresses  #621 


