### PR TITLE
feat(notion): add option to convert page content to markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -158,6 +158,7 @@
         "ngx-timeago": "3.0.0",
         "node-cron": "3.0.3",
         "nodemailer": "6.9.9",
+        "notion-to-md": "3.1.1",
         "nx-cloud": "19.0.0",
         "object-sizeof": "2.6.3",
         "openai": "4.47.1",
@@ -35973,6 +35974,18 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
       "integrity": "sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg=="
+    },
+    "node_modules/notion-to-md": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/notion-to-md/-/notion-to-md-3.1.1.tgz",
+      "integrity": "sha512-Zaa2P1B9Rx99bevFYTGuUMYbbfdHn2G1AZMsytYGDWIJjr6Ie1qp/8CorpwVUh1qrquES/V2PkEREqCuTu1zKA==",
+      "dependencies": {
+        "markdown-table": "^2.0.0",
+        "node-fetch": "2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/npm-bundled": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "ngx-timeago": "3.0.0",
     "node-cron": "3.0.3",
     "nodemailer": "6.9.9",
+    "notion-to-md": "3.1.1",
     "nx-cloud": "19.0.0",
     "object-sizeof": "2.6.3",
     "openai": "4.47.1",

--- a/packages/pieces/community/notion/package.json
+++ b/packages/pieces/community/notion/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-notion",
-  "version": "0.3.0"
+  "version": "0.3.1"
 }


### PR DESCRIPTION
## What does this PR do?

Add option to get the markdown content of a page instead of a list of blocks
