### PR TITLE
fix(todoist): wrong authorization header for custom API call

### DIFF
--- a/packages/pieces/community/todoist/package.json
+++ b/packages/pieces/community/todoist/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-todoist",
-  "version": "0.3.5"
+  "version": "0.3.6"
 }

--- a/packages/pieces/community/todoist/src/index.ts
+++ b/packages/pieces/community/todoist/src/index.ts
@@ -1,5 +1,5 @@
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
-import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { OAuth2PropertyValue, PieceAuth, createPiece } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import { todoistCreateTaskAction } from './lib/actions/create-task-action';
 import { todoistTaskCompletedTrigger } from './lib/triggers/task-completed-trigger';
@@ -25,7 +25,7 @@ export const todoist = createPiece({
       baseUrl: () => 'https://api.todoist.com/rest/v2',
       auth: todoistAuth,
       authMapping: (auth) => ({
-        Authorization: `Bearer ${auth}`,
+        Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
       }),
     }),
   ],


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes issue with Todoist piece custom API call not injecting the right authorization header.

Fixes # [(4435)](https://github.com/activepieces/activepieces/issues/4435)

