### PR TITLE
chore: release pieces framework v0.6.6

### DIFF
--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.6.4",
+  "version": "0.6.6",
   "type": "commonjs"
 }


### PR DESCRIPTION
## What does this PR do?

Republish v0.6.4 as v0.6.6 to override v0.6.5
