### PR TITLE
feat(google-drive): add support for all drives to pdf export action

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.26"
+  "version": "0.5.27"
 }

--- a/packages/pieces/community/google-drive/src/lib/action/save-file-as-pdf.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/save-file-as-pdf.action.ts
@@ -5,6 +5,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'googleapis-common';
 import { Stream } from 'stream';
+import { common } from '../common';
 
 export const saveFileAsPdf = createAction({
   displayName: 'Save file as PDF',
@@ -27,6 +28,7 @@ export const saveFileAsPdf = createAction({
       description: 'The name of the new file (do not include the extension)',
       required: true,
     }),
+    include_team_drives: common.properties.include_team_drives,
   },
   async run(context) {
     const authClient = new OAuth2Client();
@@ -43,7 +45,9 @@ export const saveFileAsPdf = createAction({
         fileId: documentId,
         mimeType: 'application/pdf',
       },
-      { responseType: 'arraybuffer' }
+      {
+        responseType: 'arraybuffer',
+      }
     );
 
     const requestBody = {
@@ -62,6 +66,7 @@ export const saveFileAsPdf = createAction({
     const file = await drive.files.create({
       requestBody,
       media: media,
+      supportsAllDrives: context.propsValue.include_team_drives,
     });
 
     return file.data;

--- a/packages/pieces/community/google-drive/src/lib/action/upload-file.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/upload-file.ts
@@ -49,7 +49,13 @@ export const googleDriveUploadFile = createAction({
 
     const result = await httpClient.sendRequest({
       method: HttpMethod.POST,
-      url: `https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&supportsAllDrives=true`,
+      url: `https://www.googleapis.com/upload/drive/v3/files`,
+      queryParams: {
+        uploadType: 'multipart',
+        supportsAllDrives: String(
+          context.propsValue.include_team_drives || false
+        ),
+      },
       body: form,
       headers: {
         ...form.getHeaders(),


### PR DESCRIPTION
## What does this PR do?

"Export to PDF" action did not work on shared drives