### PR TITLE
fix: stringify json default value

### DIFF
--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
@@ -439,12 +439,23 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
   }
 
   addOptionalProperty(propertyKey: string, property: PieceProperty) {
-    this.form.addControl(
-      propertyKey,
-      new UntypedFormControl(
-        property.defaultValue ? property.defaultValue : undefined
-      )
-    );
+    if (property.type !== PropertyType.JSON) {
+      this.form.addControl(
+        propertyKey,
+        new UntypedFormControl(
+          property.defaultValue ? property.defaultValue : undefined
+        )
+      );
+    } else {
+      this.form.addControl(
+        propertyKey,
+        new UntypedFormControl(
+          property.defaultValue
+            ? JSON.stringify(property.defaultValue, null, 2)
+            : undefined
+        )
+      );
+    }
     this.selectedOptionalProperties = {
       ...this.selectedOptionalProperties,
       [propertyKey]: property,


### PR DESCRIPTION
## What does this PR do?

Default value for optional JSON piece property wasn't being stringified before it was passed to code mirror control.

