### PR TITLE
fix: switch from Discord to community in user-avatar dropdown.

### DIFF
--- a/packages/ui/common/src/lib/components/user-avatar/user-avatar.component.html
+++ b/packages/ui/common/src/lib/components/user-avatar/user-avatar.component.html
@@ -9,7 +9,7 @@
         What's new
     </div>
     <div mat-menu-item (click)="goToCommunity()">
-        <div class="ap-flex ap-items-center ap-w-[214px]">Community <div class="ap-flex-grow"></div><svg-icon
+        <div class="ap-flex ap-items-center ap-min-w-[214px]">Community <div class="ap-flex-grow"></div><svg-icon
                 src="assets/img/custom/external-link.svg" class="ap-h-[16px] ap-w-[16px] ap-fill-[#989898]"></svg-icon>
         </div>
     </div>

--- a/packages/ui/common/src/lib/components/user-avatar/user-avatar.component.html
+++ b/packages/ui/common/src/lib/components/user-avatar/user-avatar.component.html
@@ -9,7 +9,7 @@
         What's new
     </div>
     <div mat-menu-item (click)="goToCommunity()">
-        <div class="ap-flex ap-items-center ap-w-[214px]">Discord <div class="ap-flex-grow"></div><svg-icon
+        <div class="ap-flex ap-items-center ap-w-[214px]">Community <div class="ap-flex-grow"></div><svg-icon
                 src="assets/img/custom/external-link.svg" class="ap-h-[16px] ap-w-[16px] ap-fill-[#989898]"></svg-icon>
         </div>
     </div>

--- a/packages/ui/common/src/lib/components/user-avatar/user-avatar.component.ts
+++ b/packages/ui/common/src/lib/components/user-avatar/user-avatar.component.ts
@@ -46,7 +46,7 @@ export class UserAvatarComponent {
     return this.authenticationService.currentUser.firstName[0];
   }
   goToCommunity() {
-    window.open('https://discord.gg/yvxF5k5AUb', '_blank', 'noopener');
+    window.open('https://community.activepieces.com/', '_blank', 'noopener');
   }
 
   showWhatIsNew() {


### PR DESCRIPTION
## What does this PR do?

The Discord item in the dropdown now takes the users to community.activepieces.com.
