### PR TITLE
fix(google-sheet): Get next row handling out of bound

### DIFF
--- a/packages/pieces/google-sheets/package.json
+++ b/packages/pieces/google-sheets/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.7.2"
+  "version": "0.7.3"
 }

--- a/packages/pieces/google-sheets/src/lib/actions/get-rows.ts
+++ b/packages/pieces/google-sheets/src/lib/actions/get-rows.ts
@@ -1,6 +1,6 @@
 import { Property, Store, StoreScope, Validators, createAction } from "@activepieces/pieces-framework";
 import { googleSheetsAuth } from "../..";
-import { getGoogleSheetRows, googleSheetsCommon } from "../common/common";
+import { getAllGoogleSheetRows, getGoogleSheetRows, googleSheetsCommon } from "../common/common";
 import { isNil } from "@activepieces/shared";
 
 async function getRows( store: Store , accessToken:string , spreadsheetId:string , sheetId:number , memKey:string , groupSize:number , testing:boolean ){
@@ -24,7 +24,7 @@ async function getRows( store: Store , accessToken:string , spreadsheetId:string
     if (startingRow < 1) throw Error('Starting row : ' + startingRow + ' is less than 1' + memVal);
     const endRow = startingRow + groupSize;
     if( testing == false )await store.put(memKey, endRow, StoreScope.FLOW);
-    
+
     const row = await getGoogleSheetRows({
         accessToken: accessToken,
         sheetName: sheetName,
@@ -32,6 +32,16 @@ async function getRows( store: Store , accessToken:string , spreadsheetId:string
         rowIndex_s: startingRow,
         rowIndex_e: endRow - 1
     });
+
+    if( row.length == 0 ){
+        const allRows = await getAllGoogleSheetRows({
+            accessToken: accessToken,
+            sheetName: sheetName,
+            spreadSheetId: spreadsheetId,
+        });
+        const lastRow = allRows.length + 1;
+        if( testing == false )await store.put(memKey, lastRow, StoreScope.FLOW);
+    }
 
     return row;
 }

--- a/packages/pieces/google-sheets/src/lib/actions/get-rows.ts
+++ b/packages/pieces/google-sheets/src/lib/actions/get-rows.ts
@@ -23,7 +23,8 @@ async function getRows( store: Store , accessToken:string , spreadsheetId:string
 
     if (startingRow < 1) throw Error('Starting row : ' + startingRow + ' is less than 1' + memVal);
     const endRow = startingRow + groupSize;
-
+    if( testing == false )await store.put(memKey, endRow, StoreScope.FLOW);
+    
     const row = await getGoogleSheetRows({
         accessToken: accessToken,
         sheetName: sheetName,
@@ -31,8 +32,6 @@ async function getRows( store: Store , accessToken:string , spreadsheetId:string
         rowIndex_s: startingRow,
         rowIndex_e: endRow - 1
     });
-
-    if( testing == false )await store.put(memKey, endRow, StoreScope.FLOW);
 
     return row;
 }

--- a/packages/pieces/google-sheets/src/lib/common/common.ts
+++ b/packages/pieces/google-sheets/src/lib/common/common.ts
@@ -249,7 +249,34 @@ export async function getGoogleSheetRows(params: { accessToken: string; sheetNam
 
     return res;
 }
+export async function getAllGoogleSheetRows(params: { accessToken: string; sheetName: string; spreadSheetId: string; }) {
+    const request: HttpRequest = {
+        method: HttpMethod.GET,
+        url: `${googleSheetsCommon.baseUrl}/${params.spreadSheetId}/values/${params.sheetName}`,
+        authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: params.accessToken,
+        }
+    };
+    const response = await httpClient.sendRequest<{ values: [string[]][] }>(request);
+    if (response.body.values === undefined) return [];
 
+    const res = [];
+    for (let i = 0; i < response.body.values.length; i++) {
+        const values: any = {}
+        for (let j = 0; j < response.body.values[i].length; j++) {
+            values[columnToLabel(j)] = response.body.values[i][j];
+        }
+        
+        res.push({
+            row: i + 1,
+            values
+        });
+
+    }
+
+    return res;
+}
 async function listSheetsName(access_token: string, spreadsheet_id: string) {
     return (await httpClient.sendRequest<{ sheets: { properties: { title: string, sheetId: number } }[] }>({
         method: HttpMethod.GET,


### PR DESCRIPTION
## What does this PR do?
Calling the get next row(s) rapidly will cause a race condition in which the newer calls will user the old value of the counter.
Outbound fixed
Fixes #2751 
Announcement=true