### PR TITLE
fix: Minor fixes

### DIFF
--- a/packages/pieces/http/package.json
+++ b/packages/pieces/http/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-http",
-  "version": "0.3.1"
+  "version": "0.3.2"
 }

--- a/packages/pieces/http/src/index.ts
+++ b/packages/pieces/http/src/index.ts
@@ -9,7 +9,7 @@ export const http = createPiece({
 	auth: PieceAuth.None(),
 	minimumSupportedRelease: '0.5.0',
 	actions: [httpSendRequestAction, httpReturnResponse],
-	authors: ['khaledmashaly', 'bibhuty-did-this'],
+	authors: ['khaledmashaly', 'bibhuty-did-this' ,'AbdulTheActivePiecer'],
 	triggers: [
 	],
 });

--- a/packages/pieces/http/src/lib/common/props.ts
+++ b/packages/pieces/http/src/lib/common/props.ts
@@ -6,14 +6,8 @@ const httpMethodDropdownOptions = Object.values(HttpMethod).map(m => ({
   value: m,
 }));
 
-export const httpMethodDropdown = Property.Dropdown<HttpMethod>({
+export const httpMethodDropdown = Property.StaticDropdown<HttpMethod>({
   displayName: 'Method',
   required: true,
-  refreshers: [],
-  async options() {
-    return {
-      disabled: false,
-      options: httpMethodDropdownOptions,
-    };
-  }
+  options:{options:httpMethodDropdownOptions},
 });

--- a/packages/ui/core/src/assets/scss/ng-material-override.scss
+++ b/packages/ui/core/src/assets/scss/ng-material-override.scss
@@ -681,6 +681,3 @@ mat-icon[data-mat-icon-name="custom_expand_less"] {
   width: 10px;
   height: 10px;
 }
-.mat-mdc-dialog-content {
-  max-height: 1150px !important;
-}

--- a/packages/ui/feature-builder-form-controls/src/lib/dictionary-form-control/dictionary-form-control.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/dictionary-form-control/dictionary-form-control.component.html
@@ -10,12 +10,13 @@
           #deleteButton="hoverTrackerDirective" (click)="removePair(idx)"></ap-icon-button>
       </div>
 
-      <input #key id="key" name="key" class="form-control key-control"
+      <input #key id="key" name="key" class="form-control !ap-leading-[1.9rem]  key-control ap-max-w-[50%]"
         [class.first]="isFirst && pairs.controls.length>1" [class.last]="isLast && pairs.controls.length>1"
         [class.only-one]="pairs.controls.length === 1" formControlName="key" type="text"
         (keyup)="dictionaryControlValueChanged()" placeholder="Key" apTrackHover #keyInput="hoverTrackerDirective" />
 
-      <div class="form-control value-control" [class.first]="isFirst && pairs.controls.length>1"
+
+      <div class="form-control value-control ap-max-w-[50%]" [class.first]="isFirst && pairs.controls.length>1"
         [class.last]="isLast && pairs.controls.length>1" [class.only-one]="pairs.controls.length === 1" apTrackHover
         #interpolatingTextControlContainer #valueInput="hoverTrackerDirective">
         <app-interpolating-text-form-control #textControl [insideMatField]="false" formControlName="value"

--- a/packages/ui/feature-builder-form-controls/src/lib/ui-feature-builder-form-controls.module.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/ui-feature-builder-form-controls.module.ts
@@ -28,7 +28,6 @@ import { AuthConfigsPipe } from './piece-properties-form/auth-configs.pipe';
 import { PiecePropertiesFormComponent } from './piece-properties-form/piece-properties-form.component';
 import { MatTreeModule } from '@angular/material/tree';
 import { QuillModule } from 'ngx-quill';
-
 import { WebhookTriggerMentionItemComponent } from './interpolating-text-form-control/mentions-list/webhook-trigger-mention-item/webhook-trigger-mention-item.component';
 import { BuilderAutocompleteDropdownHandlerComponent } from './interpolating-text-form-control/builder-autocomplete-dropdown-handler/builder-autocomplete-dropdown-handler.component';
 import { AutocompleteDropdownSizesButtonsComponent } from './interpolating-text-form-control/mentions-list/autocomplete-dropdown-sizes-buttons/autocomplete-dropdown-sizes-buttons.component';

--- a/packages/ui/feature-templates/src/lib/templates-dialog/template-apps-dropdown/template-apps-dropdown.component.html
+++ b/packages/ui/feature-templates/src/lib/templates-dialog/template-apps-dropdown/template-apps-dropdown.component.html
@@ -26,7 +26,7 @@
 </mat-form-field>
 
 
-<div class="ap-mt-5 ap-flex ap-flex-col ap-gap-2.5 ap-h-[265px] thin-scrollbars ap-overflow-y-scroll">
+<div class="ap-mt-5 ap-flex ap-flex-col ap-gap-2.5 ap-max-h-[265px] thin-scrollbars ap-overflow-y-scroll">
     <app-template-app-tag-container [pieces$]="pieces$" *ngFor="let p of selectedPieces" [pieceName]="p"
         (removePiece)="removePieceFromFilter(p)">
     </app-template-app-tag-container>


### PR DESCRIPTION
## What does this PR do?

1)Sets the max height of dialogs to be 65vh making it relative to screen height.
2)Converts HTTP actions dropdown to be static.
3)Fixes max width for dictionary inputs to be 50% so both key and value have equal width.

PS: Dictionary keys can't have endlines so that's why it never breaks line into two or more lines when there isn't enough space.