### PR TITLE
fix: Webhook testing section fix

### DIFF
--- a/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
@@ -185,7 +185,7 @@ const selectCurrentStepSettings = createSelector(
 const selectTriggerSelectedSampleData = createSelector(
   selectCurrentStep,
   (step) => {
-    if (step && step.type === TriggerType.PIECE && step.settings.inputUiInfo) {
+    if (step && (step.type === TriggerType.PIECE  || step.type === TriggerType.WEBHOOK) && step.settings.inputUiInfo) {
       return step.settings.inputUiInfo.currentSelectedData;
     }
     return undefined;

--- a/packages/ui/feature-builder-test-steps/src/lib/test-webhook-trigger/test-webhook-trigger.component.html
+++ b/packages/ui/feature-builder-test-steps/src/lib/test-webhook-trigger/test-webhook-trigger.component.html
@@ -28,7 +28,7 @@
                     (buttonClicked)="testStep()">Retest</ap-button>
             </div>
 
-            <mat-form-field class="ap-w-full ap-mt-2" appearance="outline" subscriptSizing="dynamic">
+            <mat-form-field class="ap-w-full ap-my-2" appearance="outline" subscriptSizing="dynamic">
                 <mat-label>
                     Data
                 </mat-label>

--- a/packages/ui/feature-builder-test-steps/src/lib/test-webhook-trigger/test-webhook-trigger.component.ts
+++ b/packages/ui/feature-builder-test-steps/src/lib/test-webhook-trigger/test-webhook-trigger.component.ts
@@ -56,7 +56,6 @@ export class TestWebhookTriggerComponent extends TestStepCoreComponent {
       .select(BuilderSelectors.selectCurrentFlowId)
       .pipe(
         switchMap((res) => {
-          debugger;
           return this.testStepService.getTriggerEventsResults(
             res?.toString() || ''
           );
@@ -152,7 +151,6 @@ export class TestWebhookTriggerComponent extends TestStepCoreComponent {
       .pipe(
         take(1),
         tap((step) => {
-          debugger;
           if (step && step.type === TriggerType.WEBHOOK) {
             const clone = { ...step };
             clone.settings = {

--- a/packages/ui/feature-builder-test-steps/src/lib/test-webhook-trigger/test-webhook-trigger.component.ts
+++ b/packages/ui/feature-builder-test-steps/src/lib/test-webhook-trigger/test-webhook-trigger.component.ts
@@ -56,6 +56,7 @@ export class TestWebhookTriggerComponent extends TestStepCoreComponent {
       .select(BuilderSelectors.selectCurrentFlowId)
       .pipe(
         switchMap((res) => {
+          debugger;
           return this.testStepService.getTriggerEventsResults(
             res?.toString() || ''
           );
@@ -151,6 +152,7 @@ export class TestWebhookTriggerComponent extends TestStepCoreComponent {
       .pipe(
         take(1),
         tap((step) => {
+          debugger;
           if (step && step.type === TriggerType.WEBHOOK) {
             const clone = { ...step };
             clone.settings = {


### PR DESCRIPTION
## What does this PR do?

Testing core webhook trigger wasn't saving and also added a little bit of space between the results dropdown and the output viewer.

