### PR TITLE
feat: add remove button to optional properties

### DIFF
--- a/packages/ui/feature-builder-form-controls/src/lib/array-form-control/array-form-control.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/array-form-control/array-form-control.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
 import {
   ControlValueAccessor,
   FormArray,
@@ -26,7 +26,7 @@ import { InsertMentionOperation } from '../interpolating-text-form-control/utils
 export class ArrayFormControlComponent implements ControlValueAccessor {
   valueChanges$: Observable<void>;
   formArray: FormArray<FormControl>;
-
+  @ViewChild('textControl') firstInput: InterpolatingTextFormControlComponent;
   onChange: (val: unknown) => void = () => {
     //ignore
   };
@@ -83,5 +83,8 @@ export class ArrayFormControlComponent implements ControlValueAccessor {
     mention: InsertMentionOperation
   ) {
     await textControl.addMention(mention);
+  }
+  focusFirstInput() {
+    this.firstInput.focusEditor();
   }
 }

--- a/packages/ui/feature-builder-form-controls/src/lib/dictionary-form-control/dictionary-form-control.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/dictionary-form-control/dictionary-form-control.component.html
@@ -10,10 +10,10 @@
           #deleteButton="hoverTrackerDirective" (click)="removePair(idx)"></ap-icon-button>
       </div>
 
-      <input #key name="key" class="form-control key-control" [class.first]="isFirst && pairs.controls.length>1"
-        [class.last]="isLast && pairs.controls.length>1" [class.only-one]="pairs.controls.length === 1"
-        formControlName="key" type="text" (keyup)="dictionaryControlValueChanged()" placeholder="Key" apTrackHover
-        #keyInput="hoverTrackerDirective" />
+      <input #key id="key" name="key" class="form-control key-control"
+        [class.first]="isFirst && pairs.controls.length>1" [class.last]="isLast && pairs.controls.length>1"
+        [class.only-one]="pairs.controls.length === 1" formControlName="key" type="text"
+        (keyup)="dictionaryControlValueChanged()" placeholder="Key" apTrackHover #keyInput="hoverTrackerDirective" />
 
       <div class="form-control value-control" [class.first]="isFirst && pairs.controls.length>1"
         [class.last]="isLast && pairs.controls.length>1" [class.only-one]="pairs.controls.length === 1" apTrackHover

--- a/packages/ui/feature-builder-form-controls/src/lib/dictionary-form-control/dictionary-form-control.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/dictionary-form-control/dictionary-form-control.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import {
   ControlValueAccessor,
   UntypedFormArray,
@@ -30,6 +30,8 @@ export class DictionaryFormControlComponent
   form!: UntypedFormGroup;
   disabled = false;
   valueChanges$: Observable<void>;
+  @ViewChild('key', { read: ElementRef })
+  firstKeyInput: ElementRef<HTMLInputElement>;
   onChange: (val: unknown) => void = (val) => {
     val;
   };
@@ -133,5 +135,8 @@ export class DictionaryFormControlComponent
       $event.stopImmediatePropagation();
     }
     mentionsDropdown.showMenuSubject$.next(true);
+  }
+  focusFirstKeyInput() {
+    this.firstKeyInput.nativeElement.focus();
   }
 }

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -28,7 +28,6 @@
     <ng-container *ngTemplateOutlet="formFieldsTemplate;context:{$implicit:property, propertyIndex:i, formGroup:form}">
     </ng-container>
   </div>
-
 </form>
 
 <ng-template let-property let-propertyIndex="propertyIndex" #formFieldsTemplate let-formGroup="formGroup">
@@ -41,9 +40,13 @@
       </ng-container>
 
       <ng-template #checkboxInputTemplate>
-        <div class="ap-flex ap-mb-[20px] ap-mr-[5px]">
+        <div class="ap-flex ap-mb-[20px] ap-mr-[5px] ap-items-center ap-gap-2">
+
           <mat-slide-toggle [formControlName]="property.key" color="primary"
             [matTooltip]="property.value.description">{{property.value.displayName}}</mat-slide-toggle>
+          <svg-icon (click)="removeConfig(property.key)" src="/assets/img/custom/close.svg"
+            *ngIf="!property.value.required" class="ap-w-[13px] ap-h-[13px] ap-cursor-pointer ap-mt-[1px]"
+            [applyClass]="true"></svg-icon>
           <div class="ap-flex-grow"></div>
           <div class="ap-cursor-pointer">
             <ng-container

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -55,10 +55,10 @@
         </div>
       </ng-template>
       <ng-template #dynamicValueTemplate let-property>
-        <span class="ap-float-right ap-mb-1 ap-mr-1 ap-text-primary ap-cursor-pointer">
+        <div class="ap-flex ap-justify-end ap-mb-1 ap-mr-1 ap-text-primary">
           <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
           </ng-container>
