### PR TITLE
feat(maileroo): send email / send email from template

### DIFF
--- a/packages/pieces/community/maileroo/.eslintrc.json
+++ b/packages/pieces/community/maileroo/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/maileroo/README.md
+++ b/packages/pieces/community/maileroo/README.md
@@ -1,0 +1,7 @@
+# pieces-maileroo
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-maileroo` to build the library.

--- a/packages/pieces/community/maileroo/package.json
+++ b/packages/pieces/community/maileroo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-maileroo",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/maileroo/project.json
+++ b/packages/pieces/community/maileroo/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "pieces-maileroo",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/maileroo/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/maileroo",
+        "tsConfig": "packages/pieces/community/maileroo/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/maileroo/package.json",
+        "main": "packages/pieces/community/maileroo/src/index.ts",
+        "assets": [
+          "packages/pieces/community/maileroo/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs pieces-maileroo {args.ver} {args.tag}",
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/maileroo/src/index.ts
+++ b/packages/pieces/community/maileroo/src/index.ts
@@ -13,7 +13,7 @@ To obtain a Maileroo API key, follow these steps:
 2. Click on the domain you want to use
 3. Click on the **Create sending key** under the API section
 4. Click **New Sending Key**
-4. Copy the key under the **Sending Key** column
+5. Copy the key under the **Sending Key** column
 `;
 
 export const mailerooAuth = PieceAuth.SecretText({

--- a/packages/pieces/community/maileroo/src/index.ts
+++ b/packages/pieces/community/maileroo/src/index.ts
@@ -1,0 +1,67 @@
+import { HttpError } from '@activepieces/pieces-common';
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import FormData from 'form-data';
+import { sendEmail } from './lib/actions/send-email';
+import { sendFromTemplate } from './lib/actions/send-from-template';
+import { sendFormData } from './lib/common/send-utils';
+
+const markdown = `
+To obtain a Maileroo API key, follow these steps:
+
+1. https://app.maileroo.com/domains
+2. Click on the domain you want to use
+3. Click on the **Create sending key** under the API section
+4. Click **New Sending Key**
+4. Copy the key under the **Sending Key** column
+`;
+
+export const mailerooAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: markdown,
+  validate: async (auth) => {
+    // This wont' matter as we are just testing the API key validity
+    const PLACEHOLDER_STRING = 'placeholder';
+
+    try {
+      const formData = new FormData();
+      formData.append('from', PLACEHOLDER_STRING);
+      formData.append('to', PLACEHOLDER_STRING);
+      formData.append('subject', PLACEHOLDER_STRING);
+      formData.append('plain', PLACEHOLDER_STRING);
+
+      await sendFormData('send', formData, auth.auth);
+    } catch (e) {
+      const status = (e as HttpError).response.status;
+
+      // It is safe to assume that that other 4xx status codes means the API key is valid
+      if (status === 401) {
+        return {
+          valid: false,
+          error: 'Invalid API key',
+        };
+      } else if (status >= 500) {
+        return {
+          valid: false,
+          error: 'An error occurred while validating the API key',
+        };
+      }
+    }
+
+    return {
+      valid: true,
+    };
+  },
+});
+
+export const maileroo = createPiece({
+  displayName: 'Maileroo',
+  auth: mailerooAuth,
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/maileroo.png',
+  categories: [PieceCategory.MARKETING],
+  authors: ['codegino'],
+  actions: [sendEmail, sendFromTemplate],
+  triggers: [],
+});

