### PR TITLE
fix: reset zoom and fit to screen on all screen sizes

### DIFF
--- a/packages/ui/canvas-utils/src/lib/panning/panner.service.ts
+++ b/packages/ui/canvas-utils/src/lib/panning/panner.service.ts
@@ -71,15 +71,14 @@ export class PannerService {
     );
     zoomScale = canvasHeight / maxPossibleViewedFlowHeight;
     zoomScale = Math.min(zoomScale, MAX_ZOOM);
-    zoomScale = Math.max(zoomScale, 0.5);
+    this.zoomService.minZoom = canvasHeight / fullFlowHeightWithWidgets;
+    const scaledFlowHeight = maxPossibleViewedFlowHeight * zoomScale;
     const newState: PanningState = {
       currentOffset: {
         x: 0,
-        // The number of pixels are affected by the zoom scale, that is why we divide by the zoom scale
         y:
-          ((canvasHeight * zoomScale - canvasHeight) / 2.0 +
-            DEFAULT_TOP_MARGIN) /
-          zoomScale,
+          (scaledFlowHeight - maxPossibleViewedFlowHeight) / 2 +
+          DEFAULT_TOP_MARGIN,
       },
       isPanning: false,
     };

--- a/packages/ui/canvas-utils/src/lib/zooming/zooming.service.ts
+++ b/packages/ui/canvas-utils/src/lib/zooming/zooming.service.ts
@@ -8,15 +8,23 @@ export class ZoomingService {
   private _zoomingScale$: BehaviorSubject<number> = new BehaviorSubject(1);
   readonly zoomingStep = 0.25;
   readonly maxZoom = 1.25;
-  readonly minZoom = 0.5;
-
+  readonly ZOOMING_ANIMATION = '400ms';
+  private _minZoom = 0.5;
+  private readonly MIN_ZOOM_CONST = 0.5;
   get zoomingScale$() {
     return this._zoomingScale$.asObservable();
   }
   get zoomingScale() {
     return this._zoomingScale$.value;
   }
+  //TODO: adjust the panning offsets to center zooming in the middle of canvas not flow
   setZoomingScale(scale: number) {
     this._zoomingScale$.next(scale);
+  }
+  get minZoom() {
+    return this._minZoom;
+  }
+  set minZoom(minZoom: number) {
+    this._minZoom = Math.min(minZoom, this.MIN_ZOOM_CONST);
   }
 }

--- a/packages/ui/feature-builder-canvas/src/lib/components/flow-item-tree/flow-item-tree.component.html
+++ b/packages/ui/feature-builder-canvas/src/lib/components/flow-item-tree/flow-item-tree.component.html
@@ -1,8 +1,8 @@
 <ng-container *ngIf="flowDrawer$ | async as flowDrawer">
   <ng-container *ngIf="transform$ | async as transform">
-    <div [style.transform]="transform" [style.transition-duration]="(isPanning$ | async) === true ? '0ms' :  '400ms'"
-      [class]="'ap-relative ap-w-full ap-h-full ap-transition-transform'">
-      <div class="ap-flex ap-flex-col ap-items-center ">
+    <div [style.transform]="transform.translate" 
+      [class]="'ap-relative ap-w-full ap-h-full '">
+      <div [style.scale]="transform.scale" class="ap-flex ap-flex-col ap-items-center ">
         <div class="ap-flex ap-justify-center ap-w-full ap-items-center ap-z-40 ap-relative ap-mb-3">
           <app-test-flow-widget></app-test-flow-widget>
           <app-view-only-mode-widget></app-view-only-mode-widget>

--- a/packages/ui/feature-builder-canvas/src/lib/components/flow-item-tree/flow-item-tree.component.ts
+++ b/packages/ui/feature-builder-canvas/src/lib/components/flow-item-tree/flow-item-tree.component.ts
@@ -26,7 +26,10 @@ type UiFlowDrawer = {
 export class FlowItemTreeComponent implements OnInit {
   navbarOpen = false;
   flowDrawer$: Observable<UiFlowDrawer>;
-  transform$: Observable<string>;
+  transform$: Observable<{
+    translate: string;
+    scale: string;
+  }>;
   readOnly$: Observable<boolean>;
   isPanning$: Observable<boolean>;
   constructor(
@@ -76,7 +79,7 @@ export class FlowItemTreeComponent implements OnInit {
   getTransform$() {
     const scale$ = this.zoomingService.zoomingScale$.pipe(
       map((val) => {
-        return `scale(${val})`;
+        return `${val}`;
       })
     );
     const translate$ = this.pannerService.panningOffset$.pipe(
@@ -90,8 +93,6 @@ export class FlowItemTreeComponent implements OnInit {
     });
 
     // Combine the scale and translate values into transform to apply animation
-    return transformObs$.pipe(
-      map(({ scale, translate }) => `${scale} ${translate}`)
-    );
+    return transformObs$;
   }
 }


### PR DESCRIPTION
I know zooming in and out is now without animation and is centered on flow not canvas, will fix this soon.

