### PR TITLE
feat: allow async auth mapping for custom API calls

### DIFF
--- a/packages/pieces/community/common/src/lib/helpers/index.ts
+++ b/packages/pieces/community/common/src/lib/helpers/index.ts
@@ -15,7 +15,7 @@ export const getAccessTokenOrThrow = (auth: OAuth2PropertyValue | undefined): st
 export function createCustomApiCallAction({ auth, baseUrl, authMapping, description, displayName, name }: {
   auth?: PieceAuthProperty,
   baseUrl: (auth?: unknown) => string,
-  authMapping?: (auth: unknown) => HttpHeaders,
+  authMapping?: (auth: unknown) => HttpHeaders | Promise<HttpHeaders>,
 //   add description as a parameter that can be null
   description?: string | null,
   displayName?: string | null,
@@ -89,7 +89,7 @@ export function createCustomApiCallAction({ auth, baseUrl, authMapping, descript
       if (authMapping) {
         headersValue = {
           ...headersValue,
-          ...authMapping(context.auth)
+          ...(await authMapping(context.auth))
         }
       }
 


### PR DESCRIPTION
## What does this PR do?

In some cases the auth mapping for a custom API call needs to be async (e.g. to retrieve a token or cookie dynamically)


