### PR TITLE
feat: retryable errors for engine execution

### DIFF
--- a/packages/engine/src/lib/handler/code-executor.ts
+++ b/packages/engine/src/lib/handler/code-executor.ts
@@ -57,7 +57,6 @@ const executeAction: ActionHandler<CodeAction> = async ({ action, executionState
 
         return executionState
             .upsertStep(action.name, failedStepOutput)
-            .setVerdict(ExecutionVerdict.FAILED)
-            .setRetryable(handledError.retryable)
+            .setVerdict(ExecutionVerdict.FAILED, handledError.verdictResponse)
     }
 }

--- a/packages/engine/src/lib/handler/code-executor.ts
+++ b/packages/engine/src/lib/handler/code-executor.ts
@@ -2,7 +2,7 @@ import { ActionType, CodeAction, GenericStepOutput, StepOutputStatus } from '@ac
 import { ActionHandler, BaseExecutor } from './base-executor'
 import { ExecutionVerdict, FlowExecutorContext } from './context/flow-execution-context'
 import { EngineConstants } from './context/engine-constants'
-import { continueIfFailureHandler, runWithExponentialBackoff } from '../helper/error-handling'
+import { continueIfFailureHandler, handleExecutionError, runWithExponentialBackoff } from '../helper/error-handling'
 import { initCodeSandbox } from '../core/code/code-sandbox'
 import { CodeModule } from '../core/code/code-sandbox-common'
 
@@ -49,9 +49,15 @@ const executeAction: ActionHandler<CodeAction> = async ({ action, executionState
         return executionState.upsertStep(action.name, stepOutput.setOutput(output)).increaseTask()
     }
     catch (e) {
-        console.error(e)
+        const handledError = handleExecutionError(e)
+
+        const failedStepOutput = stepOutput
+            .setStatus(StepOutputStatus.FAILED)
+            .setErrorMessage(handledError.message)
+
         return executionState
-            .upsertStep(action.name, stepOutput.setStatus(StepOutputStatus.FAILED).setErrorMessage((e as Error).message))
-            .setVerdict(ExecutionVerdict.FAILED, undefined)
+            .upsertStep(action.name, failedStepOutput)
+            .setVerdict(ExecutionVerdict.FAILED)
+            .setRetryable(handledError.retryable)
     }
 }

--- a/packages/engine/src/lib/handler/context/engine-constants.ts
+++ b/packages/engine/src/lib/handler/context/engine-constants.ts
@@ -6,12 +6,12 @@ type RetryConstants = {
     retryExponential: number
     retryInterval: number
 }
+
 const DEFAULT_RETRY_CONSTANTS: RetryConstants = {
-    maxAttempts: 1,
+    maxAttempts: 4,
     retryExponential: 6,
     retryInterval: 1000,
 }
