### PR TITLE
[Matrix] Ability to send a message via room alias instead of room id

### DIFF
--- a/packages/pieces/matrix/package.json
+++ b/packages/pieces/matrix/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-matrix",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/pieces/matrix/src/lib/common/common.ts
+++ b/packages/pieces/matrix/src/lib/common/common.ts
@@ -1,0 +1,31 @@
+import { httpClient, HttpMethod, AuthenticationType, HttpResponse } from "@activepieces/pieces-common";
+
+export async function getRoomId(baseUrl: string, roomAlias: string, accessToken: string): Promise<HttpResponse> {
+    const response = httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${baseUrl}/_matrix/client/r0/directory/room/${encodeURIComponent(roomAlias)}`,
+        authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: accessToken,
+        },
+    });
+
+    return response;
+}
+
+export async function sendMessage(baseUrl: string, roomId: string, accessToken: string, message: string): Promise<HttpResponse> {
+    const response = httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${baseUrl}/_matrix/client/r0/rooms/` + roomId + "/send/m.room.message",
+        authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: accessToken,
+        },
+        body: {
+            msgtype: "m.text",
+            body: message,
+        }
+    })
+
+    return response;
+}


### PR DESCRIPTION
## What does this PR do?

This PR uses the Room alias in place of the Room id.

### Motivation
The room internal id is something which depends on the client you are using and it's a bit uncomfortable to work with. Internally I just added a getRoomId function, which takes the internal id from the Room alias with an additional api call.

### Use case
Say for example you have two matrix clients, a personal one and a bot, you can get the Room alias from your personal client without opening at all your bot account with a client to get your internal room id.

