### PR TITLE
chore: view draft by default while entering the flow builder

### DIFF
--- a/packages/ui/core/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.ts
+++ b/packages/ui/core/src/app/modules/flow-builder/page/flow-builder/collection-builder.component.ts
@@ -111,9 +111,7 @@ export class CollectionBuilderComponent implements OnInit, OnDestroy {
             BuilderActions.loadInitial({
               flow: routeData.flowAndFolder.flow,
               instance: routeData.instanceData?.instance,
-              viewMode: routeData.instanceData?.instance
-                ? ViewModeEnum.SHOW_PUBLISHED
-                : ViewModeEnum.BUILDING,
+              viewMode: ViewModeEnum.BUILDING,
               appConnections: routeData.connections,
               folder: routeData.flowAndFolder.folder,
               publishedVersion: routeData.instanceData?.publishedFlowVersion,

--- a/packages/ui/feature-builder-store/src/lib/store/builder/canvas/canvas.effects.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/canvas/canvas.effects.ts
@@ -17,9 +17,7 @@ export class CanvasEffects {
       ofType(BuilderActions.loadInitial),
       map((action) => {
         return canvasActions.setInitial({
-          displayedFlowVersion: action.publishedVersion
-            ? action.publishedVersion
-            : action.flow.version,
+          displayedFlowVersion: action.flow.version,
           run: action.run,
         });
       })


### PR DESCRIPTION
## What does this PR do?

Show the draft version by default, when entering the builder instead of the published version, so it doesn't confuse people who edit their flows then refresh.
