### PR TITLE
feat(intercom): add optional keyword to filter incoming note hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -184,6 +184,7 @@
         "sqlstring": "2.3.3",
         "ssh2-sftp-client": "9.1.0",
         "string-replace-async": "3.0.2",
+        "string-strip-html": "8.5.0",
         "stripe": "14.3.0",
         "subsink": "1.0.2",
         "tiktoken": "1.0.11",
@@ -42303,6 +42304,14 @@
       "integrity": "sha512-s6hDtXJ7FKyRap/amefqrOMpkEQvxUDueyvJygQeHxCK5Za90dOMgdibCCrPdfdAYAkr8imrZ1PPXW7DOf0RzQ==",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/string-strip-html": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-8.5.0.tgz",
+      "integrity": "sha512-5ICsK1B1j0A3AF1d45m0sqQCcmi1Q+t1QpF+b794LO5FTHV+ITkGR5C+UCDJQZgs5LMuRruqr6j48PxQVIurJQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "sqlstring": "2.3.3",
     "ssh2-sftp-client": "9.1.0",
     "string-replace-async": "3.0.2",
+    "string-strip-html": "8.5.0",
     "stripe": "14.3.0",
     "subsink": "1.0.2",
     "tiktoken": "1.0.11",

--- a/packages/pieces/community/intercom/package.json
+++ b/packages/pieces/community/intercom/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-intercom",
-  "version": "0.3.5"
+  "version": "0.3.6"
 }

--- a/packages/pieces/community/intercom/src/index.ts
+++ b/packages/pieces/community/intercom/src/index.ts
@@ -21,7 +21,7 @@ export const intercomAuth = PieceAuth.OAuth2({
 export const intercom = createPiece({
   displayName: 'Intercom',
   description: 'Customer messaging platform for sales, marketing, and support',
-  minimumSupportedRelease: '0.5.0',
+  minimumSupportedRelease: '0.29.0', // introduction of new intercom APP_WEBHOOK
   logoUrl: 'https://cdn.activepieces.com/pieces/intercom.png',
   categories: [PieceCategory.CUSTOMER_SUPPORT],
   auth: intercomAuth,


### PR DESCRIPTION
## What does this PR do?

Add optional keyword prop
When the keyword is present, trigger only when one word or more is an exact match on the keyword (not a simple substring match)
i.e.:
- no keyword: always trigger when a new note is added
- `keyword`: trigger if note is "keyword this is a test" but NOT if it is "keyword2 this is a test"

ANNOUNCEMENT=true
