### PR TITLE
feat: censor connection data from run logs

### DIFF
--- a/packages/engine/src/lib/action/branch-action-handler.ts
+++ b/packages/engine/src/lib/action/branch-action-handler.ts
@@ -33,7 +33,11 @@ export class BranchActionHandler extends BaseActionHandler<BranchAction> {
     );
 
     const stepOutput = new BranchStepOutput();
-    stepOutput.input = resolvedInput;
+    stepOutput.input = await this.variableService.resolve(
+      this.action.settings,
+      executionState,
+      true
+    );
 
     try {
       const condition = evaluateConditions(resolvedInput.conditions);

--- a/packages/engine/src/lib/action/code-action-handler.ts
+++ b/packages/engine/src/lib/action/code-action-handler.ts
@@ -36,7 +36,11 @@ export class CodeActionHandler extends BaseActionHandler<CodeAction> {
     if(!artifactPackagedId){
       throw new Error("Artifact packaged id is not defined");
     }
-    stepOutput.input = params;
+    stepOutput.input = await this.variableService.resolve(
+      this.action.settings.input,
+      executionState,
+      true
+    );
     try {
       const codeExecutor = new CodeExecutor();
       stepOutput.output = await codeExecutor.executeCode(

--- a/packages/engine/src/lib/action/loop-action-handler.ts
+++ b/packages/engine/src/lib/action/loop-action-handler.ts
@@ -45,7 +45,11 @@ export class LoopOnItemActionHandler extends BaseActionHandler<LoopOnItemsAction
     );
 
     const stepOutput = new LoopOnItemsStepOutput();
-    stepOutput.input = resolvedInput;
+    stepOutput.input = await this.variableService.resolve(
+      this.action.settings,
+      executionState,
+      true 
+    );
 
     stepOutput.output = {
       index: 1,

--- a/packages/engine/src/lib/action/piece-action-handler.ts
+++ b/packages/engine/src/lib/action/piece-action-handler.ts
@@ -34,7 +34,11 @@ export class PieceActionHandler extends BaseActionHandler<PieceAction> {
     );
 
     globals.addOneTask();
-    stepOutput.input = config;
+    stepOutput.input = await this.variableService.resolve(
+      input,
+      executionState,
+      true 
+    );
 
     if(!actionName){
       throw new Error("Action name is not defined");


### PR DESCRIPTION
## What does this PR do?

Censor authentication data seen in the run logs of pieces. The step input now shows `"**CENSORED**"` in place of the authentication field.

Fixes # (1019) 

