### PR TITLE
fix: ignore x-frame-origin in forms

### DIFF
--- a/packages/ui/core/nginx.standard.conf
+++ b/packages/ui/core/nginx.standard.conf
@@ -3,6 +3,11 @@ http {
     include /etc/nginx/mime.types;
     client_max_body_size 4m;
 
+    map $request_uri $add_x_frame_options {
+        default "SAMEORIGIN";
+        "~*^/forms/" "";
+    }
+
     map $http_accept_language $accept_language {
         ~*^en en;
         ~*^fr fr;
@@ -24,7 +29,7 @@ http {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options SAMEORIGIN always;
+    add_header X-Frame-Options $add_x_frame_options always;
 
     server {
         listen 80;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes embedded forms origins with NGINX

