### PR TITLE
feat: add pagination support for project list endpoint

### DIFF
--- a/packages/server/api/src/app/ee/projects/platform-project-controller.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-controller.ts
@@ -22,6 +22,8 @@ import { platformService } from '../../platform/platform.service'
 import { projectLimitsService } from '../project-plan/project-plan.service'
 import { platformMustBeOwnedByCurrentUser } from '../authentication/ee-authorization'
 
+const DEFAULT_LIMIT_SIZE = 50
+
 export const platformProjectController: FastifyPluginAsyncTypebox = async (app) => {
     app.post('/', CreateProjectRequest, async (request, reply) => {
         const platformId = request.principal.platform.id
@@ -47,6 +49,8 @@ export const platformProjectController: FastifyPluginAsyncTypebox = async (app) 
             platformId,
             externalId: request.query.externalId,
             ownerId: undefined,
+            cursorRequest: request.query.cursor ?? null,
+            limit: request.query.limit ?? DEFAULT_LIMIT_SIZE,
         })
     })
 
@@ -123,6 +127,8 @@ const ListProjectRequestForApiKey = {
         },
         querystring: Type.Object({
             externalId: Type.Optional(Type.String()),
+            limit: Type.Optional(Type.Number({})),
+            cursor: Type.Optional(Type.String({})),
         }),
         tags: ['projects'],
         security: [SERVICE_KEY_SECURITY_OPENAPI],

