### PR TITLE
feat(linear): create project, update project, create comment action & new issue trigger

### DIFF
--- a/packages/pieces/linear/package.json
+++ b/packages/pieces/linear/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-linear",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/pieces/linear/src/index.ts
+++ b/packages/pieces/linear/src/index.ts
@@ -4,6 +4,7 @@ import { linearUpdateIssue } from './lib/actions/issues/update-issue';
 import { linearCreateProject } from './lib/actions/projects/create-project';
 import { linearUpdateProject } from './lib/actions/projects/update-project';
 import { linearCreateComment } from './lib/actions/comments/create-comment';
+import { linearNewIssue } from './lib/triggers/new-issue';
 
 const markdown = `
 To obtain your API key, follow these steps:
@@ -35,5 +36,5 @@ export const linear = createPiece({
   logoUrl: 'https://cdn.activepieces.com/pieces/linear.png',
   authors: ['kishanprmr', 'lldiegon'],
   actions: [linearCreateIssue, linearUpdateIssue, linearCreateProject, linearUpdateProject, linearCreateComment],
-  triggers: [],
+  triggers: [linearNewIssue],
 });

--- a/packages/pieces/linear/src/index.ts
+++ b/packages/pieces/linear/src/index.ts
@@ -1,6 +1,9 @@
 import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
 import { linearCreateIssue } from './lib/actions/issues/create-issue';
 import { linearUpdateIssue } from './lib/actions/issues/update-issue';
+import { linearCreateProject } from './lib/actions/projects/create-project';
+import { linearUpdateProject } from './lib/actions/projects/update-project';
+import { linearCreateComment } from './lib/actions/comments/create-comment';
 
 const markdown = `
 To obtain your API key, follow these steps:
@@ -30,7 +33,7 @@ export const linear = createPiece({
   auth: linearAuth,
   minimumSupportedRelease: '0.7.1',
   logoUrl: 'https://cdn.activepieces.com/pieces/linear.png',
-  authors: ['kishanprmr'],
-  actions: [linearCreateIssue, linearUpdateIssue],
+  authors: ['kishanprmr', 'lldiegon'],
+  actions: [linearCreateIssue, linearUpdateIssue, linearCreateProject, linearUpdateProject, linearCreateComment],
   triggers: [],
 });