-        </span>
+        </div>
         <ng-container>
           <ng-container *ngTemplateOutlet="textInputTemplate;context:{$implicit:property, formGroup:formGroup}">
           </ng-container>
@@ -74,17 +74,17 @@
 
     <ng-container *ngSwitchCase="PropertyType.DROPDOWN">
       <div>
-        <span class="ap-float-right ap-mb-1 ap-mr-1 ap-text-primary ap-cursor-pointer">
-          <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
+        <div class="ap-flex ap-justify-end ap-mb-1 ap-mr-1 ap-text-primary ">
+          <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property}">
           </ng-container>
-        </span>
+        </div>
         <ng-container
           *ngTemplateOutlet="customizedInputs && customizedInputs[property.key]? textInputTemplate:dropdownInputTemplate ;context:{$implicit:property, formGroup:formGroup}">
         </ng-container>
         <ng-template #dropdownInputTemplate>
           <div class="ap-relative">
             <div class="ap-absolute -ap-left-[20px]"
-              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2+6.5+'px'">
+              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2-15+'px'">
               <ng-container
                 *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
             </div>
@@ -118,7 +118,7 @@
     </ng-container>
     <ng-container *ngSwitchCase="PropertyType.MULTI_SELECT_DROPDOWN">
       <div>
-        <span class="ap-float-right ap-mb-1 ap-mr-1 ap-text-primary ap-cursor-pointer">
+        <span class="ap-flex ap-justify-end ap-mb-1 ap-mr-1 ap-text-primary r">
           <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
           </ng-container>
         </span>
@@ -128,7 +128,7 @@
         <ng-template #multiDropdownInputTemplate>
           <div class="ap-relative">
             <div class="ap-absolute -ap-left-[20px]"
-              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2+6.5+'px'">
+              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2-15+'px'">
 
               <ng-container
                 *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
@@ -174,17 +174,17 @@
 
     <ng-container *ngSwitchCase="PropertyType.STATIC_DROPDOWN">
       <div>
-        <span class="ap-float-right ap-mb-1 ap-mr-1 ap-text-primary ap-cursor-pointer">
+        <div class="ap-mb-1 ap-mr-1 ap-text-primary ap-flex ap-justify-end">
           <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
           </ng-container>
-        </span>
+        </div>
         <ng-container
           *ngTemplateOutlet="customizedInputs && customizedInputs[property.key]? textInputTemplate:staticDropdownInputTemplate ;context:{$implicit:property, formGroup:formGroup}">
         </ng-container>
         <ng-template #staticDropdownInputTemplate>
           <div class="ap-relative">
             <div class="ap-absolute -ap-left-[20px]"
-              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2 + 6.5+'px'">
+              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2 -15 +'px'">
               <ng-container
                 *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
             </div>
@@ -210,7 +210,7 @@
 
     <ng-container *ngSwitchCase="PropertyType.STATIC_MULTI_SELECT_DROPDOWN">
       <div>
-        <span class="ap-float-right ap-mb-1 ap-mr-1 ap-text-primary ap-cursor-pointer">
+        <span class="ap-flex ap-justify-end ap-mb-1 ap-mr-1 ap-text-primary ">
           <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
           </ng-container>
         </span>
@@ -220,7 +220,7 @@
         <ng-template #staticMultiSelectDropdownInputTemplate>
           <div class="ap-relative">
             <div class="ap-absolute -ap-left-[20px]"
-              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2 + 6.5+'px'">
+              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2 - 15 +'px'">
               <ng-container
                 *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
             </div>
@@ -245,7 +245,7 @@
 
 
     <ng-container *ngSwitchCase="PropertyType.ARRAY">
-      <span class="ap-float-right ap-mb-1 ap-mr-1 ap-text-primary ap-cursor-pointer">
+      <span class="ap-flex ap-justify-end ap-mr-1 ap-text-primary">
         <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
         </ng-container>
       </span>
@@ -266,7 +266,7 @@
 
     </ng-container>
     <ng-container *ngSwitchCase="PropertyType.OBJECT">
-      <span class="ap-float-right ap-mb-1 ap-mr-1 ap-text-primary ap-cursor-pointer">
+      <span class="ap-justify-end ap-flex ap-mb-1 ap-mr-1 ap-text-primary ">
         <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
         </ng-container>
       </span>
@@ -292,12 +292,11 @@
 
     <ng-container
       *ngIf="property.value.type === PropertyType.OAUTH2 || property.value.type === PropertyType.SECRET_TEXT || property.value.type === PropertyType.BASIC_AUTH || property.value.type === PropertyType.CUSTOM_AUTH">
