### PR TITLE
fix(code): published code artifacts get deletd when draft is edited

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "type": "commonjs"
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -46,7 +46,6 @@ export { FlowRun, FlowRunId, RunEnvironment } from './lib/flow-run/flow-run'
 export { ExecutionState } from './lib/flow-run/execution/execution-state';
 export { Project, ProjectId } from './lib/project/project';
 export * from './lib/flows/dto/create-flow-request';
-export { CloneFlowVersionRequest } from './lib/flows/dto/clone-flow-version-request';
 export { SeekPage, Cursor } from './lib/common/seek-page';
 export { apId, ApId } from './lib/common/id-generator'
 export * from "./lib/flows/trigger-events/trigger-events-dto";

--- a/packages/shared/src/lib/flows/dto/clone-flow-version-request.ts
+++ b/packages/shared/src/lib/flows/dto/clone-flow-version-request.ts
@@ -1,7 +1,0 @@
-import {Trigger} from "../triggers/trigger";
-
-export interface CloneFlowVersionRequest {
-    displayName: string;
-    trigger: Trigger,
-    valid: boolean
-}

--- a/packages/shared/src/lib/flows/flow-helper.ts
+++ b/packages/shared/src/lib/flows/flow-helper.ts
@@ -13,7 +13,7 @@ import {
 } from './actions/action';
 import { Trigger, TriggerType } from './triggers/trigger';
 import { TypeCompiler } from '@sinclair/typebox/compiler';
-import { FlowVersion } from './flow-version';
+import { FlowVersion, FlowVersionState } from './flow-version';
 import { ActivepiecesError, ErrorCode } from '../common/activepieces-error';
 
 const actionSchemaValidator = TypeCompiler.Compile(Action);
@@ -313,6 +313,9 @@ export const flowHelper = {
   ): FlowVersion {
     const clonedVersion: FlowVersion = JSON.parse(JSON.stringify(flowVersion));
     switch (operation.type) {
+      case FlowOperationType.LOCK_FLOW:
+        clonedVersion.state = FlowVersionState.LOCKED;
+        break;
       case FlowOperationType.CHANGE_NAME:
         clonedVersion.displayName = operation.request.displayName;
         break;

--- a/packages/shared/src/lib/flows/flow-operations.ts
+++ b/packages/shared/src/lib/flows/flow-operations.ts
@@ -6,6 +6,7 @@ import { Static, Type } from "@sinclair/typebox";
 
 
 export enum FlowOperationType {
+    LOCK_FLOW = "LOCK_FLOW",
     CHANGE_FOLDER = "CHANGE_FOLDER",
     IMPORT_FLOW = 'IMPORT_FLOW',
     CHANGE_NAME = "CHANGE_NAME",
@@ -22,7 +23,13 @@ export enum StepLocationRelativeToParent {
     INSIDE_LOOP = "INSIDE_LOOP"
 }
 
-const optionalNextAction =Type.Object({ nextAction: Type.Optional(Action) });
+const optionalNextAction = Type.Object({ nextAction: Type.Optional(Action) });
+
+export const LockFlowRequest = Type.Object({
+    flowId: Type.String({})
+})
+
+export type LockFlowRequest = Static<typeof LockFlowRequest>;
 
 export const ImportFlowRequest = Type.Object({
     displayName: Type.String({}),
@@ -64,6 +71,10 @@ export const UpdateTriggerRequest = Type.Union([EmptyTrigger, PieceTrigger, Webh
 export type UpdateTriggerRequest = Static<typeof UpdateTriggerRequest>;
 
 export const FlowOperationRequest = Type.Union([
+    Type.Object({
+        type: Type.Literal(FlowOperationType.LOCK_FLOW),
+        request: LockFlowRequest
+    }),
     Type.Object({
         type: Type.Literal(FlowOperationType.IMPORT_FLOW),
         request: ImportFlowRequest


### PR DESCRIPTION
This PR addresses two issues:

1. Code Artifacts: Currently, when the original draft is modified, the associated code artifacts in published version are deleted. To fix this, the solution involves duplicating the version along with its artifacts when a draft is created.

2. Publishing: The current process of publishing doesn't obtain the update lock, leading to potential issues. To resolve this, an operation that locks the flow during publishing is implemented as the solution.
