### PR TITLE
fix: sharing flow was broken

### DIFF
--- a/packages/backend/src/app/ee/flow-template/flow-template.service.ts
+++ b/packages/backend/src/app/ee/flow-template/flow-template.service.ts
@@ -10,7 +10,7 @@ const templateRepo = databaseConnection.getRepository<FlowTemplate>(FlowTemplate
 export const flowTemplateService = {
     upsert: async (platformId: string | undefined, projectId: string | undefined, { description,  type, template, blogUrl, tags, id }: CreateFlowTemplateRequest): Promise<FlowTemplate> => {
         const flowTemplate: FlowVersionTemplate = template
-        const newTags= tags?? [];
+        const newTags = tags ?? []
         await templateRepo.upsert({
             id: id ?? apId(),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/backend/src/app/ee/flow-template/flow-template.service.ts
+++ b/packages/backend/src/app/ee/flow-template/flow-template.service.ts
@@ -10,6 +10,7 @@ const templateRepo = databaseConnection.getRepository<FlowTemplate>(FlowTemplate
 export const flowTemplateService = {
     upsert: async (platformId: string | undefined, projectId: string | undefined, { description,  type, template, blogUrl, tags, id }: CreateFlowTemplateRequest): Promise<FlowTemplate> => {
         const flowTemplate: FlowVersionTemplate = template
+        const newTags= tags?? [];
         await templateRepo.upsert({
             id: id ?? apId(),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -19,7 +20,7 @@ export const flowTemplateService = {
             pieces: flowHelper.getUsedPieces(flowTemplate.trigger),
             blogUrl,
             type,
-            tags,
+            tags: newTags,
             created: new Date().toISOString(),
             updated: new Date().toISOString(),
             platformId,


### PR DESCRIPTION
## What does this PR do?

Adds a null check for tags when upserting templates, because tags array is not supposed to be null.