-      <div class="ap-flex">
-        <div class="ap-flex-grow"></div>
-        <div class="ap-cursor-pointer">
-          <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
-          </ng-container>
-        </div>
+      <div class="ap-flex ap-justify-end">
+
+        <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
+        </ng-container>
+
       </div>
 
       <ng-container
@@ -306,7 +305,7 @@
       <ng-template #connectionDropdownInputTemplate>
         <div class="ap-relative">
           <div class="ap-absolute -ap-left-[20px]"
-            [style.top]="dropdown._elementRef.nativeElement.clientHeight/2 - 13+'px'">
+            [style.top]="dropdown._elementRef.nativeElement.clientHeight/2 - 15+'px'">
             <ng-container
               *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
           </div>
@@ -358,12 +357,9 @@
 
     </ng-container>
     <ng-container *ngSwitchCase="PropertyType.JSON">
-      <div class="ap-flex">
-        <div class="ap-flex-grow"></div>
-        <span class="ap-mb-1 ap-mr-1 ap-text-primary ap-cursor-pointer">
-          <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
-          </ng-container>
-        </span>
+      <div class="ap-flex ap-justify-end">
+        <ng-container *ngTemplateOutlet="customizedInputs? dynamicVariableIcon: null; context:{$implicit:property} ">
+        </ng-container>
       </div>
 
       <ng-container
@@ -441,7 +437,7 @@
 
   <div [formGroup]="formGroup" #interpolatingTextComponentContainer (click)="$event.stopImmediatePropagation()"
     class="ap-relative" apTrackHover #textInputContainer="hoverTrackerDirective">
-    <div class="ap-absolute -ap-left-[20px]" [style.top]="textInput._elementRef.nativeElement.clientHeight/2-10+'px'">
+    <div class="ap-absolute -ap-left-[20px]" [style.top]="textInput._elementRef.nativeElement.clientHeight/2-15+'px'">
       <ng-container
         *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:textInputContainer}"></ng-container>
     </div>
@@ -464,8 +460,8 @@
 
 
 <ng-template #dynamicVariableIcon let-config>
-  <svg-icon [svgStyle]="{width:'22px', height:'22px'}" *ngIf="form.enabled" class="ap-mb-[3px]" apTrackHover
-    [class.!ap-opacity-100]="hoverTracker.isHovered" #hoverTracker="hoverTrackerDirective"
+  <svg-icon [svgStyle]="{width:'22px', height:'22px'}" *ngIf="form.enabled" class="ap-mb-[3px] ap-cursor-pointer"
+    apTrackHover [class.!ap-opacity-100]="hoverTracker.isHovered" #hoverTracker="hoverTrackerDirective"
     [class.ap-opacity-40]="customizedInputs && !customizedInputs[config.key]" src="assets/img/custom/variable.svg"
     matTooltip="Dynamic Value" (click)="toggleCustomizedInputFlag(config.key)">
   </svg-icon>

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -365,10 +365,12 @@
 
       <ng-template #jsonInputTemplate>
         <div class="code-font-sm code-size-200 code-block" #interpolatingTextControlContainer
-          (click)="$event.stopImmediatePropagation()">
+          #hoverContainer="hoverTrackerDirective" apTrackHover (click)="$event.stopImmediatePropagation()">
           <div class="ap-py-2 ap-px-4 ap-flex bar-containing-beautify-button">
             <div class="ap-flex-grow">
-              <span class="ap-text-white">{{property.value.displayName}}</span>
+              <span class="ap-text-white ap-flex ap-gap-2 ap-items-center">{{property.value.displayName}} <ng-container
+                  *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:hoverContainer, isWhite:true}"></ng-container>
+              </span>
             </div>
             <div>
               <svg-icon src="/assets/img/custom/beautify.svg" [svgStyle]="{width:'16px', height:'16px'}"
@@ -465,9 +467,10 @@
 <ng-container *ngIf="setDefaultValue$ | async"></ng-container>
 
 
-<ng-template #removeOptionalPropertyIcon let-property let-propertyUiContainer="propertyUiContainer">
+<ng-template #removeOptionalPropertyIcon let-property let-propertyUiContainer="propertyUiContainer"
+  let-isWhite="isWhite">
   <svg-icon (click)="removeConfig(property.key)" src="/assets/img/custom/close.svg" apTrackHover
     #removeIcon="hoverTrackerDirective" *ngIf="!property.value.required && form.enabled"
