### PR TITLE
Fix: pino-pretty works only in dev mode

### DIFF
--- a/packages/backend/src/app/helper/logger.ts
+++ b/packages/backend/src/app/helper/logger.ts
@@ -30,17 +30,14 @@ const initLogger = () => {
         ? 'debug'
         : 'info'
 
+    const transports = env === ApEnvironment.DEVELOPMENT
+    ? { target: 'pino-pretty', options: { translateTime: 'HH:MM:ss Z', colorize: true, ignore: 'pid,hostname' } }
+    : {};
+
     return pino({
-        level,
-        transport: {
-            target: 'pino-pretty',
-            options: {
-                translateTime: 'HH:MM:ss Z',
-                colorize: true,
-                ignore: 'pid,hostname',
-            },
-        },
-    })
+    level,
+    transports,
+    });
 }
 
 export const logger = initLogger()


### PR DESCRIPTION
## What does this PR do?

This PR removes the pino-pretty transport from the logger configuration when the app is in production mode. This is to ensure that the logs are in the default JSON format.

Fixes #910 

