### PR TITLE
Fix link to repo structure page in docs

### DIFF
--- a/docs/contributing/building-pieces/create-action.mdx
+++ b/docs/contributing/building-pieces/create-action.mdx
@@ -5,7 +5,7 @@ description: ""
 
 This tutorial will guide you through the process of creating a Hacker News piece with an action that fetches the top stories. It assumes that you are familiar with the following:
 
-* [Activepieces Repo Structure](../repo-structure) and [Activepieces Local development](../development-setup/local-development) Or [Github Codespaces](../development-setup/codespaces).
+* [Activepieces Repo Structure](../architecture/repo-structure) and [Activepieces Local development](../development-setup/local-development) Or [Github Codespaces](../development-setup/codespaces).
 * TypeScript syntax.
 
 HackerNews is a social news website that allows users to submit and vote on stories related to computer science and entrepreneurship.


### PR DESCRIPTION
The repo structure link on this page actually goes to Introduction page which is meant for users, not developers: https://www.activepieces.com/docs/contributing/building-pieces/create-action

This PR fixes the link