### PR TITLE
fix: dashboard loaders on /flows

### DIFF
--- a/packages/ui/feature-dashboard/src/lib/pages/flows-table/empty-flows-table/empty-flows-table.component.html
+++ b/packages/ui/feature-dashboard/src/lib/pages/flows-table/empty-flows-table/empty-flows-table.component.html
@@ -9,7 +9,7 @@
     <div class="ap-flex ap-items-center ap-flex-col ap-justify-center ap-gap-3">
       <div (click)="openToDemo()"
         class="ap-flex ap-items-center ap-gap-2 ap-justify-center ap-flex-col ap-border ap-border-outline ap-h-[249px] ap-w-[200px] ap-rounded ap-bg-white ap-rounded-lg ap-cursor-pointer ap-transition-colors hover:ap-border-primary hover:ap-bg-primary-light ">
-        <ng-container *ngIf="!createFlow$">
+        <ng-container *ngIf="!openToDemo$">
           <svg-icon src="assets/img/custom/arrow_right.svg" [applyClass]="true"
             class="ap-fill-primary ap-w-[26px]  ap-h-[26px]"></svg-icon>
           <div class="ap-typography-subtitle-1 ap-text-primary" i18n>Demo flow</div>
@@ -18,7 +18,7 @@
           </div>
         </ng-container>
 
-        <ap-loading-icon *ngIf="!!createFlow$" [outlineLoader]="false" [whiteLoader]="false" height="40px" width="40px">
+        <ap-loading-icon *ngIf="!!openToDemo$" [outlineLoader]="false" [whiteLoader]="false" height="40px" width="40px">
         </ap-loading-icon>
       </div>
 
@@ -49,3 +49,4 @@
 
 </div>
 <ng-container *ngIf="createFlow$ | async"></ng-container>
+<ng-container *ngIf="openToDemo$ | async"></ng-container>

--- a/packages/ui/feature-dashboard/src/lib/pages/flows-table/empty-flows-table/empty-flows-table.component.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/flows-table/empty-flows-table/empty-flows-table.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { Observable, switchMap, tap } from 'rxjs';
 import {
+  Flow,
   PopulatedFlow,
   FlowOperationType,
   TelemetryEventName,
@@ -23,6 +24,7 @@ import { demoTemplate } from './demo-flow-template';
 export class EmptyFlowsTableComponent {
   creatingFlow = false;
   createFlow$: Observable<PopulatedFlow>;
+  openToDemo$: Observable<Flow>;
   showPoweredByAp$: Observable<boolean>;
   constructor(
     private router: Router,
@@ -55,7 +57,7 @@ export class EmptyFlowsTableComponent {
   openToDemo() {
     if (!this.creatingFlow) {
       this.creatingFlow = true;
-      this.createFlow$ = this.flowService
+      this.openToDemo$ = this.flowService
         .create({
           projectId: this.authenticationService.getProjectId(),
           displayName: demoTemplate.displayName,
@@ -68,7 +70,7 @@ export class EmptyFlowsTableComponent {
                 request: demoTemplate,
               })
               .pipe(
-                tap((updatedFlow: PopulatedFlow) => {
+                tap((updatedFlow: Flow) => {
                   this.telemetryService.capture({
                     name: TelemetryEventName.DEMO_IMPORTED,
                     payload: {},


### PR DESCRIPTION
## What does this PR do?

On dashboard, both loaders starts loading simultaneously, even if we click any one of them. **This should be fixed!**

Initially,

```typescript
<div (click)="openToDemo()"
        class="ap-flex ap-items-center ap-gap-2 ap-justify-center ap-flex-col ap-border ap-border-outline ap-h-[249px] ap-w-[200px] ap-rounded ap-bg-white ap-rounded-lg ap-cursor-pointer ap-transition-colors hover:ap-border-primary hover:ap-bg-primary-light ">
      // Triggering createFlow()
        <ng-container *ngIf="!createFlow$">
          <svg-icon src="assets/img/custom/arrow_right.svg" [applyClass]="true"
            class="ap-fill-primary ap-w-[26px]  ap-h-[26px]"></svg-icon>
          <div class="ap-typography-subtitle-1 ap-text-primary" i18n>Demo flow</div>
          <div class="ap-typography-subtitle-2 ap-text-description ap-px-3" i18n>
            Learn from our Gelato maker demo flow
          </div>
        </ng-container>
        // Same variable
        <ap-loading-icon *ngIf="!!createFlow$" [outlineLoader]="false" [whiteLoader]="false" height="40px" width="40px">
        </ap-loading-icon>
      </div>
```

If we are tiggering `openToDemo()` still we are triggering `createFlow$` in both the scenerios, so, in `empty-flows-table.ts`, in the class `EmptyFlowsTableComponent`, I introduced separated the flows functions,

```typescript
  createFlow$: Observable<PopulatedFlow>;
// Used Flow as this is just a demo, so no versioning is required.
  openToDemo$: Observable<Flow>;
``` 

and changed the definition of `openToDemo()` to meet the requirements,
```typescript
  openToDemo() {
    if (!this.creatingFlow) {
      this.creatingFlow = true;
      // Changed this to openToDemo
      this.openToDemo$ = this.flowService
        .create({
          projectId: this.authenticationService.getProjectId(),
          displayName: demoTemplate.displayName,
        })
        .pipe(
          switchMap((flow) => {
            return this.flowService
              .update(flow.id, {
                type: FlowOperationType.IMPORT_FLOW,
                request: demoTemplate,
              })
              .pipe(
                // updated the Type
                tap((updatedFlow: Flow) => {
                  this.telemetryService.capture({
                    name: TelemetryEventName.DEMO_IMPORTED,
                    payload: {},
                  });
                  this.router.navigate([
                    `/flows/${updatedFlow.id}?sampleFlow=true`,
                  ]);
                })
              );
          })
        );
    }
  }
```

No Dependencies are installed to fix the issue.

Fixes #3611 

