### PR TITLE
chore: bump gmail version to 0.1.4

### DIFF
--- a/packages/pieces/gmail/package.json
+++ b/packages/pieces/gmail/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/packages/pieces/gmail/src/lib/common/props.ts
+++ b/packages/pieces/gmail/src/lib/common/props.ts
@@ -62,7 +62,7 @@ export const GmailProps = {
       }
 
       const response = await GmailRequests.getLabels(authentication as OAuth2PropertyValue)
-      
+
       return {
         disabled: false,
         options: response.body.labels.map((label) => (


### PR DESCRIPTION
## What does this PR do?

Bump version to 0.1.4