### PR TITLE
fix: multiple delays should work

### DIFF
--- a/packages/engine/src/lib/handler/context/engine-constants.ts
+++ b/packages/engine/src/lib/handler/context/engine-constants.ts
@@ -40,7 +40,6 @@ export class EngineConstants {
         public readonly flowRunId: string,
         public readonly serverUrl: string,
         public readonly retryConstants: RetryConstants,
-        public readonly executionType: ExecutionType,
         public readonly workerToken: string,
         public readonly projectId: ProjectId,
         public readonly variableService: VariableService,
@@ -55,7 +54,6 @@ export class EngineConstants {
             input.flowRunId,
             input.serverUrl,
             DEFAULT_RETRY_CONSTANTS,
-            input.executionType,
             input.workerToken,
             input.projectId,
             new VariableService({
@@ -74,7 +72,6 @@ export class EngineConstants {
             'test-run',
             input.serverUrl,
             DEFAULT_RETRY_CONSTANTS,
-            ExecutionType.BEGIN,
             input.workerToken,
             input.projectId,
             new VariableService({
@@ -92,7 +89,6 @@ export class EngineConstants {
             'execute-property',
             input.serverUrl,
             DEFAULT_RETRY_CONSTANTS,
-            ExecutionType.BEGIN,
             input.workerToken,
             input.projectId,
             new VariableService({
@@ -110,7 +106,6 @@ export class EngineConstants {
             'execute-trigger',
             input.serverUrl,
             DEFAULT_RETRY_CONSTANTS,
-            ExecutionType.BEGIN,
             input.workerToken,
             input.projectId,
             new VariableService({

--- a/packages/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/engine/src/lib/handler/context/flow-execution-context.ts
@@ -1,4 +1,4 @@
-import { ActionType, ExecutionOutput, ExecutionOutputStatus, PauseMetadata, StepOutput, StepOutputStatus, StopResponse, isNil } from '@activepieces/shared'
+import { ActionType, ExecutionOutput, ExecutionOutputStatus, LoopStepOutput, PauseMetadata, StepOutput, StepOutputStatus, StopResponse, assertEqual, isNil } from '@activepieces/shared'
 import { StepExecutionPath } from './step-execution-path'
 import { loggingUtils } from '../../helper/logging-utils'
 
@@ -43,6 +43,16 @@ export class FlowExecutorContext {
         return new FlowExecutorContext()
     }
 
+    public getLoopStepOutput({ stepName }: { stepName: string }): LoopStepOutput | undefined {
+        const stateAtPath = getStateAtPath({ currentPath: this.currentPath, steps: this.steps })
+        const stepOutput = stateAtPath[stepName]
+        if (isNil(stepOutput)) {
+            return undefined
+        }
+        assertEqual(stepOutput.type, ActionType.LOOP_ON_ITEMS, 'stepout', 'LoopStepOutput')
+        return stepOutput as LoopStepOutput
+    }
+    
     public isCompleted({ stepName }: { stepName: string }): boolean {
         const stateAtPath = getStateAtPath({ currentPath: this.currentPath, steps: this.steps })
         const stepOutput = stateAtPath[stepName]
@@ -50,6 +60,15 @@ export class FlowExecutorContext {
             return false
         }
         return stepOutput.status !== StepOutputStatus.PAUSED
+    }
+
+    public isPaused({ stepName }: { stepName: string }): boolean {
+        const stateAtPath = getStateAtPath({ currentPath: this.currentPath, steps: this.steps })
+        const stepOutput = stateAtPath[stepName]
+        if (isNil(stepOutput)) {
+            return false
+        }
+        return stepOutput.status === StepOutputStatus.PAUSED
     }
 
     public setDuration(duration: number): FlowExecutorContext {

--- a/packages/engine/src/lib/handler/loop-executor.ts
+++ b/packages/engine/src/lib/handler/loop-executor.ts
@@ -24,20 +24,24 @@ export const loopExecutor: BaseExecutor<LoopOnItemsAction> = {
             },
             executionState,
         })
-
-        let stepOutput = LoopStepOutput.init({
+        const previousStepOutput = executionState.getLoopStepOutput({ stepName: action.name })
+        let stepOutput = previousStepOutput ?? LoopStepOutput.init({
             input: censoredInput,
         })
-
         let newExecutionContext = executionState.upsertStep(action.name, stepOutput)
         const firstLoopAction = action.firstLoopAction
 
 
         for (let i = 0; i < resolvedInput.items.length; ++i) {
             const newCurrentPath = newExecutionContext.currentPath.loopIteration({ loopName: action.name, iteration: i })
-            stepOutput = stepOutput.addIteration({ index: i + 1, item: resolvedInput.items[i] })
 
-            newExecutionContext = newExecutionContext.upsertStep(action.name, stepOutput).setCurrentPath(newCurrentPath)
+            stepOutput = stepOutput.setItemAndIndex({ item: resolvedInput.items[i], index: i + 1 })
+            const addEmptyIteration = !stepOutput.hasIteration(i)
+            if (addEmptyIteration) {
+                stepOutput = stepOutput.addIteration()
+                newExecutionContext = newExecutionContext.upsertStep(action.name, stepOutput)
+            }
+            newExecutionContext = newExecutionContext.setCurrentPath(newCurrentPath)
             if (!isNil(firstLoopAction) && !constants.testSingleStepMode) {
                 newExecutionContext = await flowExecutor.execute({
                     action: firstLoopAction,

--- a/packages/engine/src/main.ts
+++ b/packages/engine/src/main.ts
@@ -74,7 +74,7 @@ function getFlowExecutionState(input: ExecuteFlowOperation): FlowExecutorContext
         case ExecutionType.RESUME: {
             let flowContext = FlowExecutorContext.empty().increaseTask(input.tasks)
             for (const [step, output] of Object.entries(input.executionState.steps)) {
-                if (output.status === StepOutputStatus.SUCCEEDED) {
+                if ([StepOutputStatus.SUCCEEDED, StepOutputStatus.PAUSED].includes(output.status)) {
                     flowContext = flowContext.upsertStep(step, output)
                 }
             }

--- a/packages/engine/test/handler/flow-rerun.test.ts
+++ b/packages/engine/test/handler/flow-rerun.test.ts
@@ -1,7 +1,6 @@
 import { flowExecutor } from '../../src/lib/handler/flow-executor'
 import { ExecutionVerdict, FlowExecutorContext } from '../../src/lib/handler/context/flow-execution-context'
 import { buildPieceAction, generateMockEngineConstants } from './test-helper'
-import { ExecutionType } from '@activepieces/shared'
 
 const failedHttpAction = buildPieceAction({
     name: 'send_http',
@@ -48,9 +47,7 @@ describe('flow retry', () => {
         })
 
         const retryFromFailed = await flowExecutor.execute({
-            action: successHttpAction, executionState: context, constants: generateMockEngineConstants({
-                executionType: ExecutionType.RESUME,
-            }),
+            action: successHttpAction, executionState: context, constants: generateMockEngineConstants({}),
         })
         expect(failedResult.verdict).toBe(ExecutionVerdict.FAILED)
         expect(retryFromFailed.verdict).toBe(ExecutionVerdict.RUNNING)

--- a/packages/engine/test/handler/test-helper.ts
+++ b/packages/engine/test/handler/test-helper.ts
@@ -1,4 +1,4 @@
-import { Action, ActionErrorHandlingOptions, ActionType, BranchAction, BranchCondition, CodeAction, ExecutionType, LoopOnItemsAction, PackageType, PieceAction, PieceType } from '@activepieces/shared'
+import { Action, ActionErrorHandlingOptions, ActionType, BranchAction, BranchCondition, CodeAction, LoopOnItemsAction, PackageType, PieceAction, PieceType } from '@activepieces/shared'
 import { VariableService } from '../../src/lib/services/variable-service'
 import { EngineConstants } from '../../src/lib/handler/context/engine-constants'
 
@@ -12,7 +12,6 @@ export const generateMockEngineConstants = (params?: Partial<EngineConstants>): 
             retryExponential: 1,
             retryInterval: 1,
         },
-        params?.executionType ?? ExecutionType.BEGIN,
         params?.workerToken ?? 'workerToken',
         params?.projectId ?? 'projectId',
         params?.variableService ?? new VariableService({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.10.68",
+  "version": "0.10.69",
   "type": "commonjs"
 }

--- a/packages/shared/src/lib/flow-run/execution/step-output.ts
+++ b/packages/shared/src/lib/flow-run/execution/step-output.ts
@@ -1,5 +1,6 @@
 import { TriggerType } from '../../flows/triggers/trigger'
 import { ActionType } from '../../flows/actions/action'
+import { isNil } from '../../common'
 
 export enum StepOutputStatus {
     FAILED = 'FAILED',
@@ -120,12 +121,27 @@ export class LoopStepOutput extends GenericStepOutput<ActionType.LOOP_ON_ITEMS, 
         })
     }
 
-    addIteration({ item, index }: { item: unknown, index: number }): LoopStepOutput {
+    hasIteration(iteration: number): boolean {
+        return !isNil(this.output?.iterations[iteration])
+    }
+    
+    setItemAndIndex({ item, index }: { item: unknown, index: number }): LoopStepOutput {
         return new LoopStepOutput({
             ...this,
             output: {
                 item,
                 index,
+                iterations: this.output?.iterations ?? [],
+            },
+        })
+    }
+
+    addIteration(): LoopStepOutput {
+        return new LoopStepOutput({
+            ...this,
+            output: {
+                item: this.output?.item,
+                index: this.output?.index,
                 iterations: [...(this.output?.iterations ?? []), {}],
             },
         })


### PR DESCRIPTION
## What does this PR do?


Remove the dependencies on execution type. It's poor to depend on that state as the flow can alternate between them. For example, if you have two delay steps after the first delay, the execution type will be resume and it will skip the other delay. 

Solution: Check if the flow is paused from the execution state and decide the state. 


This discovered a hidden bug that if there is a delay inside a loop, it will redo all the steps inside the loop as it overwrites the iteration object inside the loop with an empty one each time the loop is executed, so instead now we try to reuse old loop state if it exists and skip emptying the iteration object.