### PR TITLE
feat(slack): add upload file action and arbitrary blocks support

### DIFF
--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -14,6 +14,7 @@ import { slackSendDirectMessageAction } from './lib/actions/send-direct-message-
 import { slackSendMessageAction } from './lib/actions/send-message-action';
 import { newMessage } from './lib/triggers/new-message';
 import { newReactionAdded } from './lib/triggers/new-reaction-added';
+import { uploadFile } from "./lib/actions/upload-file";
 
 export const slackAuth = PieceAuth.OAuth2({
   description: '',
@@ -74,6 +75,7 @@ export const slack = createPiece({
     requestSendApprovalMessageAction,
     requestActionDirectMessageAction,
     requestActionMessageAction,
+      uploadFile,
     createCustomApiCallAction({
       baseUrl: () => {
         return 'https://slack.com/api';

--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
@@ -2,7 +2,13 @@ import { createAction } from '@activepieces/pieces-framework';
 import { slackSendMessage } from '../common/utils';
 import { slackAuth } from '../../';
 import { assertNotNullOrUndefined } from '@activepieces/shared';
-import { profilePicture, text, userId, username } from '../common/props';
+import {
+  profilePicture,
+  text,
+  userId,
+  username,
+  blocks,
+} from '../common/props';
 
 export const slackSendDirectMessageAction = createAction({
   auth: slackAuth,
@@ -14,10 +20,11 @@ export const slackSendDirectMessageAction = createAction({
     text,
     username,
     profilePicture,
+    blocks,
   },
   async run(context) {
     const token = context.auth.access_token;
-    const { text, userId } = context.propsValue;
+    const { text, userId, blocks } = context.propsValue;
 
     assertNotNullOrUndefined(token, 'token');
     assertNotNullOrUndefined(text, 'text');
@@ -29,6 +36,7 @@ export const slackSendDirectMessageAction = createAction({
       username: context.propsValue.username,
       profilePicture: context.propsValue.profilePicture,
       conversationId: userId,
+      blocks,
     });
   },
 });

--- a/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
@@ -1,5 +1,10 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { profilePicture, slackChannel, username } from '../common/props';
+import {
+  profilePicture,
+  slackChannel,
+  username,
+  blocks,
+} from '../common/props';
 import { slackSendMessage } from '../common/utils';
 import { slackAuth } from '../../';
 
@@ -21,10 +26,11 @@ export const slackSendMessageAction = createAction({
       displayName: 'Attachment',
       required: false,
     }),
+    blocks,
   },
   async run(context) {
     const token = context.auth.access_token;
-    const { text, channel, username, profilePicture, file } =
+    const { text, channel, username, profilePicture, file, blocks } =
       context.propsValue;
 
     return slackSendMessage({
@@ -34,6 +40,7 @@ export const slackSendMessageAction = createAction({
       profilePicture,
       conversationId: channel,
       file,
+      blocks,
     });
   },
 });

--- a/packages/pieces/community/slack/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/slack/src/lib/actions/upload-file.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { slackAuth } from '../../index';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+
+export const uploadFile = createAction({
+  auth: slackAuth,
+  name: 'uploadFile',
+  displayName: 'Upload file',
+  description: 'Upload file without sharing it to a channel or user',
+  props: {
+    file: Property.File({
+      displayName: 'Attachment',
+      required: true,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const token = context.auth.access_token;
+    const { file, title } = context.propsValue;
+    const formData = new FormData();
+    formData.append('file', new Blob([file.data]));
+    if (title !== undefined) {
+      formData.append('title', title);
+    }
+
+    const request: HttpRequest = {
+      url: `https://slack.com/api/files.upload`,
+      method: HttpMethod.POST,
+      body: formData,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token,
+      },
+    };
+    const response = await httpClient.sendRequest(request);
+    if (!response.body.ok) {
+        console.error(response);
+        throw new Error("Upload failed")
+    }
+    return response.body;
+  },
+});

--- a/packages/pieces/community/slack/src/lib/common/props.ts
+++ b/packages/pieces/community/slack/src/lib/common/props.ts
@@ -57,6 +57,12 @@ export const profilePicture = Property.ShortText({
   required: false,
 });
 
+export const blocks = Property.Json({
+  displayName: 'Block Kit blocks',
+  description: 'See https://api.slack.com/block-kit for specs',
+  required: false,
+});
+
 export const userId = Property.Dropdown<string>({
   displayName: 'User',
   description: 'Message receiver',

--- a/packages/pieces/community/slack/src/lib/common/utils.ts
+++ b/packages/pieces/community/slack/src/lib/common/utils.ts
@@ -73,7 +73,7 @@ type SlackSendMessageParams = {
   conversationId: string;
   username?: string;
   profilePicture?: string;
-  blocks?: unknown[];
+  blocks?: unknown[] | Record<string, any>;
   text: string;
   file?: ApFile;
 };


### PR DESCRIPTION
## What does this PR do?

- Add a standalone "upload file" action which does not automatically share the file
- Add arbitrary blocks support for "send message" actions

<img width="683" alt="Capture d’écran 2024-02-29 à 09 54 18" src="https://github.com/activepieces/activepieces/assets/79495/45f3c2bb-2109-4f6e-90fb-5c276a0a338a">

<img width="675" alt="Capture d’écran 2024-02-29 à 09 55 37" src="https://github.com/activepieces/activepieces/assets/79495/6e09de1e-8283-453c-80c0-6ba53f2f9a41">
