### PR TITLE
feat(telegram-bot): Fixes for critical issues /  Create Invite Link Action / Get Chat Member Action

### DIFF
--- a/packages/pieces/telegram-bot/package.json
+++ b/packages/pieces/telegram-bot/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-telegram-bot",
-  "version": "0.3.6"
+  "version": "0.3.7"
 }

--- a/packages/pieces/telegram-bot/package.json
+++ b/packages/pieces/telegram-bot/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-telegram-bot",
-  "version": "0.3.7"
+  "version": "0.3.8"
 }

--- a/packages/pieces/telegram-bot/src/index.ts
+++ b/packages/pieces/telegram-bot/src/index.ts
@@ -2,6 +2,8 @@ import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
 import { telegramSendMessageAction } from './lib/action/send-text-message.action';
 import { telegramNewMessage } from './lib/trigger/new-message';
 import { telegramSendMediaAction } from './lib/action/send-media.action';
+import { telegramGetChatMemberAction } from './lib/action/get-chat-member';
+import { telegramCreateInviteLinkAction } from './lib/action/create-invite-link';
 
 const markdownDescription = `
 **Authentication**:
@@ -25,7 +27,7 @@ export const telegramBot = createPiece({
   minimumSupportedRelease: '0.5.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/telegram_bot.png',
   auth: telegramBotAuth,
-  actions: [telegramSendMessageAction, telegramSendMediaAction],
+  actions: [telegramSendMessageAction, telegramSendMediaAction, telegramGetChatMemberAction, telegramCreateInviteLinkAction],
   authors: ['abuaboud', 'Abdallah-Alwarawreh'],
   triggers: [telegramNewMessage]
 });

--- a/packages/pieces/telegram-bot/src/lib/action/create-invite-link.ts
+++ b/packages/pieces/telegram-bot/src/lib/action/create-invite-link.ts
@@ -1,0 +1,71 @@
+import {
+  httpClient,
+  HttpMethod
+} from '@activepieces/pieces-common';
+import {
+  createAction,
+  Property
+} from '@activepieces/pieces-framework';
+import { telegramBotAuth } from '../..';
+import { telegramCommons } from '../common';
+
+const chatId = `
+**How to obtain Chat ID:**
+1. Search for the bot "@getmyid_bot" in Telegram.
+2. Start a conversation with the bot.
+3. Send the command "/my_id" to the bot.
+4. The bot will reply with your chat ID.
+
+**Note: Remember to initiate the chat with the bot, or you'll get an error for "chat not found.**
+`;
+const format = `
+[Link example](https://core.telegram.org/bots/api#formatting-options)
+`;
+export const telegramCreateInviteLinkAction = createAction({
+  auth: telegramBotAuth,
+  name: 'create_invite_link',
+  description: 'Create an invite link for a chat',
+  displayName: 'Create Invite Link',
+  props: {
+    instructions: Property.MarkDown({
+      value: chatId,
+    }),
+    chat_id: Property.ShortText({
+      displayName: 'Chat Id',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Name',
+      description: 'Name of the invite link (max 32 chars)',
+      required: false,
+    }),
+    expire_date: Property.DateTime({
+      displayName: 'Expire Date',
+      description: 'Point in time when the link will expire',
+      required: false,
+    }),
+    member_limit: Property.Number({
+      displayName: 'Member Limit',
+      description:
+        'Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999',
+      required: false,
+    }),
+  },
+  async run(ctx) {
+    return await httpClient
+      .sendRequest<never>({
+        method: HttpMethod.POST,
+        url: telegramCommons.getApiUrl(ctx.auth, 'createChatInviteLink'),
+        headers: {},
+        body: {
+          chat_id: ctx.propsValue.chat_id,
+          name: ctx.propsValue.name ?? undefined,
+          expire_date: ctx.propsValue.expire_date
+            ? Math.floor(new Date(ctx.propsValue.expire_date).getTime() / 1000)
+            : undefined,
+          member_limit: ctx.propsValue.member_limit ?? undefined,
+        },
+      })
+      .then((res) => res.body);
+  },
+});

--- a/packages/pieces/telegram-bot/src/lib/action/get-chat-member.ts
+++ b/packages/pieces/telegram-bot/src/lib/action/get-chat-member.ts
@@ -1,0 +1,59 @@
+import {
+  httpClient,
+  HttpError,
+  HttpMethod
+} from '@activepieces/pieces-common';
+import {
+  createAction,
+  Property
+} from '@activepieces/pieces-framework';
+import { telegramBotAuth } from '../..';
+import { telegramCommons } from '../common';
+
+const chatId = `
+**How to obtain Chat ID:**
+1. Search for the bot "@getmyid_bot" in Telegram.
+2. Start a conversation with the bot.
+3. Send the command "/my_id" to the bot.
+4. The bot will reply with your chat ID.
+
+**Note: Remember to initiate the chat with the bot, or you'll get an error for "chat not found.**
+`;
+const format = `
+[Link example](https://core.telegram.org/bots/api#formatting-options)
+`;
+export const telegramGetChatMemberAction = createAction({
+  auth: telegramBotAuth,
+  name: 'get_chat_member',
+  description: 'Get member info (or null) for provided chat id and user id',
+  displayName: 'Get Chat Member',
+  props: {
+    instructions: Property.MarkDown({
+      value: chatId,
+    }),
+    chat_id: Property.ShortText({
+      displayName: 'Chat Id',
+      required: true,
+    }),
+    user_id: Property.ShortText({
+      displayName: 'User Id',
+      description: 'Unique identifier for the user',
+      required: true,
+    }),
+  },
+  async run(ctx) {
+    try {
+      return await httpClient.sendRequest<never>({
+        method: HttpMethod.POST,
+        url: telegramCommons.getApiUrl(ctx.auth, 'getChatMember'),
+        headers: {},
+        body: {
+          chat_id: ctx.propsValue.chat_id,
+          user_id: ctx.propsValue.user_id,
+        },
+      }).then((res) => res.body);
+    } catch (error) {
+      return (error as HttpError).errorMessage().response.body;
+    }
+  },
+});

--- a/packages/pieces/telegram-bot/src/lib/action/send-media.action.ts
+++ b/packages/pieces/telegram-bot/src/lib/action/send-media.action.ts
@@ -43,7 +43,7 @@ export const telegramSendMediaAction = createAction({
           disabled: false,
           placeholder: 'Select media type',
           options: [
-            { label: 'Image', value: 'image' },
+            { label: 'Image', value: 'photo' },
             { label: 'Video', value: 'video' },
             { label: 'Sticker', value: 'sticker' },
             { label: 'GIF', value: 'animation' },
@@ -56,18 +56,18 @@ export const telegramSendMediaAction = createAction({
         refreshers: ['media_type'],
         async props({ media_type }) {
           const propsBuilders: Record<string, () => DynamicPropsValue> = {
-            image: () => ({
-              image: Property.File({
+            photo: () => ({
+              photo: Property.File({
                 displayName: 'Image',
                 description: 'The image to be uploaded as a file',
                 required: false,
               }),
-              imageUrl: Property.ShortText({
+              photoUrl: Property.ShortText({
                 displayName: 'Image Url',
                 description: 'The image url to be downloaded by Telegram',
                 required: false,
               }),
-              imageId: Property.ShortText({
+              photoId: Property.ShortText({
                 displayName: 'Image Id',
                 description:
                   "The image id previously uploaded to Telegram's servers",
@@ -120,19 +120,19 @@ export const telegramSendMediaAction = createAction({
             }),
             animation: () => ({
               animation: Property.File({
-                displayName: 'GIF or H.264/MPEG-4',
+                displayName: 'GIF',
                 description:
                   'The GIF or MPEG-4 without sound file to be uploaded as a auto-playing animation',
                 required: false,
               }),
               animationUrl: Property.ShortText({
-                displayName: 'GIF or H.264/MPEG-4 Url',
+                displayName: 'GIF Url',
                 description:
                   'The GIF or MPEG-4 without sound url to be downloaded by Telegram',
                 required: false,
               }),
               animationId: Property.ShortText({
-                displayName: 'GIF or H.264/MPEG-4 Id',
+                displayName: 'GIF Id',
                 description:
                   "The GIF or MPEG-4 without sound id previously uploaded to Telegram's servers",
                 required: false,
@@ -195,7 +195,7 @@ export const telegramSendMediaAction = createAction({
         ];
   
         const methods: Partial<Record<string, string>> = {
-          image: 'sendPhoto',
+          photo: 'sendPhoto',
           video: 'sendVideo',
           sticker: 'sendSticker',
           animation: 'sendAnimation',
@@ -226,7 +226,7 @@ export const telegramSendMediaAction = createAction({
         } else if (typeof url !== 'undefined' || typeof id !== 'undefined') {
           // download
           body = body || {};
-          body.photo = url ?? id;
+          body[mediaType] = url ?? id;
           body.chat_id = ctx.propsValue['chat_id'];
           body.caption = ctx.propsValue['message'];
           body.message_thread_id =

--- a/packages/pieces/telegram-bot/src/lib/common/index.ts
+++ b/packages/pieces/telegram-bot/src/lib/common/index.ts
@@ -1,15 +1,25 @@
 import { HttpMethod, HttpRequest, httpClient } from "@activepieces/pieces-common";
 
+export type SetWebhookRequest = {
+    ip_address: string,
+    max_connections: number,
+    allowed_updates: string[],
+    drop_pending_updates: boolean,
+    secret_token: string,
+}
+
 export const telegramCommons = {
     getApiUrl: (botToken: string, methodName: string) => {
         return `https://api.telegram.org/bot${botToken}/${methodName}`;
     },
-    subscribeWebhook: async (botToken: string, webhookUrl: string) => {
+    subscribeWebhook: async (botToken: string, webhookUrl: string, overrides?: Partial<SetWebhookRequest>) => {
         const request: HttpRequest = {
             method: HttpMethod.POST,
             url: `https://api.telegram.org/bot${botToken}/setWebhook`,
             body: {
-                url: webhookUrl
+                allowed_updates: [],
+                url: webhookUrl,
+                ...overrides
             }
         };
 

--- a/packages/pieces/telegram-bot/src/lib/trigger/new-message.ts
+++ b/packages/pieces/telegram-bot/src/lib/trigger/new-message.ts
@@ -40,6 +40,9 @@ export const telegramNewMessage = createTrigger({
             await telegramCommons.subscribeWebhook(
                 context.auth,
                 context.webhookUrl,
+                { 
+                    allowed_updates: []
+                }
             );
         },
         async onDisable(context) {


### PR DESCRIPTION
## Fixes:

1) Explicitly define all allowed message types to avoid reusing of previous setup. For example, if external app/call setupped webhook with `allowed_updates` equal to `['callback_query']`, the activipieces webhook will follow the same filter and miss all other updates.
2) Previous (0.3.6) update of telegram-bot introduced Send Media action with critical issue in different then Image types. Current PR fix it to make possible send Video, GIF or stickersa

## Updates: 
1) Implements **Create Invite Link** action to create invitation link with possible expiration date and member limitations
2) Implements **Get Chat Member** action to get chat member info or expected Bad Request (without run failure) 

ANNOUNCEMENT=true