-    class="ap-w-[13px] ap-h-[13px] ap-cursor-pointer ap-mt-[1px]"
+    class="ap-w-[13px] ap-h-[13px] !ap-cursor-pointer ap-mt-[1px]" [class.ap-fill-white]="isWhite"
     [class.ap-opacity-0]="!removeIcon.isHovered && !propertyUiContainer.isHovered" [applyClass]="true"></svg-icon>
 </ng-template>

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -443,7 +443,7 @@
       </mat-error>
     </mat-form-field>
     <app-builder-autocomplete-mentions-dropdown #mentionsDropdown (menuClosed)="textControl.focusEditor()"
-      [container]="interpolatingTextComponentContainer" marginTop="-20px"
+      [container]="interpolatingTextComponentContainer" marginTop="-20px" width="100%"
       (addMention)="addMention(textControl,$event)"></app-builder-autocomplete-mentions-dropdown>
   </div>
 </ng-template>
@@ -462,7 +462,7 @@
 
 <ng-template #removeOptionalPropertyIcon let-property let-propertyUiContainer="propertyUiContainer">
   <svg-icon (click)="removeConfig(property.key)" src="/assets/img/custom/close.svg" apTrackHover
-    #removeIcon="hoverTrackerDirective" *ngIf="!property.value.required"
+    #removeIcon="hoverTrackerDirective" *ngIf="!property.value.required && form.enabled"
     class="ap-w-[13px] ap-h-[13px] ap-cursor-pointer ap-mt-[1px]"
     [class.ap-opacity-0]="!removeIcon.isHovered && !propertyUiContainer.isHovered" [applyClass]="true"></svg-icon>
 </ng-template>

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -256,10 +256,11 @@
       <ng-template #arrayInputTemplate>
         <div [class.ap-mb-5]="form.disabled" #hoverContainer="hoverTrackerDirective" apTrackHover>
           <div class="ap-mb-2 ap-flex ap-gap-2 ap-items-center" [matTooltip]="property.value.description">
-            <div class="ap-pointer-events-none">{{property.value.displayName}} </div><ng-container
+            <div class="ap-cursor-pointer" (click)="array.focusFirstInput()">{{property.value.displayName}}
+            </div><ng-container
               *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:hoverContainer}"></ng-container>
           </div>
-          <app-array-form-control [formControlName]="property.key"></app-array-form-control>
+          <app-array-form-control #array [formControlName]="property.key"></app-array-form-control>
         </div>
       </ng-template>
 
@@ -277,10 +278,12 @@
       <ng-template #objectInputTemplate>
         <div [class.ap-mb-5]="form.disabled" #hoverContainer="hoverTrackerDirective" apTrackHover>
           <div class="ap-mb-2 ap-flex ap-gap-2 ap-items-center" [matTooltip]="property.value.description">
-            <div class="ap-pointer-events-none">{{property.value.displayName}} </div> <ng-container
+            <div class="ap-cursor-pointer" (click)="dictonary.focusFirstKeyInput()">{{property.value.displayName}}
+            </div>
+            <ng-container
               *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:hoverContainer}"></ng-container>
           </div>
-          <app-dictonary-form-control [formControlName]="property.key"></app-dictonary-form-control>
+          <app-dictonary-form-control #dictonary [formControlName]="property.key"></app-dictonary-form-control>
         </div>
       </ng-template>
 
@@ -473,8 +476,9 @@
 
 <ng-template #removeOptionalPropertyIcon let-property let-propertyUiContainer="propertyUiContainer"
   let-isWhite="isWhite">
-  <svg-icon (click)="removeConfig(property.key)" src="/assets/img/custom/close.svg" apTrackHover
-    #removeIcon="hoverTrackerDirective" *ngIf="!property.value.required && form.enabled"
-    class="ap-w-[13px] ap-h-[13px] !ap-cursor-pointer ap-mt-[1px]" [class.ap-fill-white]="isWhite"
-    [class.ap-opacity-0]="!removeIcon.isHovered && !propertyUiContainer.isHovered" [applyClass]="true"></svg-icon>
+  <svg-icon [matTooltip]="'Remove ' + property.value.displayName" (click)="removeConfig(property.key)"
+    src="/assets/img/custom/close.svg" apTrackHover #removeIcon="hoverTrackerDirective"
+    *ngIf="!property.value.required && form.enabled" class="ap-w-[13px] ap-h-[13px] !ap-cursor-pointer ap-mt-[1px]"
+    [class.ap-fill-white]="isWhite" [class.ap-opacity-0]="!removeIcon.isHovered && !propertyUiContainer.isHovered"
+    [applyClass]="true"></svg-icon>
 </ng-template>

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -298,6 +298,11 @@
       </ng-container>
       <ng-template #connectionDropdownInputTemplate>
         <div class="ap-relative">
