### PR TITLE
chore(metabase): rename session token key in store

### DIFF
--- a/packages/pieces/community/metabase/src/lib/common.ts
+++ b/packages/pieces/community/metabase/src/lib/common.ts
@@ -22,7 +22,7 @@ type EncryptedObject = {
 
 const algorithm = 'aes-256-cbc';
 const ivLength = 16;
-const SESSION_TOKEN_KEY = '_session_token';
+const SESSION_TOKEN_KEY = 'metabase:_session_token';
 
 function encryptString(inputString: string, key: string): EncryptedObject {
   const iv = crypto.randomBytes(ivLength); // Generate a random initialization vector


### PR DESCRIPTION
## What does this PR do?

Rename key under which the Metabase session token is stored to make it explicit that it "belongs" to the Metabase piece
