### PR TITLE
feat: add new piece html-helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,7 @@
         "ngx-socket-io": "4.6.1",
         "ngx-timeago": "3.0.0",
         "node-cron": "3.0.3",
+        "node-html-parser": "6.1.13",
         "nodemailer": "6.9.9",
         "object-sizeof": "2.6.3",
         "openai": "4.47.1",
@@ -33365,6 +33366,15 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "ngx-socket-io": "4.6.1",
     "ngx-timeago": "3.0.0",
     "node-cron": "3.0.3",
+    "node-html-parser": "6.1.13",
     "nodemailer": "6.9.9",
     "object-sizeof": "2.6.3",
     "openai": "4.47.1",

--- a/packages/pieces/community/html-helper/.eslintrc.json
+++ b/packages/pieces/community/html-helper/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/html-helper/README.md
+++ b/packages/pieces/community/html-helper/README.md
@@ -1,0 +1,7 @@
+# pieces-html-helper
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-html-helper` to build the library.

--- a/packages/pieces/community/html-helper/package.json
+++ b/packages/pieces/community/html-helper/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-html-helper",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/html-helper/project.json
+++ b/packages/pieces/community/html-helper/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "pieces-html-helper",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/html-helper/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/html-helper",
+        "tsConfig": "packages/pieces/community/html-helper/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/html-helper/package.json",
+        "main": "packages/pieces/community/html-helper/src/index.ts",
+        "assets": [
+          "packages/pieces/community/html-helper/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs pieces-html-helper {args.ver} {args.tag}",
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/html-helper/src/index.ts
+++ b/packages/pieces/community/html-helper/src/index.ts
@@ -1,0 +1,16 @@
+
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { extractElementByQuery } from "./lib/actions/extract-attribute";
+import { getElementById } from "./lib/actions/get-element-by-id";
+    
+export const htmlHelper = createPiece({
+  displayName: "Html Helper",
+  auth: PieceAuth.None(),
+  description: "Tools to manipulate HTML",
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: "https://cdn.activepieces.com/pieces/html-helper.png",
+  authors: ['pfernandez98'],
+  actions: [extractElementByQuery, getElementById],
+  triggers: [],
+});
+    

--- a/packages/pieces/community/html-helper/src/lib/actions/extract-attribute.ts
+++ b/packages/pieces/community/html-helper/src/lib/actions/extract-attribute.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { parse } from 'node-html-parser';
+
+export const extractElementByQuery = createAction({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'extractAttribute',
+  displayName: 'Get Element by Query Selector',
+  description: 'Extract the attributes from an html eleement using a query selector',
+  props: {
+    html: Property.LongText({
+      displayName: 'HTML',
+      description: 'The HTML to extract the element from',
+      required: true,
+      
+    }),
+    querySelector: Property.ShortText({
+      displayName: 'Query Selector',
+      description: 'See more here: https://www.w3schools.com/cssref/css_selectors.php',
+      required: true,
+    }),
+  },
+  async run(context) {
+
+    const {
+      html,
+      querySelector,
+    } = context.propsValue;
+
+    const htmlFromProps =  parse(html);
+    
+    const response = htmlFromProps.querySelector(querySelector)
+    if (!response) {
+      throw new Error(`No element found with query selector: ${querySelector}`);
+    }
+
+    const attributes = {
+      attrs: response.attributes,
+      innerHTML : response.innerHTML,
+      innerText : response.innerText,
+      tagName : response.tagName,
+      text : response.text,
+      outerHTML : response.outerHTML,
+      id: response.id,
+
+    }
+    return attributes;
+  },
+});
+

--- a/packages/pieces/community/html-helper/src/lib/actions/get-element-by-id.ts
+++ b/packages/pieces/community/html-helper/src/lib/actions/get-element-by-id.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { parse } from 'node-html-parser';
+
+export const getElementById = createAction({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'getElementById',
+  displayName: 'Get Element By Id',
+  description: 'Extract the attributes from an html eleement using its id',
+  props: {
+    html: Property.LongText({
+      displayName: 'HTML',
+      description: 'The HTML to extract the element from',
+      required: true,
+      
+    }),
+    elementId: Property.ShortText({
+      displayName: 'Element Id',
+      required: true,
+    }),
+  },
+  async run(context) {
+
+    const {
+      html,
+      elementId,
+    } = context.propsValue;
+
+    const htmlFromProps =  parse(html);
+    
+    const response = htmlFromProps.getElementById(elementId)
+    if (!response) {
+      throw new Error(`No element found with ID: ${elementId}`);
+    }
+
+    const attributes = {
+      attrs: response.attributes,
+      innerHTML : response.innerHTML,
+      innerText : response.innerText,
+      tagName : response.tagName,
+      text : response.text,
+      outerHTML : response.outerHTML,
+      id: response.id,
+
+    }
+    return attributes;
+  },
+});
+

--- a/packages/pieces/community/html-helper/tsconfig.json
+++ b/packages/pieces/community/html-helper/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/html-helper/tsconfig.lib.json
+++ b/packages/pieces/community/html-helper/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -245,6 +245,9 @@
       "@activepieces/piece-heartbeat": [
         "packages/pieces/community/heartbeat/src/index.ts"
       ],
+      "@activepieces/piece-html-helper": [
+        "packages/pieces/community/html-helper/src/index.ts"
+      ],
       "@activepieces/piece-http": [
         "packages/pieces/community/http/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

This adds a new piece for manipulating HTML. For now, it has 2 actions: 

- Get Element By Id
- Get Element by Query Selector

This needs a new dependency: 
```
"node-html-parser": "6.1.13"
```

