### PR TITLE
fix: save static sample data with app-webhook trigger

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -31,7 +31,7 @@ export { PrincipalType } from "./lib/authentication/model/principal-type";
 export { Principal } from "./lib/authentication/model/principal";
 export {
     CodeAction, PieceAction, LoopOnItemsAction,
-    PieceActionSettings, LoopOnItemsActionSettings, Action, ActionType, CodeActionSettings
+    PieceActionSettings, LoopOnItemsActionSettings, Action, ActionType, CodeActionSettings,StepSettings
 } from './lib/flows/actions/action'
 export { StoreEntry, StoreEntryId } from './lib/store-entry/store-entry';
 export * from './lib/user/user';

--- a/packages/shared/src/lib/flows/actions/action.ts
+++ b/packages/shared/src/lib/flows/actions/action.ts
@@ -2,6 +2,7 @@ import { Type, Static, } from '@sinclair/typebox';
 
 import { SemVerType } from '../../pieces';
 import { SampleDataSettingsObject } from '../sample-data';
+import { PieceTriggerSettings } from '../triggers/trigger';
 
 export enum ActionType {
   CODE = 'CODE',
@@ -171,3 +172,10 @@ export type LoopOnItemsAction = Static<typeof LoopOnItemsActionSchema> & { nextA
 export type PieceAction = Static<typeof PieceActionSchema> & { nextAction?: Action };
 
 export type CodeAction = Static<typeof CodeActionSchema> & { nextAction?: Action };
+
+export  type StepSettings =
+  | CodeActionSettings
+  | PieceActionSettings
+  | PieceTriggerSettings
+  | BranchActionSettings
+  | LoopOnItemsActionSettings;

--- a/packages/ui/feature-builder-right-sidebar/src/lib/edit-step-sidebar/edit-step-form-container/edit-step-form-container.component.ts
+++ b/packages/ui/feature-builder-right-sidebar/src/lib/edit-step-sidebar/edit-step-form-container/edit-step-form-container.component.ts
@@ -123,9 +123,7 @@ export class EditStepFormContainerComponent {
           if (this._selectedStep.type === TriggerType.WEBHOOK) {
             this.updateNonAppWebhookTrigger(res.step!);
           } else {
-            const newTriggerSettings = this.createNewStepSettings(
-              res.step!
-            ) as PieceTriggerSettings;
+            const newTriggerSettings = this.createPieceSettings(res.step!);
             const trigger =
               res.metadata?.triggers[newTriggerSettings.triggerName];
             if (trigger?.type === TriggerStrategy.APP_WEBHOOK) {
@@ -213,13 +211,19 @@ export class EditStepFormContainerComponent {
     }
 
     if (currentStep.type === TriggerType.PIECE) {
-      const stepSettings: PieceTriggerSettings = {
-        ...currentStep.settings,
-        ...inputControlValue,
-      };
-      return stepSettings;
+      return this.createPieceSettings(currentStep);
     }
     return inputControlValue;
+  }
+
+  createPieceSettings(step: FlowItem) {
+    const inputControlValue: StepSettings =
+      this.stepForm.get('settings')?.value;
+    const stepSettings: PieceTriggerSettings = {
+      ...step.settings,
+      ...inputControlValue,
+    };
+    return stepSettings;
   }
   copyUrl(url: string) {
     navigator.clipboard.writeText(url);

--- a/packages/ui/feature-builder-right-sidebar/src/lib/edit-step-sidebar/edit-step-form-container/edit-step-form-container.component.ts
+++ b/packages/ui/feature-builder-right-sidebar/src/lib/edit-step-sidebar/edit-step-form-container/edit-step-form-container.component.ts
@@ -22,16 +22,19 @@ import {
   ActionType,
   CodeActionSettings,
   PieceActionSettings,
+  PieceTriggerSettings,
+  StepSettings,
   TriggerType,
   UpdateActionRequest,
   UpdateTriggerRequest,
 } from '@activepieces/shared';
-import { FlagService } from '@activepieces/ui/common';
+import { ActionMetaService, FlagService } from '@activepieces/ui/common';
 import {
   BuilderSelectors,
   FlowItem,
   FlowsActions,
 } from '@activepieces/ui/feature-builder-store';
+import { TriggerBase, TriggerStrategy } from '@activepieces/pieces-framework';
 
 @Component({
   selector: 'app-edit-step-form-container',
@@ -58,7 +61,8 @@ export class EditStepFormContainerComponent {
     private formBuilder: UntypedFormBuilder,
     private store: Store,
     private snackbar: MatSnackBar,
-    private flagService: FlagService
+    private flagService: FlagService,
+    private actionMetaService: ActionMetaService
   ) {
     this.webhookUrl$ = forkJoin({
       flow: this.store.select(BuilderSelectors.selectCurrentFlow).pipe(take(1)),
@@ -99,29 +103,76 @@ export class EditStepFormContainerComponent {
           .select(BuilderSelectors.selectCurrentStep)
           .pipe(take(1));
       }),
+      switchMap((res) => {
+        if (res?.type === TriggerType.PIECE) {
+          return this.actionMetaService
+            .getPieceMetadata(res.settings.pieceName, res.settings.pieceVersion)
+            .pipe(
+              map((meta) => {
+                return { step: res, metadata: meta };
+              })
+            );
+        }
+        return of({ step: res, metadata: undefined });
+      }),
       tap((res) => {
         if (
           this._selectedStep.type === TriggerType.PIECE ||
           this._selectedStep.type === TriggerType.WEBHOOK
         ) {
-          this.store.dispatch(
-            FlowsActions.updateTrigger({
-              operation: this.prepareStepDataToSave(
-                res!
-              ) as UpdateTriggerRequest,
-            })
-          );
+          if (this._selectedStep.type === TriggerType.WEBHOOK) {
+            this.updateNonAppWebhookTrigger(res.step!);
+          } else {
+            const newTriggerSettings = this.createNewStepSettings(
+              res.step!
+            ) as PieceTriggerSettings;
+            const trigger =
+              res.metadata?.triggers[newTriggerSettings.triggerName];
+            if (trigger?.type === TriggerStrategy.APP_WEBHOOK) {
+              this.updateAppWebhookTrigger(res.step!, trigger);
+            } else {
+              this.updateNonAppWebhookTrigger(res.step!);
+            }
+          }
         } else {
           this.store.dispatch(
             FlowsActions.updateAction({
               operation: this.prepareStepDataToSave(
-                res!
+                res.step!
               ) as UpdateActionRequest,
             })
           );
         }
       }),
       map(() => void 0)
+    );
+  }
+
+  private updateNonAppWebhookTrigger(step: FlowItem) {
+    this.store.dispatch(
+      FlowsActions.updateTrigger({
+        operation: this.prepareStepDataToSave(step) as UpdateTriggerRequest,
+      })
+    );
+  }
+  private updateAppWebhookTrigger(step: FlowItem, trigger: TriggerBase) {
+    const dataToSave: UpdateTriggerRequest = this.prepareStepDataToSave(
+      step
+    ) as UpdateTriggerRequest;
+    const dataToSaveWithTriggerSampleData: UpdateTriggerRequest = {
+      ...dataToSave,
+      settings: {
+        ...dataToSave.settings,
+        inputUiInfo: {
+          ...dataToSave.settings,
+          currentSelectedData: trigger.sampleData,
+        },
+      },
+    };
+    this.store.dispatch(
+      FlowsActions.updateTrigger({
+        operation: dataToSaveWithTriggerSampleData,
+      })
     );
   }
 
@@ -138,7 +189,8 @@ export class EditStepFormContainerComponent {
   }
 
   createNewStepSettings(currentStep: FlowItem) {
-    const inputControlValue = this.stepForm.get('settings')?.value;
+    const inputControlValue: StepSettings =
+      this.stepForm.get('settings')?.value;
     if (currentStep.type === ActionType.PIECE) {
       const stepSettings: PieceActionSettings = {
         ...currentStep.settings,
@@ -161,7 +213,7 @@ export class EditStepFormContainerComponent {
     }
 
     if (currentStep.type === TriggerType.PIECE) {
-      const stepSettings = {
+      const stepSettings: PieceTriggerSettings = {
         ...currentStep.settings,
         ...inputControlValue,
       };


### PR DESCRIPTION
## What does this PR do?

Static sample data wasn't being saved for app-webhook triggers, this PR fixes that.

Tested this by stopping filterAppWebhooks method inside ActionMetaService, then added a slack trigger, selected "new message"   and switched to another step where I saw that the sample data was now being fetched in the autocomplete dropdown. 

