### PR TITLE
feat: add filter field to apitable

### DIFF
--- a/packages/pieces/apitable/package.json
+++ b/packages/pieces/apitable/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-apitable",
-  "version": "0.0.4"
+  "version": "0.0.5"
 }

--- a/packages/pieces/apitable/src/index.ts
+++ b/packages/pieces/apitable/src/index.ts
@@ -36,6 +36,7 @@ export const APITableAuth = PieceAuth.CustomAuth({
 export const apitable = createPiece({
   displayName: "APITable",
   auth: APITableAuth,
+  description: `With APITable, you can create interactive dashboards, serve as a backend for web and mobile apps, enable team collaboration, prototype and develop apps, manage projects, and integrate and automate data workflows`,
   minimumSupportedRelease: '0.5.0',
   logoUrl: "https://cdn.activepieces.com/pieces/apitable.png",
   authors: ['abdallah-alwarawreh'],

--- a/packages/pieces/apitable/src/index.ts
+++ b/packages/pieces/apitable/src/index.ts
@@ -36,7 +36,7 @@ export const APITableAuth = PieceAuth.CustomAuth({
 export const apitable = createPiece({
   displayName: "APITable",
   auth: APITableAuth,
-  description: `With APITable, you can create interactive dashboards, serve as a backend for web and mobile apps, enable team collaboration, prototype and develop apps, manage projects, and integrate and automate data workflows`,
+  description: `Interactive spreadsheets with collaboration`,
   minimumSupportedRelease: '0.5.0',
   logoUrl: "https://cdn.activepieces.com/pieces/apitable.png",
   authors: ['abdallah-alwarawreh'],

--- a/packages/pieces/apitable/src/lib/actions/find-record.ts
+++ b/packages/pieces/apitable/src/lib/actions/find-record.ts
@@ -35,6 +35,11 @@ export const apiTableFindRecord = createAction({
             description: "Specifies the page number of the page",
             required: false
         }),
+        filter: Property.LongText({
+            displayName: 'Filter',
+            description: 'The filter to apply to the records (see https://help.aitable.ai/docs/guide/manual-formula-field-overview/)',
+            required: false,
+        }),
     },
     async run(context) {
         const auth = context.auth;
@@ -44,12 +49,14 @@ export const apiTableFindRecord = createAction({
         const maxRecords = context.propsValue.maxRecords;
         const pageSize = context.propsValue.pageSize ?? 100;
         const pageNum = context.propsValue.pageNum ?? 1;
+        const filter = context.propsValue.filter;
         const apiTableUrl = auth.apiTableUrl;
 
         let query = `?pageSize=${pageSize}&pageNum=${pageNum}`;
         if (recordIds) query += `&recordIds=${recordIds.join(',')}`;
         if (fieldNames) query += `&fieldNames=${fieldNames.join(',')}`;
         if (maxRecords) query += `&maxRecords=${maxRecords}`;
+        if (filter) query += `&filterByFormula=${filter}`;
 
         const request: HttpRequest = {
             method: HttpMethod.GET,


### PR DESCRIPTION
## What does this PR do?

Adds filter field to `Find APITable Record` action in order to use `filterByFormula` possibility (quite important to unlock many possible use cases). 

### Possible use-cases
1) Store content in ApiTable and populate with OpenAI: create datasheet with possible content topic and empty "Content" column, filter records by formula `{Content} = ""` and ask ChatGPT to write it.
2) Find specific record (such as User Profile) by slug/id


