### PR TITLE
fix: accept zeros as a value in piece form

### DIFF
--- a/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/piece-properties-form/piece-properties-form.component.ts
@@ -443,7 +443,7 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
               ? prop.defaultValue.toString()
               : '';
             controls[pk] = new UntypedFormControl(
-              propValue || defaultValue,
+              propValue ?? defaultValue,
               validators
             );
           } else {
@@ -451,7 +451,7 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
               ? prop.defaultValue.base64
               : '';
             controls[pk] = new UntypedFormControl(
-              propValue || defaultValue,
+              propValue ?? defaultValue,
               validators
             );
           }
@@ -464,7 +464,7 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
             validators.push(Validators.required);
           }
           controls[pk] = new UntypedFormControl(
-            propValue || prop.defaultValue,
+            propValue ?? prop.defaultValue,
             validators
           );
           break;
@@ -475,7 +475,7 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
             validators.push(Validators.required);
           }
           controls[pk] = new UntypedFormControl(
-            propValue || prop.defaultValue,
+            propValue ?? prop.defaultValue,
             validators
           );
           break;
@@ -490,7 +490,7 @@ export class PiecePropertiesFormComponent implements ControlValueAccessor {
             });
           } else {
             controls[pk] = new UntypedFormControl(
-              propValue || prop.defaultValue || '{}',
+              propValue ?? (prop.defaultValue || '{}'),
               validators
             );
           }


### PR DESCRIPTION
## What does this PR do

If a piece action/trigger property form control was assigned 0 as a number not as a string, they wouldn't show it and instead show an empty field.