### PR TITLE
feat(google-documents): create document based on template / read document action

### DIFF
--- a/packages/pieces/google-docs/package.json
+++ b/packages/pieces/google-docs/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-docs",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/packages/pieces/google-docs/src/index.ts
+++ b/packages/pieces/google-docs/src/index.ts
@@ -2,6 +2,7 @@ import { PieceAuth, createPiece } from "@activepieces/pieces-framework";
 
 import { createDocument } from "./lib/actions/create-document";
 import { createDocumentBasedOnTemplate } from "./lib/actions/create-document-based-on-template.action";
+import { readDocument } from "./lib/actions/read-document.action";
 
 export const googleDocsAuth = PieceAuth.OAuth2({
     
@@ -17,6 +18,6 @@ export const googleDocs = createPiece({
     logoUrl: "https://cdn.activepieces.com/pieces/google-docs.png",
     authors: ['MoShizzle', 'PFernandez98'],
     auth: googleDocsAuth,
-    actions: [createDocument, createDocumentBasedOnTemplate],
+    actions: [createDocument, createDocumentBasedOnTemplate, readDocument],
     triggers: [],
 });

--- a/packages/pieces/google-docs/src/lib/actions/create-document-based-on-template.action.ts
+++ b/packages/pieces/google-docs/src/lib/actions/create-document-based-on-template.action.ts
@@ -1,40 +1,75 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { googleDocsAuth } from '../../index';
 import { Property, createAction } from "@activepieces/pieces-framework";
-import { docsCommon } from '../common';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
 
 
 export const createDocumentBasedOnTemplate = createAction({
     auth: googleDocsAuth,
     name: 'create_document_based_on_template',
-    description: 'Create a document on Google Docs based on a template',
-    displayName: 'Create Document Based on Template',
+    description: 'Edit a template file and replace the values with the ones provided',
+    displayName: 'Edit template file',
     props: {
-        title: docsCommon.title,
-        template: Property.LongText({
-            displayName: 'Template',
-            description: 'Variables should be in the format: [[variableName]]',
+        template: Property.ShortText({
+            displayName: 'Destination File',
+            description: 'The ID of the file to replace the values',
             required: true,
         }),
         values: Property.Object({
-            displayName: 'Values',
+            displayName: 'Varibles',
             description: 'Dont include the "[[]]", only the key name and its value',
+            required: true,
+        }),
+        images: Property.Object({
+            displayName: 'Images',
+            description: 'Key: Image ID (get it manually from the Read File Action), Value: Image URL',
             required: true,
         }),
     },
     async run(context) {
         
-        const template = context.propsValue.template;
-        const values = context.propsValue.values;
-        let body = template;
+        const documentId: string = context.propsValue.template;
+        const values = context.propsValue.values;        
+
+        const authClient = new OAuth2Client();
+        authClient.setCredentials(context.auth)
+        const docs = google.docs('v1');
         
+        const requests = [];
+
         for (const key in values) {
-            const value = String(values[key]);
-            body = body.replace(`[[${key}]]`, value);
+            const value = values[key];
+            requests.push({
+                replaceAllText: {
+                    containsText: {
+                        text: "[[" + key + "]]",
+                        matchCase: true,
+                    },
+                    replaceText: String(value),
+                },
+            });
         }
 
-        const document = await docsCommon.createDocument(context.propsValue.title, context.auth.access_token);
-        const response = await docsCommon.writeToDocument(document.documentId, body, context.auth.access_token);
+        for (const key in context.propsValue.images) {
+            const value = context.propsValue.images[key];
+            requests.push({
+                replaceImage: {
+                    imageObjectId: key,
+                    uri: String(value),
+                },
+            });
+        }
         
-        return response;
+        const res = await docs.documents.batchUpdate({
+            auth: authClient,
+            documentId,
+            requestBody: {
+                requests: requests,
+            }
+                
+        });
+
+    return res;
     }
 });

--- a/packages/pieces/google-docs/src/lib/actions/read-document.action.ts
+++ b/packages/pieces/google-docs/src/lib/actions/read-document.action.ts
@@ -1,0 +1,35 @@
+
+import { googleDocsAuth } from '../../index';
+import { Property, createAction } from "@activepieces/pieces-framework";
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const readDocument = createAction({
+    displayName: "Read Document",
+    auth: googleDocsAuth,
+    name: "read_document",
+    description: "Read a document from Google Docs",
+    props: {
+        documentId: Property.ShortText({
+            displayName: "Document ID",
+            description: "The ID of the document to read",
+            required: true,
+        }),
+    },
+    async run(context) {
+        const authClient = new OAuth2Client();
+        authClient.setCredentials(context.auth);
+
+        const docs = google.docs({ version: 'v1', auth: authClient });
+        const response = await docs.documents.get({
+            documentId: context.propsValue.documentId,
+        });
+
+        if (response.status !== 200) {
+            console.error(response);
+            throw new Error('Error reading document');
+        }
+
+        return response.data;
+    },
+});

--- a/packages/pieces/google-docs/src/lib/common/index.ts
+++ b/packages/pieces/google-docs/src/lib/common/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Property } from "@activepieces/pieces-framework";
 import { HttpMethod, httpClient, AuthenticationType } from "@activepieces/pieces-common";
 
@@ -51,5 +52,5 @@ export const docsCommon = {
         })
 
         return writeRequest.body;
-    }
+    },
 }

