### PR TITLE
feat: support multiple slack action buttons

### DIFF
--- a/packages/pieces/slack/package.json
+++ b/packages/pieces/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.3.5"
+  "version": "0.3.6"
 }

--- a/packages/pieces/slack/src/index.ts
+++ b/packages/pieces/slack/src/index.ts
@@ -6,6 +6,8 @@ import { slackSendMessageAction } from './lib/actions/send-message-action';
 import { newMessage } from './lib/triggers/new-message';
 import { newReactionAdded } from './lib/triggers/new-reaction-added';
 import { requestSendApprovalMessageAction } from './lib/actions/request-approval-message';
+import { requestActionDirectMessageAction } from './lib/actions/request-action-direct-message';
+import { requestActionMessageAction } from './lib/actions/request-action-message';
 
 export const slackAuth = PieceAuth.OAuth2({
   displayName: 'Authentication',
@@ -58,9 +60,11 @@ export const slack = createPiece({
     slackSendMessageAction,
     requestApprovalDirectMessageAction,
     requestSendApprovalMessageAction,
+    requestActionDirectMessageAction,
+    requestActionMessageAction
   ],
   triggers: [
     newMessage,
     newReactionAdded,
-  ],
+  ]
 })

--- a/packages/pieces/slack/src/index.ts
+++ b/packages/pieces/slack/src/index.ts
@@ -13,7 +13,7 @@ export const slackAuth = PieceAuth.OAuth2({
   displayName: 'Authentication',
   description: '',
   authUrl: 'https://slack.com/oauth/authorize',
-  tokenUrl: 'https://slack.com/api/oauth.v2.access',
+  tokenUrl: 'https://slack.com/api/oauth.access',
   required: true,
   scope: [
     'channels:read',

--- a/packages/pieces/slack/src/lib/actions/request-action-direct-message.ts
+++ b/packages/pieces/slack/src/lib/actions/request-action-direct-message.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { slackAuth } from '../..';
+import { assertNotNullOrUndefined } from '@activepieces/shared';
+import { profilePicture, text, userId, username, actions } from '../common/props';
+import { requestAction } from '../common/request-action';
+
+export const requestActionDirectMessageAction = createAction({
+  auth: slackAuth,
+  name: 'request_action_direct_message',
+  displayName: 'Request Action from A User',
+  description: 'Send a message to a user and wait until the user selects an action',
+  sampleData: {
+    action: 'selectedAction',
+  },
+  props: {
+    userId,
+    text,
+    actions,
+    username,
+    profilePicture,
+  },
+  async run(context) {
+    const { userId } = context.propsValue;
+    assertNotNullOrUndefined(userId, 'userId');
+
+    return await requestAction(userId, context);
+  },
+});

--- a/packages/pieces/slack/src/lib/actions/request-action-message.ts
+++ b/packages/pieces/slack/src/lib/actions/request-action-message.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { slackAuth } from '../..';
+import { assertNotNullOrUndefined } from '@activepieces/shared';
+import { profilePicture, text, slackChannel, username, actions } from '../common/props';
+import { requestAction } from '../common/request-action';
+
+export const requestActionMessageAction = createAction({
+  auth: slackAuth,
+  name: 'request_action_message',
+  displayName: 'Request Action in A Channel',
+  description: 'Send a message in a channel and wait until an action is selected',
+  sampleData: {
+    action: 'selectedAction',
+  },
+  props: {
+    channel: slackChannel,
+    text,
+    actions,
+    username,
+    profilePicture,
+  },
+  async run(context) {
+    const { channel } = context.propsValue;
+    assertNotNullOrUndefined(channel, 'channel');
+
+    return await requestAction(channel, context);
+  },
+});

--- a/packages/pieces/slack/src/lib/common/props.ts
+++ b/packages/pieces/slack/src/lib/common/props.ts
@@ -1,5 +1,5 @@
-import { OAuth2PropertyValue, Property } from "@activepieces/pieces-framework";
-import { AuthenticationType, httpClient, HttpMethod, HttpRequest } from "@activepieces/pieces-common";
+import { OAuth2PropertyValue, Property } from '@activepieces/pieces-framework';
+import { AuthenticationType, httpClient, HttpMethod, HttpRequest } from '@activepieces/pieces-common';
 
 export const slackChannel = Property.Dropdown({
   displayName: 'Channel',
@@ -12,10 +12,10 @@ export const slackChannel = Property.Dropdown({
         disabled: true,
         placeholder: 'connect slack account',
         options: [],
-      }
+      };
     }
-    const authentication = auth as OAuth2PropertyValue
-    const accessToken = authentication['access_token']
+    const authentication = auth as OAuth2PropertyValue;
+    const accessToken = authentication['access_token'];
     const request: HttpRequest = {
       method: HttpMethod.GET,
       url: `https://slack.com/api/conversations.list?types=public_channel,private_channel`,
@@ -23,10 +23,10 @@ export const slackChannel = Property.Dropdown({
         type: AuthenticationType.BEARER_TOKEN,
         token: accessToken,
       },
-    }
+    };
     const response = await httpClient.sendRequest<{
-      channels: { id: string; name: string }[]
-    }>(request)
+      channels: { id: string; name: string }[];
+    }>(request);
     return {
       disabled: false,
       placeholder: 'Select channel',
@@ -34,9 +34,9 @@ export const slackChannel = Property.Dropdown({
         return {
           label: ch.name,
           value: ch.id,
-        }
+        };
       }),
-    }
+    };
   },
 });
 
