### PR TITLE
fix(google-drive): new file trigger now supports shared drives

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.20"
+  "version": "0.5.21"
 }

--- a/packages/pieces/community/google-drive/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/google-drive/src/lib/triggers/new-file.ts
@@ -15,7 +15,7 @@ import { common } from '../common';
 
 const polling: Polling<
   PiecePropValueSchema<typeof googleDriveAuth>,
-  { parentFolder?: any }
+  { parentFolder?: any; include_team_drives?: boolean }
 > = {
   strategy: DedupeStrategy.TIMEBASED,
   items: async ({ auth, propsValue, lastFetchEpochMS }) => {
@@ -23,6 +23,7 @@ const polling: Polling<
       (await common.getFiles(auth, {
         parent: propsValue.parentFolder,
         createdTime: lastFetchEpochMS,
+        includeTeamDrive: propsValue.include_team_drives,
       })) ?? [];
     const items = currentValues.map((item: any) => ({
       epochMilliSeconds: dayjs(item.createdTime).valueOf(),


### PR DESCRIPTION
## What does this PR do?

The "include team drives" param was not passed to the actual polling function