### PR TITLE
docs: update docker-compose.mdx / upgrading section wording and formatting

### DIFF
--- a/docs/install/options/docker-compose.mdx
+++ b/docs/install/options/docker-compose.mdx
@@ -73,13 +73,11 @@ Review the [configurations guide]((/install/configurations/environment-variables
 To upgrade to new versions, which are installed using docker compose, perform the following steps. First, open a terminal in the activepieces repository directory and run the following commands.
 
 **1. Run the update script**
+Automatically pull:
 ```bash
 sh tools/update.sh
 ```
-
-
-To upgrade to new versions manually, which are installed using docker compose, perform the following steps. First, open a terminal in the activepieces repository directory and run the following commands.
-
+Manually pull the new docker compose file:
 **1. Pull the new docker compose file**
 ```bash
 git pull
@@ -90,13 +88,13 @@ git pull
 docker compose pull
 ```
 
-3. Review changelog for breaking changes
+**3. Review changelog for breaking changes**
 
 <Warning>
 Please review the [Breaking changes](https://activepieces.com/docs/install/breaking-changes) document.
 </Warning>
 
-4. Run the updated docker images
+**4. Run the updated docker images**
 ```
 docker compose up -d --remove-orphans
 ```

--- a/docs/install/options/docker-compose.mdx
+++ b/docs/install/options/docker-compose.mdx
@@ -72,12 +72,16 @@ Review the [configurations guide]((/install/configurations/environment-variables
 
 To upgrade to new versions, which are installed using docker compose, perform the following steps. First, open a terminal in the activepieces repository directory and run the following commands.
 
+### Automatic Pull
+
 **1. Run the update script**
-Automatically pull:
+
 ```bash
 sh tools/update.sh
 ```
-Manually pull the new docker compose file:
+
+### Manually Pull
+
 **1. Pull the new docker compose file**
 ```bash
 git pull


### PR DESCRIPTION
Wording and formatting clarification for the Upgrading Section

Wording for step 1 was unclear. As there were two step 1.
The formatting for steps 2, 3 and 4 made it seem part of the second step 1.

Combined the step 1s into sub steps and uniformed the formatting for the other steps to mimic step 1's.
