### PR TITLE
fix: corrected test code results to return falsey values instead of empty strings

### DIFF
--- a/packages/backend/src/app/workers/code-worker/code-runner.ts
+++ b/packages/backend/src/app/workers/code-worker/code-runner.ts
@@ -30,9 +30,9 @@ async function run(artifact: Buffer, input: unknown): Promise<CodeExecutionResul
         executionResult = {
             verdict: statusToCodeStatus(result.verdict),
             timeInSeconds: result.timeInSeconds ?? 0,
-            output: result.output ?? '',
-            standardOutput: result.standardOutput ?? '',
-            standardError: result.standardError ?? '',
+            output: result.output,
+            standardOutput: result.standardOutput,
+            standardError: result.standardError,
         }
 
         logger.debug(executionResult, '[CodeRunner#run] executionResult')

--- a/packages/backend/src/assets/code-executor.js
+++ b/packages/backend/src/assets/code-executor.js
@@ -7,7 +7,7 @@ const readInput = async () => {
 }
 
 const writeOutput = async (output) => {
-    const serializedOutput = JSON.stringify(output)
+    const serializedOutput = output === undefined ? 'undefined': JSON.stringify(output)
     await writeFile('output.json', serializedOutput)
 }
 
@@ -18,7 +18,7 @@ const main = async () => {
 
         const output = {
             status: 'OK',
-            response: response ? response : ''
+            response: response
         }
 
         await writeOutput(output)

--- a/packages/ui/feature-builder-test-steps/src/lib/test-code-step/test-code-step.component.ts
+++ b/packages/ui/feature-builder-test-steps/src/lib/test-code-step/test-code-step.component.ts
@@ -125,10 +125,11 @@ export class TestCodeStepComponent extends TestStepCoreComponent {
                 settings: {
                   ...step.settings,
                   inputUiInfo: {
-                    currentSelectedData:
-                      result.output === null || result.output === undefined
-                        ? JSON.stringify(result.output)
-                        : result.output,
+                    currentSelectedData: result.output
+                      ? result.output
+                      : result.output === undefined
+                      ? 'undefined'
+                      : JSON.stringify(result.output),
                     lastTestDate: new Date().toString(),
                   },
                 },


### PR DESCRIPTION

## What does this PR do?

Closes #1216 

Testing:

Created a code step and returned falsey values (undefined/null/0/false), and threw errors, but NaN are returned as null.

