### PR TITLE
feat(zoho-books): custom api call action

### DIFF
--- a/packages/pieces/community/zoho-books/.eslintrc.json
+++ b/packages/pieces/community/zoho-books/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/zoho-books/README.md
+++ b/packages/pieces/community/zoho-books/README.md
@@ -1,0 +1,7 @@
+# pieces-zoho-books
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-zoho-books` to build the library.

--- a/packages/pieces/community/zoho-books/package.json
+++ b/packages/pieces/community/zoho-books/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-zoho-books",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/zoho-books/project.json
+++ b/packages/pieces/community/zoho-books/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "pieces-zoho-books",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/zoho-books/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/zoho-books",
+        "tsConfig": "packages/pieces/community/zoho-books/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/zoho-books/package.json",
+        "main": "packages/pieces/community/zoho-books/src/index.ts",
+        "assets": [
+          "packages/pieces/community/zoho-books/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs pieces-zoho-books {args.ver} {args.tag}",
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/zoho-books/src/index.ts
+++ b/packages/pieces/community/zoho-books/src/index.ts
@@ -1,0 +1,72 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import {
+  OAuth2PropertyValue,
+  PieceAuth,
+  Property,
+  createPiece,
+} from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+
+export const zohoBooksAuth = PieceAuth.OAuth2({
+  props: {
+    location: Property.StaticDropdown({
+      displayName: 'Location',
+      description: 'The location of your Zoho Books account',
+      required: true,
+      options: {
+        options: [
+          {
+            label: 'zoho.eu (Europe)',
+            value: 'zoho.eu',
+          },
+          {
+            label: 'zoho.com (United States)',
+            value: 'zoho.com',
+          },
+          {
+            label: 'zoho.com.au (Australia)',
+            value: 'zoho.com.au',
+          },
+          {
+            label: 'zoho.jp (Japan)',
+            value: 'zoho.jp',
+          },
+          {
+            label: 'zoho.in (India)',
+            value: 'zoho.in',
+          },
+          {
+            label: 'zohocloud.ca (Canada)',
+            value: 'zohocloud.ca',
+          },
+        ],
+      },
+    }),
+  },
+  description: 'Authentication for Zoho Books',
+  scope: ['ZohoBooks.fullaccess.all'],
+  authUrl: 'https://accounts.{location}/oauth/v2/auth',
+  tokenUrl: 'https://accounts.{location}/oauth/v2/token',
+  required: true,
+});
+
+export const zohoBooks = createPiece({
+  displayName: "Zoho Books",
+  description: 'Comprehensive online accounting software for small businesses.',
+  logoUrl: "https://cdn.activepieces.com/pieces/zoho-books.png",
+  minimumSupportedRelease: '0.20.0',
+  categories: [PieceCategory.ACCOUNTING],
+  authors: ["ikus060"],
+  auth: zohoBooksAuth,
+  actions: [
+    createCustomApiCallAction({
+      baseUrl: (auth) => `https://www.zohoapis.com/books/v3/contacts`,
+      auth: zohoBooksAuth,
+      authMapping: (auth) => ({
+        Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});
+    

--- a/packages/pieces/community/zoho-books/src/index.ts
+++ b/packages/pieces/community/zoho-books/src/index.ts
@@ -60,7 +60,8 @@ export const zohoBooks = createPiece({
   auth: zohoBooksAuth,
   actions: [
     createCustomApiCallAction({
-      baseUrl: (auth) => `https://www.zohoapis.com/books/v3/contacts`,
+      baseUrl: (auth) =>
+        `https://${(auth as OAuth2PropertyValue).data['location']}/books/v3`,
       auth: zohoBooksAuth,
       authMapping: (auth) => ({
         Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,

--- a/packages/pieces/community/zoho-books/tsconfig.json
+++ b/packages/pieces/community/zoho-books/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/zoho-books/tsconfig.lib.json
+++ b/packages/pieces/community/zoho-books/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -581,6 +581,9 @@
       "@activepieces/piece-zerobounce": [
         "packages/pieces/community/zerobounce/src/index.ts"
       ],
+      "@activepieces/piece-zoho-books": [
+        "packages/pieces/community/zoho-books/src/index.ts"
+      ],
       "@activepieces/piece-zoho-crm": [
         "packages/pieces/community/zoho-crm/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Create the foundation for Zoho Books pieces. Only include Custom API Call.

Questions:
1. I'm not sure how to provide https://cdn.activepieces.com/pieces/zoho-books.png
2. For testing I used by own ClientID and Secret, but it should be possible to use the same ClientID and Secret for all Zoho pieces.
3. I've defined a fixed value for baseURL that work for US only. 

ANNOUNCEMENT=true
