### PR TITLE
fix(piece.service): fix pieces search for action names

### DIFF
--- a/packages/ui/feature-pieces/src/lib/services/piece.service.ts
+++ b/packages/ui/feature-pieces/src/lib/services/piece.service.ts
@@ -60,10 +60,14 @@ export class PieceMetadataService {
                 includeHidden: request.includeHidden ? 'true' : 'false',
                 ...spreadIfDefined('includeTags', request.includeTags),
                 ...spreadIfDefined('searchQuery', request.searchQuery),
-                ...spreadIfDefined('suggestionType', !isNil(request.searchQuery) && request.searchQuery.length > 3 ? request.suggestionType : undefined)
+                ...spreadIfDefined('suggestionType', this.shouldShowSuggestionType(request.searchQuery) ? request.suggestionType : undefined)
             }
         });
     }
+
+    private shouldShowSuggestionType(searchQuery: string | undefined) {
+        return !isNil(searchQuery) && searchQuery.length >= 2;
+      }
 
     private listCorePieces(searchQuery: string | undefined, suggestionType: SuggestionType): Observable<PieceMetadataModelSummary[]> {
         return this.listPieces({


### PR DESCRIPTION
## What does this PR do?

This PR makes partial match work for more than 2 characters for piece actions names.

Partial match for searches does not work when there are not at least 4 characters when searching for piece actions keyworks. 

Example:
![image](https://github.com/user-attachments/assets/0b66fc2a-8bbe-4c96-8af5-3d00ba670386)
![image](https://github.com/user-attachments/assets/07727e43-4b8d-47f0-867c-a43b19780f7c)

Fixes #5142

