### PR TITLE
chore: add parallel loop

### DIFF
--- a/packages/engine/src/lib/handler/context/step-execution-path.ts
+++ b/packages/engine/src/lib/handler/context/step-execution-path.ts
@@ -17,4 +17,8 @@ export class StepExecutionPath {
         const newPath = this.path.slice(0, -1)
         return new StepExecutionPath(newPath)
     }
+
+    toString(): string {
+        return this.path.flatMap(pair => pair).join('.')
+    }
 }

--- a/packages/engine/src/lib/handler/loop-executor.ts
+++ b/packages/engine/src/lib/handler/loop-executor.ts
@@ -1,8 +1,10 @@
-import { LoopOnItemsAction, LoopStepOutput, isNil } from '@activepieces/shared'
+import { Action, ExecutionOutputStatus, ExecutionType, LoopOnItemsAction, LoopStepOutput, LoopStepResult, PauseType, StepOutput, StepOutputStatus, isNil } from '@activepieces/shared'
 import { BaseExecutor } from './base-executor'
 import { ExecutionVerdict, FlowExecutorContext } from './context/flow-execution-context'
 import { flowExecutor } from './flow-executor'
 import { EngineConstants } from './context/engine-constants'
+import { createContextStore } from '../services/storage.service'
+import { Store } from '@activepieces/pieces-framework'
 
 type LoopOnActionResolvedSettings = {
     items: readonly unknown[]
@@ -18,47 +20,243 @@ export const loopExecutor: BaseExecutor<LoopOnItemsAction> = {
         executionState: FlowExecutorContext
         constants: EngineConstants
     }) {
+        const isPaused = executionState.isPaused({ stepName: action.name })
+
         const { resolvedInput, censoredInput } = await constants.variableService.resolve<LoopOnActionResolvedSettings>({
             unresolvedInput: {
                 items: action.settings.items,
             },
             executionState,
         })
-        const previousStepOutput = executionState.getLoopStepOutput({ stepName: action.name })
-        let stepOutput = previousStepOutput ?? LoopStepOutput.init({
+
+        let stepOutput = LoopStepOutput.init({
             input: censoredInput,
         })
-        let newExecutionContext = executionState.upsertStep(action.name, stepOutput)
+
+        const store = createContextStore({
+            prefix: `Loop_${constants.flowRunId}_${action.name}`,
+            flowId: constants.flowId,
+            workerToken: constants.workerToken,
+        })
+
         const firstLoopAction = action.firstLoopAction
 
+        if (isNil(firstLoopAction) || constants.testSingleStepMode) {
+            stepOutput = stepOutput.setItemAndIndex({ index: 1, item: resolvedInput.items[0] })
 
-        for (let i = 0; i < resolvedInput.items.length; ++i) {
-            const newCurrentPath = newExecutionContext.currentPath.loopIteration({ loopName: action.name, iteration: i })
-
-            stepOutput = stepOutput.setItemAndIndex({ item: resolvedInput.items[i], index: i + 1 })
-            const addEmptyIteration = !stepOutput.hasIteration(i)
-            if (addEmptyIteration) {
-                stepOutput = stepOutput.addIteration()
-                newExecutionContext = newExecutionContext.upsertStep(action.name, stepOutput)
-            }
-            newExecutionContext = newExecutionContext.setCurrentPath(newCurrentPath)
-            if (!isNil(firstLoopAction) && !constants.testSingleStepMode) {
-                newExecutionContext = await flowExecutor.execute({
-                    action: firstLoopAction,
-                    executionState: newExecutionContext,
-                    constants,
-                })
-            }
-
-            if (newExecutionContext.verdict !== ExecutionVerdict.RUNNING) {
-                return newExecutionContext
-            }
-
-            newExecutionContext = newExecutionContext.setCurrentPath(newExecutionContext.currentPath.removeLast())
-            if (constants.testSingleStepMode) {
-                break
-            }
+            return executionState.upsertStep(action.name, stepOutput)
         }
-        return newExecutionContext
+
+        if (!isPaused) {
+            const loopIterations = triggerLoopIterations(resolvedInput, executionState, stepOutput, constants, action, firstLoopAction)
+
+            return waitForIterationsToFinishOrPause(executionState, loopIterations, stepOutput, action.name, store)
+        }
+
+        const payload = constants.resumePayload?.queryParams as { requestId: string, path: string }
+
+        await resumePausedIteration(store, payload, executionState, constants, firstLoopAction)
+
+        const numberOfIterations = resolvedInput.items.length
+
+        executionState = executionState.setPauseRequestId(payload.requestId);
+
+        return generateNextFlowContext(store, action.name, stepOutput, executionState, numberOfIterations)
     },
+}
+
+function triggerLoopIterations(resolvedInput: LoopOnActionResolvedSettings,
+    loopExecutionState: FlowExecutorContext,
+    stepOutput: LoopStepOutput,
+    constants: EngineConstants,
+    action: LoopOnItemsAction,
+    firstLoopAction: Action): Promise<FlowExecutorContext>[] {
+
+    const loopIterations: Promise<FlowExecutorContext>[] = []
+
+    for (let i = 0; i < resolvedInput.items.length; ++i) {
+        const newCurrentPath = loopExecutionState.currentPath.loopIteration({ loopName: action.name, iteration: i })
+        stepOutput = stepOutput.setItemAndIndex({ index: i + 1, item: resolvedInput.items[i] })
+
+        const addEmptyIteration = !stepOutput.hasIteration(i)
+        if (addEmptyIteration) {
+            stepOutput = stepOutput.addIteration()
+        }
+        
+        const newExecutionContext = loopExecutionState
+            .upsertStep(action.name, stepOutput)
+            .setCurrentPath(newCurrentPath)
+
+        loopIterations[i] = flowExecutor.execute({
+            executionState: newExecutionContext,
+            action: firstLoopAction,
+            constants,
+        })
+    }
+
+    return loopIterations
+}
+
+async function waitForIterationsToFinishOrPause(
+    loopExecutionState: FlowExecutorContext,
+    loopIterations: Promise<FlowExecutorContext>[],
+    loopStepOutput: LoopStepOutput,
+    actionName: string,
+    store: Store): Promise<FlowExecutorContext> {
+
+    const iterationResults: { iterationContext: FlowExecutorContext, isPaused: boolean }[] = []
+    let noPausedIterations = true 
+    
+    for (const iteration of loopIterations) {
+        const iterationContext = await iteration
+        const { verdict, verdictResponse } = iterationContext
+
+        if (verdict === ExecutionVerdict.FAILED) {
+            return iterationContext.setCurrentPath(iterationContext.currentPath.removeLast())
+        }
+
+        const isPaused = verdict === ExecutionVerdict.PAUSED
+            && verdictResponse?.reason === ExecutionOutputStatus.PAUSED
+            && verdictResponse?.pauseMetadata.type === PauseType.WEBHOOK
+
+        if (isPaused) {
+            noPausedIterations = false
+        }
+
+        iterationResults.push({ iterationContext, isPaused })
+    }
+
+    if (noPausedIterations) {
+        const { iterationContext: lastIterationContext } = iterationResults[iterationResults.length - 1]
+        
+        return lastIterationContext.setCurrentPath(lastIterationContext.currentPath.removeLast())
+    }
+
+    await saveIterationResults(store, actionName, iterationResults)
+
+    return pauseLoop(loopExecutionState, loopStepOutput, actionName)
+}
+
+async function saveIterationResults(store: Store, actionName: string, iterationResults: { iterationContext: FlowExecutorContext, isPaused: boolean }[]) {
+    for (let i = 0; i < iterationResults.length; ++i) {
+        const { iterationContext, isPaused } = iterationResults[i]
+
+        const iterationOutput = iterationContext.currentState[actionName] as LoopStepResult
+        if (isPaused) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await store.put(iterationContext.currentPath.toString(), i)
+        }
+
+        const iterationResult: IterationResult = {
+            isPaused,
+            item: iterationOutput.item,
+            index: iterationOutput.index,
+            steps: iterationOutput.iterations[i],
+        }
+    
+        await store.put(`${i}`, iterationResult)
+    }
+}
+
+async function resumePausedIteration(store: Store,
+    payload: { requestId: string, path: string },
+    loopExecutionState: FlowExecutorContext,
+    constants: EngineConstants,
+    firstLoopAction: Action): Promise<void> {
+
+    // Get which iteration is being resumed
+    const iterationIndex = await store.get(payload.path) as string
+    const previousIterationResult = await store.get(iterationIndex) as IterationResult
+
+    let newExecutionContext = loopExecutionState
+
+    for (const stepKey in previousIterationResult.steps) {
+        // Adds each step from the previous execution to the current context
+        newExecutionContext = newExecutionContext.upsertStep(stepKey, previousIterationResult.steps[stepKey])
+    }
+
+    newExecutionContext = await flowExecutor.execute({
+        executionState: newExecutionContext,
+        action: firstLoopAction,
+        constants,
+    })
+
+    await updateIterationResult(newExecutionContext, loopExecutionState, previousIterationResult, iterationIndex, store)
+}
+
+async function updateIterationResult(newExecutionContext: FlowExecutorContext,
+    loopExecutionState: FlowExecutorContext,
+    currentIteration: IterationResult,
+    iterationIndex: string,
+    store: Store): Promise<void> {
+    // Get the keys of the steps that belong to the current iteration
+    const newSteps = Object.keys(newExecutionContext.steps).filter(key => !(key in loopExecutionState.steps))
+
+    const currentIterationSteps: Record<string, StepOutput> = {}
+    for (const newStep of newSteps) {
+        currentIterationSteps[`${newStep}`] = newExecutionContext.steps[newStep]
+    }
+
+    const iterationResult: IterationResult = {
+        isPaused: newExecutionContext.verdict === ExecutionVerdict.PAUSED,
+        index: currentIteration.index,
+        item: currentIteration.item,
+        steps: currentIterationSteps,
+    }
+
+    await store.put(iterationIndex, iterationResult)
+}
+
+async function generateNextFlowContext(store: Store, 
+    actionName: string, 
+    loopStepOutput: LoopStepOutput, 
+    loopExecutionState: FlowExecutorContext,
+    numberOfIterations: number): Promise<FlowExecutorContext> {
+    let areAllStepsInLoopFinished = true
+
+    const orig = loopStepOutput;
+    for (let iterationIndex = 0; iterationIndex < numberOfIterations; ++iterationIndex) {
+        const iterationResult: IterationResult | null = await store.get(`${iterationIndex}`) 
+        
+        if (!iterationResult || iterationResult.isPaused) {
+            areAllStepsInLoopFinished = false
+            break
+        }
+
+        // Add the output of the iteration to the loop output
+        loopStepOutput = loopStepOutput.setItemAndIndex({ index: iterationResult.index, item: iterationResult.item })
+
+        const loopStepResult = loopStepOutput.output as LoopStepResult
+        loopStepResult.iterations[iterationResult.index - 1] = iterationResult.steps
+    }
+
+    if (!areAllStepsInLoopFinished) {
+        return pauseLoop(loopExecutionState, orig, actionName)
+    }
+
+    return loopExecutionState.upsertStep(actionName, loopStepOutput)
+}
+
+function pauseLoop(executionState: FlowExecutorContext, stepOutput: LoopStepOutput, actionName: string): FlowExecutorContext {
+    return executionState
+        .upsertStep(actionName, stepOutput.setStatus(StepOutputStatus.PAUSED))
+        .setVerdict(ExecutionVerdict.PAUSED, {
+            reason: ExecutionOutputStatus.PAUSED,
+            pauseMetadata: {
+                requestId: executionState.pauseRequestId,
+                type: PauseType.WEBHOOK,
+                response: {},
+            },
+        })
+}
+
+type IterationResult = {
+    // Iteration input
+    item: unknown
+    // Iteration index
+    index: number
+    // Iteration state
+    isPaused: boolean
+    // Performed steps for the iteration
+    steps: Record<string, StepOutput>
 }

--- a/packages/engine/src/lib/handler/piece-executor.ts
+++ b/packages/engine/src/lib/handler/piece-executor.ts
@@ -113,6 +113,7 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
                 url.search = new URLSearchParams({
                     ...params.queryParams,
                     requestId: executionState.pauseRequestId,
+                    path: executionState.currentPath.toString(),
                 }).toString()
                 return url.toString()
             },            