--- a/packages/pieces/linear/src/lib/actions/comments/create-comment.ts
+++ b/packages/pieces/linear/src/lib/actions/comments/create-comment.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { linearAuth } from '../../..'; 
+import { props } from '../../common/props';
+import { makeClient } from '../../common/client'; 
+import { LinearDocument } from '@linear/sdk';
+
+export const linearCreateComment = createAction({
+  auth: linearAuth,
+  name: 'linear_create_comment',
+  displayName: 'Create Comment',
+  description: 'Create a new comment on an issue in Linear workspace',
+  props: {
+    team_id: props.team_id(),
+    user_id: props.assignee_id(),
+    issue_id: props.issue_id(),
+    body: Property.LongText({
+      displayName: 'Comment Body',
+      description: 'The content of the comment',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const comment: LinearDocument.CommentCreateInput = {
+      issueId: propsValue.issue_id!,
+      body: propsValue.body,
+    };
+
+    const client = makeClient(auth as string);
+    const result = await client.createComment(comment);
+    return result;
+  },
+});

--- a/packages/pieces/linear/src/lib/actions/issues/create-issue.ts
+++ b/packages/pieces/linear/src/lib/actions/issues/create-issue.ts
@@ -13,12 +13,10 @@ export const linearCreateIssue = createAction({
     team_id: props.team_id(),
     title: Property.ShortText({
       displayName: 'Title',
-      description: 'The Title of the Issue',
       required: true,
     }),
     description: Property.LongText({
       displayName: 'Description',
-      description: 'The Description of the issue',
       required: false,
     }),
     state_id: props.status_id(),

--- a/packages/pieces/linear/src/lib/actions/issues/update-issue.ts
+++ b/packages/pieces/linear/src/lib/actions/issues/update-issue.ts
@@ -13,12 +13,10 @@ export const linearUpdateIssue = createAction({
     issue_id: props.issue_id(),
     title: Property.ShortText({
       displayName: 'Title',
-      description: 'Title of the Issue',
       required: false,
     }),
     description: Property.LongText({
       displayName: 'Description',
-      description: 'Description of the issue',
       required: false,
     }),
     state_id: props.status_id(),

--- a/packages/pieces/linear/src/lib/actions/projects/create-project.ts
+++ b/packages/pieces/linear/src/lib/actions/projects/create-project.ts
@@ -1,0 +1,61 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { linearAuth } from '../../..';
+import { props } from '../../common/props';
+import { makeClient } from '../../common/client';
+import { LinearDocument } from '@linear/sdk';
+
+export const linearCreateProject = createAction({
+    auth: linearAuth,
+    name: 'linear_create_project',
+    displayName: 'Create Project',
+    description: 'Create a new project in Linear workspace',
+    props: {
+        team_id: props.team_id(),
+        name: Property.ShortText({
+            displayName: 'Project Name',
+            description: 'The name of the new project',
+            required: true,
+        }),
+        description: Property.LongText({
+            displayName: 'Description',
+            description: 'The description of the new project',
+            required: false,
+        }),
+        icon: Property.ShortText({
+            displayName: 'Icon',
+            description: 'The icon for the new project',
+            required: false,
+        }),
+        color: Property.ShortText({
+            displayName: 'Color',
+            description: 'The color for the new project',
+            required: false,
+        }),
+        startDate: Property.DateTime({
+            displayName: 'Start Date',
+            description: 'The start date for the new project',
+            required: false,
+        }),
+        targetDate: Property.DateTime({
+            displayName: 'Target Date',
+            description: 'The target date for the new project',
+            required: false,
+        }),
+        
+    },
+    async run({ auth, propsValue }) {
+      const project: LinearDocument.ProjectCreateInput = {
+        teamIds: [propsValue.team_id!],
+        name: propsValue.name,
+        description: propsValue.description,
+        icon: propsValue.icon,
+        color: propsValue.color,
+        startDate: propsValue.startDate,
+        targetDate: propsValue.targetDate,
+      };
+  
+      const client = makeClient(auth as string);
+      const result = await client.createProject(project);
+      return result;
+    },
+});

--- a/packages/pieces/linear/src/lib/actions/projects/create-project.ts
+++ b/packages/pieces/linear/src/lib/actions/projects/create-project.ts
@@ -13,32 +13,26 @@ export const linearCreateProject = createAction({
         team_id: props.team_id(),
         name: Property.ShortText({
             displayName: 'Project Name',
-            description: 'The name of the new project',
             required: true,
         }),
         description: Property.LongText({
             displayName: 'Description',
-            description: 'The description of the new project',
             required: false,
         }),
         icon: Property.ShortText({
             displayName: 'Icon',
-            description: 'The icon for the new project',
             required: false,
         }),
         color: Property.ShortText({
             displayName: 'Color',
-            description: 'The color for the new project',
             required: false,
         }),
         startDate: Property.DateTime({
             displayName: 'Start Date',
-            description: 'The start date for the new project',
             required: false,
         }),
         targetDate: Property.DateTime({
             displayName: 'Target Date',
-            description: 'The target date for the new project',
             required: false,
         }),
         

--- a/packages/pieces/linear/src/lib/actions/projects/update-project.ts
+++ b/packages/pieces/linear/src/lib/actions/projects/update-project.ts
@@ -1,0 +1,62 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { linearAuth } from '../../..';
+import { props } from '../../common/props';
+import { makeClient } from '../../common/client';
+import { LinearDocument } from '@linear/sdk';
+
+export const linearUpdateProject = createAction({
+    auth: linearAuth,
+    name: 'linear_update_project',
+    displayName: 'Update Project',
+    description: 'Update a existing project in Linear workspace',
+    props: {
+        team_id: props.team_id(),
+        project_id: props.project_id(),
+        name: Property.ShortText({
+            displayName: 'Project Name',
+            description: 'The name of the new project',
+            required: true,
+        }),
+        description: Property.LongText({
+            displayName: 'Description',
+            description: 'The description of the new project',
+            required: false,
+        }),
+        icon: Property.ShortText({
+            displayName: 'Icon',
+            description: 'The icon for the new project',
+            required: false,
+        }),
+        color: Property.ShortText({
+            displayName: 'Color',
+            description: 'The color for the new project',
+            required: false,
+        }),
+        startDate: Property.DateTime({
+            displayName: 'Start Date',
+            description: 'The start date for the new project',
+            required: false,
+        }),
+        targetDate: Property.DateTime({
+            displayName: 'Target Date',
+            description: 'The target date for the new project',
+            required: false,
+        }),
+        
+    },
+    async run({ auth, propsValue }) {
+      const project: LinearDocument.ProjectUpdateInput = {
+        teamIds: [propsValue.team_id!],
+        name: propsValue.name,
+        description: propsValue.description,
+        icon: propsValue.icon,
+        color: propsValue.color,
+        startDate: propsValue.startDate,
+        targetDate: propsValue.targetDate,
+      };
+  
+      const client = makeClient(auth as string);
+      const result = await client.updateProject(propsValue.project_id!, project);
+      return result;
+    },
+});

--- a/packages/pieces/linear/src/lib/actions/projects/update-project.ts
+++ b/packages/pieces/linear/src/lib/actions/projects/update-project.ts
@@ -14,32 +14,26 @@ export const linearUpdateProject = createAction({
         project_id: props.project_id(),
         name: Property.ShortText({
             displayName: 'Project Name',
-            description: 'The name of the new project',
             required: true,
         }),
         description: Property.LongText({
             displayName: 'Description',
-            description: 'The description of the new project',
             required: false,
         }),
         icon: Property.ShortText({
             displayName: 'Icon',
-            description: 'The icon for the new project',
             required: false,
         }),
         color: Property.ShortText({
             displayName: 'Color',
-            description: 'The color for the new project',
             required: false,
         }),
         startDate: Property.DateTime({
             displayName: 'Start Date',
-            description: 'The start date for the new project',
             required: false,
         }),
         targetDate: Property.DateTime({
             displayName: 'Target Date',
-            description: 'The target date for the new project',
             required: false,
         }),
         

--- a/packages/pieces/linear/src/lib/common/client.ts
+++ b/packages/pieces/linear/src/lib/common/client.ts
@@ -31,6 +31,21 @@ export class LinearClientWrapper {
   async updateIssue(issueId: string, input: LinearDocument.IssueUpdateInput) {
     return this.client.updateIssue(issueId, input);
   }
+  async createProject(input: LinearDocument.ProjectCreateInput) {
+    return this.client.createProject(input);
+  }
+  async listProjects(variables: LinearDocument.ProjectsQueryVariables = {}) {
+    return this.client.projects(variables);
+  }
+  async updateProject(
+    projectId: string,
+    input: LinearDocument.ProjectUpdateInput
+  ) {
+    return this.client.updateProject(projectId, input);
+  }
+  async createComment(input: LinearDocument.CommentCreateInput) {
+    return this.client.createComment(input);
+  }
 }
 
 export function makeClient(apiKey: string): LinearClientWrapper {

--- a/packages/pieces/linear/src/lib/common/client.ts
+++ b/packages/pieces/linear/src/lib/common/client.ts
@@ -46,6 +46,15 @@ export class LinearClientWrapper {
   async createComment(input: LinearDocument.CommentCreateInput) {
     return this.client.createComment(input);
   }
+  async createWebhook(input: LinearDocument.WebhookCreateInput) {
+    return this.client.createWebhook(input);
+  }
+  async listWebhooks(variables: LinearDocument.WebhooksQueryVariables = {}) {
+    return this.client.webhooks(variables);
+  }
+  async deleteWebhook(webhookId: string) {
+    return this.client.deleteWebhook(webhookId);
+  }
 }
 
 export function makeClient(apiKey: string): LinearClientWrapper {

--- a/packages/pieces/linear/src/lib/common/props.ts
+++ b/packages/pieces/linear/src/lib/common/props.ts
@@ -5,7 +5,7 @@ import { LinearDocument } from '@linear/sdk';
 export const props = {
   team_id: (required = true) =>
     Property.Dropdown({
-      description: 'The team for which the issue will be created',
+      description: 'The team for which the issue, project or comment will be created',
       displayName: 'Team',
       required,
       refreshers: ['auth'],
@@ -98,7 +98,7 @@ export const props = {
     }),
   assignee_id: (required = false) =>
     Property.Dropdown({
-      description: 'Assignee of the Issue',
+      description: 'Assignee of the Issue / Comment',
       displayName: 'Assignee',
       required,
       refreshers: ['auth'],
@@ -187,5 +187,37 @@ export const props = {
           }),
         };
       },
+    }),
+
+  project_id: (required = true) =>
+    Property.Dropdown({
+      displayName: 'Project',
+      required,
+      description: 'ID of Linear Project',
+      refreshers: ['team_id'],
+      options: async ({ auth, team_id }) => {
+        if (!auth || !team_id) {
+          return {
+            disabled: true,
+            placeholder: 'connect your account first and select team',
+            options: [],
+          };
+        }
+        const client = makeClient(auth as string);
+        const filter: LinearDocument.ProjectsQueryVariables = {
+          first: 50,
+          orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,
+        };
+        const projects = await client.listProjects(filter);
+        return {
+          disabled: false,
+          options: projects.nodes.map((project) => {
+            return {
+              label: project.name,
+              value: project.id,
+            };
+          }),
+        };
+      }
     }),
 };

--- a/packages/pieces/linear/src/lib/triggers/new-issue.ts
+++ b/packages/pieces/linear/src/lib/triggers/new-issue.ts
@@ -2,7 +2,6 @@ import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
 import { linearAuth } from '../..';
 import { makeClient } from '../common/client';
 import { props } from '../common/props';
-// import { nanoid } from 'nanoid';
 
 export const linearNewIssue = createTrigger({
     auth: linearAuth,
@@ -64,9 +63,9 @@ export const linearNewIssue = createTrigger({
     },
     type: TriggerStrategy.WEBHOOK,
     async onEnable(context) {
-        // const randomTag = `ap_new_issue_${nanoid()}`;
         const client = makeClient(context.auth as string);
         const webhook = await client.createWebhook({
+            label: 'ActivePieces New Issue',
             url: context.webhookUrl,
             teamId: context.propsValue['team_id'],
             resourceTypes: ['Issue'],

--- a/packages/pieces/linear/src/lib/triggers/new-issue.ts
+++ b/packages/pieces/linear/src/lib/triggers/new-issue.ts
@@ -1,0 +1,100 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { linearAuth } from '../..';
+import { makeClient } from '../common/client';
+import { props } from '../common/props';
+// import { nanoid } from 'nanoid';
+
+export const linearNewIssue = createTrigger({
+    auth: linearAuth,
+    name: 'new_issue',
+    displayName: 'New Issue',
+    description: 'Triggers when Linear receives a new issue',
+    props: {
+        team_id: props.team_id(),
+    },
+    sampleData: {
+        // Sample data structure based on Linear's webhook payload for issues
+        "action": "create",
+        "data": {
+            "id": "issue_1",
+            "identifier": "1",
+            "title": "Test issue",
+            "description": "This is a test issue",
+            "priority": "priority_1",
+            "priorityLabel": "High",
+            "state": "state_1",
+            "stateLabel": "In Progress",
+            "team": {
+                "id": "team_1",
+                "name": "Test team",
+                "key": "test-team",
+                "description": "This is a test team",
+                "archived": false,
+                "createdAt": "2023-09-05T12:00:00.000Z",
+                "updatedAt": "2023-09-05T12:00:00.000Z"
+            },
+            "creator": {
+                "id": "user_1",
+                "name": "Test user",
+                "email": "test@gmail.com",
+                "avatarUrl": "https://avatars.githubusercontent.com/u/1?v=4",
+                "createdAt": "2023-09-05T12:00:00.000Z",
+                "updatedAt": "2023-09-05T12:00:00.000Z"
+            },
+            "assignee": {
+                "id": "user_1",
+                "name": "Test user",
+                "email": "test@gmail.com",
+                "avatarUrl": "https://avatars.githubusercontent.com/u/1?v=4",
+                "createdAt": "2023-09-05T12:00:00.000Z",
+                "updatedAt": "2023-09-05T12:00:00.000Z"
+            },
+            "labels": [
+                {
+                    "id": "label_1",
+                    "name": "Test label",
+                    "color": "#000000",
+                    "createdAt": "2023-09-05T12:00:00.000Z",
+                    "updatedAt": "2023-09-05T12:00:00.000Z"
+                }
+            ],
+            "createdAt": "2023-09-05T12:00:00.000Z",
+            "updatedAt": "2023-09-05T12:00:00.000Z"
+        }
+    },
+    type: TriggerStrategy.WEBHOOK,
+    async onEnable(context) {
+        // const randomTag = `ap_new_issue_${nanoid()}`;
+        const client = makeClient(context.auth as string);
+        const webhook = await client.createWebhook({
+            url: context.webhookUrl,
+            teamId: context.propsValue['team_id'],
+            resourceTypes: ['Issue'],
+        });
+        if (webhook.success && webhook.webhook) {
+            await context.store?.put<WebhookInformation>('_new_issue_trigger', {
+                webhookId: (await webhook.webhook).id,
+            });
+        } else {
+            console.error("Failed to create the webhook");
+        }
+    },
+    async onDisable(context) {
+        const client = makeClient(context.auth as string);
+        const response = await context.store?.get<WebhookInformation>('_new_issue_trigger');
+        if (response && response.webhookId) {
+            await client.deleteWebhook(response.webhookId);
+        }
+    },
+    async run(context) {
+        const body = context.payload.body as { action: string; data: unknown };
+        if (body.action === 'create') {
+            return [body.data];
+        }
+        return [];
+    },
+});
+
+interface WebhookInformation {
+  webhookId: string;
+}


### PR DESCRIPTION
## What does this PR do?

This combination of triggers and actions allows me to:

- Get one step closer to automating client onboarding by creating a project board.
- Get notifications of new issues in my private discord server.
- Let ChatGPT brainstorm about new issues and place a comment to the issue/task with the output.

Announcement=true