### PR TITLE
feat(branch): add new condition "(number) is equal to"

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5731,6 +5731,12 @@
                                                         "enum": [
                                                           "NUMBER_IS_LESS_THAN"
                                                         ]
+                                                      },
+                                                      {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "NUMBER_IS_EQUAL_TO"
+                                                        ]
                                                       }
                                                     ]
                                                   }

--- a/packages/engine/src/lib/handler/branch-executor.ts
+++ b/packages/engine/src/lib/handler/branch-executor.ts
@@ -128,6 +128,12 @@ function evaluateConditions(conditionGroups: BranchCondition[][]): boolean {
                     andGroup = andGroup && firstValue < secondValue
                     break
                 }
+                case BranchOperator.NUMBER_IS_EQUAL_TO: {
+                    const firstValue = parseStringToNumber(castedCondition.firstValue)
+                    const secondValue = parseStringToNumber(castedCondition.secondValue)
+                    andGroup = andGroup && firstValue == secondValue
+                    break
+                }
                 case BranchOperator.BOOLEAN_IS_TRUE:
                     andGroup = andGroup && !!castedCondition.firstValue
                     break

--- a/packages/engine/test/handler/flow-branching.test.ts
+++ b/packages/engine/test/handler/flow-branching.test.ts
@@ -306,4 +306,46 @@ describe('flow with branching different conditions', () => {
         })
     })
 
+    it('should execute branch with two equal numbers', async () => {
+        const result = await executeBranchActionWithOneCondition(
+            {
+                operator: BranchOperator.NUMBER_IS_EQUAL_TO,
+                firstValue: '1',
+                secondValue: '1',
+            },
+        )
+        expect(result.verdict).toBe(ExecutionVerdict.RUNNING)
+        expect(result.steps.branch.output).toEqual({
+            condition: true,
+        })
+    })
+
+    it('should execute branch with the first number greater than the second one', async () => {
+        const result = await executeBranchActionWithOneCondition(
+            {
+                operator: BranchOperator.NUMBER_IS_GREATER_THAN,
+                firstValue: '2',
+                secondValue: '1',
+            },
+        )
+        expect(result.verdict).toBe(ExecutionVerdict.RUNNING)
+        expect(result.steps.branch.output).toEqual({
+            condition: true,
+        })
+    })
+
+    it('should execute branch with the first number less than the second one', async () => {
+        const result = await executeBranchActionWithOneCondition(
+            {
+                operator: BranchOperator.NUMBER_IS_LESS_THAN,
+                firstValue: '1',
+                secondValue: '2',
+            },
+        )
+        expect(result.verdict).toBe(ExecutionVerdict.RUNNING)
+        expect(result.steps.branch.output).toEqual({
+            condition: true,
+        })
+    })
+
 })

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.10.70",
+  "version": "0.10.71",
   "type": "commonjs"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.10.69",
+  "version": "0.10.70",
   "type": "commonjs"
 }

--- a/packages/shared/src/lib/flows/actions/action.ts
+++ b/packages/shared/src/lib/flows/actions/action.ts
@@ -101,6 +101,7 @@ export enum BranchOperator {
     TEXT_DOES_NOT_END_WITH = 'TEXT_DOES_NOT_END_WITH',
     NUMBER_IS_GREATER_THAN = 'NUMBER_IS_GREATER_THAN',
     NUMBER_IS_LESS_THAN = 'NUMBER_IS_LESS_THAN',
+    NUMBER_IS_EQUAL_TO = 'NUMBER_IS_EQUAL_TO',
     BOOLEAN_IS_TRUE = 'BOOLEAN_IS_TRUE',
     BOOLEAN_IS_FALSE = 'BOOLEAN_IS_FALSE',
     EXISTS = 'EXISTS',
@@ -147,6 +148,7 @@ const BranchConditionValid = (addMinLength: boolean) => Type.Union([
         operator: Type.Optional(Type.Union([
             Type.Literal( BranchOperator.NUMBER_IS_GREATER_THAN),
             Type.Literal( BranchOperator.NUMBER_IS_LESS_THAN),
+            Type.Literal( BranchOperator.NUMBER_IS_EQUAL_TO),
         ])),
     }),
     Type.Object({


### PR DESCRIPTION
## What does this PR do?

I added the "(number) is equal to" to the conditions of a branch step.
I get you can do the same with the "(Text) exactly matches", but I think is better to have a dedicated condition for numbers... I mean, you could use the "(Text) exactly matches" for booleans too but instead, we have two separate conditions.

![image](https://github.com/activepieces/activepieces/assets/54374282/44604b39-0b14-433b-bc07-8e074a7cbab2)
