### PR TITLE
fix: return basic platform response for members

### DIFF
--- a/packages/backend/src/app/authentication/authorization.ts
+++ b/packages/backend/src/app/authentication/authorization.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, ErrorCode, PrincipalType, isNil } from '@activepieces/shared'
+import { ActivepiecesError, ErrorCode, PrincipalType } from '@activepieces/shared'
 import { onRequestHookHandler, preSerializationHookHandler } from 'fastify'
 import { logger } from '../helper/logger'
 
@@ -13,27 +13,39 @@ export const allowWorkersOnly: onRequestHookHandler = (request, _res, done) => {
     done()
 }
 
-export const entitiesMustBeOwnedByCurrentProject: preSerializationHookHandler<Payload> = (request, _response, payload, done) => {
+/**
+ * Throws an authz error if response entities contain a `projectId` property and
+ * the `projectId` property value does not match the principal's `projectId`.
+ * Otherwise, does nothing.
+ */
+export const entitiesMustBeOwnedByCurrentProject: preSerializationHookHandler<Payload | null> = (request, _response, payload, done) => {
     logger.trace({ payload, principal: request.principal, route: request.routeConfig }, 'entitiesMustBeOwnedByCurrentProject')
 
-    if (!isNil(payload)) {
-        const projectId = request.principal.projectId
+    if (payload) {
+        const principalProjectId = request.principal.projectId
+        let verdict: AuthzVerdict = 'ALLOW'
 
-        let someEntityNotOwnedByCurrentProject = false
-        const payloadIsSingleEntity = !isNil(payload.projectId)
-
-        if (payloadIsSingleEntity) {
-            someEntityNotOwnedByCurrentProject = payload.projectId !== projectId
+        if ('projectId' in payload) {
+            if (payload.projectId !== principalProjectId) {
+                verdict = 'DENY'
+            }
         }
-        else if (Array.isArray(payload.data)) {
-            someEntityNotOwnedByCurrentProject = payload.data.some(entity => entity.projectId !== projectId)
+        else if ('data' in payload && Array.isArray(payload.data)) {
+            const someEntityNotOwnedByCurrentProject = payload.data.some(entity => {
+                return 'projectId' in entity && entity.projectId !== principalProjectId
+            })
+
+            if (someEntityNotOwnedByCurrentProject) {
+                verdict = 'DENY'
+            }
         }
 
-
-        if (someEntityNotOwnedByCurrentProject) {
+        if (verdict === 'DENY') {
             throw new ActivepiecesError({
                 code: ErrorCode.AUTHORIZATION,
-                params: {},
+                params: {
+                    message: 'not owned by current project',
+                },
             })
         }
     }
@@ -41,10 +53,14 @@ export const entitiesMustBeOwnedByCurrentProject: preSerializationHookHandler<Pa
     done()
 }
 
-type WithProjectId = {
-    projectId: string
+type SingleEntity = {
+    projectId?: string
 }
 
-type Payload = WithProjectId & {
-    data: WithProjectId[] | undefined
+type MultipleEntities = {
+    data: SingleEntity[]
 }
+
+type Payload = SingleEntity | MultipleEntities
+
+type AuthzVerdict = 'ALLOW' | 'DENY'

--- a/packages/backend/src/app/ee/platform/platform.controller.ts
+++ b/packages/backend/src/app/ee/platform/platform.controller.ts
@@ -1,13 +1,13 @@
 import { FastifyPluginAsyncTypebox, Type } from '@fastify/type-provider-typebox'
-import { UpdatePlatformRequestBody } from '@activepieces/ee-shared'
-import { ApId, assertEqual } from '@activepieces/shared'
+import { Platform, UpdatePlatformRequestBody } from '@activepieces/ee-shared'
+import { ApId, Principal, assertEqual } from '@activepieces/shared'
 import { platformService } from './platform.service'
 import { platformMustBeOwnedByCurrentUser } from '../authentication/ee-authorization'
 
 export const platformController: FastifyPluginAsyncTypebox = async (app) => {
-    app.addHook('onRequest', platformMustBeOwnedByCurrentUser)
+    app.post('/:id', UpdatePlatformRequest, async (req, res) => {
+        await platformMustBeOwnedByCurrentUser.call(app, req, res)
 
-    app.post('/:id', UpdatePlatformRequest, async (req) => {
         return platformService.update({
             id: req.params.id,
             userId: req.principal.id,
@@ -17,9 +17,30 @@ export const platformController: FastifyPluginAsyncTypebox = async (app) => {
 
     app.get('/:id', GetPlatformRequest, async (req) => {
         assertEqual(req.principal.platform?.id, req.params.id, 'userPlatformId', 'paramId')
-        return platformService.getOneOrThrow(req.params.id)
+        const platform = await platformService.getOneOrThrow(req.params.id)
+
+        return buildResponse({
+            platform,
+            principal: req.principal,
+        })
     })
 }
+
+const buildResponse = ({ platform, principal }: BuildResponseParams): Platform | PlatformBasics => {
+    if (platform.ownerId === principal.id) {
+        return platform
+    }
+
+    const { id, name, defaultLocale } = platform
+    return { id, name, defaultLocale }
+}
+
+type BuildResponseParams = {
+    platform: Platform
+    principal: Principal
+}
+
+type PlatformBasics = Pick<Platform, 'id' | 'name' | 'defaultLocale'>
 
 const UpdatePlatformRequest = {
     schema: {

--- a/packages/shared/src/lib/common/activepieces-error.ts
+++ b/packages/shared/src/lib/common/activepieces-error.ts
@@ -76,7 +76,9 @@ ErrorCode.APP_CONNECTION_NOT_FOUND,
 
 export type AuthorizationErrorParams = BaseErrorParams<
 ErrorCode.AUTHORIZATION,
-Record<string, never>
+{
+    message?: string
+}
 >
 
 export type PermissionDeniedErrorParams = BaseErrorParams<


### PR DESCRIPTION
## What does this PR do?

- fix: return basic platform response for members
- fix: project ownership middleware, allow response to continue if `projectId` doesn't exists in response entity

