### PR TITLE
fix: trigger sample data is undefined for empty triggers

### DIFF
--- a/packages/backend/src/app/flows/step-run/step-run-service.ts
+++ b/packages/backend/src/app/flows/step-run/step-run-service.ts
@@ -188,7 +188,7 @@ const executeBranch = async ({ step, flowVersion, projectId }: ExecuteParams<Bra
         triggerPayload: {
             duration: 0,
             input: {},
-            output: flowVersion.trigger.settings.inputUiInfo.currentSelectedData,
+            output: flowVersion.trigger.settings?.inputUiInfo?.currentSelectedData,
             status: StepOutputStatus.SUCCEEDED,
         },
         sourceFlowVersion: flowVersion,


### PR DESCRIPTION
## What does this PR do?

Doesn't check for sample data on empty triggers.

