### PR TITLE
fix: improve displaying primitive data (text, numbers and booleans) in sample data view

### DIFF
--- a/packages/ui/common/src/lib/components/json-view/json-view.component.html
+++ b/packages/ui/common/src/lib/components/json-view/json-view.component.html
@@ -20,19 +20,24 @@
         </div>
       }
    
-      @if(showText)
+      @if(contentType === 'object')
       {
-        <div class="ap-px-4 ap-py-2 ap-text-wrap ap-break-all "> 
-          {{_content}} 
-        </div>
-      }
-      @else{
         <div class="ap-pl-2 ap-mb-2 thin-scrollbars">
           <json-editor
           [options]="jsonEditorOptions"
           [formControl]="jsonFormController" 
            #editor
         ></json-editor>
+        </div>
+      
+      }
+      @else{
+        <div class="ap-px-4 ap-py-2 ap-text-wrap ap-break-all ap-typography-body-2" 
+        [class.view-number]="contentType === 'number' || contentType === 'bigint'"
+        [class.view-string]="contentType === 'string' || contentType === 'undefined' || contentType === 'symbol' || contentType === 'function'"
+        [class.view-boolean]="contentType === 'boolean'"
+        > 
+       <pre>{{_content}}</pre>  
         </div>
       }
     </div>

--- a/packages/ui/common/src/lib/components/json-view/json-view.component.ts
+++ b/packages/ui/common/src/lib/components/json-view/json-view.component.ts
@@ -15,21 +15,32 @@ import { JsonEditorOptions } from 'ang-jsoneditor';
 export class JsonViewComponent {
   jsonFormController = new FormControl({});
   _content = '';
-  showText = false;
+  contentIsAnObject = false;
+  contentType:
+    | 'object'
+    | 'string'
+    | 'number'
+    | 'boolean'
+    | 'bigint'
+    | 'symbol'
+    | 'function'
+    | 'undefined' = 'string';
   containerHeight = 0;
   @Input() hideTitle = false;
   @Input() hideMaximize = false;
   @Input() viewTitle: string;
   jsonEditorOptions: JsonEditorOptions = new JsonEditorOptions();
   @Input() set content(value: unknown) {
-    if (typeof value === 'string') {
-      this._content = value;
-    } else {
+    this.contentType = typeof value;
+    if (this.contentType === 'object') {
       this._content = JSON.stringify(value, null, 2);
-    }
-    this.showText = !this.isContentAnObject(this._content);
-    if (!this.showText) {
       this.jsonFormController.setValue(JSON.parse(this._content));
+    } else {
+      if (typeof value === 'string' && this.isStringValidJson(value)) {
+        this._content = JSON.stringify(JSON.parse(value), null, 2);
+      } else {
+        this._content = JSON.stringify(value);
+      }
     }
     this.setExpandAllNodesInEditor();
   }
@@ -54,15 +65,18 @@ export class JsonViewComponent {
   }
 
   downloadContent() {
-    downloadFile(this._content, this.viewTitle, this.showText ? 'txt' : 'json');
+    downloadFile(
+      this._content,
+      this.viewTitle,
+      this.contentIsAnObject ? 'txt' : 'json'
+    );
   }
-
-  private isContentAnObject(content: string) {
+  private isStringValidJson(str: string) {
     try {
-      const value = JSON.parse(content);
-      return typeof value === 'object' && value !== null;
+      JSON.parse(str);
     } catch (e) {
       return false;
     }
+    return true;
   }
 }

--- a/packages/ui/core/src/assets/scss/json-editor-override.scss
+++ b/packages/ui/core/src/assets/scss/json-editor-override.scss
@@ -23,6 +23,16 @@
   --code-editor-green: #0f9b68;
   --code-editor-blue: #0d57a8;
 }
+.view-boolean {
+  color: var(--code-editor-purple) !important;
+}
+.view-string {
+  color: var(--code-editor-blue) !important;
+}
+.view-number {
+  color: var(--code-editor-green) !important;
+}
+
 .jsoneditor-url {
     color: var(--code-editor-blue) !important;
   }


### PR DESCRIPTION
This fixes the issue that is reported here:  https://community.activepieces.com/t/unable-to-convert-json-to-text/4233/4

