### PR TITLE
feat(openai): add optional organization ID for better API usage count

### DIFF
--- a/packages/pieces/community/openai/package.json
+++ b/packages/pieces/community/openai/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-openai",
-  "version": "0.3.22"
+  "version": "0.4.0"
 }

--- a/packages/pieces/community/openai/src/index.ts
+++ b/packages/pieces/community/openai/src/index.ts
@@ -7,6 +7,7 @@ import {
 import {
   PieceAuth,
   createPiece,
+  Property,
 } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import { askAssistant } from './lib/actions/ask-assistant';
@@ -27,10 +28,23 @@ Follow these instructions to get your OpenAI API Key:
 It is strongly recommended that you add your credit card information to your OpenAI account and upgrade to the paid plan **before** generating the API Key. This will help you prevent 429 errors.
 `;
 
-export const openaiAuth = PieceAuth.SecretText({
+export type OpenAIAuth = {
+  apiKey: string;
+  organizationId?: string;
+};
+export const openaiAuth = PieceAuth.CustomAuth({
   description: markdownDescription,
-  displayName: 'API Key',
   required: true,
+  props: {
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API Key',
+      required: true,
+    }),
+    organizationId: Property.ShortText({
+      displayName: 'Organization ID',
+      required: false,
+    }),
+  },
   validate: async (auth) => {
     try {
       await httpClient.sendRequest<{
@@ -40,7 +54,10 @@ export const openaiAuth = PieceAuth.SecretText({
         method: HttpMethod.GET,
         authentication: {
           type: AuthenticationType.BEARER_TOKEN,
-          token: auth.auth as string,
+          token: auth.auth.apiKey,
+        },
+        headers: {
+          'OpenAI-Organization': auth.auth.organizationId,
         },
       });
       return {
@@ -49,7 +66,7 @@ export const openaiAuth = PieceAuth.SecretText({
     } catch (e) {
       return {
         valid: false,
-        error: 'Invalid API key',
+        error: 'Invalid API key or organization ID',
       };
     }
   },
@@ -80,6 +97,16 @@ export const openai = createPiece({
       },
     }),
   ],
-  authors: ["aboudzein","astorozhevsky","Willianwg","Nilesh","Salem-Alaa","kishanprmr","MoShizzle","khaledmashaly","abuaboud"],
+  authors: [
+    'aboudzein',
+    'astorozhevsky',
+    'Willianwg',
+    'Nilesh',
+    'Salem-Alaa',
+    'kishanprmr',
+    'MoShizzle',
+    'khaledmashaly',
+    'abuaboud',
+  ],
   triggers: [],
 });

--- a/packages/pieces/community/openai/src/lib/actions/ask-assistant.ts
+++ b/packages/pieces/community/openai/src/lib/actions/ask-assistant.ts
@@ -5,7 +5,7 @@ import {
   Validators,
 } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
-import { openaiAuth } from '../..';
+import { OpenAIAuth, openaiAuth } from '../..';
 import { sleep } from '../common/common';
 
 export const askAssistant = createAction({
@@ -29,7 +29,8 @@ export const askAssistant = createAction({
         }
         try {
           const openai = new OpenAI({
-            apiKey: auth as string,
+            apiKey: (auth as OpenAIAuth).apiKey,
+            organization: (auth as OpenAIAuth).organizationId,
           });
           const assistants = await openai.beta.assistants.list();
 
@@ -65,7 +66,8 @@ export const askAssistant = createAction({
   },
   async run({ auth, propsValue, store }) {
     const openai = new OpenAI({
-      apiKey: auth,
+      apiKey: auth.apiKey,
+      organization: auth.organizationId,
     });
     const { assistant, prompt, memoryKey } = propsValue;
     const runCheckDelay = 1000;

--- a/packages/pieces/community/openai/src/lib/actions/generate-image.ts
+++ b/packages/pieces/community/openai/src/lib/actions/generate-image.ts
@@ -99,7 +99,8 @@ export const generateImage = createAction({
   },
   async run({ auth, propsValue }) {
     const openai = new OpenAI({
-      apiKey: auth,
+      apiKey: auth.apiKey,
+      organization: auth.organizationId,
     });
 
     const { quality, resolution, model, prompt } = propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/send-prompt.ts
+++ b/packages/pieces/community/openai/src/lib/actions/send-prompt.ts
@@ -5,7 +5,7 @@ import {
   Validators,
 } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
-import { openaiAuth } from '../..';
+import { OpenAIAuth, openaiAuth } from '../..';
 import {
   calculateMessagesTokenSize,
   exceedsHistoryLimit,
@@ -36,7 +36,8 @@ export const askOpenAI = createAction({
         }
         try {
           const openai = new OpenAI({
-            apiKey: auth as string,
+            apiKey: (auth as OpenAIAuth).apiKey,
+            organization: (auth as OpenAIAuth).organizationId,
           });
           const response = await openai.models.list();
           // We need to get only LLM models
@@ -119,7 +120,8 @@ export const askOpenAI = createAction({
   },
   async run({ auth, propsValue, store }) {
     const openai = new OpenAI({
-      apiKey: auth,
+      apiKey: auth.apiKey,
+      organization: auth.organizationId,
     });
     const {
       model,

--- a/packages/pieces/community/openai/src/lib/actions/text-to-speech.ts
+++ b/packages/pieces/community/openai/src/lib/actions/text-to-speech.ts
@@ -111,7 +111,8 @@ export const textToSpeech = createAction({
   },
   async run({ auth, propsValue, files }) {
     const openai = new OpenAI({
-      apiKey: auth,
+      apiKey: auth.apiKey,
+      organization: auth.organizationId,
     });
     const { voice, format, model, text, speed } = propsValue;
 

--- a/packages/pieces/community/openai/src/lib/actions/transcriptions.ts
+++ b/packages/pieces/community/openai/src/lib/actions/transcriptions.ts
@@ -48,7 +48,8 @@ export const transcribeAction = createAction({
     form.append('language', language);
 
     const headers = {
-      Authorization: `Bearer ${context.auth}`,
+      Authorization: `Bearer ${context.auth.apiKey}`,
+      'OpenAI-Organization': context.auth.organizationId,
     };
 
     const request: HttpRequest = {

--- a/packages/pieces/community/openai/src/lib/actions/translation.ts
+++ b/packages/pieces/community/openai/src/lib/actions/translation.ts
@@ -32,7 +32,8 @@ export const translateAction = createAction({
     form.append('model', 'whisper-1');
 
     const headers = {
-      Authorization: `Bearer ${context.auth}`,
+      Authorization: `Bearer ${context.auth.apiKey}`,
+      'OpenAI-Organization': context.auth.organizationId,
     };
 
     const request: HttpRequest = {

--- a/packages/pieces/community/openai/src/lib/actions/vision-prompt.ts
+++ b/packages/pieces/community/openai/src/lib/actions/vision-prompt.ts
@@ -95,7 +95,8 @@ export const visionPrompt = createAction({
   },
   async run({ auth, propsValue }) {
     const openai = new OpenAI({
-      apiKey: auth,
+      apiKey: auth.apiKey,
+      organization: auth.organizationId,
     });
     const { temperature, maxTokens, topP, frequencyPenalty, presencePenalty } =
       propsValue;


### PR DESCRIPTION
## What does this PR do?

Add optional `organizationId` param to the connection (breaking change as it changes the connection type to `CustomAuth`) and pass it to OpenAI
