### PR TITLE
chore: added open in new tab on middle mouse click and on right clicking flow name

### DIFF
--- a/packages/ui/feature-dashboard/src/lib/pages/flows-table/flows-table.component.html
+++ b/packages/ui/feature-dashboard/src/lib/pages/flows-table/flows-table.component.html
@@ -13,10 +13,13 @@
         <div
           class=" ap-rounded ap-border ap-border-solid ap-border-dividers ap-p-[30px] ap-pb-[80px] ap-flex ap-flex-col">
           <app-flows-table-title></app-flows-table-title>
-          <table mat-table [dataSource]="dataSource" class="ap-w-[100%] " aria-label="Flows">
+          <table mat-table [dataSource]="dataSource" class="ap-w-[100%]" aria-label="Flows">
             <ng-container matColumnDef="name">
               <th mat-header-cell *matHeaderCellDef>Name</th>
-              <td mat-cell *matCellDef="let flow">{{ flow.version.displayName }}</td>
+              <td mat-cell *matCellDef="let flow"><a class="!ap-typography-body-2 !ap-no-underline !ap-text-body"
+                  (auxclick)="$event.stopPropagation()" [href]="'/flows/'+flow.id">
+                  {{ flow.version.displayName }}
+                </a></td>
             </ng-container>
             <ng-container matColumnDef="steps">
               <th mat-header-cell *matHeaderCellDef>Steps</th>
@@ -77,14 +80,17 @@
                         [applyClass]="true"></svg-icon>
                       <span class="ap-text-danger">Delete</span>
                     </div>
-
                   </button>
                 </mat-menu>
             </ng-container>
 
             <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-            <tr class="ap-cursor-pointer hover:!ap-bg-hover" (click)="openBuilder(row, $event)" mat-row
+
+            <tr class="ap-cursor-pointer hover:!ap-bg-hover" (click)="openBuilder(row, $event)"
+              (auxclick)="openBuilder(row, $event)" mat-row contextmenu="mymenu"
               [class.ap-hidden]="dataSource.isLoading$ | async" *matRowDef="let row; columns: displayedColumns"></tr>
+
+
           </table>
           <ng-container *ngIf="dataSource.data.length===0 && (dataSource.isLoading$ | async) === false">
             <div class="ap-flex ap-items-center ap-justify-center ap-my-8  ap-flex-grow">

--- a/packages/ui/feature-dashboard/src/lib/pages/flows-table/flows-table.component.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/flows-table/flows-table.component.ts
@@ -102,7 +102,7 @@ export class FlowsTableComponent implements OnInit {
 
   openBuilder(flow: Flow, event: MouseEvent) {
     const link = '/flows/' + flow.id;
-    if (event.ctrlKey) {
+    if (event.ctrlKey || event.which == 2 || event.button == 4) {
       // Open in new tab
       window.open(link, '_blank', 'noopener');
     } else {


### PR DESCRIPTION
## What does this PR do?

Closes #1250 
Opens flows in a new tab if you middle click on the row, and if you right click on the name you will see "open in new tab".

![image](https://github.com/activepieces/activepieces/assets/106555838/ce3e0254-3906-4dc6-8a6d-906a63730ac3)


