### PR TITLE
fix: fixed logos observable in connections table

### DIFF
--- a/packages/ui/feature-dashboard/src/lib/pages/connections-table/connections-table.datasource.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/connections-table/connections-table.datasource.ts
@@ -76,10 +76,11 @@ export class ConnectionsTableDataSource extends DataSource<any> {
         this.paginator.next = res.next;
         this.paginator.previous = res.previous;
         this.data = res.data;
+        console.log(this.data);
       }),
       switchMap((res) => {
         const logos: Observable<string | undefined>[] = res.data.map((item) =>
-          this.pieceMetadataService.getPieceNameLogo(item.appName)
+          this.pieceMetadataService.getPieceNameLogo(item.appName).pipe(take(1))
         );
         return forkJoin(logos).pipe(
           map((logos) => {


### PR DESCRIPTION
## What does this PR do?

Logos in connections table were a list of observables that don't get completed and are used with a forkJoin.
