### PR TITLE
feat(smtp): add senderName property

### DIFF
--- a/packages/pieces/community/smtp/package.json
+++ b/packages/pieces/community/smtp/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-smtp",
-  "version": "0.2.3"
+  "version": "0.2.4"
 }

--- a/packages/pieces/community/smtp/src/index.ts
+++ b/packages/pieces/community/smtp/src/index.ts
@@ -93,6 +93,7 @@ export const smtp = createPiece({
     'khaledmashaly',
     'abuaboud',
     'pfernandez98',
+    'tahboubali'
   ],
   auth: smtpAuth,
   actions: [sendEmail],

--- a/packages/pieces/community/smtp/src/index.ts
+++ b/packages/pieces/community/smtp/src/index.ts
@@ -87,13 +87,13 @@ export const smtp = createPiece({
   logoUrl: 'https://cdn.activepieces.com/pieces/smtp.png',
   categories: [PieceCategory.CORE],
   authors: [
+    'tahboubali',
     'abaza738',
     'kishanprmr',
     'MoShizzle',
     'khaledmashaly',
     'abuaboud',
-    'pfernandez98',
-    'tahboubali'
+    'pfernandez98'
   ],
   auth: smtpAuth,
   actions: [sendEmail],

--- a/packages/pieces/community/smtp/src/lib/actions/send-email.ts
+++ b/packages/pieces/community/smtp/src/lib/actions/send-email.ts
@@ -11,8 +11,12 @@ export const sendEmail = createAction({
   description: 'Send an email using a custom SMTP server.',
   props: {
     from: Property.ShortText({
-      displayName: 'From',
+      displayName: 'From Email',
       required: true,
+    }),
+    senderName: Property.ShortText({
+      displayName: "Sender Name",
+      required: false,
     }),
     to: Property.Array({
       displayName: 'To',
@@ -94,7 +98,7 @@ export const sendEmail = createAction({
     }
 
     const info = await transporter.sendMail({
-      from: propsValue.from,
+      from: getFrom(propsValue.senderName, propsValue.from),
       to: propsValue.to.join(','),
       cc: propsValue.cc?.join(','),
       inReplyTo: propsValue.replyTo,
@@ -109,3 +113,10 @@ export const sendEmail = createAction({
     return info;
   },
 });
+
+function getFrom(senderName: string|undefined, from: string) {
+  if (senderName) {
+    return `"${senderName}" <${from}>`
+  } 
+  return from;
+}


### PR DESCRIPTION
In this pull request, I added a `senderName` property to the send email action. I also added a `getFrom` function that takes in a senderName and a from, and returns the from. If the senderName isn't undefined, it returns a string with the following format: "`senderName`" <`from`>, otherwise it will just return the `from` value passed.

ANNOUNCEMENT=true