### PR TITLE
feat: suport false value when creating google-contact

### DIFF
--- a/packages/pieces/community/google-contacts/package.json
+++ b/packages/pieces/community/google-contacts/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-contacts",
-  "version": "0.3.6"
+  "version": "0.3.7"
 }

--- a/packages/pieces/community/google-contacts/src/lib/action/create-contact.ts
+++ b/packages/pieces/community/google-contacts/src/lib/action/create-contact.ts
@@ -61,19 +61,19 @@ export const googleContactsAddContactAction = createAction({
       ],
     };
     const contact: Record<string, unknown> = {};
-    if (context.propsValue['email']) {
+    if (context.propsValue['email'] && context.propsValue['email'] != "false") {
       contact['emailAddresses'] = [{ value: context.propsValue['email'] }];
     }
 
-    if (context.propsValue['phoneNumber']) {
+    if (context.propsValue['phoneNumber'] && context.propsValue['phoneNumber'] != "false") {
       contact['phoneNumbers'] = [{ value: context.propsValue['phoneNumber'] }];
     }
 
-    if (context.propsValue['company'] || context.propsValue['jobTitle']) {
+    if ((context.propsValue['company'] && context.propsValue['company'] != "false") || (context.propsValue['jobTitle'] && context.propsValue['jobTitle'] != "false")) {
       contact['organizations'] = [
         {
-          name: context.propsValue['company'] || undefined,
-          title: context.propsValue['jobTitle'] || undefined,
+          name: (context.propsValue['company'] && context.propsValue['company'] != "false") || undefined,
+          title: (context.propsValue['jobTitle'] && context.propsValue['jobTitle'] != "false") || undefined,
         },
       ];
     }


### PR DESCRIPTION
## What does this PR do?

Using dynamic value for phoneNumber, companyName and email when creating Google Contact, if the dynamic value has a boolean value of false, it get converted into string "false" and the value created in Google Contact is "false".

I'm not sure this would be the expected result for users. I'm not sure of the policies regarding data conversion between types in ActivePieces either. So you are free to recommend me alternative implementation. I will do the same for the update-contact action I'm working on.

e.g.: in Google Contacts
![image](https://github.com/activepieces/activepieces/assets/921251/42549862-d541-479b-b0dc-ef4b5064849c)

e.g.: In Activepieces
![image](https://github.com/activepieces/activepieces/assets/921251/ba357a74-c525-4066-885b-86fedb528fe1)


