### PR TITLE
fix: retry on internal error

### DIFF
--- a/packages/backend/src/app/helper/engine-helper.ts
+++ b/packages/backend/src/app/helper/engine-helper.ts
@@ -23,6 +23,7 @@ import {
     ExecuteValidateAuthResponse,
     ApEnvironment,
     EngineTestOperation,
+    CodeActionSettings,
 } from '@activepieces/shared'
 import { Sandbox, sandboxManager } from '../workers/sandbox'
 import { system } from './system/system'
@@ -42,6 +43,7 @@ import { packageManager } from './package-manager'
 import { pieceMetadataService } from '../pieces/piece-metadata-service'
 import { flowVersionService } from '../flows/flow-version/flow-version.service'
 import { codeBuilder } from '../workers/code-worker/code-builder'
+import { fileService } from '../file/file.service'
 
 const apEnvironment = system.get(SystemProp.ENVIRONMENT)
 
@@ -329,13 +331,17 @@ export const engineHelper = {
         logger.debug(operation, '[EngineHelper#executeAction] operation')
 
         const sandbox = await sandboxManager.obtainSandbox(apId())
+        const sourceId = (operation.step.settings as CodeActionSettings).artifactSourceId!
+        const fileEntity = await fileService.getOneOrThrow({
+            projectId: operation.projectId,
+            fileId: sourceId,
+        })
         await sandbox.recreate()
-        await codeBuilder.processCodeStep(
-            operation.step,
-            sandbox.getSandboxFolderPath(),
-            operation.flowVersion.id,
-            operation.projectId,
-        )
+        await codeBuilder.processCodeStep({
+            codeZip: fileEntity.data,
+            sourceCodeId: sourceId,
+            buildPath: sandbox.getSandboxFolderPath(),
+        } )
         const input = {
             ...operation,
             workerToken: await generateWorkerToken({ projectId: operation.projectId }),

--- a/packages/backend/src/app/workers/flow-worker/flow-worker.ts
+++ b/packages/backend/src/app/workers/flow-worker/flow-worker.ts
@@ -1,14 +1,15 @@
 import fs from 'fs-extra'
 import {
-    Action,
     ActionType,
     ActivepiecesError,
     apId,
+    CodeActionSettings,
     ErrorCode,
     ExecuteFlowOperation,
     ExecutionOutput,
     ExecutionOutputStatus,
     ExecutionType,
+    File,
     FileId,
     flowHelper,
     FlowRunId,
@@ -16,7 +17,6 @@ import {
     FlowVersionState,
     ProjectId,
     StepOutputStatus,
-    Trigger,
     TriggerType,
 } from '@activepieces/shared'
 import { Sandbox, sandboxManager } from '../sandbox'
@@ -29,13 +29,13 @@ import { captureException, logger } from '../../helper/logger'
 import { pieceManager } from '../../flows/common/piece-installer'
 import { isNil } from '@activepieces/shared'
 import { getServerUrl } from '../../helper/public-ip-utils'
-import { acquireLock } from '../../helper/lock'
 import {
     PackageInfo,
 } from '../../helper/package-manager'
 import { codeBuilder } from '../code-worker/code-builder'
 import sizeof from 'object-sizeof'
 import { MAX_LOG_SIZE } from '@activepieces/shared'
+import { acquireLock } from '../../helper/lock'
 
 type InstallPiecesParams = {
     path: string
@@ -64,7 +64,7 @@ const extractFlowPieces = async ({
 }: {
     projectId: ProjectId
     flowVersion: FlowVersion
-}) => {
+}): Promise<PackageInfo[]> => {
     const pieces: PackageInfo[] = []
     const steps = flowHelper.getAllSteps(flowVersion.trigger)
 
@@ -191,8 +191,8 @@ async function executeFlow(jobData: OneTimeJobData): Promise<void> {
 
     // Don't use sandbox for draft versions, since they are mutable and we don't want to cache them.
     const key =
-    flowVersion.id +
-    (FlowVersionState.DRAFT === flowVersion.state ? '-draft' + apId() : '')
+        flowVersion.id +
+        (FlowVersionState.DRAFT === flowVersion.state ? '-draft' + apId() : '')
     const sandbox = await sandboxManager.obtainSandbox(key)
     const startTime = Date.now()
     logger.info(
@@ -212,16 +212,14 @@ async function executeFlow(jobData: OneTimeJobData): Promise<void> {
             })
 
             logger.info(
-                `[${jobData.runId}] Preparing sandbox ${sandbox.boxId} took ${
-                    Date.now() - startTime
+                `[${jobData.runId}] Preparing sandbox ${sandbox.boxId} took ${Date.now() - startTime
                 }ms`,
             )
         }
         else {
             await sandbox.clean()
             logger.info(
-                `[${jobData.runId}] Reusing sandbox ${sandbox.boxId} took ${
-                    Date.now() - startTime
+                `[${jobData.runId}] Reusing sandbox ${sandbox.boxId} took ${Date.now() - startTime
                 }ms`,
             )
         }
@@ -250,10 +248,8 @@ async function executeFlow(jobData: OneTimeJobData): Promise<void> {
         })
 
         logger.info(
-            `[FlowWorker#executeFlow] flowRunId=${
-                jobData.runId
-            } executionOutputStats=${executionOutput.status} sandboxId=${
-                sandbox.boxId
+            `[FlowWorker#executeFlow] flowRunId=${jobData.runId
+            } executionOutputStats=${executionOutput.status} sandboxId=${sandbox.boxId
             } duration=${Date.now() - startTime} ms`,
         )
     }
@@ -268,8 +264,6 @@ async function executeFlow(jobData: OneTimeJobData): Promise<void> {
             })
         }
         else {
-            logger.error(e, `[${jobData.runId}] Error executing flow`)
-            captureException(e as Error)
             await flowRunService.finish({
                 flowRunId: jobData.runId,
                 status: ExecutionOutputStatus.INTERNAL_ERROR,
@@ -277,6 +271,8 @@ async function executeFlow(jobData: OneTimeJobData): Promise<void> {
                 logsFileId: null,
                 tags: [],
             })
+            sandboxManager.markAsNotCached(sandbox.boxId)
+            throwErrorToRetry(e as Error, jobData.runId)
         }
     }
     finally {
@@ -284,7 +280,14 @@ async function executeFlow(jobData: OneTimeJobData): Promise<void> {
     }
 }
 
-async function saveToLogFile({ fileId, projectId, executionOutput }: { fileId: FileId | undefined, projectId: ProjectId, executionOutput: ExecutionOutput }) {
+
+function throwErrorToRetry(error: Error, runId: string): void {
+    captureException(error)
+    logger.error(error, '[FlowWorker#executeFlow] Error executing flow run id' + runId)
+    throw error
+}
+
+async function saveToLogFile({ fileId, projectId, executionOutput }: { fileId: FileId | undefined, projectId: ProjectId, executionOutput: ExecutionOutput }): Promise<File> {
     // TODO REMOVE THIS, DELETE TEMPORARY 
     if (executionOutput.status !== ExecutionOutputStatus.PAUSED) {
         executionOutput.executionState.lastStepState = {}
@@ -309,35 +312,77 @@ async function downloadFiles(
     projectId: ProjectId,
     flowVersion: FlowVersion,
 ): Promise<void> {
-    logger.info(`[${flowVersion.id}] Acquiring flow lock to build codes`)
-    const flowLock = await acquireLock({
-        key: flowVersion.id,
-        timeout: 180000,
-    })
-    try {
-        const buildPath = sandbox.getSandboxFolderPath()
-        await ensureBuildDirectory(buildPath)
-        const codeSteps = getCodeSteps(flowVersion.trigger)
-
-        await Promise.all(
-            codeSteps.map((step) =>
-                codeBuilder.processCodeStep(step, buildPath, flowVersion.id, projectId),
-            ),
-        )
-    }
-    finally {
-        logger.info(`[${flowVersion.id}] Releasing flow lock`)
-        await flowLock.release()
-    }
+    const buildPath = sandbox.getSandboxFolderPath()
+    await ensureBuildDirectory(buildPath)
+    const codeSteps = await getCodeSteps(projectId, flowVersion)
+    await Promise.all(
+        codeSteps.map((step) =>
+            codeBuilder.processCodeStep({
+                codeZip: step.zipFile,
+                sourceCodeId: step.sourceId,
+                buildPath,
+            }),
+        ),
+    )
 }
 
 async function ensureBuildDirectory(buildPath: string): Promise<void> {
     await fs.ensureDir(`${buildPath}/codes/`)
 }
 
-function getCodeSteps(trigger: Trigger): (Action | Trigger)[] {
-    const steps = flowHelper.getAllSteps(trigger)
-    return steps.filter((step) => step.type === ActionType.CODE)
+async function getCodeSteps(projectId: ProjectId, flowVersion: FlowVersion): Promise<{ sourceId: string, zipFile: Buffer }[]> {
+    switch (flowVersion.state) {
+        case FlowVersionState.DRAFT:
+            return getCodeStepsWithLock(projectId, flowVersion)
+        case FlowVersionState.LOCKED:
+            return getCodeStepsWithoutLock(projectId, flowVersion)
+    }
+}
+
+async function getCodeStepsWithLock(projectId: ProjectId, flowVersion: FlowVersion): Promise<{ sourceId: string, zipFile: Buffer }[]> {
+    const flowLock = await acquireLock({
+        key: flowVersion.id,
+        timeout: 180000,
+    })
+    try {
+        return getCodeStepsWithoutLock(projectId, flowVersion)
+    }
+    finally {
+        flowLock.release()
+    }
+}
+
+async function getCodeStepsWithoutLock(projectId: ProjectId, flowVersion: FlowVersion): Promise<{ sourceId: string, zipFile: Buffer }[]> {
+    const steps = flowHelper.getAllSteps(flowVersion.trigger).filter((step) => step.type === ActionType.CODE)
+    const promises = []
+
+    for (const step of steps) {
+        const codeSettings = step.settings as CodeActionSettings
+        if (isNil(codeSettings.artifactSourceId)) {
+            throw new ActivepiecesError({
+                code: ErrorCode.VALIDATION,
+                params: {
+                    message: `Missing artifactSourceId for code step ${flowVersion.id}`,
+                },
+            })
+        }
+        const promise = fileService.getOneOrThrow({
+            fileId: codeSettings.artifactSourceId,
+            projectId,
+        })
+        promises.push(promise)
+    }
+
+    const results = await Promise.all(promises)
+
+    return results.map((sourceEntity, index) => {
+        const step = steps[index]
+        const codeSettings = step.settings as CodeActionSettings
+        return {
+            sourceId: codeSettings.artifactSourceId!,
+            zipFile: sourceEntity.data,
+        }
+    })
 }
 
 export const flowWorker = {

--- a/packages/backend/src/app/workers/sandbox.ts
+++ b/packages/backend/src/app/workers/sandbox.ts
@@ -315,6 +315,14 @@ export default class SandboxManager {
         return oldestSandbox
     }
 
+    async markAsNotCached(sandboxId: number): Promise<void> {
+        const sandbox = this.sandboxes.get(sandboxId)
+        if (!sandbox) {
+            throw new Error('Sandbox not found')
+        }
+        sandbox.cached = false
+    }
+
     async returnSandbox(sandboxId: number): Promise<void> {
         const release = await this.mutex.acquire()
         const sandbox = this.sandboxes.get(sandboxId)

--- a/packages/ui/common/src/lib/components/status-icon/state-icon.component.ts
+++ b/packages/ui/common/src/lib/components/status-icon/state-icon.component.ts
@@ -69,8 +69,9 @@ export class StateIconComponent implements OnInit, OnChanges {
       case StepOutputStatus.SUCCEEDED:
       case StepOutputStatus.STOPPED:
         return 'Succeeded';
-      case ExecutionOutputStatus.FAILED:
       case ExecutionOutputStatus.INTERNAL_ERROR:
+        return 'Internal Error';
+      case ExecutionOutputStatus.FAILED:
       case ExecutionOutputStatus.TIMEOUT:
       case StepOutputStatus.FAILED:
         return 'Failed';


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

1- Failed Jobs weren't able to retry, due the error is not thrown
2- Running acquireLock should only be for draft versions and only while loading files, not while building.
