### PR TITLE
fix(common): http doesn't add query params correctly

### DIFF
--- a/packages/pieces/common/package.json
+++ b/packages/pieces/common/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "commonjs"
 }

--- a/packages/pieces/common/src/lib/http/axios/axios-http-client.ts
+++ b/packages/pieces/common/src/lib/http/axios/axios-http-client.ts
@@ -29,6 +29,7 @@ export class AxiosHttpClient extends BaseHttpClient {
             const config:AxiosRequestConfig = {
                 method: axiosRequestMethod,
                 url,
+                params: request.queryParams,
                 headers,
                 data: request.body,
                 timeout

--- a/packages/pieces/common/src/lib/http/core/base-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/base-http-client.ts
@@ -24,13 +24,6 @@ export abstract class BaseHttpClient implements HttpClient {
     request: HttpRequest<RequestBody>
   ): string {
     const url = new URL(`${this.baseUrl}${request.url}`);
-
-    if (request.queryParams) {
-      for (const [name, value] of Object.entries(request.queryParams)) {
-        url.searchParams.append(name, value);
-      }
-    }
-
     return url.toString();
   }
 


### PR DESCRIPTION
## What does this PR do?

When testing the trigger, I'm getting a 404 error because the URL is invalid. HttpClient code fixed.

Fixes #2993
