### PR TITLE
feat: show indicator for add btn

### DIFF
--- a/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/add-button-core.ts
+++ b/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/add-button-core.ts
@@ -1,0 +1,20 @@
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+import {
+  BuilderSelectors,
+  canvasActions,
+} from '@activepieces/ui/feature-builder-store';
+
+export class AddButtonCore {
+  static id = 0;
+  addButtonId = AddButtonCore.id++;
+  selectedAddBtnId$: Observable<number | undefined>;
+  constructor(protected store: Store) {
+    this.selectedAddBtnId$ = this.store.select(
+      BuilderSelectors.selectLastClickedAddBtnId
+    );
+  }
+  setSelectedAddBtnId() {
+    this.store.dispatch(canvasActions.setAddButtonId({ id: this.addButtonId }));
+  }
+}

--- a/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/big-add-button/big-add-button.component.html
+++ b/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/big-add-button/big-add-button.component.html
@@ -1,6 +1,8 @@
 <div class="big-add-button ap-flex ap-items-center ap-justify-center ap-absolute ap-cursor-pointer" tabindex="1"
-    [class.big-add-button-drop-indicator]="showDropZoneIndicator" (focus)="showBoxShadow = true"
-    (blur)="showBoxShadow = false" [class.box-shadow]="showBoxShadow" [style.top]="top" [style.left]="left">
+    (click)="setSelectedAddBtnId()"
+    [class.big-add-button-drop-indicator]="showDropZoneIndicator || (selectedAddBtnId$ | async) === addButtonId"
+    (focus)="showBoxShadow = true" (blur)="showBoxShadow = false" [class.box-shadow]="showBoxShadow" [style.top]="top"
+    [style.left]="left">
     <svg-icon *ngIf="!showDropZoneIndicator" src="./assets/img/custom/plus.svg" class="add-icon"
         [applyClass]="true"></svg-icon>
 </div>

--- a/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/big-add-button/big-add-button.component.ts
+++ b/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/big-add-button/big-add-button.component.ts
@@ -1,13 +1,18 @@
 import { Component, Input } from '@angular/core';
+import { AddButtonCore } from '../add-button-core';
+import { Store } from '@ngrx/store';
 
 @Component({
   selector: 'app-big-add-button',
   templateUrl: './big-add-button.component.html',
   styleUrls: ['./big-add-button.component.scss'],
 })
