### PR TITLE
feat: Disable taking sample data by default from piece triggers

### DIFF
--- a/packages/ui/core/src/assets/scss/ng-material-override.scss
+++ b/packages/ui/core/src/assets/scss/ng-material-override.scss
@@ -709,3 +709,7 @@ mat-icon[data-mat-icon-name="custom_expand_less"]
   width: 10px;
   height: 10px;
 }
+.mat-mdc-dialog-content
+{
+  max-height: 1150px !important;
+}

--- a/packages/ui/feature-builder-canvas/src/lib/test-flow-widget/test-flow-widget.component.html
+++ b/packages/ui/feature-builder-canvas/src/lib/test-flow-widget/test-flow-widget.component.html
@@ -2,68 +2,18 @@
   <div class="ap-min-h-[35px]">
     <ng-container
       *ngIf="(instanceRunStatus$ | async) !== statusEnum.RUNNING && (shouldHideTestWidget$| async )===false">
-      <div (click)="testFlowButtonClicked(currentFlow,modalTemplate)" @fadeIn
-        [matTooltip]="testFlowButtonDisabledTooltip" [class.ap-pointer-events-none]="isSaving$ | async"
-        [class.ap-cursor-auto]="isSaving$ | async"
-        class="ap-typography-body-2 ap-bg-primary-light ap-rounded-full ap-border ap-border-solid ap-border-primary-medium ap-transition-colors ap-py-1.5 ap-px-2.5 ap-text-primary ap-cursor-pointer hover:ap-border-primary-dark">
-        {{(isSaving$ | async)? 'Saving...': 'Test flow'}}
+      <div [matTooltip]="(isTriggerTested$ | async) === false ? 'Test trigger first' : ''">
+        <div (click)="testFlowButtonClicked(currentFlow)" @fadeIn
+          [class.ap-grayscale]="(isTriggerTested$ | async) === false"
+          [class.ap-pointer-events-none]="(isSaving$ | async) || (isTriggerTested$ | async) === false"
+          [class.ap-cursor-auto]="isSaving$ | async" class="ap-typography-body-2 ap-bg-primary-light ap-rounded-full
+         ap-border ap-border-solid ap-border-primary-medium ap-transition-all
+          ap-py-1.5 ap-px-2.5 ap-text-primary ap-cursor-pointer hover:ap-border-primary-dark">
+          {{(isSaving$ | async)? 'Saving...': 'Test flow'}}
+        </div>
       </div>
     </ng-container>
   </div>
 </ng-container>
-
-
-
 <ng-container *ngIf="executeTest$ |async"></ng-container>
 <ng-container *ngIf="instanceRunStatusChecker$ | async"></ng-container>
-<ng-template #modalTemplate>
-  <ap-dialog-title-template>
-    Test Flow
-  </ap-dialog-title-template>
-  <ng-container *ngIf="selectedFlow$ | async as currentFLow">
-    <mat-dialog-content>
-      <div class="ap-w-[450px] ap-max-w-[500px] json-editor">
-        <div class="ap-mb-2 ap-pointer-events-none">Webhook Payload (JSON)
-          <p class="ap-typography-caption">Pass the following object in as the webhook payload:</p>
-        </div>
-        <div class="code-font-sm code-size-200 code-block">
-          <div class="ap-py-2 ap-px-4 ap-flex bar-containing-beautify-button">
-            <div class="ap-flex-grow">
-              <span class="ap-text-white">Payload</span>
-            </div>
-            <div>
-              <svg-icon src="/assets/img/custom/beautify.svg" [svgStyle]="{width:'16px', height:'16px'}"
-                matTooltip="beautify" class="ap-cursor-pointer" (click)="beautify()"> </svg-icon>
-            </div>
-          </div>
-          <ngx-codemirror cdkFocusInitial [formControl]="payloadControl" [autoFocus]="true"
-            [options]="codeEditorOptions"></ngx-codemirror>
-        </div>
-        <div *ngIf="submitted && payloadControl.invalid">
-          <p @fadeInUp *ngIf="payloadControl.hasError('required');else invalidJson"
-            class="ap-text-danger ap-typography-caption">
-            Payload is required
-          </p>
-          <ng-template #invalidJson>
-            <p @fadeInUp class="ap-text-danger ap-typography-caption">
-              Payload is not a valid JSON object, please use double quotations.
-            </p>
-          </ng-template>
-        </div>
-      </div>
-
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <div class="ap-flex ap-gap-2.5">
-        <ap-button btnColor="basic" mat-dialog-close btnSize="default" btnColor="basic">
-          Cancel
-        </ap-button>
-        <ap-button btnSize="default" btnColor="primary" (click)="testFlowWithPayload(currentFLow)">
-          Test
-        </ap-button>
-      </div>
-    </mat-dialog-actions>
-  </ng-container>
-
-
-</ng-template>

