### PR TITLE
chore: sed: 1: ".env": invalid command code

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,6 +1,13 @@
 cp .env.example .env
-sed -i 's|AP_POSTGRES_PASSWORD=.*|AP_POSTGRES_PASSWORD='"$(openssl rand -hex 32)"'|g' .env
-sed -i 's|AP_JWT_SECRET=.*|AP_JWT_SECRET='"$(openssl rand -hex 32)"'|g' .env
-sed -i 's|ENCRYPTION_KEY=.*|ENCRYPTION_KEY='"$(openssl rand -hex 16)"'|g' .env
+
+if [[ $OSTYPE == 'darwin'* ]]; then
+  sed -i '' -e 's|AP_POSTGRES_PASSWORD=.*|AP_POSTGRES_PASSWORD='"$(openssl rand -hex 32)"'|g' .env
+  sed -i '' -e 's|AP_JWT_SECRET=.*|AP_JWT_SECRET='"$(openssl rand -hex 32)"'|g' .env
+  sed -i '' -e 's|ENCRYPTION_KEY=.*|ENCRYPTION_KEY='"$(openssl rand -hex 16)"'|g' .env
+else
+  sed -i 's|AP_POSTGRES_PASSWORD=.*|AP_POSTGRES_PASSWORD='"$(openssl rand -hex 32)"'|g' .env
+  sed -i 's|AP_JWT_SECRET=.*|AP_JWT_SECRET='"$(openssl rand -hex 32)"'|g' .env
+  sed -i 's|ENCRYPTION_KEY=.*|ENCRYPTION_KEY='"$(openssl rand -hex 16)"'|g' .env
+fi;
 
 echo "A .env file containing random passwords and secrets has been successfully generated."

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,6 +1,8 @@
+#!/usr/bin/env bash
+
 cp .env.example .env
 
-if [[ $OSTYPE == 'darwin'* ]]; then
+if [ "$(uname)" == "Darwin" ]; then
   sed -i '' -e 's|AP_POSTGRES_PASSWORD=.*|AP_POSTGRES_PASSWORD='"$(openssl rand -hex 32)"'|g' .env
   sed -i '' -e 's|AP_JWT_SECRET=.*|AP_JWT_SECRET='"$(openssl rand -hex 32)"'|g' .env
   sed -i '' -e 's|ENCRYPTION_KEY=.*|ENCRYPTION_KEY='"$(openssl rand -hex 16)"'|g' .env

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -2,7 +2,7 @@
 
 cp .env.example .env
 
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
   sed -i '' -e 's|AP_POSTGRES_PASSWORD=.*|AP_POSTGRES_PASSWORD='"$(openssl rand -hex 32)"'|g' .env
   sed -i '' -e 's|AP_JWT_SECRET=.*|AP_JWT_SECRET='"$(openssl rand -hex 32)"'|g' .env
   sed -i '' -e 's|ENCRYPTION_KEY=.*|ENCRYPTION_KEY='"$(openssl rand -hex 16)"'|g' .env


### PR DESCRIPTION
## What does this PR do?

On Mac OS, executing the command `sh tools/deploy.sh` causes the errors:

```sh
sed: 1: ".env": invalid command code .
sed: 1: ".env": invalid command code .
sed: 1: ".env": invalid command code .
A .env file containing random passwords and secrets has been successfully generated.
```

This change performs checking that the operating system is [macOS](https://wikipedia.org/wiki/Mac OS) and executes `sed ...` in a different way as described [here](https://stackoverflow.com/a/19457213).

## Type of change

- [X] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- use Mac OS :)
- clone the repo
- `sh tools/deploy.sh`
