### PR TITLE
fix: improve docker layer caching and ignored files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,11 @@
 .angular
-node_modules
+.dockerignore
 .env
+.git
+.gitattributes
+.github
+deploy
+Dockerfile
 dist
+docs
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ COPY . .
 RUN apt update && apt install -y cmake libopenblas-dev patchelf
 
 # Install backend dependencies and build the projects
+COPY .npmrc package.json package-lock.json ./
 RUN npm ci
+
+COPY . .
 RUN npx nx run-many --target=build --projects=backend,ui-core --skip-nx-cache
 
 # Install backend production dependencies


### PR DESCRIPTION
An easy change in the Dockerfile to improve layer caching of subsequent builds, and avoid cache invalidation due to unrelated files.