--- a/packages/pieces/google-drive/package.json
+++ b/packages/pieces/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.6"
+  "version": "0.5.7"
 }

--- a/packages/pieces/google-drive/src/index.ts
+++ b/packages/pieces/google-drive/src/index.ts
@@ -8,6 +8,7 @@ import { newFolder } from './lib/triggers/new-folder';
 import { readFile } from './lib/action/read-file';
 import { googleDriveListFiles } from './lib/action/list-files.action';
 import { googleDriveSearchFolder } from './lib/action/search-folder.action';
+import { duplicateFileAction } from './lib/action/duplicate-file.action';
 
 export const googleDriveAuth = PieceAuth.OAuth2({
     description: "",
@@ -20,9 +21,9 @@ export const googleDriveAuth = PieceAuth.OAuth2({
 export const googleDrive = createPiece({
 	minimumSupportedRelease: '0.5.6',
     logoUrl: 'https://cdn.activepieces.com/pieces/google-drive.png',
-	actions: [googleDriveCreateNewFolder, googleDriveCreateNewTextFile, googleDriveUploadFile, readFile, googleDriveListFiles, googleDriveSearchFolder],
+	actions: [googleDriveCreateNewFolder, googleDriveCreateNewTextFile, googleDriveUploadFile, readFile, googleDriveListFiles, googleDriveSearchFolder, duplicateFileAction],
 	displayName: "Google Drive",
-	authors: ['kanarelo', 'BastienMe', 'MoShizzle', 'Armangiau', 'vitalini', 'pfernandez98'],
+	authors: ['kanarelo', 'BastienMe', 'MoShizzle', 'Armangiau', 'vitalini', 'PFernandez98'],
 	triggers: [newFile, newFolder],
     auth: googleDriveAuth,
 });

--- a/packages/pieces/google-drive/src/lib/action/duplicate-file.action.ts
+++ b/packages/pieces/google-drive/src/lib/action/duplicate-file.action.ts
@@ -1,0 +1,58 @@
+import { googleDriveAuth } from '../../index';
+import { Property, createAction } from "@activepieces/pieces-framework";
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const duplicateFileAction = createAction({
+    displayName: "Duplicate File",
+    auth: googleDriveAuth,
+    name: "duplicate_file",
+    description: "Duplicate a file from Google Drive. Returns the new file ID.",
+    props: {
+        fileId: Property.ShortText({
+            displayName: "File ID",
+            description: "The ID of the file to duplicate",
+            required: true,
+        }),
+        name: Property.ShortText({
+            displayName: "Name",
+            description: "The name of the new file",
+            required: true,
+        }),
+        folderId: Property.ShortText({
+            displayName: "Folder ID",
+            description: "The ID of the folder where the file will be duplicated",
+            required: true,
+        }),
+    },
+    async run(context) {
+        const authClient = new OAuth2Client();
+        authClient.setCredentials(context.auth)
+
+        const fileId = context.propsValue.fileId;
+        const nameForNewFile = context.propsValue.name;
+
+        const drive = google.drive({ version: 'v3', auth: authClient });
+
+        const response = await drive.files.copy({fileId, auth: authClient});
+
+        if (response.status !== 200) {
+            console.error(response);
+            throw new Error('Error duplicating file');
+        }
+
+        const newFileId = response.data.id;
+
+        const body = {'name': nameForNewFile};
+
+        drive.files.update
+        
+
+        const respUpdate = await drive.files.update({ 
+            fileId: String(newFileId), 
+            requestBody: body, 
+        });
+
+        return respUpdate.data;
+    },
+});


### PR DESCRIPTION
## What does this PR do?

- Rename the Create document based on template to Edit Template File
- Added the Replace images to the above action
- Added the Read document action to Google Docs to get all details from a document (and object IDs to send to the 1st action)
- Added the Duplicate File to Google drive.

ANNOUNCEMENT=true 
