### PR TITLE
chore: remove number prop from custom auth

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "type": "commonjs"
 }

--- a/packages/shared/src/lib/pieces/property/custom-auth-prop.ts
+++ b/packages/shared/src/lib/pieces/property/custom-auth-prop.ts
@@ -1,10 +1,10 @@
 
 import { PropertyType } from "../model/property-type";
-import { BasePropertySchema, CheckboxProperty, NumberProperty, SecretTextProperty, ShortTextProperty, TPropertyValue } from "./base-prop";
+import { BasePropertySchema, CheckboxProperty, SecretTextProperty, ShortTextProperty, TPropertyValue } from "./base-prop";
 import { StaticDropdownProperty } from "./dropdown-prop";
 import { StaticPropsValue } from "./property";
 
-export type CustomAuthProp = ShortTextProperty<boolean> | SecretTextProperty<boolean> | NumberProperty<boolean> | StaticDropdownProperty<unknown, boolean> | CheckboxProperty<boolean>;
+export type CustomAuthProp = ShortTextProperty<boolean> | SecretTextProperty<boolean> | StaticDropdownProperty<unknown, boolean> | CheckboxProperty<boolean>;
 export interface CustomAuthProps {
 	[name: string]: CustomAuthProp;
 }


### PR DESCRIPTION
## What does this PR do?

Number property is unsupported in custom auth.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

