### PR TITLE
fix(server): remove body from get request

### DIFF
--- a/packages/pieces/http/src/lib/actions/send-http-request-action.ts
+++ b/packages/pieces/http/src/lib/actions/send-http-request-action.ts
@@ -53,7 +53,7 @@ export const httpSendRequestAction = createAction({
         url,
         headers: headers as HttpHeaders,
         queryParams: queryParams as QueryParams,
-        body,
+        body: (method !== "GET") ? body : undefined,
         timeout: timeout ? timeout * 1000 : 0,
       };
 


### PR DESCRIPTION
## What does this PR do?
Removes the HTTP body from the HTTP Piece in a HTTP GET request

Fixes #2087 

