### PR TITLE
fix: truncate webhook url + reset test step section height 

### DIFF
--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/canvas-utils/horizontal-sidebar-separator/horizontal-sidebar-separator.component.ts
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/canvas-utils/horizontal-sidebar-separator/horizontal-sidebar-separator.component.ts
@@ -1,5 +1,11 @@
 import { CdkDragMove } from '@angular/cdk/drag-drop';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  Output,
+} from '@angular/core';
 import { map, Observable, tap } from 'rxjs';
 import { TestStepService } from '../../../../service/test-step.service';
 
@@ -8,7 +14,7 @@ import { TestStepService } from '../../../../service/test-step.service';
   templateUrl: './horizontal-sidebar-separator.component.html',
   styleUrls: ['./horizontal-sidebar-separator.component.scss'],
 })
-export class HorizontalSidebarSeparatorComponent {
+export class HorizontalSidebarSeparatorComponent implements OnDestroy {
   animate = false;
   resizerKnobIsBeingDragged = false;
   @Input() resizerArea: HTMLElement;
@@ -16,6 +22,7 @@ export class HorizontalSidebarSeparatorComponent {
   @Output() resizerDragged: EventEmitter<CdkDragMove> = new EventEmitter();
   @Output() resizerDragStarted = new EventEmitter();
   @Output() resizerDragStopped = new EventEmitter();
+  @Output() resetTopResizerSectionHeight = new EventEmitter();
   dragPosition = { x: 0, y: 0 };
   elevateResizer$: Observable<void>;
   constructor(private testStepService: TestStepService) {
@@ -32,7 +39,11 @@ export class HorizontalSidebarSeparatorComponent {
       map(() => void 0)
     );
   }
+
   resizerIsBeingDragged(dragMoveEvent: CdkDragMove) {
     this.resizerDragged.next(dragMoveEvent);
+  }
+  ngOnDestroy(): void {
+    this.resetTopResizerSectionHeight.emit();
   }
 }

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/edit-step-sidebar/edit-step-accordion/edit-step-accodion.component.html
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/edit-step-sidebar/edit-step-accordion/edit-step-accodion.component.html
@@ -34,7 +34,7 @@
                         (buttonClicked)="copyUrl(url)"></app-icon-button></p>
 
                     <div class="ap-typography-caption ap-flex ap-flex-col ap-gap-2">
-                      <p [matTooltip]="url"> {{url}} </p>
+                      <p [matTooltip]="url" class="ap-truncate"> {{url}} </p>
                     </div>
 
                   </section>

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/flow-right-sidebar.component.html
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/flow-right-sidebar.component.html
@@ -16,7 +16,8 @@
       <ng-container *ngIf="currentStep.type === TriggerType.WEBHOOK">
         <div class="resizer-area" #resizerArea>
           <app-horizontal-sidebar-separator [resizerArea]="resizerArea" topStyle="calc( 100% - 10px )"
-            (resizerDragged)="resizerDragged($event)" (resizerDragStarted)="resizerDragStarted()">
+            (resetTopResizerSectionHeight)="resetTopResizerSectionHeight()" (resizerDragged)="resizerDragged($event)"
+            (resizerDragStarted)="resizerDragStarted()">
           </app-horizontal-sidebar-separator>
         </div>
         <div class="bottom-resizer-section" #selectedStepResultContainer>

--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/flow-right-sidebar.component.ts
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/flow-right-sidebar.component.ts
@@ -3,6 +3,7 @@ import {
   ElementRef,
   NgZone,
   OnInit,
+  Renderer2,
   ViewChild,
 } from '@angular/core';
 import { RightSideBarType } from '../../../../common/model/enum/right-side-bar-type.enum';
@@ -39,7 +40,8 @@ export class FlowRightSidebarComponent implements OnInit {
   constructor(
     private store: Store,
     private ngZone: NgZone,
-    private testStepService: TestStepService
+    private testStepService: TestStepService,
+    private renderer2: Renderer2
   ) {}
 
   ngOnInit(): void {
@@ -72,16 +74,35 @@ export class FlowRightSidebarComponent implements OnInit {
   resizerDragged(dragMoveEvent: CdkDragMove) {
     const height = this.editStepSectionRect.height + dragMoveEvent.distance.y;
     this.ngZone.runOutsideAngular(() => {
-      this.editStepSection.nativeElement.style.height = `${height}px`;
-      this.selectedStepResultContainer.nativeElement.style.maxHeight = `calc(100% - ${height}px - 5px)`;
+      this.renderer2.setStyle(
+        this.editStepSection.nativeElement,
+        'height',
+        `${height}px`
+      );
+      this.renderer2.setStyle(
+        this.selectedStepResultContainer.nativeElement,
+        'max-height',
+        `calc(100% - ${height}px - 5px)`
+      );
     });
   }
   resizerAnimation() {
     this.animateSectionsHeightChange = true;
-    this.editStepSection.nativeElement.style.height = `calc(50% - 30px)`;
-    this.selectedStepResultContainer.nativeElement.style.maxHeight = `calc(50% + 26px)`;
+    this.renderer2.setStyle(
+      this.editStepSection.nativeElement,
+      'height',
+      `calc(50% - 30px)`
+    );
+    this.renderer2.setStyle(
+      this.selectedStepResultContainer.nativeElement,
+      'max-height',
+      `calc(50% + 26px)`
+    );
     setTimeout(() => {
       this.animateSectionsHeightChange = false;
     }, 150);
+  }
+  resetTopResizerSectionHeight() {
+    this.renderer2.removeStyle(this.editStepSection.nativeElement, 'height');
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the following UI issues:
1)If the webhook URL is too long it overflows, I truncated it.
2)If someone resizes the test step section switches steps then goes back to the webhook trigger step, it looks messy. so I reset the size on step change.
![image](https://user-images.githubusercontent.com/106555838/226171775-1b189207-b52a-40a2-9be4-20366b1a797d.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
