### PR TITLE
feat: allow retrieving project git config using API token

### DIFF
--- a/packages/server/api/src/app/ee/git-repos/git-repo.module.ts
+++ b/packages/server/api/src/app/ee/git-repos/git-repo.module.ts
@@ -159,7 +159,7 @@ const ConfigureRepoRequestSchema = {
 
 const ListRepoRequestSchema = {
     config: {
-        allowedPrincipals: [PrincipalType.USER],
+        allowedPrincipals: [PrincipalType.USER, PrincipalType.SERVICE],
     },
     schema: {
         querystring: Type.Object({


### PR DESCRIPTION
## What does this PR do?

Allow using the `api/v1/git-repos` endpoint using an API key (for continuous deployment purpose)