### PR TITLE
refactor: centralise sandbox releasing

### DIFF
--- a/packages/backend/.eslintrc.json
+++ b/packages/backend/.eslintrc.json
@@ -92,7 +92,9 @@
                 "@typescript-eslint/keyword-spacing": "error",
                 "@typescript-eslint/explicit-function-return-type": "warn",
                 "@typescript-eslint/no-floating-promises": "error",
-                "@typescript-eslint/no-misused-promises": "warn"
+                "@typescript-eslint/no-misused-promises": "warn",
+                "no-return-await": "off",
+                "@typescript-eslint/return-await": ["error", "in-try-catch"]
             }
         }
     ]

--- a/packages/backend/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/backend/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -166,7 +166,7 @@ export const appConnectionService = {
     },
 
     async countByProject({ projectId }: CountByProjectParams): Promise<number> {
-        return await repo.countBy({ projectId })
+        return repo.countBy({ projectId })
     },
 }
 

--- a/packages/backend/src/app/app-event-routing/app-event-routing.service.ts
+++ b/packages/backend/src/app/app-event-routing/app-event-routing.service.ts
@@ -10,7 +10,7 @@ const appEventRoutingRepo = databaseConnection.getRepository(AppEventRoutingEnti
 
 export const appEventRoutingService = {
     async listListeners({ appName, event, identifierValue }: { appName: string, event: string, identifierValue: string }): Promise<AppEventRouting[]> {
-        return await appEventRoutingRepo.findBy({ appName, event, identifierValue })
+        return appEventRoutingRepo.findBy({ appName, event, identifierValue })
     },
     async createListeners({ appName, events, identifierValue, flowId, projectId }: {
         appName: string

--- a/packages/backend/src/app/authentication/lib/access-token-manager.ts
+++ b/packages/backend/src/app/authentication/lib/access-token-manager.ts
@@ -36,7 +36,7 @@ const getSecret = async (): Promise<string> => {
 }
 
 const getSecretFromStore = async (): Promise<string | null> => {
-    return await localFileStore.load(SystemProp.JWT_SECRET)
+    return localFileStore.load(SystemProp.JWT_SECRET)
 }
 
 const generateAndStoreSecret = async (): Promise<string> => {

--- a/packages/backend/src/app/authentication/lib/password-hasher.ts
+++ b/packages/backend/src/app/authentication/lib/password-hasher.ts
@@ -9,7 +9,7 @@ const SCRYPT_SEPERATOR = '~'
 
 export const passwordHasher = {
     hash: async (plainTextPassword: string): Promise<string> => {
-        return await bcrypt.hash(plainTextPassword, SALT_ROUNDS)
+        return bcrypt.hash(plainTextPassword, SALT_ROUNDS)
     },
 
     compare: async (plainTextPassword: string, hashedPassword: string): Promise<boolean> => {

--- a/packages/backend/src/app/chatbot/bots/chatbots.ts
+++ b/packages/backend/src/app/chatbot/bots/chatbots.ts
@@ -27,7 +27,7 @@ export const runBot = async ({
     }
     try {
         const embeddingsTool = embeddings.create({ botId, openAIApiKey: auth.secret_text })
-        return bot.run({
+        return await bot.run({
             input,
             llm: llm(auth.secret_text, 'gpt-3.5-turbo'),
             embeddings: embeddingsTool,

--- a/packages/backend/src/app/ee/app-credentials/app-credentials.module.ts
+++ b/packages/backend/src/app/ee/app-credentials/app-credentials.module.ts
@@ -37,7 +37,7 @@ const appCredentialController: FastifyPluginAsyncTypebox = async (fastify) => {
                 Body: UpsertAppCredentialRequest
             }>,
         ) => {
-            return await appCredentialService.upsert({
+            return appCredentialService.upsert({
                 projectId: request.principal.projectId,
                 request: request.body,
             })

--- a/packages/backend/src/app/ee/app-credentials/app-credentials.service.ts
+++ b/packages/backend/src/app/ee/app-credentials/app-credentials.service.ts
@@ -28,7 +28,7 @@ export const appCredentialService = {
         return paginationHelper.createPage<AppCredential>(data, cursor)
     },
     async getOneOrThrow(id: AppCredentialId): Promise<AppCredential> {
-        return await appCredentialRepo.findOneByOrFail({ id })
+        return appCredentialRepo.findOneByOrFail({ id })
     },
     async upsert({ projectId, request }: { projectId: ProjectId, request: UpsertAppCredentialRequest }): Promise<AppCredential | null> {
         await appCredentialRepo.upsert({

--- a/packages/backend/src/app/ee/authentication/federated-authn/federated-authn-service.ts
+++ b/packages/backend/src/app/ee/authentication/federated-authn/federated-authn-service.ts
@@ -15,7 +15,7 @@ export const federatedAuthnService = {
 
     async claim({ providerName, code }: ClaimParams): Promise<AuthenticationResponse> {
         const provider = providers[providerName]
-        return await provider.authenticate(code)
+        return provider.authenticate(code)
     },
 }
 

--- a/packages/backend/src/app/ee/billing/billing/billing.module.ts
+++ b/packages/backend/src/app/ee/billing/billing/billing.module.ts
@@ -59,7 +59,7 @@ const billingController: FastifyPluginAsyncTypebox = async (fastify) => {
             const sig = request.headers['stripe-signature'] as string
             try {
                 await handleWebhook({ payload: payloadString as string, signature: sig })
-                return reply.status(StatusCodes.OK).send()
+                return await reply.status(StatusCodes.OK).send()
             }
             catch (err) {
                 logger.error(err)

--- a/packages/backend/src/app/ee/billing/project-plan/project-plan.service.ts
+++ b/packages/backend/src/app/ee/billing/project-plan/project-plan.service.ts
@@ -80,7 +80,7 @@ async function createInitialPlan({ projectId }: { projectId: ProjectId }): Promi
             stripeSubscriptionId: null,
             subscriptionStartDatetime: project.created,
         }, ['projectId'])
-        return projectPlanRepo.findOneByOrFail({ projectId })
+        return await projectPlanRepo.findOneByOrFail({ projectId })
     }
     finally {
         await projectPlanLock.release()

--- a/packages/backend/src/app/ee/connection-keys/connection-key.module.ts
+++ b/packages/backend/src/app/ee/connection-keys/connection-key.module.ts
@@ -45,7 +45,7 @@ const connectionKeyController: FastifyPluginAsyncTypebox = async (fastify) => {
                 Querystring: GetOrDeleteConnectionFromTokenRequest
             }>,
         ) => {
-            return await connectionKeyService.getConnection(request.query)
+            return connectionKeyService.getConnection(request.query)
         },
     )
 
@@ -62,7 +62,7 @@ const connectionKeyController: FastifyPluginAsyncTypebox = async (fastify) => {
                 Body: UpsertConnectionFromToken
             }>,
         ) => {
-            return await connectionKeyService.createConnection(request.body)
+            return connectionKeyService.createConnection(request.body)
         },
     )
 
@@ -74,7 +74,7 @@ const connectionKeyController: FastifyPluginAsyncTypebox = async (fastify) => {
     {
         Querystring: ListConnectionKeysRequest
     }>) => {
-        return await connectionKeyService.list(request.principal.projectId, request.query.cursor ?? null, request.query.limit ?? DEFAULT_LIMIT_SIZE)
+        return connectionKeyService.list(request.principal.projectId, request.query.cursor ?? null, request.query.limit ?? DEFAULT_LIMIT_SIZE)
     })
 
 
@@ -90,7 +90,7 @@ const connectionKeyController: FastifyPluginAsyncTypebox = async (fastify) => {
                 Body: UpsertSigningKeyConnection
             }>,
         ) => {
-            return await connectionKeyService.upsert({
+            return connectionKeyService.upsert({
                 projectId: request.principal.projectId,
                 request: request.body,
             })

--- a/packages/backend/src/app/ee/connection-keys/connection-key.service.ts
+++ b/packages/backend/src/app/ee/connection-keys/connection-key.service.ts
@@ -70,7 +70,7 @@ export const connectionKeyService = {
         switch (appCredential.settings.type) {
             case AppCredentialType.API_KEY: {
                 const apiRequest = request as UpsertApiKeyConnectionFromToken
-                return await appConnectionService.upsert({
+                return appConnectionService.upsert({
                     projectId,
                     request: {
                         name: `${appCredential.appName}_${connectionName}`,
@@ -85,7 +85,7 @@ export const connectionKeyService = {
             }
             case AppCredentialType.OAUTH2: {
                 const apiRequest = request as UpsertOAuth2ConnectionFromToken
-                return await appConnectionService.upsert({
+                return appConnectionService.upsert({
                     projectId,
                     request: {
                         name: `${appCredential.appName}_${connectionName}`,

--- a/packages/backend/src/app/ee/flow-template/flow-template.module.ts
+++ b/packages/backend/src/app/ee/flow-template/flow-template.module.ts
@@ -22,7 +22,7 @@ const flowTemplateController: FastifyPluginAsyncTypebox = async (fastify) => {
             params: GetIdParams,
         },
     }, async (request) => {
-        return await flowTemplateService.getOrthrow(request.params.id)
+        return flowTemplateService.getOrthrow(request.params.id)
     })
 
     fastify.get('/', {
@@ -30,7 +30,7 @@ const flowTemplateController: FastifyPluginAsyncTypebox = async (fastify) => {
             querystring: ListFlowTemplatesRequest,
         },
     }, async (request) => {
-        return await flowTemplateService.list(request.query)
+        return flowTemplateService.list(request.query)
     })
 
     fastify.post('/', {

--- a/packages/backend/src/app/ee/helper/email/email-service.ts
+++ b/packages/backend/src/app/ee/helper/email/email-service.ts
@@ -174,7 +174,7 @@ async function renderTemplate({
 }
 
 async function readTemplateFile(templateName: string): Promise<string> {
-    return await fs.readFile(`./packages/backend/src/assets/emails/${templateName}.html`, 'utf-8')
+    return fs.readFile(`./packages/backend/src/assets/emails/${templateName}.html`, 'utf-8')
 }
 
 type InvitationEmailTemplate = {

--- a/packages/backend/src/app/ee/pieces/admin-piece-module.ts
+++ b/packages/backend/src/app/ee/pieces/admin-piece-module.ts
@@ -13,7 +13,7 @@ export const adminPieceModule: FastifyPluginAsyncTypebox = async (app) => {
 
 const adminPieceController: FastifyPluginCallbackTypebox = (app, _opts, done) => {
     app.post('/', CreatePieceRequest, async (req): Promise<PieceMetadataModel> => {
-        return await pieceMetadataService.create({
+        return pieceMetadataService.create({
             pieceMetadata: req.body as PieceMetadata,
             packageType: PackageType.REGISTRY,
             pieceType: PieceType.OFFICIAL,

--- a/packages/backend/src/app/ee/pieces/platform-piece-module.ts
+++ b/packages/backend/src/app/ee/pieces/platform-piece-module.ts
@@ -23,7 +23,7 @@ const platformPieceController: FastifyPluginCallbackTypebox = (app, _opts, done)
             platformId,
             userId: req.principal.id,
         })
-        return await pieceService.installPiece({
+        return pieceService.installPiece({
             packageType,
             pieceName,
             pieceVersion,

--- a/packages/backend/src/app/ee/platform/platform.service.ts
+++ b/packages/backend/src/app/ee/platform/platform.service.ts
@@ -23,7 +23,7 @@ export const platformService = {
             cloudAuthEnabled: true,
         }
 
-        return await repo.save(newPlatform)
+        return repo.save(newPlatform)
     },
 
     async update(params: UpdateParams): Promise<Platform> {
@@ -51,7 +51,7 @@ export const platformService = {
             ...spreadIfDefined('defaultLocale', params.defaultLocale),
         }
 
-        return await repo.save(updatedPlatform)
+        return repo.save(updatedPlatform)
     },
 
     async getOneOrThrow(id: PlatformId): Promise<Platform> {

--- a/packages/backend/src/app/ee/project-members/project-member.module.ts
+++ b/packages/backend/src/app/ee/project-members/project-member.module.ts
@@ -23,7 +23,7 @@ const projectMemberController: FastifyPluginAsyncTypebox = async (fastify) => {
             querystring: ListProjectMembersRequest,
         },
     }, async (request) => {
-        return await projectMemberService.list(request.principal.projectId, request.query.cursor ?? null, request.query.limit ?? DEFAULT_LIMIT_SIZE)
+        return projectMemberService.list(request.principal.projectId, request.query.cursor ?? null, request.query.limit ?? DEFAULT_LIMIT_SIZE)
     })
 
     fastify.post(

--- a/packages/backend/src/app/ee/project-members/project-member.service.ts
+++ b/packages/backend/src/app/ee/project-members/project-member.service.ts
@@ -159,7 +159,7 @@ export const projectMemberService = {
         return member?.role ?? null
     },
     async listByUserId(userId: UserId): Promise<ProjectMemberSchema[]> {
-        return await projectMemberRepo.find({
+        return projectMemberRepo.find({
             where: {
                 userId,
             },

--- a/packages/backend/src/app/ee/projects/platform-project-controller.ts
+++ b/packages/backend/src/app/ee/projects/platform-project-controller.ts
@@ -45,7 +45,7 @@ const enterpriseProjectController: FastifyPluginCallbackTypebox = (fastify, _opt
             }),
         },
     }, async (request) => {
-        return await platformProjectService.getAll({
+        return platformProjectService.getAll({
             ownerId: request.principal.id,
             platformId: request.query.platformId,
         })

--- a/packages/backend/src/app/ee/projects/platform-project-service.ts
+++ b/packages/backend/src/app/ee/projects/platform-project-service.ts
@@ -33,7 +33,7 @@ export const platformProjectService = {
                 ],
             )
             .getMany()
-        return await Promise.all(projectPlans.map(enrichWithUsageAndPlan))
+        return Promise.all(projectPlans.map(enrichWithUsageAndPlan))
     },
 
     async update({ userId, projectId, request, platformId }: { userId: string, projectId: ProjectId, request: UpdateProjectPlatformRequest, platformId?: PlatformId }): Promise<ProjectWithUsageAndPlan | null> {

--- a/packages/backend/src/app/flags/flag.service.ts
+++ b/packages/backend/src/app/flags/flag.service.ts
@@ -13,13 +13,13 @@ const flagRepo = databaseConnection.getRepository(FlagEntity)
 
 export const flagService = {
     save: async (flag: FlagType): Promise<Flag> => {
-        return await flagRepo.save({
+        return flagRepo.save({
             id: flag.id,
             value: flag.value,
         })
     },
     async getOne(flagId: ApFlagId): Promise<Flag | null> {
-        return await flagRepo.findOneBy({
+        return flagRepo.findOneBy({
             id: flagId,
         })
     },

--- a/packages/backend/src/app/flows/flow-run/flow-run-controller.ts
+++ b/packages/backend/src/app/flows/flow-run/flow-run-controller.ts
@@ -32,7 +32,7 @@ export const flowRunController: FastifyPluginCallbackTypebox = (app, _options, d
         const { projectId } = req.principal
         const { flowVersionId } = req.body
 
-        return await flowRunService.test({
+        return flowRunService.test({
             projectId,
             flowVersionId,
         })

--- a/packages/backend/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/backend/src/app/flows/flow-run/flow-run-service.ts
@@ -38,7 +38,7 @@ const getFlowRunOrCreate = async (params: GetOrCreateParams): Promise<Partial<Fl
     const { id, projectId, flowId, flowVersionId, flowDisplayName, environment } = params
 
     if (id) {
-        return await flowRunService.getOneOrThrow({
+        return flowRunService.getOneOrThrow({
             id,
             projectId,
         })
@@ -207,7 +207,7 @@ export const flowRunService = {
     },
 
     async getOne({ projectId, id }: GetOneParams): Promise<FlowRun | null> {
-        return await flowRunRepo.findOneBy({
+        return flowRunRepo.findOneBy({
             projectId,
             id,
         })
@@ -237,7 +237,7 @@ export const flowRunService = {
             finishTime: MoreThanOrEqual(finishTime),
         }
 
-        return await flowRunRepo.findBy(query)
+        return flowRunRepo.findBy(query)
     },
 }
 

--- a/packages/backend/src/app/flows/flow-version/flow-version.service.ts
+++ b/packages/backend/src/app/flows/flow-version/flow-version.service.ts
@@ -38,7 +38,7 @@ const flowVersionRepo = databaseConnection.getRepository<FlowVersion>(FlowVersio
 
 export const flowVersionService = {
     async lockPieceVersions(projectId: ProjectId, mutatedFlowVersion: FlowVersion): Promise<FlowVersion> {
-        return await flowHelper.transferFlowAsync(mutatedFlowVersion, async (step) => {
+        return flowHelper.transferFlowAsync(mutatedFlowVersion, async (step) => {
             const clonedStep = JSON.parse(JSON.stringify(step))
             switch (step.type) {
                 case ActionType.PIECE:
@@ -94,7 +94,7 @@ export const flowVersionService = {
         if (isNil(id)) {
             return null
         }
-        return await flowVersionRepo.findOneBy({
+        return flowVersionRepo.findOneBy({
             id,
         })
     },
@@ -143,7 +143,7 @@ export const flowVersionService = {
             valid: false,
             state: FlowVersionState.DRAFT,
         }
-        return await flowVersionRepo.save(flowVersion)
+        return flowVersionRepo.save(flowVersion)
     },
 }
 

--- a/packages/backend/src/app/flows/flow/flow.controller.ts
+++ b/packages/backend/src/app/flows/flow/flow.controller.ts
@@ -29,7 +29,7 @@ export const flowController: FastifyPluginAsyncTypebox = async (fastify) => {
             },
         },
         async (request) => {
-            return await flowService.create({ projectId: request.principal.projectId, request: request.body })
+            return flowService.create({ projectId: request.principal.projectId, request: request.body })
         },
     )
 
@@ -63,7 +63,7 @@ export const flowController: FastifyPluginAsyncTypebox = async (fastify) => {
                 return
             }
             // END EE
-            return await flowService.update({ userId: request.principal.id, flowId: request.params.flowId, request: request.body, projectId: request.principal.projectId })
+            return flowService.update({ userId: request.principal.id, flowId: request.params.flowId, request: request.body, projectId: request.principal.projectId })
         },
     )
 

--- a/packages/backend/src/app/flows/folder/folder.controller.ts
+++ b/packages/backend/src/app/flows/folder/folder.controller.ts
@@ -24,7 +24,7 @@ export const folderController: FastifyPluginAsyncTypebox = async (fastify) => {
             },
         },
         async (request) => {
-            return await folderService.create({ projectId: request.principal.projectId, request: request.body })
+            return folderService.create({ projectId: request.principal.projectId, request: request.body })
         },
     )
 
@@ -38,7 +38,7 @@ export const folderController: FastifyPluginAsyncTypebox = async (fastify) => {
             },
         },
         async (request) => {
-            return await folderService.update({ projectId: request.principal.projectId, folderId: request.params.folderId, request: request.body })
+            return folderService.update({ projectId: request.principal.projectId, folderId: request.params.folderId, request: request.body })
         },
     )
 
@@ -65,7 +65,7 @@ export const folderController: FastifyPluginAsyncTypebox = async (fastify) => {
             },
         },
         async (request) => {
-            return await folderService.list({ projectId: request.principal.projectId, cursorRequest: request.query.cursor ?? null, limit: request.query.limit ?? DEFUALT_PAGE_SIZE })
+            return folderService.list({ projectId: request.principal.projectId, cursorRequest: request.query.cursor ?? null, limit: request.query.limit ?? DEFUALT_PAGE_SIZE })
         },
     )
 

--- a/packages/backend/src/app/flows/step-run/step-run-service.ts
+++ b/packages/backend/src/app/flows/step-run/step-run-service.ts
@@ -192,41 +192,36 @@ const executeBranch = async ({ step, flowVersion, projectId }: ExecuteParams<Bra
         type: SandBoxCacheType.NONE,
     })
 
-    try {
-        const { status, result, standardError, standardOutput } = await engineHelper.executeTest(sandbox, testInput)
+    const { status, result, standardError, standardOutput } = await engineHelper.executeTest(sandbox, testInput)
 
-        if (status !== EngineResponseStatus.OK || result.status !== ExecutionOutputStatus.SUCCEEDED) {
-            return {
-                success: false,
-                output: null,
-                standardError,
-                standardOutput,
-            }
-        }
-
-        const branchStepOutput = new ExecutionState(result.executionState).getStepOutput<BranchStepOutput>({
-            stepName: branchStep.name,
-            ancestors: [],
-        })
-
-        if (isNil(branchStepOutput)) {
-            return {
-                success: false,
-                output: null,
-                standardError,
-                standardOutput,
-            }
-        }
-
+    if (status !== EngineResponseStatus.OK || result.status !== ExecutionOutputStatus.SUCCEEDED) {
         return {
-            success: true,
-            output: branchStepOutput.output,
+            success: false,
+            output: null,
             standardError,
             standardOutput,
         }
     }
-    finally {
-        await sandboxProvisioner.release({ sandbox })
+
+    const branchStepOutput = new ExecutionState(result.executionState).getStepOutput<BranchStepOutput>({
+        stepName: branchStep.name,
+        ancestors: [],
+    })
+
+    if (isNil(branchStepOutput)) {
+        return {
+            success: false,
+            output: null,
+            standardError,
+            standardOutput,
+        }
+    }
+
+    return {
+        success: true,
+        output: branchStepOutput.output,
+        standardError,
+        standardOutput,
     }
 }
 

--- a/packages/backend/src/app/flows/trigger-events/trigger-event.module.ts
+++ b/packages/backend/src/app/flows/trigger-events/trigger-event.module.ts
@@ -23,7 +23,7 @@ const triggerEventController: FastifyPluginAsyncTypebox = async (fastify) => {
                 id: request.query.flowId,
             })
 
-            return await triggerEventService.test({
+            return triggerEventService.test({
                 projectId: request.principal.projectId,
                 flow,
             })
@@ -38,7 +38,7 @@ const triggerEventController: FastifyPluginAsyncTypebox = async (fastify) => {
             },
         },
         async (request) => {
-            return await triggerEventService.saveEvent({
+            return triggerEventService.saveEvent({
                 projectId: request.principal.projectId,
                 flowId: request.query.flowId,
                 payload: request.body,
@@ -55,7 +55,7 @@ const triggerEventController: FastifyPluginAsyncTypebox = async (fastify) => {
         },
         async (request) => {
             const flow = await flowService.getOneOrThrow({ projectId: request.principal.projectId, id: request.query.flowId })
-            return await triggerEventService.list({
+            return triggerEventService.list({
                 projectId: request.principal.projectId,
                 flow,
                 cursor: request.query.cursor ?? null,

--- a/packages/backend/src/app/helper/engine-helper.ts
+++ b/packages/backend/src/app/helper/engine-helper.ts
@@ -357,7 +357,7 @@ export const engineHelper = {
             workerToken: await generateWorkerToken({ projectId: operation.projectId }),
         }
 
-        return await execute(
+        return execute(
             EngineOperationType.EXECUTE_VALIDATE_AUTH,
             sandbox,
             input,

--- a/packages/backend/src/app/helper/lock.ts
+++ b/packages/backend/src/app/helper/lock.ts
@@ -62,7 +62,7 @@ const acquireMemoryLock = async (key: string): Promise<ApLock> => {
 
 const acquireRedisLock = async (key: string, timeout: number): Promise<ApLock> => {
     try {
-        return redLock.acquire([key], timeout, {
+        return await redLock.acquire([key], timeout, {
             retryCount: Math.ceil(timeout / 2000) * 2,
             retryDelay: 2000,
         })

--- a/packages/backend/src/app/helper/package-manager.ts
+++ b/packages/backend/src/app/helper/package-manager.ts
@@ -61,15 +61,15 @@ export const packageManager = {
         ]
 
         const dependencyArgs = dependencies.map(d => `${d.alias}@${d.spec}`)
-        return await runCommand(path, 'add', ...dependencyArgs, ...config)
+        return runCommand(path, 'add', ...dependencyArgs, ...config)
     },
 
     async init({ path }: InitParams): Promise<PackageManagerOutput> {
-        return await runCommand(path, 'init')
+        return runCommand(path, 'init')
     },
 
     async exec({ path, command }: ExecParams): Promise<PackageManagerOutput> {
-        return await runCommand(path, command)
+        return runCommand(path, command)
     },
 
     async link({ path, linkPath }: LinkParams): Promise<PackageManagerOutput> {
@@ -78,7 +78,7 @@ export const packageManager = {
             '--config.auto-install-peers=true',
         ]
 
-        return await runCommand(path, 'link', linkPath, ...config)
+        return runCommand(path, 'link', linkPath, ...config)
     },
 }
 

--- a/packages/backend/src/app/helper/trigger-utils.ts
+++ b/packages/backend/src/app/helper/trigger-utils.ts
@@ -73,7 +73,7 @@ export const triggerUtils = {
                         handshakeConfig.paramName &&
             handshakeConfig.paramName.toLowerCase() in payload.headers
                     ) {
-                        return await executeHandshake({
+                        return executeHandshake({
                             flowVersion,
                             projectId,
                             payload,
@@ -86,7 +86,7 @@ export const triggerUtils = {
                         handshakeConfig.paramName &&
             handshakeConfig.paramName in payload.queryParams
                     ) {
-                        return await executeHandshake({
+                        return executeHandshake({
                             flowVersion,
                             projectId,
                             payload,
@@ -101,7 +101,7 @@ export const triggerUtils = {
             payload.body !== null &&
             handshakeConfig.paramName in payload.body
                     ) {
-                        return await executeHandshake({
+                        return executeHandshake({
                             flowVersion,
                             projectId,
                             payload,
@@ -186,7 +186,7 @@ export const triggerUtils = {
             return null
         }
 
-        return await disablePieceTrigger({
+        return disablePieceTrigger({
             projectId,
             flowVersion,
             simulate,

--- a/packages/backend/src/app/pieces/base-piece-module.ts
+++ b/packages/backend/src/app/pieces/base-piece-module.ts
@@ -46,7 +46,7 @@ const basePiecesController: FastifyPluginAsyncTypebox = async (app) => {
 
         const decodeScope = decodeURIComponent(scope)
         const decodedName = decodeURIComponent(name)
-        return await pieceMetadataService.getOrThrow({
+        return pieceMetadataService.getOrThrow({
             projectId: req.principal.type === PrincipalType.UNKNOWN ? undefined : req.principal.projectId,
             name: `${decodeScope}/${decodedName}`,
             version,
@@ -63,7 +63,7 @@ const basePiecesController: FastifyPluginAsyncTypebox = async (app) => {
         const { version } = req.query
 
         const decodedName = decodeURIComponent(name)
-        return await pieceMetadataService.getOrThrow({
+        return pieceMetadataService.getOrThrow({
             projectId: req.principal.projectId,
             name: decodedName,
             version,
@@ -106,7 +106,7 @@ const basePiecesController: FastifyPluginAsyncTypebox = async (app) => {
             })
         }
 
-        return await pieceMetadataService.stats()
+        return pieceMetadataService.stats()
     })
 
     app.delete('/:id', {
@@ -116,7 +116,7 @@ const basePiecesController: FastifyPluginAsyncTypebox = async (app) => {
             }),
         },
     }, async (req): Promise<void> => {
-        return await pieceMetadataService.delete({
+        return pieceMetadataService.delete({
             projectId: req.principal.projectId,
             id: req.params.id,
         })

--- a/packages/backend/src/app/pieces/piece-metadata-service/cloud-piece-metadata-service.ts
+++ b/packages/backend/src/app/pieces/piece-metadata-service/cloud-piece-metadata-service.ts
@@ -53,7 +53,7 @@ export const CloudPieceMetadataService = (): PieceMetadataService => {
         },
 
         async stats(): Promise<AllPiecesStats> {
-            return await pieceStatsService.get()
+            return pieceStatsService.get()
         },
 
         async getExactPieceVersion({ name, version, projectId }): Promise<string> {

--- a/packages/backend/src/app/pieces/piece-metadata-service/db-piece-metadata-service.ts
+++ b/packages/backend/src/app/pieces/piece-metadata-service/db-piece-metadata-service.ts
@@ -98,7 +98,7 @@ export const DbPieceMetadataService = (): PieceMetadataService => {
                 })
             }
 
-            return await repo.save({
+            return repo.save({
                 id: apId(),
                 projectId,
                 packageType,
@@ -129,7 +129,7 @@ export const DbPieceMetadataService = (): PieceMetadataService => {
         },
 
         async stats(): Promise<AllPiecesStats> {
-            return await pieceStatsService.get()
+            return pieceStatsService.get()
         },
 
         async getExactPieceVersion({ name, version, projectId }): Promise<string> {

--- a/packages/backend/src/app/pieces/piece-service/index.ts
+++ b/packages/backend/src/app/pieces/piece-service/index.ts
@@ -56,7 +56,7 @@ export const pieceService = {
 const getPiecePackage = async (params: AddPieceParams): Promise<PiecePackage> => {
     switch (params.packageType) {
         case PackageType.ARCHIVE: {
-            return await pieceServiceHooks.get().getPieceArchivePackage(params)
+            return pieceServiceHooks.get().getPieceArchivePackage(params)
         }
 
         case PackageType.REGISTRY: {

--- a/packages/backend/src/app/project/project-service.ts
+++ b/packages/backend/src/app/project/project-service.ts
@@ -17,7 +17,7 @@ export const projectService = {
     },
 
     async getOne(projectId: ProjectId): Promise<Project | null> {
-        return await projectRepo.findOneBy({
+        return projectRepo.findOneBy({
             id: projectId,
         })
     },
@@ -39,7 +39,7 @@ export const projectService = {
         return project
     },
     async getUserProject(ownerId: UserId): Promise<Project> {
-        return await projectRepo.findOneByOrFail({
+        return projectRepo.findOneByOrFail({
             ownerId,
         })
     },

--- a/packages/backend/src/app/store-entry/store-entry.controller.ts
+++ b/packages/backend/src/app/store-entry/store-entry.controller.ts
@@ -62,7 +62,7 @@ export const storeEntryController: FastifyPluginAsyncTypebox = async (fastify) =
                 return reply.status(StatusCodes.FORBIDDEN)
             }
             else {
-                return await storeEntryService.delete({
+                return storeEntryService.delete({
                     projectId: request.principal.projectId, key: request.query.key,
                 })
             }

--- a/packages/backend/src/app/store-entry/store-entry.service.ts
+++ b/packages/backend/src/app/store-entry/store-entry.service.ts
@@ -9,7 +9,7 @@ export const storeEntryService = {
         const previousEntry = await this.getOne({ projectId, key: request.key })
         if (previousEntry !== null) {
             await storeEntryRepo.update(previousEntry.id, request)
-            return await this.getOne({ projectId, key: request.key })
+            return this.getOne({ projectId, key: request.key })
         }
         else {
             const entryRequest: Omit<StoreEntry, 'created' | 'updated'> = {
@@ -18,11 +18,11 @@ export const storeEntryService = {
                 value: request.value,
                 projectId,
             }
-            return await storeEntryRepo.save(entryRequest)
+            return storeEntryRepo.save(entryRequest)
         }
     },
     async getOne({ projectId, key }: { projectId: ProjectId, key: string }): Promise<StoreEntry | null> {
-        return await storeEntryRepo.findOneBy({
+        return storeEntryRepo.findOneBy({
             projectId,
             key,
         })

--- a/packages/backend/src/app/webhooks/webhook-service.ts
+++ b/packages/backend/src/app/webhooks/webhook-service.ts
@@ -118,7 +118,7 @@ export const webhookService = {
             }),
         )
 
-        return await Promise.all(createFlowRuns)
+        return Promise.all(createFlowRuns)
     },
 
     async simulationCallback({ flow, payload }: CallbackParams): Promise<void> {

--- a/packages/backend/src/app/webhooks/webhook-simulation/webhook-simulation-controller.ts
+++ b/packages/backend/src/app/webhooks/webhook-simulation/webhook-simulation-controller.ts
@@ -7,7 +7,7 @@ export const webhookSimulationController: FastifyPluginCallbackTypebox = (app, _
         const { flowId } = req.body
         const { projectId } = req.principal
 
-        return await webhookSimulationService.create({
+        return webhookSimulationService.create({
             flowId,
             projectId,
         })
@@ -17,7 +17,7 @@ export const webhookSimulationController: FastifyPluginCallbackTypebox = (app, _
         const { flowId } = req.query
         const { projectId } = req.principal
 
-        return await webhookSimulationService.get({
+        return webhookSimulationService.get({
             flowId,
             projectId,
         })
@@ -27,7 +27,7 @@ export const webhookSimulationController: FastifyPluginCallbackTypebox = (app, _
         const { flowId } = req.query
         const { projectId } = req.principal
 
-        return await webhookSimulationService.delete({
+        return webhookSimulationService.delete({
             flowId,
             projectId,
         })

--- a/packages/backend/src/app/webhooks/webhook-simulation/webhook-simulation-service.ts
+++ b/packages/backend/src/app/webhooks/webhook-simulation/webhook-simulation-service.ts
@@ -24,7 +24,7 @@ type AcquireLockParams = {
 
 const createLock = async ({ flowId }: AcquireLockParams): Promise<ApLock> => {
     const key = `${flowId}-webhook-simulation`
-    return await acquireLock({ key, timeout: 5000 })
+    return acquireLock({ key, timeout: 5000 })
 }
 
 const webhookSimulationRepo = databaseConnection.getRepository(WebhookSimulationEntity)

--- a/packages/backend/src/app/webhooks/webhook-simulation/webhook-simulation-side-effects.ts
+++ b/packages/backend/src/app/webhooks/webhook-simulation/webhook-simulation-side-effects.ts
@@ -13,7 +13,7 @@ type PreCreateParams = BaseParams
 type PreDeleteParams = BaseParams
 
 const getFlowOrThrow = async ({ projectId, flowId }: GetFlowParams): Promise<Flow> => {
-    return await flowService.getOneOrThrow({
+    return flowService.getOneOrThrow({
         id: flowId,
         projectId,
     })

--- a/packages/backend/src/app/workers/flow-worker/flow-worker.ts
+++ b/packages/backend/src/app/workers/flow-worker/flow-worker.ts
@@ -307,14 +307,14 @@ const getSandbox = async ({ projectId, flowVersion, runEnvironment }: GetSandbox
     const codeSteps = getCodeSteps(flowVersion)
     switch (runEnvironment) {
         case RunEnvironment.PRODUCTION:
-            return await sandboxProvisioner.provision({
+            return sandboxProvisioner.provision({
                 type: SandBoxCacheType.FLOW,
                 flowVersionId: flowVersion.id,
                 pieces,
                 codeSteps,
             })
         case RunEnvironment.TESTING:
-            return await sandboxProvisioner.provision({
+            return sandboxProvisioner.provision({
                 type: SandBoxCacheType.NONE,
                 pieces,
                 codeSteps,

--- a/packages/backend/src/app/workers/flow-worker/flow-worker.ts
+++ b/packages/backend/src/app/workers/flow-worker/flow-worker.ts
@@ -259,9 +259,6 @@ async function executeFlow(jobData: OneTimeJobData): Promise<void> {
             throwErrorToRetry(e as Error, jobData.runId)
         }
     }
-    finally {
-        await sandboxProvisioner.release({ sandbox })
-    }
 }
 
 function throwErrorToRetry(error: Error, runId: string): void {

--- a/packages/engine/src/lib/executors/flow-executor.ts
+++ b/packages/engine/src/lib/executors/flow-executor.ts
@@ -358,7 +358,7 @@ export class FlowExecutor {
             action: actionHandler.nextAction,
         })
 
-        return await this.iterateFlow({
+        return this.iterateFlow({
             actionHandler: nextActionHandler,
             ancestors,
         })

--- a/packages/engine/src/lib/helper/piece-helper.ts
+++ b/packages/engine/src/lib/helper/piece-helper.ts
@@ -277,7 +277,7 @@ export const pieceHelper = {
 
             if (property.type === PropertyType.DYNAMIC) {
                 const dynamicProperty = property as DynamicProperties<boolean>
-                return dynamicProperty.props(resolvedProps, ctx)
+                return await dynamicProperty.props(resolvedProps, ctx)
             }
 
             if (property.type === PropertyType.MULTI_SELECT_DROPDOWN) {
@@ -285,11 +285,11 @@ export const pieceHelper = {
                 unknown,
                 boolean
                 >
-                return multiSelectProperty.options(resolvedProps, ctx)
+                return await multiSelectProperty.options(resolvedProps, ctx)
             }
 
             const dropdownProperty = property as DropdownProperty<unknown, boolean>
-            return dropdownProperty.options(resolvedProps, ctx)
+            return await dropdownProperty.options(resolvedProps, ctx)
         }
         catch (e) {
             console.error(e)


### PR DESCRIPTION
- Centralise sandbox releasing in the `engineHelper`
- Configure the `return-await` lint rule to be `in-try-catch` for backend and engine