### PR TITLE
Fix: fasten saving steps and fix failing to save steps with long sample data

### DIFF
--- a/packages/ui/feature-builder-store/src/lib/store/flow/flow.effects.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/flow/flow.effects.ts
@@ -40,6 +40,7 @@ import {
 import { canvasActions } from '../builder/canvas/canvas.action';
 import { ViewModeActions } from '../builder/viewmode/view-mode.action';
 import { ViewModeEnum } from '../../model';
+import { FlowStructureUtil } from '../../utils/flowStructureUtil';
 @Injectable()
 export class FlowsEffects {
   loadInitial$ = createEffect(() => {
@@ -220,24 +221,34 @@ export class FlowsEffects {
         const genSavedId = UUID.UUID();
         let flowOperation: FlowOperationRequest;
         switch (action.type) {
-          case FlowsActionType.UPDATE_TRIGGER:
+          case FlowsActionType.UPDATE_TRIGGER: {
+            const op =
+              FlowStructureUtil.removeAnySubequentStepsFromFlowOperationStep(
+                action.operation
+              ) as typeof action.operation;
             flowOperation = {
               type: FlowOperationType.UPDATE_TRIGGER,
-              request: action.operation,
+              request: op,
             };
             break;
+          }
           case FlowsActionType.ADD_ACTION:
             flowOperation = {
               type: FlowOperationType.ADD_ACTION,
               request: action.operation,
             };
             break;
-          case FlowsActionType.UPDATE_ACTION:
+          case FlowsActionType.UPDATE_ACTION: {
+            const op =
+              FlowStructureUtil.removeAnySubequentStepsFromFlowOperationStep(
+                action.operation
+              ) as typeof action.operation;
             flowOperation = {
               type: FlowOperationType.UPDATE_ACTION,
-              request: action.operation,
+              request: op,
             };
             break;
+          }
           case FlowsActionType.DELETE_ACTION:
             flowOperation = {
               type: FlowOperationType.DELETE_ACTION,

--- a/packages/ui/feature-builder-store/src/lib/utils/flowStructureUtil.ts
+++ b/packages/ui/feature-builder-store/src/lib/utils/flowStructureUtil.ts
@@ -1,4 +1,5 @@
 import {
+  Action,
   ActionType,
   BranchAction,
   LoopOnItemsAction,
@@ -81,5 +82,24 @@ export class FlowStructureUtil {
     return (
       flowHelper.getAllSteps(trigger).findIndex((f) => stepName === f.name) + 1
     );
+  }
+
+  public static removeAnySubequentStepsFromFlowOperationStep(
+    req: Trigger | Action
+  ): typeof req {
+    const clone: Trigger | Action = JSON.parse(JSON.stringify(req));
+    if (clone.nextAction) clone.nextAction = undefined;
+    switch (clone.type) {
+      case ActionType.BRANCH: {
+        clone.onFailureAction = undefined;
+        clone.onSuccessAction = undefined;
+        break;
+      }
+      case ActionType.LOOP_ON_ITEMS: {
+        clone.firstLoopAction = undefined;
+        break;
+      }
+    }
+    return clone;
   }
 }


### PR DESCRIPTION
## What does this PR do?

Remove nextAction,firstLoopAction, onSuccessAction and onFailuireAction from being sent to backend on UPDATE_ACTION.

