### PR TITLE
fix(airtable): "Create record" action used to fail when there was number inputs, now it doesn't

### DIFF
--- a/packages/pieces/airtable/package.json
+++ b/packages/pieces/airtable/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-airtable",
-  "version": "0.3.6"
+  "version": "0.3.7"
 }

--- a/packages/pieces/airtable/src/lib/actions/create-record.ts
+++ b/packages/pieces/airtable/src/lib/actions/create-record.ts
@@ -1,4 +1,4 @@
-import { DynamicPropsValue, createAction } from "@activepieces/pieces-framework";
+import { DynamicPropsValue, Property, createAction } from "@activepieces/pieces-framework";
 import { airtableCommon } from "../common";
 import { airtableAuth } from "../../index";
 
@@ -10,7 +10,12 @@ export const airtableCreateRecordAction = createAction({
   props: {
     base: airtableCommon.base,
     tableId: airtableCommon.tableId,
-    fields: airtableCommon.fields
+    fields: airtableCommon.fields,
+    typecast: Property.Checkbox({
+      required:false,
+      displayName:"Typecast",
+      description: "Automatic data conversion from text to the appropriate type.",
+    })
   },
   async run(context) {
     const personalToken = context.auth
@@ -29,6 +34,7 @@ export const airtableCreateRecordAction = createAction({
       baseId,
       tableId: tableId as string,
       fields: newFields,
+      typecast: context.propsValue.typecast
     })
   },
 })

--- a/packages/pieces/airtable/src/lib/actions/create-record.ts
+++ b/packages/pieces/airtable/src/lib/actions/create-record.ts
@@ -1,4 +1,4 @@
-import { DynamicPropsValue, Property, createAction } from "@activepieces/pieces-framework";
+import { DynamicPropsValue, createAction } from "@activepieces/pieces-framework";
 import { airtableCommon } from "../common";
 import { airtableAuth } from "../../index";
 
@@ -11,11 +11,6 @@ export const airtableCreateRecordAction = createAction({
     base: airtableCommon.base,
     tableId: airtableCommon.tableId,
     fields: airtableCommon.fields,
-    typecast: Property.Checkbox({
-      required:false,
-      displayName:"Typecast",
-      description: "Automatic data conversion from text to the appropriate type, toggle it on if you have a field that needs to be a number.",
-    })
   },
   async run(context) {
     const personalToken = context.auth
@@ -33,8 +28,6 @@ export const airtableCreateRecordAction = createAction({
       personalToken,
       baseId,
       tableId: tableId as string,
-      fields: newFields,
-      typecast: context.propsValue.typecast
-    })
+      fields: newFields})
   },
 })

--- a/packages/pieces/airtable/src/lib/actions/create-record.ts
+++ b/packages/pieces/airtable/src/lib/actions/create-record.ts
@@ -14,7 +14,7 @@ export const airtableCreateRecordAction = createAction({
     typecast: Property.Checkbox({
       required:false,
       displayName:"Typecast",
-      description: "Automatic data conversion from text to the appropriate type.",
+      description: "Automatic data conversion from text to the appropriate type, toggle it on if you have a field that needs to be a number.",
     })
   },
   async run(context) {

--- a/packages/pieces/airtable/src/lib/common/index.ts
+++ b/packages/pieces/airtable/src/lib/common/index.ts
@@ -494,5 +494,4 @@ interface Params {
   searchField?: string;
   fieldNames?: string[];
   limitToView?: string;
-  typecast?:boolean
 }

--- a/packages/pieces/airtable/src/lib/common/index.ts
+++ b/packages/pieces/airtable/src/lib/common/index.ts
@@ -377,6 +377,7 @@ export const airtableCommon = {
     fields,
     tableId,
     baseId,
+    typecast
   }: Params) {
     const request: HttpRequest = {
       method: HttpMethod.POST,
@@ -387,6 +388,7 @@ export const airtableCommon = {
       },
       body: {
         fields,
+        typecast
       },
     };
 
@@ -493,4 +495,5 @@ interface Params {
   searchField?: string;
   fieldNames?: string[];
   limitToView?: string;
+  typecast?:boolean
 }

--- a/packages/pieces/airtable/src/lib/common/index.ts
+++ b/packages/pieces/airtable/src/lib/common/index.ts
@@ -377,7 +377,6 @@ export const airtableCommon = {
     fields,
     tableId,
     baseId,
-    typecast
   }: Params) {
     const request: HttpRequest = {
       method: HttpMethod.POST,
@@ -388,7 +387,7 @@ export const airtableCommon = {
       },
       body: {
         fields,
-        typecast
+        typecast:true
       },
     };
 


### PR DESCRIPTION
## What does this PR do?

Adds typecast property to body of create record request, so text values get accepted for number fields.
