### PR TITLE
chore: add categories and mentionIconUrl to piece

### DIFF
--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "type": "commonjs"
 }

--- a/packages/pieces/framework/src/lib/piece.ts
+++ b/packages/pieces/framework/src/lib/piece.ts
@@ -1,6 +1,6 @@
 import { Trigger } from './trigger/trigger'
 import { Action } from './action/action'
-import { EventPayload, ParseEventResponse } from '@activepieces/shared'
+import { EventPayload, ParseEventResponse, PieceCategory } from '@activepieces/shared'
 import { PieceBase, PieceMetadata } from './piece-metadata'
 import { PieceAuthProperty } from './property'
 
@@ -19,6 +19,8 @@ export class Piece<PieceAuth extends PieceAuthProperty = PieceAuthProperty> impl
     public readonly minimumSupportedRelease?: string,
     public readonly maximumSupportedRelease?: string,
     public readonly description: string = '',
+    public readonly mentionIconUrl?:string,
+    public readonly categories?:PieceCategory[]
   ) {
     actions.forEach(action => this._actions[action.name] = action)
     triggers.forEach(trigger => this._triggers[trigger.name] = trigger)
@@ -66,6 +68,8 @@ export const createPiece = <PieceAuth extends PieceAuthProperty>(params: CreateP
     params.minimumSupportedRelease,
     params.maximumSupportedRelease,
     params.description,
+    params.mentionIconUrl,
+    params.categories
   )
 }
 
@@ -79,7 +83,9 @@ type CreatePieceParams<PieceAuth extends PieceAuthProperty = PieceAuthProperty> 
   minimumSupportedRelease?: string
   maximumSupportedRelease?: string
   actions: Action<PieceAuth>[]
-  triggers: Trigger<PieceAuth>[]
+  triggers: Trigger<PieceAuth>[],
+  mentionIconUrl?:string,
+  categories?: PieceCategory[]
 }
 
 type PieceEventProcessors = {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "commonjs"
 }

--- a/packages/shared/src/lib/pieces/piece.ts
+++ b/packages/shared/src/lib/pieces/piece.ts
@@ -19,3 +19,8 @@ export type PiecePackage = {
     projectId: ProjectId
     archiveId?: FileId
 }
+
+export enum PieceCategory
+{
+    CORE= "CORE"
+}


### PR DESCRIPTION
## What does this PR do?

Adds piece categories and mention icon url to createPiece parameters.

mention icon url --> used inside mentions (using previous steps in inputs through the "insert data" pop up).
categories --> will be used for now in deciding if the piece is a core piece or not, but further expansion could include categorising the pieces in the marketing website.

