### PR TITLE
fix: remove add pragma no cache

### DIFF
--- a/packages/ui/core/nginx.standard.conf
+++ b/packages/ui/core/nginx.standard.conf
@@ -75,7 +75,6 @@ http {
 
         location ~* \.(css|js|jpg|jpeg|png|gif|ico|svg)$ {
             root /usr/share/nginx/html/en;
-            add_header Pragma "no-cache";
             add_header Expires "0";
             add_header Cache-Control "public, max-age=31536000, immutable";
         }


### PR DESCRIPTION
## What does this PR do?

This is not required, It was added because of automated security report, but this is not needed as there is no user information stored in this route or can be cached.