+          <div class="ap-absolute -ap-left-[20px]"
+            [style.top]="dropdown._elementRef.nativeElement.clientHeight/2 - 13+'px'">
+            <ng-container
+              *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
+          </div>
           <app-add-edit-connection-button class="edit-selected-auth ap-z-40"
             *ngIf="formGroup.enabled && formGroup.get(property.key)!.value" btnSize="extraSmall"
             [isEditConnectionButton]="true" [authProperty]="property.value" [pieceName]="pieceName"
@@ -306,7 +311,8 @@
             (connectionPropertyValueChanged)="connectionValueChanged($event)" [triggerName]="actionOrTriggerName">
             Edit
           </app-add-edit-connection-button>
-          <mat-form-field class="ap-w-full" appearance="outline">
+          <mat-form-field class="ap-w-full" appearance="outline" #dropdown #dropdownUiContainer="hoverTrackerDirective"
+            apTrackHover>
             <mat-label> {{ property.value.displayName }} </mat-label>
             <mat-select [formControlName]="property.key" [compareWith]="dropdownCompareWithFunction">
               <mat-option *ngFor="let opt of ((allAuthConfigs$ | async)!| authConfigsForPiece:pieceName)"
@@ -392,7 +398,6 @@
       <ng-container *ngIf="(refreshableConfigsLoadingFlags$[property.key] | async) === false ||
         (refreshableConfigsLoadingFlags$[property.key] | async) === undefined ||
         (refreshableConfigsLoadingFlags$[property.key] | async) === null; else loading">
-
         <div class="ap-flex ap-flex-col ap-gap-2">
           <div *ngFor="let cp of (dynamicPropsObservables$[property.key] | async)| objectToArray; let i = index">
             <ng-container

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -82,26 +82,35 @@
           *ngTemplateOutlet="customizedInputs && customizedInputs[property.key]? textInputTemplate:dropdownInputTemplate ;context:{$implicit:property, formGroup:formGroup}">
         </ng-container>
         <ng-template #dropdownInputTemplate>
-          <mat-form-field class="ap-w-full" appearance="outline">
-            <mat-label> {{ (refreshableConfigsLoadingFlags$[property.key] | async)? 'Loading...' :
-              property.value.displayName
-              }}</mat-label>
-            <mat-select [formControlName]="property.key" [compareWith]="dropdownCompareWithFunction">
-              <ng-container *ngIf="dropdownOptionsObservables$[property.key]| async as state">
+          <div class="ap-relative">
+            <div class="ap-absolute -ap-left-[20px]"
+              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2+6.5+'px'">
+              <ng-container
+                *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
+            </div>
+            <mat-form-field class="ap-w-full" appearance="outline" #dropdown
+              #dropdownUiContainer="hoverTrackerDirective" apTrackHover>
+              <mat-label> {{ (refreshableConfigsLoadingFlags$[property.key] | async)? 'Loading...' :
+                property.value.displayName
+                }}</mat-label>
+              <mat-select [formControlName]="property.key" [compareWith]="dropdownCompareWithFunction">
+                <ng-container *ngIf="dropdownOptionsObservables$[property.key]| async as state">
 
-                <mat-option *ngFor="let opt of state.options" [value]="opt.value">
-                  {{opt.label}}
-                </mat-option>
-                <mat-option [disabled]="true"
-                  *ngIf="state.disabled && ((refreshableConfigsLoadingFlags$[property.key] | async) === false || !refreshableConfigsLoadingFlags$[property.key])">
-                  <div> {{state.placeholder}} </div>
-                </mat-option>
-              </ng-container>
-            </mat-select>
-            <mat-error *ngIf="formGroup.get(property.key)?.invalid">
-              {{property.value.displayName}} is required
-            </mat-error>
-          </mat-form-field>
+                  <mat-option *ngFor="let opt of state.options" [value]="opt.value">
+                    {{opt.label}}
+                  </mat-option>
+                  <mat-option [disabled]="true"
+                    *ngIf="state.disabled && ((refreshableConfigsLoadingFlags$[property.key] | async) === false || !refreshableConfigsLoadingFlags$[property.key])">
+                    <div> {{state.placeholder}} </div>
+                  </mat-option>
+                </ng-container>
+              </mat-select>
+              <mat-error *ngIf="formGroup.get(property.key)?.invalid">
+                {{property.value.displayName}} is required
+              </mat-error>
+            </mat-form-field>
+          </div>
+
         </ng-template>
 
       </div>
@@ -117,35 +126,45 @@
           *ngTemplateOutlet="customizedInputs && customizedInputs[property.key]? textInputTemplate:multiDropdownInputTemplate ;context:{$implicit:property, formGroup:formGroup}">
         </ng-container>
         <ng-template #multiDropdownInputTemplate>
