### PR TITLE
fix(GenerateBanners): remove deprecated fields

### DIFF
--- a/packages/pieces/community/generatebanners/package.json
+++ b/packages/pieces/community/generatebanners/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-generatebanners",
-  "version": "0.3.1"
+  "version": "0.3.2"
 }

--- a/packages/pieces/community/generatebanners/src/lib/actions/renderTemplate.action.ts
+++ b/packages/pieces/community/generatebanners/src/lib/actions/renderTemplate.action.ts
@@ -78,17 +78,8 @@ export const renderTemplate = createAction({
             label: 'Document (pdf)',
             value: 'pdf',
           },
-          {
-            label: 'Video (mp4)',
-            value: 'mp4',
-          },
         ],
       },
-    }),
-    audio_url: Property.ShortText({
-      displayName: 'Audio url',
-      description: 'Link to an audio file. Only used for videos.',
-      required: false,
     }),
     variables: Property.DynamicProperties({
       displayName: 'Variables',
@@ -155,8 +146,6 @@ export const renderTemplate = createAction({
         propsValue.template_id
       }/sign-url?filetype=${encodeURIComponent(
         propsValue.filetype
-      )}&audioUrl=${encodeURIComponent(
-        propsValue.audio_url || ''
       )}&${query.join('&')}`,
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,


### PR DESCRIPTION
## What does this PR do?

- Removed the `video` format as GenerateBanners only supports generating PNG/JPEG/PDFs at the moment.
- Removed the `audio_url` field for the same reason
