### PR TITLE
fix: UX for reordering array

### DIFF
--- a/packages/ui/core/src/assets/scss/ng-material-override.scss
+++ b/packages/ui/core/src/assets/scss/ng-material-override.scss
@@ -764,3 +764,12 @@ app-templates-dialog
 .connections-dropdown-container {
   max-height: var(--mat-form-field-container-text-line-height)
 }
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1) ;
+}
+.cdk-drop-list-dragging :not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+.drag-list:active{
+  cursor: grabbing !important;
+}

--- a/packages/ui/feature-builder-form-controls/src/lib/components/array-form-control/array-form-control-text-item.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/components/array-form-control/array-form-control-text-item.component.ts
@@ -1,57 +1,86 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  Renderer2,
+} from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'app-array-form-control-text-item',
   template: `
-    <div class="ap-flex ap-gap-1 ap-justify-between ap-items-center" cdkDrag>
-      <mat-icon matTooltip="Drag to move" cdkDragHandle
-        >drag_indicator</mat-icon
-      >
-      <div class="ap-flex-grow" #interpolatingTextControlContainer>
-        <mat-form-field
-          apTrackHover
-          #valueInput="hoverTrackerDirective"
-          class="ap-w-[100%]"
-          [subscriptSizing]="'dynamic'"
-        >
-          <mat-label>Item {{ idx + 1 }}</mat-label>
-          <app-interpolating-text-form-control
-            #textControl
-            [stepMetaDataForMentions]="[]"
-            [insideMatField]="false"
-            [formControl]="formControl"
-            (click)="
-              formControl.enabled ? handler.showMentionsDropdown() : null
-            "
-          ></app-interpolating-text-form-control>
-          <app-builder-autocomplete-dropdown-handler
-            #handler
-            [container]="interpolatingTextControlContainer"
-            (mentionEmitted)="textControl.addMention($event)"
-          >
-          </app-builder-autocomplete-dropdown-handler>
-        </mat-form-field>
-      </div>
+    <div [class.ap-opacity-0]="dragging">
       <div
-        class="ap-flex ap-items-center ap-pl-2"
-        (click)="removeValue.emit(idx)"
+        class="ap-flex ap-gap-1 ap-justify-between ap-items-center"
+        cdkDrag
+        cdkDragBoundary=".drag-list"
+        (cdkDragStarted)="grabbingStarted()"
+        (cdkDragEnded)="grabbingEnded()"
       >
-        <svg-icon
-          src="assets/img/custom/close.svg"
-          class="ap-w-[15px] ap-h-[15px] ap-cursor-pointer"
-          [applyClass]="true"
-          [matTooltip]="removeItemTooltip"
+        <mat-icon
+          [matTooltip]="hideTooltip ? '' : dragTooltip"
+          class="ap-cursor-grab"
+          cdkDragHandle
+          >drag_indicator</mat-icon
         >
-        </svg-icon>
+        <div class="ap-flex-grow" #interpolatingTextControlContainer>
+          <mat-form-field
+            apTrackHover
+            #valueInput="hoverTrackerDirective"
+            class="ap-w-[100%]"
+            [subscriptSizing]="'dynamic'"
+          >
+            <mat-label>Item {{ idx + 1 }}</mat-label>
+            <app-interpolating-text-form-control
+              #textControl
+              [stepMetaDataForMentions]="[]"
+              [insideMatField]="false"
+              [formControl]="control"
+              (click)="control.enabled ? handler.showMentionsDropdown() : null"
+            ></app-interpolating-text-form-control>
+            <app-builder-autocomplete-dropdown-handler
+              #handler
+              [container]="interpolatingTextControlContainer"
+              (mentionEmitted)="textControl.addMention($event)"
+            >
+            </app-builder-autocomplete-dropdown-handler>
+          </mat-form-field>
+        </div>
+        <div
+          class="ap-flex ap-items-center ap-justify-center ap-h-[30px] ap-w-[30px] ap-cursor-pointer "
+          [matTooltip]="hideTooltip ? '' : removeItemTooltip"
+          (click)="removeValue.emit(idx)"
+        >
+          <svg-icon
+            src="assets/img/custom/close.svg"
+            class="ap-w-[15px] ap-h-[15px] "
+            [applyClass]="true"
+          >
+          </svg-icon>
+        </div>
       </div>
     </div>
   `,
 })
 export class ArrayFormControlTextItemComponent {
   removeItemTooltip = $localize`Remove item`;
-
+  dragTooltip = $localize`Drag to reorder`;
+  dragging = false;
   @Input({ required: true }) idx: number;
-  @Input({ required: true }) formControl: FormControl;
+  @Input({ required: true }) control: FormControl;
+  @Input({ required: true }) hideTooltip = false;
   @Output() removeValue = new EventEmitter<number>();
+  @Output() itemDragStateChanged = new EventEmitter<boolean>();
+  constructor(private renderer: Renderer2) {}
+  grabbingStarted() {
+    this.renderer.addClass(document.body, 'dragging');
+    this.dragging = true;
+    this.itemDragStateChanged.emit(true);
+  }
+  grabbingEnded() {
+    this.renderer.removeClass(document.body, 'dragging');
+    this.dragging = false;
+    this.itemDragStateChanged.emit(false);
+  }
 }

