### PR TITLE
Make Message Input Required in Telegram Piece Action

### DIFF
--- a/packages/pieces/telegram-bot/package.json
+++ b/packages/pieces/telegram-bot/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-telegram-bot",
-  "version": "0.2.3"
+  "version": "0.2.4"
 }

--- a/packages/pieces/telegram-bot/src/lib/action/send-text-message.action.ts
+++ b/packages/pieces/telegram-bot/src/lib/action/send-text-message.action.ts
@@ -16,7 +16,7 @@ export const telegramSendMessageAction = createAction({
         message: Property.LongText({
             displayName: 'Message',
             description: 'The message to be sent',
-            required: false,
+            required: true,
         })
     },
     sampleData: {},


### PR DESCRIPTION
## What does this PR do?

Since the telegram piece action doesn't run successfully without the message field, I've changed it to 'required'

Fixes #1038 

