### PR TITLE
fix: unquoted migration parameter

### DIFF
--- a/packages/backend/src/app/database/migration/postgres/1686138629812-unifyPieceName.ts
+++ b/packages/backend/src/app/database/migration/postgres/1686138629812-unifyPieceName.ts
@@ -126,7 +126,7 @@ async function updatePieceMetadata(queryRunner: QueryRunner, revert: boolean): P
 
     for (const pieceMetadata of pieceMetadatas) {
         const updatedName = getPackageNameForPiece(pieceMetadata.name, revert)
-        const updateQuery = `UPDATE piece_metadata SET name = '${updatedName}' WHERE id = ${pieceMetadata.id};`
+        const updateQuery = `UPDATE piece_metadata SET name = '${updatedName}' WHERE id = '${pieceMetadata.id}';`
         await queryRunner.connection.query(updateQuery)
         count++
     }


### PR DESCRIPTION
Just ran into this when updating from 0.3.9 to 0.8.0.

