### PR TITLE
docs: update links to 'Building pieces'

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Using the enterprise features (under the packages/ee folder) with a self-hosted 
 
 ## Contributions
 
-We welcome contributions big or small and in different directions. The best way to do this is to check this [document](https://www.activepieces.com/docs/contributing/building-pieces/overview) and we are always up to talk on [our Discord Server](https://discord.gg/2jUXBKDdP8).
+We welcome contributions big or small and in different directions. The best way to do this is to check this [document](https://www.activepieces.com/docs/contributing/building-pieces/create-action) and we are always up to talk on [our Discord Server](https://discord.gg/2jUXBKDdP8).
 
 ## Contributors 🦫
 

--- a/docs/contributing/overview.mdx
+++ b/docs/contributing/overview.mdx
@@ -6,7 +6,7 @@ description: ''
 We welcome and appreciate contributions of all kinds to the Activepieces project. Whether you are a developer, designer, user, or simply have suggestions for improvements, we encourage you to get involved.
 
 ## Building Pieces
-We encourage you to build new [Pieces](https://github.com/orgs/activepieces/projects/5/views/1) as they are the main driver for usage growth. If you'd like to build a piece, check out [Building Pieces](./building-pieces/overview) for instructions and best practices.
+We encourage you to build new [Pieces](https://github.com/orgs/activepieces/projects/5/views/1) as they are the main driver for usage growth. If you'd like to build a piece, check out [Building Pieces](https://www.activepieces.com/docs/contributing/building-pieces/create-action) for instructions and best practices.
 
 ## How to Contribute
 

--- a/docs/pieces/custom-pieces.mdx
+++ b/docs/pieces/custom-pieces.mdx
@@ -23,6 +23,6 @@ You can request a new piece by:
 
 **3. Make the piece**
 
-If you are a developer and don't wish to wait until the piece is built by the community, we've put up a [guide to building a new piece](https://www.activepieces.com/docs/contributing/building-pieces/overview).
+If you are a developer and don't wish to wait until the piece is built by the community, we've put up a [guide to building a new piece](https://www.activepieces.com/docs/contributing/building-pieces/create-action).
 
 You can follow the structure and steps in the guide to build your piece for your own use or to contribute with it to Activepieces.


### PR DESCRIPTION
## What does this PR do?

Update the documentation links for the "Building piece" documentation page. It appears it had been moved.

