### PR TITLE
docs: fix an typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ src="https://github.com/activepieces/activepieces/assets/1812998/76c97441-c285-4
 
 # ✨ What Is Activepieces?
 
-Activepieces is a **automation** builder, designed to be **extensible** through a **type-safe** pieces framework written in **Typescript**.
+Activepieces is an **automation** builder, designed to be **extensible** through a **type-safe** pieces framework written in **Typescript**.
 
 <br>
 <br>


### PR DESCRIPTION
###PULL REQUEST TITLE

Appropriate Article Use

###ISSUE

Inappropriate Article Use

###CHANGES

an article used before "automation" word

###SOLUTION

Use an article instead of a 

I hope you look out into this and consider my contribution.



