### PR TITLE
fix(sendfox): created contact not in the right list

### DIFF
--- a/packages/pieces/sendfox/package.json
+++ b/packages/pieces/sendfox/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-sendfox",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/pieces/sendfox/src/lib/actions/create-contact.ts
+++ b/packages/pieces/sendfox/src/lib/actions/create-contact.ts
@@ -37,6 +37,6 @@ export const createContact = createAction({
         if( list ) request_body['lists'] = [list];
 
         const response = ( await callsendfoxApi(HttpMethod.POST, 'contacts', accessToken, request_body )).body;
-        return { list_id: list , response: response};
+        return { response: response};
     },
 });

--- a/packages/pieces/sendfox/src/lib/actions/create-contact.ts
+++ b/packages/pieces/sendfox/src/lib/actions/create-contact.ts
@@ -34,9 +34,9 @@ export const createContact = createAction({
         const request_body: { [key: string]: any } = { email : email } ;
         if( firstname ) request_body['first_name'] = firstname;
         if( lastname ) request_body['last_name'] = lastname;
-        if( list ) request_body['list_ids'] = [list];
+        if( list ) request_body['lists'] = [list];
 
         const response = ( await callsendfoxApi(HttpMethod.POST, 'contacts', accessToken, request_body )).body;
-        return [response];
+        return { list_id: list , response: response};
     },
 });

--- a/packages/pieces/sendfox/src/lib/actions/create-contact.ts
+++ b/packages/pieces/sendfox/src/lib/actions/create-contact.ts
@@ -37,6 +37,6 @@ export const createContact = createAction({
         if( list ) request_body['lists'] = [list];
 
         const response = ( await callsendfoxApi(HttpMethod.POST, 'contacts', accessToken, request_body )).body;
-        return { response: response};
+        return response;
     },
 });


### PR DESCRIPTION
## What does this PR do?
A bug where the list id shown when the user created is not used by the endpoint.
Fixes # (issue)

ANNOUNCEMENT=true