--- a/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
@@ -542,6 +542,24 @@ const selectStepLogoUrl = (stepName: string) => {
     }
   );
 };
+
+const selectFlowTriggerIsTested = createSelector(selectCurrentFlow, (flow) => {
+  if (
+    (flow.version.trigger.type === TriggerType.PIECE &&
+      flow.version.trigger.settings.pieceName === CORE_SCHEDULE) ||
+    flow.version.trigger.settings.pieceName === 'schedule'
+  ) {
+    return true;
+  }
+  switch (flow.version.trigger.type) {
+    case TriggerType.EMPTY:
+      return false;
+    case TriggerType.WEBHOOK:
+      return !!flow.version.trigger.settings.inputUiInfo.currentSelectedData;
+    case TriggerType.PIECE:
+      return !!flow.version.trigger.settings.inputUiInfo.currentSelectedData;
+  }
+});
 export const BuilderSelectors = {
   selectReadOnly,
   selectViewMode,
@@ -592,4 +610,5 @@ export const BuilderSelectors = {
   selectHasFlowBeenPublished,
   selectStepResultsAccordion,
   selectStepDisplayNameAndDfsIndexForIterationOutput,
+  selectFlowTriggerIsTested,
 };

--- a/packages/ui/feature-builder-test-steps/src/lib/test-piece-webhook-trigger/test-piece-webhook-trigger.component.html
+++ b/packages/ui/feature-builder-test-steps/src/lib/test-piece-webhook-trigger/test-piece-webhook-trigger.component.html
@@ -15,7 +15,7 @@
                     [disabled]="(isValid$ | async) === false || (isSaving$ | async) === true">Test
                     Trigger </ap-button>
             </div>
-            <div>
+            <div class="ap-typography-subtitle-2 ap-text-description">
                 Or
             </div>
             <ap-button btnColor="primary" btnStyle="stroked" btnSize="medium" (buttonClicked)="useMockData()"
@@ -26,7 +26,8 @@
             <div class="ap-flex ap-items-center">
                 <div class="ap-min-h-[48px] ap-gap-2  ap-flex ap-items-center">
                     <svg-icon src="assets/img/custom/success-step-result.svg"
-                        [svgStyle]="{ width: '21px', height: '20px' }" matTooltip="Step succeeded"></svg-icon> Tested
+                        [svgStyle]="{ width: '21px', height: '20px' }" matTooltip="Step succeeded"></svg-icon>
+                    Tested
                     Successfully
                 </div>
                 <div class="ap-flex-grow">

--- a/packages/ui/feature-templates/src/lib/templates-dialog/template-apps-dropdown/template-apps-dropdown.component.ts
+++ b/packages/ui/feature-templates/src/lib/templates-dialog/template-apps-dropdown/template-apps-dropdown.component.ts
@@ -63,7 +63,12 @@ export class TemplateAppsDropdownComponent implements ControlValueAccessor {
         return this.pieces$.pipe(
           map((pieces) => {
             return pieces.filter((p) => {
-              return p.displayName.toLowerCase().includes(search);
+              return (
+                p.displayName
+                  .toLowerCase()
+                  .includes(search.toLocaleLowerCase()) &&
+                !this.selectedPieces.includes(p.name)
+              );
             });
           })
         );
@@ -129,6 +134,7 @@ export class TemplateAppsDropdownComponent implements ControlValueAccessor {
   }
   addPieceToFilter(pieceName: string) {
     this.selectedPieces.push(pieceName);
+    this.searchControl.setValue('');
     this.dropdownControl.setValue('', { emitEvent: false });
     this.setPiecesToShowInDropdown();
     this.onChange(this.selectedPieces);


### PR DESCRIPTION
## What does this PR do?

Currently, if the flow's trigger is not tested, it gets sample data from the sample data within the code for the trigger, this PR stops that and asks the user to test the trigger if it doesn't have selected sample data, unless it is a schedule, and fixes minor issues with templates dialog. 

Closes #1508 

