### PR TITLE
fix: Fixed inserting data into Json inputs from data insertion popup

### DIFF
--- a/packages/ui/core/src/app/app.module.ts
+++ b/packages/ui/core/src/app/app.module.ts
@@ -42,7 +42,14 @@ const monacoConfig: NgxMonacoEditorConfig = {
     const monaco = (window as any).monaco;
     monaco.editor.defineTheme('apTheme', apMonacoTheme);
     monaco.editor.defineTheme('cobalt2', cobalt2);
-  }, // here monaco object will be available as window.monaco use this function to extend monaco editor functionalities.
+    const stopImportResolutionError = () => {
+      monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+        diagnosticCodesToIgnore: [2792],
+      });
+    };
+    stopImportResolutionError();
+    // Assuming you have already initialized the Monaco editor instance as 'editor'
+  },
 };
 export function tokenGetter() {
   const jwtToken: any = localStorage.getItem(environment.jwtTokenName);

--- a/packages/ui/feature-builder-form-controls/src/lib/interpolating-text-form-control/builder-autocomplete-dropdown-handler/builder-autocomplete-dropdown-handler.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/interpolating-text-form-control/builder-autocomplete-dropdown-handler/builder-autocomplete-dropdown-handler.component.ts
@@ -14,6 +14,7 @@ import {
   InsertMentionOperation,
 } from '@activepieces/ui/common';
 import { BuilderSelectors } from '@activepieces/ui/feature-builder-store';
+import { mentionsListId } from '../builder-autocomplete-mentions-dropdown/builder-autocomplete-mentions-dropdown.component';
 
 @Component({
   selector: 'app-builder-autocomplete-dropdown-handler',
@@ -38,7 +39,10 @@ export class BuilderAutocompleteDropdownHandlerComponent {
       .asObservable()
       .pipe(
         filter((res) => res.id === this.id),
-        tap((res) => this.mentionEmitted.emit(res.insert))
+        tap((res) => {
+          this.mentionEmitted.emit(res.insert);
+          document.getElementById(mentionsListId)?.focus();
+        })
       );
   }
   showMentionsDropdown() {

--- a/packages/ui/feature-builder-form-controls/src/lib/interpolating-text-form-control/builder-autocomplete-mentions-dropdown/builder-autocomplete-mentions-dropdown.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/interpolating-text-form-control/builder-autocomplete-mentions-dropdown/builder-autocomplete-mentions-dropdown.component.html
@@ -1,5 +1,5 @@
 <div @fadeIn (mouseover)="mouseWithinToggle(true)" (mouseleave)="mouseWithinToggle(false)" #mentionsList
-    id="mentionsList"
+    [id]="mentionsListId" tabindex="1"
     class="ap-transition-opacity ap-overflow-hidden dropdown-shadow ap-absolute  ap-z-50 ap-bg-white ap-border ap-border-outline ap-border-solid !ap-rounded-lg"
     [class.ap-h-full]="(interpolatingTextFormControlService.dataInsertionPopupSize$ | async )==='fullscreen'"
     [class.ap-w-full]="(interpolatingTextFormControlService.dataInsertionPopupSize$ | async )==='fullscreen'"

--- a/packages/ui/feature-builder-form-controls/src/lib/interpolating-text-form-control/builder-autocomplete-mentions-dropdown/builder-autocomplete-mentions-dropdown.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/interpolating-text-form-control/builder-autocomplete-mentions-dropdown/builder-autocomplete-mentions-dropdown.component.ts
@@ -18,7 +18,7 @@ import {
   ViewModeEnum,
 } from '@activepieces/ui/feature-builder-store';
 import { MatDialog } from '@angular/material/dialog';
-
+export const mentionsListId = 'mentionsList';
 @Component({
   selector: 'app-builder-autocomplete-mentions-dropdown',
   templateUrl: './builder-autocomplete-mentions-dropdown.component.html',
@@ -27,7 +27,7 @@ import { MatDialog } from '@angular/material/dialog';
   animations: [fadeIn400ms],
 })
 export class BuilderAutocompleteMentionsDropdownComponent {
-  @ViewChild('mentionsList', { read: ElementRef }) mentionsList:
+  @ViewChild(mentionsListId, { read: ElementRef }) mentionsList:
     | ElementRef<HTMLDivElement>
     | undefined;
   showMenuObs$: Observable<boolean>;
@@ -35,6 +35,7 @@ export class BuilderAutocompleteMentionsDropdownComponent {
   @Input() mouseWithin = false;
   @Input() container: HTMLElement;
   focusChecker: NodeJS.Timer | undefined;
+  readonly mentionsListId = mentionsListId;
   constructor(
     public interpolatingTextFormControlService: BuilderAutocompleteMentionsDropdownService,
     private store: Store,

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -426,7 +426,7 @@
             </div>
           </div>
           <div class="ap-h-[300px]">
-            <ngx-monaco-editor class="!ap-h-full !ap-w-full" [formControlName]="property.key"
+            <ngx-monaco-editor (onInit)="onInit($event)" class="!ap-h-full !ap-w-full" [formControlName]="property.key"
               (click)="handler.showMentionsDropdown()" [options]="codeEditorOptions"></ngx-monaco-editor>
           </div>
 

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
@@ -133,7 +133,7 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
   setDefaultValue$: Observable<null>;
   OnChange: (value: unknown) => void;
   OnTouched: () => void;
-
+  jsonMonacoEditor: any;
   constructor(
     private fb: UntypedFormBuilder,
     private actionMetaDataService: PieceMetadataService,
@@ -507,11 +507,12 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
   };
 
   addMentionToJsonControl(mention: InsertMentionOperation) {
-    const monaco = (window as any).monaco.editor.getEditors()[0];
-    console.log(monaco);
-    monaco.trigger('keyboard', 'type', {
+    this.jsonMonacoEditor.trigger('keyboard', 'type', {
       text: mention.insert.mention.serverValue,
     });
+  }
+  onInit(monacoEditor: any) {
+    this.jsonMonacoEditor = monacoEditor;
   }
   formValueMiddleWare(formValue: Record<string, unknown>) {
     const formattedValue: Record<string, unknown> = { ...formValue };


### PR DESCRIPTION
## What does this PR do?

1)Silencing import errors inside typescript editors.
2)Inserting data from data insertion popup into json editors works.

PS: imports will have type "any" now, which is something we might need to note in our docs or find a way to install types packages locally and resolve them.

