### PR TITLE
updated path to reflect new directory (backend was renamed to server/api in February)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
                 "**/node_modules/**"
             ],
             "type": "node",
-            "localRoot": "${workspaceFolder}/packages/backend",
+            "localRoot": "${workspaceFolder}/packages/server/api",
             "remoteRoot": "/usr/src/app",
             "restart": true,
             "autoAttachChildProcesses": false


### PR DESCRIPTION
## What does this PR do?

I'm trying to run and debug the codebase locally and I realised that out of the box you cannot use the launch config to attach to the running process. This is due to the directory structure changing in February, and this file wasn't updated

Fixes # (issue)

