### PR TITLE
fix: remove controls from previous value

### DIFF
--- a/packages/frontend/src/app/modules/common/components/configs-form/configs-form.component.ts
+++ b/packages/frontend/src/app/modules/common/components/configs-form/configs-form.component.ts
@@ -226,8 +226,14 @@ export class ConfigsFormComponent implements ControlValueAccessor {
               });
             }),
             tap((res) => {
+              const fg = this.form.get(parentConfig.key) as UntypedFormGroup;
+              const removedControlsKeys = Object.keys(fg.controls).filter(
+                (key) => res.find((c) => c.key === key) === undefined
+              );
+              removedControlsKeys.forEach((removedKey) => {
+                fg.removeControl(removedKey);
+              });
               res.forEach((childConfig) => {
-                const fg = this.form.get(parentConfig.key) as UntypedFormGroup;
                 const childConfigControl = fg.get(childConfig.key);
                 if (childConfigControl) {
                   if (childConfig.required) {


### PR DESCRIPTION
## What does this PR do?

So basically, if someone edits a refresher of a dynamic property, we return a new list of properties to render, the issue is the value of the previous list stays, so this PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