-
 
 export class EngineConstants {
     public static readonly API_URL = 'http://127.0.0.1:3000/'

--- a/packages/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/engine/src/lib/handler/context/flow-execution-context.ts
@@ -185,6 +185,7 @@ export class FlowExecutorContext {
             tasks: this.tasks,
             tags: [...this.tags],
             steps: await loggingUtils.trimExecution(this.steps),
+            retryable: this.retryable,
         }
         switch (this.verdict) {
             case ExecutionVerdict.FAILED:

--- a/packages/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/engine/src/lib/handler/context/flow-execution-context.ts
@@ -23,14 +23,20 @@ export class FlowExecutorContext {
     tags: readonly string[]
     steps: Readonly<Record<string, StepOutput>>
     currentState: Record<string, unknown>
-    /**
-     * Execution duration in milliseconds
-     */
-    duration: number
     pauseRequestId: string
     verdict: ExecutionVerdict
     verdictResponse: VerdictResponse | undefined
     currentPath: StepExecutionPath
+
+    /**
+     * Execution time in milliseconds
+     */
+    duration: number
+
+    /**
+     * Indicates whether flow run can be retried when execution fails
+     */
+    retryable?: boolean
 
     constructor(copyFrom?: FlowExecutorContext) {
         this.tasks = copyFrom?.tasks ?? 0
@@ -42,12 +48,13 @@ export class FlowExecutorContext {
         this.verdict = copyFrom?.verdict ?? ExecutionVerdict.RUNNING
         this.verdictResponse = copyFrom?.verdictResponse ?? undefined
         this.currentPath = copyFrom?.currentPath ?? StepExecutionPath.empty()
+        this.retryable = copyFrom?.retryable
     }
-
 
     static empty(): FlowExecutorContext {
         return new FlowExecutorContext()
     }
+
     public setPauseRequestId(pauseRequestId: string): FlowExecutorContext {
         return new FlowExecutorContext({
             ...this,
@@ -157,11 +164,18 @@ export class FlowExecutorContext {
         })
     }
 
-    public setVerdict(verdict: ExecutionVerdict, response: VerdictResponse | undefined): FlowExecutorContext {
+    public setVerdict(verdict: ExecutionVerdict, response?: VerdictResponse): FlowExecutorContext {
         return new FlowExecutorContext({
             ...this,
             verdict,
             verdictResponse: response,
+        })
+    }
+
+    public setRetryable(retryable: boolean): FlowExecutorContext {
+        return new FlowExecutorContext({
+            ...this,
+            retryable,
         })
     }
 

--- a/packages/engine/src/lib/handler/piece-executor.ts
+++ b/packages/engine/src/lib/handler/piece-executor.ts
@@ -142,8 +142,7 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
 
         return executionState
             .upsertStep(action.name, failedStepOutput)
-            .setVerdict(ExecutionVerdict.FAILED)
-            .setRetryable(handledError.retryable)
+            .setVerdict(ExecutionVerdict.FAILED, handledError.verdictResponse)
     }
 }
 

--- a/packages/engine/src/lib/handler/piece-executor.ts
+++ b/packages/engine/src/lib/handler/piece-executor.ts
@@ -7,8 +7,7 @@ import { createFilesService } from '../services/files.service'
 import { createConnectionService } from '../services/connections.service'
 import { EngineConstants } from './context/engine-constants'
 import { pieceLoader } from '../helper/piece-loader'
-import { utils } from '../utils'
-import { continueIfFailureHandler, runWithExponentialBackoff } from '../helper/error-handling'
+import { continueIfFailureHandler, handleExecutionError, runWithExponentialBackoff } from '../helper/error-handling'
 import { URL } from 'url'
 
 type HookResponse = { stopResponse: StopHookParams | undefined, pauseResponse: PauseHookParams | undefined, tags: string[], stopped: boolean, paused: boolean }
@@ -113,7 +112,7 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
         const runMethodToExecute = (constants.testSingleStepMode && !isNil(pieceAction.test)) ? pieceAction.test : pieceAction.run
         const output = await runMethodToExecute(context)
         const newExecutionContext = executionState.addTags(hookResponse.tags)
-        
+
         if (hookResponse.stopped) {
             assertNotNullOrUndefined(hookResponse.stopResponse, 'stopResponse')
             return newExecutionContext.upsertStep(action.name, stepOutput.setOutput(output)).setVerdict(ExecutionVerdict.SUCCEEDED, {
@@ -133,13 +132,16 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
         return newExecutionContext.upsertStep(action.name, stepOutput.setOutput(output)).increaseTask().setVerdict(ExecutionVerdict.RUNNING, undefined)
     }
     catch (e) {
-        const errorMessage = await utils.tryParseJson((e as Error).message)
-        console.error(errorMessage)
+        const handledError = handleExecutionError(e)
+
+        const failedStepOutput = stepOutput
+            .setStatus(StepOutputStatus.FAILED)
+            .setErrorMessage(handledError.message)
 
         return executionState
-            .upsertStep(action.name, stepOutput.setStatus(StepOutputStatus.FAILED).setErrorMessage(errorMessage))
-            .setVerdict(ExecutionVerdict.FAILED, undefined)
-
+            .upsertStep(action.name, failedStepOutput)
+            .setVerdict(ExecutionVerdict.FAILED)
+            .setRetryable(handledError.retryable)
     }
 }
 

--- a/packages/engine/src/lib/helper/error-handling.ts
+++ b/packages/engine/src/lib/helper/error-handling.ts
@@ -1,34 +1,75 @@
 import { CodeAction, PieceAction } from '@activepieces/shared'
 import { ExecutionVerdict, FlowExecutorContext } from '../handler/context/flow-execution-context'
 import { EngineConstants } from '../handler/context/engine-constants'
+import { RetryableError } from './execution-errors'
 
 export async function runWithExponentialBackoff<T extends CodeAction | PieceAction>(
     executionState: FlowExecutorContext,
     action: T,
     constants: EngineConstants,
-    requestFunction: (request: { action: T, executionState: FlowExecutorContext, constants: EngineConstants }) => Promise<FlowExecutorContext>,
+    requestFunction: RequestFunction<T>,
     attemptCount = 1,
 ): Promise<FlowExecutorContext> {
     const resultExecutionState = await requestFunction({ action, executionState, constants })
     const retryEnabled = action.settings.errorHandlingOptions?.retryOnFailure?.value
 
-    if (resultExecutionState.verdict === ExecutionVerdict.FAILED && attemptCount < constants.retryConstants.maxAttempts && retryEnabled && !constants.testSingleStepMode) {
+    if (
+        resultExecutionState.verdict === ExecutionVerdict.FAILED &&
+        attemptCount < constants.retryConstants.maxAttempts &&
+        retryEnabled &&
+        !constants.testSingleStepMode
+    ) {
         const backoffTime = Math.pow(constants.retryConstants.retryExponential, attemptCount) * constants.retryConstants.retryInterval
         await new Promise(resolve => setTimeout(resolve, backoffTime))
         return runWithExponentialBackoff(executionState, action, constants, requestFunction, attemptCount + 1)
     }
+
     return resultExecutionState
 }
 
-export async function continueIfFailureHandler<T extends CodeAction | PieceAction>(
+export async function continueIfFailureHandler(
     executionState: FlowExecutorContext,
-    action: T,
+    action: CodeAction | PieceAction,
     constants: EngineConstants,
 ): Promise<FlowExecutorContext> {
     const continueOnFailure = action.settings.errorHandlingOptions?.continueOnFailure?.value
 
-    if (executionState.verdict === ExecutionVerdict.FAILED && continueOnFailure && !constants.testSingleStepMode) {
-        return executionState.setVerdict(ExecutionVerdict.RUNNING, undefined).increaseTask()
+    if (
+        executionState.verdict === ExecutionVerdict.FAILED &&
+        continueOnFailure &&
+        !constants.testSingleStepMode
+    ) {
+        return executionState
+            .setVerdict(ExecutionVerdict.RUNNING, undefined)
+            .increaseTask()
     }
+
     return executionState
+}
+
+export const handleExecutionError = (error: unknown): ErrorHandlingResponse => {
+    logError(error)
+
+    return {
+        message: error instanceof Error ? error.message : JSON.stringify(error),
+        retryable: error instanceof RetryableError,
+    }
+}
+
+const logError = (error: unknown): void => {
+    const serializedError = JSON.stringify(error, Object.getOwnPropertyNames(error))
+    console.error(serializedError)
+}
+
+type Request<T extends CodeAction | PieceAction> = {
+    action: T
+    executionState: FlowExecutorContext
+    constants: EngineConstants
+}
+
+type RequestFunction<T extends CodeAction | PieceAction> = (request: Request<T>) => Promise<FlowExecutorContext>
+
+type ErrorHandlingResponse = {
+    message: string
+    retryable: boolean
 }

--- a/packages/engine/src/lib/helper/error-handling.ts
+++ b/packages/engine/src/lib/helper/error-handling.ts
@@ -14,7 +14,7 @@ export async function runWithExponentialBackoff<T extends CodeAction | PieceActi
     const retryEnabled = action.settings.errorHandlingOptions?.retryOnFailure?.value
 
     if (
-        resultExecutionState.verdict === ExecutionVerdict.FAILED &&
+        executionFailedWithRetryableError(resultExecutionState) &&
         attemptCount < constants.retryConstants.maxAttempts &&
         retryEnabled &&
         !constants.testSingleStepMode
@@ -59,6 +59,11 @@ export const handleExecutionError = (error: unknown): ErrorHandlingResponse => {
 const logError = (error: unknown): void => {
     const serializedError = JSON.stringify(error, Object.getOwnPropertyNames(error))
     console.error(serializedError)
+}
+
+const executionFailedWithRetryableError = (flowExecutorContext: FlowExecutorContext): boolean => {
+    return flowExecutorContext.verdict === ExecutionVerdict.FAILED &&
+        [true, undefined].includes(flowExecutorContext.retryable)
 }
 
 type Request<T extends CodeAction | PieceAction> = {

--- a/packages/engine/src/lib/helper/execution-errors.ts
+++ b/packages/engine/src/lib/helper/execution-errors.ts
@@ -5,29 +5,29 @@ export class ExecutionError extends Error {
     }
 }
 
-export class RetryableError extends ExecutionError {}
+export class EngineError extends ExecutionError {}
 
-export class NonRetryableError extends ExecutionError {}
+export class UserError extends ExecutionError {}
 
-export class ConnectionNotFoundError extends NonRetryableError {
+export class ConnectionNotFoundError extends UserError {
     constructor(connectionName: string, cause?: unknown) {
         super('ConnectionNotFound', `connection (${connectionName}) not found`, cause)
     }
 }
 
-export class ConnectionLoadingError extends NonRetryableError {
+export class ConnectionLoadingError extends EngineError {
     constructor(connectionName: string, cause?: unknown) {
         super('ConnectionLoadingFailure', `Failed to load connection (${connectionName})`, cause)
     }
 }
 
-export class StorageError extends NonRetryableError {
+export class StorageError extends EngineError {
     constructor(key: string, cause?: unknown) {
         super('StorageError', `Failed to read/write key (${key})`, cause)
     }
 }
 
-export class FetchError extends RetryableError {
+export class FetchError extends EngineError {
     constructor(url: string, cause?: unknown) {
         super('FetchError', `Failed to fetch from ${url}`, cause)
     }

--- a/packages/engine/src/lib/helper/execution-errors.ts
+++ b/packages/engine/src/lib/helper/execution-errors.ts
@@ -1,13 +1,34 @@
-export class ConnectionNotFoundError extends Error {
-    constructor(connectionName: string) {
-        super(`connection (${connectionName}) not found`)
-        this.name = 'ConnectionNotFound'
+export class ExecutionError extends Error {
+    constructor(name: string, message: string, public cause?: unknown) {
+        super(message)
+        this.name = name
     }
 }
 
-export class ConnectionLoadingFailureError extends Error {
-    constructor(connectionName: string, url: string, execption: unknown) {
-        super(`Failed to load connection (${connectionName}) from ${url} error: ${JSON.stringify(execption)}`)
-        this.name = 'ConnectionLoadingFailure'
+export class RetryableError extends ExecutionError {}
+
+export class NonRetryableError extends ExecutionError {}
+
+export class ConnectionNotFoundError extends NonRetryableError {
+    constructor(connectionName: string, cause?: unknown) {
+        super('ConnectionNotFound', `connection (${connectionName}) not found`, cause)
+    }
+}
+
+export class ConnectionLoadingError extends NonRetryableError {
+    constructor(connectionName: string, cause?: unknown) {
+        super('ConnectionLoadingFailure', `Failed to load connection (${connectionName})`, cause)
+    }
+}
+
+export class StorageError extends NonRetryableError {
+    constructor(key: string, cause?: unknown) {
+        super('StorageError', `Failed to read/write key (${key})`, cause)
+    }
+}
+
+export class FetchError extends RetryableError {
+    constructor(url: string, cause?: unknown) {
+        super('FetchError', `Failed to fetch from ${url}`, cause)
     }
 }

--- a/packages/engine/src/lib/services/connections.service.ts
+++ b/packages/engine/src/lib/services/connections.service.ts
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes'
-import { AppConnection, AppConnectionType, CloudOAuth2ConnectionValue, BasicAuthConnectionValue, OAuth2ConnectionValueWithApp, isNil } from '@activepieces/shared'
+import { AppConnection, AppConnectionType, CloudOAuth2ConnectionValue, BasicAuthConnectionValue, OAuth2ConnectionValueWithApp } from '@activepieces/shared'
 import { EngineConstants } from '../handler/context/engine-constants'
-import { ConnectionLoadingFailureError, ConnectionNotFoundError } from '../helper/execution-errors'
+import { ConnectionLoadingError, ConnectionNotFoundError, ExecutionError, FetchError } from '../helper/execution-errors'
 
 export const createConnectionService = ({ projectId, workerToken }: CreateConnectionServiceParams): ConnectionService => {
     return {
@@ -17,46 +17,39 @@ export const createConnectionService = ({ projectId, workerToken }: CreateConnec
                 })
 
                 if (!response.ok) {
-                    return handleErrors({
-                        httpStatus: response.status,
+                    return handleResponseError({
                         connectionName,
-                        url,
+                        httpStatus: response.status,
                     })
                 }
 
-                const connection: AppConnection | null = await response.json()
-
-                if (isNil(connection)) {
-                    return handleNotFoundError(connectionName)
-                }
-
+                const connection = await response.json()
                 return getConnectionValue(connection)
             }
             catch (e) {
-                if (e instanceof ConnectionNotFoundError) {
+                if (e instanceof ExecutionError) {
                     throw e
                 }
 
-                return handleErrors({
-                    connectionName,
-                    exception: e,
+                return handleFetchError({
                     url,
+                    cause: e,
                 })
             }
         },
     }
 }
 
-const handleErrors = ({ httpStatus, connectionName, url, exception }: HandleErrorsParams): never => {
+const handleResponseError = ({ connectionName, httpStatus }: HandleResponseErrorParams): never => {
     if (httpStatus === StatusCodes.NOT_FOUND.valueOf()) {
-        handleNotFoundError(connectionName)
+        throw new ConnectionNotFoundError(connectionName)
     }
 
-    throw new ConnectionLoadingFailureError(connectionName, url, exception)
+    throw new ConnectionLoadingError(connectionName)
 }
 
-const handleNotFoundError = (connectionName: string): never => {
-    throw new ConnectionNotFoundError(connectionName)
+const handleFetchError = ({ url, cause }: HandleFetchErrorParams): never => {
+    throw new FetchError(url, cause)
 }
 
 const getConnectionValue = (connection: AppConnection): ConnectionValue => {
@@ -73,11 +66,11 @@ const getConnectionValue = (connection: AppConnection): ConnectionValue => {
 }
 
 type ConnectionValue =
- | OAuth2ConnectionValueWithApp
- | CloudOAuth2ConnectionValue
- | BasicAuthConnectionValue
- | Record<string, unknown>
- | string
+    | OAuth2ConnectionValueWithApp
+    | CloudOAuth2ConnectionValue
+    | BasicAuthConnectionValue
+    | Record<string, unknown>
+    | string
 
 type ConnectionService = {
     obtain(connectionName: string): Promise<ConnectionValue>
@@ -88,9 +81,12 @@ type CreateConnectionServiceParams = {
     workerToken: string
 }
 
-type HandleErrorsParams = {
-    httpStatus?: number
+type HandleResponseErrorParams = {
     connectionName: string
+    httpStatus: number
+}
+
+type HandleFetchErrorParams = {
     url: string
-    exception?: unknown
+    cause: unknown
 }

--- a/packages/engine/src/lib/services/storage.service.ts
+++ b/packages/engine/src/lib/services/storage.service.ts
@@ -1,53 +1,95 @@
+import { URL } from 'node:url'
 import { Store, StoreScope } from '@activepieces/pieces-framework'
-import { DeletStoreEntryRequest, FlowId, PutStoreEntryRequest, StoreEntry } from '@activepieces/shared'
+import { DeleteStoreEntryRequest, FlowId, PutStoreEntryRequest, StoreEntry } from '@activepieces/shared'
+import { StatusCodes } from 'http-status-codes'
 import { EngineConstants } from '../handler/context/engine-constants'
+import { FetchError, StorageError } from '../helper/execution-errors'
 
-export const createStorageService = ({ workerToken }: { workerToken: string }) => {
+export const createStorageService = ({ workerToken }: CreateStorageServiceParams): StorageService => {
     return {
         async get(key: string): Promise<StoreEntry | null> {
-            const response = await fetch(`${EngineConstants.API_URL}v1/store-entries?key=${encodeURIComponent(key)}`, {
-                headers: {
-                    Authorization: 'Bearer ' + workerToken,
-                },
-            })
+            const url = buildUrl(key)
 
-            if (response.ok) {
-                return (await response.json()) ?? null
+            try {
+                const response = await fetch(url, {
+                    headers: {
+                        Authorization: `Bearer ${workerToken}`,
+                    },
+                })
+
+                if (!response.ok) {
+                    return await handleResponseError({
+                        key,
+                        response,
+                    })
+                }
+
+                return await response.json()
             }
+            catch (e) {
+                return handleFetchError({
+                    url,
+                    cause: e,
+                })
+            }
+        },
 
-            if (response.status === 404) {
+        async put(request: PutStoreEntryRequest): Promise<StoreEntry | null> {
+            const url = buildUrl()
+
+            try {
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${workerToken}`,
+                    },
+                    body: JSON.stringify(request),
+                })
+
+                if (!response.ok) {
+                    return await handleResponseError({
+                        key: request.key,
+                        response,
+                    })
+                }
+
+                return await response.json()
+            }
+            catch (e) {
+                return handleFetchError({
+                    url,
+                    cause: e,
+                })
+            }
+        },
+
+        async delete(request: DeleteStoreEntryRequest): Promise<null> {
+            const url = buildUrl(request.key)
+
+            try {
+                const response = await fetch(url, {
+                    method: 'DELETE',
+                    headers: {
+                        Authorization: `Bearer ${workerToken}`,
+                    },
+                })
+
+                if (!response.ok) {
+                    await handleResponseError({
+                        key: request.key,
+                        response,
+                    })
+                }
+
                 return null
             }
-
-            const body = await response.text()
-            throw new Error('Failed to fetch store entry ' + response.status + ' ' + body)
-        },
-        async put(request: PutStoreEntryRequest): Promise<StoreEntry | null> {
-            const response = await fetch(`${EngineConstants.API_URL}v1/store-entries`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: 'Bearer ' + workerToken,
-                },
-                body: JSON.stringify(request),
-            })
-            if (!response.ok) {
-                throw new Error(JSON.stringify(await response.json()))
+            catch (e) {
+                return handleFetchError({
+                    url,
+                    cause: e,
+                })
             }
-            return (await response.json()) ?? null
-        },
-        async delete(request: DeletStoreEntryRequest): Promise<StoreEntry | null> {
-            const response = await fetch(`${EngineConstants.API_URL}v1/store-entries?key=${encodeURIComponent(request.key)}`, {
-                method: 'DELETE',
-                headers: {
-                    Authorization: 'Bearer ' + workerToken,
-                },
-            })
-            if (!response.ok) {
-                throw new Error('Failed to delete store entry')
-            }
-            await response.text()
-            return null
         },
     }
 }
@@ -86,4 +128,47 @@ function createKey(prefix: string, scope: StoreScope, flowId: FlowId, key: strin
         case StoreScope.FLOW:
             return prefix + 'flow_' + flowId + '/' + key
     }
+}
+
+const buildUrl = (key?: string): URL => {
+    const url = new URL(`${EngineConstants.API_URL}v1/store-entries`)
+
+    if (key) {
+        url.searchParams.set('key', key)
+    }
+
+    return url
+}
+
+const handleResponseError = async ({ key, response }: HandleResponseErrorParams): Promise<null> => {
+    if (response.status === StatusCodes.NOT_FOUND.valueOf()) {
+        return null
+    }
+
+    const cause = await response.text()
+    throw new StorageError(key, cause)
+}
+
+const handleFetchError = ({ url, cause }: HandleFetchErrorParams): never => {
+    throw new FetchError(url.toString(), cause)
+}
+
+type CreateStorageServiceParams = {
+    workerToken: string
+}
+
+type StorageService = {
+    get(key: string): Promise<StoreEntry | null>
+    put(request: PutStoreEntryRequest): Promise<StoreEntry | null>
+    delete(request: DeleteStoreEntryRequest): Promise<null>
+}
+
+type HandleResponseErrorParams = {
+    key: string
+    response: Response
+}
+
+type HandleFetchErrorParams = {
+    url: URL
+    cause: unknown
 }

--- a/packages/engine/src/lib/services/storage.service.ts
+++ b/packages/engine/src/lib/services/storage.service.ts
@@ -1,7 +1,7 @@
 import { URL } from 'node:url'
 import { Store, StoreScope } from '@activepieces/pieces-framework'
 import { StatusCodes } from 'http-status-codes'
-import { DeletStoreEntryRequest, FlowId, FlowRunId, PutStoreEntryRequest, StoreEntry } from '@activepieces/shared'
+import { DeleteStoreEntryRequest, FlowId, FlowRunId, PutStoreEntryRequest, StoreEntry } from '@activepieces/shared'
 import { EngineConstants } from '../handler/context/engine-constants'
 import { FetchError, StorageError } from '../helper/execution-errors'
 

--- a/packages/engine/test/handler/flow-error-handling.test.ts
+++ b/packages/engine/test/handler/flow-error-handling.test.ts
@@ -36,13 +36,13 @@ describe('piece with error handling', () => {
                 name: 'send_http',
                 pieceName: '@activepieces/piece-http',
                 actionName: 'send_request',
-                input: { 
+                input: {
                     'method': 'POST',
                     'url': 'https://cloud.activepieces.com/api/v1/flags',
                     'headers': {},
                     'queryParams': {},
-                    'body_type': 'none', 
-                    'body': {}, 
+                    'body_type': 'none',
+                    'body': {},
                 },
                 errorHandlingOptions: {
                     continueOnFailure: {
@@ -54,22 +54,23 @@ describe('piece with error handling', () => {
                 },
             }), executionState: FlowExecutorContext.empty(), constants: generateMockEngineConstants(),
         })
+
+        const expectedError = {
+            response: {
+                status: 404,
+                body: {
+                    statusCode: 404,
+                    error: 'Not Found',
+                    message: 'Route not found',
+                },
+            },
+            request: {},
+        }
+
         expect(result.verdict).toBe(ExecutionVerdict.RUNNING)
         expect(result.steps.send_http.status).toBe('FAILED')
-        expect(result.steps.send_http.errorMessage).toEqual({
-            request: {
-                
-            },
-            response: {
-                'body': {
-                    'error': 'Not Found',
-                    'message': 'Route not found',
-                    'statusCode': 404,
-                },
-                status: 404,
-            },
-        })
-          
+        expect(result.steps.send_http.errorMessage).toEqual(JSON.stringify(expectedError))
+
     })
 
 })

--- a/packages/engine/test/handler/flow-piece.test.ts
+++ b/packages/engine/test/handler/flow-piece.test.ts
@@ -31,28 +31,27 @@ describe('pieceExecutor', () => {
                     'url': 'https://cloud.activepieces.com/api/v1/asd',
                     'method': 'GET',
                     'headers': {},
-                    'body_type': 'none', 
-                    'body': {}, 
+                    'body_type': 'none',
+                    'body': {},
                     'queryParams': {},
                 },
             }), executionState: FlowExecutorContext.empty(), constants: generateMockEngineConstants(),
         })
+
+        const expectedError = {
+            response: {
+                status: 404,
+                body: {
+                    statusCode: 404,
+                    error: 'Not Found',
+                    message: 'Route not found',
+                },
+            },
+            request: {},
+        }
+
         expect(result.verdict).toBe(ExecutionVerdict.FAILED)
         expect(result.steps.send_http.status).toBe('FAILED')
-        expect(result.steps.send_http.errorMessage).toEqual({
-            request: {
-                
-            },
-            response: {
-                'body': {
-                    'error': 'Not Found',
-                    'message': 'Route not found',
-                    'statusCode': 404,
-                },
-                status: 404,
-            },
-        })
+        expect(result.steps.send_http.errorMessage).toEqual(JSON.stringify(expectedError))
     })
-
-
 })

--- a/packages/server/api/src/app/store-entry/store-entry.controller.ts
+++ b/packages/server/api/src/app/store-entry/store-entry.controller.ts
@@ -1,7 +1,7 @@
 import { FastifyRequest } from 'fastify'
 import { storeEntryService } from './store-entry.service'
 import {
-    DeletStoreEntryRequest,
+    DeleteStoreEntryRequest,
     GetStoreEntryRequest,
     PrincipalType,
     PutStoreEntryRequest,
@@ -62,12 +62,12 @@ export const storeEntryController: FastifyPluginAsyncTypebox = async (
         '/',
         {
             schema: {
-                querystring: DeletStoreEntryRequest,
+                querystring: DeleteStoreEntryRequest,
             },
         },
         async (
             request: FastifyRequest<{
-                Querystring: DeletStoreEntryRequest
+                Querystring: DeleteStoreEntryRequest
             }>,
             reply,
         ) => {

--- a/packages/server/api/src/app/workers/flow-worker/flow-worker.ts
+++ b/packages/server/api/src/app/workers/flow-worker/flow-worker.ts
@@ -229,13 +229,11 @@ async function executeFlow(jobData: OneTimeJobData): Promise<void> {
             input,
         )
 
-
-
-        if (result.status === FlowRunStatus.FAILED && result.retryable) {
+        if (result.status === FlowRunStatus.INTERNAL_ERROR) {
             const retryError = new ActivepiecesError({
                 code: ErrorCode.ENGINE_OPERATION_FAILURE,
                 params: {
-                    message: result.error?.message ?? 'retryable error',
+                    message: result.error?.message ?? 'internal error',
                 },
             })
 

--- a/packages/server/api/src/app/workers/flow-worker/flow-worker.ts
+++ b/packages/server/api/src/app/workers/flow-worker/flow-worker.ts
@@ -229,6 +229,19 @@ async function executeFlow(jobData: OneTimeJobData): Promise<void> {
             input,
         )
 
+
+
+        if (result.status === FlowRunStatus.FAILED && result.retryable) {
+            const retryError = new ActivepiecesError({
+                code: ErrorCode.ENGINE_OPERATION_FAILURE,
+                params: {
+                    message: result.error?.message ?? 'retryable error',
+                },
+            })
+
+            throwErrorToRetry(retryError, jobData.runId)
+        }
+
         if (
             jobData.synchronousHandlerId &&
             jobData.hookType === HookType.BEFORE_LOG

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.10.94",
+  "version": "0.10.95",
   "type": "commonjs"
 }

--- a/packages/shared/src/lib/flow-run/execution/flow-execution.ts
+++ b/packages/shared/src/lib/flow-run/execution/flow-execution.ts
@@ -43,7 +43,7 @@ export const StopResponse = Type.Object({
 
 export type StopResponse = Static<typeof StopResponse>
 
-const BaseExecutiionResponse = {
+const BaseExecutionResponse = {
     ...ExecutionState,
     duration: Type.Number(),
     tasks: Type.Number(),
@@ -53,24 +53,29 @@ const BaseExecutiionResponse = {
         message: Type.String(),
     })),
     stopResponse: Type.Optional(StopResponse),
+
+    /**
+     * Indicates whether flow run can be retried when execution fails
+     */
+    retryable: Type.Optional(Type.Boolean()),
 }
 
 export const FlowRunResponse = Type.Union([
     Type.Object({
+        ...BaseExecutionResponse,
         status: Type.Literal(FlowRunStatus.PAUSED),
-        ...BaseExecutiionResponse,
         pauseMetadata: Type.Optional(PauseMetadata),
     }),
     Type.Object({
-        status: Type.Union([Type.Literal(FlowRunStatus.FAILED), 
-            Type.Literal(FlowRunStatus.SUCCEEDED), 
+        ...BaseExecutionResponse,
+        status: Type.Union([Type.Literal(FlowRunStatus.FAILED),
+            Type.Literal(FlowRunStatus.SUCCEEDED),
             Type.Literal(FlowRunStatus.RUNNING),
             Type.Literal(FlowRunStatus.QUOTA_EXCEEDED),
             Type.Literal(FlowRunStatus.TIMEOUT),
             Type.Literal(FlowRunStatus.INTERNAL_ERROR),
             Type.Literal(FlowRunStatus.STOPPED),
         ]),
-        ...BaseExecutiionResponse,
     }),
 ])
 export type FlowRunResponse = Static<typeof FlowRunResponse> & ExecutionState

--- a/packages/shared/src/lib/flow-run/execution/flow-execution.ts
+++ b/packages/shared/src/lib/flow-run/execution/flow-execution.ts
@@ -53,11 +53,6 @@ const BaseExecutionResponse = {
         message: Type.String(),
     })),
     stopResponse: Type.Optional(StopResponse),
-
-    /**
-     * Indicates whether flow run can be retried when execution fails
-     */
-    retryable: Type.Optional(Type.Boolean()),
 }
 
 export const FlowRunResponse = Type.Union([

--- a/packages/shared/src/lib/store-entry/dto/store-entry-request.ts
+++ b/packages/shared/src/lib/store-entry/dto/store-entry-request.ts
@@ -16,8 +16,8 @@ export const GetStoreEntryRequest = Type.Object({
 
 export type GetStoreEntryRequest = Static<typeof GetStoreEntryRequest>
 
-export const DeletStoreEntryRequest = Type.Object({
+export const DeleteStoreEntryRequest = Type.Object({
     key: Type.String({}),
 })
 
-export type DeletStoreEntryRequest = Static<typeof DeletStoreEntryRequest>
+export type DeleteStoreEntryRequest = Static<typeof DeleteStoreEntryRequest>


### PR DESCRIPTION
## What does this PR do?
- Introduces `Retryable` and `NonRetryable` execution errors for the engine
- Refactors step retry logic to not retry `NonRetryable` errors
- Fixes `maxAttempts` being set to 1 for step retries
- Fixes #4137 