--- a/packages/ui/feature-builder-form-controls/src/lib/components/array-form-control/array-form-control.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/components/array-form-control/array-form-control.component.html
@@ -5,23 +5,25 @@
     </div>
     <ng-container *ngTemplateOutlet="dynamicInputTemplate"></ng-container>
   </div>
-  <div cdkDropList [cdkDropListData]="formArray.controls" (cdkDropListDropped)="drop($event)">
+  <div cdkDropList [cdkDropListData]="formArray.controls" (cdkDropListDropped)="drop($event)" class="drag-list" > 
     @for (objectControl of formArray.controls; track objectControl; let idx =
     $index; let isFirst = $first; let isLast = $last) {
-    <div class="ap-mb-4">
-      <app-array-form-control-text-item [class.ap-mb-4]="!isLast" [idx]="idx" [formControl]="getFormControlAtIndex(idx)"
+    <div class="ap-mb-4" >
+      <app-array-form-control-text-item [class.ap-mb-4]="!isLast" [idx]="idx" [control]="formArray.controls[idx] | abstractFormControlCaster"
+        [hideTooltip]="isAnItemBeingDragged" (itemDragStateChanged)="isAnItemBeingDragged = $event"
         (removeValue)="remove($event)"></app-array-form-control-text-item>
     </div>
     } @empty {
     <div class="ap-border-dashed ap-border-2 ap-border-gray-500 ap-rounded ap-p-3 ap-text-center">
       The list is empty
     </div>
-    } @if (formArray.enabled) {
+    } 
+  </div>
+  @if (formArray.enabled) {
     <ap-button btnColor="primary" btnStyle="basic" (buttonClicked)="addValue()" type="button" btnSize="medium">
       + Add Item
     </ap-button>
     }
-  </div>
   <div class="ap-flex-grow" #spacer></div>
 </div>
 @if (updateValueOnChange$ | async) {}

--- a/packages/ui/feature-builder-form-controls/src/lib/components/array-form-control/array-form-control.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/components/array-form-control/array-form-control.component.ts
@@ -57,8 +57,7 @@ export class ArrayFormControlComponent
   @Input({ required: true }) webhookPrefix: string;
   @Input({ required: true }) formPieceTriggerPrefix: string;
   @Input({ required: true }) input: Record<string, any> = {};
-
-  removeItemTooltip = $localize`Remove item`;
+  isAnItemBeingDragged = false;
   updateValueOnChange$: Observable<void> = new Observable<void>();
   createForm(propertiesValues: Record<string, unknown> | string) {
     const properties = this.property.properties;
@@ -169,10 +168,6 @@ export class ArrayFormControlComponent
     this.firstInput.focusEditor();
   }
 
-  getFormControlAtIndex(index: number): FormControl {
-    const control = this.formArray.controls[index];
-    return control as any;
-  }
   getFormControlGroupAtIndex(c: any): FormControl {
     return c as any;
   }