--- a/packages/pieces/community/slack/src/lib/actions/request-approval-direct-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/request-approval-direct-message.ts
@@ -34,8 +34,14 @@ export const requestApprovalDirectMessageAction = createAction({
       assertNotNullOrUndefined(token, 'token');
       assertNotNullOrUndefined(text, 'text');
       assertNotNullOrUndefined(userId, 'userId');
-      const approvalLink = `${context.serverUrl}v1/flow-runs/${context.run.id}/resume?action=approve`;
-      const disapprovalLink = `${context.serverUrl}v1/flow-runs/${context.run.id}/resume?action=disapprove`;
+
+      const approvalLink = context.generateResumeUrl({
+        queryParams: { action: 'approve' },
+      })
+
+      const disapprovalLink = context.generateResumeUrl({
+        queryParams: { action: 'disapprove' },
+      })
 
       return await slackSendMessage({
         token,


### PR DESCRIPTION
## What does this PR do?

This PR adds support for running iterations of a loop in parallel.
- We start by triggering all iterations.
- Then we wait for the iterations to finish.
-  If any of the iterations are in a paused state, the results are saved to be used after the resume
- We only exit the loop after all iterations have finished, that is, if any are paused we will wait for the resume.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Depends one:
- https://github.com/activepieces/activepieces/pull/3870
- https://github.com/activepieces/activepieces/pull/3871