### PR TITLE
docs: Update example piece auth code reference link.

### DIFF
--- a/docs/developers/piece-reference/examples.mdx
+++ b/docs/developers/piece-reference/examples.mdx
@@ -21,11 +21,11 @@ To get the full benefit, it is recommended to read the [quickstart guide](quicks
 ## Authentication
 
 **OAuth2:**
-- [Slack](https://github.com/activepieces/activepieces/tree/main/packages/pieces/slack/)
-- [Gmail](https://github.com/activepieces/activepieces/tree/main/packages/pieces/gmail/)
+- [Slack](https://github.com/activepieces/activepieces/blob/main/packages/pieces/slack/src/index.ts)
+- [Gmail](https://github.com/activepieces/activepieces/blob/main/packages/pieces/gmail/src/index.ts)
 
 **API Key:**
-- [Sendgrid](https://github.com/activepieces/activepieces/tree/main/packages/pieces/sendgrid/src/lib/)
+- [Sendgrid](https://github.com/activepieces/activepieces/blob/main/packages/pieces/sendgrid/src/index.ts)
 
 **Basic Authentication:**
-- [Twilio](https://github.com/activepieces/activepieces/tree/main/packages/pieces/twilio/src/lib)
+- [Twilio](https://github.com/activepieces/activepieces/blob/main/packages/pieces/twilio/src/index.ts)


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Updated docs for code reference link in piece authentication examples. 

Currently, links are referring to the root directory of the piece, not to the actual piece auth implementation.
