### PR TITLE
docs: fix broken links. Changes to links to point to new community folder

### DIFF
--- a/docs/developers/piece-reference/examples.mdx
+++ b/docs/developers/piece-reference/examples.mdx
@@ -9,23 +9,23 @@ To get the full benefit, it is recommended to read the tutorial first.
 ## Triggers:
 
 **Webhooks:**
-- [New Form Submission on Typeform](https://github.com/activepieces/activepieces/blob/main/packages/pieces/typeform/src/lib/trigger/new-submission.ts)
+- [New Form Submission on Typeform](https://github.com/activepieces/activepieces/blob/main/packages/pieces/community/typeform/src/lib/trigger/new-submission.ts)
 
 **Polling:**
-- [New Completed Task On Todoist](https://github.com/activepieces/activepieces/blob/main/packages/pieces/todoist/src/lib/triggers/task-completed-trigger.ts)
+- [New Completed Task On Todoist](https://github.com/activepieces/activepieces/blob/main/packages/pieces/community/todoist/src/lib/triggers/task-completed-trigger.ts)
 
 ## Actions:
-- [Send a message On Discord](https://github.com/activepieces/activepieces/blob/main/packages/pieces/discord/src/lib/actions/send-message-webhook.ts)
-- [Send an mail On Gmail](https://github.com/activepieces/activepieces/blob/main/packages/pieces/gmail/src/lib/actions/send-email-action.ts)
+- [Send a message On Discord](https://github.com/activepieces/activepieces/blob/main/packages/pieces/community/discord/src/lib/actions/send-message-webhook.ts)
+- [Send an mail On Gmail](https://github.com/activepieces/activepieces/blob/main/packages/pieces/community/gmail/src/lib/actions/send-email-action.ts)
 
 ## Authentication
 
 **OAuth2:**
-- [Slack](https://github.com/activepieces/activepieces/blob/main/packages/pieces/slack/src/index.ts)
-- [Gmail](https://github.com/activepieces/activepieces/blob/main/packages/pieces/gmail/src/index.ts)
+- [Slack](https://github.com/activepieces/activepieces/blob/main/packages/pieces/community/slack/src/index.ts)
+- [Gmail](https://github.com/activepieces/activepieces/blob/main/packages/pieces/community/gmail/src/index.ts)
 
 **API Key:**
-- [Sendgrid](https://github.com/activepieces/activepieces/blob/main/packages/pieces/sendgrid/src/index.ts)
+- [Sendgrid](https://github.com/activepieces/activepieces/blob/main/packages/pieces/community/sendgrid/src/index.ts)
 
 **Basic Authentication:**
-- [Twilio](https://github.com/activepieces/activepieces/blob/main/packages/pieces/twilio/src/index.ts)
+- [Twilio](https://github.com/activepieces/activepieces/blob/main/packages/pieces/community/twilio/src/index.ts)


### PR DESCRIPTION
## What does this PR do?

Pieces were moved to community folder, links in website point to previous file location


