### PR TITLE
feat: ING Bank Australia

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,17 @@ ARG VARIANT=18-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libgbm1 \
+    libasound2 \
+    libpangocairo-1.0-0 \
+    libxss1 \
+    libgtk-3-0
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         python3 \
         g++ \
         build-essential \
-        git && \
+        git \
+        libnss3 \
+        libatk1.0-0 \
+        libatk-bridge2.0-0 \
+        libcups2 \
+        libgbm1 \
+        libasound2 \
+        libpangocairo-1.0-0 \
+        libxss1 \
+        libgtk-3-0 && \
     yarn config set python /usr/bin/python3 && \
     npm install -g node-gyp
 

--- a/packages/pieces/community/ing-australia/.eslintrc.json
+++ b/packages/pieces/community/ing-australia/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/ing-australia/README.md
+++ b/packages/pieces/community/ing-australia/README.md
@@ -1,0 +1,9 @@
+# pieces-ing-australia
+
+This library allows a user to download ING Bank Australia transactions in CSV, QIF and OFX formats. This can then be used for feeding into other software, such as ActualBudget.
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-ing-australia` to build the library.

--- a/packages/pieces/community/ing-australia/package.json
+++ b/packages/pieces/community/ing-australia/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@activepieces/piece-ing-australia",
+  "version": "0.0.1",
+  "dependencies": {
+    "ing-au-login": "2.0.7",
+    "puppeteer": "22.13.1",
+    "moment": "2.30.1",
+    "axios": "1.7.2",
+    "qs": "6.12.3"
+  }
+}

--- a/packages/pieces/community/ing-australia/project.json
+++ b/packages/pieces/community/ing-australia/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-ing-australia",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/ing-australia/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/ing-australia",
+        "tsConfig": "packages/pieces/community/ing-australia/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/ing-australia/package.json",
+        "main": "packages/pieces/community/ing-australia/src/index.ts",
+        "assets": [
+          "packages/pieces/community/ing-australia/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/ing-australia/src/index.ts
+++ b/packages/pieces/community/ing-australia/src/index.ts
@@ -1,0 +1,39 @@
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { PieceCategory } from '@activepieces/shared';
+import { downloadTransactions } from './lib/actions/download-transactions';
+
+export const ingAustraliaAuth = PieceAuth.BasicAuth({
+  description: 'Enter your client number and PIN code',
+  required: true,
+  username: {
+      displayName: 'Client number',
+      description: 'Enter your ING Bank Australia client number',
+  },
+  password: {
+      displayName: 'PIN code',
+      description: 'Enter your PIN code',
+  },
+  // Optional Validation
+  validate: async ({auth}) => {
+      if(auth){
+          return {
+              valid: true,
+          }
+      }
+      return {
+          valid: false,
+          error: ''
+      }
+  }
+});
+
+export const ingAustralia = createPiece({
+  displayName: "ING Bank Australia",
+  categories: [PieceCategory.ACCOUNTING],
+  auth: ingAustraliaAuth,
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: "https://www.ing.com.au/img/logos/ing.webp",
+  authors: [],
+  actions: [downloadTransactions],
+  triggers: [],
+});

--- a/packages/pieces/community/ing-australia/src/index.ts
+++ b/packages/pieces/community/ing-australia/src/index.ts
@@ -1,17 +1,40 @@
-import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import {
+    createPiece,
+    PieceAuth,
+    Property,
+  } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import { downloadTransactions } from './lib/actions/download-transactions';
 
-export const ingAustraliaAuth = PieceAuth.BasicAuth({
-  description: 'Enter your client number and PIN code',
+export const ingAustraliaAuth = PieceAuth.CustomAuth({
+  description: 'Enter details required to authenticate with ING Bank Australia.',
   required: true,
-  username: {
-      displayName: 'Client number',
-      description: 'Enter your ING Bank Australia client number',
-  },
-  password: {
-      displayName: 'PIN code',
-      description: 'Enter your PIN code',
+  props: {
+    username: Property.ShortText({
+        displayName: 'Client number',
+        required: true,
+        description: 'Enter your ING Bank Australia client number.',
+    }),
+    password: PieceAuth.SecretText({
+        displayName: 'PIN code',
+        description: 'Enter your PIN code.',
+        required: true,
+    }),
+    browserless_url: Property.LongText({
+        displayName: 'Browserless URL',
+        required: true,
+        description: 'Enter a Browserless URL the configured token in the following format: ' +
+        '192.168.1.10:3000?token=6R0W53R135510\n\n' +
+        'Additional details: A Browserless service is required to be running, in order ' + 
+        'to log into the ING Bank of Australia. This is because we need to make ' +
+        'use of a web browser to insert your client number and pin code, to then ' + 
+        'get acces to additional services, such as downloading transactions.\n\n' +
+        'If one is self-hosting, one method to set up Browserless, is to create it ' +
+        'via Docker Compose, within the ActivePieces Docker compose file.\n\n' +
+        'Documentation can be found here: https://docs.browserless.io/docker/docker-quickstart/\n' +
+        'The provided Docker run command can be converted to a Docker compose file via: ' +
+        'https://www.composerize.com/',
+    }),
   },
   // Optional Validation
   validate: async ({auth}) => {

--- a/packages/pieces/community/ing-australia/src/lib/actions/download-transactions.ts
+++ b/packages/pieces/community/ing-australia/src/lib/actions/download-transactions.ts
@@ -1,0 +1,140 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+
+import { ingAustraliaAuth } from '../..';
+import { retrieveAuthToken, fetchTransactions } from '../common';
+
+export const downloadTransactions = createAction({
+  name: 'downloadTransactions',
+  auth: ingAustraliaAuth,
+  displayName: 'Download Transactions',
+  description:
+    'Download bank transactions in multiple formats, such as CSV or OFX.',
+  props: {
+    account_number: Property.ShortText({
+      displayName: 'Account Number',
+      required: true,
+    }),
+    download_format: Property.StaticDropdown({
+      displayName: 'Download Format',
+      description: 'Select the format to download transactions in',
+      required: true,
+      options: {
+          options: [
+              {
+                  label: 'CSV (Excel)',
+                  value: 'csv'
+              },
+              {
+                  label: 'OFX (MYOB, MS Money)',
+                  value: 'ofx'
+              },
+              {
+                label: 'QIF (Quicken)',
+                value: 'qif'
+              }
+          ]
+      }
+    }),
+    search_query: Property.LongText({
+      displayName: 'Search query',
+      description: 'Query for transactions to download',
+      defaultValue: '',
+      required: false
+  }),
+  min_amount: Property.Number({
+    displayName: 'Minimum Amount',
+    description: 'Enter the minimum amount, in dollars ($)',
+    required: false,
+  }),
+  max_amount: Property.Number({
+    displayName: 'Maximum Amount',
+    description: 'Enter the maximum amount, in dollars ($)',
+    required: false,
+  }),
+  transaction_type: Property.StaticDropdown({
+    displayName: 'Transactions',
+    description: 'Select the specific type of of transactions to download',
+    required: true,
+    options: {
+        options: [
+            {
+              label: 'All',
+              value: 0
+            },
+            {
+              label: 'Bank cheques',
+              value: 1
+            },
+            {
+              label: 'BPAY payments',
+              value: 2
+            },
+            {
+              label: 'Cash and purchases',
+              value: 4
+            },
+            {
+              label: 'Cheque deposits',
+              value: 3
+            },
+            {
+              label: 'Deposits',
+              value: 11
+            },
+            {
+              label: 'Direct debits',
+              value: 5
+            },
+        ]
+    }
+  }),
+  period_in_days: Property.StaticDropdown({
+    displayName: 'Period',
+    description: 'Select the period of transactions to download',
+    required: true,
+    options: {
+        options: [
+            {
+              label: 'Last 30 days',
+              value: 30
+            },
+            {
+              label: 'Last 60 days',
+              value: 60
+            },
+            {
+              label: 'Last 90 days',
+              value: 90
+            },
+            {
+              label: 'Last 6 months',
+              value: 183
+            },
+            {
+              label: 'Last 12 months',
+              value: 365
+            },
+            {
+              label: 'All available (last 5 years)',
+              value: 1827
+            },
+        ]
+    }
+  }),
+  },
+  async run(context) {
+    const authToken = await retrieveAuthToken(context); 
+
+    const data = await fetchTransactions(
+      authToken,
+      context.propsValue['account_number'],
+      context.propsValue.download_format,
+      context.propsValue.search_query ?? '',
+      context.propsValue.period_in_days,
+      context.propsValue.min_amount ?? '',
+      context.propsValue.max_amount ?? '',
+      (context.propsValue.transaction_type == 0) ? '' : context.propsValue.transaction_type
+    );
+    return data;
+  },
+});

--- a/packages/pieces/community/ing-australia/src/lib/common.ts
+++ b/packages/pieces/community/ing-australia/src/lib/common.ts
@@ -1,4 +1,4 @@
-import { launch } from 'puppeteer';
+import { connect } from 'puppeteer';
 import { login } from 'ing-au-login';
 
 import axios from 'axios';
@@ -9,9 +9,8 @@ import moment from 'moment';
 export async function retrieveAuthToken(context: any) {
     // Log into the ING web portal, using the browser.
     let authToken = "";
-    const browser = await launch({
-      headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    const browser = await connect({
+      browserWSEndpoint: 'ws://' + context.auth.browserless_url
     });
     const page = await browser.newPage();
     try {

--- a/packages/pieces/community/ing-australia/src/lib/common.ts
+++ b/packages/pieces/community/ing-australia/src/lib/common.ts
@@ -1,0 +1,72 @@
+import { launch } from 'puppeteer';
+import { login } from 'ing-au-login';
+
+import axios from 'axios';
+import qs from 'qs';
+import moment from 'moment';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function retrieveAuthToken(context: any) {
+    // Log into the ING web portal, using the browser.
+    let authToken = "";
+    const browser = await launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    const page = await browser.newPage();
+    try {
+      // TODO: Handle cases where ING locks a user out, and requests that they reset
+      // their PIN code. Return error message telling a user what to do.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        try {
+          authToken = await login(
+            page,
+            context.auth.username,
+            context.auth.password
+          );
+          console.log(authToken);
+          break;
+        } catch (e) {
+          const message = (e as Error).message
+          console.log(message);
+        }
+      }
+    } finally {
+      await page.close();
+      await browser.close();
+    }
+
+    return authToken;
+}
+
+export async function fetchTransactions(
+    authToken: string,
+    accountNumber: string,
+    downloadFormat: string,
+    searchQuery: string,
+    periodInDays: number,
+    minAmount: number | string,
+    maxAmount: number | string,
+    transactionType: number | string
+) {
+    const url =
+      'https://www.ing.com.au/api/ExportTransactions/Service/ExportTransactionsService.svc/json/ExportTransactions/ExportTransactions'
+    const data = {
+      'X-AuthToken': authToken,
+      AccountNumber: accountNumber,
+      Format: downloadFormat,
+      FilterStartDate: moment()
+        .subtract(periodInDays, 'days')
+        .format('YYYY-MM-DDTHH:mm:ssZZ'),
+      FilterEndDate: moment()
+        .format('YYYY-MM-DDTHH:mmssZZ'),
+      FilterMinValue: minAmount,
+      FilterMaxValue: maxAmount,
+      FilterProductTransactionTypeId: transactionType,
+      SearchQuery: searchQuery,
+      IsSpecific: 'false',
+    }
+    const response = await axios.post(url, qs.stringify(data));
+    return response.data;
+}

--- a/packages/pieces/community/ing-australia/tsconfig.json
+++ b/packages/pieces/community/ing-australia/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/ing-australia/tsconfig.lib.json
+++ b/packages/pieces/community/ing-australia/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

This PR introduces the ING Bank Australia piece, which allows a user to download their bank statements in multiple formats, such as CSV or QIF.

These statements can then be added to e.g. Actual Budget ([piece](https://github.com/activepieces/activepieces/pull/5093)) or Firefly III.

![Screenshot_20240723_081845](https://github.com/user-attachments/assets/67af09e1-7c4c-4c46-ac0e-787066dcba38)

Credit to https://github.com/adamroyle/ing-au-login, for the code to log into ING.

## Dependencies

In order for this PR to work in ActivePieces, the following dependencies will need to be installed:

* NPM: `npm install ing-au-login puppeteer`
* APT, in the Dockerfile: `sudo apt install libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libgbm1 libasound2 libpangocairo-1.0-0 libxss1 libgtk-3-0` (https://gist.github.com/tavinus/7effd4b3dac87cb4366e3767679a192f) - For the headless browser.
* ING Bank Australia logo will need to be re-uploaded to a permanent location.