### PR TITLE
feat(trello): card moved to list / new card created trigger

### DIFF
--- a/packages/pieces/trello/package.json
+++ b/packages/pieces/trello/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-trello",
-  "version": "0.3.0"
+  "version": "0.3.1"
 }

--- a/packages/pieces/trello/src/index.ts
+++ b/packages/pieces/trello/src/index.ts
@@ -1,6 +1,8 @@
 import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
 import { createCard } from './lib/actions/create-card';
 import { getCard } from './lib/actions/get-card';
+import { cardMovedTrigger } from './lib/triggers/cardMoved';
+import { newCardTrigger } from './lib/triggers/newCard';
 
 const markdownProperty = `
 To obtain your API key and token, follow these steps:
@@ -28,8 +30,8 @@ export const trello = createPiece({
   displayName: 'Trello',
   minimumSupportedRelease: '0.5.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/trello.png',
-  authors: ['ShayPunter'],
+  authors: ['ShayPunter','Salem-Alaa'],
   auth: trelloAuth,
   actions: [createCard, getCard],
-  triggers: []
+  triggers: [cardMovedTrigger,newCardTrigger]
 });

--- a/packages/pieces/trello/src/lib/common/props/card.ts
+++ b/packages/pieces/trello/src/lib/common/props/card.ts
@@ -53,3 +53,61 @@ export type TrelloCard = {
     subscribed: boolean;
     url: string;
   }
+export type TrelloCardMoved = {
+    action: {
+        display: {
+            translationKey: string;
+            entities: {
+                card: {
+                    type: string;
+                    idList: string;
+                    id: string;
+                    shortLink: string;
+                    text: string;
+                };
+                listBefore: {
+                    type: string;
+                    id: string;
+                    text: string;
+                };
+                listAfter: {
+                    type: string;
+                    id: string;
+                    text: string;
+                };
+                memberCreator: {
+                    type: string;
+                    id: string;
+                    username: string;
+                    text: string;
+                };
+            };
+        };
+    };
+}
+export type TrelloNewCard = {
+    action: {
+        display: {
+            translationKey: string;
+            entities: {
+                card: {
+                    type: string;
+                    id: string;
+                    shortLink: string;
+                    text: string;
+                };
+                list: {
+                    type: string;
+                    id: string;
+                    text: string;
+                };
+                memberCreator: {
+                    type: string;
+                    id: string;
+                    username: string;
+                    text: string;
+                };
+            };
+        };
+    };    
+}

--- a/packages/pieces/trello/src/lib/triggers/cardMoved.ts
+++ b/packages/pieces/trello/src/lib/triggers/cardMoved.ts
@@ -1,0 +1,79 @@
+import { trelloAuth } from "../..";
+import { TriggerStrategy, createTrigger } from "@activepieces/pieces-framework";
+import { trelloCommon } from "../common";
+import { TrelloCardMoved } from "../common/props/card";
+import { isNil } from "@activepieces/shared";
+
+
+
+
+export const cardMovedTrigger = createTrigger({
+    auth: trelloAuth,
+    name: 'card_moved_to_list',
+    displayName: 'Card Moved to list',
+    description: 'Trigger when a card is moved to the list specified',
+    props: {
+        board_id: trelloCommon.board_id,
+        list_id: trelloCommon.list_id,
+    },
+    type: TriggerStrategy.WEBHOOK,
+    async onEnable(context) {
+        const element_id = context.propsValue.list_id;
+        const webhooks = await trelloCommon.list_webhooks(context.auth);
+        const webhook = webhooks.find((webhook) => webhook.idModel === element_id && webhook.callbackURL === context.webhookUrl);
+        if (webhook) {
+            context.webhookUrl = webhook.callbackURL;
+            return;
+        }
+        const response = await trelloCommon.create_webhook(
+            context.auth,
+            element_id,
+            context.webhookUrl,
+        );
+        await context.store.put('webhook_id', response.id);
+    },
+    async onDisable(context) {
+        const webhook_id = await context.store.get('webhook_id') as string;
+        if (isNil(webhook_id)) {
+            return;
+        }
+        const webhooks = await trelloCommon.list_webhooks(context.auth);
+        const webhook = webhooks.find((webhook) => webhook.callbackURL === context.webhookUrl);
+        if (!webhook) {
+            return;
+        }
+        await trelloCommon.delete_webhook(
+            context.auth,
+            webhook_id,
+        );
+    },
+    async run(context) {
+        const response = context.payload.body as TrelloCardMoved;
+        const response_body = response.action.display;
+        if( response.action.display.translationKey !== 'action_move_card_from_list_to_list' ) {
+            return [];
+        }
+        if( response_body.entities.listAfter.id !== context.propsValue.list_id ) {
+            return [];
+        }
+        if( response_body.entities.listBefore.id === context.propsValue.list_id ) {
+            return [];
+        }
+        return [response_body];
+    },
+    async test(context) {
+        const response = context.payload.body as TrelloCardMoved;
+        const response_body = response.action.display;
+        if( response.action.display.translationKey !== 'action_move_card_from_list_to_list' ) {
+            return [];
+        }
+        if( response_body.entities.listAfter.id !== context.propsValue.list_id ) {
+            return [];
+        }
+        if( response_body.entities.listBefore.id === context.propsValue.list_id ) {
+            return [];
+        }
+        return [response_body];
+    },
+    sampleData: {},
+});

--- a/packages/pieces/trello/src/lib/triggers/newCard.ts
+++ b/packages/pieces/trello/src/lib/triggers/newCard.ts
@@ -1,0 +1,75 @@
+import { trelloAuth } from "../..";
+import { TriggerStrategy, createTrigger } from "@activepieces/pieces-framework";
+import { trelloCommon } from "../common";
+import { TrelloNewCard } from "../common/props/card";
+import { isNil } from "@activepieces/shared";
+
+export const newCardTrigger = createTrigger({
+    auth: trelloAuth,
+    name: 'new_card',
+    displayName: 'New Card',
+    description: 'Trigger when a new card is created',
+    props: {
+        board_id: trelloCommon.board_id,
+        list_id_opt: trelloCommon.list_id_opt,
+    },
+    type: TriggerStrategy.WEBHOOK,
+    async onEnable(context) {
+        const element_id = context.propsValue.list_id_opt || context.propsValue.board_id;
+        const webhooks = await trelloCommon.list_webhooks(context.auth);
+        const webhook = webhooks.find((webhook) => webhook.idModel === element_id && webhook.callbackURL === context.webhookUrl);
+        if (webhook) {
+            context.webhookUrl = webhook.callbackURL;
+            return;
+        }
+        const response = await trelloCommon.create_webhook(
+            context.auth,
+            element_id,
+            context.webhookUrl,
+        );
+        await context.store.put('webhook_id', response.id);
+    },
+    async onDisable(context) {
+        const webhook_id = await context.store.get('webhook_id') as string;
+        if (isNil(webhook_id)) {
+            return;
+        }
+        const webhooks = await trelloCommon.list_webhooks(context.auth);
+        const webhook = webhooks.find((webhook) => webhook.callbackURL === context.webhookUrl);
+        if (!webhook) {
+            return;
+        }
+        await trelloCommon.delete_webhook(
+            context.auth,
+            webhook_id,
+        );
+    },
+    async run(context){
+        const body = context.payload.body as TrelloNewCard;
+        if( body.action.display.translationKey !== 'action_create_card' ) {
+            return [];
+        }
+        if( context.propsValue.list_id_opt ) {
+            if( body.action.display.entities.list.id !== context.propsValue.list_id_opt ) {
+                return [];
+            }
+        }
+
+        return [body];
+    },
+    async test(context){
+        const body = context.payload.body as TrelloNewCard;
+        if( body.action.display.translationKey !== 'action_create_card' ) {
+            return [];
+        }
+        // know check if the user chosen a list
+        if( context.propsValue.list_id_opt ) {
+            if( body.action.display.entities.list.id !== context.propsValue.list_id_opt ) {
+                return [];
+            }
+        }
+
+        return [body];
+    },
+    sampleData: {},
+});


### PR DESCRIPTION
## What does this PR do?
Creating two new triggers to handle the following:
1 - card moved to list : to inform the user when a card is moved to a specified list.
2 - new card created : to inform the user when a card is created inside a board.
in the second trigger the user can limit the scope to a certain list

Fixes # (issue)

ANNOUNCEMENT=true