--- a/packages/pieces/community/maileroo/src/lib/actions/send-email.ts
+++ b/packages/pieces/community/maileroo/src/lib/actions/send-email.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+
+import { mailerooAuth } from '../../';
+import {
+  createCommonProps,
+  createFormData,
+  sendFormData,
+} from '../common/send-utils';
+
+export const sendEmail = createAction({
+  auth: mailerooAuth,
+  name: 'sendEmail',
+  displayName: 'Send an Email',
+  description: 'send email',
+  props: {
+    ...createCommonProps(),
+    content_type: Property.Dropdown<'text' | 'html'>({
+      displayName: 'Content Type',
+      refreshers: [],
+      required: true,
+      defaultValue: 'html',
+      options: async () => {
+        return {
+          disabled: false,
+          options: [
+            { label: 'Plain Text', value: 'text' },
+            { label: 'HTML', value: 'html' },
+          ],
+        };
+      },
+    }),
+    content: Property.ShortText({
+      displayName: 'Content',
+      description: 'HTML is only allowed if you selected HTML as type',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const formData = createFormData(context.propsValue);
+
+    const { content_type, content } = context.propsValue;
+
+    if (content_type === 'text') {
+      formData.append('plain', content);
+    } else if (content_type === 'html') {
+      formData.append('html', content);
+    }
+
+    const res = await sendFormData('send', formData, context.auth);
+
+    return res.body;
+  },
+});

--- a/packages/pieces/community/maileroo/src/lib/actions/send-from-template.ts
+++ b/packages/pieces/community/maileroo/src/lib/actions/send-from-template.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+
+import { mailerooAuth } from '../../';
+import {
+  createCommonProps,
+  createFormData,
+  sendFormData,
+} from '../common/send-utils';
+
+export const sendFromTemplate = createAction({
+  auth: mailerooAuth,
+  name: 'sendFromTemplate',
+  displayName: 'Send from template',
+  description: 'Send and email from a Maileroo template',
+  props: {
+    ...createCommonProps(),
+    template_id: Property.ShortText({
+      displayName: 'Template ID',
+      description: 'The ID of the template to use',
+      required: true,
+    }),
+    template_data: Property.Object({
+      displayName: 'Template Data',
+      description:
+        'Data to fill in the template. The string `{{name}}` in the template body will be replaced with the value of `name`',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const formData = createFormData(context.propsValue);
+
+    const { template_id, template_data } = context.propsValue;
+
+    formData.append('template_id', template_id);
+    formData.append('template_data', JSON.stringify(template_data));
+
+    const res = await sendFormData('send-template', formData, context.auth);
+
+    return res.body;
+  },
+});

--- a/packages/pieces/community/maileroo/src/lib/actions/send-from-template.ts
+++ b/packages/pieces/community/maileroo/src/lib/actions/send-from-template.ts
@@ -14,7 +14,7 @@ export const sendFromTemplate = createAction({
   description: 'Send and email from a Maileroo template',
   props: {
     ...createCommonProps(),
-    template_id: Property.ShortText({
+    template_id: Property.Number({
       displayName: 'Template ID',
       description: 'The ID of the template to use',
       required: true,

--- a/packages/pieces/community/maileroo/src/lib/common/send-utils.ts
+++ b/packages/pieces/community/maileroo/src/lib/common/send-utils.ts
@@ -15,8 +15,8 @@ export const createCommonProps = () => {
       required: true,
     }),
     from: Property.ShortText({
-      displayName: 'Sender Email (From)',
-      description: 'Sender email',
+      displayName: 'Sender Email(Your SMTP Email)',
+      description: 'Sender email. This should come from your SMTP accounts.',
       required: true,
     }),
     subject: Property.ShortText({
@@ -37,6 +37,11 @@ export const createCommonProps = () => {
     reply_to: Property.ShortText({
       displayName: 'Reply To',
       description: 'Email to receive replies on (defaults to sender)',
+      required: false,
+    }),
+    attachment: Property.File({
+      displayName: 'Attachment',
+      description: 'File to attach to the email you want to send',
       required: false,
     }),
   };
@@ -73,7 +78,7 @@ export const sendFormData = async (
     url: `https://smtp.maileroo.com/${url}`,
     body: formData,
     headers: {
-      HEADER_AUTH_KEY: auth,
+      ['X-API-Key']: auth,
       ...formData.getHeaders(),
     },
   });

--- a/packages/pieces/community/maileroo/src/lib/common/send-utils.ts
+++ b/packages/pieces/community/maileroo/src/lib/common/send-utils.ts
@@ -1,0 +1,80 @@
+import { Property, StaticPropsValue } from '@activepieces/pieces-framework';
+import FormData from 'form-data';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createCommonProps = () => {
+  return {
+    to: Property.Array({
+      displayName: 'To',
+      description: 'Emails of the recipients',
+      required: true,
+    }),
+    from_name: Property.ShortText({
+      displayName: 'Sender Name',
+      description: 'Sender name',
+      required: true,
+    }),
+    from: Property.ShortText({
+      displayName: 'Sender Email (From)',
+      description: 'Sender email',
+      required: true,
+    }),
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: undefined,
+      required: true,
+    }),
+    bcc: Property.Array({
+      displayName: 'BCC',
+      description: 'List of emails in bcc',
+      required: false,
+    }),
+    cc: Property.Array({
+      displayName: 'CC',
+      description: 'List of emails in cc',
+      required: false,
+    }),
+    reply_to: Property.ShortText({
+      displayName: 'Reply To',
+      description: 'Email to receive replies on (defaults to sender)',
+      required: false,
+    }),
+  };
+};
+
+export const createFormData = (
+  propsValue: StaticPropsValue<ReturnType<typeof createCommonProps>>
+): FormData => {
+  const { to, from, from_name, reply_to, subject, cc, bcc } = propsValue;
+
+  const formData = new FormData();
+  formData.append('from', `${from_name} <${from}>`);
+  formData.append('to', to.join(','));
+  formData.append('subject', subject);
+  formData.append('reply_to', reply_to ?? from);
+
+  if (cc) {
+    formData.append('cc', cc.join(','));
+  }
+  if (bcc) {
+    formData.append('bcc', bcc.join(','));
+  }
+
+  return formData;
+};
+
+export const sendFormData = async (
+  url: string,
+  formData: FormData,
+  auth: string
+) => {
+  return httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: `https://smtp.maileroo.com/${url}`,
+    body: formData,
+    headers: {
+      HEADER_AUTH_KEY: auth,
+      ...formData.getHeaders(),
+    },
+  });
+};

--- a/packages/pieces/community/maileroo/tsconfig.json
+++ b/packages/pieces/community/maileroo/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/maileroo/tsconfig.lib.json
+++ b/packages/pieces/community/maileroo/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -308,6 +308,9 @@
       "@activepieces/piece-mailer-lite": [
         "packages/pieces/community/mailer-lite/src/index.ts"
       ],
+      "@activepieces/piece-maileroo": [
+        "packages/pieces/community/maileroo/src/index.ts"
+      ],
       "@activepieces/piece-mastodon": [
         "packages/pieces/community/mastodon/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

This will add a new piece for [Maileroo](https://maileroo.com) to enable user to send an email via Maileroo's email server. 

The piece has the following actions:
- Send a regular email
- Send an email template defined in Maileroo

Each action requires common mail props such as `to`, `from`, `from_name`, `subject`, `bcc`, `cc`, `reply_to`

ANNOUNCEMENT=true
