### PR TITLE
fix(storage-piece): "Key <key> is not an array" error when using add-to-list action

### DIFF
--- a/packages/pieces/community/store/src/lib/actions/store-add-to-list.ts
+++ b/packages/pieces/community/store/src/lib/actions/store-add-to-list.ts
@@ -42,12 +42,19 @@ export const storageAddtoList = createAction({
     }),
   },
   async run(context) {
-    const items =
+    let items =
       (await context.store.get<unknown[]>(
         context.propsValue['key'],
         context.propsValue.store_scope
       )) ?? [];
-    if (!Array.isArray(items)) {
+    try {
+      if(typeof items === 'string') {
+        items = JSON.parse(items)
+      }
+      if (!Array.isArray(items)) {
+        throw new Error(`Key ${context.propsValue['key']} is not an array`);
+      }
+    } catch(err) {
       throw new Error(`Key ${context.propsValue['key']} is not an array`);
     }
     if (context.propsValue['ignore_if_exists']) {


### PR DESCRIPTION
## What does this PR do?
Array data, in the storage piece, is stored as a string ( despite the JSONB column data type ). This makes it impossible for the user to use the add-to-list action, which assumes that the data retrieved from the storage is an array ( if not empty ) and tries to push items to it.

Fixes #3759 

