### PR TITLE
chore: remove unique email and platform null constraints

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1713221809186-RemoveUniqueEmailOnUser.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1713221809186-RemoveUniqueEmailOnUser.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class RemoveUniqueEmailOnUser1713221809186 implements MigrationInterface {
+    name = 'RemoveUniqueEmailOnUser1713221809186'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX "public"."idx_user_partial_unique_email_platform_id_is_null"
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_partial_unique_email_platform_id_is_null" ON "user" ("email")
+            WHERE ("platformId" IS NULL)
+        `)
+    }
+
+}

--- a/packages/server/api/src/app/database/migration/sqlite/1713222892743-RemoveUniqueEmailOnUser.ts
+++ b/packages/server/api/src/app/database/migration/sqlite/1713222892743-RemoveUniqueEmailOnUser.ts
@@ -1,0 +1,569 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class RemoveUniqueEmailOnUser1713222892743 implements MigrationInterface {
+    name = 'RemoveUniqueEmailOnUser1713222892743'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX "idx_flow_version_flow_id"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "temporary_flow_version" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "flowId" varchar(21) NOT NULL,
+                "displayName" varchar NOT NULL,
+                "trigger" text,
+                "updatedBy" varchar,
+                "valid" boolean NOT NULL,
+                "state" varchar NOT NULL,
+                CONSTRAINT "fk_flow_version_flow" FOREIGN KEY ("flowId") REFERENCES "flow" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "temporary_flow_version"(
+                    "id",
+                    "created",
+                    "updated",
+                    "flowId",
+                    "displayName",
+                    "trigger",
+                    "updatedBy",
+                    "valid",
+                    "state"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "flowId",
+                "displayName",
+                "trigger",
+                "updatedBy",
+                "valid",
+                "state"
+            FROM "flow_version"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "flow_version"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "temporary_flow_version"
+                RENAME TO "flow_version"
+        `)
+        await queryRunner.query(`
+            CREATE INDEX "idx_flow_version_flow_id" ON "flow_version" ("flowId")
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_user_partial_unique_email_platform_id_is_null"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_user_platform_id_email"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_user_platform_id_external_id"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "temporary_user" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "email" varchar NOT NULL,
+                "firstName" varchar NOT NULL,
+                "lastName" varchar NOT NULL,
+                "password" varchar NOT NULL,
+                "status" varchar NOT NULL,
+                "trackEvents" boolean,
+                "newsLetter" boolean,
+                "imageUrl" varchar,
+                "title" varchar,
+                "externalId" varchar,
+                "platformId" varchar,
+                "verified" boolean NOT NULL
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "temporary_user"(
+                    "id",
+                    "created",
+                    "updated",
+                    "email",
+                    "firstName",
+                    "lastName",
+                    "password",
+                    "status",
+                    "trackEvents",
+                    "newsLetter",
+                    "imageUrl",
+                    "title",
+                    "externalId",
+                    "platformId",
+                    "verified"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "email",
+                "firstName",
+                "lastName",
+                "password",
+                "status",
+                "trackEvents",
+                "newsLetter",
+                "imageUrl",
+                "title",
+                "externalId",
+                "platformId",
+                "verified"
+            FROM "user"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "user"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "temporary_user"
+                RENAME TO "user"
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_platform_id_email" ON "user" ("platformId", "email")
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_platform_id_external_id" ON "user" ("platformId", "externalId")
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_user_platform_id_email"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_user_platform_id_external_id"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "temporary_user" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "email" varchar NOT NULL,
+                "firstName" varchar NOT NULL,
+                "lastName" varchar NOT NULL,
+                "password" varchar NOT NULL,
+                "status" varchar NOT NULL,
+                "trackEvents" boolean,
+                "newsLetter" boolean,
+                "imageUrl" varchar,
+                "title" varchar,
+                "externalId" varchar,
+                "platformId" varchar,
+                "verified" boolean NOT NULL
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "temporary_user"(
+                    "id",
+                    "created",
+                    "updated",
+                    "email",
+                    "firstName",
+                    "lastName",
+                    "password",
+                    "status",
+                    "trackEvents",
+                    "newsLetter",
+                    "imageUrl",
+                    "title",
+                    "externalId",
+                    "platformId",
+                    "verified"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "email",
+                "firstName",
+                "lastName",
+                "password",
+                "status",
+                "trackEvents",
+                "newsLetter",
+                "imageUrl",
+                "title",
+                "externalId",
+                "platformId",
+                "verified"
+            FROM "user"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "user"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "temporary_user"
+                RENAME TO "user"
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_platform_id_external_id" ON "user" ("platformId", "externalId")
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_platform_id_email" ON "user" ("platformId", "email")
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_flow_version_flow_id"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "temporary_flow_version" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "flowId" varchar(21) NOT NULL,
+                "displayName" varchar NOT NULL,
+                "trigger" text,
+                "updatedBy" varchar,
+                "valid" boolean NOT NULL,
+                "state" varchar NOT NULL,
+                CONSTRAINT "fk_flow_version_flow" FOREIGN KEY ("flowId") REFERENCES "flow" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+                CONSTRAINT "fk_updated_by_user_flow" FOREIGN KEY ("updatedBy") REFERENCES "user" ("id") ON DELETE
+                SET NULL ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "temporary_flow_version"(
+                    "id",
+                    "created",
+                    "updated",
+                    "flowId",
+                    "displayName",
+                    "trigger",
+                    "updatedBy",
+                    "valid",
+                    "state"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "flowId",
+                "displayName",
+                "trigger",
+                "updatedBy",
+                "valid",
+                "state"
+            FROM "flow_version"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "flow_version"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "temporary_flow_version"
+                RENAME TO "flow_version"
+        `)
+        await queryRunner.query(`
+            CREATE INDEX "idx_flow_version_flow_id" ON "flow_version" ("flowId")
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "temporary_tag" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "platformId" varchar NOT NULL,
+                "name" varchar NOT NULL,
+                CONSTRAINT "UQ_0aaf8e30187e0b89ebc9c4764ba" UNIQUE ("platformId", "name"),
+                CONSTRAINT "FK_9dec09e187398715b7f1e32a6cb" FOREIGN KEY ("platformId") REFERENCES "platform" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "temporary_tag"("id", "created", "updated", "platformId", "name")
+            SELECT "id",
+                "created",
+                "updated",
+                "platformId",
+                "name"
+            FROM "tag"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "tag"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "temporary_tag"
+                RENAME TO "tag"
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "tag"
+                RENAME TO "temporary_tag"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "tag" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "platformId" varchar NOT NULL,
+                "name" varchar NOT NULL,
+                CONSTRAINT "UQ_0aaf8e30187e0b89ebc9c4764ba" UNIQUE ("platformId", "name")
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "tag"("id", "created", "updated", "platformId", "name")
+            SELECT "id",
+                "created",
+                "updated",
+                "platformId",
+                "name"
+            FROM "temporary_tag"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "temporary_tag"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_flow_version_flow_id"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "flow_version"
+                RENAME TO "temporary_flow_version"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "flow_version" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "flowId" varchar(21) NOT NULL,
+                "displayName" varchar NOT NULL,
+                "trigger" text,
+                "updatedBy" varchar,
+                "valid" boolean NOT NULL,
+                "state" varchar NOT NULL,
+                CONSTRAINT "fk_flow_version_flow" FOREIGN KEY ("flowId") REFERENCES "flow" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "flow_version"(
+                    "id",
+                    "created",
+                    "updated",
+                    "flowId",
+                    "displayName",
+                    "trigger",
+                    "updatedBy",
+                    "valid",
+                    "state"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "flowId",
+                "displayName",
+                "trigger",
+                "updatedBy",
+                "valid",
+                "state"
+            FROM "temporary_flow_version"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "temporary_flow_version"
+        `)
+        await queryRunner.query(`
+            CREATE INDEX "idx_flow_version_flow_id" ON "flow_version" ("flowId")
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_user_platform_id_email"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_user_platform_id_external_id"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "user"
+                RENAME TO "temporary_user"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "user" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "email" varchar NOT NULL,
+                "firstName" varchar NOT NULL,
+                "lastName" varchar NOT NULL,
+                "password" varchar NOT NULL,
+                "status" varchar NOT NULL,
+                "trackEvents" boolean,
+                "newsLetter" boolean,
+                "imageUrl" varchar,
+                "title" varchar,
+                "externalId" varchar,
+                "platformId" varchar,
+                "verified" boolean NOT NULL,
+                CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22" UNIQUE ("email")
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "user"(
+                    "id",
+                    "created",
+                    "updated",
+                    "email",
+                    "firstName",
+                    "lastName",
+                    "password",
+                    "status",
+                    "trackEvents",
+                    "newsLetter",
+                    "imageUrl",
+                    "title",
+                    "externalId",
+                    "platformId",
+                    "verified"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "email",
+                "firstName",
+                "lastName",
+                "password",
+                "status",
+                "trackEvents",
+                "newsLetter",
+                "imageUrl",
+                "title",
+                "externalId",
+                "platformId",
+                "verified"
+            FROM "temporary_user"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "temporary_user"
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_platform_id_external_id" ON "user" ("platformId", "externalId")
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_platform_id_email" ON "user" ("platformId", "email")
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_user_platform_id_external_id"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_user_platform_id_email"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "user"
+                RENAME TO "temporary_user"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "user" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "email" varchar NOT NULL,
+                "firstName" varchar NOT NULL,
+                "lastName" varchar NOT NULL,
+                "password" varchar NOT NULL,
+                "status" varchar NOT NULL,
+                "trackEvents" boolean,
+                "newsLetter" boolean,
+                "imageUrl" varchar,
+                "title" varchar,
+                "externalId" varchar,
+                "platformId" varchar,
+                "verified" boolean NOT NULL,
+                CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22" UNIQUE ("email")
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "user"(
+                    "id",
+                    "created",
+                    "updated",
+                    "email",
+                    "firstName",
+                    "lastName",
+                    "password",
+                    "status",
+                    "trackEvents",
+                    "newsLetter",
+                    "imageUrl",
+                    "title",
+                    "externalId",
+                    "platformId",
+                    "verified"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "email",
+                "firstName",
+                "lastName",
+                "password",
+                "status",
+                "trackEvents",
+                "newsLetter",
+                "imageUrl",
+                "title",
+                "externalId",
+                "platformId",
+                "verified"
+            FROM "temporary_user"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "temporary_user"
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_platform_id_external_id" ON "user" ("platformId", "externalId")
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_platform_id_email" ON "user" ("platformId", "email")
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_user_partial_unique_email_platform_id_is_null" ON "user" ("email")
+            WHERE "platformId" IS NULL
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_flow_version_flow_id"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "flow_version"
+                RENAME TO "temporary_flow_version"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "flow_version" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "flowId" varchar(21) NOT NULL,
+                "displayName" varchar NOT NULL,
+                "trigger" text,
+                "updatedBy" varchar,
+                "valid" boolean NOT NULL,
+                "state" varchar NOT NULL,
+                CONSTRAINT "fk_flow_version_flow" FOREIGN KEY ("flowId") REFERENCES "flow" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+                CONSTRAINT "fk_updated_by_user_flow" FOREIGN KEY ("updatedBy") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "flow_version"(
+                    "id",
+                    "created",
+                    "updated",
+                    "flowId",
+                    "displayName",
+                    "trigger",
+                    "updatedBy",
+                    "valid",
+                    "state"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "flowId",
+                "displayName",
+                "trigger",
+                "updatedBy",
+                "valid",
+                "state"
+            FROM "temporary_flow_version"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "temporary_flow_version"
+        `)
+        await queryRunner.query(`
+            CREATE INDEX "idx_flow_version_flow_id" ON "flow_version" ("flowId")
+        `)
+    }
+
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -125,6 +125,7 @@ import { MigrateInputUiInfo1711411372480 } from './migration/postgres/1711411372
 import { AddProjectUsageColumnToPiece1711768296861 } from './migration/postgres/1711768296861-AddProjectUsageColumnToPiece'
 import { AddPieceTags1712107871405 } from './migration/postgres/1712107871405-AddPieceTags'
 import { PiecesProjectLimits1712279318440 } from './migration/postgres/1712279318440-PiecesProjectLimits'
