### PR TITLE
Fix: Google sheets checking team drive is now optional

### DIFF
--- a/packages/pieces/google-sheets/package.json
+++ b/packages/pieces/google-sheets/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.6.4"
+  "version": "0.6.5"
 }

--- a/packages/pieces/google-sheets/src/lib/common/common.ts
+++ b/packages/pieces/google-sheets/src/lib/common/common.ts
@@ -7,7 +7,7 @@ export const googleSheetsCommon = {
         displayName: 'Include Team Drive Sheets',
         description: 'Determines if sheets from Team Drives should be included in the results.',
         defaultValue: false,
-        required: true,
+        required: false,
     }),
     spreadsheet_id: Property.Dropdown({
         displayName: "Spreadsheet",

--- a/packages/ui/feature-dashboard/src/lib/pages/flows-table/flows-table.component.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/flows-table/flows-table.component.ts
@@ -182,8 +182,11 @@ export class FlowsTableComponent implements OnInit {
         }
       }
       case TriggerType.EMPTY: {
-        console.error("Flow can't be published with empty trigger");
-        return '';
+        console.error(
+          "Flow can't be published with empty trigger " +
+            flow.version.displayName
+        );
+        return 'assets/img/custom/warn.svg';
       }
     }
   }
@@ -200,8 +203,11 @@ export class FlowsTableComponent implements OnInit {
           : 'Real time flow';
       }
       case TriggerType.EMPTY: {
-        console.error("Flow can't be published with empty trigger");
-        return '';
+        console.error(
+          "Flow can't be published with empty trigger " +
+            flow.version.displayName
+        );
+        return 'Please contact support as your published flow has a problem';
       }
     }
   }

--- a/packages/ui/feature-dashboard/src/lib/pages/flows-table/flows-table.component.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/flows-table/flows-table.component.ts
@@ -181,8 +181,10 @@ export class FlowsTableComponent implements OnInit {
           return 'assets/img/custom/triggers/instant-filled.svg';
         }
       }
-      case TriggerType.EMPTY:
-        throw new Error("Flow can't be published with empty trigger");
+      case TriggerType.EMPTY: {
+        console.error("Flow can't be published with empty trigger");
+        return '';
+      }
     }
   }
 
@@ -197,8 +199,10 @@ export class FlowsTableComponent implements OnInit {
           ? `Runs ${cronstrue.toString(cronExpression).toLocaleLowerCase()}`
           : 'Real time flow';
       }
-      case TriggerType.EMPTY:
-        throw new Error("Flow can't be published with empty trigger");
+      case TriggerType.EMPTY: {
+        console.error("Flow can't be published with empty trigger");
+        return '';
+      }
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

1) Making google sheets "new row" trigger property that checks team drive for sheets optional.
2) Stop throwing errors when retrieving trigger icon in flows' table.

