### PR TITLE
fix: show correct flow status after first publish (on) and refresh runs table after a retry 

### DIFF
--- a/packages/ui/feature-builder-store/src/lib/store/flow/flows.reducer.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/flow/flows.reducer.ts
@@ -167,6 +167,7 @@ const _flowsReducer = createReducer(
     clonedState.flow.publishedVersionId = publishedFlowVersionId;
     clonedState.flow.version.state = FlowVersionState.LOCKED;
     clonedState.savingStatus &= ~BuilderSavingStatusEnum.PUBLISHING;
+    clonedState.flow.status = FlowStatus.ENABLED;
     return clonedState;
   }),
   on(FlowsActions.publishFailed, (state) => {

--- a/packages/ui/feature-dashboard/src/lib/pages/runs-table/runs-table.component.html
+++ b/packages/ui/feature-dashboard/src/lib/pages/runs-table/runs-table.component.html
@@ -46,7 +46,7 @@
           </th>
           <td mat-cell *matCellDef="let run" class="!ap-text-center">
             <button mat-icon-button (click)="$event.stopImmediatePropagation()" [matMenuTriggerFor]="menu"
-              *ngIf="isRetryEnabled(run)">
+              *ngIf="run.status ===  ExecutionOutputStatus.FAILED || run.status === ExecutionOutputStatus.INTERNAL_ERROR || run.status === ExecutionOutputStatus.QUOTA_EXCEEDED">
               <mat-icon>more_vert</mat-icon>
             </button>
             <mat-menu #menu="matMenu" xPosition="before">
@@ -82,3 +82,4 @@
 </div>
 <ng-container *ngIf="updateNotificationsValue$ | async"></ng-container>
 <ng-container *ngIf="changeRunStatus$ | async"></ng-container>
+<ng-container *ngIf="retryFlow$ | async"> </ng-container>

--- a/packages/ui/feature-dashboard/src/lib/pages/runs-table/runs-table.datasource.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/runs-table/runs-table.datasource.ts
@@ -32,13 +32,16 @@ const REFRESH_TABLE_DELAY = 15000;
 export class RunsTableDataSource extends DataSource<FlowRun> {
   data: FlowRun[] = [];
   isLoading$: BehaviorSubject<boolean> = new BehaviorSubject(true);
-  refresh$: BehaviorSubject<boolean> = new BehaviorSubject(true);
+  refreshForExecutingRuns$: BehaviorSubject<boolean> = new BehaviorSubject(
+    true
+  );
   refreshTimer: NodeJS.Timeout | undefined;
   constructor(
     private queryParams$: Observable<Params>,
     private paginator: ApPaginatorComponent,
     private store: Store,
-    private instanceRunService: InstanceRunService
+    private instanceRunService: InstanceRunService,
+    private refreshForReruns$: Observable<boolean>
   ) {
     super();
   }
@@ -56,7 +59,8 @@ export class RunsTableDataSource extends DataSource<FlowRun> {
         .select(ProjectSelectors.selectCurrentProject)
         .pipe(filter((project) => !!project))
         .pipe(take(1)),
-      refresh: this.refresh$.asObservable(),
+      refresh: this.refreshForExecutingRuns$.asObservable(),
+      refreshForReruns: this.refreshForReruns$,
     }).pipe(
       tap(() => {
         this.isLoading$.next(true);
@@ -88,7 +92,7 @@ export class RunsTableDataSource extends DataSource<FlowRun> {
           res.data.find((run) => run.status === ExecutionOutputStatus.RUNNING)
         ) {
           this.refreshTimer = setTimeout(() => {
-            this.refresh$.next(true);
+            this.refreshForExecutingRuns$.next(true);
           }, REFRESH_TABLE_DELAY);
         }
       }),

--- a/packages/ui/feature-dashboard/src/lib/pages/runs-table/runs.service.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/runs-table/runs.service.ts
@@ -8,17 +8,15 @@ import { Injectable } from '@angular/core';
 export class RunsService {
   constructor(private http: HttpClient) {}
 
-  async retry(runId: string, strategy: FlowRetryStrategy) {
-    return this.http
-      .post(
-        environment.apiUrl + `/flow-runs/${runId}/retry`,
-        {},
-        {
-          params: {
-            strategy,
-          },
-        }
-      )
-      .subscribe();
+  retry(runId: string, strategy: FlowRetryStrategy) {
+    return this.http.post<void>(
+      environment.apiUrl + `/flow-runs/${runId}/retry`,
+      {},
+      {
+        params: {
+          strategy,
+        },
+      }
+    );
   }
 }


### PR DESCRIPTION
## What does this PR do?