-          <mat-form-field class="ap-w-full" appearance="outline">
-            <mat-label> {{ (refreshableConfigsLoadingFlags$[property.key] | async)? 'Loading...' :
-              property.value.displayName
-              }}</mat-label>
-            <mat-select
-              [style.display]="((dropdownOptionsObservables$[property.key] | async) === undefined || (dropdownOptionsObservables$[property.key] | async) === null ||  (dropdownOptionsObservables$[property.key] | async)?.disabled === true)? 'none':'block' "
-              multiple [formControlName]="property.key" [compareWith]="dropdownCompareWithFunction">
-              <ng-container *ngIf="dropdownOptionsObservables$[property.key]| async as state">
+          <div class="ap-relative">
+            <div class="ap-absolute -ap-left-[20px]"
+              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2+6.5+'px'">
 
-                <mat-option *ngFor="let opt of state.options" [value]="opt.value">
-                  {{opt.label}}
-                </mat-option>
-              </ng-container>
-            </mat-select>
-            <ng-container
-              *ngIf="!!(dropdownOptionsObservables$[property.key] | async) &&  (dropdownOptionsObservables$[property.key] | async)?.disabled === true; ">
-              <mat-select [formControlName]="property.key" [compareWith]="dropdownCompareWithFunction">
+              <ng-container
+                *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
+            </div>
+            <mat-form-field class="ap-w-full" appearance="outline" #dropdown
+              #dropdownUiContainer="hoverTrackerDirective" apTrackHover>
+              <mat-label> {{ (refreshableConfigsLoadingFlags$[property.key] | async)? 'Loading...' :
+                property.value.displayName
+                }}</mat-label>
+              <mat-select
+                [style.display]="((dropdownOptionsObservables$[property.key] | async) === undefined || (dropdownOptionsObservables$[property.key] | async) === null ||  (dropdownOptionsObservables$[property.key] | async)?.disabled === true)? 'none':'block' "
+                multiple [formControlName]="property.key" [compareWith]="dropdownCompareWithFunction">
                 <ng-container *ngIf="dropdownOptionsObservables$[property.key]| async as state">
-                  <mat-option [disabled]="true"
-                    *ngIf="state.disabled && ((refreshableConfigsLoadingFlags$[property.key] | async) === false || !refreshableConfigsLoadingFlags$[property.key])">
-                    <div> {{state.placeholder}} </div>
+
+                  <mat-option *ngFor="let opt of state.options" [value]="opt.value">
+                    {{opt.label}}
                   </mat-option>
                 </ng-container>
               </mat-select>
-            </ng-container>
-            <mat-error *ngIf="formGroup.get(property.key)?.invalid">
-              {{property.value.displayName}} is required
-            </mat-error>
-          </mat-form-field>
+              <ng-container
+                *ngIf="!!(dropdownOptionsObservables$[property.key] | async) &&  (dropdownOptionsObservables$[property.key] | async)?.disabled === true; ">
+                <mat-select [formControlName]="property.key" [compareWith]="dropdownCompareWithFunction">
+                  <ng-container *ngIf="dropdownOptionsObservables$[property.key]| async as state">
+                    <mat-option [disabled]="true"
+                      *ngIf="state.disabled && ((refreshableConfigsLoadingFlags$[property.key] | async) === false || !refreshableConfigsLoadingFlags$[property.key])">
+                      <div> {{state.placeholder}} </div>
+                    </mat-option>
+                  </ng-container>
+                </mat-select>
+              </ng-container>
+              <mat-error *ngIf="formGroup.get(property.key)?.invalid">
+                {{property.value.displayName}} is required
+              </mat-error>
+            </mat-form-field>
+          </div>
+
         </ng-template>
 
       </div>
@@ -163,18 +182,26 @@
           *ngTemplateOutlet="customizedInputs && customizedInputs[property.key]? textInputTemplate:staticDropdownInputTemplate ;context:{$implicit:property, formGroup:formGroup}">
         </ng-container>
         <ng-template #staticDropdownInputTemplate>
-          <mat-form-field class="ap-w-full" appearance="outline">
-            <mat-label> {{ property.value.displayName }} </mat-label>
-            <mat-select [matTooltip]="property.value.description" [formControlName]="property.key"
-              [compareWith]="dropdownCompareWithFunction">
-              <mat-option *ngFor="let opt of property.value.options.options" [value]="opt.value">
-                {{opt.label}}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="formGroup.get(property.key)?.invalid">
-              {{property.value.displayName}} is required
-            </mat-error>
-          </mat-form-field>
+          <div class="ap-relative">
+            <div class="ap-absolute -ap-left-[20px]"
+              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2 + 6.5+'px'">
+              <ng-container
+                *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
+            </div>
+            <mat-form-field class="ap-w-full" appearance="outline" apTrackHover
+              #dropdownUiContainer="hoverTrackerDirective" #dropdown>
+              <mat-label> {{ property.value.displayName }} </mat-label>
+              <mat-select [matTooltip]="property.value.description" [formControlName]="property.key"
+                [compareWith]="dropdownCompareWithFunction">
+                <mat-option *ngFor="let opt of property.value.options.options" [value]="opt.value">
+                  {{opt.label}}
+                </mat-option>
+              </mat-select>
+              <mat-error *ngIf="formGroup.get(property.key)?.invalid">
+                {{property.value.displayName}} is required
+              </mat-error>
+            </mat-form-field>
+          </div>
         </ng-template>
 
       </div>
