### PR TITLE
feat: add ntfy

### DIFF
--- a/packages/pieces/ntfy/.eslintrc.json
+++ b/packages/pieces/ntfy/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/ntfy/README.md
+++ b/packages/pieces/ntfy/README.md
@@ -1,0 +1,7 @@
+# pieces-ntfy
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running lint
+
+Run `nx lint pieces-ntfy` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/pieces/ntfy/package.json
+++ b/packages/pieces/ntfy/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-ntfy",
+  "version": "0.0.1"
+}

--- a/packages/pieces/ntfy/project.json
+++ b/packages/pieces/ntfy/project.json
@@ -1,0 +1,36 @@
+{
+  "name": "pieces-ntfy",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/ntfy/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/ntfy",
+        "tsConfig": "packages/pieces/ntfy/tsconfig.lib.json",
+        "packageJson": "packages/pieces/ntfy/package.json",
+        "main": "packages/pieces/ntfy/src/index.ts",
+        "assets": [
+          "packages/pieces/ntfy/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies"
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": [
+        "{options.outputFile}"
+      ],
+      "options": {
+        "lintFilePatterns": [
+          "packages/pieces/ntfy/**/*.ts"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/ntfy/src/index.ts
+++ b/packages/pieces/ntfy/src/index.ts
@@ -1,0 +1,15 @@
+
+import { createPiece } from "@activepieces/pieces-framework";
+import packageJson from "../package.json";
+import { sendNotification } from './lib/actions/send-notification';
+
+export const gotify = createPiece({
+  name: "ntfy",
+  displayName: "Ntfy",
+  logoUrl: "https://cdn.activepieces.com/pieces/ntfy.png",
+  version: packageJson.version,
+  minimumSupportedRelease: "0.0.1",
+  authors: ["MyWay"],
+  actions: [sendNotification],
+  triggers: [],
+});

--- a/packages/pieces/ntfy/src/lib/actions/send-notification.ts
+++ b/packages/pieces/ntfy/src/lib/actions/send-notification.ts
@@ -1,0 +1,115 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { AuthenticationType, httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export const sendNotification = createAction({
+    name: "send_notification",
+    displayName: "Send Notification",
+    description: "Send a notification to ntfy",
+    props: {
+        authentication: Property.CustomAuth({
+            displayName: "Authentication",
+            description: `
+            To obtain a token:
+            
+            1. Log in to your Ntfy instance.
+            2. Click on Account
+            3. Go under, on Access tokens and click on the button icon to copy your Token or CREATE ACCESS TOKEN if you do not have
+            4. Please pay attention to the expiration time when copying/creating a Token.
+            4. Copy your access token & and paste them into the fields below.
+            `,
+            props: {
+                base_url: Property.ShortText({
+                    displayName: "Server URL",
+                    description: "Ntfy Instance URL",
+                    required: true,
+                }),
+                access_token: Property.SecretText({
+                    displayName: "Access Token",
+                    description: "Ntfy Access Token",
+                    required: false,
+                })
+            },
+            required: true,
+        }),
+        topic: Property.ShortText({
+            displayName: "Topic",
+            description: "The topic/channel to send the notification to, e.g. test1",
+            required: true,
+        }),
+        title: Property.ShortText({
+            displayName: "Title",
+            description: "The title of the notification",
+            required: false,
+        }),
+        message: Property.LongText({
+            displayName: "Message",
+            description: "The message to send",
+            required: true,
+        }),
+        priority: Property.ShortText({
+            displayName: "Priority",
+            description: "The priority of the notification (1-5). 1 is lowest priority.",
+            required: false,
+        }),
+        tags: Property.Array({
+            displayName: "Tags",
+            description: "The tags for the notification.",
+            required: false,
+        }),
+        icon: Property.ShortText({
+            displayName: "Icon",
+            description: "The absolute URL to your icon, e.g. https://example.com/communityIcon_xnt6chtnr2j21.png",
+            required: false,
+        }),
+        actions: Property.LongText({
+            displayName: "Actions",
+            description: "Add Action buttons to notifications, see https://docs.ntfy.sh/publish/#action-buttons",
+            required: false,
+        }),
+        click: Property.ShortText({
+            displayName: "Click",
+            description: "You can define which URL to open when a notification is clicked, see https://docs.ntfy.sh/publish/#click-action",
+            required: false,
+        }),
+        delay: Property.ShortText({
+            displayName: "Delay",
+            description: "Let ntfy send messages at a later date, e.g. 'tomorrow, 10am', see https://docs.ntfy.sh/publish/#scheduled-delivery",
+            required: false,
+        }),
+    },
+    async run({ propsValue }) {
+        const baseUrl = propsValue.authentication.base_url.replace(/\/$/, "");
+        const accessToken = propsValue.authentication.access_token;
+
+        const topic = propsValue.topic;
+        const title = propsValue.title;
+        const message = propsValue.message;
+        const priority = propsValue.priority;
+        const tags = propsValue.tags;
+        const icon = propsValue.icon;
+        const actions = propsValue.actions;
+        const click = propsValue.click;
+        const delay = propsValue.delay;
+
+        return await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `${baseUrl}/${topic}`,
+            ...(accessToken) && {
+                authentication: {
+                    type: AuthenticationType.BEARER_TOKEN,
+                    token: accessToken,
+                }
+            },
+            headers: {
+                'X-Message': message,
+                'X-Title': title,
+                'X-Priority': priority,
+                'X-Tags': tags?.join(','),
+                'X-Icon': icon,
+                'X-Actions': actions,
+                'X-Click': click,
+                'X-Delay': delay,
+            },
+        });
+    }
+})

--- a/packages/pieces/ntfy/tsconfig.json
+++ b/packages/pieces/ntfy/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/ntfy/tsconfig.lib.json
+++ b/packages/pieces/ntfy/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -96,6 +96,7 @@
       "@activepieces/piece-mindee": ["packages/pieces/mindee/src/index.ts"],
       "@activepieces/piece-monday": ["packages/pieces/monday/src/index.ts"],
       "@activepieces/piece-notion": ["packages/pieces/notion/src/index.ts"],
+      "@activepieces/piece-ntfy": ["packages/pieces/ntfy/src/index.ts"],
       "@activepieces/piece-openai": ["packages/pieces/openai/src/index.ts"],
       "@activepieces/piece-pipedrive": [
         "packages/pieces/pipedrive/src/index.ts"


### PR DESCRIPTION
## What does this PR do?

This PR adds support for Ntfy: https://docs.ntfy.sh/

### Required parameters

- topic
- message

### Optional parameters

- title
- priority
- tags
- icon (an absolute url to the icon)
- actions (an action button as specified at https://docs.ntfy.sh/publish/#action-buttons)
- click (a url to open when the notification is clicked)
- delay (schedule the notification once received by ntfy, e.g. 10m means 10 minutes since received by ntfy)

### Auth
Auth uses an optional access token, which the user can generate from their web panel, or using ntfy's cli tool.

