### PR TITLE
fix: gmail piece send email new line

### DIFF
--- a/packages/pieces/gmail/package.json
+++ b/packages/pieces/gmail/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.2.6"
+  "version": "0.2.7"
 }

--- a/packages/pieces/gmail/src/lib/actions/send-email-action.ts
+++ b/packages/pieces/gmail/src/lib/actions/send-email-action.ts
@@ -37,7 +37,8 @@ export const gmailSendEmailAction = createAction({
 			"mime-version: 1.0",
 			"content-type: text/html"
 		];
-		const message = headers.join("\n") + "\n\n" + (configValue.propsValue['body_html'] ?? configValue.propsValue['body_text'])
+		const plainTextBody = configValue.propsValue['body_text'].replace(/\n/g, '<br>');
+		const message = headers.join("\n") + "\n\n" + (configValue.propsValue['body_html'] ?? plainTextBody);
 		const requestBody: SendEmailRequestBody = {
 			raw: Buffer.from(message).toString("base64").replace(/\+/g, '-').replace(/\//g, '_'),
 		};


### PR DESCRIPTION
## What does this PR do?

Replaces new lines in the body text of gmail send email action with a <br> tag

Fixes #1102 
<img width="398" alt="Screenshot 2023-04-20 at 6 24 55 PM" src="https://user-images.githubusercontent.com/19731056/233373613-751a2c81-8632-4f0c-ba97-fc27fe46fb55.png">
<img width="380" alt="Screenshot 2023-04-20 at 6 25 13 PM" src="https://user-images.githubusercontent.com/19731056/233373642-ae8fd584-5220-4a7f-b0dc-a63ad5f6f1e3.png">



