### PR TITLE
Fixed issue #781

### DIFF
--- a/packages/engine/src/lib/helper/piece-helper.ts
+++ b/packages/engine/src/lib/helper/piece-helper.ts
@@ -3,7 +3,7 @@ import {
     Action,
     ActionContext,
     DropdownProperty,
-    DropdownState,
+    MainDropdownState,
     DynamicProperties,
     DynamicPropsValue,
     MultiSelectDropdownProperty,
@@ -216,7 +216,7 @@ export const pieceHelper = {
                 disabled: true,
                 options: [],
                 placeholder: "Throws an error, reconnect or refresh the page"
-            } as DropdownState<unknown>;
+            } as MainDropdownState<unknown>; //MainDropdownState extends DropdownState;
         }
     },
 

--- a/packages/engine/src/lib/helper/piece-helper.ts
+++ b/packages/engine/src/lib/helper/piece-helper.ts
@@ -3,7 +3,8 @@ import {
     Action,
     ActionContext,
     DropdownProperty,
-    MainDropdownState,
+    DropdownOption,
+    DropdownState,
     DynamicProperties,
     DynamicPropsValue,
     MultiSelectDropdownProperty,
@@ -216,7 +217,10 @@ export const pieceHelper = {
                 disabled: true,
                 options: [],
                 placeholder: "Throws an error, reconnect or refresh the page"
-            } as MainDropdownState<unknown>; //MainDropdownState extends DropdownState;
+            } as DropdownState<unknown> & {
+                placeholder?: string,
+                options: DropdownOption<unknown>[],
+            }
         }
     },
 

--- a/packages/pieces/framework/src/lib/property/dropdown-prop.ts
+++ b/packages/pieces/framework/src/lib/property/dropdown-prop.ts
@@ -5,7 +5,6 @@ import { OAuth2PropertyValue } from "./oauth2-prop";
 
 export type DropdownState<T> = {
 	disabled?: boolean;
-
 }
 
 export type DropdownOption<T> = {
@@ -13,27 +12,24 @@ export type DropdownOption<T> = {
 	value: T;
 };
 
-// MainDropdownState extends DropdownState and adds placeholder and options
-export type MainDropdownState<T> = DropdownState<T> & {
-	placeholder?: string;
-	options: DropdownOption<T>[];
-  };
 
 
 export type DropdownProperty<T, R extends boolean> = BasePropertySchema & {
 	refreshers: string[];
-	options: (propsValue: Record<string, undefined | OAuth2PropertyValue | number | string | object | BasicAuthPropertyValue | unknown[]>) => Promise<MainDropdownState<T>>
+	options: (propsValue: Record<string, undefined | OAuth2PropertyValue | number | string | object | BasicAuthPropertyValue | unknown[]>) => Promise<DropdownState<T>>
 } & TPropertyValue<T, PropertyType.DROPDOWN, R>;
 
 export type StaticDropdownProperty<T, R extends boolean> = BasePropertySchema & {
-	options: MainDropdownState<T>;
+	placeholder?: string;
+	options: DropdownOption<T>;
 } & TPropertyValue<T, PropertyType.STATIC_DROPDOWN, R>;
 
 export type MultiSelectDropdownProperty<T, R extends boolean> = BasePropertySchema & {
 	refreshers: string[];
-	options: (propsValue: Record<string, OAuth2PropertyValue | number | string | object | BasicAuthPropertyValue | unknown[]>) => Promise<MainDropdownState<T>>
+	options: (propsValue: Record<string, OAuth2PropertyValue | number | string | object | BasicAuthPropertyValue | unknown[]>) => Promise<DropdownState<T>>
 } & TPropertyValue<T[], PropertyType.MULTI_SELECT_DROPDOWN, R>;
 
 export type StaticMultiSelectDropdownProperty<T, R extends boolean> = BasePropertySchema & {
-	options: MainDropdownState<T>[];
+	placeholder?: string;
+	options: DropdownOption<T>;
 } & TPropertyValue<T[], PropertyType.STATIC_MULTI_SELECT_DROPDOWN, R>;

--- a/packages/pieces/framework/src/lib/property/dropdown-prop.ts
+++ b/packages/pieces/framework/src/lib/property/dropdown-prop.ts
@@ -5,8 +5,7 @@ import { OAuth2PropertyValue } from "./oauth2-prop";
 
 export type DropdownState<T> = {
 	disabled?: boolean;
-	placeholder?: string;
-	options: DropdownOption<T>[];
+
 }
 
 export type DropdownOption<T> = {
@@ -14,20 +13,27 @@ export type DropdownOption<T> = {
 	value: T;
 };
 
+// MainDropdownState extends DropdownState and adds placeholder and options
+export type MainDropdownState<T> = DropdownState<T> & {
+	placeholder?: string;
+	options: DropdownOption<T>[];
+  };
+
+
 export type DropdownProperty<T, R extends boolean> = BasePropertySchema & {
 	refreshers: string[];
-	options: (propsValue: Record<string, undefined | OAuth2PropertyValue | number | string | object | BasicAuthPropertyValue | unknown[]>) => Promise<DropdownState<T>>
+	options: (propsValue: Record<string, undefined | OAuth2PropertyValue | number | string | object | BasicAuthPropertyValue | unknown[]>) => Promise<MainDropdownState<T>>
 } & TPropertyValue<T, PropertyType.DROPDOWN, R>;
 
 export type StaticDropdownProperty<T, R extends boolean> = BasePropertySchema & {
-	options: DropdownState<T>;
+	options: MainDropdownState<T>;
 } & TPropertyValue<T, PropertyType.STATIC_DROPDOWN, R>;
 
 export type MultiSelectDropdownProperty<T, R extends boolean> = BasePropertySchema & {
 	refreshers: string[];
-	options: (propsValue: Record<string, OAuth2PropertyValue | number | string | object | BasicAuthPropertyValue | unknown[]>) => Promise<DropdownState<T>>
+	options: (propsValue: Record<string, OAuth2PropertyValue | number | string | object | BasicAuthPropertyValue | unknown[]>) => Promise<MainDropdownState<T>>
 } & TPropertyValue<T[], PropertyType.MULTI_SELECT_DROPDOWN, R>;
 
 export type StaticMultiSelectDropdownProperty<T, R extends boolean> = BasePropertySchema & {
-	options: DropdownState<T>;
+	options: MainDropdownState<T>[];
 } & TPropertyValue<T[], PropertyType.STATIC_MULTI_SELECT_DROPDOWN, R>;


### PR DESCRIPTION
Title: Update type definition for StaticDropdownProperty and MultiSelectDropdownProperty

Description:
This pull request updates the type definition for `StaticDropdownProperty` and `MultiSelectDropdownProperty` to fix an issue where the `options` property was nested inside an object in the `DropdownState` type. The updated definition separates `options` from `DropdownState` and includes a `placeholder` property. 


I have also updated the return statement in the piece-helper.ts file to use the new `MainDropdownState<T>` type, which extends `DropdownState<T>` and includes the `placeholder` property.

Please let me know if you have any questions or feedback on this change.



Fixes #781 
