### PR TITLE
feat: add SimplePDF piece

### DIFF
--- a/packages/pieces/simplepdf/.eslintrc.json
+++ b/packages/pieces/simplepdf/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/simplepdf/README.md
+++ b/packages/pieces/simplepdf/README.md
@@ -1,0 +1,7 @@
+# pieces-simplepdf
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-simplepdf` to build the library.

--- a/packages/pieces/simplepdf/package.json
+++ b/packages/pieces/simplepdf/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-simplepdf",
-  "version": "0.0.1"
+  "version": "1.0.0"
 }

--- a/packages/pieces/simplepdf/package.json
+++ b/packages/pieces/simplepdf/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-simplepdf",
+  "version": "0.0.1"
+}

--- a/packages/pieces/simplepdf/project.json
+++ b/packages/pieces/simplepdf/project.json
@@ -1,0 +1,42 @@
+{
+  "name": "pieces-simplepdf",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/simplepdf/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/simplepdf",
+        "tsConfig": "packages/pieces/simplepdf/tsconfig.lib.json",
+        "packageJson": "packages/pieces/simplepdf/package.json",
+        "main": "packages/pieces/simplepdf/src/index.ts",
+        "assets": [
+          "packages/pieces/simplepdf/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies"
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs pieces-simplepdf {args.ver} {args.tag}",
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": [
+        "{options.outputFile}"
+      ],
+      "options": {
+        "lintFilePatterns": [
+          "packages/pieces/simplepdf/**/*.ts"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/simplepdf/src/index.ts
+++ b/packages/pieces/simplepdf/src/index.ts
@@ -1,0 +1,12 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { simplePDFNewSubmission } from './lib/triggers/new-submission';
+
+export const simplepdf = createPiece({
+  displayName: 'SimplePDF',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.7.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/simplepdf.png',
+  authors: ['bendersej'],
+  actions: [],
+  triggers: [simplePDFNewSubmission],
+});

--- a/packages/pieces/simplepdf/src/lib/triggers/new-submission.ts
+++ b/packages/pieces/simplepdf/src/lib/triggers/new-submission.ts
@@ -1,0 +1,52 @@
+import {
+  createTrigger,
+  PieceAuth,
+  Property,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+
+const markdown = `
+- Paste this URL in the webhook integration endpoint: {{webhookUrl}}
+- Click update (keep other settings unchanged)
+<br>
+<br>
+
+_[Read more about configuring webhooks](https://simplepdf.eu/help/how-to/configure-webhooks-pdf-form-submissions)_
+`;
+
+export const simplePDFNewSubmission = createTrigger({
+  name: 'new-submission',
+  displayName: 'New Submission',
+  auth: PieceAuth.None(),
+  description: 'Triggers when a form receives a new submission',
+  props: {
+    md: Property.MarkDown({
+      value: markdown,
+    }),
+  },
+  type: TriggerStrategy.WEBHOOK,
+  sampleData: {
+    document: {
+      id: 'b7615a68-9e1f-4eac-bd20-5e80632a4d9e',
+      name: 'your_document.pdf',
+    },
+    submission: {
+      id: '80146d5b-a068-490f-8eb9-fe393ba11396',
+      submitted_at: '2023-06-04T11:54:58.995Z',
+      url: 'https://cdn.simplepdf.eu/simple-pdf/assets/webhooks-playground.pdf',
+    },
+    context: {
+      environment: 'production',
+      customer_id: '123',
+    },
+  },
+  async onEnable(context) {
+    // Empty
+  },
+  async onDisable(context) {
+    // Empty
+  },
+  async run(context) {
+    return [context.payload.body.data];
+  },
+});

--- a/packages/pieces/simplepdf/tsconfig.json
+++ b/packages/pieces/simplepdf/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/simplepdf/tsconfig.lib.json
+++ b/packages/pieces/simplepdf/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -161,6 +161,9 @@
       ],
       "@activepieces/piece-sftp": ["packages/pieces/sftp/src/index.ts"],
       "@activepieces/piece-shopify": ["packages/pieces/shopify/src/index.ts"],
+      "@activepieces/piece-simplepdf": [
+        "packages/pieces/simplepdf/src/index.ts"
+      ],
       "@activepieces/piece-slack": ["packages/pieces/slack/src/index.ts"],
       "@activepieces/piece-smtp": ["packages/pieces/smtp/src/index.ts"],
       "@activepieces/piece-soap": ["packages/pieces/soap/src/index.ts"],


### PR DESCRIPTION
## What does this PR do?

This PR introduces the SimplePDF piece.

I will amend the existing blog post once this PR is merged as it was previously using the webhook piece: https://simplepdf.eu/help/how-to/connect-simplepdf-with-activepieces-to-automate-your-pdf-forms-processing

## Notes

I ran into some issues when developing, namely:
- Setting up my environment via Codespaces didn't work (a call to localhost:3000/flags kept failing and the UI was not displayed)
- My local environment failed initially because of a NX postinstall script: I had to `npm install nx` separately and then run `npm install`
- It appears that when testing the flow, even though I am returning `context.payload.body.data` in the run context, I am getting the full request (including the headers), is that expected?

