### PR TITLE
Open AI Piece: additional optional inputs

### DIFF
--- a/packages/pieces/openai/src/index.ts
+++ b/packages/pieces/openai/src/index.ts
@@ -8,6 +8,6 @@ export const openai = createPiece({
   logoUrl: 'https://cdn.activepieces.com/pieces/openai.png',
   version: packageJson.version,
   actions: [askOpenAI],
-  authors: ['aboudzein', 'creed983'],
+  authors: ['aboudzein', 'creed983', 'astorozhevsky',],
   triggers: [],
 });

--- a/packages/pieces/openai/src/lib/actions/send-prompt.ts
+++ b/packages/pieces/openai/src/lib/actions/send-prompt.ts
@@ -15,7 +15,23 @@ export const askOpenAI = createAction({
       required: true,
       description: 'The question to ask OpenAI.',
     }),
-
+    model: Property.StaticDropdown({
+      displayName: 'Model',
+      required: false,
+      description: 'The model which will generate the completion. Some models are suitable for natural language tasks, others specialize in code.',
+      options: {
+        options: [
+          {
+            label: 'gpt-3.5-turbo',
+            value: 'gpt-3.5-turbo',
+          },
+          {
+            label: 'gpt-3.5-turbo-0301',
+            value: 'gpt-3.5-turbo-0301',
+          },
+        ],
+      },
+    }),
     temperature: Property.Number({
       displayName: 'Temperature',
       required: false,
@@ -26,6 +42,21 @@ export const askOpenAI = createAction({
       required: false,
       description: 'The maximum number of tokens in the generated text.',
     }),
+    topP: Property.Number({
+      displayName: 'Top P',
+      required: false,
+      description: 'Controls diversity via nucleus sampling: 0.5 means half of all likelihood-weighted options are considered.',
+    }),
+    frequencyPenalty: Property.Number({
+      displayName: 'Frequency penalty',
+      required: false,
+      description: 'How much to penalize new tokens based on their existing frequency in the text so far. Decreases the model\'s likelihood to repeat the same line verbatim.',
+    }),
+    presencePenalty: Property.Number({
+      displayName: 'Presence penalty',
+      required: false,
+      description: 'How much to penalize new tokens based on whether they appear in the text so far. Increases the model\'s likelihood to talk about new topics.',
+    }),
   },
   sampleData: {},
   async run({ propsValue }) {
@@ -34,6 +65,10 @@ export const askOpenAI = createAction({
     });
     const openai = new OpenAIApi(configuration);
 
+    let model = 'gpt-3.5-turbo';
+    if (propsValue.model) {
+      model = propsValue.model;
+    }
     let temperature = 0.9;
     if (propsValue.temperature) {
       temperature = propsValue.temperature;
@@ -42,18 +77,30 @@ export const askOpenAI = createAction({
     if (propsValue.maxTokens) {
       maxTokens = propsValue.maxTokens;
     }
+    let topP = 1;
+    if (propsValue.topP) {
+      topP = propsValue.topP;
+    }
+    let frequencyPenalty = 0.0;
+    if (propsValue.frequencyPenalty) {
+      frequencyPenalty = propsValue.frequencyPenalty;
+    }
+    let presencePenalty = 0.6;
+    if (propsValue.presencePenalty) {
+      presencePenalty = propsValue.presencePenalty;
+    }
 
     const response = await openai.createChatCompletion({
-      model: 'gpt-3.5-turbo',
+      model: model,
       messages: [{
         role: "user",
         content: propsValue['prompt']!
       }],
       temperature: temperature,
       max_tokens: maxTokens,
-      top_p: 1,
-      frequency_penalty: 0.0,
-      presence_penalty: 0.6,
+      top_p: topP,
+      frequency_penalty: frequencyPenalty,
+      presence_penalty: presencePenalty,
     });
     return response.data.choices[0].message?.content.trim();
   }

--- a/packages/pieces/openai/src/lib/actions/send-prompt.ts
+++ b/packages/pieces/openai/src/lib/actions/send-prompt.ts
@@ -40,7 +40,7 @@ export const askOpenAI = createAction({
     maxTokens: Property.Number({
       displayName: 'Maximum Tokens',
       required: false,
-      description: 'The maximum number of tokens in the generated text.',
+      description: 'The maximum number of tokens to generate. Requests can use up to 2,048 or 4,000 tokens shared between prompt and completion. The exact limit varies by model. (One token is roughly 4 characters for normal English text)',
     }),
     topP: Property.Number({
       displayName: 'Top P',

--- a/packages/pieces/openai/src/lib/actions/send-prompt.ts
+++ b/packages/pieces/openai/src/lib/actions/send-prompt.ts
@@ -35,7 +35,7 @@ export const askOpenAI = createAction({
     temperature: Property.Number({
       displayName: 'Temperature',
       required: false,
-      description: 'Controls the creativity of the generated text.',
+      description: 'Controls randomness: Lowering results in less random completions. As the temperature approaches zero, the model will become deterministic and repetitive.',
     }),
     maxTokens: Property.Number({
       displayName: 'Maximum Tokens',


### PR DESCRIPTION
## What does this PR do?

Currently, some of the properties are hardcoded. This change adds the ability for the user to configure properties such as:

- Model
- Top P
- Frequency penalty
- Presence penalty

<img width="1594" alt="Screenshot 2023-03-09 at 19 10 22" src="https://user-images.githubusercontent.com/11055414/224117447-625318ac-87b1-407d-96f1-172d8849ce41.png">

P.S. Descriptions are taken from hints in the Open AI playground.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- Create a new flow
- Add piece "Open AI"
- Add "Optional Inputs"
- Test flow