### PR TITLE
feat(slack): add search message action

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -15,10 +15,11 @@ import { slackSendMessageAction } from './lib/actions/send-message-action';
 import { newMessage } from './lib/triggers/new-message';
 import { newReactionAdded } from './lib/triggers/new-reaction-added';
 import { uploadFile } from './lib/actions/upload-file';
+import { searchMessages } from './lib/actions/search-messages';
 
 export const slackAuth = PieceAuth.OAuth2({
   description: '',
-  authUrl: 'https://slack.com/oauth/v2/authorize',
+  authUrl: 'https://slack.com/oauth/v2/authorize?user_scope=search:read',
   tokenUrl: 'https://slack.com/api/oauth.v2.access',
   required: true,
   scope: [
@@ -68,7 +69,16 @@ export const slack = createPiece({
       return signature === computedSignature;
     },
   },
-  authors: ["rita-gorokhod","AdamSelene","Abdallah-Alwarawreh","kishanprmr","MoShizzle","AbdulTheActivePiecer","khaledmashaly","abuaboud"],
+  authors: [
+    'rita-gorokhod',
+    'AdamSelene',
+    'Abdallah-Alwarawreh',
+    'kishanprmr',
+    'MoShizzle',
+    'AbdulTheActivePiecer',
+    'khaledmashaly',
+    'abuaboud',
+  ],
   actions: [
     slackSendDirectMessageAction,
     slackSendMessageAction,
@@ -77,6 +87,7 @@ export const slack = createPiece({
     requestActionDirectMessageAction,
     requestActionMessageAction,
     uploadFile,
+    searchMessages,
     createCustomApiCallAction({
       baseUrl: () => {
         return 'https://slack.com/api';

--- a/packages/pieces/community/slack/src/lib/actions/search-messages.ts
+++ b/packages/pieces/community/slack/src/lib/actions/search-messages.ts
@@ -1,0 +1,56 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { slackAuth } from '../..';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+import {assertNotNullOrUndefined} from "@activepieces/shared";
+
+export const searchMessages = createAction({
+  name: 'searchMessages',
+  displayName: 'Search messages',
+  description: 'Searches for messages matching a query',
+  auth: slackAuth,
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search query',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const userToken = auth.data['authed_user']?.access_token;
+    if (userToken === undefined) {
+      throw new Error("Missing user token, please re-authenticate")
+    }
+    const request: HttpRequest = {
+      method: HttpMethod.GET,
+      url: 'https://slack.com/api/search.messages',
+      queryParams: {
+        query: propsValue.query,
+        count: '100',
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: userToken,
+      },
+    };
+
+    let page = 1;
+    let pageCount = Infinity;
+    const matches = [];
+    while (page < pageCount) {
+      request.queryParams!.page = String(page);
+      const response = await httpClient.sendRequest(request);
+
+      if (!response.body.ok) {
+        throw new Error(response.body.error);
+      }
+      pageCount = response.body['messages']['pagination']['page_count'];
+      page += 1;
+      matches.push(...response.body['messages']['matches']);
+    }
+    return matches;
+  },
+});


### PR DESCRIPTION
## What does this PR do?
Add action to search messages using Slack's query syntax
Pagination is handled

_You will need to re-authenticate your connection to get the extra `search:read` scope_



