### PR TITLE
fix:  skip updateFailureCount when flow is disabled

### DIFF
--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -329,8 +329,11 @@ export const flowService = {
             id: flowId,
             projectId,
         })
+        
         const { schedule } = flow
-        if (isNil(schedule)) {
+        const skipUpdateFlowCount = isNil(schedule) || flow.status === FlowStatus.DISABLED 
+
+        if ( skipUpdateFlowCount ) {
             return
         }
         const newFailureCount = success ? 0 : (schedule.failureCount ?? 0) + 1


### PR DESCRIPTION
## What does this PR do?

It triggers if the user exceeded the max limit of failures in executing a trigger flow it will stop it and send an email to the user to review the flow, fix it and publish it again

