### PR TITLE
fix: added additional condition to adjust top-resizer-section height

### DIFF
--- a/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/flow-right-sidebar.component.html
+++ b/packages/frontend/src/app/modules/flow-builder/page/flow-builder/flow-right-sidebar/flow-right-sidebar.component.html
@@ -7,8 +7,8 @@
 
 
   <ng-container *ngIf="rightSidebarType === sidebarType.EDIT_STEP">
-    <div class="ap-relative" #editStepSection
-      [class.top-resizer-section]="(currentStep$ | async)?.type === TriggerType.WEBHOOK ||(currentStep$ | async)?.type === TriggerType.PIECE "
+    <div class="ap-relative" #editStepSection [class.top-resizer-section]="(currentStep$ | async)?.type === TriggerType.WEBHOOK ||
+       ((currentStep$ | async)?.type === TriggerType.PIECE && (isCurrentStepPollingTrigger$ | async)) "
       [class.ap-transition-all]="animateSectionsHeightChange">
       <app-edit-step-sidebar>
       </app-edit-step-sidebar>


### PR DESCRIPTION
## What does this PR do?

Fixes a bug when editing a webhook piece trigger, wouldn't show all the fields.
Before:
![image](https://user-images.githubusercontent.com/106555838/229360520-79ed8d76-17a6-49f9-88fd-6fbfb364ff72.png)

After:
![image](https://user-images.githubusercontent.com/106555838/229360504-b16d7bf6-c561-42a2-bfe4-40df3a7c55b2.png)



