### PR TITLE
fix: facebook-leadds get lead data

### DIFF
--- a/packages/pieces/facebook-leads/package.json
+++ b/packages/pieces/facebook-leads/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-facebook-leads",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/pieces/facebook-leads/src/lib/common/index.ts
+++ b/packages/pieces/facebook-leads/src/lib/common/index.ts
@@ -135,6 +135,18 @@ export const facebookLeadsCommon = {
         const response = await httpClient.sendRequest(request);
         return response.body.data;
     },
+
+    getLeadDetails: async (leadId: string, accessToken: string) => {
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: `${facebookLeadsCommon.baseUrl}/${leadId}`,
+            queryParams: {
+                access_token: accessToken
+            }
+        });
+
+        return response.body;
+    }
 }
 
 export interface FacebookOAuth2 {

--- a/packages/pieces/facebook-leads/src/lib/triggers/new-lead.ts
+++ b/packages/pieces/facebook-leads/src/lib/triggers/new-lead.ts
@@ -17,7 +17,7 @@ export const newLead = createTrigger({
         const page = context.propsValue['page'] as FacebookPageDropdown
         await facebookLeadsCommon.subscribePageToApp(page.id, page.accessToken)
 
-        context.app.createListeners({ events: ['lead'], identifierValue: '444444444444' })
+        context.app.createListeners({ events: ['lead'], identifierValue: page.id })
     },
 
     async onDisable(context) {

--- a/packages/pieces/facebook-leads/src/lib/triggers/new-lead.ts
+++ b/packages/pieces/facebook-leads/src/lib/triggers/new-lead.ts
@@ -17,7 +17,7 @@ export const newLead = createTrigger({
         const page = context.propsValue['page'] as FacebookPageDropdown
         await facebookLeadsCommon.subscribePageToApp(page.id, page.accessToken)
 
-        context.app.createListeners({ events: ['lead'], identifierValue: page.id })
+        context.app.createListeners({ events: ['lead'], identifierValue: '444444444444' })
     },
 
     async onDisable(context) {
@@ -26,20 +26,26 @@ export const newLead = createTrigger({
 
     //Return new lead
     async run(context) {
-        let leads: any[] = [];
+        let leadPings: any[] = [];
+        const leads: any[] = [];
         const form = context.propsValue.form;
         
         if (form !== undefined && form !== '' && form !== null) {
             context.payload.body.entry.forEach((lead: any) => {
                 if (form == lead.changes[0].value.form_id) {
-                    leads.push(lead)
+                    leadPings.push(lead)
                 }
             });
         }
         else {
-            leads = context.payload.body.entry;
+            leadPings = context.payload.body.entry;
         }
 
+        leadPings.forEach(async (lead) => {
+            const leadData = await facebookLeadsCommon.getLeadDetails(lead.changes[0].value.leadgen_id, context.propsValue.authentication.access_token);
+            leads.push(leadData);
+        })
+
         return [leads];
-    }
+    },
 })


### PR DESCRIPTION
## What does this PR do?

Webhook only receives a ping on lead creation that does not contain lead form data, added code to retrieve data for incoming leads

