### PR TITLE
fix(matomo): Ensure compatibility with v5 API

### DIFF
--- a/packages/pieces/community/matomo/package.json
+++ b/packages/pieces/community/matomo/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-matomo",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/pieces/community/matomo/src/lib/api.ts
+++ b/packages/pieces/community/matomo/src/lib/api.ts
@@ -7,20 +7,29 @@ import {
 import { MatomoAuthType } from './auth';
 
 const matomoAPI = async (
-  api: string,
-  auth: MatomoAuthType,
-  queryParams: QueryParams = {}
+  api         : string,
+  auth        : MatomoAuthType,
+  queryParams : QueryParams = {}
 ) => {
-  queryParams['module'] = 'API';
-  queryParams['format'] = 'JSON';
-  queryParams['method'] = api;
-  queryParams['token_auth'] = auth.tokenAuth;
-  queryParams['idSite'] = auth.siteId;
+	queryParams['module'] = 'API';
+	queryParams['format'] = 'JSON';
+	queryParams['method'] = api;
+	queryParams['idSite'] = auth.siteId;
+
+  const formData = new FormData();
+  formData.append('token_auth', auth.tokenAuth);
+
+  console.log('queryParams', queryParams);
+  console.log('formData', formData);
 
   const request: HttpRequest = {
-    method: HttpMethod.POST,
-    url: `${auth.domain}`,
-    queryParams: queryParams,
+	method      : HttpMethod.POST,
+	url         : `${auth.domain}`,
+	queryParams : queryParams,
+	body        : formData,
+	headers     : {
+		'Content-Type': 'multipart/form-data',
+	},
   };
   const response = await httpClient.sendRequest(request);
 

--- a/packages/pieces/community/matomo/src/lib/api.ts
+++ b/packages/pieces/community/matomo/src/lib/api.ts
@@ -19,9 +19,6 @@ const matomoAPI = async (
   const formData = new FormData();
   formData.append('token_auth', auth.tokenAuth);
 
-  console.log('queryParams', queryParams);
-  console.log('formData', formData);
-
   const request: HttpRequest = {
 	method      : HttpMethod.POST,
 	url         : `${auth.domain}`,


### PR DESCRIPTION
## What does this PR do?

Matomo v5 was released and the API token needs to be added to the POST request parameters. This fixes the integration to support v5. 

ANNOUNCEMENT=true