### PR TITLE
fix: rotate image degree description

### DIFF
--- a/packages/pieces/community/image-helper/package.json
+++ b/packages/pieces/community/image-helper/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-image-helper",
-  "version": "0.0.3"
+  "version": "0.0.4"
 }

--- a/packages/pieces/community/image-helper/src/lib/actions/rotate-image.action.ts
+++ b/packages/pieces/community/image-helper/src/lib/actions/rotate-image.action.ts
@@ -12,7 +12,7 @@ export const rotateImage = createAction({
     }),
     degree: Property.StaticDropdown({
       displayName: 'Degree',
-      description: 'Specifies the degree of rotation for the image. For clockwise rotation make the degree positive, otherwise make it negative.',
+      description: 'Specifies the degree of clockwise rotation applied to the image.',
       required: true,
       options: {
         options: [


### PR DESCRIPTION
## What does this PR do?
fixes the description of the degree field in rotate image action found inside image-helper piece.


