### PR TITLE
feat: moved http and storage to core in the add new step list

### DIFF
--- a/packages/frontend/src/app/app.module.ts
+++ b/packages/frontend/src/app/app.module.ts
@@ -1,4 +1,8 @@
-import { APP_INITIALIZER, CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
+import {
+  APP_INITIALIZER,
+  CUSTOM_ELEMENTS_SCHEMA,
+  NgModule,
+} from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -27,138 +31,154 @@ import { DashboardContainerComponent } from './modules/dashboard/dashboard-conta
 import { UserLoggedIn } from './guards/user-logged-in.guard';
 
 @NgModule({
-	declarations: [AppComponent, NotFoundComponent, RedirectUrlComponent],
-	imports: [
-		CommonModule,
-		BrowserModule,
-		FlowBuilderModule,
-		AppRoutingModule,
-		BrowserAnimationsModule,
-		StoreModule.forRoot({}),
-		StoreDevtoolsModule.instrument({
-			maxAge: 25, // Retains last 25 states
-			autoPause: true, // Pauses recording actions and state changes when the extension window is not open
-		}),
-		EffectsModule.forRoot(),
-		HttpClientModule,
-		FontAwesomeModule,
-		JwtModule.forRoot({
-			config: {
-				tokenGetter,
-				allowedDomains: [extractHostname(environment.apiUrl)],
-			},
-		}),
-		...dynamicModules(),
-		AngularSvgIconModule,
-		CommonLayoutModule
-	],
-	providers: [
-		{
-			provide: APP_INITIALIZER,
-			useFactory: initializeAppCustomLogic,
-			multi: true,
-			deps: [Router, FlagService],
-		},
-	],
-	schemas: [CUSTOM_ELEMENTS_SCHEMA],
-	exports: [],
-	bootstrap: [AppComponent],
+  declarations: [AppComponent, NotFoundComponent, RedirectUrlComponent],
+  imports: [
+    CommonModule,
+    BrowserModule,
+    FlowBuilderModule,
+    AppRoutingModule,
+    BrowserAnimationsModule,
+    StoreModule.forRoot({}),
+    StoreDevtoolsModule.instrument({
+      maxAge: 25, // Retains last 25 states
+      autoPause: true, // Pauses recording actions and state changes when the extension window is not open
+    }),
+    EffectsModule.forRoot(),
+    HttpClientModule,
+    FontAwesomeModule,
+    JwtModule.forRoot({
+      config: {
+        tokenGetter,
+        allowedDomains: [extractHostname(environment.apiUrl)],
+      },
+    }),
+    ...dynamicModules(),
+    AngularSvgIconModule,
+    CommonLayoutModule,
+  ],
+  providers: [
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeAppCustomLogic,
+      multi: true,
+      deps: [Router, FlagService],
+    },
+  ],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  exports: [],
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}
 
-export function initializeAppCustomLogic(router: Router, flagService: FlagService): () => Promise<void> {
-	return () =>
-		new Promise((resolve) => {
-			console.log('***Angular init***');
+export function initializeAppCustomLogic(
+  router: Router,
+  flagService: FlagService
+): () => Promise<void> {
+  return () =>
+    new Promise((resolve) => {
+      console.log('***Angular init***');
 
-			flagService.getEdition().subscribe((edition) => {
-				console.log("edition " + edition);
-				router.resetConfig([
-					...dynamicRoutes(edition)
-				]);
-				console.log('***Angular Finished***');
-				resolve();
-			});
-		});
+      flagService.getEdition().subscribe((edition) => {
+        console.log('edition ' + edition);
+        router.resetConfig([...dynamicRoutes(edition)]);
+        console.log('***Angular Finished***');
+        resolve();
+      });
+    });
 }
 
 function dynamicRoutes(edition: string) {
-	const coreRoutes = [
-		{
-			path: '',
-			component: DashboardContainerComponent,
-			canActivate: [UserLoggedIn],
-			children: [
-				{
-					path: '',
-					loadChildren: () => import('./modules/dashboard/dashboard-layout.module').then(m => m.DashboardLayoutModule),
-				},
-			],
-		},
-		{
-			path: '',
-			children: [
-				{
-					path: '',
-					loadChildren: () => import('./modules/flow-builder/flow-builder.module').then(m => m.FlowBuilderModule),
-				},
-			],
-		}
-	];
-	const suffixRoutes = [{
-		path: 'redirect',
-		component: RedirectUrlComponent,
-	},
-	{
-		path: '**',
-		component: NotFoundComponent,
-		title: 'AP-404',
-	}];
-	let editionRoutes: any[] = [];
-	switch (edition) {
-		case ApEdition.ENTERPRISE:
-			editionRoutes = [
-				{
-					path: '',
-					component: FirebaseAuthContainerComponent,
-					children: [
-						{
-							path: '',
-							loadChildren: () => import('../../../ee/firebase-auth/frontend/firebase-auth.module').then(m => m.FirebaseAuthLayoutModule),
-						},
-					],
-				}
-			];
-			break;
-		case ApEdition.COMMUNITY:
-			editionRoutes = [{
-				path: '',
-				component: AuthLayoutComponent,
-				children: [
-					{
-						path: '',
-						loadChildren: () => import('./modules/auth/auth.module').then(m => m.AuthLayoutModule),
-					},
-				],
-			}];
-			break;
-	}
-	return [...coreRoutes, ...editionRoutes, ...suffixRoutes];
+  const coreRoutes = [
+    {
+      path: '',
+      component: DashboardContainerComponent,
+      canActivate: [UserLoggedIn],
+      children: [
+        {
+          path: '',
+          loadChildren: () =>
+            import('./modules/dashboard/dashboard-layout.module').then(
+              (m) => m.DashboardLayoutModule
+            ),
+        },
+      ],
+    },
+    {
+      path: '',
+      children: [
+        {
+          path: '',
+          loadChildren: () =>
+            import('./modules/flow-builder/flow-builder.module').then(
+              (m) => m.FlowBuilderModule
+            ),
+        },
+      ],
+    },
+  ];
+  const suffixRoutes = [
+    {
+      path: 'redirect',
+      component: RedirectUrlComponent,
+    },
+    {
+      path: '**',
+      component: NotFoundComponent,
+      title: 'AP-404',
+    },
+  ];
+  let editionRoutes: any[] = [];
+  switch (edition) {
+    case ApEdition.ENTERPRISE:
+      editionRoutes = [
+        {
+          path: '',
+          component: FirebaseAuthContainerComponent,
+          children: [
+            {
+              path: '',
+              loadChildren: () =>
+                import(
+                  '../../../ee/firebase-auth/frontend/firebase-auth.module'
+                ).then((m) => m.FirebaseAuthLayoutModule),
+            },
+          ],
+        },
+      ];
+      break;
+    case ApEdition.COMMUNITY:
+      editionRoutes = [
+        {
+          path: '',
+          component: AuthLayoutComponent,
+          children: [
+            {
+              path: '',
+              loadChildren: () =>
+                import('./modules/auth/auth.module').then(
+                  (m) => m.AuthLayoutModule
+                ),
+            },
+          ],
+        },
+      ];
+      break;
+  }
+  return [...coreRoutes, ...editionRoutes, ...suffixRoutes];
 }
 
-
 function dynamicModules() {
-	return [FirebaseAuthLayoutModule];
+  return [FirebaseAuthLayoutModule];
 }
 
 function extractHostname(url: string): string {
-	// for relative urls we should return empty string
-	if (url.startsWith("/")) {
-		return "";
-	}
-	const parsedUrl = new URL(url);;
-	if (parsedUrl.port.length > 0) {
-		return parsedUrl.hostname + ":" + parsedUrl.port;
-	}
-	return parsedUrl.host;
+  // for relative urls we should return empty string
+  if (url.startsWith('/')) {
+    return '';
+  }
+  const parsedUrl = new URL(url);
+  if (parsedUrl.port.length > 0) {
+    return parsedUrl.hostname + ':' + parsedUrl.port;
+  }
+  return parsedUrl.host;
 }

--- a/packages/frontend/src/app/modules/common/model/flow-builder/flow-item.ts
+++ b/packages/frontend/src/app/modules/common/model/flow-builder/flow-item.ts
@@ -1,19 +1,19 @@
 import { Action, Trigger } from '@activepieces/shared';
 
 export type FlowItemRenderInfo = {
-	boundingBox?: BoundingBox;
-	connectionsBox?: BoundingBox;
-	xOffset?: number;
-	yOffset?: number;
-	yOffsetFromLastNode?: number;
-	width?: number;
-	height?: number;
-	nextAction?: FlowItem;
+  boundingBox?: BoundingBox;
+  connectionsBox?: BoundingBox;
+  xOffset?: number;
+  yOffset?: number;
+  yOffsetFromLastNode?: number;
+  width?: number;
+  height?: number;
+  nextAction?: FlowItem;
 };
 
 export type FlowItem = (Action | Trigger) & FlowItemRenderInfo;
 
 export interface BoundingBox {
-	width: number;
-	height: number;
+  width: number;
+  height: number;
 }

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/step-type-sidebar/step-type-sidebar.component.ts
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/step-type-sidebar/step-type-sidebar.component.ts
@@ -73,16 +73,16 @@ export class StepTypeSidebarComponent implements OnInit {
     const coreItemsDetails$ = this._showTriggers
       ? this.store.select(BuilderSelectors.selectFlowItemDetailsForCoreTriggers)
       : this.store.select(BuilderSelectors.selectCoreFlowItemsDetails);
-    const connectorComponentsItemsDetails$ = this._showTriggers
+    const customPiecesItemDetails$ = this._showTriggers
       ? this.store.select(
-        BuilderSelectors.selectFlowItemDetailsForConnectorComponentsTriggers
+        BuilderSelectors.selectFlowItemDetailsForCustomPiecesTriggers
       )
       : this.store.select(
-        BuilderSelectors.selectFlowItemDetailsForConnectorComponents
+        BuilderSelectors.selectFlowItemDetailsForCustomPiecesActions
       );
 
     const allItemDetails$ = forkJoin({
-      apps: connectorComponentsItemsDetails$.pipe(take(1)),
+      apps: customPiecesItemDetails$.pipe(take(1)),
       core: coreItemsDetails$.pipe(take(1)),
     }).pipe(
       map((res) => {
@@ -103,7 +103,7 @@ export class StepTypeSidebarComponent implements OnInit {
 
     this.tabsAndTheirLists.push({
       displayName: this._showTriggers ? 'App Events' : 'App Actions',
-      list$: this.applySearchToObservable(connectorComponentsItemsDetails$),
+      list$: this.applySearchToObservable(customPiecesItemDetails$),
       emptyListText: 'Oops! We didn\'t find any results.',
     });
   }

--- a/packages/frontend/src/app/modules/flow-builder/store/builder/builder.selector.ts
+++ b/packages/frontend/src/app/modules/flow-builder/store/builder/builder.selector.ts
@@ -2,7 +2,7 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { GlobalBuilderState } from '../model/builder-state.model';
 import { RightSideBarType } from '../../../common/model/enum/right-side-bar-type.enum';
 import { LeftSideBarType } from '../../../common/model/enum/left-side-bar-type.enum';
-import { AppConnection,  Config, Flow, FlowRun } from '@activepieces/shared';
+import { AppConnection,  Config, Flow, FlowRun, PieceActionSettings } from '@activepieces/shared';
 import { TabState } from '../model/tab-state';
 import { ViewModeEnum } from '../model/enums/view-mode.enum';
 import { FlowItem } from '../../../common/model/flow-builder/flow-item';
@@ -227,16 +227,16 @@ export const selectFlowItemDetailsForCoreTriggers = createSelector(
 		return state.coreTriggerFlowItemsDetails.filter(details => details.type !== TriggerType.EMPTY);
 	}
 );
-export const selectFlowItemDetailsForConnectorComponents = createSelector(
+export const selectFlowItemDetailsForCustomPiecesActions = createSelector(
 	selectAllFlowItemsDetails,
 	(state: FlowItemsDetailsState) => {
-		return state.connectorComponentsActionsFlowItemDetails;
+		return state.customPiecesActionsFlowItemDetails;
 	}
 );
-export const selectFlowItemDetailsForConnectorComponentsTriggers = createSelector(
+export const selectFlowItemDetailsForCustomPiecesTriggers = createSelector(
 	selectAllFlowItemsDetails,
 	(state: FlowItemsDetailsState) => {
-		return state.connectorComponentsTriggersFlowItemDetails;
+		return state.customPiecesTriggersFlowItemDetails;
 	}
 );
 
@@ -246,13 +246,23 @@ export const selectFlowItemDetails = (flowItem: FlowItem) =>
 		if (triggerItemDetails) {
 			return triggerItemDetails;
 		}
+		if((flowItem.settings as PieceActionSettings)?.pieceName == 'storage' || (flowItem.settings as PieceActionSettings)?.pieceName == 'http' )
+		{
+			const details = state.coreFlowItemsDetails.find(p => p.extra?.appName === (flowItem.settings as PieceActionSettings)?.pieceName )
+			if(!details)
+			{
+				throw new Error(`${(flowItem.settings as PieceActionSettings)?.pieceName } not found in core nor custom pieces details`)
+			}
+			return details;
+		}
+		debugger;
 		if (flowItem.type === ActionType.PIECE) {
-			return state.connectorComponentsActionsFlowItemDetails.find(
+			return state.customPiecesActionsFlowItemDetails.find(
 				f => f.extra!.appName === flowItem.settings.pieceName
 			);
 		}
 		if (flowItem.type === TriggerType.PIECE) {
-			return state.connectorComponentsTriggersFlowItemDetails.find(
+			return state.customPiecesTriggersFlowItemDetails.find(
 				f => f.extra!.appName === flowItem.settings.pieceName
 			);
 		}
@@ -363,13 +373,13 @@ function findStepLogoUrl(step:FlowItem,flowItemsDetailsState:FlowItemsDetailsSta
 		{
 			return 'assets/img/custom/piece/storage.png'
 		}
-		return flowItemsDetailsState.connectorComponentsActionsFlowItemDetails.find(i => i.extra?.appName === step.settings.pieceName)!.logoUrl!;
+		return flowItemsDetailsState.customPiecesActionsFlowItemDetails.find(i => i.extra?.appName === step.settings.pieceName)!.logoUrl!;
 	}
 	else if(step.type === TriggerType.PIECE )
 	{
 
 	
-		return flowItemsDetailsState.connectorComponentsTriggersFlowItemDetails.find(i => i.extra?.appName === step.settings.pieceName)!.logoUrl!;
+		return flowItemsDetailsState.customPiecesTriggersFlowItemDetails.find(i => i.extra?.appName === step.settings.pieceName)!.logoUrl!;
 	}
 	else 
 	{
@@ -419,11 +429,11 @@ export const BuilderSelectors = {
 	selectAllConfigs,
 	selectConfig,
 	selectFlowsValidity,
-	selectFlowItemDetailsForConnectorComponents,
+	selectFlowItemDetailsForCustomPiecesActions,
 	selectAppConnectionsDropdownOptions,
 	selectCurrentCollectionInstance,
 	selectIsPublishing,
-	selectFlowItemDetailsForConnectorComponentsTriggers,
+	selectFlowItemDetailsForCustomPiecesTriggers,
 	selectAllAppConnections,
 	selectAllConfigsForMentionsDropdown,
 	selectAllFlowSteps,

--- a/packages/frontend/src/app/modules/flow-builder/store/builder/flow-item-details/flow-items-details.action.ts
+++ b/packages/frontend/src/app/modules/flow-builder/store/builder/flow-item-details/flow-items-details.action.ts
@@ -2,18 +2,18 @@ import { createAction, props } from '@ngrx/store';
 import { FlowItemsDetailsState } from '../../model/flow-items-details-state.model';
 
 export enum FlowItemDetailsActionType {
-	LOAD = '[FLOW_ITEMS_DETAILS] LOAD',
-	LOADED_SUCCESSFULLY = '[FLOW_ITEMS_DETAILS] LOADED_SUCCESSFULLY',
+  LOAD = '[FLOW_ITEMS_DETAILS] LOAD',
+  LOADED_SUCCESSFULLY = '[FLOW_ITEMS_DETAILS] LOADED_SUCCESSFULLY',
 }
 
 const loadFlowItemsDetails = createAction(FlowItemDetailsActionType.LOAD);
 
 const flowItemsDetailsLoadedSuccessfully = createAction(
-	FlowItemDetailsActionType.LOADED_SUCCESSFULLY,
-	props<{ flowItemsDetailsLoaded: FlowItemsDetailsState }>()
+  FlowItemDetailsActionType.LOADED_SUCCESSFULLY,
+  props<{ flowItemsDetailsLoaded: FlowItemsDetailsState }>()
 );
 
 export const FlowItemDetailsActions = {
-	loadFlowItemsDetails,
-	flowItemsDetailsLoadedSuccessfully,
+  loadFlowItemsDetails,
+  flowItemsDetailsLoadedSuccessfully,
 };

--- a/packages/frontend/src/app/modules/flow-builder/store/builder/flow-item-details/flow-items-details.reducer.ts
+++ b/packages/frontend/src/app/modules/flow-builder/store/builder/flow-item-details/flow-items-details.reducer.ts
@@ -4,8 +4,8 @@ import { FlowItemsDetailsState } from '../../model/flow-items-details-state.mode
 const initialState: FlowItemsDetailsState = {
 	coreFlowItemsDetails: [],
 	coreTriggerFlowItemsDetails: [],
-	connectorComponentsActionsFlowItemDetails: [],
-	connectorComponentsTriggersFlowItemDetails: [],
+	customPiecesActionsFlowItemDetails: [],
+	customPiecesTriggersFlowItemDetails: [],
 	loaded: false,
 };
 export const flowItemsDetailsReducer = createReducer(

--- a/packages/frontend/src/app/modules/flow-builder/store/model/flow-items-details-state.model.ts
+++ b/packages/frontend/src/app/modules/flow-builder/store/model/flow-items-details-state.model.ts
@@ -1,16 +1,15 @@
 import { FlowItemDetails } from '../../page/flow-builder/flow-right-sidebar/step-type-sidebar/step-type-item/flow-item-details';
 
 export interface FlowItemsDetailsState {
-	coreFlowItemsDetails: FlowItemDetails[];
-	coreTriggerFlowItemsDetails: FlowItemDetails[];
-	connectorComponentsActionsFlowItemDetails: FlowItemDetails[];
-	connectorComponentsTriggersFlowItemDetails: FlowItemDetails[];
-	loaded: boolean;
+  coreFlowItemsDetails: FlowItemDetails[];
+  coreTriggerFlowItemsDetails: FlowItemDetails[];
+  customPiecesActionsFlowItemDetails: FlowItemDetails[];
+  customPiecesTriggersFlowItemDetails: FlowItemDetails[];
+  loaded: boolean;
 }
 
-export interface StepMetaData 
-{
-	logoUrl:string;
-	displayName:string;
-	name:string;
+export interface StepMetaData {
+  logoUrl: string;
+  displayName: string;
+  name: string;
 }


### PR DESCRIPTION
## What does this PR do?

Moves http and storage pieces to the "Core" category in the list shown once the user wants to add a step.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

Add a storage and an http piece and everything will work the same, and tested backwards compatibility. 
