### PR TITLE
feat: display error invalid template

### DIFF
--- a/packages/ui/common/src/lib/components/dialogs/import-flow-dialog/import-flow-dialog.component.ts
+++ b/packages/ui/common/src/lib/components/dialogs/import-flow-dialog/import-flow-dialog.component.ts
@@ -71,12 +71,13 @@ export class ImportFlowDialogComponent {
           projectId: this.data.projectId,
         }).pipe(
           switchMap((flow) => this.importFlow(flow.id, template, false)),
-          catchError((err) => {            
+          catchError((err) => {
+            console.error(err);
             this.snackBar.open($localize`The uploaded template is invalid`);
-            this.loading = false;            
+            this.loading = false;
             return of(void 0);
-          })          
-          );
+          })
+        );
       }
       this.cd.markForCheck();
     };

--- a/packages/ui/common/src/lib/components/dialogs/import-flow-dialog/import-flow-dialog.component.ts
+++ b/packages/ui/common/src/lib/components/dialogs/import-flow-dialog/import-flow-dialog.component.ts
@@ -14,6 +14,7 @@ import {
 import { Observable, catchError, map, of, switchMap, tap } from 'rxjs';
 import { FlowService, TelemetryService } from '../../../service';
 import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 type ImportTemplateWithoutExistingFlowData = { projectId: string };
 type ImportFlowToOverwriteFlowData = { flowToOverwriteId: string };
@@ -38,6 +39,7 @@ export class ImportFlowDialogComponent {
     private flowService: FlowService,
     private telemetryService: TelemetryService,
     private router: Router,
+    private snackBar: MatSnackBar,
     @Inject(MAT_DIALOG_DATA)
     public data: ImporFlowDialogData,
     private cd: ChangeDetectorRef
@@ -67,7 +69,14 @@ export class ImportFlowDialogComponent {
         this.importFLow$ = this.createFlow({
           displayName: template.name,
           projectId: this.data.projectId,
-        }).pipe(switchMap((flow) => this.importFlow(flow.id, template, false)));
+        }).pipe(
+          switchMap((flow) => this.importFlow(flow.id, template, false)),
+          catchError((err) => {            
+            this.snackBar.open($localize`The uploaded template is invalid`);
+            this.loading = false;            
+            return of(void 0);
+          })          
+          );
       }
       this.cd.markForCheck();
     };


### PR DESCRIPTION
Fixes #4311 

## Things to Consider 
Initially had written the code below

```
catchError((err: HttpErrorResponse) => {
   const status = err?.status;
   if (status === StatusCodes.BAD_REQUEST) {
     this.snackBar.open($localize`The uploaded template is invalid`);
     this.loading = false;
     }
   return of(void 0);
})
```

However when I tried different json files, sometimes instead of an HTTPErrorResponse, it was giving a TypeError, as shown below:

![image](https://github.com/activepieces/activepieces/assets/29670290/c3f7de3b-ca23-4f91-8745-264aabec0b57)

Hence instead of looking for any particular type of error, I decided to just show the message as long as we get any error. Hope that is ok.

