### PR TITLE
feat(photoroom): add action to remove the background of an arbitrary image

### DIFF
--- a/packages/pieces/community/photoroom/.eslintrc.json
+++ b/packages/pieces/community/photoroom/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {},
+        "extends": [
+        "plugin:prettier/recommended"
+        ],
+      "plugins": ["prettier"]
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/photoroom/README.md
+++ b/packages/pieces/community/photoroom/README.md
@@ -1,0 +1,7 @@
+# pieces-photoroom
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-photoroom` to build the library.

--- a/packages/pieces/community/photoroom/package.json
+++ b/packages/pieces/community/photoroom/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-photoroom",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/photoroom/project.json
+++ b/packages/pieces/community/photoroom/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "pieces-photoroom",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/photoroom/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/photoroom",
+        "tsConfig": "packages/pieces/community/photoroom/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/photoroom/package.json",
+        "main": "packages/pieces/community/photoroom/src/index.ts",
+        "assets": [
+          "packages/pieces/community/photoroom/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs pieces-photoroom {args.ver} {args.tag}",
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/photoroom/src/index.ts
+++ b/packages/pieces/community/photoroom/src/index.ts
@@ -1,0 +1,22 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { removeBackground } from './lib/actions/remove-background';
+
+export const photoroomAuth = PieceAuth.CustomAuth({
+  required: true,
+  props: {
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API key',
+      required: true,
+    }),
+  },
+});
+
+export const photoroom = createPiece({
+  displayName: 'Photoroom',
+  auth: photoroomAuth,
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/photoroom.png',
+  authors: ['AdamSelene', 'Charles-Go'],
+  actions: [removeBackground],
+  triggers: [],
+});

--- a/packages/pieces/community/photoroom/src/lib/actions/remove-background.ts
+++ b/packages/pieces/community/photoroom/src/lib/actions/remove-background.ts
@@ -1,0 +1,38 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { photoroomAuth } from '../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const removeBackground = createAction({
+  name: 'removeBackground',
+  displayName: 'Remove background',
+  description: 'Remove the background of the image given as input',
+  auth: photoroomAuth,
+  props: {
+    file: Property.File({ displayName: 'Image file', required: true }),
+    filename: Property.ShortText({
+      displayName: 'Generated filename',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue, files }) {
+    const form = new FormData();
+    form.append('image_file', new Blob([propsValue.file.data]));
+    const response = await httpClient.sendRequest({
+      url: `https://sdk.photoroom.com/v1/segment`,
+      method: HttpMethod.POST,
+      headers: {
+        'x-api-key': auth.apiKey,
+        'Content-Type': 'multipart/form-data',
+      },
+      body: form,
+    });
+    const imageUrl = await files.write({
+      fileName: propsValue.filename,
+      data: Buffer.from(response.body.result_b64, 'base64'),
+    });
+    return {
+      fileName: propsValue.filename,
+      url: imageUrl,
+    };
+  },
+});

--- a/packages/pieces/community/photoroom/tsconfig.json
+++ b/packages/pieces/community/photoroom/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/photoroom/tsconfig.lib.json
+++ b/packages/pieces/community/photoroom/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -387,6 +387,9 @@
         "packages/pieces/community/pastefy/src/index.ts"
       ],
       "@activepieces/piece-pdf": ["packages/pieces/community/pdf/src/index.ts"],
+      "@activepieces/piece-photoroom": [
+        "packages/pieces/community/photoroom/src/index.ts"
+      ],
       "@activepieces/piece-pipedrive": [
         "packages/pieces/community/pipedrive/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?
Add photoroom integration with action to remove the background of an image
![2024-04-22 15_11_17_alanmarmot in the desert (2)](https://github.com/activepieces/activepieces/assets/79495/93777e56-9863-4b03-bb75-a792c696636c)
![unknown](https://github.com/activepieces/activepieces/assets/79495/65b1b362-f5a5-4abc-8430-92c5736c113a)


ANNOUNCEMENT=true 