### PR TITLE
fix(piece-framework): axios http client to support array query parameter multiple times

### DIFF
--- a/packages/pieces/community/common/package.json
+++ b/packages/pieces/community/common/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "commonjs"
 }

--- a/packages/pieces/community/common/package.json
+++ b/packages/pieces/community/common/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "commonjs"
 }

--- a/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
+++ b/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
@@ -26,13 +26,15 @@ export class AxiosHttpClient extends BaseHttpClient {
       const headers = this.getHeaders(request);
       const axiosRequestMethod = this.getAxiosRequestMethod(request.method);
       const timeout = request.timeout ? request.timeout : 0;
+
+      for (const key in request.queryParams) {
+        queryParams.append(key, request.queryParams[key])
+      }
+
       const config: AxiosRequestConfig = {
         method: axiosRequestMethod,
         url: urlWithoutQueryParams,
-        params: {
-          ...queryParams,
-          ...request.queryParams,
-        },
+        params: queryParams,
         headers,
         data: request.body,
         timeout,

--- a/packages/pieces/community/common/src/lib/http/core/base-http-client.ts
+++ b/packages/pieces/community/common/src/lib/http/core/base-http-client.ts
@@ -25,14 +25,14 @@ export abstract class BaseHttpClient implements HttpClient {
     request: HttpRequest<RequestBody>
   ): {
     urlWithoutQueryParams: string;
-    queryParams: Record<string, string>;
+    queryParams: URLSearchParams;
   } {
     const url = new URL(`${this.baseUrl}${request.url}`);
     const urlWithoutQueryParams = `${url.origin}${url.pathname}`;
-    const queryParams: Record<string, string> = {};
+    const queryParams = new URLSearchParams();
     // Extract query parameters
     url.searchParams.forEach((value, key) => {
-      queryParams[key] = value;
+      queryParams.append(key, value);
     });
     return {
       urlWithoutQueryParams,


### PR DESCRIPTION
## What does this PR do?

This PR add support for the same query parameter to be used multiple times in the same request. When an endpoint we are using has a query parameter that expects an array, generally the request looks like:

- '...?key=value1&key=value2'

We cannot support this using a Record object. So I changed it to a URLSearchParams object


