### PR TITLE
fix: replaced image.png with the correct text

### DIFF
--- a/packages/ui/feature-builder-right-sidebar/src/lib/edit-step-sidebar/edit-step-form-container/edit-step-form-container.component.html
+++ b/packages/ui/feature-builder-right-sidebar/src/lib/edit-step-sidebar/edit-step-form-container/edit-step-form-container.component.html
@@ -14,7 +14,7 @@
               </mat-form-field>
 
               <ap-markdown [fullWidth]="true"
-                data="If you are expecting a reply from image.png, append <b>/sync</b> to the URL.<br> <br>
+                data="If you are expecting a reply from this webhook, append <b>/sync</b> to the URL.<br> <br>
                   In that case, you will also have to add an <b>HTTP step</b>  with return response to the end of your flow."></ap-markdown>
             </section>
           </ng-container>


### PR DESCRIPTION
## What does this PR do?

Fixed typo in webhook trigger markdown.

