### PR TITLE
fix: added flow folder id in move action as param

### DIFF
--- a/packages/ui/feature-dashboard/src/lib/pages/flows-table/move-flow-to-folder-dialog/move-flow-to-folder-dialog.component.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/flows-table/move-flow-to-folder-dialog/move-flow-to-folder-dialog.component.ts
@@ -62,6 +62,7 @@ export class MoveFlowToFolderDialogComponent {
             this.store.dispatch(
               FolderActions.moveFlow({
                 targetFolderId: this.foldersForm.controls.folder.value,
+                flowFolderId: this.data.folderId,
               })
             );
             this.dialogRef.close(true);

--- a/packages/ui/feature-dashboard/src/lib/store/folders/folders.actions.ts
+++ b/packages/ui/feature-dashboard/src/lib/store/folders/folders.actions.ts
@@ -41,7 +41,7 @@ const selectFolder = createAction(
 );
 const moveFlow = createAction(
   FoldersActionType.MOVE_FLOW,
-  props<{ targetFolderId: string }>()
+  props<{ targetFolderId: string; flowFolderId?: string | null }>()
 );
 const renameFolder = createAction(
   FoldersActionType.RENAME_FOLDER,

--- a/packages/ui/feature-dashboard/src/lib/store/folders/folders.reducer.ts
+++ b/packages/ui/feature-dashboard/src/lib/store/folders/folders.reducer.ts
@@ -121,13 +121,15 @@ const _foldersReducer = createReducer(
       };
     }
   }),
-  on(FolderActions.moveFlow, (state, { targetFolderId }) => {
+  on(FolderActions.moveFlow, (state, { targetFolderId, flowFolderId }) => {
     const folders = [...state.folders];
     let uncategorizedFlowsNumber = state.uncategorizedFlowsNumber;
+
     const targetFolderIndex = folders.findIndex((f) => f.id === targetFolderId);
-    const currentlySelectedFolderIndex = folders.findIndex(
-      (f) => f.id === state.selectedFolder?.id
-    );
+    const currentlySelectedFolderIndex = !state.displayAllFlows
+      ? folders.findIndex((f) => f.id === state.selectedFolder?.id)
+      : folders.findIndex((f) => f.id === flowFolderId);
+
     if (targetFolderIndex < 0) {
       uncategorizedFlowsNumber++;
     } else {


### PR DESCRIPTION
## What does this PR do?

We had an issue when moving folders while displaying all flows, counting flows wasn't getting calculated correctly.

