### PR TITLE
chore: added url encoding for code parameter

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -109,7 +109,7 @@ app.get(
             reply.send("The code is missing in url");
         }
         else {
-            reply.type('text/html').send(`<script>if(window.opener){window.opener.postMessage({ 'code': '${params['code']}' },'*')}</script> <html>Redirect succuesfully, this window should close now</html>`)
+            reply.type('text/html').send(`<script>if(window.opener){window.opener.postMessage({ 'code': '${encodeURIComponent(params['code'])}' },'*')}</script> <html>Redirect succuesfully, this window should close now</html>`)
         }
     }
 );


### PR DESCRIPTION
## Description

The `code` parameter shall be URL encoded using `encodeURIComponent()` before being reflected in the `reply.send()` call, in order to escape special characters that can be rendered as malicious JS.

## PoC 
Sending `code` parameter with value `test' },'*')} else alert(1);//` will cause cross-site scripting. 