### PR TITLE
feat(WordPress): rename piece to WordPress, with a capital P

### DIFF
--- a/docs/about/changelog.mdx
+++ b/docs/about/changelog.mdx
@@ -1095,7 +1095,7 @@ Full Changelog: [View on GitHub](https://github.com/activepieces/activepieces/co
 2. If you want to enable sign-up, refer to the configuration. You must also manually add the Templates URL to load the templates and set `AP_TEMPLATES_SOURCE_URL` in your `.env` file to `https://cloud.activepieces.com/api/v1/flow-templates`.
 
 **Pieces:**
-- Wordpress: Support Upload Media in Create Post Action
+- WordPress: Support Upload Media in Create Post Action
 - Resend: Send Email Actions 
 - Instagram for Business: Upload Photo / Upload Reel Actions by @MoShizzle
 - Pastefy: Create Folder / Create Paste / Delete Folder / Delete Paste / Edit Paste / Get Folder / Get Paste Actions
@@ -1196,7 +1196,7 @@ Full Changelog: [View on GitHub](https://github.com/activepieces/activepieces/co
 **Fixes:**
 
 - Fixed the saving indicator in the builder.
-- Wordpress will now show all categories and tags.
+- WordPress will now show all categories and tags.
 - If a flow times out or has an internal error, a snackbar will now show up; before, it would just keep loading.
 - Fixed a bug in Branch Conditions where "or" between condition groups didn't work.
 - When you add a new folder, it will now scroll to the newest folder too.
@@ -1566,7 +1566,7 @@ https://github.com/activepieces/activepieces/compare/0.3.6...0.3.7
     - Cal.Com: Includes triggers for cancelled bookings, created bookings, and rescheduled bookings
     - RSS: Includes a trigger for new items in the feed
     - Clickup: Includes actions for getting lists, creating folderless lists, getting tasks, getting task comments, and getting spaces actions
-    - Wordpress: Includes actions for creating Wordpress posts and triggering new Wordpress posts
+    - WordPress: Includes actions for creating WordPress posts and triggering new WordPress posts
     - Github: Includes triggers for new pull requests and new issues
     - Posthog: Includes actions for capture events / creating project
     - Google Tasks: Includes actions for creating task

--- a/packages/pieces/community/wordpress/package.json
+++ b/packages/pieces/community/wordpress/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-wordpress",
-  "version": "0.3.11"
+  "version": "0.3.12"
 }

--- a/packages/pieces/community/wordpress/src/index.ts
+++ b/packages/pieces/community/wordpress/src/index.ts
@@ -11,9 +11,9 @@ import {
   createPiece,
 } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
-import { createWordpressPage } from './lib/actions/create-page.action';
-import { createWordpressPost } from './lib/actions/create-post.action';
-import { getWordpressPost } from './lib/actions/get-post.action';
+import { createWordPressPage } from './lib/actions/create-page.action';
+import { createWordPressPost } from './lib/actions/create-post.action';
+import { getWordPressPost } from './lib/actions/get-post.action';
 import { wordpressCommon } from './lib/common';
 import { wordpressNewPost } from './lib/trigger/new-post.trigger';
 
@@ -21,7 +21,7 @@ const markdownPropertyDescription = `
 **Enable Basic Authentication:**
 
 1. Download the plugin from: https://github.com/WP-API/Basic-Auth (Click on Code -> Download Zip)
-2. Log in to your Wordpress dashboard.
+2. Log in to your WordPress dashboard.
 3. Go to "Plugins" and click "Add New."
 4. Choose "Upload Plugin" and select the downloaded file.
 5. Install and activate the plugin.
@@ -95,7 +95,7 @@ export const wordpressAuth = PieceAuth.CustomAuth({
 });
 
 export const wordpress = createPiece({
-  displayName: 'Wordpress',
+  displayName: 'WordPress',
   description: 'Open-source website creation software',
 
   minimumSupportedRelease: '0.5.0',
@@ -104,9 +104,9 @@ export const wordpress = createPiece({
   auth: wordpressAuth,
   authors: ["pfernandez98","Salem-Alaa","kishanprmr","MoShizzle","AbdulTheActivePiecer","khaledmashaly","abuaboud"],
   actions: [
-    createWordpressPost,
-    createWordpressPage,
-    getWordpressPost,
+    createWordPressPost,
+    createWordPressPage,
+    getWordPressPost,
     createCustomApiCallAction({
       baseUrl: (auth) =>
         (auth as { website_url: string }).website_url.trim() + '/wp-json/wp/v2',

--- a/packages/pieces/community/wordpress/src/lib/actions/create-page.action.ts
+++ b/packages/pieces/community/wordpress/src/lib/actions/create-page.action.ts
@@ -8,10 +8,10 @@ import {
 } from '@activepieces/pieces-common';
 import { wordpressAuth } from '../..';
 
-export const createWordpressPage = createAction({
+export const createWordPressPage = createAction({
   auth: wordpressAuth,
   name: 'create_page',
-  description: 'Create new page on Wordpress',
+  description: 'Create new page on WordPress',
   displayName: 'Create Page',
   props: {
     title: Property.ShortText({

--- a/packages/pieces/community/wordpress/src/lib/actions/create-post.action.ts
+++ b/packages/pieces/community/wordpress/src/lib/actions/create-post.action.ts
@@ -3,7 +3,7 @@ import {
   PiecePropValueSchema,
   Property,
 } from '@activepieces/pieces-framework';
-import { wordpressCommon, WordpressMedia } from '../common';
+import { wordpressCommon, WordPressMedia } from '../common';
 import {
   httpClient,
   HttpMethod,
@@ -12,10 +12,10 @@ import {
 import FormData from 'form-data';
 import { wordpressAuth } from '../..';
 
-export const createWordpressPost = createAction({
+export const createWordPressPost = createAction({
   auth: wordpressAuth,
   name: 'create_post',
-  description: 'Create new post on Wordpress',
+  description: 'Create new post on WordPress',
   displayName: 'Create Post',
   props: {
     title: Property.ShortText({
@@ -192,7 +192,7 @@ export const createWordpressPost = createAction({
           password: connection.password,
           page: pageCursor,
         };
-        const result: WordpressMedia[] = [];
+        const result: WordPressMedia[] = [];
         let media = await wordpressCommon.getMedia(getMediaParams);
         if (media.totalPages === 0) {
           result.push(...media.media);

--- a/packages/pieces/community/wordpress/src/lib/actions/get-post.action.ts
+++ b/packages/pieces/community/wordpress/src/lib/actions/get-post.action.ts
@@ -3,7 +3,7 @@ import {
   PiecePropValueSchema,
   Property,
 } from '@activepieces/pieces-framework';
-import { wordpressCommon, WordpressMedia } from '../common';
+import { wordpressCommon, WordPressMedia } from '../common';
 import {
   httpClient,
   HttpMethod,
@@ -12,10 +12,10 @@ import {
 import FormData from 'form-data';
 import { wordpressAuth } from '../..';
 
-export const getWordpressPost = createAction({
+export const getWordPressPost = createAction({
   auth: wordpressAuth,
   name: 'get_post',
-  description: 'Get a post from Wordpress',
+  description: 'Get a post from WordPress',
   displayName: 'Get Post Details',
   props: {
     id: Property.Number({

--- a/packages/pieces/community/wordpress/src/lib/common/index.ts
+++ b/packages/pieces/community/wordpress/src/lib/common/index.ts
@@ -6,7 +6,7 @@ import {
   HttpRequest,
 } from '@activepieces/pieces-common';
 import { wordpressAuth } from '../..';
-export type WordpressMedia = { id: string; title: { rendered: string } };
+export type WordPressMedia = { id: string; title: { rendered: string } };
 
 const PAGE_HEADER = 'x-wp-totalpages';
 
@@ -104,7 +104,7 @@ export const wordpressCommon = {
         password: params.password,
       },
     };
-    const response = await httpClient.sendRequest<WordpressMedia[]>(request);
+    const response = await httpClient.sendRequest<WordPressMedia[]>(request);
     return {
       media: response.body,
       totalPages:

--- a/packages/pieces/community/wordpress/src/lib/trigger/new-post.trigger.ts
+++ b/packages/pieces/community/wordpress/src/lib/trigger/new-post.trigger.ts
@@ -170,7 +170,7 @@ const getPosts = async (
   authors: string,
   startDate: number
 ) => {
-  //Wordpress accepts date only if they come after the start of the unix time stamp in 1970
+  //WordPress accepts date only if they come after the start of the unix time stamp in 1970
   let afterDate = dayjs(startDate).toISOString();
   if (startDate === 0) {
     afterDate = dayjs(startDate).add(1, 'day').toISOString();


### PR DESCRIPTION
## What does this PR do?

WordPress is written with a capital P. In some cases, this was done correctly but inconsistently so. This pull tries to fix that. Most annoyingly, the trigger was listed with a lowercase p, and as a long-time WordPress core contributor, this pained me :)

![CleanShot 2024-03-27 at 10 40 59](https://github.com/activepieces/activepieces/assets/487629/284e4dd1-4cf1-468b-901c-fe312334052a)
