### PR TITLE
feat(slack): add reaction to message action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@sendgrid/mail": "8.0.0",
         "@sentry/node": "7.64.0",
         "@sinclair/typebox": "0.26.8",
+        "@slack/web-api": "7.0.4",
         "@supabase/supabase-js": "2.33.1",
         "@types/imapflow": "1.0.18",
         "@types/showdown": "2.0.6",
@@ -11497,6 +11498,66 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "dependencies": {
+        "@types/node": ">=18.0.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.11.0.tgz",
+      "integrity": "sha512-UlIrDWvuLaDly3QZhCPnwUSI/KYmV1N9LyhuH6EDKCRS1HWZhyTG3Ja46T3D0rYfqdltKYFXbJSSRPwZpwO0cQ==",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.0.4.tgz",
+      "integrity": "sha512-21tbte7N8itwjG7nsiQbDmXP9T/oqEILuvyL2UtgaZxfSY4a1JWWsLGL5n/hcgS2WE2oxmEHsBuhuRkZDwDovw==",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.6.5",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@slack/web-api/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@smithy/abort-controller": {
@@ -27220,6 +27281,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@sendgrid/mail": "8.0.0",
     "@sentry/node": "7.64.0",
     "@sinclair/typebox": "0.26.8",
+    "@slack/web-api": "7.0.4",
     "@supabase/supabase-js": "2.33.1",
     "@types/imapflow": "1.0.18",
     "@types/showdown": "2.0.6",

--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.5.7"
+  "version": "0.5.8"
 }

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -1,9 +1,5 @@
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
-import {
-  OAuth2PropertyValue,
-  PieceAuth,
-  createPiece,
-} from '@activepieces/pieces-framework';
+import { OAuth2PropertyValue, PieceAuth, createPiece } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import crypto from 'node:crypto';
 import { requestActionDirectMessageAction } from './lib/actions/request-action-direct-message';
@@ -21,107 +17,109 @@ import { findUserByEmailAction } from './lib/actions/find-user-by-email';
 import { updateProfileAction } from './lib/actions/update-profile';
 import { createChannelAction } from './lib/actions/create-channel';
 import { newChannelTrigger } from './lib/triggers/new-channel';
+import { addRectionToMessageAction } from './lib/actions/add-reaction-to-message';
 
 export const slackAuth = PieceAuth.OAuth2({
-  description: '',
-  authUrl:
-    'https://slack.com/oauth/v2/authorize?user_scope=search:read,users.profile:write',
-  tokenUrl: 'https://slack.com/api/oauth.v2.access',
-  required: true,
-  scope: [
-    'channels:read',
-    'channels:manage',
-    'channels:history',
-    'chat:write',
-    'groups:read',
-    'groups:write',
-    'reactions:read',
-    'mpim:read',
-    'mpim:write',
-    'im:write',
-    'users:read',
-    'files:write',
-    'files:read',
-    'users:read.email',
-  ],
+	description: '',
+	authUrl: 'https://slack.com/oauth/v2/authorize?user_scope=search:read,users.profile:write',
+	tokenUrl: 'https://slack.com/api/oauth.v2.access',
+	required: true,
+	scope: [
+		'channels:read',
+		'channels:manage',
+		'channels:history',
+		'chat:write',
+		'groups:read',
+		'groups:write',
+		'reactions:read',
+		'mpim:read',
+		'mpim:write',
+		'im:write',
+		'users:read',
+		'files:write',
+		'files:read',
+		'users:read.email',
+		'reactions:write',
+	],
 });
 
 export const slack = createPiece({
-  displayName: 'Slack',
-  description: 'Channel-based messaging platform',
-  minimumSupportedRelease: '0.20.0',
-  logoUrl: 'https://cdn.activepieces.com/pieces/slack.png',
-  categories: [PieceCategory.COMMUNICATION],
-  auth: slackAuth,
-  events: {
-    parseAndReply: ({ payload }) => {
-      const payloadBody = payload.body as PayloadBody;
-      if (payloadBody.challenge) {
-        return {
-          reply: {
-            body: payloadBody['challenge'],
-            headers: {},
-          },
-        };
-      }
-      return {
-        event: payloadBody?.event?.type,
-        identifierValue: payloadBody.team_id,
-      };
-    },
-    verify: ({ webhookSecret, payload }) => {
-      // Construct the signature base string
-      const timestamp = payload.headers['x-slack-request-timestamp'];
-      const signature = payload.headers['x-slack-signature'];
-      const signatureBaseString = `v0:${timestamp}:${payload.rawBody}`;
-      const hmac = crypto.createHmac('sha256', webhookSecret);
-      hmac.update(signatureBaseString);
-      const computedSignature = `v0=${hmac.digest('hex')}`;
-      return signature === computedSignature;
-    },
-  },
-  authors: [
-    'rita-gorokhod',
-    'AdamSelene',
-    'Abdallah-Alwarawreh',
-    'kishanprmr',
-    'MoShizzle',
-    'AbdulTheActivePiecer',
-    'khaledmashaly',
-    'abuaboud',
-  ],
-  actions: [
-    slackSendDirectMessageAction,
-    slackSendMessageAction,
-    requestApprovalDirectMessageAction,
-    requestSendApprovalMessageAction,
-    requestActionDirectMessageAction,
-    requestActionMessageAction,
-    uploadFile,
-    searchMessages,
-    findUserByEmailAction,
-    updateMessage,
-    createChannelAction,
-    updateProfileAction,
-    createCustomApiCallAction({
-      baseUrl: () => {
-        return 'https://slack.com/api';
-      },
-      auth: slackAuth,
-      authMapping: (auth) => {
-        return {
-          Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
-        };
-      },
-    }),
-  ],
-  triggers: [newMessage, newReactionAdded, newChannelTrigger],
+	displayName: 'Slack',
+	description: 'Channel-based messaging platform',
+	minimumSupportedRelease: '0.20.0',
+	logoUrl: 'https://cdn.activepieces.com/pieces/slack.png',
+	categories: [PieceCategory.COMMUNICATION],
+	auth: slackAuth,
+	events: {
+		parseAndReply: ({ payload }) => {
+			const payloadBody = payload.body as PayloadBody;
+			if (payloadBody.challenge) {
+				return {
+					reply: {
+						body: payloadBody['challenge'],
+						headers: {},
+					},
+				};
+			}
+			return {
+				event: payloadBody?.event?.type,
+				identifierValue: payloadBody.team_id,
+			};
+		},
+		verify: ({ webhookSecret, payload }) => {
+			// Construct the signature base string
+			const timestamp = payload.headers['x-slack-request-timestamp'];
+			const signature = payload.headers['x-slack-signature'];
+			const signatureBaseString = `v0:${timestamp}:${payload.rawBody}`;
+			const hmac = crypto.createHmac('sha256', webhookSecret);
+			hmac.update(signatureBaseString);
+			const computedSignature = `v0=${hmac.digest('hex')}`;
+			return signature === computedSignature;
+		},
+	},
+	authors: [
+		'rita-gorokhod',
+		'AdamSelene',
+		'Abdallah-Alwarawreh',
+		'kishanprmr',
+		'MoShizzle',
+		'AbdulTheActivePiecer',
+		'khaledmashaly',
+		'abuaboud',
+	],
+	actions: [
+		addRectionToMessageAction,
+		slackSendDirectMessageAction,
+		slackSendMessageAction,
+		requestApprovalDirectMessageAction,
+		requestSendApprovalMessageAction,
+		requestActionDirectMessageAction,
+		requestActionMessageAction,
+		uploadFile,
+		searchMessages,
+		findUserByEmailAction,
+		updateMessage,
+		createChannelAction,
+		updateProfileAction,
+		createCustomApiCallAction({
+			baseUrl: () => {
+				return 'https://slack.com/api';
+			},
+			auth: slackAuth,
+			authMapping: (auth) => {
+				return {
+					Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
+				};
+			},
+		}),
+	],
+	triggers: [newMessage, newReactionAdded, newChannelTrigger],
 });
 
 type PayloadBody = {
-  challenge: string;
-  event: {
-    type: string;
-  };
-  team_id: string;
+	challenge: string;
+	event: {
+		type: string;
+	};
+	team_id: string;
 };

--- a/packages/pieces/community/slack/src/lib/actions/add-reaction-to-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/add-reaction-to-message.ts
@@ -1,18 +1,15 @@
 import { slackAuth } from '../../';
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { slackChannel, slackInfo } from '../common/props';
-import {
-	AuthenticationType,
-	httpClient,
-	HttpMethod,
-	HttpRequest,
-} from '@activepieces/pieces-common';
+
+import { WebClient } from '@slack/web-api';
 
 export const addRectionToMessageAction = createAction({
 	auth: slackAuth,
 	name: 'slack-add-reaction-to-message',
 	displayName: 'Add Reaction to Message',
 	description: 'Add an emoji reaction to a message.',
+
 	props: {
 		info: slackInfo,
 		channel: slackChannel,
@@ -28,25 +25,18 @@ export const addRectionToMessageAction = createAction({
 			description: 'e.g.`thumbsup`',
 		}),
 	},
+
 	async run(context) {
 		const { channel, ts, reaction } = context.propsValue;
 
-		const request: HttpRequest = {
-			method: HttpMethod.POST,
-			url: 'https://slack.com/api/reactions.add',
-			authentication: {
-				type: AuthenticationType.BEARER_TOKEN,
-				token: context.auth.access_token,
-			},
-			body: {
-				channel,
-				timestamp: ts,
-				name: reaction,
-			},
-		};
+		const slack = new WebClient(context.auth.access_token);
 
-		const response = await httpClient.sendRequest(request);
+		const response = await slack.reactions.add({
+			channel,
+			timestamp: ts,
+			name: reaction,
+		});
 
-		return response.body;
+		return response;
 	},
 });

--- a/packages/pieces/community/slack/src/lib/actions/add-reaction-to-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/add-reaction-to-message.ts
@@ -1,0 +1,52 @@
+import { slackAuth } from '../../';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { slackChannel, slackInfo } from '../common/props';
+import {
+	AuthenticationType,
+	httpClient,
+	HttpMethod,
+	HttpRequest,
+} from '@activepieces/pieces-common';
+
+export const addRectionToMessageAction = createAction({
+	auth: slackAuth,
+	name: 'slack-add-reaction-to-message',
+	displayName: 'Add Reaction to Message',
+	description: 'Add an emoji reaction to a message.',
+	props: {
+		info: slackInfo,
+		channel: slackChannel,
+		ts: Property.ShortText({
+			displayName: 'Message ts',
+			description:
+				'Provide the ts (timestamp) value of the message to update, e.g. `1710304378.475129`.',
+			required: true,
+		}),
+		reaction: Property.ShortText({
+			displayName: 'Reaction (emoji) name',
+			required: true,
+			description: 'e.g.`thumbsup`',
+		}),
+	},
+	async run(context) {
+		const { channel, ts, reaction } = context.propsValue;
+
+		const request: HttpRequest = {
+			method: HttpMethod.POST,
+			url: 'https://slack.com/api/reactions.add',
+			authentication: {
+				type: AuthenticationType.BEARER_TOKEN,
+				token: context.auth.access_token,
+			},
+			body: {
+				channel,
+				timestamp: ts,
+				name: reaction,
+			},
+		};
+
+		const response = await httpClient.sendRequest(request);
+
+		return response.body;
+	},
+});

--- a/packages/server/api/test/integration/cloud/platform/platform.test.ts
+++ b/packages/server/api/test/integration/cloud/platform/platform.test.ts
@@ -242,8 +242,9 @@ describe('Platform API', () => {
             expect(response?.statusCode).toBe(StatusCodes.OK)
             const responseBody = response?.json()
 
-            expect(Object.keys(responseBody)).toHaveLength(4)
+            expect(Object.keys(responseBody)).toHaveLength(5)
             expect(responseBody.id).toBe(mockPlatform.id)
+            expect(responseBody.gitSyncEnabled).toBeDefined()
             expect(responseBody.name).toBe(mockPlatform.name)
             expect(responseBody.defaultLocale).toBe(mockPlatform.defaultLocale)
             expect(responseBody.projectRolesEnabled).toBe(mockPlatform.projectRolesEnabled)


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3227 

This actions required following new scopes for Oauth2 app:

- reactions:write

ANNOUNCEMENT=true


