### PR TITLE
fix: increase limit for getting platform managed oauth2 apps

### DIFF
--- a/packages/ui/common/src/lib/service/oauth-2-apps.service.ts
+++ b/packages/ui/common/src/lib/service/oauth-2-apps.service.ts
@@ -1,6 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { OAuthApp, UpsertOAuth2AppRequest } from '@activepieces/ee-shared';
+import {
+  OAuthApp,
+  UpsertOAuth2AppRequest,
+  ListOAuth2AppRequest,
+} from '@activepieces/ee-shared';
 import { environment } from '../environments/environment';
 import { SeekPage } from '@activepieces/shared';
 
@@ -14,8 +18,14 @@ export class OAuth2AppsService {
     return this.http.post<void>(`${environment.apiUrl}/oauth-apps`, req);
   }
   listOAuth2AppsCredentials() {
+    const listOAuth2AppRequest: ListOAuth2AppRequest = {
+      limit: 1000000,
+    };
     return this.http.get<SeekPage<OAuthApp>>(
-      `${environment.apiUrl}/oauth-apps`
+      `${environment.apiUrl}/oauth-apps`,
+      {
+        params: listOAuth2AppRequest,
+      }
     );
   }
   deleteOAuth2AppCredentials(credentialId: string) {


### PR DESCRIPTION
## What does this PR do?

Not all managed oauth2 apps were being listed, this fixes that.

