### PR TITLE
chore: remove iframe options temporary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "activepieces",
   "version": "0.27.0",
-  "rcVersion": "0.27.0-rc.8",
+  "rcVersion": "0.27.0-iframe-options",
   "scripts": {
     "prepare": "husky install",
     "serve:frontend": "nx serve ui-core",

--- a/packages/ui/core/nginx.standard.conf
+++ b/packages/ui/core/nginx.standard.conf
@@ -3,11 +3,6 @@ http {
     include /etc/nginx/mime.types;
     client_max_body_size 4m;
 
-    map $request_uri $add_x_frame_options {
-        default "SAMEORIGIN";
-        "~*^/forms/" "";
-    }
-
     map $http_accept_language $accept_language {
         ~*^en en;
         ~*^fr fr;
@@ -29,7 +24,6 @@ http {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options $add_x_frame_options always;
 
     server {
         listen 80;


### PR DESCRIPTION
## What does this PR do?

This currently causing an issue for embed users, we should add it back with configurable way and currently the responsibility should be moved to load balancer to add the header.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

