### PR TITLE
fix: redirect url wasn't being shown in instructions for creating connection

### DIFF
--- a/packages/pieces/twitter/package.json
+++ b/packages/pieces/twitter/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-twitter",
-  "version": "0.2.1"
+  "version": "0.2.2"
 }

--- a/packages/pieces/twitter/src/index.ts
+++ b/packages/pieces/twitter/src/index.ts
@@ -10,7 +10,7 @@ If you don't have the crednetials down below, please follow these steps to obtai
 
 2. Under the **Settings** tab then under **User authentication settings** section, click "Set up".
 
-3. Check on **Read and write** for "App permissions" and **Native App** for "Type of App", fill in your website url and let the **Callback URI / Redirect URL** be <your_website_url>/redirect .
+3. Check on **Read and write** for "App permissions" and **Native App** for "Type of App", fill in your website url and let the **Callback URI / Redirect URL** be **(your_website_url)/redirect** .
 
 4. Go back to your app settings page and click the **Keys and tokens** tab.
 


### PR DESCRIPTION
## What does this PR do?


redirect url wasn't being shown in instructions for creating connection, this fixes it.
