### PR TITLE
feat(intercom): add trigger (webhook) to receive conversation notes

### DIFF
--- a/packages/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/engine/src/lib/helper/trigger-helper.ts
@@ -133,14 +133,6 @@ export const triggerHelper = {
                 }
             case TriggerHookType.RUN: {
                 if (trigger.type === TriggerStrategy.APP_WEBHOOK) {
-                    if (params.edition === ApEdition.COMMUNITY) {
-                        return {
-                            success: false,
-                            message: 'App webhooks are not supported in community edition',
-                            output: [],
-                        }
-                    }
-
                     if (!params.appWebhookUrl) {
                         throw new Error(`App webhook url is not available for piece name ${pieceName}`)
                     }

--- a/packages/pieces/community/intercom/package.json
+++ b/packages/pieces/community/intercom/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-intercom",
-  "version": "0.3.4"
+  "version": "0.3.5"
 }

--- a/packages/pieces/community/intercom/src/lib/triggers/note-added-to-conversation.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/note-added-to-conversation.ts
@@ -1,0 +1,42 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  getAccessTokenOrThrow,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { intercomAuth } from '../..';
+import { intercomCommon } from '../common';
+
+export const noteAddedToConversation = createTrigger({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'noteAddedToConversation',
+  displayName: 'Note added to conversation',
+  description: 'Triggers when a note is added to a conversation',
+  props: {},
+  sampleData: {},
+  auth: intercomAuth,
+  type: TriggerStrategy.APP_WEBHOOK,
+  async onEnable(context) {
+    const response = await httpClient.sendRequest({
+      url: 'https://api.intercom.io/me',
+      method: HttpMethod.GET,
+      headers: intercomCommon.intercomHeaders,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: getAccessTokenOrThrow(context.auth),
+      },
+    });
+
+    context.app.createListeners({
+      events: ['conversation.admin.noted'],
+      identifierValue: response.body['app']['id_code'],
+    });
+  },
+  async onDisable(context) {
+    // implement webhook deletion logic
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/server/api/src/app/app-event-routing/app-event-routing.module.ts
+++ b/packages/server/api/src/app/app-event-routing/app-event-routing.module.ts
@@ -6,6 +6,7 @@ import { webhookService } from '../webhooks/webhook-service'
 import { AppEventRouting } from './app-event-routing.entity'
 import { appEventRoutingService } from './app-event-routing.service'
 import { facebookLeads } from '@activepieces/piece-facebook-leads'
+import { intercom } from '@activepieces/piece-intercom'
 import { slack } from '@activepieces/piece-slack'
 import { square } from '@activepieces/piece-square'
 import { Piece } from '@activepieces/pieces-framework'
@@ -23,12 +24,14 @@ const appWebhooks: Record<string, Piece> = {
     slack,
     square,
     'facebook-leads': facebookLeads,
+    intercom,
 }
 
 const pieceNames: Record<string, string> = {
     slack: '@activepieces/piece-slack',
     square: '@activepieces/piece-square',
     'facebook-leads': '@activepieces/piece-facebook-leads',
+    intercom: '@activepieces/piece-intercom',
 }
 
 export const appEventRoutingModule: FastifyPluginAsyncTypebox = async (app) => {


### PR DESCRIPTION
## What does this PR do?

Add a new APP_WEBHOOK trigger for `intercom` to receive conversation note events
More types ("topics" for Intercom) will be added later

In order to work the `AP_APP_WEBHOOK_SECRETS` env var must be updated

```
AP_APP_WEBHOOK_SECRETS='{"@activepieces/piece-intercom": {"webhookSecret": "<your OAuth client secret>"}}'
```