### PR TITLE
feat: add templates

### DIFF
--- a/packages/backend/src/app/flows/flow-version/flow-version.service.ts
+++ b/packages/backend/src/app/flows/flow-version/flow-version.service.ts
@@ -31,6 +31,7 @@ import { FlowVersionEntity } from './flow-version-entity'
 import { flowVersionSideEffects } from './flow-version-side-effects'
 import { pieceMetadataLoader } from '../../pieces/piece-metadata-loader'
 import { FlowViewMode, DEFAULT_SAMPLE_DATA_SETTINGS } from '@activepieces/shared'
+import { isNil } from 'lodash'
 
 const branchSetttingsValidaotr = TypeCompiler.Compile(BranchActionSettingsWithValidation)
 const loopSettingsValidator = TypeCompiler.Compile(LoopOnItemsActionSettingsWithValidation)
@@ -207,6 +208,9 @@ async function removeSecrets(flowVersion: FlowVersion | null) {
 }
 
 function replaceConnections(obj: Record<string, unknown>): Record<string, unknown> {
+    if(isNil(obj)){
+        return obj
+    }
     const replacedObj: Record<string, unknown> = {}
 
     for (const [key, value] of Object.entries(obj)) {

--- a/packages/backend/src/app/flows/flow/flow.controller.ts
+++ b/packages/backend/src/app/flows/flow/flow.controller.ts
@@ -4,6 +4,8 @@ import {
     FlowId,
     FlowOperationRequest,
     FlowVersionId,
+    FlowViewMode,
+    GetFlowRequest,
     ListFlowsRequest,
 } from '@activepieces/shared'
 import { StatusCodes } from 'http-status-codes'
@@ -13,7 +15,6 @@ import { GuessFlowRequest, CountFlowsRequest } from '@activepieces/shared'
 import { flowGuessService } from '@ee/magic-wand/openai'
 import { flowVersionService } from '../flow-version/flow-version.service'
 import { logger } from '../../helper/logger'
-
 
 const DEFUALT_PAGE_SIZE = 10
 
@@ -42,7 +43,7 @@ export const flowController = async (fastify: FastifyInstance) => {
                 trigger: trigger,
             }
             await flowVersionService.overwriteVersion(flowVersion.id, flowVersion)
-            return flowService.getOne({ id: flow.id, versionId: undefined, projectId: request.principal.projectId, includeArtifacts: false })
+            return flowService.getOne({ id: flow.id, versionId: undefined, projectId: request.principal.projectId, viewMode: FlowViewMode.NO_ARTIFACTS })
         },
     )
 