-export class BigAddButtonComponent {
+export class BigAddButtonComponent extends AddButtonCore {
   @Input() top = '';
   @Input() left = '';
-  showBoxShadow = false;
   @Input() showDropZoneIndicator = false;
+  showBoxShadow = false;
+  constructor(store: Store) {
+    super(store);
+  }
 }

--- a/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/small-add-button/small-add-button.component.html
+++ b/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/small-add-button/small-add-button.component.html
@@ -1,4 +1,4 @@
 <div class="add-button ap-cursor-pointer ap-absolute" tabindex="1"
-    [class.add-button-drop-indicator]="showDropzoneIndicator && (isInDraggingMode$ | async)" [style.top]="top"
-    [style.left]="left">
+    [class.add-button-drop-indicator]="showDropzoneIndicator && (isInDraggingMode$ | async) || (selectedAddBtnId$ | async) === addButtonId"
+    (click)="setSelectedAddBtnId()" [style.top]="top" [style.left]="left">
 </div>

--- a/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/small-add-button/small-add-button.component.html
+++ b/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/small-add-button/small-add-button.component.html
@@ -1,4 +1,4 @@
 <div class="add-button ap-cursor-pointer ap-absolute" tabindex="1"
-    [class.add-button-drop-indicator]="showDropzoneIndicator && (isInDraggingMode$ | async) || (selectedAddBtnId$ | async) === addButtonId"
+    [class.add-button-drop-indicator]="showDropzoneIndicator || (selectedAddBtnId$ | async) === addButtonId"
     (click)="setSelectedAddBtnId()" [style.top]="top" [style.left]="left">
 </div>

--- a/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/small-add-button/small-add-button.component.ts
+++ b/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/small-add-button/small-add-button.component.ts
@@ -1,18 +1,21 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { FlowRendererService } from '@activepieces/ui/feature-builder-store';
 import { Observable } from 'rxjs';
+import { AddButtonCore } from '../add-button-core';
+import { Store } from '@ngrx/store';
 
 @Component({
   selector: 'app-small-add-button',
   templateUrl: './small-add-button.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SmallAddButtonComponent {
+export class SmallAddButtonComponent extends AddButtonCore {
   @Input() left = '';
   @Input() top = '';
   @Input() showDropzoneIndicator = false;
   isInDraggingMode$: Observable<boolean>;
-  constructor(private flowRendererService: FlowRendererService) {
+  constructor(private flowRendererService: FlowRendererService, store: Store) {
+    super(store);
     this.isInDraggingMode$ =
       this.flowRendererService.draggingSubject.asObservable();
   }

--- a/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/small-add-button/small-add-button.component.ts
+++ b/packages/ui/feature-builder-canvas/src/lib/flow-item-tree/flow-item/flow-item-connection/small-add-button/small-add-button.component.ts
@@ -1,6 +1,4 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { FlowRendererService } from '@activepieces/ui/feature-builder-store';
-import { Observable } from 'rxjs';
 import { AddButtonCore } from '../add-button-core';
 import { Store } from '@ngrx/store';
 
@@ -13,10 +11,8 @@ export class SmallAddButtonComponent extends AddButtonCore {
   @Input() left = '';
   @Input() top = '';
   @Input() showDropzoneIndicator = false;
-  isInDraggingMode$: Observable<boolean>;
-  constructor(private flowRendererService: FlowRendererService, store: Store) {
+
+  constructor(store: Store) {
     super(store);
-    this.isInDraggingMode$ =
-      this.flowRendererService.draggingSubject.asObservable();
   }
 }

--- a/packages/ui/feature-builder-store/src/lib/model/canvas-state.ts
+++ b/packages/ui/feature-builder-store/src/lib/model/canvas-state.ts
@@ -25,6 +25,7 @@ export interface CanvasState {
   selectedStepName: string;
   isGeneratingFlowComponentOpen: boolean;
   displayedFlowVersion: FlowVersion;
+  clickedAddBtnId?: number;
 }
 
 export interface StepTypeSideBarProps {

--- a/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
@@ -542,6 +542,9 @@ const selectStepLogoUrl = (stepName: string) => {
     }
   );
 };
+const selectLastClickedAddBtnId = createSelector(selectCanvasState, (state) => {
+  return state.clickedAddBtnId;
+});
 export const BuilderSelectors = {
   selectReadOnly,
   selectViewMode,
@@ -592,4 +595,5 @@ export const BuilderSelectors = {
   selectHasFlowBeenPublished,
   selectStepResultsAccordion,
   selectStepDisplayNameAndDfsIndexForIterationOutput,
+  selectLastClickedAddBtnId,
 };

--- a/packages/ui/feature-builder-store/src/lib/store/builder/canvas/canvas.action.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/canvas/canvas.action.ts
@@ -20,6 +20,8 @@ export enum CanvasActionType {
   CLOSE_GENERATE_FLOW_COMPONENT = '[CANVAS] CLOSE_GENERATE_FLOW_COMPONENT',
   SET_RUN = '[CANVAS] SET_RUN',
   EXIT_RUN = '[CANVAS] EXIT_RUN',
+  SET_ADD_BUTTON_ID = '[CANVAS] SET_ADD_BUTTON_ID',
+  CLEAR_ADD_BUTTON_ID = '[CANVAS] CLEAR_ADD_BUTTON_ID',
 }
 
 const setInitial = createAction(
@@ -31,6 +33,11 @@ const setLeftSidebar = createAction(
   props<{ sidebarType: LeftSideBarType }>()
 );
 
+const setAddButtonId = createAction(
+  CanvasActionType.SET_ADD_BUTTON_ID,
+  props<{ id: number }>()
+);
+const clearAddButtonId = createAction(CanvasActionType.SET_ADD_BUTTON_ID);
 const setRightSidebar = createAction(
   CanvasActionType.SET_RIGHT_SIDEBAR,
   props<{
@@ -84,4 +91,6 @@ export const canvasActions = {
   closeGenerateFlowComponent,
   setRun,
   exitRun,
+  setAddButtonId,
+  clearAddButtonId,
 };

--- a/packages/ui/feature-builder-store/src/lib/store/builder/canvas/canvas.effects.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/canvas/canvas.effects.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Actions, concatLatestFrom, createEffect, ofType } from '@ngrx/effects';
-import { map, switchMap, tap } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { BuilderActions } from '../builder.action';
 import { canvasActions } from './canvas.action';
 import { EMPTY, of } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { BuilderSelectors } from '../builder.selector';
-import { LeftSideBarType } from '../../../model';
+import { LeftSideBarType, RightSideBarType } from '../../../model';
 import { RunDetailsService } from '../../../service/run-details.service';
 
 @Injectable()
@@ -20,6 +20,23 @@ export class CanvasEffects {
           displayedFlowVersion: action.flow.version,
           run: action.run,
         });
+      })
+    );
+  });
+  clearAddBtnIdOnClosingRightSidebar$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(canvasActions.setRightSidebar),
+      filter((action) => action.sidebarType === RightSideBarType.NONE),
+      switchMap(() => {
+        return of(canvasActions.clearAddButtonId());
+      })
+    );
+  });
+  clearAddBtnIdOnStepSelection$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(canvasActions.selectStepByName),
+      switchMap(() => {
+        return of(canvasActions.clearAddButtonId());
       })
     );
   });

--- a/packages/ui/feature-builder-store/src/lib/store/builder/canvas/canvas.reducer.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/canvas/canvas.reducer.ts
@@ -203,6 +203,11 @@ const __CanvasReducer = createReducer(
     const clonedState: CanvasState = JSON.parse(JSON.stringify(state));
     clonedState.displayedFlowVersion = flow.version;
     return clonedState;
+  }),
+  on(canvasActions.setAddButtonId, (state, { id }) => {
+    const clonedState: CanvasState = JSON.parse(JSON.stringify(state));
+    clonedState.clickedAddBtnId = id;
+    return clonedState;
   })
 );
 


### PR DESCRIPTION
## What does this PR do?

Currently if you click on an add button within the flow, you would need to remember the add button you clicked to know where the step will be placed.
To fix this this PR adds an indicator to show where the new step will be placed.
![image](https://github.com/activepieces/activepieces/assets/106555838/71cd5927-3fb5-4554-9c32-bb93a8223c18)
![image](https://github.com/activepieces/activepieces/assets/106555838/18134997-91a9-4ebd-9a04-da8caa4576e6)





