### PR TITLE
fix: stopped connections dropdown from overflowing the reconnect button

### DIFF
--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.html
@@ -298,16 +298,7 @@
       </ng-container>
       <ng-template #connectionDropdownInputTemplate>
         <div class="ap-relative">
-          <app-add-edit-connection-button class="edit-selected-auth ap-z-40"
-            *ngIf="formGroup.enabled && formGroup.get(property.key)!.value" btnSize="extraSmall"
-            [isEditConnectionButton]="true" [authProperty]="property.value" [pieceName]="pieceName"
-            [pieceVersion]="pieceVersion" [propertyKey]="property.key"
-            [selectedConnectionInterpolatedString]="formGroup.get(property.key)!.value"
-            (connectionPropertyValueChanged)="connectionValueChanged($event)" [triggerName]="actionOrTriggerName">
-            <div class="ap-px-2">
-              Reconnect
-            </div>
-          </app-add-edit-connection-button>
+
           <mat-form-field subscriptSizing="dynamic" class="ap-w-full" appearance="outline" #dropdown
             #dropdownUiContainer="hoverTrackerDirective" apTrackHover>
             <mat-label> Connection </mat-label>
@@ -338,7 +329,32 @@
                   </div>
                 </div>
               </mat-option>
+
+              <mat-select-trigger>
+                <div class="ap-flex ap-gap-[6px] ap-pr-1">
+                  <div class="ap-w-full ap-truncate">
+                    {{((allAuthConfigs$ | async)!|
+                    selectedAuthConfig:pieceName:formGroup.value[property.key])?.label?.name
+                    ||
+                    ''}}
+                  </div>
+                  <div class=" -ap-mt-[6px]">
+                    <app-add-edit-connection-button *ngIf="formGroup.enabled && formGroup.get(property.key)!.value"
+                      (click)="$event.stopPropagation()" btnSize="extraSmall" [isEditConnectionButton]="true"
+                      [authProperty]="property.value" [pieceName]="pieceName" [pieceVersion]="pieceVersion"
+                      [propertyKey]="property.key"
+                      [selectedConnectionInterpolatedString]="formGroup.get(property.key)!.value"
+                      (connectionPropertyValueChanged)="connectionValueChanged($event)"
+                      [triggerName]="actionOrTriggerName">
+                      <div class="ap-px-2">
+                        Reconnect
+                      </div>
+                    </app-add-edit-connection-button>
+                  </div>
+                </div>
+              </mat-select-trigger>
             </mat-select>
+
           </mat-form-field>
           <app-add-edit-connection-button btnSize="medium" class="ap-hidden" *ngIf="formGroup.enabled"
             [isEditConnectionButton]="false" #addConnectionBtn [authProperty]="property.value" [pieceName]="pieceName"

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/selected-auth-config.pipe.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/selected-auth-config.pipe.ts
@@ -9,10 +9,10 @@ export class SelectedAuthConfigsPipe implements PipeTransform {
   transform(
     value: ConnectionDropdownItem[],
     pieceName: string,
-    controlValue:string
+    controlValue: string
   ): ConnectionDropdownItem | undefined {
-    return value.filter(
-      (item) => item.label.appName === pieceName || !item.label.appName
-    ).find(item=> item.value === controlValue);
+    return value
+      .filter((item) => item.label.appName === pieceName || !item.label.appName)
+      .find((item) => item.value === controlValue);
   }
 }

--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/selected-auth-config.pipe.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/selected-auth-config.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { ConnectionDropdownItem } from '@activepieces/ui/feature-builder-store';
+
+@Pipe({
+  name: 'selectedAuthConfig',
+  pure: true,
+})
+export class SelectedAuthConfigsPipe implements PipeTransform {
+  transform(
+    value: ConnectionDropdownItem[],
+    pieceName: string,
+    controlValue:string
+  ): ConnectionDropdownItem | undefined {
+    return value.filter(
+      (item) => item.label.appName === pieceName || !item.label.appName
+    ).find(item=> item.value === controlValue);
+  }
+}

--- a/packages/ui/feature-builder-form-controls/src/lib/ui-feature-builder-form-controls.module.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/ui-feature-builder-form-controls.module.ts
@@ -44,7 +44,6 @@ const exportedDeclarations = [
   PiecePropertiesFormComponent,
   BuilderAutocompleteMentionsDropdownComponent,
   BuilderAutocompleteDropdownHandlerComponent,
-  
 ];
 @NgModule({
   imports: [
@@ -77,7 +76,7 @@ const exportedDeclarations = [
     AuthConfigsPipe,
     AutocompleteDropdownSizesButtonsComponent,
     DropdownPropertySearchPipe,
-    SelectedAuthConfigsPipe
+    SelectedAuthConfigsPipe,
   ],
   exports: [...exportedDeclarations],
 })

--- a/packages/ui/feature-builder-form-controls/src/lib/ui-feature-builder-form-controls.module.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/ui-feature-builder-form-controls.module.ts
@@ -33,6 +33,7 @@ import { BuilderAutocompleteDropdownHandlerComponent } from './interpolating-tex
 import { AutocompleteDropdownSizesButtonsComponent } from './interpolating-text-form-control/mentions-list/autocomplete-dropdown-sizes-buttons/autocomplete-dropdown-sizes-buttons.component';
 import { DropdownPropertySearchPipe } from './piece-properties-form/dropdown-search.pipe';
 import { MarkdownModule } from 'ngx-markdown';
+import { SelectedAuthConfigsPipe } from './piece-properties-form/selected-auth-config.pipe';
 const exportedDeclarations = [
   ArrayFormControlComponent,
   BranchConditionFormControlComponent,
@@ -43,6 +44,7 @@ const exportedDeclarations = [
   PiecePropertiesFormComponent,
   BuilderAutocompleteMentionsDropdownComponent,
   BuilderAutocompleteDropdownHandlerComponent,
+  
 ];
 @NgModule({
   imports: [
@@ -75,6 +77,7 @@ const exportedDeclarations = [
     AuthConfigsPipe,
     AutocompleteDropdownSizesButtonsComponent,
     DropdownPropertySearchPipe,
+    SelectedAuthConfigsPipe
   ],
   exports: [...exportedDeclarations],
 })

--- a/packages/ui/feature-connections/src/lib/dialogs/cloud-oauth2-connection-dialog/cloud-oauth2-connection-dialog.component.html
+++ b/packages/ui/feature-connections/src/lib/dialogs/cloud-oauth2-connection-dialog/cloud-oauth2-connection-dialog.component.html
@@ -5,7 +5,7 @@
 
 <mat-dialog-content>
 
-  <form class="ap-flex ap-flex-col ap-gap-2 ap-w-[430px]" [formGroup]="settingsForm" (keyup.enter)="submit()"
+  <form class="ap-flex ap-flex-col ap-gap-2 ap-min-w-[430px]" [formGroup]="settingsForm" (keyup.enter)="submit()"
     (submit)="submit()">
     <mat-form-field class="ap-w-full" appearance="outline">
       <mat-label>Name</mat-label>


### PR DESCRIPTION
## What does this PR do?


Before:
![image](https://github.com/activepieces/activepieces/assets/106555838/16efa9f1-6645-46a1-bf97-676515cf7cdd)



After
![image](https://github.com/activepieces/activepieces/assets/106555838/789a83d1-6f4b-41e1-9962-c8da1ec48a04)
