### PR TITLE
feat: add AuthValidationContext

### DIFF
--- a/packages/pieces/community/framework/package.json
+++ b/packages/pieces/community/framework/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "type": "commonjs"
 }

--- a/packages/pieces/community/framework/src/lib/context.ts
+++ b/packages/pieces/community/framework/src/lib/context.ts
@@ -148,6 +148,10 @@ export type ActionContext<
   | BeginExecutionActionContext<PieceAuth, ActionProps>
   | ResumeExecutionActionContext<PieceAuth, ActionProps>;
 
+export type AuthValidationContext = {
+    store: Store;
+}
+
 export interface FilesService {
   write({
     fileName,

--- a/packages/pieces/community/framework/src/lib/property/authentication/common.ts
+++ b/packages/pieces/community/framework/src/lib/property/authentication/common.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { AuthValidationContext } from "../../context";
 
 export const BasePieceAuthSchema = Type.Object({
     displayName: Type.String(),
@@ -8,5 +9,5 @@ export const BasePieceAuthSchema = Type.Object({
 export type BasePieceAuthSchema<AuthValueSchema> = {
     displayName: string;
     description?: string;
-    validate?: (params: { auth: AuthValueSchema }) => Promise<{ valid: true } | { valid: false, error: string }>;
+    validate?: (params: { auth: AuthValueSchema; ctx: AuthValidationContext}) => Promise<{ valid: true } | { valid: false, error: string }>;
 }


### PR DESCRIPTION
## What does this PR do?

Pass a new AuthValidationContext to `validate` method of `PieceAuth` to make it possible to store / retrieve values from storage (`PROJECT` scope only obviously - even though it is not enforced)

This will allow us to handle some authentication schemes where a token needs to be periodically refreshed (e.g. [Metabase](https://www.metabase.com/learn/administration/metabase-api#authenticate-your-requests-with-a-session-token))


