### PR TITLE
docs: update initialize-embed.mdx

### DIFF
--- a/docs/embedding/configuration/initialize-embed.mdx
+++ b/docs/embedding/configuration/initialize-embed.mdx
@@ -24,7 +24,7 @@ The following scripts shouldn't contain async or defer attributes.
 <script>
 activepieces.configure(
  {
-    prefix: "/";
+    prefix: "/",
     instanceUrl:"http://your-instance-url.com",
     jwtToken:"GENERATED_JWT_TOKEN",
     embedding: {


### PR DESCRIPTION
there was an error in json config minor one you guys putted a ; instead of ,

## Fixed syntax error in documentation

There was a jus a minor syntax error.

Fixes # (issue)

