### PR TITLE
feat(intercom): add various conversation triggers

### DIFF
--- a/packages/pieces/community/intercom/package.json
+++ b/packages/pieces/community/intercom/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-intercom",
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/packages/pieces/community/intercom/src/index.ts
+++ b/packages/pieces/community/intercom/src/index.ts
@@ -13,6 +13,13 @@ import crypto from 'node:crypto';
 import { noteAddedToConversation } from './lib/triggers/note-added-to-conversation';
 import { addNoteToConversation } from './lib/actions/add-note-to-conversation';
 import { replyToConversation } from './lib/actions/reply-to-conversation';
+import { newConversationFromUser } from './lib/triggers/new-conversation-from-user';
+import { replyFromUser } from './lib/triggers/reply-from-user';
+import { replyFromAdmin } from './lib/triggers/reply-from-admin';
+import { conversationAssigned } from './lib/triggers/conversation-assigned';
+import { conversationClosed } from './lib/triggers/conversation-closed';
+import { conversationSnoozed } from './lib/triggers/conversation-snoozed';
+import { conversationUnsnoozed } from './lib/triggers/conversation-unsnoozed';
 
 export const intercomAuth = PieceAuth.OAuth2({
   authUrl: 'https://app.{region}.com/oauth',
@@ -41,7 +48,16 @@ export const intercom = createPiece({
   logoUrl: 'https://cdn.activepieces.com/pieces/intercom.png',
   categories: [PieceCategory.CUSTOMER_SUPPORT],
   auth: intercomAuth,
-  triggers: [noteAddedToConversation],
+  triggers: [
+    newConversationFromUser,
+    replyFromUser,
+    replyFromAdmin,
+    noteAddedToConversation,
+    conversationAssigned,
+    conversationClosed,
+    conversationSnoozed,
+    conversationUnsnoozed,
+  ],
   authors: [
     'kishanprmr',
     'MoShizzle',
@@ -58,9 +74,7 @@ export const intercom = createPiece({
     replyToConversation,
     createCustomApiCallAction({
       baseUrl: (auth) =>
-        `https://api.${
-          (auth as OAuth2PropertyValue).props?.['region']
-        }.io`,
+        `https://api.${(auth as OAuth2PropertyValue).props?.['region']}.io`,
       auth: intercomAuth,
       authMapping: async (auth) => ({
         Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,

--- a/packages/pieces/community/intercom/src/lib/triggers/conversation-assigned.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/conversation-assigned.ts
@@ -1,0 +1,34 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { intercomAuth } from '../..';
+import { intercomClient } from '../common';
+
+export const conversationAssigned = createTrigger({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'conversationAssigned',
+  displayName: 'Conversation assigned to any Intercom admin',
+  description:
+    'Triggers when a conversation is assigned to an admin',
+  props: {},
+  sampleData: {},
+  auth: intercomAuth,
+  type: TriggerStrategy.APP_WEBHOOK,
+  async onEnable(context) {
+    const client = intercomClient(context.auth);
+    const response: { app: { id_code: string } } = await client.get({
+      url: '/me',
+    });
+    context.app.createListeners({
+      events: ['conversation.admin.assigned'],
+      identifierValue: response['app']['id_code'],
+    });
+  },
+  async onDisable(context) {
+    // implement webhook deletion logic
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/intercom/src/lib/triggers/conversation-closed.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/conversation-closed.ts
@@ -1,0 +1,34 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { intercomAuth } from '../..';
+import { intercomClient } from '../common';
+
+export const conversationClosed = createTrigger({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'conversationClosed',
+  displayName: 'Conversation closed',
+  description:
+    'Triggers when a conversation is closed',
+  props: {},
+  sampleData: {},
+  auth: intercomAuth,
+  type: TriggerStrategy.APP_WEBHOOK,
+  async onEnable(context) {
+    const client = intercomClient(context.auth);
+    const response: { app: { id_code: string } } = await client.get({
+      url: '/me',
+    });
+    context.app.createListeners({
+      events: ['conversation.admin.closed'],
+      identifierValue: response['app']['id_code'],
+    });
+  },
+  async onDisable(context) {
+    // implement webhook deletion logic
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/intercom/src/lib/triggers/conversation-snoozed.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/conversation-snoozed.ts
@@ -1,0 +1,34 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { intercomAuth } from '../..';
+import { intercomClient } from '../common';
+
+export const conversationSnoozed = createTrigger({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'conversationSnoozed',
+  displayName: 'Conversation snoozed',
+  description:
+    'Triggers when a conversation is snoozed',
+  props: {},
+  sampleData: {},
+  auth: intercomAuth,
+  type: TriggerStrategy.APP_WEBHOOK,
+  async onEnable(context) {
+    const client = intercomClient(context.auth);
+    const response: { app: { id_code: string } } = await client.get({
+      url: '/me',
+    });
+    context.app.createListeners({
+      events: ['conversation.admin.snoozed'],
+      identifierValue: response['app']['id_code'],
+    });
+  },
+  async onDisable(context) {
+    // implement webhook deletion logic
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/intercom/src/lib/triggers/conversation-unsnoozed.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/conversation-unsnoozed.ts
@@ -1,0 +1,34 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { intercomAuth } from '../..';
+import { intercomClient } from '../common';
+
+export const conversationUnsnoozed = createTrigger({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'conversationUnsnoozed',
+  displayName: 'Conversation unsnoozed',
+  description:
+    'Triggers when a conversation is unsnoozed',
+  props: {},
+  sampleData: {},
+  auth: intercomAuth,
+  type: TriggerStrategy.APP_WEBHOOK,
+  async onEnable(context) {
+    const client = intercomClient(context.auth);
+    const response: { app: { id_code: string } } = await client.get({
+      url: '/me',
+    });
+    context.app.createListeners({
+      events: ['conversation.admin.unsnoozed'],
+      identifierValue: response['app']['id_code'],
+    });
+  },
+  async onDisable(context) {
+    // implement webhook deletion logic
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/intercom/src/lib/triggers/new-conversation-from-user.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/new-conversation-from-user.ts
@@ -1,0 +1,34 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { intercomAuth } from '../..';
+import { intercomClient } from '../common';
+
+export const newConversationFromUser = createTrigger({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'newConversationFromUser',
+  displayName: 'New conversation from a user or lead',
+  description:
+    'Triggers when a conversation is created by a user or lead (not an admin)',
+  props: {},
+  sampleData: {},
+  auth: intercomAuth,
+  type: TriggerStrategy.APP_WEBHOOK,
+  async onEnable(context) {
+    const client = intercomClient(context.auth);
+    const response: { app: { id_code: string } } = await client.get({
+      url: '/me',
+    });
+    context.app.createListeners({
+      events: ['conversation.user.created'],
+      identifierValue: response['app']['id_code'],
+    });
+  },
+  async onDisable(context) {
+    // implement webhook deletion logic
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/intercom/src/lib/triggers/reply-from-admin.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/reply-from-admin.ts
@@ -1,0 +1,34 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { intercomAuth } from '../..';
+import { intercomClient } from '../common';
+
+export const replyFromAdmin = createTrigger({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'replyFromAdmin',
+  displayName: 'Reply from an Intercom admin',
+  description:
+    'Triggers when a reply is received from an Intercom admin (not a user or lead)',
+  props: {},
+  sampleData: {},
+  auth: intercomAuth,
+  type: TriggerStrategy.APP_WEBHOOK,
+  async onEnable(context) {
+    const client = intercomClient(context.auth);
+    const response: { app: { id_code: string } } = await client.get({
+      url: '/me',
+    });
+    context.app.createListeners({
+      events: ['conversation.admin.replied'],
+      identifierValue: response['app']['id_code'],
+    });
+  },
+  async onDisable(context) {
+    // implement webhook deletion logic
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/intercom/src/lib/triggers/reply-from-user.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/reply-from-user.ts
@@ -1,0 +1,34 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { intercomAuth } from '../..';
+import { intercomClient } from '../common';
+
+export const replyFromUser = createTrigger({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'replyFromUser',
+  displayName: 'Reply from a user or lead',
+  description:
+    'Triggers when a reply is received from a user or lead (not an admin)',
+  props: {},
+  sampleData: {},
+  auth: intercomAuth,
+  type: TriggerStrategy.APP_WEBHOOK,
+  async onEnable(context) {
+    const client = intercomClient(context.auth);
+    const response: { app: { id_code: string } } = await client.get({
+      url: '/me',
+    });
+    context.app.createListeners({
+      events: ['conversation.user.replied'],
+      identifierValue: response['app']['id_code'],
+    });
+  },
+  async onDisable(context) {
+    // implement webhook deletion logic
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});


### PR DESCRIPTION
## What does this PR do?

Add triggers for additional Intercom webhooks:
- new conversation from user
- new reply from user
- new reply from admin
- conversation assigned to admin
- conversation closed
- conversation snoozed
- conversation un-snoozed

ANNOUNCEMENT=true