+import { RemoveUniqueEmailOnUser1713221809186 } from './migration/postgres/1713221809186-RemoveUniqueEmailOnUser'
 import { system, SystemProp } from '@activepieces/server-shared'
 import { ApEdition, ApEnvironment, isNil } from '@activepieces/shared'
 
@@ -206,6 +207,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
         MigrateInputUiInfo1711411372480,
         AddProjectUsageColumnToPiece1711768296861,
         AddPieceTags1712107871405,
+        RemoveUniqueEmailOnUser1713221809186,
     ]
 
     const edition = getEdition()

--- a/packages/server/api/src/app/database/sqlite-connection.ts
+++ b/packages/server/api/src/app/database/sqlite-connection.ts
@@ -38,6 +38,7 @@ import { AddDeletedToProjectSqlite1710248182409 } from './migration/sqlite/17102
 import { AddMissingInputUiInfoSqlite1711412511624 } from './migration/sqlite/1711412511624-AddMissingInputUiInfoSqlite'
 import { AddProjectUsageColumnToPieceSqlite1711768479150 } from './migration/sqlite/1711768479150-AddProjectUsageColumnToPieceSqlite'
 import { AddTagsToPiecesSqlite1712180673961 } from './migration/sqlite/1712180673961-AddTagsToPiecesSqlite'
