### PR TITLE
feat: count the number of consecutive failure for every scheduled Job

### DIFF
--- a/packages/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/engine/src/lib/helper/trigger-helper.ts
@@ -66,6 +66,7 @@ export const triggerHelper = {
                 scheduleOptions = {
                     cronExpression: request.cronExpression,
                     timezone: request.timezone ?? 'UTC',
+                    failureCount: request.failureCount ?? 0,
                 }
             },
             webhookUrl: params.webhookUrl,

--- a/packages/server/api/src/app/flows/flow/flow-service-side-effects.ts
+++ b/packages/server/api/src/app/flows/flow/flow-service-side-effects.ts
@@ -63,6 +63,7 @@ export const flowSideEffects = {
             scheduleOptions: {
                 ...scheduleOptions,
                 type: ScheduleType.CRON_EXPRESSION,
+                failureCount: flowToUpdate.schedule?.failureCount ?? 0,
             },
         }
     },
@@ -102,6 +103,7 @@ export const flowSideEffects = {
             scheduleOptions: {
                 ...scheduleOptions,
                 type: ScheduleType.CRON_EXPRESSION,
+                failureCount: 0,
             },
         }
     },

--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -315,12 +315,12 @@ export const flowService = {
         })
     },
 
-    async updateFaliureCount({
+    async updateFailureCount({
         flowId,
         projectId,
         failureCount,
         entityManager,
-    }: UpdateFaliureCountParams): Promise<PopulatedFlow> {
+    }: UpdateFailureCountParams): Promise<PopulatedFlow> {
         const flowToUpdate = await this.getOneOrThrow({
             id: flowId,
             projectId,
@@ -439,7 +439,7 @@ export const flowService = {
         flowId,
         projectId,
         entityManager,
-    }: GetFaliureCountParams): Promise<number> {
+    }: GetFailureCountParams): Promise<number> {
         const flowToUpdate = await this.getOneOrThrow({
             id: flowId,
             projectId,
@@ -562,14 +562,14 @@ type UpdateStatusParams = {
     entityManager?: EntityManager
 }
 
-type UpdateFaliureCountParams = {
+type UpdateFailureCountParams = {
     flowId: FlowId
     projectId: ProjectId
     failureCount: number
     entityManager?: EntityManager
 }
 
-type GetFaliureCountParams = {
+type GetFailureCountParams = {
     flowId: FlowId
     projectId: ProjectId
     entityManager?: EntityManager

--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -315,6 +315,32 @@ export const flowService = {
         })
     },
 
+    async updateFaliureCount({
+        flowId,
+        projectId,
+        failureCount,
+        entityManager,
+    }: UpdateFaliureCountParams): Promise<PopulatedFlow> {
+        const flowToUpdate = await this.getOneOrThrow({
+            id: flowId,
+            projectId,
+            entityManager,
+        })
+
+        if (flowToUpdate.schedule) {
+            flowToUpdate.schedule.failureCount = failureCount
+        }
+
+        await flowRepo(entityManager).save(flowToUpdate)
+
+        return this.getOnePopulatedOrThrow({
+            id: flowId,
+            projectId,
+            entityManager,
+        })
+    },
+
+
     async updatedPublishedVersionId({
         id,
         userId,
@@ -408,6 +434,25 @@ export const flowService = {
             blogUrl: '',
         }
     },
+
+    async getFailureCount({
+        flowId,
+        projectId,
+        entityManager,
+    }: GetFaliureCountParams): Promise<number> {
+        const flowToUpdate = await this.getOneOrThrow({
+            id: flowId,
+            projectId,
+            entityManager,
+        })
+        if (flowToUpdate.schedule === null || flowToUpdate.schedule === undefined) {
+            return 0
+        }
+        else {
+            return flowToUpdate.schedule.failureCount ?? 0
+        }
+    },
+
 
     async count({ projectId, folderId }: CountParams): Promise<number> {
         if (folderId === undefined) {
@@ -514,6 +559,19 @@ type UpdateStatusParams = {
     id: FlowId
     projectId: ProjectId
     newStatus: FlowStatus
+    entityManager?: EntityManager
+}
+
+type UpdateFaliureCountParams = {
+    flowId: FlowId
+    projectId: ProjectId
+    failureCount: number
+    entityManager?: EntityManager
+}
+
+type GetFaliureCountParams = {
+    flowId: FlowId
+    projectId: ProjectId
     entityManager?: EntityManager
 }
 

--- a/packages/server/api/src/app/flows/trigger/hooks/enable-trigger-hook.ts
+++ b/packages/server/api/src/app/flows/trigger/hooks/enable-trigger-hook.ts
@@ -113,6 +113,7 @@ EngineHelperTriggerResult<TriggerHookType.ON_ENABLE>
                         scheduleOptions: {
                             cronExpression: renewConfiguration.cronExpression,
                             timezone: 'UTC',
+                            failureCount: 0,
                         },
                     })
                     break
@@ -127,6 +128,7 @@ EngineHelperTriggerResult<TriggerHookType.ON_ENABLE>
                 engineHelperResponse.result.scheduleOptions = {
                     cronExpression: POLLING_FREQUENCY_CRON_EXPRESSON,
                     timezone: 'UTC',
+                    failureCount: 0,
                 }
                 // BEGIN EE
                 const edition = system.getEdition()

--- a/packages/server/api/src/app/workers/engine-controller.ts
+++ b/packages/server/api/src/app/workers/engine-controller.ts
@@ -1,4 +1,4 @@
-import { GetFailureCountRequest, GetRunForWorkerRequest, JobStatus, logger, QueueName, SharedSystemProp, system, UpdateJobRequest } from '@activepieces/server-shared'
+import { GetRunForWorkerRequest, JobStatus, logger, QueueName, SharedSystemProp, system, UpdateFailureCountRequest, UpdateJobRequest } from '@activepieces/server-shared'
 import { ActivepiecesError, ApEdition, ApEnvironment, assertNotNullOrUndefined, EngineHttpResponse, EnginePrincipal, ErrorCode, ExecutionState, FlowRunResponse, FlowRunStatus, FlowStatus, GetFlowVersionForWorkerRequest, GetFlowVersionForWorkerRequestType, isNil, PauseType, PopulatedFlow, PrincipalType, ProgressUpdateType, RemoveStableJobEngineRequest, StepOutput, UpdateRunProgressRequest, WebsocketClientEvent } from '@activepieces/shared'
 import { FastifyPluginAsyncTypebox, Type } from '@fastify/type-provider-typebox'
 import { StatusCodes } from 'http-status-codes'
@@ -53,28 +53,12 @@ export const flowEngineWorker: FastifyPluginAsyncTypebox = async (app) => {
     })
 
     app.post('/update-failure-count', UpdateFailureCount, async (request) => {
-        const { flowId, projectId, failureCount } = request.body
+        const { flowId, projectId, success } = request.body
         await flowService.updateFailureCount({
             flowId,
             projectId,
-            failureCount,
+            success,
         })
-    })
-
-    app.post('/failure-count', {
-        config: {
-            allowedPrincipals: [PrincipalType.ENGINE],
-        },
-        schema: {
-            body: GetFailureCountRequest,
-        },
-    }, async (request) => {
-        const { flowId, projectId } = request.body
-        const count = await flowService.getFailureCount({
-            flowId,
-            projectId,
-        })
-        return count
     })
 
     app.post('/update-run', UpdateStepProgress, async (request) => {
@@ -358,11 +342,7 @@ const UpdateFailureCount = {
         allowedPrincipals: [PrincipalType.ENGINE],
     },
     schema: {
-        body: Type.Object({
-            flowId: Type.String(),
-            projectId: Type.String(),
-            failureCount: Type.Number(),
-        }),
+        body: UpdateFailureCountRequest,
     },
 }
 

--- a/packages/server/api/src/app/workers/engine-controller.ts
+++ b/packages/server/api/src/app/workers/engine-controller.ts
@@ -52,9 +52,9 @@ export const flowEngineWorker: FastifyPluginAsyncTypebox = async (app) => {
         return {}
     })
 
-    app.post('/update-failure-count', UpdateFaliureCount, async (request) => {
+    app.post('/update-failure-count', UpdateFailureCount, async (request) => {
         const { flowId, projectId, failureCount } = request.body
-        await flowService.updateFaliureCount({
+        await flowService.updateFailureCount({
             flowId,
             projectId,
             failureCount,
@@ -353,7 +353,7 @@ const UpdateStepProgress = {
     },
 }
 
-const UpdateFaliureCount = {
+const UpdateFailureCount = {
     config: {
         allowedPrincipals: [PrincipalType.ENGINE],
     },

--- a/packages/server/api/src/app/workers/memory/ap-memory-queue.ts
+++ b/packages/server/api/src/app/workers/memory/ap-memory-queue.ts
@@ -9,6 +9,7 @@ export type ApJob<T> = {
     cronExpression?: string
     cronTimezone?: string
     nextFireAtEpochSeconds?: number
+    failureCount?: number
 }
 
 export class ApMemoryQueue<T> {

--- a/packages/server/shared/package.json
+++ b/packages/server/shared/package.json
@@ -8,7 +8,8 @@
     "pino-loki": "2.1.3",
     "@activepieces/shared": "*",
     "fastify": "4.12.0",
-    "async-mutex": "0.4.0"
+    "async-mutex": "0.4.0",
+    "@sinclair/typebox": "0.31.28"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/server/shared/src/lib/job/index.ts
+++ b/packages/server/shared/src/lib/job/index.ts
@@ -35,11 +35,27 @@ export const UpdateJobRequest = Type.Object({
 })
 export type UpdateJobRequest = Static<typeof UpdateJobRequest>
 
+export const UpdateFailureCountRequest = Type.Object({
+    flowId: Type.String(),
+    projectId: Type.String(),
+    failureCount: Type.Number(),
+})
+
+export type UpdateFailureCountRequest = Static<typeof UpdateFailureCountRequest>
+
 export const ApQueueJob = Type.Object({
     id: Type.String(),
     data: JobData,
     engineToken: Type.String(),
 })
+
+export type GetFailureCountRequest = Static<typeof GetFailureCountRequest>
+
+export const GetFailureCountRequest = Type.Object({
+    flowId: Type.String(),
+    projectId: Type.String(),
+})
+
 
 export type ApQueueJob = Static<typeof ApQueueJob>
 

--- a/packages/server/shared/src/lib/job/index.ts
+++ b/packages/server/shared/src/lib/job/index.ts
@@ -38,7 +38,7 @@ export type UpdateJobRequest = Static<typeof UpdateJobRequest>
 export const UpdateFailureCountRequest = Type.Object({
     flowId: Type.String(),
     projectId: Type.String(),
-    failureCount: Type.Number(),
+    success: Type.Boolean(),
 })
 
 export type UpdateFailureCountRequest = Static<typeof UpdateFailureCountRequest>
@@ -48,14 +48,6 @@ export const ApQueueJob = Type.Object({
     data: JobData,
     engineToken: Type.String(),
 })
-
-export type GetFailureCountRequest = Static<typeof GetFailureCountRequest>
-
-export const GetFailureCountRequest = Type.Object({
-    flowId: Type.String(),
-    projectId: Type.String(),
-})
-
 
 export type ApQueueJob = Static<typeof ApQueueJob>
 

--- a/packages/server/worker/src/lib/api/server-api.service.ts
+++ b/packages/server/worker/src/lib/api/server-api.service.ts
@@ -1,6 +1,6 @@
 
 import { PieceMetadataModel } from '@activepieces/pieces-framework'
-import { ApQueueJob, DeleteWebhookSimulationRequest, exceptionHandler, GetRunForWorkerRequest, networkUtls, PollJobRequest, QueueName, ResumeRunRequest, SavePayloadRequest, SendWebhookUpdateRequest, SubmitPayloadsRequest, UpdateJobRequest } from '@activepieces/server-shared'
+import { ApQueueJob, DeleteWebhookSimulationRequest, exceptionHandler, GetFailureCountRequest, GetRunForWorkerRequest, networkUtls, PollJobRequest, QueueName, ResumeRunRequest, SavePayloadRequest, SendWebhookUpdateRequest, SubmitPayloadsRequest, UpdateFailureCountRequest, UpdateJobRequest } from '@activepieces/server-shared'
 import { ActivepiecesError, ErrorCode, FlowRun, GetFlowVersionForWorkerRequest, GetPieceRequestQuery, PopulatedFlow, RemoveStableJobEngineRequest, UpdateRunProgressRequest, WorkerMachineHealthcheckRequest } from '@activepieces/shared'
 import { StatusCodes } from 'http-status-codes'
 import { heartbeat } from '../utils/heartbeat'
@@ -65,6 +65,15 @@ export const engineApiService = (engineToken: string) => {
         },
         async updateJobStatus(request: UpdateJobRequest): Promise<void> {
             await client.post('/v1/engine/update-job', request)
+        },
+        async updateFaliureCount(request: UpdateFailureCountRequest): Promise<void> {
+            await client.post('/v1/engine/update-failure-count', request)
+        },
+        async getFaliureCount(request: GetFailureCountRequest): Promise<number> {
+            return client.post<number>('/v1/engine/failure-count', {
+                flowId: request.flowId,
+                projectId: request.projectId,
+            })
         },
         async getRun(request: GetRunForWorkerRequest): Promise<FlowRun> {
             return client.get<FlowRun>('/v1/engine/runs/' + request.runId, {})

--- a/packages/server/worker/src/lib/api/server-api.service.ts
+++ b/packages/server/worker/src/lib/api/server-api.service.ts
@@ -66,10 +66,10 @@ export const engineApiService = (engineToken: string) => {
         async updateJobStatus(request: UpdateJobRequest): Promise<void> {
             await client.post('/v1/engine/update-job', request)
         },
-        async updateFaliureCount(request: UpdateFailureCountRequest): Promise<void> {
+        async updateFailureCount(request: UpdateFailureCountRequest): Promise<void> {
             await client.post('/v1/engine/update-failure-count', request)
         },
-        async getFaliureCount(request: GetFailureCountRequest): Promise<number> {
+        async getFailureCount(request: GetFailureCountRequest): Promise<number> {
             return client.post<number>('/v1/engine/failure-count', {
                 flowId: request.flowId,
                 projectId: request.projectId,

--- a/packages/server/worker/src/lib/api/server-api.service.ts
+++ b/packages/server/worker/src/lib/api/server-api.service.ts
@@ -1,6 +1,6 @@
 
 import { PieceMetadataModel } from '@activepieces/pieces-framework'
-import { ApQueueJob, DeleteWebhookSimulationRequest, exceptionHandler, GetFailureCountRequest, GetRunForWorkerRequest, networkUtls, PollJobRequest, QueueName, ResumeRunRequest, SavePayloadRequest, SendWebhookUpdateRequest, SubmitPayloadsRequest, UpdateFailureCountRequest, UpdateJobRequest } from '@activepieces/server-shared'
+import { ApQueueJob, DeleteWebhookSimulationRequest, exceptionHandler, GetRunForWorkerRequest, networkUtls, PollJobRequest, QueueName, ResumeRunRequest, SavePayloadRequest, SendWebhookUpdateRequest, SubmitPayloadsRequest, UpdateFailureCountRequest, UpdateJobRequest } from '@activepieces/server-shared'
 import { ActivepiecesError, ErrorCode, FlowRun, GetFlowVersionForWorkerRequest, GetPieceRequestQuery, PopulatedFlow, RemoveStableJobEngineRequest, UpdateRunProgressRequest, WorkerMachineHealthcheckRequest } from '@activepieces/shared'
 import { StatusCodes } from 'http-status-codes'
 import { heartbeat } from '../utils/heartbeat'
@@ -68,12 +68,6 @@ export const engineApiService = (engineToken: string) => {
         },
         async updateFailureCount(request: UpdateFailureCountRequest): Promise<void> {
             await client.post('/v1/engine/update-failure-count', request)
-        },
-        async getFailureCount(request: GetFailureCountRequest): Promise<number> {
-            return client.post<number>('/v1/engine/failure-count', {
-                flowId: request.flowId,
-                projectId: request.projectId,
-            })
         },
         async getRun(request: GetRunForWorkerRequest): Promise<FlowRun> {
             return client.get<FlowRun>('/v1/engine/runs/' + request.runId, {})

--- a/packages/server/worker/src/lib/trigger/hooks/extract-trigger-payload-hooks.ts
+++ b/packages/server/worker/src/lib/trigger/hooks/extract-trigger-payload-hooks.ts
@@ -29,14 +29,14 @@ export async function extractPayloads(
             }),
             projectId,
         })
-        const isDisabled = await handleFaliureFlow(flowVersion, projectId, engineToken)
+        const isDisabled = await handleFailureFlow(flowVersion, projectId, engineToken)
         if (isDisabled) {
             // TODO disable the trigger
             // return []
         }
         if (!isNil(result) && result.success && Array.isArray(result.output)) {
             const engineConroller = engineApiService(engineToken)
-            await engineConroller.updateFaliureCount({
+            await engineConroller.updateFailureCount({
                 flowId: flowVersion.flowId,
                 projectId,
                 failureCount: 0,
@@ -51,7 +51,7 @@ export async function extractPayloads(
                 flowId: flowVersion.flowId,
             }, 'Failed to execute trigger')
             
-            const isDisabled = await handleFaliureFlow(flowVersion, projectId, engineToken)
+            const isDisabled = await handleFailureFlow(flowVersion, projectId, engineToken)
             if (isDisabled) {
                 // TODO disable the trigger
             }
@@ -69,7 +69,7 @@ export async function extractPayloads(
                 flowId: flowVersion.flowId,
             }, 'Failed to execute trigger due to timeout')
 
-            const isDisabled = await handleFaliureFlow(flowVersion, projectId, engineToken)
+            const isDisabled = await handleFailureFlow(flowVersion, projectId, engineToken)
             if (isDisabled) {
                 // Disable the trigger
             }
@@ -81,10 +81,10 @@ export async function extractPayloads(
     }
 }
 
-async function handleFaliureFlow(flowVersion: FlowVersion, projectId: ProjectId, engineToken: string): Promise<boolean> {
+async function handleFailureFlow(flowVersion: FlowVersion, projectId: ProjectId, engineToken: string): Promise<boolean> {
     const engineConroller = engineApiService(engineToken)
 
-    const failureCount = await engineConroller.getFaliureCount({
+    const failureCount = await engineConroller.getFailureCount({
         flowId: flowVersion.flowId,
         projectId,
     })
@@ -93,7 +93,7 @@ async function handleFaliureFlow(flowVersion: FlowVersion, projectId: ProjectId,
         return true
     }
 
-    await engineConroller.updateFaliureCount({
+    await engineConroller.updateFailureCount({
         flowId: flowVersion.flowId,
         projectId,
         failureCount: failureCount + 1,

--- a/packages/server/worker/src/lib/trigger/hooks/extract-trigger-payload-hooks.ts
+++ b/packages/server/worker/src/lib/trigger/hooks/extract-trigger-payload-hooks.ts
@@ -35,8 +35,8 @@ export async function extractPayloads(
             // return []
         }
         if (!isNil(result) && result.success && Array.isArray(result.output)) {
-            const engineConroller = engineApiService(engineToken)
-            await engineConroller.updateFailureCount({
+            const engineController = engineApiService(engineToken)
+            await engineController.updateFailureCount({
                 flowId: flowVersion.flowId,
                 projectId,
                 failureCount: 0,
@@ -82,9 +82,9 @@ export async function extractPayloads(
 }
 
 async function handleFailureFlow(flowVersion: FlowVersion, projectId: ProjectId, engineToken: string): Promise<boolean> {
-    const engineConroller = engineApiService(engineToken)
+    const engineController = engineApiService(engineToken)
 
-    const failureCount = await engineConroller.getFailureCount({
+    const failureCount = await engineController.getFailureCount({
         flowId: flowVersion.flowId,
         projectId,
     })
@@ -93,7 +93,7 @@ async function handleFailureFlow(flowVersion: FlowVersion, projectId: ProjectId,
         return true
     }
 
-    await engineConroller.updateFailureCount({
+    await engineController.updateFailureCount({
         flowId: flowVersion.flowId,
         projectId,
         failureCount: failureCount + 1,

--- a/packages/server/worker/src/lib/utils/engine-installer.ts
+++ b/packages/server/worker/src/lib/utils/engine-installer.ts
@@ -1,6 +1,7 @@
 import { copyFile } from 'node:fs/promises'
-import { fileExists, logger, memoryLock, SharedSystemProp, system } from '@activepieces/server-shared'
+import { logger, memoryLock, SharedSystemProp, system } from '@activepieces/server-shared'
 import { ApEnvironment } from '@activepieces/shared'
+import { cacheHandler, CacheState } from './cache-handler'
 
 const engineExecutablePath = system.getOrThrow(
     SharedSystemProp.ENGINE_EXECUTABLE_PATH,
@@ -14,14 +15,19 @@ export const engineInstaller = {
     async install({ path }: InstallParams): Promise<void> {
         const lock = await memoryLock.acquire(`engineInstaller#${path}`)
         try {
+
+            const cache = cacheHandler(path) 
+            
+            const engineFileExists =  await cache.cacheCheckState('main.js') === CacheState.READY
             logger.debug({ path }, '[engineInstaller#install]')
-            const engineFileExists = await fileExists(`${path}/main.js`)
             if (!engineFileExists || isDev) {
-                await copyFile(engineExecutablePath, `${path}/main.js`)
+                await copyFile(engineExecutablePath, `${path}/main.js`) 
+                await cache.setCache('main.js', CacheState.READY)
             }
-            const engineMapFileExists = await fileExists(`${path}/main.js.map`)
+            const engineMapFileExists =  await cache.cacheCheckState('main.js.map') === CacheState.READY
             if (!engineMapFileExists || isDev) {
                 await copyFile(`${engineExecutablePath}.map`, `${path}/main.js.map`)
+                await cache.setCache('main.js.map', CacheState.READY)
             }
         }
         finally {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.10.114",
+  "version": "0.10.115",
   "type": "commonjs"
 }

--- a/packages/shared/src/lib/engine/engine-operation.ts
+++ b/packages/shared/src/lib/engine/engine-operation.ts
@@ -185,6 +185,7 @@ export type ExecuteValidateAuthResponse =
 export type ScheduleOptions = {
     cronExpression: string
     timezone: string
+    failureCount: number
 }
 
 export type EngineResponse<T> = {

--- a/packages/shared/src/lib/flows/flow.ts
+++ b/packages/shared/src/lib/flows/flow.ts
@@ -18,6 +18,7 @@ export const FlowScheduleOptions = Type.Object({
     type: Type.Literal(ScheduleType.CRON_EXPRESSION),
     cronExpression: Type.String(),
     timezone: Type.String(),
+    failureCount: Type.Optional(Type.Number()),
 })
 
 export type FlowScheduleOptions = Static<typeof FlowScheduleOptions>


### PR DESCRIPTION
## What does this PR do?

Added a new field called "failureCount" stored in the database to count the number of consecutive failures for every scheduled Job to use it later on removing the stuck job in the queue 