--- a/packages/ui/feature-builder-form-controls/src/lib/components/dictionary-form-control/dictionary-form-control.component.html
+++ b/packages/ui/feature-builder-form-controls/src/lib/components/dictionary-form-control/dictionary-form-control.component.html
@@ -21,29 +21,34 @@
       *ngIf="!(isLast && disabled && idx > 0)"
       [formGroup]="getPair(idx)"
     >
-      <div class="delete-btn-container">
-        <ap-icon-button
-          [width]="9"
-          [height]="9"
-          iconFilename="delete.svg"
-          *ngIf="pairs.enabled"
-          [tooltipText]="
+      <div class="delete-btn-container" >
+        <div
+          class="ap-flex ap-items-center ap-justify-center ap-h-[30px] ap-w-[30px] ap-cursor-pointer delete-btn ap-z-40 ap-transition "
+          apTrackHover
+          #deleteButton="hoverTrackerDirective"
+          [matTooltip]="
             !deleteButton.isHovered &&
             !keyInput.isHovered &&
             !valueInput.isHovered
               ? ''
-              : 'Remove Item'
+              : removeItemTooltip
           "
-          class="delete-btn ap-z-40"
-          [class.opacity-0]="
-            !deleteButton.isHovered &&
-            !keyInput.isHovered &&
-            !valueInput.isHovered
-          "
-          apTrackHover
-          #deleteButton="hoverTrackerDirective"
+           [class.opacity-0]="
+           !deleteButton.isHovered &&
+           !keyInput.isHovered &&
+           !valueInput.isHovered
+         "
           (click)="removePair(idx)"
-        ></ap-icon-button>
+        >
+          <svg-icon
+            src="assets/img/custom/close.svg"
+            class="ap-w-[15px] ap-h-[15px] "
+            [applyClass]="true"
+          >
+          </svg-icon>
+        </div>
+
+   
       </div>
 
       <input

--- a/packages/ui/feature-builder-form-controls/src/lib/components/dictionary-form-control/dictionary-form-control.component.scss
+++ b/packages/ui/feature-builder-form-controls/src/lib/components/dictionary-form-control/dictionary-form-control.component.scss
@@ -70,7 +70,7 @@
 
   .delete-btn {
     position: absolute;
-    left: -30px;
+    left: -25px;
     height: 100%;
     display: flex;
     align-items: center;

--- a/packages/ui/feature-builder-form-controls/src/lib/components/dictionary-form-control/dictionary-form-control.component.ts
+++ b/packages/ui/feature-builder-form-controls/src/lib/components/dictionary-form-control/dictionary-form-control.component.ts
@@ -29,6 +29,7 @@ export class DictionaryFormControlComponent
   extends ControlThatUsesMentionsCoreComponent
   implements ControlValueAccessor, OnInit
 {
+  removeItemTooltip = $localize`Remove item`;
   @Input() propertyDisplayName = '';
   form!: UntypedFormGroup;
   disabled = false;
@@ -96,6 +97,10 @@ export class DictionaryFormControlComponent
   removePair(indexOfPair: number) {
     if (this.pairs.length > 1) {
       this.pairs.removeAt(indexOfPair);
+      this.onChange(this.formatControlValue());
+    } else {
+      this.pairs.at(indexOfPair).get('key')?.setValue('');
+      this.pairs.at(indexOfPair).get('value')?.setValue('');
       this.onChange(this.formatControlValue());
     }
   }


### PR DESCRIPTION
Fixes 

1) Dragging an element didn't hide it in the list which made things confusing. 
2) Dragging an element didn't change the cursor to grabbing.
3) Dragging an element didn't have a limit, you could drag it anywhere which could make people think they can swap between arrays and that's not the case.
4) The remove item icon had to be clicked itself exactly without any extra space around it, so there is space added now around it a bit so you don't have to exactly click the icon.
5) Dragging wasn't animated.
6) Tooltips were not internationalised, please make sure that's the case always.
7) Remove icon wasn't changed for dictionary. 
8) Angular don't like to have passed input params to a component called "formControl", so name it something like "control" if you ever need to pass a formControl as an input. 