### PR TITLE
fix: wasn't able to attach a debugger to the running process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
                 "**/node_modules/**"
             ],
             "type": "node",
-            "localRoot": "${workspaceFolder}/packages/backend",
+            "localRoot": "${workspaceFolder}/packages/server/api",
             "remoteRoot": "/usr/src/app",
             "restart": true,
             "autoAttachChildProcesses": false


### PR DESCRIPTION
## What does this PR do?

It looks like the folder structure was changed in February to rename backend to server/api. This meant that when you try and attach the debugger in vscode it was giving an error (directory not found)

Fixes # (issue)

