### PR TITLE
Fix/remove highlighting for string results

### DIFF
--- a/packages/ui/common/src/lib/components/json-view/json-view-dialog/json-view-dialog.component.html
+++ b/packages/ui/common/src/lib/components/json-view/json-view-dialog/json-view-dialog.component.html
@@ -1,8 +1,9 @@
 <ap-dialog-title-template>{{title}}</ap-dialog-title-template>
 <mat-dialog-content>
     <div class="code-container  ap-min-w-[500px] ap-min-h-[500px] ap-max-h-[500px] ap-max-w-[750px]">
-        <div class="code-area">
-            <pre class="line-numbers ap-max-h-[500px] ap-pb-1"><code class="language-js"
+        <div class="code-area ap-min-w-[500px] ap-min-h-[500px]">
+            <pre class="line-numbers ap-max-h-[500px]  ap-min-w-[500px] ap-min-h-[500px] ap-pb-1"
+                [class.ap-px-4]="!highlight" [class.ap-py-3]="!highlight"><code class="language-js"
                 [innerHTML]="content | outputLog:false"></code></pre>
         </div>
     </div>

--- a/packages/ui/common/src/lib/components/json-view/json-view-dialog/json-view-dialog.component.ts
+++ b/packages/ui/common/src/lib/components/json-view/json-view-dialog/json-view-dialog.component.ts
@@ -16,6 +16,7 @@ import { HighlightService } from '../../../service/highlight.service';
 export class JsonViewDialogComponent implements AfterViewInit {
   title = '';
   content = '';
+  highlight = false;
   constructor(
     @Inject(MAT_DIALOG_DATA) dialogData: { title: string; content: string },
     private highlightService: HighlightService
@@ -24,6 +25,9 @@ export class JsonViewDialogComponent implements AfterViewInit {
     this.content = dialogData.content;
   }
   ngAfterViewInit(): void {
-    this.highlightService.highlightAll();
+    if (typeof this.content !== 'string') {
+      this.highlight = true;
+      this.highlightService.highlightAll();
+    }
   }
 }

--- a/packages/ui/common/src/lib/components/json-view/json-view.component.html
+++ b/packages/ui/common/src/lib/components/json-view/json-view.component.html
@@ -11,7 +11,10 @@
     </div>
   </div>
   <div class="code-area">
-    <pre class="line-numbers ap-pb-1 "><code class="language-js"
+    <pre *ngIf="highlight" class="line-numbers ap-pb-1 "><code class="language-js"
       [innerHTML]="_content | outputLog"></code></pre>
+    <pre *ngIf="!highlight" [innerHTML]="_content" class="ap-px-4 ap-py-3 ap-break-all">
+
+    </pre>
   </div>
 </div>

--- a/packages/ui/common/src/lib/components/json-view/json-view.component.ts
+++ b/packages/ui/common/src/lib/components/json-view/json-view.component.ts
@@ -18,25 +18,20 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 })
 export class JsonViewComponent implements AfterViewInit {
   highlight = false;
+  _content: unknown;
   @Input() isInput = false;
   @Input() title: string;
   @Input() maxHeight: number | undefined = undefined;
-
-  _content: unknown;
   @Input() set content(value: unknown) {
     this.highlight = false;
     this._content = value;
-    if (
-      typeof this._content === 'string' &&
-      this._content !== 'undefined' &&
-      this._content !== '0' &&
-      this._content !== 'null' &&
-      this._content !== JSON.stringify('')
-    ) {
-      this._content = `"${this._content}"`;
+    if (typeof this._content !== 'string') {
+      this.highlight = true;
     }
     setTimeout(() => {
-      this.highlightService.highlightAll();
+      if (this.highlight) {
+        this.highlightService.highlightAll();
+      }
     }, 10);
   }
 
@@ -47,8 +42,7 @@ export class JsonViewComponent implements AfterViewInit {
   ) {}
 
   ngAfterViewInit(): void {
-    if (!this.highlight) {
-      this.highlight = true;
+    if (this.highlight) {
       this.highlightService.highlightAll();
     }
   }
@@ -60,16 +54,7 @@ export class JsonViewComponent implements AfterViewInit {
   }
   copyContent() {
     if (typeof this._content === 'string') {
-      if (
-        this._content !== 'undefined' &&
-        this._content !== '0' &&
-        this._content !== 'null' &&
-        this._content !== JSON.stringify('')
-      ) {
-        copyText(this._content.slice(1, this._content.length - 1));
-      } else {
-        copyText(this._content);
-      }
+      copyText(this._content);
     } else {
       copyText(JSON.stringify(this._content));
     }

--- a/packages/ui/common/src/lib/pipe/output-log.pipe.ts
+++ b/packages/ui/common/src/lib/pipe/output-log.pipe.ts
@@ -43,7 +43,10 @@ export class OutputLogPipe implements PipeTransform {
 
   isJsonString(str: string) {
     try {
-      JSON.parse(str);
+      const result = JSON.parse(str);
+      if (typeof result === 'number') {
+        return false;
+      }
     } catch (e) {
       return false;
     }

--- a/packages/ui/feature-builder-right-sidebar/src/lib/step-type-sidebar/step-type-sidebar.component.html
+++ b/packages/ui/feature-builder-right-sidebar/src/lib/step-type-sidebar/step-type-sidebar.component.html
@@ -2,9 +2,9 @@
   <ap-sidebar-header (closeClicked)="closeSidebar()" [title]="sideBarDisplayName"></ap-sidebar-header>
 
   <ng-container *ngIf="flowItemDetailsLoaded$ | async; else loading">
-    <mat-form-field (click)="$event.stopPropagation();" appearance="outline" class="ap-w-full ap-px-5">
+    <mat-form-field (click)="$event.stopPropagation();" class="ap-w-full ap-px-5">
       <mat-icon matPrefix color="placeholder-icon" svgIcon="search"></mat-icon>
-      <input [formControl]="searchFormControl" matInput placeholder="Search" autocomplete="off">
+      <input #searchInput [formControl]="searchFormControl" matInput placeholder="Search" autocomplete="off">
     </mat-form-field>
     <mat-tab-group #tabGroup>
       <mat-tab *ngFor="let tab of tabsAndTheirLists; let i = index">
@@ -29,3 +29,5 @@
   </ng-template>
 
   <ng-container *ngIf="flowTypeSelected$ |async"></ng-container>
+
+  <ng-container *ngIf="focusSearchInput$ |async"></ng-container>


### PR DESCRIPTION
## What does this PR do?

Removes highlighting for strings, stop considering (string numbers) as (numbers) and focus search input in step type list when trying to replace trigger or add a step.

Tests:
1)
![image](https://github.com/activepieces/activepieces/assets/106555838/ceb49f42-0697-4f76-b59e-699750d46f90)
![image](https://github.com/activepieces/activepieces/assets/106555838/b8eb33f0-2c9f-4816-b352-d0169eb114af)

2)
![image](https://github.com/activepieces/activepieces/assets/106555838/5c8003eb-3da3-4610-9aae-8c4092a58fc5)

3) Clicked on any add button or replace trigger and the input will get focused

