### PR TITLE
chore: remove client secret in client grant and user custom oauth2

### DIFF
--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -112,10 +112,14 @@ export const appConnectionService = {
 
         const appConnection = decryptConnection(encryptedAppConnection)
         if (!needRefresh(appConnection)) {
-            return appConnection
+            return oauth2Util.removeRefreshTokenAndClientSecret(appConnection)
         }
 
-        return lockAndRefreshConnection({ projectId, name })
+        const refreshedConnection = await lockAndRefreshConnection({ projectId, name })
+        if (isNil(refreshedConnection)) {
+            return null
+        }
+        return oauth2Util.removeRefreshTokenAndClientSecret(refreshedConnection)
     },
 
     async getOneOrThrow(params: GetOneParams): Promise<AppConnection> {

--- a/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
@@ -3,6 +3,8 @@ import { pieceMetadataService } from '../../../pieces/piece-metadata-service'
 import { PropertyType } from '@activepieces/pieces-framework'
 import {
     ActivepiecesError,
+    AppConnection,
+    AppConnectionType,
     assertNotNullOrUndefined,
     BaseOAuth2ConnectionValue,
     deleteProps,
@@ -15,6 +17,22 @@ export const oauth2Util = {
     isExpired,
     isUserError,
     getOAuth2TokenUrl,
+    removeRefreshTokenAndClientSecret
+}
+
+function removeRefreshTokenAndClientSecret(connection: AppConnection): AppConnection {
+    if (connection.value.type === AppConnectionType.OAUTH2 && connection.value.grant_type === OAuth2GrantType.CLIENT_CREDENTIALS) {
+        connection.value.client_secret = '(REDACTED)'
+    }
+    if (connection.value.type === AppConnectionType.OAUTH2
+        || connection.value.type === AppConnectionType.CLOUD_OAUTH2
+        || connection.value.type === AppConnectionType.PLATFORM_OAUTH2) {
+        connection.value = {
+            ...connection.value,
+            refresh_token: '(REDACTED)',
+        }
+    }
+    return connection
 }
 
 function isExpired(connection: BaseOAuth2ConnectionValue): boolean {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Worker doesn't need access to refresh token and client secret in case the user define it (use my own credential option), this is not a vulnerability but it's always better to expose minimum number of information / secrets through api. 
