### PR TITLE
fix(slack): properly propagate Slack API errors

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.3.21"
+  "version": "0.4.0"
 }

--- a/packages/pieces/community/slack/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/slack/src/lib/actions/upload-file.ts
@@ -45,8 +45,7 @@ export const uploadFile = createAction({
     };
     const response = await httpClient.sendRequest(request);
     if (!response.body.ok) {
-        console.error(response);
-        throw new Error("Upload failed")
+        throw new Error(response.body.error)
     }
     return response.body;
   },

--- a/packages/pieces/community/slack/src/lib/common/utils.ts
+++ b/packages/pieces/community/slack/src/lib/common/utils.ts
@@ -61,6 +61,10 @@ export const slackSendMessage = async ({
     response = await httpClient.sendRequest(request);
   }
 
+  if (!response.body.ok) {
+      throw new Error(response.body.error);
+  }
+
   return {
     success: true,
     request_body: request.body,


### PR DESCRIPTION
## What does this PR do?

Properly fail when Slack reports an API error (HTTP code may be 200)
This is probably a breaking change for some flows (hence the version change)


