### PR TITLE
Chore: unify pieces names #829

### DIFF
--- a/tools/scripts/update-pieces-metadata/generate-metadata.ts
+++ b/tools/scripts/update-pieces-metadata/generate-metadata.ts
@@ -1,11 +1,23 @@
-import { cwd } from 'node:process'
-import { resolve } from 'node:path'
-import { readdir } from 'node:fs/promises'
+import assert from 'node:assert'
 import { PieceMetadata } from '../../../packages/shared/src'
+import { getAvailablePieceNames } from '../utils/get-available-piece-names'
+import { readPackageJson, PackageJson } from '../utils/files'
 
 type Piece = {
-  displayName: string;
-  metadata(): PieceMetadata;
+    name: string
+    displayName: string
+    metadata(): PieceMetadata
+}
+
+const extractPieceNameFromPackageJson = (packageJson: PackageJson): string => {
+    const { name } = packageJson
+    const pieceNameRegex = /^@activepieces\/piece-(?<pieceName>.+)$/
+    const matchResult = name.match(pieceNameRegex)
+    const pieceName = matchResult?.groups?.pieceName
+
+    assert(pieceName, `[generateMetadata] package name "${name}" is not on the form "@activepieces/piece-xyz`)
+
+    return pieceName;
 }
 
 const byDisplayNameIgnoreCase = (a: Piece, b: Piece) => {
@@ -19,16 +31,18 @@ export const generateMetadata = async (): Promise<PieceMetadata[]> => {
 
     const pieces: Piece[] = [];
 
-    const frameworkPackages = ['framework', 'apps']
-    const piecePackagePath = resolve(cwd(), 'packages', 'pieces')
-    const piecePackageDirectories = await readdir(piecePackagePath)
-    const filteredPiecePackageDirectories = piecePackageDirectories.filter(d => !frameworkPackages.includes(d))
+    const piecePackageNames = await getAvailablePieceNames();
 
-    /* pieces that are migrated to a standalone package */
-    for (const pieceDirectory of filteredPiecePackageDirectories) {
-        const index = resolve(piecePackagePath, pieceDirectory, 'src', 'index.ts')
-        const module = await import(index)
+    for (const packageName of piecePackageNames) {
+        const packagePath = `packages/pieces/${packageName}`
+
+        const packageJson = await readPackageJson(packagePath)
+        const pieceName = extractPieceNameFromPackageJson(packageJson)
+
+        const module = await import(`${packagePath}/src/index.ts`)
         const piece = Object.values<Piece>(module)[0]
+
+        piece.name = pieceName
         pieces.push(piece)
     }
 

--- a/tools/scripts/utils/files.ts
+++ b/tools/scripts/utils/files.ts
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises'
+
+export type PackageJson = {
+  name: string
+  version: string
+}
+
+export type ProjectJson = {
+  name: string
+}
+
+const readJsonFile = async <T> (path: string): Promise<T> => {
+  console.info(`[readJsonFile] path=${path}`)
+
+  const jsonFile = await readFile(path, { encoding: 'utf-8' })
+  return JSON.parse(jsonFile) as T
+}
+
+export const readPackageJson = async (path: string): Promise<PackageJson> => {
+  return await readJsonFile(`${path}/package.json`)
+}
+
+export const readProjectJson = async (path: string): Promise<ProjectJson> => {
+  return await readJsonFile(`${path}/project.json`)
+}

--- a/tools/scripts/utils/get-available-piece-names.ts
+++ b/tools/scripts/utils/get-available-piece-names.ts
@@ -1,7 +1,7 @@
 import { readdir } from 'node:fs/promises'
 
 export const getAvailablePieceNames = async (): Promise<string[]> => {
-  const frameworkPackages = ['framework', 'apps']
+  const ignoredPackages = ['framework', 'apps']
   const packageNames = await readdir('packages/pieces')
-  return packageNames.filter(p => !frameworkPackages.includes(p))
+  return packageNames.filter(p => !ignoredPackages.includes(p))
 }

--- a/tools/scripts/utils/publish-nx-project.ts
+++ b/tools/scripts/utils/publish-nx-project.ts
@@ -1,33 +1,9 @@
 import assert from 'node:assert'
 import { ExecException } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
 import { exit, argv } from 'node:process'
-import { exec } from './exec'
 import axios, { AxiosError } from 'axios'
-
-type PackageJson = {
-  name: string
-  version: string
-}
-
-type ProjectJson = {
-  name: string
-}
-
-const readJsonFile = async <T> (path: string): Promise<T> => {
-  console.info(`[readJsonFile] path=${path}`)
-
-  const jsonFile = await readFile(path, { encoding: 'utf-8' })
-  return JSON.parse(jsonFile) as T
-}
-
-const readPackageJson = async (path: string): Promise<PackageJson> => {
-  return await readJsonFile(`${path}/package.json`)
-}
-
-const readProjectJson = async (path: string): Promise<ProjectJson> => {
-  return await readJsonFile(`${path}/project.json`)
-}
+import { exec } from './exec'
+import { readPackageJson, readProjectJson } from './files'
 
 const getLatestPublishedVersion = async (packageName: string): Promise<string | null> => {
   console.info(`[getLatestPublishedVersion] packageName=${packageName}`)


### PR DESCRIPTION
## What does this PR do?

Programmatically set piece name from its npm package name to avoid human error

Fixes #829 

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
