### PR TITLE
fix: hide-instance-information

### DIFF
--- a/packages/backend/src/app/flags/flag.controller.ts
+++ b/packages/backend/src/app/flags/flag.controller.ts
@@ -2,8 +2,11 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { flagService } from './flag.service'
 
 export const flagController = async (app: FastifyInstance) => {
+
     app.get('/', async (_request: FastifyRequest, reply: FastifyReply) => {
-        const flags = await flagService.getAll()
+        const rawToken = _request.headers.authorization
+        const isAuthenticated = !(rawToken === undefined || rawToken === null)
+        const flags = await flagService.getAll(isAuthenticated)
         const flagMap: Record<string, unknown> = {}
         flags.forEach(flag => {
             flagMap[flag.id as string] = flag.value

--- a/packages/backend/src/app/flags/flag.controller.ts
+++ b/packages/backend/src/app/flags/flag.controller.ts
@@ -2,7 +2,6 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { flagService } from './flag.service'
 
 export const flagController = async (app: FastifyInstance) => {
-
     app.get('/', async (_request: FastifyRequest, reply: FastifyReply) => {
         const rawToken = _request.headers.authorization
         const isAuthenticated = !(rawToken === undefined || rawToken === null)

--- a/packages/backend/src/app/flags/flag.service.ts
+++ b/packages/backend/src/app/flags/flag.service.ts
@@ -24,7 +24,7 @@ export const flagService = {
     async getCurrentVersion(): Promise<string> {
         return (await import('../../../../../package.json')).version
     },
-    async getAll(): Promise<Flag[]> {
+    async getAll(isAuthenticated: boolean): Promise<Flag[]> {
         const flags = await flagRepo.find({})
         const now = new Date().toISOString()
         const created = now
@@ -32,7 +32,7 @@ export const flagService = {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const currentVersion = (await import('../../../../../package.json')).version
         const latestVersion = (await this.getCurrentVersion())
-        flags.push(
+        const publicFlags = [
             {
                 id: ApFlagId.ENVIRONMENT,
                 value: system.get(SystemProp.ENVIRONMENT),
@@ -94,6 +94,14 @@ export const flagService = {
                 updated,
             },
             {
+                id: ApFlagId.TEMPLATES_SOURCE_URL,
+                value: system.get(SystemProp.TEMPLATES_SOURCE_URL),
+                created,
+                updated,
+            }
+        ]
+        const privateFlags = [
+            {
                 id: ApFlagId.CURRENT_VERSION,
                 value: currentVersion,
                 created,
@@ -104,14 +112,13 @@ export const flagService = {
                 value: latestVersion,
                 created,
                 updated,
-            },
-            {
-                id: ApFlagId.TEMPLATES_SOURCE_URL,
-                value: system.get(SystemProp.TEMPLATES_SOURCE_URL),
-                created,
-                updated,
-            },
-        )
+            }
+        ]
+        if (isAuthenticated) {
+            flags.push(...publicFlags, ...privateFlags);
+        } else {
+            flags.push(...publicFlags);
+        }
 
         return flags
     },

--- a/packages/backend/src/app/flags/flag.service.ts
+++ b/packages/backend/src/app/flags/flag.service.ts
@@ -98,7 +98,7 @@ export const flagService = {
                 value: system.get(SystemProp.TEMPLATES_SOURCE_URL),
                 created,
                 updated,
-            }
+            },
         ]
         const privateFlags = [
             {
@@ -112,11 +112,12 @@ export const flagService = {
                 value: latestVersion,
                 created,
                 updated,
-            }
+            },
         ]
         if (isAuthenticated) {
             flags.push(...publicFlags, ...privateFlags);
-        } else {
+        } 
+        else {
             flags.push(...publicFlags);
         }
 


### PR DESCRIPTION
## What does this PR do?
In the `/v1/flags` route, the sensitive information regarding the AP instance version is only visible for an authenticated request

Fixes #1209

