### PR TITLE
fix: triggering saving in read-only mode

### DIFF
--- a/packages/ui/feature-builder-form-controls/src/lib/components/new-piece-properties-form/properties-controls-helper.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/components/new-piece-properties-form/properties-controls-helper.ts
@@ -27,9 +27,7 @@ export const createFormControlsWithTheirValidators = (
   //Angular forms get enabled after adding controls automatically: https://github.com/angular/angular/issues/23236
   const isFormDisabled = form.disabled;
   removeAllFormControls(form);
-
   Object.entries(propertiesMap).forEach(([propertyName, property]) => {
-    1;
     if (propertiesMap[propertyName].type === PropertyType.MARKDOWN) {
       return;
     }
@@ -39,10 +37,8 @@ export const createFormControlsWithTheirValidators = (
       customizedInputs,
       propertyName
     );
-
     const ctrl = createControl(fb, property, value, validators);
-
-    form.addControl(propertyName, ctrl);
+    form.addControl(propertyName, ctrl, { emitEvent: false });
   });
   if (isFormDisabled) {
     form.disable({ emitEvent: false });

--- a/packages/ui/feature-builder-store/src/lib/store/flow/flow.effects.ts
+++ b/packages/ui/feature-builder-store/src/lib/store/flow/flow.effects.ts
@@ -284,8 +284,16 @@ export class FlowsEffects {
       ofType(...SingleFlowModifyingState),
       concatLatestFrom(() => [
         this.store.select(BuilderSelectors.selectCurrentFlow),
+        this.store.select(BuilderSelectors.selectReadOnly),
       ]),
-      concatMap(([action, flow]) => {
+      concatMap(([action, flow, isReadonly]) => {
+        if (isReadonly) {
+          console.error(
+            'Activepieces: Trying to modify a readonly flow',
+            action
+          );
+          return EMPTY;
+        }
         const genSavedId = UUID.UUID();
         let flowOperation: FlowOperationRequest;
         switch (action.type) {


### PR DESCRIPTION
## What does this PR do?

Stop triggering saving when adding new form controls and prevent saving in read-only mode.
