### PR TITLE
fix: stop propagating space press inside dropdown

### DIFF
--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -499,6 +499,7 @@
   <mat-form-field subscriptSizing="dynamic" appearance="fill" (click)="$event.stopPropagation();"
     #searchField="elementDirective" class="ap-w-full ap-mb-2" apElementDirective>
     <mat-icon matPrefix color="placeholder-icon" svgIcon="search"></mat-icon>
-    <input #searchInput [formControl]="searchControl" matInput placeholder="Search" autocomplete="off">
+    <input #searchInput [formControl]="searchControl" matInput placeholder="Search" autocomplete="off"
+      (keydown.Space)="$event.stopPropagation()">
   </mat-form-field>
 </ng-template>

--- a/packages/ui/feature-templates/src/lib/templates-dialog/template-apps-dropdown/template-apps-dropdown.component.html
+++ b/packages/ui/feature-templates/src/lib/templates-dialog/template-apps-dropdown/template-apps-dropdown.component.html
@@ -7,7 +7,8 @@
         <mat-form-field subscriptSizing="dynamic" appearance="fill" (click)="$event.stopPropagation();"
             #searchField="elementDirective" class="ap-w-full ap-mb-2" apElementDirective>
             <mat-icon matPrefix color="placeholder-icon" svgIcon="search"></mat-icon>
-            <input #searchInput [formControl]="searchControl" matInput placeholder="Search" autocomplete="off">
+            <input #searchInput [formControl]="searchControl" matInput placeholder="Search" autocomplete="off"
+                (keydown.Space)="$event.stopPropagation()">
         </mat-form-field>
         <div class="ap-overflow-y-scroll"
             [style.height]="'calc(100% - '+ searchField.elementRef.nativeElement.clientHeight + 'px '+ '- 0.5rem '+ ')'">


### PR DESCRIPTION
## What does this PR do?

Stop dropdowns from closing on pressing space inside dropdown search.

