### PR TITLE
fix: change incorrect spelling of Multiplication in math helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "rcVersion": "0.27.0-rc.0",
   "scripts": {
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.26.2",
+  "version": "0.26.1",
   "rcVersion": "0.27.0-rc.0",
   "scripts": {
     "prepare": "husky install",

--- a/packages/pieces/community/math-helper/package.json
+++ b/packages/pieces/community/math-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-math-helper",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "dependencies": {
     "@activepieces/pieces-framework": "0.7.30",
     "@activepieces/shared": "0.10.105",

--- a/packages/pieces/community/math-helper/src/lib/actions/multiplication.ts
+++ b/packages/pieces/community/math-helper/src/lib/actions/multiplication.ts
@@ -7,7 +7,7 @@ import {
 export const multiplication = createAction({
   name: 'multiplication_math',
   auth: PieceAuth.None(),
-  displayName: 'Multiplicattion',
+  displayName: 'Multiplication',
   description: 'Multiply first number by the second number',
   errorHandlingOptions: {
     continueOnFailure: {


### PR DESCRIPTION
## What does this PR do?

It fixes the spelling of Multiplication in math helper which was incorrectly there as Multiplicattion
