### PR TITLE
fix: infinite test flow loading

### DIFF
--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Release:
     env:
-      MY_VERSION: 4
+      MY_VERSION: 5
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code

--- a/packages/ui/feature-builder-canvas/src/lib/test-flow-widget/test-flow-widget.component.ts
+++ b/packages/ui/feature-builder-canvas/src/lib/test-flow-widget/test-flow-widget.component.ts
@@ -6,7 +6,6 @@ import {
   map,
   Observable,
   of,
-  switchMap,
   takeUntil,
   takeWhile,
   tap,
@@ -30,6 +29,7 @@ import {
   BuilderSelectors,
   TestRunBarComponent,
 } from '@activepieces/ui/feature-builder-store';
+import { concatMap } from 'rxjs/operators';
 import { canvasActions } from '@activepieces/ui/feature-builder-store';
 
 @Component({
@@ -135,8 +135,8 @@ export class TestFlowWidgetComponent implements OnInit {
   setStatusChecker(runId: string) {
     this.instanceRunStatusChecker$ = interval(1500).pipe(
       takeUntil(this.testRunSnackbar.instance.exitButtonClicked),
-      switchMap(() => this.instanceRunService.get(runId)),
-      switchMap((instanceRun) => {
+      concatMap(() => this.instanceRunService.get(runId)),
+      concatMap((instanceRun) => {
         if (
           instanceRun.status !== ExecutionOutputStatus.RUNNING &&
           instanceRun.logsFileId !== null

--- a/packages/ui/feature-builder-left-sidebar/src/lib/run-details/steps-results-list/step-result.component.ts
+++ b/packages/ui/feature-builder-left-sidebar/src/lib/run-details/steps-results-list/step-result.component.ts
@@ -73,7 +73,7 @@ export class StepResultComponent implements OnInit, AfterViewInit {
       BuilderSelectors.selectStepLogoUrl(this.stepResult.stepName)
     );
     const stepOutput = this.stepResult.output?.output as any;
-    if (stepOutput.iterations !== undefined) {
+    if (stepOutput?.iterations !== undefined) {
       this.isLoopStep = true;
       const loopOutput = this.stepResult.output as LoopOnItemsStepOutput;
       loopOutput.output?.iterations.forEach((iteration) => {


### PR DESCRIPTION
If the log loading exceeds 1500 ms, the subsequent test flow poll will be triggered, leading to the cancellation of the log loading. This results in an infinite loading loop.

