### PR TITLE
fix: stringify falsey values

### DIFF
--- a/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
@@ -128,6 +128,12 @@ const selectStepTestSampleData = createSelector(selectCurrentStep, (step) => {
   }
   return undefined;
 });
+const selectStepTestSampleDataStringified = createSelector(
+  selectStepTestSampleData,
+  (res) => {
+    return res ? res : res === undefined ? 'undefined' : JSON.stringify(res);
+  }
+);
 const selectLastTestDate = createSelector(selectCurrentStep, (step) => {
   if (
     step &&
@@ -465,4 +471,5 @@ export const BuilderSelectors = {
   selectStepTestSampleData,
   selectLastTestDate,
   selectNumberOfInvalidSteps,
+  selectStepTestSampleDataStringified,
 };

--- a/packages/ui/feature-builder-test-steps/src/lib/test-piece-step/test-piece-step.component.ts
+++ b/packages/ui/feature-builder-test-steps/src/lib/test-piece-step/test-piece-step.component.ts
@@ -37,12 +37,11 @@ export class TestPieceStepComponent extends TestStepCoreComponent {
       BuilderSelectors.selectStepValidity
     );
     this.lastTestResult$ = this.store
-      .select(BuilderSelectors.selectStepTestSampleData)
+      .select(BuilderSelectors.selectStepTestSampleDataStringified)
       .pipe(
         distinctUntilChanged((prev, current) => {
           return deepEqual(prev, current);
-        }),
-        map((res)=>res? res : res === undefined? 'undefined':JSON.stringify(res))
+        })
       );
     this.lastTestDate$ = this.store
       .select(BuilderSelectors.selectLastTestDate)


### PR DESCRIPTION
## What does this PR do?

Stringify falsey values returned from testing step (only frontend).

closes #1215 

Testing:

Went to create new record action in Airtable and returned falsey (0/false/null/undefined) values and all were visible.
