### PR TITLE
fix: Array inputs shouldn't send empty strings to backend

### DIFF
--- a/packages/ui/feature-builder-form-controls/src/lib/array-form-control/array-form-control.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/array-form-control/array-form-control.component.ts
@@ -56,6 +56,12 @@ export class ArrayFormControlComponent implements ControlValueAccessor {
           { emitEvent: false }
         );
       });
+      if (obj.length === 0) {
+        this.formArray.push(
+          new FormControl<string>('', { nonNullable: true }),
+          { emitEvent: false }
+        );
+      }
       if (
         this.formArray.length > 0 &&
         this.formArray.controls[this.formArray.length - 1].value

--- a/packages/ui/feature-builder-form-controls/src/lib/array-form-control/array-form-control.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/array-form-control/array-form-control.component.ts
@@ -25,7 +25,7 @@ import { InsertMentionOperation } from '@activepieces/ui/common';
 })
 export class ArrayFormControlComponent implements ControlValueAccessor {
   valueChanges$: Observable<void>;
-  formArray: FormArray<FormControl>;
+  formArray: FormArray<FormControl<string>>;
   @ViewChild('textControl') firstInput: InterpolatingTextFormControlComponent;
   onChange: (val: unknown) => void = () => {
     //ignore
@@ -35,10 +35,12 @@ export class ArrayFormControlComponent implements ControlValueAccessor {
   };
 
   constructor(private fb: FormBuilder) {
-    this.formArray = this.fb.array([new FormControl('')]);
+    this.formArray = this.fb.array([
+      new FormControl<string>(''),
+    ] as FormControl<string>[]);
     this.valueChanges$ = this.formArray.valueChanges.pipe(
       tap((val) => {
-        this.onChange(val);
+        this.onChange(val.filter((v) => v !== ''));
       }),
       map(() => {
         return void 0;
@@ -49,13 +51,16 @@ export class ArrayFormControlComponent implements ControlValueAccessor {
     if (obj) {
       this.formArray.clear();
       obj.forEach((val) => {
-        this.formArray.push(new FormControl(val), { emitEvent: false });
+        this.formArray.push(
+          new FormControl<string>(val, { nonNullable: true }),
+          { emitEvent: false }
+        );
       });
       if (
         this.formArray.length > 0 &&
         this.formArray.controls[this.formArray.length - 1].value
       ) {
-        this.formArray.push(new FormControl(''));
+        this.formArray.push(new FormControl<string>('', { nonNullable: true }));
       }
     }
   }
@@ -73,7 +78,7 @@ export class ArrayFormControlComponent implements ControlValueAccessor {
     }
   }
   addValue() {
-    this.formArray.push(new FormControl(''));
+    this.formArray.push(new FormControl<string>('', { nonNullable: true }));
   }
   removeValue(index: number) {
     if (this.formArray.controls.length > 1) {

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
@@ -395,8 +395,8 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
             ? propValue
             : Array.isArray(prop.defaultValue) && prop.defaultValue.length > 0
             ? prop.defaultValue
-            : [''];
-          controls[pk] = new UntypedFormControl(controlValue, validators);
+            : [];
+          controls[pk] = new UntypedFormControl(controlValue);
           break;
         }
         case PropertyType.MARKDOWN: {
@@ -408,7 +408,7 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
             : typeof prop.defaultValue === 'object'
             ? prop.defaultValue
             : {};
-          controls[pk] = new UntypedFormControl(controlValue, validators);
+          controls[pk] = new UntypedFormControl(controlValue);
           break;
         }
         case PropertyType.BASIC_AUTH:
@@ -422,7 +422,7 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
           break;
         }
         case PropertyType.CHECKBOX: {
-          controls[pk] = new UntypedFormControl(propValue || false, validators);
+          controls[pk] = new UntypedFormControl(propValue || false);
           break;
         }
         case PropertyType.DATE_TIME:


### PR DESCRIPTION
## What does this PR do?

Stop array inputs from sending empty strings to backend.


