### PR TITLE
fix: use $ syntax instead of ? in database migration

### DIFF
--- a/packages/backend/src/app/database/migration/common/1696245170061-add-piece-type-and-package-type-to-flow-version.ts
+++ b/packages/backend/src/app/database/migration/common/1696245170061-add-piece-type-and-package-type-to-flow-version.ts
@@ -9,14 +9,14 @@ export class AddPieceTypeAndPackageTypeToFlowVersion1696245170061 implements Mig
         let updatedFlows = 0
         for (const { id } of flowVersionIds) {
             // Fetch FlowVersion record by ID
-            const flowVersion = await queryRunner.query('SELECT * FROM flow_version WHERE id = ?', [id])
+            const flowVersion = await queryRunner.query('SELECT * FROM flow_version WHERE id = $1', [id])
             if (flowVersion.length > 0) {
                 const updated = traverseAndUpdateSubFlow(
                     addPackageTypeAndPieceTypeToPieceStepSettings,
                     flowVersion[0].trigger,
                 )
                 if (updated) {
-                    await queryRunner.query('UPDATE flow_version SET trigger = ? WHERE id = ?', [flowVersion[0].trigger, flowVersion[0].id])
+                    await queryRunner.query('UPDATE flow_version SET trigger = $1 WHERE id = $2', [flowVersion[0].trigger, flowVersion[0].id])
                 }
             }
             updatedFlows++
@@ -33,7 +33,7 @@ export class AddPieceTypeAndPackageTypeToFlowVersion1696245170061 implements Mig
         const flowVersionIds = await queryRunner.query('SELECT id FROM flow_version')
         for (const { id } of flowVersionIds) {
             // Fetch FlowVersion record by ID
-            const flowVersion = await queryRunner.query('SELECT * FROM flow_version WHERE id = ?', [id])
+            const flowVersion = await queryRunner.query('SELECT * FROM flow_version WHERE id = $1', [id])
 
             if (flowVersion.length > 0) {
                 const updated = traverseAndUpdateSubFlow(
@@ -41,7 +41,7 @@ export class AddPieceTypeAndPackageTypeToFlowVersion1696245170061 implements Mig
                     flowVersion[0].trigger,
                 )
                 if (updated) {
-                    await queryRunner.query('UPDATE flow_version SET trigger = ? WHERE id = ?', [flowVersion[0].trigger, flowVersion[0].id])
+                    await queryRunner.query('UPDATE flow_version SET trigger = $1 WHERE id = $2', [flowVersion[0].trigger, flowVersion[0].id])
                 }
             }
         }

--- a/packages/backend/src/app/database/migration/common/1697969398200-store-code-inside-flow.ts
+++ b/packages/backend/src/app/database/migration/common/1697969398200-store-code-inside-flow.ts
@@ -49,19 +49,19 @@ export class StoreCodeInsideFlow1697969398200 implements MigrationInterface {
                 const updated = await traverseAndUpdateSubFlow(stepFunction, template.template.trigger, queryRunner, template.projectId, template.id)
 
                 if (updated) {
-                    await queryRunner.query('UPDATE flow_template SET template = ? WHERE id = ?', [template.template, template.id])
+                    await queryRunner.query('UPDATE flow_template SET template = $1 WHERE id = $2', [template.template, template.id])
                 }
             }
         }
     }
 
     private async findFlowVersionById(queryRunner: QueryRunner, id: string): Promise<FlowVersion | undefined> {
-        const flowVersion = await queryRunner.query('SELECT * FROM flow_version WHERE id = ? LIMIT 1', [id])
+        const flowVersion = await queryRunner.query('SELECT * FROM flow_version WHERE id = $1', [id])
         return flowVersion[0]
     }
 
     private async updateFlowVersion(queryRunner: QueryRunner, id: string, flowVersion: FlowVersion): Promise<void> {
-        await queryRunner.query('UPDATE flow_version SET "flowId" = ?, trigger = ? WHERE id = ?', [flowVersion.flowId, flowVersion.trigger, id])
+        await queryRunner.query('UPDATE flow_version SET "flowId" = $1, trigger = $2 WHERE id = $3', [flowVersion.flowId, flowVersion.trigger, id])
     }
 }
 
@@ -96,7 +96,7 @@ const flattenCodeStep = async (codeStep: CodeStep, queryRunner: QueryRunner, flo
     const sourceCodeId = codeStep.settings.artifactSourceId
     const sourceCode = codeStep.settings.sourceCode
     if (!isNil(sourceCodeId) && isNil(sourceCode)) {
-        const [file] = await queryRunner.query('SELECT * FROM file WHERE id = ? LIMIT 1', [sourceCodeId])
+        const [file] = await queryRunner.query('SELECT * FROM file WHERE id = $1', [sourceCodeId])
         if (isNil(file)) {
             logger.warn(`StoreCodeInsideFlow1697969398100: file not found for file id ${sourceCodeId} in flow ${flowId} of flow version ${flowVersionId}`)
             return

--- a/packages/backend/src/app/flows/flow-version/flow-version-side-effects.ts
+++ b/packages/backend/src/app/flows/flow-version/flow-version-side-effects.ts
@@ -38,10 +38,11 @@ export const flowVersionSideEffects = {
                     projectId,
                     flowId: flowVersion.flowId,
                 })
-            } catch (e) {
+            }
+            catch (e) {
                 // Ignore error and continue the operation peacefully
                 captureException(e)
             }
         }
-    }
+    },
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

The '?' Style is not supported in postgres, and it used in common migration 

