### PR TITLE
feat: filter flow runs by `flowId`

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,6 +55,7 @@ services:
       - postgres_data_dev:/var/lib/postgresql/data
     networks:
       - activepieces_dev
+#    command: -c log_statement=all -c shared_preload_libraries=auto_explain -c auto_explain.log_min_duration=0
 
   redis:
     image: redis:7.0.7

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -1,0 +1,9 @@
+# Backend
+
+## scripts
+
+### Generate database migrations
+
+```sh
+npx nx db-migration backend -- --name project-usage-unique-project-id
+```

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -5,5 +5,5 @@
 ### Generate database migrations
 
 ```sh
-npx nx db-migration backend -- --name project-usage-unique-project-id
+npx nx db-migration backend -- --name migration-name
 ```

--- a/packages/backend/project.json
+++ b/packages/backend/project.json
@@ -63,6 +63,12 @@
       "options": {
         "command": "ts-node -r tsconfig-paths/register -P packages/backend/tsconfig.app.json ./node_modules/typeorm/cli.js"
       }
+    },
+    "db-migration": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "nx db backend -- migration:generate -d packages/backend/src/app/database/database-connection.ts packages/backend/src/app/database/migration/{args.name}"
+      }
     }
   },
   "tags": []

--- a/packages/backend/src/app/database/database-connection.ts
+++ b/packages/backend/src/app/database/database-connection.ts
@@ -39,6 +39,7 @@ import { RemoveCollections1680986182074 } from './migration/1680986182074-Remove
 import { StoreAllPeriods1681019096716 } from './migration/1681019096716-StoreAllPeriods'
 import { AllowNullableStoreEntryAndTrigger1683040965874 } from './migration/1683040965874-allow-nullable-store-entry'
 import { RenameNotifications1683195711242 } from './migration/1683195711242-rename-notifications'
+import { ListFlowRunsIndices1683199709317 } from './migration/1683199709317-list-flow-runs-indices'
 
 const database = system.getOrThrow(SystemProp.POSTGRES_DATABASE)
 const host = system.getOrThrow(SystemProp.POSTGRES_HOST)
@@ -80,6 +81,7 @@ const getMigrations = () => {
         StoreAllPeriods1681019096716,
         AllowNullableStoreEntryAndTrigger1683040965874,
         RenameNotifications1683195711242,
+        ListFlowRunsIndices1683199709317,
     ]
 }
 

--- a/packages/backend/src/app/database/migration/1683199709317-list-flow-runs-indices.ts
+++ b/packages/backend/src/app/database/migration/1683199709317-list-flow-runs-indices.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ListFlowRunsIndices1683199709317 implements MigrationInterface {
+    name = 'ListFlowRunsIndices1683199709317'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP INDEX "public"."idx_run_project_id"')
+        await queryRunner.query('CREATE INDEX "idx_run_project_id_environment_created_desc" ON "flow_run" ("projectId", "environment", "created" DESC) ')
+        await queryRunner.query('CREATE INDEX "idx_run_project_id_flow_id_environment_created_desc" ON "flow_run" ("projectId", "flowId", "environment", "created" DESC) ')
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP INDEX "public"."idx_run_project_id_flow_id_environment_created_desc"')
+        await queryRunner.query('DROP INDEX "public"."idx_run_project_id_environment_created_desc"')
+        await queryRunner.query('CREATE INDEX "idx_run_project_id" ON "flow_run" ("projectId") ')
+    }
+
+}

--- a/packages/backend/src/app/database/migration/1683199709317-list-flow-runs-indices.ts
+++ b/packages/backend/src/app/database/migration/1683199709317-list-flow-runs-indices.ts
@@ -6,11 +6,15 @@ export class ListFlowRunsIndices1683199709317 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query('DROP INDEX "public"."idx_run_project_id"')
         await queryRunner.query('CREATE INDEX "idx_run_project_id_environment_created_desc" ON "flow_run" ("projectId", "environment", "created" DESC) ')
+        await queryRunner.query('CREATE INDEX "idx_run_project_id_environment_status_created_desc" ON "flow_run" ("projectId", "environment", "status", "created" DESC) ')
         await queryRunner.query('CREATE INDEX "idx_run_project_id_flow_id_environment_created_desc" ON "flow_run" ("projectId", "flowId", "environment", "created" DESC) ')