@@ -191,18 +218,27 @@
           *ngTemplateOutlet="customizedInputs && customizedInputs[property.key]? textInputTemplate:staticMultiSelectDropdownInputTemplate ;context:{$implicit:property, formGroup:formGroup}">
         </ng-container>
         <ng-template #staticMultiSelectDropdownInputTemplate>
-          <mat-form-field class="ap-w-full" appearance="outline">
-            <mat-label> {{ property.value.displayName }} </mat-label>
-            <mat-select [matTooltip]="property.value.description" [formControlName]="property.key" multiple
-              [compareWith]="dropdownCompareWithFunction">
-              <mat-option *ngFor="let opt of property.value.options.options" [value]="opt.value">
-                {{opt.label}}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="formGroup.get(property.key)?.invalid">
-              {{property.value.displayName}} is required
-            </mat-error>
-          </mat-form-field>
+          <div class="ap-relative">
+            <div class="ap-absolute -ap-left-[20px]"
+              [style.top]="dropdown._elementRef.nativeElement.clientHeight/2 + 6.5+'px'">
+              <ng-container
+                *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:dropdownUiContainer}"></ng-container>
+            </div>
+            <mat-form-field #dropdown class="ap-w-full" appearance="outline"
+              #dropdownUiContainer="hoverTrackerDirective" apTrackHover>
+              <mat-label> {{ property.value.displayName }} </mat-label>
+              <mat-select [matTooltip]="property.value.description" [formControlName]="property.key" multiple
+                [compareWith]="dropdownCompareWithFunction">
+                <mat-option *ngFor="let opt of property.value.options.options" [value]="opt.value">
+                  {{opt.label}}
+                </mat-option>
+              </mat-select>
+              <mat-error *ngIf="formGroup.get(property.key)?.invalid">
+                {{property.value.displayName}} is required
+              </mat-error>
+            </mat-form-field>
+          </div>
+
         </ng-template>
       </div>
     </ng-container>

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -254,9 +254,11 @@
       </ng-container>
 
       <ng-template #arrayInputTemplate>
-        <div [class.ap-mb-5]="form.disabled">
-          <div class="ap-mb-2 ap-pointer-events-none" [matTooltip]="property.value.description">
-            {{property.value.displayName}}</div>
+        <div [class.ap-mb-5]="form.disabled" #hoverContainer="hoverTrackerDirective" apTrackHover>
+          <div class="ap-mb-2 ap-flex ap-gap-2 ap-items-center" [matTooltip]="property.value.description">
+            <div class="ap-pointer-events-none">{{property.value.displayName}} </div><ng-container
+              *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:hoverContainer}"></ng-container>
+          </div>
           <app-array-form-control [formControlName]="property.key"></app-array-form-control>
         </div>
       </ng-template>
@@ -273,9 +275,11 @@
       </ng-container>
 
       <ng-template #objectInputTemplate>
-        <div [class.ap-mb-5]="form.disabled">
-          <div class="ap-mb-2 ap-pointer-events-none" [matTooltip]="property.value.description">
-            {{property.value.displayName}}</div>
+        <div [class.ap-mb-5]="form.disabled" #hoverContainer="hoverTrackerDirective" apTrackHover>
+          <div class="ap-mb-2 ap-flex ap-gap-2 ap-items-center" [matTooltip]="property.value.description">
+            <div class="ap-pointer-events-none">{{property.value.displayName}} </div> <ng-container
+              *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:hoverContainer}"></ng-container>
+          </div>
           <app-dictonary-form-control [formControlName]="property.key"></app-dictonary-form-control>
         </div>
       </ng-template>

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -42,11 +42,10 @@
       <ng-template #checkboxInputTemplate>
         <div class="ap-flex ap-mb-[20px] ap-mr-[5px] ap-items-center ap-gap-2">
 
