### PR TITLE
feat(piece/postgres): add checkbox to toggle SSL on or off

### DIFF
--- a/packages/pieces/postgres/package.json
+++ b/packages/pieces/postgres/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-postgres",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds a new checkbox to enable or disable SSL connection. Previously the connection would always attempt an SSL connection.

The "Enforce Encryption" has also been changed to "Verify server certificate", as that is more appropriate.
