### PR TITLE
docs: Fix typo in getting started > introduction

### DIFF
--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -52,7 +52,7 @@ The visual builder as well provides native support for TypeScript code and npm p
 
 ### Intuitive Visual Editor 
 
-It's designed to be simple and easy to use, even for **no code** user.
+It's designed to be simple and easy to use, even for **no-code** users.
 
 ![](/resources/visual-builder.gif)
 


### PR DESCRIPTION
(Note: My first ever PR to an open-source project)

Fixed typo in docs from "**no code** user" to "**no-code** users".