-          <mat-slide-toggle [formControlName]="property.key" color="primary"
-            [matTooltip]="property.value.description">{{property.value.displayName}}</mat-slide-toggle>
-          <svg-icon (click)="removeConfig(property.key)" src="/assets/img/custom/close.svg"
-            *ngIf="!property.value.required" class="ap-w-[13px] ap-h-[13px] ap-cursor-pointer ap-mt-[1px]"
-            [applyClass]="true"></svg-icon>
+          <mat-slide-toggle apTrackHover #slider="hoverTrackerDirective" [formControlName]="property.key"
+            color="primary" [matTooltip]="property.value.description">{{property.value.displayName}}</mat-slide-toggle>
+          <ng-container
+            *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:slider}"></ng-container>
           <div class="ap-flex-grow"></div>
           <div class="ap-cursor-pointer">
             <ng-container
@@ -389,8 +388,14 @@
 <ng-container *ngIf="configDropdownChanged$  | keyvalue"></ng-container>
 
 <ng-template #textInputTemplate let-property let-formGroup="formGroup">
-  <div [formGroup]="formGroup" #interpolatingTextComponentContainer (click)="$event.stopImmediatePropagation()">
-    <mat-form-field class="ap-w-full" appearance="outline"
+
+  <div [formGroup]="formGroup" #interpolatingTextComponentContainer (click)="$event.stopImmediatePropagation()"
+    class="ap-relative" apTrackHover #textInputContainer="hoverTrackerDirective">
+    <div class="ap-absolute -ap-left-[20px]" [style.top]="textInput._elementRef.nativeElement.clientHeight/2-10+'px'">
+      <ng-container
+        *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:textInputContainer}"></ng-container>
+    </div>
+    <mat-form-field class="ap-w-full" appearance="outline" #textInput
       (click)="isTriggerPieceForm?null: mentionsDropdown.showMenuSubject$.next(true)">
       <mat-label>{{property.value.displayName}}</mat-label>
       <app-interpolating-text-form-control #textControl [matTooltip]="property.value.description"
@@ -417,3 +422,11 @@
 </ng-template>
 
 <ng-container *ngIf="setDefaultValue$ | async"></ng-container>
+
+
+<ng-template #removeOptionalPropertyIcon let-property let-propertyUiContainer="propertyUiContainer">
+  <svg-icon (click)="removeConfig(property.key)" src="/assets/img/custom/close.svg" apTrackHover
+    #removeIcon="hoverTrackerDirective" *ngIf="!property.value.required"
+    class="ap-w-[13px] ap-h-[13px] ap-cursor-pointer ap-mt-[1px]"
+    [class.ap-opacity-0]="!removeIcon.isHovered && !propertyUiContainer.isHovered" [applyClass]="true"></svg-icon>
+</ng-template>

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
@@ -178,7 +178,7 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
         this.requiredProperties[pk] = this.properties[pk];
       } else {
         this.allOptionalProperties[pk] = this.properties[pk];
-        if (propertiesValues[pk]) {
+        if (propertiesValues[pk] !== undefined) {
           this.selectedOptionalProperties[pk] = this.properties[pk];
         }
       }

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
@@ -416,7 +416,6 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
         );
       }
     });
-
     return controls;
   }
   getControl(configKey: string) {
@@ -450,7 +449,8 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
         new UntypedFormControl(
           property.defaultValue
             ? JSON.stringify(property.defaultValue, null, 2)
-            : undefined
+            : '',
+          [jsonValidator]
         )
       );
     }

--- a/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
@@ -428,19 +428,19 @@ const selectAppConnectionsForMentionsDropdown = createSelector(
 
 const selectAllStepsForMentionsDropdown = createSelector(
   selectCurrentStep,
-  selectCurrentFlow,
+  selectShownFlowVersion,
   selectAllFlowItemsDetails,
   (
     currentStep,
-    flow,
+    flowVersion,
     flowItemDetails
   ): (MentionListItem & { step: FlowItem })[] => {
-    if (!currentStep || !flow || !flow.version || !flow.version.trigger) {
+    if (!currentStep || !flowVersion || !flowVersion.trigger) {
       return [];
     }
     const path = FlowStructureUtil.findPathToStep(
       currentStep,
-      flow?.version?.trigger
+      flowVersion?.trigger
     );
     return path.map((s) => {
       return {


### PR DESCRIPTION
## What does this PR do?

Closes #1082.

Property types tested:
1)Any singular property using the textTemplate.
2)All dropdowns including multiselect and static versions.
3)Authentication dropdown.
4)Dictionary.
5)Array. 
6)Checkbox (slide toggle)
7)JSON.

I haven't accounted for optional dynamic properties, as I don't know how to handle removing a refresher atm.
I have this suggestion:
1)Make compilation of pieces throw an error if an optional dynamic property is used.
2)Throw an error if a refresher is an optional property, so basically any optional property should have an empty array of refreshers if it is of type (dropdown, multiselect dropdown or dynamic) .