### PR TITLE
fix: isolate mode with local file pieces

### DIFF
--- a/packages/backend/src/app/flows/common/piece-manager/local-piece-manager.ts
+++ b/packages/backend/src/app/flows/common/piece-manager/local-piece-manager.ts
@@ -31,6 +31,7 @@ export class LocalPieceManager extends PieceManager {
             })
             await updatePackageJson(pieceMetadata.directoryPath!, frameworkPackages)
             await packageManager.link({
+                packageName: pieceMetadata.name,
                 path: projectPath,
                 linkPath: pieceMetadata.directoryPath!,
             })
@@ -41,11 +42,13 @@ export class LocalPieceManager extends PieceManager {
 const linkFrameworkPackages = async (projectPath: string, baseLinkPath: string, frameworkPackages: Record<string, string>): Promise<void> => {
     await updatePackageJson(join(baseLinkPath, 'framework'), frameworkPackages)
     await packageManager.link({
+        packageName: '@activepieces/pieces-framework',
         path: projectPath,
         linkPath: `${baseLinkPath}/framework`,
     })
     await updatePackageJson(join(baseLinkPath, 'common'), frameworkPackages)
     await packageManager.link({
+        packageName: '@activepieces/pieces-common',
         path: projectPath,
         linkPath: `${baseLinkPath}/common`,
     })

--- a/packages/backend/src/app/workers/sandbox/isolate-sandbox.ts
+++ b/packages/backend/src/app/workers/sandbox/isolate-sandbox.ts
@@ -3,7 +3,7 @@ import { arch, cwd } from 'node:process'
 import path from 'node:path'
 import { exec } from 'node:child_process'
 import { ExecuteSandboxResult, AbstractSandbox, SandboxCtorParams } from './abstract-sandbox'
-import { EngineResponseStatus } from '@activepieces/shared'
+import { EngineResponseStatus, assertNotNullOrUndefined } from '@activepieces/shared'
 import { logger } from '../../helper/logger'
 import { system } from '../../helper/system/system'
 import { SystemProp } from '../../helper/system/system-prop'
@@ -46,11 +46,15 @@ export class IsolateSandbox extends AbstractSandbox {
             const basePath = path.resolve(__dirname.split('/dist')[0])
             const pieceSource = system.getOrThrow(SystemProp.PIECES_SOURCE)
             const codeExecutorSandboxType = system.get(SystemProp.CODE_EXECUTOR_SANDBOX_TYPE)
+            const cachePath = this._cachePath
+            assertNotNullOrUndefined(cachePath, 'cachePath')
             const fullCommand = [
                 '--dir=/usr/bin/',
                 `--dir=/etc/=${etcDir}`,
-                `--dir=${basePath}=/${basePath}:maybe`,
-                `--dir=${IsolateSandbox.cacheBindPath}=${this._cachePath}`,
+                `--dir=${path.join(basePath, '.pnpm')}=/${path.join(basePath, '.pnpm')}:maybe`,
+                `--dir=${path.join(basePath, 'dist')}=/${path.join(basePath, 'dist')}:maybe`,
+                `--dir=${path.join(basePath, 'node_modules')}=/${path.join(basePath, 'node_modules')}:maybe`,
+                `--dir=${IsolateSandbox.cacheBindPath}=${path.resolve(cachePath)}`,
                 '--share-net',
                 `--box-id=${this.boxId}`,
                 '--processes',


### PR DESCRIPTION
## What does this PR do?

The issue is that pnpm uses relative symbolic links. When isolating the directory, it gets bound to `/root/`, which is different from where the relative link is constructed, causing it to fail. This change aims to replace all relative symbolic links with absolute paths after linking using pnpm.

Additionally, unrelated to the bug, this PR restricts the bound folder to `node_modules`, `dist`, and `.pnpm`.