### PR TITLE
feat: added Pushover support

### DIFF
--- a/packages/pieces/pushover/.eslintrc.json
+++ b/packages/pieces/pushover/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/pushover/README.md
+++ b/packages/pieces/pushover/README.md
@@ -1,0 +1,7 @@
+# pieces-pushover
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running lint
+
+Run `nx lint pieces-pushover` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/pieces/pushover/package.json
+++ b/packages/pieces/pushover/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-pushover",
+  "version": "0.0.1"
+}

--- a/packages/pieces/pushover/project.json
+++ b/packages/pieces/pushover/project.json
@@ -1,0 +1,36 @@
+{
+  "name": "pieces-pushover",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/pushover/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/pushover",
+        "tsConfig": "packages/pieces/pushover/tsconfig.lib.json",
+        "packageJson": "packages/pieces/pushover/package.json",
+        "main": "packages/pieces/pushover/src/index.ts",
+        "assets": [
+          "packages/pieces/pushover/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies"
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": [
+        "{options.outputFile}"
+      ],
+      "options": {
+        "lintFilePatterns": [
+          "packages/pieces/pushover/**/*.ts"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/pushover/src/index.ts
+++ b/packages/pieces/pushover/src/index.ts
@@ -1,0 +1,15 @@
+
+import { createPiece } from "@activepieces/pieces-framework";
+import packageJson from "../package.json";
+import { sendNotification } from './lib/actions/send-notification';
+
+export const pushover = createPiece({
+  name: "pushover",
+  displayName: "Pushover",
+  logoUrl: "https://cdn.activepieces.com/pieces/pushover.png",
+  version: packageJson.version,
+  minimumSupportedRelease: "0.0.1",
+  authors: ['MyWay'],
+  actions: [sendNotification],
+  triggers: [],
+});

--- a/packages/pieces/pushover/src/lib/actions/send-notification.ts
+++ b/packages/pieces/pushover/src/lib/actions/send-notification.ts
@@ -1,0 +1,117 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export const sendNotification = createAction({
+    name: "send_notification",
+    displayName: "Send Notification",
+    description: "Send a notification to Pushover",
+    props: {
+        authentication: Property.CustomAuth({
+            displayName: "Authentication",
+            description: `
+            To obtain the api token:
+            
+            1. Log in to Pushover.
+            2. Click on your Application or on Create an Application/API Token
+            3. Copy the API Token/Key.
+
+            To obtain the user key:
+            1. Log in to Pushover
+            2. Copy your Your User Key
+
+            Note if you want to send the message to your group, you should specify a group key instead of the user key
+            `,
+            props: {
+                api_token: Property.SecretText({
+                    displayName: "Api Token",
+                    description: "Pushover Api Token",
+                    required: true,
+                }),
+                user_key: Property.SecretText({
+                    displayName: "User Key",
+                    description: "Pushover User Key",
+                    required: true,
+                }),
+            },
+            required: true,
+        }),
+        title: Property.ShortText({
+            displayName: "Title",
+            description: "The title of the notification",
+            required: false,
+        }),
+        message: Property.LongText({
+            displayName: "Message",
+            description: "The message to send",
+            required: true,
+        }),
+        priority: Property.Number({
+            displayName: "Priority",
+            description: "The priority of the notification (-2 to 2). -2 is lowest priority. If set to 2, you should also specify Retry and Expire.",
+            required: false,
+        }),
+        retry: Property.Number({
+            displayName: "Retry",
+            description: "Works only if priority is set to 2. Specifies how often (in seconds) the Pushover servers will send the same notification to the user.",
+            required: false,
+        }),
+        expire: Property.Number({
+            displayName: "Expire",
+            description: "Works only if priority is set to 2. Specifies how many seconds your notification will continue to be retried for (every retry seconds).",
+            required: false,
+        }),
+        url: Property.ShortText({
+            displayName: "URL",
+            description: "A supplementary URL to show with your message.",
+            required: false,
+        }),
+        url_title: Property.ShortText({
+            displayName: "URL Title",
+            description: "A title for the URL specified as the url input parameter, otherwise just the URL is shown.",
+            required: false,
+        }),
+        timestamp: Property.ShortText({
+            displayName: "Timestamp",
+            description: "a Unix timestamp of a time to display instead of when our API received it.",
+            required: false,
+        }),
+        device: Property.ShortText({
+            displayName: "Device",
+            description: "The name of one of your devices to send just to that device instead of all devices.",
+            required: false,
+        }),
+    },
+    async run({ propsValue }) {
+        const baseUrl = 'https://api.pushover.net/1/messages.json';
+        const apiToken = propsValue.authentication.api_token;
+        const userKey = propsValue.authentication.user_key;
+
+        const title = propsValue.title;
+        const message = propsValue.message;
+        const priority = propsValue.priority;
+        const url = propsValue.url;
+        const url_title = propsValue.url_title;
+        const timestamp = propsValue.timestamp;
+        const device = propsValue.device;
+        const retry = propsValue.retry;
+        const expire = propsValue.expire;
+
+        return await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: baseUrl,
+            body: {
+                token: apiToken,
+                user: userKey,
+                title,
+                message,
+                url,
+                url_title,
+                timestamp,
+                device,
+                ...(priority) && { priority: +priority },
+                ...(retry) && { retry: +retry },
+                ...(expire) && { expire: +expire },
+            }
+        });
+    }
+})

--- a/packages/pieces/pushover/tsconfig.json
+++ b/packages/pieces/pushover/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/pushover/tsconfig.lib.json
+++ b/packages/pieces/pushover/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -104,6 +104,7 @@
       ],
       "@activepieces/piece-postgres": ["packages/pieces/postgres/src/index.ts"],
       "@activepieces/piece-posthog": ["packages/pieces/posthog/src/index.ts"],
+      "@activepieces/piece-pushover": ["packages/pieces/pushover/src/index.ts"],
       "@activepieces/piece-rss": ["packages/pieces/rss/src/index.ts"],
       "@activepieces/piece-salesforce": [
         "packages/pieces/salesforce/src/index.ts"


### PR DESCRIPTION
## What does this PR do?

This PR adds support for Pushover notifications.

### Required parameters
- message

### Supported optional parameters
- title
- url
- url_title
- timestamp
- device
- priority (when set to 2, it needs 2 additional parameters set: retry and expire)

### Auth
Pushover uses an API Token plus a User Key (or a Group Key).

More info at https://pushover.net/