### PR TITLE
fix(trello): auth instructions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "activepieces",
-      "version": "0.12.2",
+      "version": "0.13.0",
       "dependencies": {
         "@angular/animations": "16.2.6",
         "@angular/cdk": "16.2.6",

--- a/packages/pieces/trello/package.json
+++ b/packages/pieces/trello/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-trello",
-  "version": "0.3.2"
+  "version": "0.3.3"
 }

--- a/packages/pieces/trello/src/index.ts
+++ b/packages/pieces/trello/src/index.ts
@@ -8,11 +8,14 @@ import { HttpMethod, HttpRequest, httpClient } from '@activepieces/pieces-common
 const markdownProperty = `
 To obtain your API key and token, follow these steps:
 
-1. Go to https://trello.com/app-key
-2. Copy **Personal Key** and enter it into the Trello API Key connection
-3. Click **generate a Token** in trello
-4. Copy the token and paste it into the Trello Token connection
-5. Your connection should now work!
+1. Go to https://trello.com/power-ups/admin
+2. Click **New** to create a new power-up
+3. Enter power-up information, and click **Create**
+4. From the API Key page, click **Generate a new API key**
+5. Copy **API Key** and enter it into the Trello API Key connection
+6. Click **manually generate a Token** next to the API key field
+7. Copy the token and paste it into the Trello Token connection
+8. Your connection should now work!
 `;
 export const trelloAuth = PieceAuth.BasicAuth({
   description: markdownProperty,
@@ -57,7 +60,7 @@ export const trello = createPiece({
   displayName: 'Trello',
   minimumSupportedRelease: '0.5.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/trello.png',
-  authors: ['ShayPunter','Salem-Alaa'],
+  authors: ['ShayPunter','Salem-Alaa','MoShizzle'],
   auth: trelloAuth,
   actions: [createCard, getCard],
   triggers: [cardMovedTrigger,newCardTrigger]


### PR DESCRIPTION
## What does this PR do?

Updates the instructions to get Trello API key and token

ANNOUNCEMENT=true
