### PR TITLE
fix: update project_usage <-> project relation as many-to-one

### DIFF
--- a/packages/ee/billing/backend/usage.entity.ts
+++ b/packages/ee/billing/backend/usage.entity.ts
@@ -28,7 +28,7 @@ export const ProjectUsageEntity = new EntitySchema<ProjectUsageSchema>({
     ],
     relations: {
         project: {
-            type: "one-to-one",
+            type: "many-to-one",
             target: "project",
             cascade: true,
             onDelete: "CASCADE",


### PR DESCRIPTION
This PR fixes the unique constraint generated by TypeORM on the one-to-one relation

Tested and no unique constraint generated after switching to `many-to-one`