### PR TITLE
feat(stable-diffusion-web-ui): text to image action

### DIFF
--- a/packages/pieces/community/stable-diffusion-webui/.eslintrc.json
+++ b/packages/pieces/community/stable-diffusion-webui/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {},
+        "extends": [
+        "plugin:prettier/recommended"
+        ],
+      "plugins": ["prettier"]
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/stable-diffusion-webui/README.md
+++ b/packages/pieces/community/stable-diffusion-webui/README.md
@@ -1,0 +1,9 @@
+# pieces-stable-diffusion-webui
+
+This library was generated with [Nx](https://nx.dev).
+
+Integration with [Stable Diffusion web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui)
+
+## Building
+
+Run `nx build pieces-stable-diffusion-webui` to build the library.

--- a/packages/pieces/community/stable-diffusion-webui/package.json
+++ b/packages/pieces/community/stable-diffusion-webui/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-stable-diffusion-webui",
+  "version": "0.0.2"
+}

--- a/packages/pieces/community/stable-diffusion-webui/project.json
+++ b/packages/pieces/community/stable-diffusion-webui/project.json
@@ -1,0 +1,43 @@
+{
+  "name": "pieces-stable-diffusion-webui",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/stable-diffusion-webui/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/stable-diffusion-webui",
+        "tsConfig": "packages/pieces/community/stable-diffusion-webui/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/stable-diffusion-webui/package.json",
+        "main": "packages/pieces/community/stable-diffusion-webui/src/index.ts",
+        "assets": [
+          "packages/pieces/community/stable-diffusion-webui/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs pieces-stable-diffusion-webui {args.ver} {args.tag}",
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ],
+      "options": {
+        "lintFilePatterns": [
+          "packages/pieces/community/stable-diffusion-webui/**/*.ts"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/stable-diffusion-webui/src/index.ts
+++ b/packages/pieces/community/stable-diffusion-webui/src/index.ts
@@ -1,0 +1,30 @@
+import {
+  createPiece,
+  PieceAuth,
+  Property,
+} from '@activepieces/pieces-framework';
+import { textToImage } from './lib/actions/text-to-image';
+
+export const stableDiffusionAuth = PieceAuth.CustomAuth({
+  required: true,
+  props: {
+    baseUrl: Property.ShortText({
+      displayName: 'Stable Diffusion web UI API base URL',
+      required: true,
+    }),
+  },
+});
+
+export type StableDiffusionAuthType = {
+  baseUrl: string;
+};
+
+export const stableDiffusion = createPiece({
+  displayName: 'Stable Dffusion web UI',
+  auth: stableDiffusionAuth,
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/stable-diffusion-webui.png',
+  authors: ['AdamSelene'],
+  actions: [textToImage],
+  triggers: [],
+});

--- a/packages/pieces/community/stable-diffusion-webui/src/lib/actions/text-to-image.ts
+++ b/packages/pieces/community/stable-diffusion-webui/src/lib/actions/text-to-image.ts
@@ -1,0 +1,100 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { randomBytes } from 'node:crypto';
+import { kebabCase } from 'lodash';
+
+import {
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+import { stableDiffusionAuth, StableDiffusionAuthType } from '../../index';
+
+export const textToImage = createAction({
+  name: 'textToImage',
+  displayName: 'Text to Image',
+  description: '',
+  auth: stableDiffusionAuth,
+  props: {
+    prompt: Property.LongText({
+      displayName: 'Prompt',
+      required: true,
+    }),
+    model: Property.Dropdown({
+      displayName: 'Model',
+      required: true,
+      refreshers: ['auth'],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please authenticate first',
+          };
+        }
+        const { baseUrl } = auth as StableDiffusionAuthType;
+        const request: HttpRequest = {
+          method: HttpMethod.GET,
+          url: `${baseUrl}/sdapi/v1/sd-models`,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        };
+        const response = await httpClient.sendRequest(request);
+        const options = response.body
+          ?.map((model: { model_name: string }) => {
+            return {
+              label: model.model_name,
+              value: model.model_name,
+            };
+          })
+          ?.sort((a: { label: string }, b: { label: string }) =>
+            a['label'].localeCompare(b['label'])
+          );
+        return {
+          options: options,
+        };
+      },
+    }),
+    advancedParameters: Property.Object({
+      displayName: 'Advanced parameters (key/value)',
+      required: false,
+      description: 'Refer to API documentation',
+    }),
+  },
+  async run({ auth, propsValue, files }) {
+    const request: HttpRequest = {
+      method: HttpMethod.POST,
+      url: `${auth.baseUrl}/sdapi/v1/txt2img`,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ...propsValue.advancedParameters,
+        prompt: propsValue.prompt,
+        override_settings: {
+          sd_model_checkpoint: propsValue.model,
+        },
+        override_settings_restore_afterwards: true,
+      }),
+    };
+    const response = await httpClient.sendRequest(request);
+    const images = await Promise.all(
+      response.body['images']?.map(async (imageBase64: string) => {
+        const fileName = `${randomBytes(16).toString('hex')}-${kebabCase(
+          propsValue.prompt
+        ).slice(0, 42)}.png`;
+        const imageUrl = await files.write({
+          fileName,
+          data: Buffer.from(imageBase64, 'base64'),
+        });
+        return {
+          fileName,
+          url: imageUrl,
+        };
+      })
+    );
+    return {
+      images,
+    };
+  },
+});

--- a/packages/pieces/community/stable-diffusion-webui/tsconfig.json
+++ b/packages/pieces/community/stable-diffusion-webui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/stable-diffusion-webui/tsconfig.lib.json
+++ b/packages/pieces/community/stable-diffusion-webui/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -453,6 +453,9 @@
       "@activepieces/piece-stability-ai": [
         "packages/pieces/community/stability-ai/src/index.ts"
       ],
+      "@activepieces/piece-stable-diffusion-webui": [
+        "packages/pieces/community/stable-diffusion-webui/src/index.ts"
+      ],
       "@activepieces/piece-store": [
         "packages/pieces/community/store/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Add Piece to use the text-to-image API from [Stable Diffusion web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) - returns base64 images (similar to image-helper)

<img width="371" alt="Capture d’écran 2024-02-28 à 22 59 54" src="https://github.com/alan-eu/activepieces/assets/79495/9cbbad61-94a9-49ac-9228-953cb1572ad7">
