### PR TITLE
fix(openrouter): removing the lead and trill spaces

### DIFF
--- a/packages/pieces/open-router/package.json
+++ b/packages/pieces/open-router/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-open-router",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/pieces/open-router/src/lib/actions/ask-open-router.ts
+++ b/packages/pieces/open-router/src/lib/actions/ask-open-router.ts
@@ -91,6 +91,8 @@ export const askOpenRouterAction = createAction({
             }
         };
         const response = await httpClient.sendRequest<promptResponse>(request);
-        return  response.body.choices[0].text.trim();
+        const responseText = response.body.choices[0].text;
+        const trimmedResponse = responseText.trim();
+        return  trimmedResponse;
     }
 });

--- a/packages/pieces/open-router/src/lib/actions/ask-open-router.ts
+++ b/packages/pieces/open-router/src/lib/actions/ask-open-router.ts
@@ -91,6 +91,6 @@ export const askOpenRouterAction = createAction({
             }
         };
         const response = await httpClient.sendRequest<promptResponse>(request);
-        return  response.body.choices[0].text;
+        return  response.body.choices[0].text.trim();
     }
 });


### PR DESCRIPTION
## What does this PR do?
open router returns leading and trilling spaces.

Fixes #2906

