### PR TITLE
fix: resolve token url from props in oauth2

### DIFF
--- a/packages/backend/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/backend/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -173,43 +173,63 @@ const validateConnectionValue = async (
     params: ValidateConnectionValueParams,
 ): Promise<AppConnectionValue> => {
     const { connection, projectId } = params
-
+   
     switch (connection.value.type) {
-        case AppConnectionType.PLATFORM_OAUTH2:
+        case AppConnectionType.PLATFORM_OAUTH2:{
+            const tokenUrl = await oauth2Util.getOAuth2TokenUrl({
+                projectId,
+                pieceName: connection.pieceName,
+                props: connection.value.props,
+            })
             return oauth2Handler[connection.value.type].claim({
                 projectId,
                 pieceName: connection.pieceName,
                 request: {
                     grantType: OAuth2GrantType.AUTHORIZATION_CODE,
                     code: connection.value.code,
+                    tokenUrl,
                     clientId: connection.value.client_id,
-                    tokenUrl: connection.value.token_url!,
+                    props: connection.value.props,
                     authorizationMethod: connection.value.authorization_method,
                     codeVerifier: connection.value.code_challenge,
                     redirectUrl: connection.value.redirect_url,
                 },
             })
-        case AppConnectionType.CLOUD_OAUTH2:
+        }
+        case AppConnectionType.CLOUD_OAUTH2:{
+            const tokenUrl = await oauth2Util.getOAuth2TokenUrl({
+                projectId,
+                pieceName: connection.pieceName,
+                props: connection.value.props,
+            })
             return oauth2Handler[connection.value.type].claim({
                 projectId,
                 pieceName: connection.pieceName,
                 request: {
+                    tokenUrl,
                     grantType: OAuth2GrantType.AUTHORIZATION_CODE,
                     code: connection.value.code,
+                    props: connection.value.props,
                     clientId: connection.value.client_id,
-                    tokenUrl: connection.value.token_url!,
                     authorizationMethod: connection.value.authorization_method,
                     codeVerifier: connection.value.code_challenge,
                 },
             })
-        case AppConnectionType.OAUTH2:
+        }
+        case AppConnectionType.OAUTH2:{
+            const tokenUrl = await oauth2Util.getOAuth2TokenUrl({
+                projectId,
+                pieceName: connection.pieceName,
+                props: connection.value.props,
+            })
             return oauth2Handler[connection.value.type].claim({
                 projectId,
                 pieceName: connection.pieceName,
                 request: {
+                    tokenUrl,
                     code: connection.value.code,
                     clientId: connection.value.client_id,
-                    tokenUrl: connection.value.token_url!,
+                    props: connection.value.props,
                     grantType: connection.value.grant_type!,
                     redirectUrl: connection.value.redirect_url,
                     clientSecret: connection.value.client_secret,
@@ -217,7 +237,7 @@ const validateConnectionValue = async (
                     codeVerifier: connection.value.code_challenge,
                 },
             })
-
+        }
         case AppConnectionType.CUSTOM_AUTH:
         case AppConnectionType.BASIC_AUTH:
         case AppConnectionType.SECRET_TEXT:
@@ -230,6 +250,7 @@ const validateConnectionValue = async (
 
     return connection.value
 }
+
 
 function decryptConnection(
     encryptedConnection: AppConnectionSchema,

--- a/packages/backend/src/app/app-connection/app-connection-service/oauth2/oauth2-service.ts
+++ b/packages/backend/src/app/app-connection/app-connection-service/oauth2/oauth2-service.ts
@@ -13,6 +13,7 @@ export type RefreshOAuth2Request<T extends BaseOAuth2ConnectionValue> = {
 }
 
 export type OAuth2RequestBody = {
+    props?: Record<string, string>
     code: string
     clientId: string
     tokenUrl: string

--- a/packages/backend/src/app/app-connection/app-connection-service/oauth2/services/cloud-oauth2-service.ts
+++ b/packages/backend/src/app/app-connection/app-connection-service/oauth2/services/cloud-oauth2-service.ts
@@ -24,6 +24,7 @@ async function refresh({ pieceName, connectionValue }: RefreshOAuth2Request<Clou
     return {
         ...connectionValue,
         ...response,
+        props: connectionValue.props,
         type: AppConnectionType.CLOUD_OAUTH2,
     }
 }
@@ -39,9 +40,14 @@ async function claim({ request, pieceName }: ClaimOAuth2Request): Promise<CloudO
             pieceName,
             edition: getEdition(),
         }
-        return (await axios.post<CloudOAuth2ConnectionValue>('https://secrets.activepieces.com/claim', cloudRequest, {
+        const value = (await axios.post<CloudOAuth2ConnectionValue>('https://secrets.activepieces.com/claim', cloudRequest, {
             timeout: 10000,
         })).data
+        return {
+            ...value,
+            token_url: request.tokenUrl,
+            props: request.props,
+        }
     }
     catch (e: unknown) {
         logger.error(e)

--- a/packages/backend/src/app/app-connection/app-connection-service/oauth2/services/credentials-oauth2-service.ts
+++ b/packages/backend/src/app/app-connection/app-connection-service/oauth2/services/credentials-oauth2-service.ts
@@ -57,10 +57,12 @@ async function claim({ request }: ClaimOAuth2Request): Promise<OAuth2ConnectionV
         return {
             type: AppConnectionType.OAUTH2,
             ...oauth2Util.formatOAuth2Response(response),
+            token_url: request.tokenUrl,
             client_id: request.clientId,
             client_secret: request.clientSecret!,
             redirect_url: request.redirectUrl!,
             grant_type: grantType,
+            props: request.props,
             authorization_method: authorizationMethod,
         }
     }
@@ -130,7 +132,10 @@ async function refresh(
         appConnection,
         oauth2Util.formatOAuth2Response({ ...response }),
     )
-    return mergedObject
+    return {
+        ...mergedObject,
+        props: appConnection.props,
+    }
 }
 
 /**

--- a/packages/backend/src/app/ee/connection-keys/connection-key.service.ts
+++ b/packages/backend/src/app/ee/connection-keys/connection-key.service.ts
@@ -97,7 +97,6 @@ export const connectionKeyService = {
                             type: AppConnectionType.OAUTH2,
                             redirect_url: apiRequest.redirectUrl,
                             code: apiRequest.code,
-                            token_url: appCredential.settings.tokenUrl,
                             scope: appCredential.settings.scope,
                             client_id: appCredential.settings.clientId,
                             client_secret: appCredential.settings.clientSecret!,

--- a/packages/shared/src/lib/app-connection/dto/upsert-app-connection-request.ts
+++ b/packages/shared/src/lib/app-connection/dto/upsert-app-connection-request.ts
@@ -36,7 +36,6 @@ export const UpsertPlatformOAuth2Request = Type.Object({
         props: Type.Optional(Type.Record(Type.String(), Type.String())),
         scope: Type.String(),
         type: Type.Literal(AppConnectionType.PLATFORM_OAUTH2),
-        token_url: Type.Optional(Type.String({})),
         redirect_url: Type.String({}),
     }),
 }, {
@@ -56,7 +55,6 @@ export const UpsertCloudOAuth2Request = Type.Object({
         props: Type.Optional(Type.Record(Type.String(), Type.String())),
         scope: Type.String(),
         type: Type.Literal(AppConnectionType.CLOUD_OAUTH2),
-        token_url: Type.Optional(Type.String({})),
     }),
 }, {
     title: 'Cloud OAuth2',
@@ -82,7 +80,6 @@ export const UpsertOAuth2Request = Type.Object({
         client_id: Type.String({}),
         client_secret: Type.String({}),
         grant_type: Type.Optional(Type.Enum(OAuth2GrantType)),
-        token_url: Type.String({}),
         props: Type.Optional(Type.Record(Type.String(), Type.Any())),
         scope: Type.String(),
         code: Type.String(),

--- a/packages/ui/feature-connections/src/lib/dialogs/managed-oauth2-connection-dialog/managed-oauth2-connection-dialog.component.ts
+++ b/packages/ui/feature-connections/src/lib/dialogs/managed-oauth2-connection-dialog/managed-oauth2-connection-dialog.component.ts
@@ -161,14 +161,12 @@ export class ManagedOAuth2ConnectionDialogComponent implements OnInit {
       ? this.dialogData.connectionToUpdate.name
       : this.settingsForm.controls.name.value;
     const popupResponse = this.settingsForm.value.value!;
-    const { tokenUrl } = this.getTokenAndUrl();
     if (this.dialogData.connectionType === AppConnectionType.CLOUD_OAUTH2) {
       const newConnection: UpsertCloudOAuth2Request = {
         projectId: this.authenticationService.getProjectId(),
         pieceName: this.dialogData.pieceName,
         type: AppConnectionType.CLOUD_OAUTH2,
         value: {
-          token_url: tokenUrl,
           code: popupResponse.code,
           authorization_method:
             this.dialogData.pieceAuthProperty.authorizationMethod,
@@ -189,7 +187,6 @@ export class ManagedOAuth2ConnectionDialogComponent implements OnInit {
         pieceName: this.dialogData.pieceName,
         type: AppConnectionType.PLATFORM_OAUTH2,
         value: {
-          token_url: tokenUrl,
           code: popupResponse.code,
           authorization_method:
             this.dialogData.pieceAuthProperty.authorizationMethod,
@@ -264,7 +261,7 @@ export class ManagedOAuth2ConnectionDialogComponent implements OnInit {
   }
 
   get cloudConnectionPopupSettings(): OAuth2PopupParams {
-    const { authUrl } = this.getTokenAndUrl();
+    const { authUrl } = this.getAuthUrl();
     return {
       auth_url: authUrl,
       client_id: this._managedOAuth2ConnectionPopupSettings.client_id,
@@ -275,16 +272,11 @@ export class ManagedOAuth2ConnectionDialogComponent implements OnInit {
     };
   }
 
-  getTokenAndUrl() {
+  getAuthUrl() {
     let authUrl = this.dialogData.pieceAuthProperty.authUrl;
-    let tokenUrl = this.dialogData.pieceAuthProperty.tokenUrl;
     if (this.dialogData.pieceAuthProperty.props) {
       Object.keys(this.dialogData.pieceAuthProperty.props).forEach((key) => {
         authUrl = authUrl.replaceAll(
-          `{${key}}`,
-          this.settingsForm.controls.props.value[key]
-        );
-        tokenUrl = tokenUrl.replaceAll(
           `{${key}}`,
           this.settingsForm.controls.props.value[key]
         );
@@ -292,7 +284,6 @@ export class ManagedOAuth2ConnectionDialogComponent implements OnInit {
     }
     return {
       authUrl: authUrl,
-      tokenUrl: tokenUrl,
     };
   }
 

--- a/packages/ui/feature-connections/src/lib/dialogs/oauth2-connection-dialog/oauth2-connection-dialog.component.ts
+++ b/packages/ui/feature-connections/src/lib/dialogs/oauth2-connection-dialog/oauth2-connection-dialog.component.ts
@@ -169,7 +169,6 @@ export class OAuth2ConnectionDialogComponent implements OnInit {
     const connectionName = this.dialogData.connectionToUpdate
       ? this.dialogData.connectionToUpdate.name
       : this.settingsForm.controls.name.value;
-    const { tokenUrl } = this.getTokenAndUrl();
     const newConnection: UpsertOAuth2Request = {
       projectId: this.authenticatiionService.getProjectId(),
       name: connectionName,
@@ -188,7 +187,6 @@ export class OAuth2ConnectionDialogComponent implements OnInit {
         client_secret: this.settingsForm.controls.client_secret.value,
         redirect_url: this.settingsForm.controls.redirect_url.getRawValue(),
         scope: this.dialogData.pieceAuthProperty.scope.join(' ') || '',
-        token_url: tokenUrl,
         props: this.dialogData.pieceAuthProperty.props
           ? this.settingsForm.controls.props.value
           : undefined,
@@ -261,7 +259,7 @@ export class OAuth2ConnectionDialogComponent implements OnInit {
 
   getOAuth2Settings(): OAuth2PopupParams {
     const formValue = this.settingsForm.getRawValue();
-    const { authUrl } = this.getTokenAndUrl();
+    const { authUrl } = this.getAuthUrl();
     return {
       auth_url: authUrl,
       client_id: formValue.client_id,
@@ -272,16 +270,11 @@ export class OAuth2ConnectionDialogComponent implements OnInit {
     };
   }
 
-  getTokenAndUrl() {
+  getAuthUrl() {
     let authUrl = this.dialogData.pieceAuthProperty.authUrl;
-    let tokenUrl = this.dialogData.pieceAuthProperty.tokenUrl;
     if (this.dialogData.pieceAuthProperty.props) {
       Object.keys(this.dialogData.pieceAuthProperty.props).forEach((key) => {
         authUrl = authUrl.replaceAll(
-          `{${key}}`,
-          this.settingsForm.controls.props.value[key]
-        );
-        tokenUrl = tokenUrl.replaceAll(
           `{${key}}`,
           this.settingsForm.controls.props.value[key]
         );
@@ -289,7 +282,6 @@ export class OAuth2ConnectionDialogComponent implements OnInit {
     }
     return {
       authUrl: authUrl,
-      tokenUrl: tokenUrl,
     };
   }
 


### PR DESCRIPTION
## What does this pull request (PR) do?

In Salesforce, the authentication URL is constructed based on the filled dropdown (Production / Development). We resolve these variables in the UI, but that doesn't work for connection cards as they don't resolve in the UI.

This logic has been moved to the backend.