+        await queryRunner.query('CREATE INDEX "idx_run_project_id_flow_id_environment_status_created_desc" ON "flow_run" ("projectId", "flowId", "environment", "status", "created" DESC) ')
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP INDEX "public"."idx_run_project_id_flow_id_environment_status_created_desc"')
         await queryRunner.query('DROP INDEX "public"."idx_run_project_id_flow_id_environment_created_desc"')
+        await queryRunner.query('DROP INDEX "public"."idx_run_project_id_environment_status_created_desc"')
         await queryRunner.query('DROP INDEX "public"."idx_run_project_id_environment_created_desc"')
         await queryRunner.query('CREATE INDEX "idx_run_project_id" ON "flow_run" ("projectId") ')
     }

--- a/packages/backend/src/app/flows/flow-run/flow-run-controller.ts
+++ b/packages/backend/src/app/flows/flow-run/flow-run-controller.ts
@@ -1,4 +1,5 @@
-import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify'
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox'
 import { CreateFlowRunRequest, FlowRunId, ListFlowRunsRequest, RunEnvironment } from '@activepieces/shared'
 import { ActivepiecesError, ErrorCode } from '@activepieces/shared'
 import { flowRunService } from './flow-run-service'
@@ -10,7 +11,7 @@ type GetOnePathParams = {
     id: FlowRunId
 }
 
