### PR TITLE
fix: show step icons in import flow page 

### DIFF
--- a/packages/ui/core/src/app/app.module.ts
+++ b/packages/ui/core/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { cobalt2 } from './monaco-themes/cobalt-2-theme';
 import { EeComponentsModule } from '@activepieces/ee-components';
 import { UiFeatureAuthenticationModule } from '@activepieces/ui/feature-authentication';
 import { InterfacesComponent } from './modules/interfaces/interfaces.component';
+import { UiFeaturePiecesModule } from '@activepieces/ui/feature-pieces';
 
 const monacoConfig: NgxMonacoEditorConfig = {
   baseUrl: '/assets', // configure base path for monaco editor. Starting with version 8.0.0 it defaults to './assets'. Previous releases default to '/assets'
@@ -92,6 +93,7 @@ export function playerFactory() {
         allowedDomains: [extractHostname(environment.apiUrl)],
       },
     }),
+    UiFeaturePiecesModule,
     AngularSvgIconModule.forRoot(),
     UiCommonModule,
     LottieModule.forRoot({ player: playerFactory }),


### PR DESCRIPTION
Here: 
![image](https://github.com/activepieces/activepieces/assets/106555838/746ce0d7-c83b-431c-804f-38b4282da678)
