### PR TITLE
chore: add text wrap to test output window and format thrown error message

### DIFF
--- a/packages/ui/common/src/lib/components/json-view/json-view.component.html
+++ b/packages/ui/common/src/lib/components/json-view/json-view.component.html
@@ -16,7 +16,7 @@
   <div class="code-area">
     <pre *ngIf="highlight" class="line-numbers thin-scrollbars  ap-pb-1 "><code class="language-js"
       [innerHTML]="_content | outputLog"></code></pre>
-    <pre *ngIf="!highlight" [innerHTML]="_content | outputLog" class="ap-px-4 thin-scrollbars ap-py-3 ap-break-all">
+    <pre *ngIf="!highlight" [innerHTML]="_content | outputLog" class="ap-px-4 thin-scrollbars ap-py-3 wrap-text">
 
     </pre>
   </div>

--- a/packages/ui/common/src/lib/components/json-view/json-view.component.scss
+++ b/packages/ui/common/src/lib/components/json-view/json-view.component.scss
@@ -16,3 +16,8 @@
 .code-header{
   padding: 0.625rem 1rem;
 }
+
+.wrap-text {
+  white-space: pre-wrap;
+  word-wrap: normal;
+}

--- a/packages/ui/feature-builder-test-steps/src/lib/test-action/test-action.component.ts
+++ b/packages/ui/feature-builder-test-steps/src/lib/test-action/test-action.component.ts
@@ -259,6 +259,6 @@ function formatErrorMessage(errorMessage: string): string {
   const indentationStep = '  ';
   return errorMessagesSplit.reduce((acc, current, index) => {
     const indentation = indentationStep.repeat(index);
-    return `${acc}${indentation}Error ${index}: ${current.trim()}\n`;
+    return `${acc}${indentation}Error ${index + 1}: ${current.trim()}\n`;
   }, '');
 }

--- a/packages/ui/feature-builder-test-steps/src/lib/test-action/test-action.component.ts
+++ b/packages/ui/feature-builder-test-steps/src/lib/test-action/test-action.component.ts
@@ -92,7 +92,9 @@ export class TestActionComponent extends TestStepCoreComponent {
                 if (res.success) {
                   this.saveStepTestResult(res.output);
                 } else {
-                  this.errorResponse = res.output;
+                  this.errorResponse = formatErrorMessage(
+                    res.output?.toString() || ''
+                  );
                 }
               })
             );
@@ -246,4 +248,17 @@ export class TestActionComponent extends TestStepCoreComponent {
         map(() => void 0)
       );
   }
+}
+
+function formatErrorMessage(errorMessage: string): string {
+  const errorMessagesSplit = errorMessage.split('Error:');
+  if (errorMessagesSplit.length < 2) {
+    return errorMessage;
+  }
+
+  const indentationStep = '  ';
+  return errorMessagesSplit.reduce((acc, current, index) => {
+    const indentation = indentationStep.repeat(index);
+    return `${acc}${indentation}Error ${index}: ${current.trim()}\n`;
+  }, '');
 }


### PR DESCRIPTION
## What does this PR do?

Added wrap-text for Test output window and prettified nested thrown errors for readability.

**Before**
![Screenshot 2024-02-28 165742](https://github.com/activepieces/activepieces/assets/54935347/bbc2a6cc-749c-4ad7-a4a1-17ce91ca0dbd)

**After**
![Screenshot 2024-02-28 165615](https://github.com/activepieces/activepieces/assets/54935347/a9928e68-23b6-45b6-bdbe-a96adfdc1b39)
![Screenshot 2024-02-28 170755](https://github.com/activepieces/activepieces/assets/54935347/71520f81-7465-4ee6-b4d4-d40949bd964c)


Note:
- Did not add word wrapping for extended output module