### PR TITLE
fix: apply log level configuration to default logger

### DIFF
--- a/packages/backend/src/app/helper/logger.ts
+++ b/packages/backend/src/app/helper/logger.ts
@@ -54,7 +54,7 @@ const initLogger = (): Logger => {
         })
     }
 
-    return pino({ level, transport: targets });
+    return pino({ level, transport: { targets }});
 }
 
 export const logger = initLogger()

--- a/packages/backend/src/app/helper/logger.ts
+++ b/packages/backend/src/app/helper/logger.ts
@@ -54,9 +54,7 @@ const initLogger = (): Logger => {
         })
     }
 
-    return pino(pino.transport({
-        targets,
-    }))
+    return pino({ level, transport: targets });
 }
 
 export const logger = initLogger()

--- a/packages/backend/src/app/helper/logger.ts
+++ b/packages/backend/src/app/helper/logger.ts
@@ -54,7 +54,7 @@ const initLogger = (): Logger => {
         })
     }
 
-    return pino({ level, transport: { targets }});
+    return pino({ level, transport: { targets } })
 }
 
 export const logger = initLogger()


### PR DESCRIPTION
When running activepieces in docker, the AP_LOG_LEVEL variable has no affect. This is because `pino` is initialized without the log level configuration variable. This PR fixes it.