### PR TITLE
fix(google-drive): exclude folders from file polling

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.23"
+  "version": "0.5.24"
 }

--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.22"
+  "version": "0.5.23"
 }

--- a/packages/pieces/community/google-drive/src/lib/common/index.ts
+++ b/packages/pieces/community/google-drive/src/lib/common/index.ts
@@ -102,12 +102,12 @@ export const common = {
       );
     q.push(`trashed = false`);
     const response = await drive.files.list({
-      q: q.join(' and '),
+      q: q.concat("mimeType!='application/vnd.google-apps.folder'").join(' and '),
       fields: 'files(id, name, mimeType, webViewLink, kind)',
       orderBy: order ?? 'createdTime asc',
       supportsAllDrives: true,
       includeItemsFromAllDrives: search?.includeTeamDrive,
-    });
+    });    
 
     return response.data.files;
   },


### PR DESCRIPTION
## What does this PR do?
Filters folders from being polled in Google drive trigger new file action with get file content enabled.