@@ -63,10 +63,10 @@ export const userId = Property.Dropdown<string>({
         disabled: true,
         placeholder: 'connect slack account',
         options: [],
-      }
+      };
     }
 
-    const accessToken = (auth as OAuth2PropertyValue).access_token
+    const accessToken = (auth as OAuth2PropertyValue).access_token;
 
     const request: HttpRequest = {
       method: HttpMethod.GET,
@@ -75,20 +75,20 @@ export const userId = Property.Dropdown<string>({
         type: AuthenticationType.BEARER_TOKEN,
         token: accessToken,
       },
-    }
+    };
 
-    const response = await httpClient.sendRequest<UserListResponse>(request)
+    const response = await httpClient.sendRequest<UserListResponse>(request);
 
-    const options = response.body.members.map(member => ({
+    const options = response.body.members.map((member) => ({
       label: member.name,
       value: member.id,
-    }))
+    }));
 
     return {
       disabled: false,
       placeholder: 'Select channel',
       options,
-    }
+    };
   },
 });
 
@@ -98,9 +98,14 @@ export const text = Property.LongText({
   required: true,
 });
 
+export const actions = Property.Array({
+  displayName: 'Action Buttons',
+  required: true,
+});
+
 type UserListResponse = {
   members: {
-    id: string
-    name: string
-  }[]
-}
+    id: string;
+    name: string;
+  }[];
+};

--- a/packages/pieces/slack/src/lib/common/request-action.ts
+++ b/packages/pieces/slack/src/lib/common/request-action.ts
@@ -35,7 +35,7 @@ export const requestAction = async (conversationId: string, context: any) => {
     assertNotNullOrUndefined(text, 'text');
 
     const actionElements = actionTextToIds.map((action: any) => {
-      const actionLink = `${context.serverUrl}v1/flow-runs/${context.run.id}/resume?action=${encodeURI(action.actionId)}`;
+      const actionLink = `${context.serverUrl}v1/flow-runs/${context.run.id}/resume?action=${action.actionId}`;
 
       return {
         type: 'button',

--- a/packages/pieces/slack/src/lib/common/request-action.ts
+++ b/packages/pieces/slack/src/lib/common/request-action.ts
@@ -1,0 +1,79 @@
+import { slackSendMessage } from './utils';
+import { assertNotNullOrUndefined, ExecutionType, PauseType } from '@activepieces/shared';
+
+export const requestAction = async (conversationId: string, context: any) => {
+  const { actions } = context.propsValue;
+  assertNotNullOrUndefined(actions, 'actions');
+
+  if (!actions.length) {
+    throw new Error(`Must have at least one button action`);
+  }
+
+  const actionTextToIds = actions.map((actionText: string) => {
+    if (!actionText) {
+      throw new Error(`Button text for the action cannot be empty`);
+    }
+
+    return {
+      actionText,
+      actionId: encodeURI(actionText as string),
+    };
+  });
+
+  if (context.executionType === ExecutionType.BEGIN) {
+    context.run.pause({
+      pauseMetadata: {
+        type: PauseType.WEBHOOK,
+        actions: actionTextToIds.map((action: any) => action.actionId),
+      },
+    });
+
+    const token = context.auth.access_token;
+    const { text, username, profilePicture } = context.propsValue;
+
+    assertNotNullOrUndefined(token, 'token');
+    assertNotNullOrUndefined(text, 'text');
+
+    const actionElements = actionTextToIds.map((action: any) => {
+      const actionLink = `${context.serverUrl}v1/flow-runs/${context.run.id}/resume?action=${encodeURI(action.actionId)}`;
+
+      return {
+        type: 'button',
+        text: {
+          type: 'plain_text',
+          text: action.actionText,
+        },
+        style: 'primary',
+        url: actionLink,
+      };
+    });
+
+    return await slackSendMessage({
+      token,
+      text: `${context.propsValue.text}`,
+      username,
+      profilePicture,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `${context.propsValue.text}`,
+          },
+        },
+        {
+          type: 'actions',
+          block_id: 'actions',
+          elements: actionElements,
+        },
+      ],
+      conversationId: conversationId,
+    });
+  } else {
+    const payload = context.resumePayload as { action: string };
+
+    return {
+      action: decodeURI(payload.action),
+    };
+  }
+};


### PR DESCRIPTION
## What does this PR do?

Allows to send an approval-like message to a user/channel and wait for an action to be selected. The motivation is that the approval piece only supports two actions (approve/deny), whereas this is generic and allows multiple actions.

