### PR TITLE
feat: open dashboard to folder from builder

### DIFF
--- a/packages/ui/feature-builder-header/src/lib/flow-builder-header.component.html
+++ b/packages/ui/feature-builder-header/src/lib/flow-builder-header.component.html
@@ -9,8 +9,8 @@
       <ap-icon-button [width]="7" [height]="14" iconFilename="back.svg" [tooltipText]="'Home'"
         (buttonClicked)="redirectHome(false)" (auxclick)="redirectHome(true)"></ap-icon-button>
       <div class="ap-flex-grow ap-flex ap-items-center ap-gap-2" #spacer>
-        <div class="ap-typography-body-1 ap-truncate ap-max-w-[150px] ap-cursor-pointer hover:ap-underline" #folderName
-          (click)="openDashboardToFolder()"
+        <div class="ap-typography-body-1 ap-truncate ap-max-w-[150px] ap-cursor-pointer hover:ap-text-[#000000]"
+          #folderName (click)="openDashboardToFolder()"
           [matTooltip]="folderName.scrollWidth > folderName.clientWidth? (folderDisplayName$|async) || '' : ''">
           {{folderDisplayName$ | async}}
         </div>

--- a/packages/ui/feature-builder-header/src/lib/flow-builder-header.component.html
+++ b/packages/ui/feature-builder-header/src/lib/flow-builder-header.component.html
@@ -9,7 +9,8 @@
       <ap-icon-button [width]="7" [height]="14" iconFilename="back.svg" [tooltipText]="'Home'"
         (buttonClicked)="redirectHome(false)" (auxclick)="redirectHome(true)"></ap-icon-button>
       <div class="ap-flex-grow ap-flex ap-items-center ap-gap-2" #spacer>
-        <div class="ap-typography-body-1 ap-truncate ap-max-w-[150px]" #folderName
+        <div class="ap-typography-body-1 ap-truncate ap-max-w-[150px] ap-cursor-pointer hover:ap-underline" #folderName
+          (click)="openDashboardToFolder()"
           [matTooltip]="folderName.scrollWidth > folderName.clientWidth? (folderDisplayName$|async) || '' : ''">
           {{folderDisplayName$ | async}}
         </div>
@@ -61,3 +62,4 @@
 <ng-container *ngIf="deleteFlowDialogClosed$|async"></ng-container>
 <ng-container *ngIf="downloadFile$ | async"></ng-container>
 <ng-container *ngIf="duplicateFlow$|async"></ng-container>
+<ng-container *ngIf="openDashboardOnFolder$ | async"></ng-container>

--- a/packages/ui/feature-builder-header/src/lib/flow-builder-header.component.ts
+++ b/packages/ui/feature-builder-header/src/lib/flow-builder-header.component.ts
@@ -37,7 +37,7 @@ export class FlowBuilderHeaderComponent implements OnInit {
   folderDisplayName$: Observable<string>;
   duplicateFlow$: Observable<void>;
   showGuessFlowBtn$: Observable<boolean>;
-
+  openDashboardOnFolder$: Observable<string>;
   constructor(
     public dialogService: MatDialog,
     private store: Store,
@@ -142,5 +142,20 @@ export class FlowBuilderHeaderComponent implements OnInit {
         return void 0;
       })
     );
+  }
+
+  openDashboardToFolder() {
+    this.openDashboardOnFolder$ = this.store
+      .select(BuilderSelectors.selectCurrentFlowFolderId)
+      .pipe(
+        take(1),
+        tap((folderId) => {
+          this.router.navigate(['/flows'], {
+            queryParams: {
+              folderId,
+            },
+          });
+        })
+      );
   }
 }

--- a/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/builder/builder.selector.ts
@@ -120,7 +120,12 @@ export const selectCurrentFlowFolderName = createSelector(
     return state.folder.displayName;
   }
 );
-
+const selectCurrentFlowFolderId = createSelector(selectFlowState, (state) => {
+  if (!state.folder) {
+    return 'NULL';
+  }
+  return state.folder.id;
+});
 export const selectCurrentFlowValidity = createSelector(
   selectCurrentFlow,
   (flow: Flow | undefined) => {
@@ -592,4 +597,5 @@ export const BuilderSelectors = {
   selectHasFlowBeenPublished,
   selectStepResultsAccordion,
   selectStepDisplayNameAndDfsIndexForIterationOutput,
+  selectCurrentFlowFolderId,
 };


### PR DESCRIPTION
## What does this PR do?

Inside the builder if you press the folder name you can go back to the dashboard (flows table) with the folder selected.