+import { RemoveUniqueEmailOnUser1713222892743 } from './migration/sqlite/1713222892743-RemoveUniqueEmailOnUser'
 import { system, SystemProp } from '@activepieces/server-shared'
 import { ApEdition, ApEnvironment } from '@activepieces/shared'
 
@@ -98,6 +99,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
         AddMissingInputUiInfoSqlite1711412511624,
         AddProjectUsageColumnToPieceSqlite1711768479150,
         AddTagsToPiecesSqlite1712180673961,
+        RemoveUniqueEmailOnUser1713222892743,
     ]
     const edition = getEdition()
     if (edition !== ApEdition.COMMUNITY) {

--- a/packages/server/api/src/app/user/user-entity.ts
+++ b/packages/server/api/src/app/user/user-entity.ts
@@ -64,10 +64,6 @@ export const UserEntity = new EntitySchema<UserSchema>({
             columns: ['platformId', 'externalId'],
             unique: true,
         },
-        {
-            name: 'idx_user_partial_unique_email_platform_id_is_null',
-            synchronize: false,
-        },
     ],
     relations: {
         projects: {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR removes the platform Id is null and email is unique constraints. This change should fix the TypeORM migration for all SQLite3 migrations. Now, it will show no changes after migration instead of an infinite number of migrations.