### PR TITLE
fix: new connection is selected when creating one from within dropdown

### DIFF
--- a/packages/frontend/src/app/modules/common/components/configs-form/configs-form.component.html
+++ b/packages/frontend/src/app/modules/common/components/configs-form/configs-form.component.html
@@ -193,7 +193,8 @@
                 [value]="opt.value">
                 {{opt.label.name}}
               </mat-option>
-              <mat-option *ngIf="((allAuthConfigs$ | async)!| authConfigsForPiece:pieceName)?.length === 0"
+              <mat-option
+                [style.display]="((allAuthConfigs$ | async)!| authConfigsForPiece:pieceName)?.length === 0 ? 'flex': 'none'"
                 class="add-auth">
                 <div class="ap-flex">
                   <div class="ap-flex-grow">No connections</div>


### PR DESCRIPTION
Fixes # (issue)

Addresses #599 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

1)Have a piece with no connections.
2)Create a connection from the add button inside the dropdown

