### PR TITLE
fix: added optional inputs

### DIFF
--- a/packages/pieces/mailchimp/src/lib/actions/add-member-to-list.action/add-member-to-list.action.ts
+++ b/packages/pieces/mailchimp/src/lib/actions/add-member-to-list.action/add-member-to-list.action.ts
@@ -9,6 +9,16 @@ export const addMemberToList = createAction({
     description: "Add a member to an existing Mailchimp audience (list)",
     props: {
         authentication: mailChimpAuth,
+        first_name: Property.ShortText({
+            displayName: 'First Name',
+            description: 'First name of the new contact',
+            required: false,
+        }),
+        last_name: Property.ShortText({
+            displayName: 'Last Name',
+            description: 'Last name of the new contact',
+            required: false,
+        }),
         email: Property.ShortText({
             displayName: 'Email',
             description: 'Email of the new contact',


### PR DESCRIPTION
## What does this PR do?

Adds first name and last name as optional inputs in the mailchimp piece.

Fixes #1164 