@@ -77,7 +78,7 @@ export const flowController = async (fastify: FastifyInstance) => {
                 Body: FlowOperationRequest
             }>,
         ) => {
-            const flow = await flowService.getOne({ id: request.params.flowId, versionId: undefined, projectId: request.principal.projectId, includeArtifacts: false })
+            const flow = await flowService.getOne({ id: request.params.flowId, versionId: undefined, projectId: request.principal.projectId, viewMode: FlowViewMode.NO_ARTIFACTS })
             if (flow === null) {
                 throw new ActivepiecesError({ code: ErrorCode.FLOW_NOT_FOUND, params: { id: request.params.flowId } })
             }
@@ -119,21 +120,23 @@ export const flowController = async (fastify: FastifyInstance) => {
 
     fastify.get(
         '/:flowId',
+        {
+            schema: {
+                querystring: GetFlowRequest,
+            },
+        },
         async (
             request: FastifyRequest<{
                 Params: {
                     flowId: FlowId
                 }
-                Querystring: {
-                    versionId: FlowVersionId | undefined
-                    includeArtifacts: boolean | undefined
-                }
+                Querystring: GetFlowRequest
             }>,
         ) => {
             const versionId: FlowVersionId | undefined = request.query.versionId
-            const includeArtifacts = request.query.includeArtifacts ?? false
-            const flow = await flowService.getOne({ id: request.params.flowId, versionId: versionId, projectId: request.principal.projectId, includeArtifacts })
-            if (flow === null) {
+            const viewMode = request.query.viewMode ?? FlowViewMode.NO_ARTIFACTS
+            const flow = await flowService.getOne({ id: request.params.flowId, versionId: versionId, projectId: request.principal.projectId, viewMode })
+            if (!flow) {
                 throw new ActivepiecesError({ code: ErrorCode.FLOW_NOT_FOUND, params: { id: request.params.flowId } })
             }
             return flow

--- a/packages/backend/src/app/webhooks/webhook-service.ts
+++ b/packages/backend/src/app/webhooks/webhook-service.ts
@@ -5,6 +5,7 @@ import {
     FlowId,
     FlowInstanceStatus,
     FlowVersion,
+    FlowViewMode,
     ProjectId,
     RunEnvironment,
 } from '@activepieces/shared'
@@ -132,13 +133,12 @@ function extractHostname(url: string): string | null {
 
 const getLatestFlowVersionOrThrow = async (flowId: FlowId, projectId: ProjectId): Promise<FlowVersion> => {
     const flowVersionId = undefined
-    const includeArtifacts = false
 
     const flowVersion = await flowVersionService.getFlowVersion(
         projectId,
         flowId,
         flowVersionId,
-        includeArtifacts,
+        FlowViewMode.NO_ARTIFACTS,
     )
 
     if (isNil(flowVersion)) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "type": "commonjs"
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -44,20 +44,19 @@ export * from './lib/flows/flow-helper';
 export { FlowRun, FlowRunId, RunEnvironment } from './lib/flow-run/flow-run'
 export { ExecutionState } from './lib/flow-run/execution/execution-state';
 export { Project, ProjectId } from './lib/project/project';
-export { ListFlowsRequest } from './lib/flows/dto/list-flows-request';
 export * from './lib/flows/dto/create-flow-request';
 export { CloneFlowVersionRequest } from './lib/flows/dto/clone-flow-version-request';
 export { SeekPage, Cursor } from './lib/common/seek-page';
 export { apId, ApId } from './lib/common/id-generator'
 export * from "./lib/flows/trigger-events/trigger-events-dto";
 export * from "./lib/flows/trigger-events/trigger-event";
-export {SampleDataSettings} from './lib/flows/sample-data'
+export * from './lib/flows/sample-data'
 export * from "./lib/project/update-project-request";
 export * from './lib/common/base-model';
 export * from './lib/flows/flow-instances';
 export * from "./lib/flows/folders/folder";
 export * from "./lib/flows/folders/folder-requests";
 import { TypeSystem } from '@sinclair/typebox/system'
+export * from "./lib/flows/dto/list-flows-request";
 // Look at https://github.com/sinclairzx81/typebox/issues/350
 TypeSystem.ExactOptionalPropertyTypes = false;
-

--- a/packages/shared/src/lib/flows/actions/action.ts
+++ b/packages/shared/src/lib/flows/actions/action.ts
@@ -23,15 +23,7 @@ export const CodeActionSettings = Type.Object({
   artifactPackagedId: Type.Optional(Type.String({})),
   artifact: Type.Optional(Type.String({})),
   input: Type.Record(Type.String({}), Type.Any()),
-  inputUiInfo:Type.Optional(Type.Object(
-    {
-      currentSelectedData: Type.Optional(Type.Unknown()),
-      lastTestDate: Type.Optional(Type.String()),
-    },
-    {
-      additionalProperties: true
-    }
-  ))
+  inputUiInfo:Type.Optional(SampleDataSettingsObject)
 });
 
 

--- a/packages/shared/src/lib/flows/dto/list-flows-request.ts
+++ b/packages/shared/src/lib/flows/dto/list-flows-request.ts
@@ -7,4 +7,18 @@ export const ListFlowsRequest = Type.Object({
     cursor: Type.Optional(Type.String({})),
 });
 
+export enum FlowViewMode {
+    NO_ARTIFACTS = "NO_ARTIFACTS",
+    WITH_ARTIFACTS= "WITH_ARTIFACTS",
+    TEMPLATE = "TEMPLATE"
+}
+
 export type ListFlowsRequest = Omit<Static<typeof ListFlowsRequest>, "cursor"> & { cursor: Cursor | undefined };
+
+export const GetFlowRequest = Type.Object({
+    versionId: Type.Optional(Type.String({})),
+    viewMode: Type.Optional(Type.Enum(FlowViewMode))
+})
+
+export type GetFlowRequest = Static<typeof GetFlowRequest>
+

--- a/packages/shared/src/lib/flows/dto/list-flows-request.ts
+++ b/packages/shared/src/lib/flows/dto/list-flows-request.ts
@@ -17,7 +17,7 @@ export type ListFlowsRequest = Omit<Static<typeof ListFlowsRequest>, "cursor"> &
 
 export const GetFlowRequest = Type.Object({
     versionId: Type.Optional(Type.String({})),
-    viewMode: Type.Optional(Type.Enum(FlowViewMode))
+    viewMode: Type.Optional(Type.Union([Type.Literal(FlowViewMode.NO_ARTIFACTS), Type.Literal(FlowViewMode.WITH_ARTIFACTS)]))
 })
 
 export type GetFlowRequest = Static<typeof GetFlowRequest>

--- a/packages/shared/src/lib/flows/flow-helper.ts
+++ b/packages/shared/src/lib/flows/flow-helper.ts
@@ -29,6 +29,10 @@ function isValid(flowVersion: FlowVersion) {
   return valid;
 }
 
+function isAction(type: ActionType | TriggerType): boolean {
+  return Object.entries(ActionType).some(([, value]) => value === type);
+}
+
 function deleteAction(
   flowVersion: FlowVersion,
   request: DeleteActionRequest
@@ -70,16 +74,16 @@ function deleteAction(
   }
 }
 
-function traverseFlowInternal(step: Trigger | Action | undefined): (Action | Trigger)[] {
+function traverseInternal(step: Trigger | Action | undefined): (Action | Trigger)[] {
   const steps: (Action | Trigger)[] = [];
   while (step !== undefined && step !== null) {
     steps.push(step);
     if (step.type === ActionType.BRANCH) {
-      steps.push(...traverseFlowInternal(step.onFailureAction));
-      steps.push(...traverseFlowInternal(step.onSuccessAction));
+      steps.push(...traverseInternal(step.onFailureAction));
+      steps.push(...traverseInternal(step.onSuccessAction));
     }
     if (step.type === ActionType.LOOP_ON_ITEMS) {
-      steps.push(...traverseFlowInternal(step.firstLoopAction));
+      steps.push(...traverseInternal(step.firstLoopAction));
     }
     step = step.nextAction;
   }
@@ -88,7 +92,7 @@ function traverseFlowInternal(step: Trigger | Action | undefined): (Action | Tri
 
 
 function getAllSteps(flowVersion: FlowVersion): (Action | Trigger)[] {
-  return traverseFlowInternal(flowVersion.trigger);
+  return traverseInternal(flowVersion.trigger);
 }
 
 function getStep(
@@ -322,6 +326,7 @@ export const flowHelper = {
     return clonedVersion;
   },
   getStep: getStep,
+  isAction: isAction,
   getAllSteps: getAllSteps,
   clone: (flowVersion: FlowVersion): FlowVersion => {
     return JSON.parse(JSON.stringify(flowVersion));

--- a/packages/shared/src/lib/flows/flow-helper.ts
+++ b/packages/shared/src/lib/flows/flow-helper.ts
@@ -74,6 +74,13 @@ function deleteAction(
   }
 }
 
+function getUsedPieces(trigger: Trigger): string[] {
+  return traverseInternal(trigger)
+  .filter((step) => step.type === ActionType.PIECE || step.type === TriggerType.PIECE)
+  .map((step) => step.settings.pieceName)
+  .filter((value, index, self) => self.indexOf(value) === index);
+}
+
 function traverseInternal(step: Trigger | Action | undefined): (Action | Trigger)[] {
   const steps: (Action | Trigger)[] = [];
   while (step !== undefined && step !== null) {
@@ -328,6 +335,7 @@ export const flowHelper = {
   getStep: getStep,
   isAction: isAction,
   getAllSteps: getAllSteps,
+  getUsedPieces: getUsedPieces,
   clone: (flowVersion: FlowVersion): FlowVersion => {
     return JSON.parse(JSON.stringify(flowVersion));
   },

--- a/packages/shared/src/lib/flows/flow-operations.ts
+++ b/packages/shared/src/lib/flows/flow-operations.ts
@@ -1,3 +1,4 @@
+import { Action } from "./actions/action";
 import {
     CodeActionSchema, BranchActionSchema, LoopOnItemsActionSchema, PieceActionSchema,
 } from "./actions/action";
@@ -21,6 +22,13 @@ export enum StepLocationRelativeToParent {
     AFTER = "AFTER",
     INSIDE_LOOP = "INSIDE_LOOP"
 }
+
+export const ImportFlowRequest = Type.Object({
+    displayName: Type.String({}),
+    trigger: Type.Union([Type.Composite([WebhookTrigger, Type.Object({ nextAction: Action })]), Type.Composite([PieceTrigger, Type.Object({ nextAction: Action })])]),
+})
+
+export type ImportFlowRequest = Static<typeof ImportFlowRequest>;
 
 export const ChangeFolderRequest = Type.Object({
     folderId: Type.Optional(Type.String({})),
@@ -55,6 +63,10 @@ export const UpdateTriggerRequest = Type.Union([EmptyTrigger, PieceTrigger, Webh
 export type UpdateTriggerRequest = Static<typeof UpdateTriggerRequest>;
 
 export const FlowOperationRequest = Type.Union([
+    Type.Object({
+        type: Type.Literal(FlowOperationType.IMPORT_FLOW),
+        request: ImportFlowRequest
+    }),
     Type.Object({
         type: Type.Literal(FlowOperationType.CHANGE_NAME),
         request: ChangeNameRequest

--- a/packages/shared/src/lib/flows/folders/list-folders-response.ts
+++ b/packages/shared/src/lib/flows/folders/list-folders-response.ts
@@ -1,3 +1,3 @@
-import { Folder } from "../folders/folder";
+import { Folder } from "./folder";
 
 export type FolderDto = Folder & {numberOfFlows:number}

--- a/packages/shared/src/lib/flows/sample-data.ts
+++ b/packages/shared/src/lib/flows/sample-data.ts
@@ -12,3 +12,9 @@ export const SampleDataSettingsObject = Type.Object(
 )
 
 export type SampleDataSettings = Static<typeof SampleDataSettingsObject>;
+
+export const DEFAULT_SAMPLE_DATA_SETTINGS: SampleDataSettings = {
+  currentSelectedData: undefined,
+  customizedInputs: undefined,
+  lastTestDate: undefined,
+}

--- a/packages/shared/src/lib/flows/triggers/trigger.ts
+++ b/packages/shared/src/lib/flows/triggers/trigger.ts
@@ -27,8 +27,8 @@ export type EmptyTrigger = Static<typeof EmptyTrigger>;
 export const WebhookTrigger = Type.Object({
   ...commonProps,
   type: Type.Literal(TriggerType.WEBHOOK),
-  settings:Type.Object({
-    inputUiInfo:SampleDataSettingsObject
+  settings: Type.Object({
+    inputUiInfo: SampleDataSettingsObject
   })
 });
 

--- a/packages/ui/core/src/app/app.module.ts
+++ b/packages/ui/core/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { UserLoggedIn } from './guards/user-logged-in.guard';
 import { DashboardContainerComponent } from '@activepieces/ui/feature-dashboard';
 import { FeatureCommandBarModule } from '@activepieces/ui/feature-command-bar';
 import { AuthLayoutComponent } from '@activepieces/ui/feature-authentication';
+import { ImportFlowComponent } from './modules/import-flow/import-flow.component';
 
 export function tokenGetter() {
   const jwtToken: any = localStorage.getItem(environment.jwtTokenName);
@@ -37,7 +38,12 @@ export function tokenGetter() {
 }
 
 @NgModule({
-  declarations: [AppComponent, NotFoundComponent, RedirectUrlComponent],
+  declarations: [
+    AppComponent,
+    NotFoundComponent,
+    RedirectUrlComponent,
+    ImportFlowComponent,
+  ],
   imports: [
     CommonModule,
     BrowserModule,
@@ -122,6 +128,11 @@ function dynamicRoutes(edition: string) {
     },
   ];
   const suffixRoutes: Route[] = [
+    {
+      canActivate: [UserLoggedIn],
+      path: 'templates/:templateId',
+      component: ImportFlowComponent,
+    },
     {
       path: 'redirect',
       component: RedirectUrlComponent,

--- a/packages/ui/core/src/app/modules/import-flow/import-flow.component.html
+++ b/packages/ui/core/src/app/modules/import-flow/import-flow.component.html
@@ -1,0 +1,5 @@
+<div *ngIf="loadFlow$ | async"
+  class="ap-flex ap-flex-grow ap-justify-center ap-items-center ap-h-full route-loader ap-w-full">
+  <svg-icon [svgStyle]="{ width: '50px', height: '50px' }" src="assets/img/custom/loading.svg"
+    class="loading-spin-animation grey-spinner" [applyClass]="true"></svg-icon>
+</div>

--- a/packages/ui/core/src/app/modules/import-flow/import-flow.component.ts
+++ b/packages/ui/core/src/app/modules/import-flow/import-flow.component.ts
@@ -1,0 +1,61 @@
+import { FlowOperationType } from '@activepieces/shared';
+import { FlowService } from '@activepieces/ui/common';
+import { HttpClient } from '@angular/common/http';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { catchError, map, Observable, of, switchMap, tap } from 'rxjs';
+
+@Component({
+  selector: 'app-import-flow',
+  templateUrl: './import-flow.component.html',
+  styleUrls: [],
+})
+export class ImportFlowComponent implements OnInit {
+  loadFlow$: Observable<void> = new Observable<void>();
+  constructor(
+    private route: ActivatedRoute,
+    private http: HttpClient,
+    private flowService: FlowService,
+    private router: Router
+  ) {}
+  ngOnInit(): void {
+    this.loadFlow$ = this.route.params
+      .pipe(
+        switchMap((params) => {
+          const templateId = encodeURIComponent(params['templateId']);
+          return this.http
+            .get<{ template: { displayName: string; trigger: any } }>(
+              `https://cdn.activepieces.com/templates/${templateId}.json`
+            )
+            .pipe(
+              switchMap((templateJson) => {
+                return this.flowService
+                  .create({
+                    displayName: templateJson.template.displayName,
+                  })
+                  .pipe(
+                    switchMap((flow) => {
+                      return this.flowService
+                        .update(flow.id, {
+                          type: FlowOperationType.IMPORT_FLOW,
+                          request: templateJson.template,
+                        })
+                        .pipe(
+                          tap((updatedFlow) => {
+                            this.router.navigate(['flows', updatedFlow.id]);
+                          })
+                        );
+                    })
+                  );
+              })
+            );
+        }),
+        catchError((error) => {
+          console.error(error);
+          this.router.navigate(['not-found']);
+          return of(null);
+        })
+      )
+      .pipe(map(() => void 0));
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds support for both exporting and importing templates. Importing templates is particularly important for AI.

Current Template JSON

```json
{
  "template": {
       // Data returned from GET /flows/id/template
   }
}
```
Tests:

- [X] Code step with content
- [X] Loop piece with pieces
- [X] Branch pieces with pieces on both sides
- [X] Invalid template URL
- [X] Template URL while not logged in
- [X] Verify that authentication tabs get deleted
- [ ] Verify that sample data gets deleted.