### PR TITLE
feat: allow retrieving platform info using API key

### DIFF
--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -11,6 +11,7 @@ import {
     Platform,
     PlatformWithoutSensitiveData,
     Principal,
+    PrincipalType,
     UpdatePlatformRequestBody,
 } from '@activepieces/shared'
 
@@ -50,8 +51,22 @@ const buildResponse = ({
         }
     }
 
-    const { id, name, defaultLocale, projectRolesEnabled, gitSyncEnabled, flowIssuesEnabled } = platform
-    return { id, name, defaultLocale, projectRolesEnabled, gitSyncEnabled, flowIssuesEnabled }
+    const {
+        id,
+        name,
+        defaultLocale,
+        projectRolesEnabled,
+        gitSyncEnabled,
+        flowIssuesEnabled,
+    } = platform
+    return {
+        id,
+        name,
+        defaultLocale,
+        projectRolesEnabled,
+        gitSyncEnabled,
+        flowIssuesEnabled,
+    }
 }
 
 type BuildResponseParams = {
@@ -59,7 +74,15 @@ type BuildResponseParams = {
     principal: Principal
 }
 
-type PlatformBasics = Pick<Platform, 'id' | 'name' | 'defaultLocale' | 'projectRolesEnabled' | 'gitSyncEnabled' | 'flowIssuesEnabled'>
+type PlatformBasics = Pick<
+Platform,
+| 'id'
+| 'name'
+| 'defaultLocale'
+| 'projectRolesEnabled'
+| 'gitSyncEnabled'
+| 'flowIssuesEnabled'
+>
 
 const UpdatePlatformRequest = {
     schema: {
@@ -74,6 +97,9 @@ const UpdatePlatformRequest = {
 }
 
 const GetPlatformRequest = {
+    config: {
+        allowedPrincipals: [PrincipalType.USER, PrincipalType.SERVICE],
+    },
     schema: {
         params: Type.Object({
             id: ApId,


### PR DESCRIPTION
## What does this PR do?

We want to be able to get the list of allowed / denied pieces via an API call authenticated with an API key

**This has not been tested** (API keys are an `ee` feature which is harder to test on a dev setup 😬 )