### PR TITLE
feat(slack): add optional filename param when uploading a file

### DIFF
--- a/packages/pieces/community/slack/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/slack/src/lib/actions/upload-file.ts
@@ -21,16 +21,22 @@ export const uploadFile = createAction({
       displayName: 'Title',
       required: false,
     }),
+    filename: Property.ShortText({
+      displayName: 'Filename',
+      required: false,
+    }),
   },
   async run(context) {
     const token = context.auth.access_token;
-    const { file, title } = context.propsValue;
+    const { file, title, filename } = context.propsValue;
     const formData = new FormData();
     formData.append('file', new Blob([file.data]));
     if (title !== undefined) {
       formData.append('title', title);
     }
-
+    if (filename !== undefined) {
+      formData.append('filename', filename);
+    }
     const request: HttpRequest = {
       url: `https://slack.com/api/files.upload`,
       method: HttpMethod.POST,


### PR DESCRIPTION
## What does this PR do?

Add optional `filename` param when uploading a file via the dedicated action - to avoid image URLs ending with `/blob` thus allowing proper image previews when sharing the URL in a message as a separate action
