### PR TITLE
 changed success to succeeded

### DIFF
--- a/packages/ui/feature-dashboard/src/lib/pages/runs-table/runs-table.component.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/runs-table/runs-table.component.ts
@@ -108,7 +108,7 @@ export class RunsTableComponent implements OnInit {
       case ExecutionOutputStatus.RUNNING:
         return 'Running';
       case ExecutionOutputStatus.SUCCEEDED:
-        return 'Success';
+        return 'Succeeded';
       case ExecutionOutputStatus.FAILED:
         return 'Failed';
       case ExecutionOutputStatus.TIMEOUT:


### PR DESCRIPTION
## What does this PR do?

[BUG]: "Success" to "Succeeded" #1311
closes #1311 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
It's inconsistent with Failed:
![image](https://github.com/activepieces/activepieces/assets/55488549/eb2a1062-f455-49d3-9255-f15af391d53f)

Fixes # (issue)

