### PR TITLE
docs: updated codespace dev configuration

### DIFF
--- a/docs/contributing/development-setup/codespaces.mdx
+++ b/docs/contributing/development-setup/codespaces.mdx
@@ -21,7 +21,7 @@ GitHub Codespaces is a cloud development platform that enables developers to wri
 
 6. Copy the backend URL (port 3000) and paste it into the `apiUrl` field. Then, append `/v1` to it in `packages/frontend/src/environments/environment.ts`, for example: `https://CODESPACES_NAME-5v694j5wwc7gr4-3000.preview.app.github.dev/v1`
 
-7. Go to the "Ports" tab and open the URL for port 4200.
+7. Go to the "Ports" tab and open the URL for port 4200. Right click on the port 4200 row and set the "Port Visibility" to "Public".
 
 <Warning>
 Please note that each time the Codespaces environment is restarted, you need to modify the port's visibility to public.


### PR DESCRIPTION
Without setting the 4200 port visibility to public, the activepieces frontend served from codespaces fails on a CORS issue and never loads.

## What does this PR do?

Updates codespaces setup docs.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Follow the [codespaces dev setup](https://www.activepieces.com/docs/contributing/development-setup/codespaces) and find that it's not loading the frontend. Follow the updated docs, it works.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->