-export const flowRunController: FastifyPluginCallback = (app, _options, done): void => {
+export const flowRunController: FastifyPluginCallbackTypebox = (app, _options, done): void => {
 
     app.post(
         '/',
@@ -33,10 +34,13 @@ export const flowRunController: FastifyPluginCallback = (app, _options, done): v
 
     // list
     app.get('/', {
-        schema: ListFlowRunsRequest,
-    }, async (request: FastifyRequest<{ Querystring: ListFlowRunsRequest }>, reply: FastifyReply) => {
+        schema: {
+            querystring: ListFlowRunsRequest,
+        },
+    }, async (request, reply) => {
         const flowRunPage = await flowRunService.list({
             projectId: request.principal.projectId,
+            flowId: request.query.flowId,
             cursor: request.query.cursor ?? null,
             limit: Number(request.query.limit ?? DEFAULT_PAGING_LIMIT),
         })

--- a/packages/backend/src/app/flows/flow-run/flow-run-controller.ts
+++ b/packages/backend/src/app/flows/flow-run/flow-run-controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox'
-import { CreateFlowRunRequest, FlowRunId, ListFlowRunsRequest, RunEnvironment } from '@activepieces/shared'
+import { CreateFlowRunRequest, FlowRunId, ListFlowRunsRequestQuery, RunEnvironment } from '@activepieces/shared'
 import { ActivepiecesError, ErrorCode } from '@activepieces/shared'
 import { flowRunService } from './flow-run-service'
 
@@ -35,12 +35,13 @@ export const flowRunController: FastifyPluginCallbackTypebox = (app, _options, d
     // list
     app.get('/', {
         schema: {
-            querystring: ListFlowRunsRequest,
+            querystring: ListFlowRunsRequestQuery,
         },
     }, async (request, reply) => {
         const flowRunPage = await flowRunService.list({
             projectId: request.principal.projectId,
             flowId: request.query.flowId,
+            status: request.query.status,
             cursor: request.query.cursor ?? null,
             limit: Number(request.query.limit ?? DEFAULT_PAGING_LIMIT),
         })

--- a/packages/backend/src/app/flows/flow-run/flow-run-entity.ts
+++ b/packages/backend/src/app/flows/flow-run/flow-run-entity.ts
@@ -39,8 +39,16 @@ export const FlowRunEntity = new EntitySchema<FlowRunSchema>({
             columns: ['projectId', 'environment', 'created'],
         },
         {
+            name: 'idx_run_project_id_environment_status_created_desc',
+            columns: ['projectId', 'environment', 'status', 'created'],
+        },
+        {
             name: 'idx_run_project_id_flow_id_environment_created_desc',
             columns: ['projectId', 'flowId', 'environment', 'created'],
+        },
+        {
+            name: 'idx_run_project_id_flow_id_environment_status_created_desc',
+            columns: ['projectId', 'flowId', 'environment', 'status', 'created'],
         },
     ],
     relations: {

--- a/packages/backend/src/app/flows/flow-run/flow-run-entity.ts
+++ b/packages/backend/src/app/flows/flow-run/flow-run-entity.ts
@@ -35,9 +35,12 @@ export const FlowRunEntity = new EntitySchema<FlowRunSchema>({
     },
     indices: [
         {
-            name: 'idx_run_project_id',
-            columns: ['projectId'],
-            unique: false,
+            name: 'idx_run_project_id_environment_created_desc',
+            columns: ['projectId', 'environment', 'created'],
+        },
+        {
+            name: 'idx_run_project_id_flow_id_environment_created_desc',
+            columns: ['projectId', 'flowId', 'environment', 'created'],
         },
     ],
     relations: {

--- a/packages/backend/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/backend/src/app/flows/flow-run/flow-run-service.ts
@@ -31,7 +31,7 @@ import { flowRepo } from '../flow/flow.repo'
 export const repo = databaseConnection.getRepository(FlowRunEntity)
 
 export const flowRunService = {
-    async list({ projectId, flowId, cursor, limit }: ListParams): Promise<SeekPage<FlowRun>> {
+    async list({ projectId, flowId, status, cursor, limit }: ListParams): Promise<SeekPage<FlowRun>> {
         const decodedCursor = paginationHelper.decodeCursor(cursor)
         const paginator = buildPaginator({
             entity: FlowRunEntity,
@@ -46,6 +46,7 @@ export const flowRunService = {
         const query = repo.createQueryBuilder('flow_run').where({
             projectId,
             ...spreadIfDefined('flowId', flowId),
+            ...spreadIfDefined('status', status),
             environment: RunEnvironment.PRODUCTION,
         })
 
@@ -130,6 +131,7 @@ export const flowRunService = {
 type ListParams = {
     projectId: ProjectId
     flowId: FlowId | undefined
+    status: ExecutionOutputStatus | undefined
     cursor: Cursor | null
     limit: number
 }

--- a/packages/backend/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/backend/src/app/flows/flow-run/flow-run-service.ts
@@ -12,6 +12,7 @@ import {
     TelemetryEventName,
     ApEdition,
     FlowId,
+    spreadIfDefined,
 } from '@activepieces/shared'
 import { getEdition } from '../../helper/secret-helper'
 import { databaseConnection } from '../../database/database-connection'
@@ -26,7 +27,6 @@ import { usageService } from '@ee/billing/backend/usage.service'
 import { logger } from '../../helper/logger'
 import { notifications } from '../../helper/notifications'
 import { flowRepo } from '../flow/flow.repo'
-import { isUndefined } from 'lodash'
 
 export const repo = databaseConnection.getRepository(FlowRunEntity)
 
@@ -43,21 +43,12 @@ export const flowRunService = {
             },
         })
 
-        const spreadIfDefined = (flowId: FlowId | undefined) => {
-            const result: { flowId?: FlowId } = {}
-
-            if (!isUndefined(flowId)) {
-                result.flowId = flowId
-            }
-
-            return result
-        }
-
         const query = repo.createQueryBuilder('flow_run').where({
             projectId,
-            ...spreadIfDefined(flowId),
+            ...spreadIfDefined('flowId', flowId),
             environment: RunEnvironment.PRODUCTION,
         })
+
         const { data, cursor: newCursor } = await paginator.paginate(query)
         return paginationHelper.createPage<FlowRun>(data, newCursor)
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "type": "commonjs"
 }

--- a/packages/shared/src/lib/common/index.ts
+++ b/packages/shared/src/lib/common/index.ts
@@ -1,2 +1,2 @@
-export * from './utils/semVer';
+export * from './utils';
 export * from './base-model'

--- a/packages/shared/src/lib/common/utils/index.ts
+++ b/packages/shared/src/lib/common/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './object-utils'
+export * from './semVer'

--- a/packages/shared/src/lib/common/utils/object-utils.ts
+++ b/packages/shared/src/lib/common/utils/object-utils.ts
@@ -1,0 +1,11 @@
+import { isNil } from 'lodash'
+
+export const spreadIfDefined = <T>(key: string, value: T | undefined | null) => {
+    if (isNil(value)) {
+        return {}
+    }
+
+    return {
+        [key]: value
+    }
+}

--- a/packages/shared/src/lib/flow-run/dto/list-flow-runs-request.ts
+++ b/packages/shared/src/lib/flow-run/dto/list-flow-runs-request.ts
@@ -1,7 +1,9 @@
+import { ApId } from "../../common/id-generator";
 import {Cursor} from "../../common/seek-page";
 import { Static, Type } from "@sinclair/typebox";
 
 export const ListFlowRunsRequest = Type.Object({
+    flowId: Type.Optional(ApId),
     limit: Type.Optional(Type.Number({})),
     cursor: Type.Optional(Type.String({})),
 });

--- a/packages/shared/src/lib/flow-run/dto/list-flow-runs-request.ts
+++ b/packages/shared/src/lib/flow-run/dto/list-flow-runs-request.ts
@@ -1,12 +1,13 @@
 import { ApId } from "../../common/id-generator";
 import {Cursor} from "../../common/seek-page";
 import { Static, Type } from "@sinclair/typebox";
+import { ExecutionOutputStatus } from "../execution/execution-output";
 
-export const ListFlowRunsRequest = Type.Object({
+export const ListFlowRunsRequestQuery = Type.Object({
     flowId: Type.Optional(ApId),
+    status: Type.Optional(Type.Enum(ExecutionOutputStatus)),
     limit: Type.Optional(Type.Number({})),
     cursor: Type.Optional(Type.String({})),
 });
 
-export type ListFlowRunsRequest = Static<typeof ListFlowRunsRequest> & {cursor: Cursor};
-
+export type ListFlowRunsRequestQuery = Static<typeof ListFlowRunsRequestQuery> & {cursor: Cursor};


### PR DESCRIPTION
## What does this PR do?

- Add optional filters for flow run: `flowId`, and `status`
- Also added compound indices to cover the following queries:
  - list flow runs by `projectId`, `environment`, and `created` DESC
  - list flow runs by `projectId`, `environment` , `status`, and `created` DESC
  - list flow runs by `projectId`, `flowId`, `environment`, and `created` DESC
  - list flow runs by `projectId`, `flowId`, `environment` , `status`, and `created` DESC
- example for `explain` before indices
  ```
  2023-05-03 19:54:06.866 UTC [414] LOG:  execute <unnamed>: SELECT "flow_run"."id" AS "flow_run_id", "flow_run"."created" AS "flow_run_created", "flow_run"."updated" AS "flow_run_updated", "flow_run"."projectId" AS "flow_run_projectId", "flow_run"."flowId" AS "flow_run_flowId", "flow_run"."flowVersionId" AS "flow_run_flowVersionId", "flow_run"."environment" AS "flow_run_environment", "flow_run"."flowDisplayName" AS "flow_run_flowDisplayName", "flow_run"."logsFileId" AS "flow_run_logsFileId", "flow_run"."status" AS "flow_run_status", "flow_run"."startTime" AS "flow_run_startTime", "flow_run"."finishTime" AS "flow_run_finishTime" FROM "flow_run" "flow_run" WHERE ("flow_run"."projectId" = $1 AND "flow_run"."flowId" = $2 AND "flow_run"."environment" = $3) ORDER BY "flow_run"."created" DESC LIMIT 11
  2023-05-03 19:54:06.866 UTC [414] DETAIL:  parameters: $1 = 'n4oPYiycaJRWulBTIZ5xD', $2 = 'sDG1imZ8hDfljLAoevX50', $3 = 'PRODUCTION'
  2023-05-03 19:54:06.866 UTC [414] LOG:  duration: 0.052 ms  plan:
         Query Text: SELECT "flow_run"."id" AS "flow_run_id", "flow_run"."created" AS "flow_run_created", "flow_run"."updated" AS "flow_run_updated", "flow_run"."projectId" AS "flow_run_projectId", "flow_run"."flowId" AS "flow_run_flowId", "flow_run"."flowVersionId" AS "flow_run_flowVersionId", "flow_run"."environment" AS "flow_run_environment", "flow_run"."flowDisplayName" AS "flow_run_flowDisplayName", "flow_run"."logsFileId" AS "flow_run_logsFileId", "flow_run"."status" AS "flow_run_status", "flow_run"."startTime" AS "flow_run_startTime", "flow_run"."finishTime" AS "flow_run_finishTime" FROM "flow_run" "flow_run" WHERE ("flow_run"."projectId" = $1 AND "flow_run"."flowId" = $2 AND "flow_run"."environment" = $3) ORDER BY "flow_run"."created" DESC LIMIT 11
         Limit  (cost=8.18..8.18 rows=1 width=428)
                ->  Sort  (cost=8.18..8.18 rows=1 width=428)
                       Sort Key: created DESC
                       ->  Index Scan using idx_run_project_id on flow_run  (cost=0.14..8.17 rows=1 width=428)
                       Index Cond: (("projectId")::text = 'n4oPYiycaJRWulBTIZ5xD'::text)
                       Filter: ((("flowId")::text = 'sDG1imZ8hDfljLAoevX50'::text) AND ((environment)::text = 'PRODUCTION'::text))
  ```
- example `explain` after indices
  ```
  2023-05-04 11:58:27.945 UTC [75] LOG:  execute <unnamed>: SELECT "flow_run"."id" AS "flow_run_id", "flow_run"."created" AS "flow_run_created", "flow_run"."updated" AS "flow_run_updated", "flow_run"."projectId" AS "flow_run_projectId", "flow_run"."flowId" AS "flow_run_flowId", "flow_run"."flowVersionId" AS "flow_run_flowVersionId", "flow_run"."environment" AS "flow_run_environment", "flow_run"."flowDisplayName" AS "flow_run_flowDisplayName", "flow_run"."logsFileId" AS "flow_run_logsFileId", "flow_run"."status" AS "flow_run_status", "flow_run"."startTime" AS "flow_run_startTime", "flow_run"."finishTime" AS "flow_run_finishTime" FROM "flow_run" "flow_run" WHERE ("flow_run"."projectId" = $1 AND "flow_run"."flowId" = $2 AND "flow_run"."environment" = $3) ORDER BY "flow_run"."created" DESC LIMIT 11
  2023-05-04 11:58:27.945 UTC [75] DETAIL:  parameters: $1 = 'qyxelJnde5mttWV0TCxU2', $2 = 'IYvFfmTMSUeDrmr45bEVN', $3 = 'PRODUCTION'
  2023-05-04 11:58:27.945 UTC [75] LOG:  duration: 0.005 ms  plan:
         Query Text: SELECT "flow_run"."id" AS "flow_run_id", "flow_run"."created" AS "flow_run_created", "flow_run"."updated" AS "flow_run_updated", "flow_run"."projectId" AS "flow_run_projectId", "flow_run"."flowId" AS "flow_run_flowId", "flow_run"."flowVersionId" AS "flow_run_flowVersionId", "flow_run"."environment" AS "flow_run_environment", "flow_run"."flowDisplayName" AS "flow_run_flowDisplayName", "flow_run"."logsFileId" AS "flow_run_logsFileId", "flow_run"."status" AS "flow_run_status", "flow_run"."startTime" AS "flow_run_startTime", "flow_run"."finishTime" AS "flow_run_finishTime" FROM "flow_run" "flow_run" WHERE ("flow_run"."projectId" = $1 AND "flow_run"."flowId" = $2 AND "flow_run"."environment" = $3) ORDER BY "flow_run"."created" DESC LIMIT 11
         Limit  (cost=0.14..8.17 rows=1 width=428)
                ->  Index Scan using idx_run_project_id_flow_id_environment_created_desc on flow_run  (cost=0.14..8.17 rows=1 width=428)
                       Index Cond: ((("projectId")::text = 'qyxelJnde5mttWV0TCxU2'::text) AND (("flowId")::text = 'IYvFfmTMSUeDrmr45bEVN'::text) AND ((environment)::text = 'PRODUCTION'::text))
  ```
- As evident from the `explain` output, all stages were replaced by an index scan even the sort stage!
- Why do we need compound indices?
  - because I wanted to test them out, and
  - because we have 120k flow runs right now in db, for perspective, we have 2k users and 4k flows, so flow runs are growing exponentially

Fixes #701 
