### PR TITLE
fix: docs links that are broken

### DIFF
--- a/docs/developers/sharing-pieces/overview.mdx
+++ b/docs/developers/sharing-pieces/overview.mdx
@@ -4,6 +4,6 @@ description: "Learn the different ways to publish your own piece on activepieces
 ---
 
 ## Methods
-- [Contribute Back](/contribute): Publish your piece by contributing back your piece to main repository.
-- [Community](/community): Publish your piece on npm directly and share it with the community.
-- [Private](/private): Publish your piece on activepieces privately.
+- [Contribute Back](/developers/sharing-pieces/contribute): Publish your piece by contributing back your piece to main repository.
+- [Community](/developers/sharing-pieces/community): Publish your piece on npm directly and share it with the community.
+- [Private](/developers/sharing-pieces/private): Publish your piece on activepieces privately.


### PR DESCRIPTION
## What does this PR do?

Fixes some broken documentation links about piece sharing