--- a/packages/server/api/src/app/ee/projects/platform-project-service.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-service.ts
@@ -12,6 +12,7 @@ import {
     ActivepiecesError,
     ErrorCode,
     FlowStatus,
+    Cursor,
 } from '@activepieces/shared'
 import { EntityManager, Equal, In, IsNull } from 'typeorm'
 import {
@@ -35,6 +36,7 @@ import { transaction } from '../../core/db/transaction'
 import { flowService } from '../../flows/flow/flow.service'
 import { repoFactory } from '../../core/db/repo-factory'
 import { platformProjectSideEffects } from './platform-project-side-effects'
+import { buildPaginator } from '../../helper/pagination/build-paginator'
 
 const projectRepo = repoFactory(ProjectEntity)
 const projectMemberRepo = repoFactory(ProjectMemberEntity)
@@ -44,13 +46,27 @@ export const platformProjectService = {
         ownerId,
         platformId,
         externalId,
+        cursorRequest,
+        limit,
     }: {
         ownerId: UserId | undefined
         platformId?: PlatformId
         externalId?: string
+        cursorRequest: Cursor | null
+        limit: number
     }): Promise<SeekPage<ProjectWithLimits>> {
+        const decodedCursor = paginationHelper.decodeCursor(cursorRequest)
+        const paginator = buildPaginator({
+            entity: ProjectEntity,
+            query: {
+                limit,
+                order: 'ASC',
+                afterCursor: decodedCursor.nextCursor,
+                beforeCursor: decodedCursor.previousCursor,
+            },
+        })
         const filters = await createFilters(ownerId, platformId, externalId)
-        const projectPlans = await projectRepo()
+        const queryBuilder = projectRepo()
             .createQueryBuilder('project')
             .leftJoinAndMapOne(
                 'project.plan',
@@ -59,38 +75,48 @@ export const platformProjectService = {
                 'project.id = "project_plan"."projectId"',
             )
             .where(filters)
-            // TODO add pagination
-            .limit(50)
-            .getMany()
+        const { data, cursor } = await paginator.paginate(queryBuilder)
         const projects: ProjectWithLimits[] = await Promise.all(
-            projectPlans.map(enrichWithUsageAndPlan),
+            data.map(enrichWithUsageAndPlan),
         )
-        return paginationHelper.createPage<ProjectWithLimits>(
-            projects,
-            null,
-        )
+        return paginationHelper.createPage<ProjectWithLimits>(projects, cursor)
     },
 
-    async update({ projectId, request }: UpdateParams): Promise<ProjectWithLimits> {
-        await projectRepo().update({
-            id: projectId,
-            deleted: IsNull(),
-        }, {
-            displayName: request.displayName,
-            notifyStatus: request.notifyStatus,
-        })
+    async update({
+        projectId,
+        request,
+    }: UpdateParams): Promise<ProjectWithLimits> {
+        await projectRepo().update(
+            {
+                id: projectId,
+                deleted: IsNull(),
+            },
+            {
+                displayName: request.displayName,
+                notifyStatus: request.notifyStatus,
+            },
+        )
         if (!isNil(request.plan)) {
             const isCloud = getEdition() === ApEdition.CLOUD
-            const isSubscribed = isCloud ? (await projectBillingService.getOrCreateForProject(projectId)).subscriptionStatus === ApSubscriptionStatus.ACTIVE : false
+            const isSubscribed = isCloud
+                ? (await projectBillingService.getOrCreateForProject(projectId))
+                    .subscriptionStatus === ApSubscriptionStatus.ACTIVE
+                : false
             const project = await projectService.getOneOrThrow(projectId)
-            const isCloudProject = project.platformId && flagService.isCloudPlatform(project.platformId)
+            const isCloudProject =
+        project.platformId && flagService.isCloudPlatform(project.platformId)
 
             if (isSubscribed || !isCloudProject) {
-                const newTasks = isCloudProject ? request.plan.tasks : Math.min(request.plan.tasks, MAXIMUM_ALLOWED_TASKS)
-                await projectLimitsService.upsert({
-                    ...spreadIfDefined('teamMembers', request.plan.teamMembers),
-                    tasks: newTasks,
-                }, projectId)
+                const newTasks = isCloudProject
+                    ? request.plan.tasks
+                    : Math.min(request.plan.tasks, MAXIMUM_ALLOWED_TASKS)
+                await projectLimitsService.upsert(
+                    {
+                        ...spreadIfDefined('teamMembers', request.plan.teamMembers),
+                        tasks: newTasks,
+                    },
+                    projectId,
+                )
             }
         }
         return this.getWithPlanAndUsageOrThrow(projectId)
@@ -172,12 +198,20 @@ async function enrichWithUsageAndPlan(
 ): Promise<ProjectWithLimits> {
     return {
         ...project,
-        plan: await projectLimitsService.getOrCreateDefaultPlan(project.id, DEFAULT_FREE_PLAN_LIMIT),
-        usage: await projectUsageService.getUsageForBillingPeriod(project.id, projectUsageService.getCurrentingStartPeriod(project.created)),
+        plan: await projectLimitsService.getOrCreateDefaultPlan(
+            project.id,
+            DEFAULT_FREE_PLAN_LIMIT,
+        ),
+        usage: await projectUsageService.getUsageForBillingPeriod(
+            project.id,
+            projectUsageService.getCurrentingStartPeriod(project.created),
+        ),
     }
 }
 
-const assertAllProjectFlowsAreDisabled = async (params: AssertAllProjectFlowsAreDisabledParams): Promise<void> => {
+const assertAllProjectFlowsAreDisabled = async (
+    params: AssertAllProjectFlowsAreDisabledParams,
+): Promise<void> => {
     const { projectId, entityManager } = params
 
     const projectHasEnabledFlows = await flowService.existsByProjectAndStatus({
@@ -196,7 +230,11 @@ const assertAllProjectFlowsAreDisabled = async (params: AssertAllProjectFlowsAre
     }
 }
 
-const softDeleteOrThrow = async ({ id, platformId, entityManager }: SoftDeleteOrThrowParams): Promise<void> => {
+const softDeleteOrThrow = async ({
+    id,
+    platformId,
+    entityManager,
+}: SoftDeleteOrThrowParams): Promise<void> => {
     const deleteResult = await projectRepo(entityManager).softDelete({
         id,
         platformId,

--- a/packages/server/api/src/app/ee/projects/platform-user-project-controller.ts
+++ b/packages/server/api/src/app/ee/projects/platform-user-project-controller.ts
@@ -24,6 +24,8 @@ export const usersProjectController: FastifyPluginCallbackTypebox = (
         return platformProjectService.getAll({
             ownerId: request.principal.id,
             platformId: request.query.platformId,
+            cursorRequest: null,
+            limit: 50,
         })
     })
 
@@ -33,6 +35,8 @@ export const usersProjectController: FastifyPluginCallbackTypebox = (
         async (request) => {
             const allProjects = await platformProjectService.getAll({
                 ownerId: request.principal.id,
+                cursorRequest: null,
+                limit: 50,
             })
             const project = allProjects.data.find(
                 (project) => project.id === request.params.projectId,


### PR DESCRIPTION
## What does this PR do?

Enable pagination for the list projects endpoint (which currently only returns 50 projects)



