### PR TITLE
chore: fixes relating to inputs info icon

### DIFF
--- a/packages/ui/core/src/assets/img/custom/info.svg
+++ b/packages/ui/core/src/assets/img/custom/info.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="48px" viewBox="0 0 24 24" width="48px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" ><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>

--- a/packages/ui/core/src/assets/scss/material-theme-helper.scss
+++ b/packages/ui/core/src/assets/scss/material-theme-helper.scss
@@ -74,11 +74,7 @@
   padding: 3px 24px 20px 24px !important;
 }
 
-.material-icons {
-  font-size: 20px !important;
-  height: 20px !important;
-  width: 20px !important;
-}
+
 
 .folder-list-item
 {

--- a/packages/ui/core/src/assets/scss/ng-material-override.scss
+++ b/packages/ui/core/src/assets/scss/ng-material-override.scss
@@ -674,8 +674,7 @@ app-dashboard-container .mat-drawer {
 .mat-mdc-form-field-icon-prefix > .mat-icon,
 .mat-mdc-form-field-icon-suffix > .mat-icon {
   padding: 12px 9px 12px 12px !important;
-  height: 16px !important;
-  width: 16px;
+  transform: scale(0.84);
 }
 mat-icon[data-mat-icon-name="custom_expand_more"],
 mat-icon[data-mat-icon-name="custom_expand_less"] {

--- a/packages/ui/feature-builder-form-controls/src/lib/code-artifact-form-control/code-artifact-form-control.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/code-artifact-form-control/code-artifact-form-control.component.ts
@@ -107,12 +107,14 @@ export class CodeArtifactFormControlComponent
       .beforeClosed()
       .pipe(
         tap(() => {
-          this.codeEditorOptions = JSON.parse(
-            JSON.stringify(this.codeEditorOptions)
-          );
+          this.reinitialiseEditor();
         }),
         map(() => void 0)
       );
+  }
+  /**Check ngx-monaco-editor-v2 code, you will see the editor gets reinitialised once the options are changed, no public api to do that otherwise. */
+  private reinitialiseEditor() {
+    this.codeEditorOptions = JSON.parse(JSON.stringify(this.codeEditorOptions));
   }
 
   setupValueListener() {

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -36,7 +36,7 @@
 
     <ng-container *ngSwitchCase="PropertyType.MARKDOWN">
       <ng-container *ngIf="convertMarkdown(property.value.description) | async as markdown">
-        <ap-markdown [fullWidth]="true" [data]="markdown" > </ap-markdown>
+        <ap-markdown [fullWidth]="true" [data]="markdown"> </ap-markdown>
       </ng-container>
     </ng-container>
 
@@ -48,11 +48,10 @@
       <ng-template #checkboxInputTemplate>
         <div class="ap-flex ap-mb-[20px] ap-mr-[5px] ap-items-center ap-gap-2">
 
-          <div class="ap-flex ap-items-center ap-gap-2 ap-align-center">
-            <mat-slide-toggle apTrackHover #slider="hoverTrackerDirective" [formControlName]="property.key" color="primary"
+          <div apTrackHover #slider="hoverTrackerDirective" class="ap-flex ap-items-center ap-gap-2 ap-align-center">
+            <mat-slide-toggle [formControlName]="property.key" color="primary"
               class="ap-flex-grow-1">{{property.value.displayName}}</mat-slide-toggle>
-              <ng-container
-              *ngTemplateOutlet="propInfo; context{$implicit:property}"></ng-container>  
+            <ng-container *ngTemplateOutlet="propInfo; context{$implicit:property}"></ng-container>
           </div>
 
           <ng-container
@@ -82,7 +81,7 @@
       <ng-container *ngTemplateOutlet="textInputTemplate;context:{$implicit:property, formGroup:formGroup}">
       </ng-container>
     </div>
-    
+
     <ng-container *ngSwitchCase="PropertyType.DROPDOWN">
       <div>
         <div class="ap-flex ap-justify-end ap-mb-1 ap-mr-1 ap-text-primary ">
@@ -101,6 +100,8 @@
             </div>
             <mat-form-field class="ap-w-full" appearance="outline" #dropdown
               #dropdownUiContainer="hoverTrackerDirective" apTrackHover>
+              <mat-icon class="!ap-text-form-label" matSuffix *ngIf="property.value.description"
+                [matTooltip]="property.value.description">info</mat-icon>
               <mat-label> {{ (refreshableConfigsLoadingFlags$[property.key] | async)? 'Loading...' :
                 property.value.displayName
                 }}</mat-label>
@@ -153,12 +154,15 @@
             </div>
             <mat-form-field class="ap-w-full" appearance="outline" #dropdown
               #dropdownUiContainer="hoverTrackerDirective" apTrackHover>
+              <mat-icon class="!ap-text-form-label" matSuffix *ngIf="property.value.description"
+                [matTooltip]="property.value.description">info</mat-icon>
               <mat-label> {{ (refreshableConfigsLoadingFlags$[property.key] | async)? 'Loading...' :
                 property.value.displayName
                 }}</mat-label>
-              <mat-select (closed)="searchControl.setValue('')"
-                [style.display]="((dropdownOptionsObservables$[property.key] | async) === undefined || (dropdownOptionsObservables$[property.key] | async) === null ||  (dropdownOptionsObservables$[property.key] | async)?.disabled === true)? 'none':'block' "
-                multiple [formControlName]="property.key" [compareWith]="dropdownCompareWithFunction">
+              <mat-select (closed)="searchControl.setValue('')" [style.display]="((dropdownOptionsObservables$[property.key] | async) === undefined 
+                || (dropdownOptionsObservables$[property.key] | async) === null || 
+                 (dropdownOptionsObservables$[property.key] | async)?.disabled === true)? 'none':'block' " multiple
+                [formControlName]="property.key" [compareWith]="dropdownCompareWithFunction">
                 <ng-container *ngIf="dropdownOptionsObservables$[property.key]| async as state">
                   <ng-container *ngTemplateOutlet="searchInputForDropdowns"></ng-container>
                   <div class="thin-scrollbars ap-max-h-[190px] ap-overflow-y-auto">
@@ -211,6 +215,8 @@
             </div>
             <mat-form-field class="ap-w-full" appearance="outline" apTrackHover
               #dropdownUiContainer="hoverTrackerDirective" #dropdown>
+              <mat-icon class="!ap-text-form-label" matSuffix *ngIf="property.value.description"
+                [matTooltip]="property.value.description">info</mat-icon>
               <mat-label> {{ property.value.displayName }} </mat-label>
               <mat-select [matTooltip]="property.value.description" [formControlName]="property.key"
                 (closed)="searchControl.setValue('')" [compareWith]="dropdownCompareWithFunction">
@@ -252,6 +258,8 @@
             </div>
             <mat-form-field #dropdown class="ap-w-full" appearance="outline"
               #dropdownUiContainer="hoverTrackerDirective" apTrackHover>
+              <mat-icon class="!ap-text-form-label" matSuffix *ngIf="property.value.description"
+                [matTooltip]="property.value.description">info</mat-icon>
               <mat-label> {{ property.value.displayName }} </mat-label>
               <mat-select (closed)="searchControl.setValue('')" [matTooltip]="property.value.description"
                 [formControlName]="property.key" multiple [compareWith]="dropdownCompareWithFunction">
@@ -286,8 +294,7 @@
       <ng-template #arrayInputTemplate>
         <div [class.ap-mb-5]="form.disabled" #hoverContainer="hoverTrackerDirective" apTrackHover>
           <div class="ap-mb-2 ap-flex ap-gap-2 ap-items-center">
-            <ng-container
-            *ngTemplateOutlet="propInfo; context{$implicit:property}"></ng-container>
+            <ng-container *ngTemplateOutlet="propInfo; context{$implicit:property}"></ng-container>
             <div class="ap-cursor-pointer" (click)="array.focusFirstInput()">{{property.value.displayName}}
             </div>
             <ng-container
@@ -311,8 +318,7 @@
       <ng-template #objectInputTemplate>
         <div [class.ap-mb-5]="form.disabled" #hoverContainer="hoverTrackerDirective" apTrackHover>
           <div class="ap-mb-2 ap-flex ap-gap-2 ap-items-center">
-            <ng-container
-              *ngTemplateOutlet="propInfo; context{$implicit:property}"></ng-container>
+            <ng-container *ngTemplateOutlet="propInfo; context{$implicit:property}"></ng-container>
             <div class="ap-cursor-pointer" (click)="dictonary.focusFirstKeyInput()">{{property.value.displayName}}
             </div>
             <ng-container
@@ -405,10 +411,11 @@
           (click)="$event.stopImmediatePropagation()">
           <div class="ap-py-2 ap-px-4 ap-flex bar-containing-beautify-button">
             <div class="ap-flex-grow">
-              
+
               <span class="ap-text-white ap-flex ap-gap-2 ap-items-center">
-                <ng-container *ngTemplateOutlet="propInfo; context{$implicit:property}"></ng-container>
-                {{property.value.displayName}} 
+                <ng-container
+                  *ngTemplateOutlet="propInfo; context{$implicit:property,extraClass:'!ap-text-white ap-rounded-full !ap-text-[25px]'}"></ng-container>
+                {{property.value.displayName}}
                 <ng-container
                   *ngTemplateOutlet="removeOptionalPropertyIcon; context{$implicit:property, propertyUiContainer:hoverContainer, isWhite:true}"></ng-container>
               </span>
@@ -486,10 +493,10 @@
     <mat-form-field class="ap-w-full" appearance="outline" #textInput
       (click)="isTriggerPieceForm?null: handler.showMentionsDropdown()">
       <mat-label>{{property.value.displayName}}</mat-label>
-      <app-interpolating-text-form-control #textControl 
-        [formControlName]="property.key" [attr.name]="property.key"
+      <app-interpolating-text-form-control #textControl [formControlName]="property.key" [attr.name]="property.key"
         (editorFocused)="handler.showMentionsDropdown()"></app-interpolating-text-form-control>
-      <mat-icon matSuffix *ngIf="property.value.description" [matTooltip]="property.value.description">info</mat-icon>
+      <mat-icon class="!ap-text-form-label" matSuffix *ngIf="property.value.description"
+        [matTooltip]="property.value.description">info</mat-icon>
       <mat-error *ngIf="formGroup.get(property.key)?.invalid">
         {{property.value.displayName}} is required
       </mat-error>
@@ -531,7 +538,7 @@
   </mat-form-field>
 </ng-template>
 
-<ng-template #propInfo let-property>
+<ng-template #propInfo let-property let-extraClass="extraClass">
   <mat-icon *ngIf="property.value.description" [matTooltip]="property.value.description"
-  class="ap-cursor-pointer">info</mat-icon>
+    [class]="'!ap-text-form-label ap-scale-[0.86] '+( extraClass? extraClass : '')">info</mat-icon>
 </ng-template>


### PR DESCRIPTION
## What does this PR do?

1) Fixes a problem related to mat-icon size, if it is not a multiple of 24px, use css transform:scale to adjust it.
2) Changes the color of the info icon inside JSON inputs to be white.
3) Added the info Icon to dropdowns.

