### PR TITLE
chore: fixed wrong date in changelog

### DIFF
--- a/docs/about/changelog.mdx
+++ b/docs/about/changelog.mdx
@@ -14,7 +14,7 @@ Semantic versioning is a standardized way of versioning software projects. It us
 
 Here's the revised text with improved grammar and spelling:
 
-### 4/1/2023
+### 4/1/2024
 
 **✨ Exciting New Features**
 


### PR DESCRIPTION
The latest update in the changelog has 4/1/2023 so I changed it to 4/1/2024