### PR TITLE
fix: change pulumi project name in package.json

### DIFF
--- a/deploy/pulumi/package.json
+++ b/deploy/pulumi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "activepieces",
+  "name": "pulumi",
   "main": "index.ts",
   "devDependencies": {
     "@types/node": "^18"


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR resolves the issue where the activepieces project was incorrectly defined in multiple locations within our repository. Specifically, in the root path and under deploy/pulumi. This caused build failures due to non-unique naming conflicts detected by our build tools.

## Changes Made
* Changed the project name in `deploy/pulumi/package.json` to have a unique identifier.

## Log Summary
* API & GUI:
```
[API]
[API]  NX   The following projects are defined in multiple locations:
[API]
[API] - activepieces:
[API]   - .
[API]   - deploy/pulumi
[API]
[API] To fix this, set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name.
[API]
[API] Because of the error the Nx daemon process has exited. The next Nx command is going to restart the daemon process.
[API] If the error persists, please run "nx reset".
[API]
[GUI]
[GUI]  NX   The following projects are defined in multiple locations:
[GUI]
[GUI] - activepieces:
[GUI]   - .
[GUI]   - deploy/pulumi
[GUI]
[GUI] To fix this, set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name.
[GUI]
[GUI] Because of the error the Nx daemon process has exited. The next Nx command is going to restart the daemon process.
[GUI] If the error persists, please run "nx reset".
[GUI]
[GUI] Because of the error the Nx daemon process has exited. The next Nx command is going to restart the daemon process.
[GUI] If the error persists, please run "nx reset".
[GUI]
```
* PCS:
```
[PCS]  NX   The following projects are defined in multiple locations:
[PCS]
[PCS] - activepieces:
[PCS]   - .
[PCS]   - deploy/pulumi
[PCS]
[PCS] To fix this, set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name.
[PCS]
[PCS] Because of the error the Nx daemon process has exited. The next Nx command is going to restart the daemon process.
[PCS] If the error persists, please run "nx reset".
```