### PR TITLE
Chore/increase sidebar max width

### DIFF
--- a/packages/ui/core/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.scss
+++ b/packages/ui/core/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.scss
@@ -3,7 +3,7 @@
 
 $drawer-min-width: 25.4375rem;
 $drawers-margin: 0.625rem;
-$drawer-max-width: 33.333333vw;
+$drawer-max-width: 47vw;
 
 .canvas {
   background: linear-gradient(

--- a/packages/ui/core/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.ts
+++ b/packages/ui/core/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.ts
@@ -192,6 +192,7 @@ export class CollectionBuilderComponent implements OnInit, OnDestroy {
 
   rightDrawHandleDragStopped() {
     this.rightSidebarDragging = false;
+    this.builderService.refreshCodeMirror$.next();
   }
 
   leftDrawerHandleDragEnded() {

--- a/packages/ui/feature-builder-form-controls/src/lib/code-artifact-form-control/code-artifact-form-control.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/code-artifact-form-control/code-artifact-form-control.component.html
@@ -12,8 +12,9 @@
       </div>
     </div>
 
-    <ngx-codemirror formControlName="content" [options]="codeEditorOptions"></ngx-codemirror>
+    <ngx-codemirror #codeMirror formControlName="content" [options]="codeEditorOptions"></ngx-codemirror>
 
   </div>
 </form>
 <ng-container *ngIf="updateComponentValue$|async"></ng-container>
+<ng-container *ngIf="refreshCodeMirror$ | async"></ng-container>

--- a/packages/ui/feature-builder-form-controls/src/lib/code-artifact-form-control/code-artifact-form-control.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/code-artifact-form-control/code-artifact-form-control.component.ts
@@ -11,6 +11,8 @@ import { Observable, tap } from 'rxjs';
 import { CodeArtifactControlFullscreenComponent } from './code-artifact-control-fullscreen/code-artifact-control-fullscreen.component';
 import { MatTooltip } from '@angular/material/tooltip';
 import { Artifact } from '@activepieces/ui/common';
+import { CodemirrorComponent } from '@ctrl/ngx-codemirror';
+import { CollectionBuilderService } from '@activepieces/ui/feature-builder-store';
 
 export interface CodeArtifactForm {
   content: FormControl<string>;
@@ -38,7 +40,8 @@ export class CodeArtifactFormControlComponent
       package: string;
     }>
   >;
-
+  refreshCodeMirror$: Observable<void>;
+  @ViewChild('codeMirror') codeMirror: CodemirrorComponent;
   @ViewChild('tooltip') tooltip: MatTooltip;
   hideDelayForFullscreenTooltip = 2000;
   codeArtifactForm: FormGroup<CodeArtifactForm>;
@@ -53,12 +56,20 @@ export class CodeArtifactFormControlComponent
   };
   constructor(
     private formBuilder: FormBuilder,
-    private dialogService: MatDialog
+    private dialogService: MatDialog,
+    private builderService: CollectionBuilderService
   ) {
     this.codeArtifactForm = this.formBuilder.group({
       content: new FormControl('', { nonNullable: true }),
       package: new FormControl('', { nonNullable: true }),
     });
+    this.refreshCodeMirror$ = this.builderService.refreshCodeMirror$
+      .asObservable()
+      .pipe(
+        tap(() => {
+          this.codeMirror.codeMirror?.refresh();
+        })
+      );
   }
   ngOnInit(): void {
     this.setupValueListener();

--- a/packages/ui/feature-builder-store/src/lib/service/collection-builder.service.ts
+++ b/packages/ui/feature-builder-store/src/lib/service/collection-builder.service.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 @Injectable({ providedIn: 'root' })
 export class CollectionBuilderService {
   lastSuccessfulSaveDate = '';
+  refreshCodeMirror$ = new Subject<void>();
   componentToShowInsidePortal$ = new Subject<
     ComponentPortal<unknown> | undefined
   >();


### PR DESCRIPTION
## What does this PR do?

Increases the min width of sidebars for people who want to use the editor to write a long piece of text.

CodeMirror becomes unclickable after resizing the containing sidebar, now it gets refreshed after the resizing is done.