### PR TITLE
fix(smtp): change port to text temporary

### DIFF
--- a/packages/pieces/smtp/package.json
+++ b/packages/pieces/smtp/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-smtp",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/pieces/smtp/src/lib/actions/send-email.ts
+++ b/packages/pieces/smtp/src/lib/actions/send-email.ts
@@ -23,12 +23,13 @@ export const sendEmail = createAction({
                     displayName: 'Password',
                     required: true,
                 }),
-                port: Property.Number({
+                port: Property.ShortText({
                     displayName: 'Port',
                     required: true,
                 }),
                 TLS: Property.Checkbox({
                     displayName: 'Use TLS',
+                    defaultValue: false,
                     required: true,
                 }),
             },


### PR DESCRIPTION
## What does this PR do?

Number and Text are currently treated same, and number is not currently supported in in custom auth.

This is released as temporary to fix until we support it in next release. 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

