### PR TITLE
feat: allow to sync custom pieces folder to platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cli": "npx ts-node packages/cli/src/index.ts",
     "create-piece": "npx ts-node packages/cli/src/index.ts pieces create",
     "create-action": "npx ts-node packages/cli/src/index.ts actions create",
+    "sync-pieces": "npx ts-node packages/cli/src/index.ts pieces sync",
     "publish-piece": "npx ts-node tools/scripts/utils/publish-piece.ts"
   },
   "private": true,

--- a/packages/backend/src/app/ee/pieces/platform-piece-module.ts
+++ b/packages/backend/src/app/ee/pieces/platform-piece-module.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsyncTypebox, Type } from '@fastify/type-provider-typebox'
 import { FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox'
-import { ActivepiecesError, AddPieceRequestBody, ErrorCode, PieceScope, PlatformRole, Principal, PrincipalType } from '@activepieces/shared'
+import { ActivepiecesError, AddPieceRequestBody, EndpointScope, ErrorCode, PieceScope, PlatformRole, Principal, PrincipalType } from '@activepieces/shared'
 import { pieceService } from '../../pieces/piece-service'
 import { StatusCodes } from 'http-status-codes'
 
@@ -12,6 +12,7 @@ const platformPieceController: FastifyPluginCallbackTypebox = (app, _opts, done)
     app.post('/', {
         config: {
             allowedPrincipals: [PrincipalType.USER, PrincipalType.SERVICE],
+            scope: EndpointScope.PLATFORM,
         },
         schema: {
             tags: ['pieces'],

--- a/packages/backend/src/app/helper/error-handler.ts
+++ b/packages/backend/src/app/helper/error-handler.ts
@@ -29,6 +29,7 @@ export const errorHandler = async (
             [ErrorCode.DOMAIN_NOT_ALLOWED]: StatusCodes.FORBIDDEN,
             [ErrorCode.EMAIL_AUTH_DISABLED]: StatusCodes.FORBIDDEN,
             [ErrorCode.INVALID_OTP]: StatusCodes.GONE,
+            [ErrorCode.VALIDATION]: StatusCodes.CONFLICT,
             [ErrorCode.INVITATION_ONLY_SIGN_UP]: StatusCodes.FORBIDDEN,
             [ErrorCode.AUTHENTICATION]: StatusCodes.UNAUTHORIZED,
         }

--- a/packages/backend/src/app/pieces/base-piece-module.ts
+++ b/packages/backend/src/app/pieces/base-piece-module.ts
@@ -73,7 +73,7 @@ const basePiecesController: FastifyPluginAsyncTypebox = async (app) => {
 
         const decodedName = decodeURIComponent(name)
         return pieceMetadataService.getOrThrow({
-            projectId: req.principal.projectId,
+            projectId: req.principal.type === PrincipalType.UNKNOWN ? undefined : req.principal.projectId,
             name: decodedName,
             version,
         })

--- a/packages/backend/src/app/pieces/piece-service/index.ts
+++ b/packages/backend/src/app/pieces/piece-service/index.ts
@@ -46,6 +46,9 @@ export const pieceService = {
         catch (error) {
             logger.error(error, '[PieceService#add]')
 
+            if ((error as ActivepiecesError).error.code === ErrorCode.VALIDATION) {
+                throw error
+            }
             throw new ActivepiecesError({
                 code: ErrorCode.ENGINE_OPERATION_FAILURE,
                 params: {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,11 +2,13 @@ import { Command } from 'commander';
 import { createActionCommand } from './lib/commands/create-action';
 import { createPieceCommand } from './lib/commands/create-piece';
 import { createTriggerCommand } from './lib/commands/create-trigger';
+import { syncPieceCommand } from './lib/commands/sync-pieces';
 
 const pieceCommand = new Command('pieces')
   .description('Manage pieces');
 
 pieceCommand.addCommand(createPieceCommand);
+pieceCommand.addCommand(syncPieceCommand)
 
 const actionCommand = new Command('actions')
   .description('Manage actions');

--- a/packages/cli/src/lib/commands/sync-pieces.ts
+++ b/packages/cli/src/lib/commands/sync-pieces.ts
@@ -1,0 +1,67 @@
+import { Command } from "commander";
+import { findAllPieces } from "../utils/piece-utils";
+import { readPackageJson, readProjectJson } from "../utils/files";
+import path, { join } from "path";
+import { exec } from "../utils/exec";
+import FormData from 'form-data';
+import fs from 'fs';
+import chalk from "chalk";
+import axios, { AxiosError } from 'axios';
+
+
+async function syncPieces(apiUrl: string, apiKey: string) {
+    const piecesFolder = await findAllPieces(join(process.cwd(), 'packages', 'pieces', 'custom'));
+    for (const pieceFolder of piecesFolder) {
+        const projectJson = await readProjectJson(pieceFolder);
+        const packageJson = await readPackageJson(pieceFolder);
+
+        await exec('npx nx build ' + projectJson.name);
+
+        const compiledPath = path.resolve('dist/packages' + pieceFolder.split('/packages')[1]);
+        const { stdout } = await exec('cd ' + compiledPath + ' && npm pack --json');
+        const tarFileName = JSON.parse(stdout)[0].filename;
+        const formData = new FormData();
+        console.log('Uploading ' + tarFileName);
+        formData.append('pieceArchive', fs.createReadStream(join(compiledPath, tarFileName)));
+        formData.append('pieceName', packageJson.name);
+        formData.append('pieceVersion', packageJson.version);
+        formData.append('packageType', 'ARCHIVE');
+        formData.append('scope', 'PLATFORM');
+
+        try {
+            await axios.post(`${apiUrl}/v1/pieces`, formData, {
+                headers: {
+                    'Authorization': `Bearer ${apiKey}`,
+                    ...formData.getHeaders()
+                }
+            });
+            console.info(chalk.green(`Piece '${packageJson.name}' published.`));
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            if (axiosError.response) {
+                if (axiosError.response.status === 409) {
+                    console.info(chalk.yellow(`Piece '${packageJson.name}' and '${packageJson.version}' already published.`));
+                } else if (Math.floor(axiosError.response.status / 100) !== 2) {
+                    console.info(chalk.red(`Error publishing piece '${packageJson.name}', ` + JSON.stringify(axiosError.response.data)));
+                } else {
+                    console.error(chalk.red(`Unexpected error: ${error.message}`));
+                }
+            } else {
+                console.error(chalk.red(`Unexpected error: ${error.message}`));
+            }
+        }
+    }
+}
+
+export const syncPieceCommand = new Command('sync')
+    .description('Find new pieces versions and sync them with the database')
+    .requiredOption('-h, --apiUrl <url>', 'API URL ex: https://cloud.activepieces.com/api')
+    .action(async (options) => {
+        const apiKey = process.env.AP_API_KEY;
+        const apiUrlWithoutTrailSlash = options.apiUrl.replace(/\/$/, '');
+        if (!apiKey) {
+            console.error(chalk.red('AP_API_KEY environment variable is required'));
+            process.exit(1);
+        }
+        await syncPieces(apiUrlWithoutTrailSlash, apiKey);
+    });

--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -3,8 +3,8 @@ import { readdir, stat } from 'node:fs/promises'
 import { resolve, join } from 'node:path'
 import { cwd } from 'node:process'
 
-export async function findAllPieces(): Promise<string[]> {
-    const piecesPath = resolve(cwd(), 'packages', 'pieces')
+export async function findAllPieces(path?: string): Promise<string[]> {
+    const piecesPath = path ?? resolve(cwd(), 'packages', 'pieces')
     const paths = await traverseFolder(piecesPath)
     return paths
 }


### PR DESCRIPTION
This will sync all pieces in customer folder to your platform, example usage.

AP_API_KEY=PLATFORM_API_KEY npm run sync-pieces -- --apiUrl http://localhost:3000
