### PR TITLE
[Matrix piece] Ability to send a message via room alias instead of room id

### DIFF
--- a/packages/pieces/matrix/src/lib/actions/send-message.ts
+++ b/packages/pieces/matrix/src/lib/actions/send-message.ts
@@ -1,5 +1,6 @@
 import { createAction, Property } from "@activepieces/pieces-framework";
-import { AuthenticationType, httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+import { getRoomId, sendMessage as sendMatrixMessage } from '../common/common';
 
 export const sendMessage = createAction({
     name: "send_message",
@@ -27,11 +28,11 @@ export const sendMessage = createAction({
                     required: true,
                 })
             },
-            required: true
+            required: true,
         }),
-        room_id: Property.ShortText({
-            displayName: "Internal Room ID",
-            description: "Copy it from room settings -> advanced -> internal room Id",
+        room_alias: Property.ShortText({
+            displayName: "Room Alias",
+            description: "Copy it from room settings -> advanced -> room addresses -> main address",
             required: true,
         }),
         message: Property.LongText({
@@ -42,17 +43,9 @@ export const sendMessage = createAction({
     },
     async run({ propsValue }) {
         const baseUrl = propsValue.authentication.base_url.replace(/\/$/, "");
-        return await httpClient.sendRequest({
-            method: HttpMethod.POST,
-            url: `${baseUrl}/_matrix/client/r0/rooms/` + propsValue.room_id + "/send/m.room.message",
-            authentication: {
-                type: AuthenticationType.BEARER_TOKEN,
-                token: propsValue.authentication.access_token,
-            },
-            body: {
-                msgtype: "m.text",
-                body: propsValue.message,
-            }
-        })
+        const accessToken = propsValue.authentication.access_token;
+        const roomId = (await getRoomId(baseUrl, propsValue.room_alias, accessToken)).body.room_id;
+
+        return await sendMatrixMessage(baseUrl, roomId, accessToken, propsValue.message);
     }
 })

--- a/packages/pieces/matrix/src/lib/common/common.ts
+++ b/packages/pieces/matrix/src/lib/common/common.ts
@@ -1,0 +1,31 @@
+import { httpClient, HttpMethod, AuthenticationType, HttpResponse } from "@activepieces/pieces-common";
+
+export async function getRoomId(baseUrl: string, roomAlias: string, accessToken: string): Promise<HttpResponse> {
+    const response = httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${baseUrl}/_matrix/client/r0/directory/room/${encodeURIComponent(roomAlias)}`,
+        authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: accessToken,
+        },
+    });
+
+    return response;
+}
+
+export async function sendMessage(baseUrl: string, roomId: string, accessToken: string, message: string): Promise<HttpResponse> {
+    const response = httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${baseUrl}/_matrix/client/r0/rooms/` + roomId + "/send/m.room.message",
+        authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: accessToken,
+        },
+        body: {
+            msgtype: "m.text",
+            body: message,
+        }
+    })
+
+    return response;
+}


### PR DESCRIPTION
## What does this PR do?

This PR uses the Room alias in place of the Room id.

### Motivation
The room internal id is something which depends on the client you are using and it's a bit uncomfortable to work with. Internally I just added a getRoomId function, which takes the internal id from the Room alias with an additional api call. 

### Use case
Say for example you have two matrix clients, a personal one and a bot, you can get the Room alias from your personal client without opening at all your bot account with a client to get your internal room id.
