### PR TITLE
fix: find rows should return row instead of single value

### DIFF
--- a/packages/pieces/google-sheets/package.json
+++ b/packages/pieces/google-sheets/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.3.1"
+  "version": "0.4.0"
 }

--- a/packages/pieces/google-sheets/src/lib/actions/find-rows.ts
+++ b/packages/pieces/google-sheets/src/lib/actions/find-rows.ts
@@ -39,7 +39,7 @@ export const findRowsAction = createAction({
                     for (const key in value) {
                         if(value[key].includes(propsValue.search_value) && key.toLowerCase() === alphabet[column]){
                             matchingRows.push({
-                                [row]: value[key],
+                                [row]: value,
                             });
                         }
                     }

--- a/packages/pieces/google-sheets/src/lib/actions/find-rows.ts
+++ b/packages/pieces/google-sheets/src/lib/actions/find-rows.ts
@@ -39,7 +39,7 @@ export const findRowsAction = createAction({
                     for (const key in value) {
                         if(value[key].includes(propsValue.search_value) && key.toLowerCase() === alphabet[column]){
                             matchingRows.push({
-                                [key]: value[key],
+                                [row]: value[key],
                             });
                         }
                     }


### PR DESCRIPTION
Fixed find-rows action in Google Sheets piece, it should now return the row number instead of the column name.

also changed the value returned, instead of only the key matching the search parameter, it should now return the entire row. this should be helpful if the returned data were to be used in the preceding steps in a flow.
 

