### PR TITLE
fix: importing pieces was failing if one import fails

### DIFF
--- a/packages/backend/.env
+++ b/packages/backend/.env
@@ -1,4 +1,4 @@
-AP_WEBHOOK_URL="https://0bf6-79-134-149-183.ngrok.io"
+AP_WEBHOOK_URL="http://localhost:3000"
 AP_ENGINE_EXECUTABLE_PATH="dist/packages/engine/main.js"
 AP_ENCRYPTION_KEY="7e19fad4c13eaea8f657afb12e8f9c40"
 AP_ENVIRONMENT="dev"

--- a/packages/backend/src/app/pieces/piece-metadata-loader.ts
+++ b/packages/backend/src/app/pieces/piece-metadata-loader.ts
@@ -67,14 +67,12 @@ const filePieceMetadataLoader = (): PieceMetadataLoader => {
         const piecesMetadata: PieceMetadata[] = [];
 
         for (const piecePackage of filteredPiecePackages) {
-            try
-            {
+            try {
                 const module = await import(`../../../../pieces/${piecePackage}/src/index.ts`)
                 const piece = Object.values<Piece>(module)[0]
                 piecesMetadata.push(piece.metadata())
             }
-            catch(ex)
-            {
+            catch(ex) {
                 logger.error(ex);
             }
         }

--- a/packages/backend/src/app/pieces/piece-metadata-loader.ts
+++ b/packages/backend/src/app/pieces/piece-metadata-loader.ts
@@ -7,7 +7,7 @@ import { Piece } from "@activepieces/framework";
 import { ActivepiecesError, ApEnvironment, ErrorCode, PieceMetadata, PieceMetadataSummary } from "@activepieces/shared";
 import { system } from "../helper/system/system";
 import { SystemProp } from "../helper/system/system-prop";
-import { logger } from "../helper/logger";
+import { captureException, logger } from "../helper/logger";
 
 type PieceMetadataLoader = {
     /**
@@ -73,6 +73,7 @@ const filePieceMetadataLoader = (): PieceMetadataLoader => {
                 piecesMetadata.push(piece.metadata())
             }
             catch(ex) {
+                captureException(ex);
                 logger.error(ex);
             }
         }

--- a/packages/backend/src/app/pieces/piece-metadata-loader.ts
+++ b/packages/backend/src/app/pieces/piece-metadata-loader.ts
@@ -59,7 +59,7 @@ const cdnPieceMetadataLoader = (): PieceMetadataLoader => {
  */
 const filePieceMetadataLoader = (): PieceMetadataLoader => {
     const loadPiecesMetadata = async (): Promise<PieceMetadata[]> => {
-        const frameworkPackages = ['framework', 'apps']
+        const frameworkPackages = ['framework', 'apps', 'dist']
         const piecesPath = resolve(cwd(), 'packages', 'pieces')
         const piecePackages = await readdir(piecesPath)
         const filteredPiecePackages = piecePackages.filter(d => !frameworkPackages.includes(d))
@@ -67,9 +67,16 @@ const filePieceMetadataLoader = (): PieceMetadataLoader => {
         const piecesMetadata: PieceMetadata[] = [];
 
         for (const piecePackage of filteredPiecePackages) {
-            const module = await import(`../../../../pieces/${piecePackage}/src/index.ts`)
-            const piece = Object.values<Piece>(module)[0]
-            piecesMetadata.push(piece.metadata())
+            try
+            {
+                const module = await import(`../../../../pieces/${piecePackage}/src/index.ts`)
+                const piece = Object.values<Piece>(module)[0]
+                piecesMetadata.push(piece.metadata())
+            }
+            catch(ex)
+            {
+                logger.error(ex);
+            }
         }
 
         return sortBy(piecesMetadata, [p => p.displayName.toUpperCase()])

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.html
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.html
@@ -15,7 +15,11 @@
             " (cdkDragStarted)="rightDrawerHandleDragStarted()" (cdkDragEnded)="rightDrawHandleDragStopped()">
             <div class="knob"></div>
           </div>
-          <app-flow-right-sidebar></app-flow-right-sidebar>
+          <div class="right-side-bar-container ap-overflow-y-scroll ap-h-full"
+            [class.!ap-overflow-y-hidden]="(currentStep$ | async)?.type === TriggerType.WEBHOOK">
+            <app-flow-right-sidebar></app-flow-right-sidebar>
+          </div>
+
         </mat-drawer>
         <mat-drawer-content [class.no-transition]="rightSidebarDragging || leftSidebarDragging">
           <div class="box">

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.scss
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.scss
@@ -122,3 +122,11 @@ mat-drawer[position=start]{
   z-index: 9999;
   text-align: center;
 }
+
+.right-side-bar-container
+{
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+}

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.ts
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.ts
@@ -51,8 +51,8 @@ export class CollectionBuilderComponent implements OnInit, OnDestroy {
   leftSidebarDragging = false;
   loadInitialData$: Observable<void> = new Observable<void>();
   cursorStyle$: Observable<string>;
-  currentStep$:Observable<FlowItem | null | undefined>;
-  TriggerType=TriggerType;
+  currentStep$: Observable<FlowItem | null | undefined>;
+  TriggerType = TriggerType;
   constructor(
     private store: Store,
     public pieceBuilderService: CollectionBuilderService,

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.ts
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.ts
@@ -25,10 +25,12 @@ import {
   Collection,
   ExecutionOutputStatus,
   Instance,
+  TriggerType,
 } from '@activepieces/shared';
 import { Title } from '@angular/platform-browser';
 import { LeftSideBarType } from '../../../common/model/enum/left-side-bar-type.enum';
 import { PannerService } from './canvas-utils/panning/panner.service';
+import { FlowItem } from '../../../common/model/flow-builder/flow-item';
 
 @Component({
   selector: 'app-collection-builder',
@@ -49,6 +51,8 @@ export class CollectionBuilderComponent implements OnInit, OnDestroy {
   leftSidebarDragging = false;
   loadInitialData$: Observable<void> = new Observable<void>();
   cursorStyle$: Observable<string>;
+  currentStep$:Observable<FlowItem | null | undefined>;
+  TriggerType=TriggerType;
   constructor(
     private store: Store,
     public pieceBuilderService: CollectionBuilderService,
@@ -59,6 +63,7 @@ export class CollectionBuilderComponent implements OnInit, OnDestroy {
     private titleService: Title,
     private pannerService: PannerService
   ) {
+    this.currentStep$ = this.store.select(BuilderSelectors.selectCurrentStep);
     this.cursorStyle$ = this.pannerService.isGrabbing$.asObservable().pipe(
       map((val) => {
         if (val) {

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/flow-right-sidebar.component.html
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/flow-right-sidebar.component.html
@@ -7,7 +7,8 @@
 
 
   <ng-container *ngIf="rightSidebarType === sidebarType.EDIT_STEP">
-    <div #editStepSection class="top-resizer-section" [class.ap-transition-all]="animateSectionsHeightChange">
+    <div #editStepSection [class.top-resizer-section]="(currentStep$ | async)?.type === TriggerType.WEBHOOK"
+      [class.ap-transition-all]="animateSectionsHeightChange">
       <app-edit-step-sidebar>
       </app-edit-step-sidebar>
     </div>

--- a/packages/frontend/src/app/modules/flow-builder/store/builder/builder.selector.ts
+++ b/packages/frontend/src/app/modules/flow-builder/store/builder/builder.selector.ts
@@ -157,8 +157,7 @@ export const selectFlowSelectedId = createSelector(
 export const selectCurrentStep = createSelector(
   selectFlowsState,
   (flowsState: FlowsState) => {
-    if(!flowsState.selectedFlowId)
-    {
+    if (!flowsState.selectedFlowId) {
       return undefined;
     }
     const selectedFlowTabsState =

--- a/packages/frontend/src/app/modules/flow-builder/store/builder/builder.selector.ts
+++ b/packages/frontend/src/app/modules/flow-builder/store/builder/builder.selector.ts
@@ -157,8 +157,12 @@ export const selectFlowSelectedId = createSelector(
 export const selectCurrentStep = createSelector(
   selectFlowsState,
   (flowsState: FlowsState) => {
+    if(!flowsState.selectedFlowId)
+    {
+      return undefined;
+    }
     const selectedFlowTabsState =
-      flowsState.tabsState[flowsState.selectedFlowId!.toString()];
+      flowsState.tabsState[flowsState.selectedFlowId.toString()];
     if (!selectedFlowTabsState) {
       return undefined;
     }


### PR DESCRIPTION
## What does this PR do?
Fixes importing pieces, so it doesn't fully fail when importing on package fails to import.
Fixes an issue with overflowing on right side bar, any step other than webhook height wasn't 100%.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

