### PR TITLE
fix(openai): support fine-tuned model by approximate tokens length 

### DIFF
--- a/packages/pieces/openai/package.json
+++ b/packages/pieces/openai/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-openai",
-  "version": "0.3.13"
+  "version": "0.3.14"
 }

--- a/packages/pieces/openai/src/lib/common/common.ts
+++ b/packages/pieces/openai/src/lib/common/common.ts
@@ -83,11 +83,17 @@ export const streamToBuffer = (stream: any) => {
 }
 
 export const calculateTokensFromString = (string: string, model: string) => {
-    const encoder = encoding_for_model(model as any);
-    const tokens = encoder.encode(string);
-    encoder.free();
+    try {
+        const encoder = encoding_for_model(model as any);
+        const tokens = encoder.encode(string);
+        encoder.free();
 
-    return tokens.length;
+        return tokens.length;
+    }
+    catch (e) {
+        // Model not supported by tiktoken, every 4 chars is a token
+        return Math.round(string.length / 4);
+    }
 }
 
 export const calculateMessagesTokenSize = async (messages: any[], model: string) => {


### PR DESCRIPTION
## What does this PR do?

Fixes an issue with fine-tuned models not being supported by tiktoken, so we manually calculate tokens for these models now