### PR TITLE
chore: docker compose dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: '3'
 
 services:
   backend:
@@ -9,44 +9,44 @@ services:
       AP_REDIS_HOST: redis
     privileged: true
     ports:
-     - "3000:3000"
-     - "9229:9229"
+      - 3000:3000
+      - 9229:9229
     networks:
       - activepieces_dev
     volumes:
-     - ./:/usr/src/app
+      - ./:/usr/src/app
     working_dir: /usr/src/app
     entrypoint:
-     - npx
-     - nx
-     - serve
-     - backend
+      - npx
+      - nx
+      - serve
+      - backend
     depends_on:
-     - postgres
-     - redis
+      - postgres
+      - redis
 
   frontend:
     image: activepieces/ap-base:3
     ports:
-     - "4200:4200"
-     - "9222:9222"
+      - 4200:4200
+      - 9222:9222
     networks:
       - activepieces_dev
     volumes:
-     - ./:/usr/src/app
+      - ./:/usr/src/app
     working_dir: /usr/src/app
     entrypoint:
-     - npx
-     - nx
-     - serve
-     - frontend
+      - npx
+      - nx
+      - serve
+      - frontend
     depends_on:
-     - backend
+      - backend
 
   postgres:
     image: postgres:14.4
     ports:
-     - "5432:5432"
+      - 5432:5432
     environment:
       POSTGRES_DB: activepieces
       POSTGRES_USER: postgres

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,11 +16,8 @@ services:
     volumes:
       - ./:/usr/src/app
     working_dir: /usr/src/app
-    entrypoint:
-      - npx
-      - nx
-      - serve
-      - backend
+    command: >
+      bash -c "chmod +x ./docker-dev-entrypoint.sh && ./docker-dev-entrypoint.sh && npx nx serve backend"
     depends_on:
       - postgres
       - redis
@@ -35,11 +32,8 @@ services:
     volumes:
       - ./:/usr/src/app
     working_dir: /usr/src/app
-    entrypoint:
-      - npx
-      - nx
-      - serve
-      - frontend
+    command: >
+      bash -c "chmod +x ./docker-dev-entrypoint.sh && ./docker-dev-entrypoint.sh && npx nx serve frontend"
     depends_on:
       - backend
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,6 +56,8 @@ services:
       - redis_data_dev:/data
     networks:
       - activepieces_dev
+    ports:
+      - 6379:6379
 
 volumes:
   postgres_data_dev:

--- a/docker-dev-entrypoint.sh
+++ b/docker-dev-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+npm i --legacy-peer-deps


### PR DESCRIPTION
## What does this PR do?

- formatted docker-compose.dev.yml
- added running `npm i` inside a container 

The backend does not start on the Mac OS due to the error:

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/11055414/224803434-fa20130e-234e-4177-8d7b-fffaad0e99ca.png">

I've found the answer here - https://stackoverflow.com/a/20590261, that **bcrypt compiled on OSX will not quite work on Linux**:

> I've found that bcrypt compiled on OSX will not quite work on Linux. In other words, if you check in the bcrypt compiled on your local OSX workstation, and try to run the node app on your linux servers, you will see the error above.

So, if the dependencies installed locally do not match the dependencies required in the container, then it is a good practice to run `npm i` inside the container to ensure that the correct dependencies are installed.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- `sh tools/deploy.sh`
- `docker compose -f ./docker-compose.dev.yml up`
