### PR TITLE
fix: update build cloud nx with the updated template

### DIFF
--- a/.github/workflows/build-cloud-nx.yml
+++ b/.github/workflows/build-cloud-nx.yml
@@ -1,30 +1,32 @@
-name: build-cloud-nx
-
+name: CI
 on:
   push:
     branches:
       - main
   pull_request:
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   main:
-    name: Nx Cloud - Main Job
-    secrets:
-      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.14.0
-    with:
-      number-of-agents: 3
-      init-commands: |
-        npx nx-cloud start-ci-run --stop-agents-after="build" --agent-count=3
-      parallel-commands-on-agents: |
-        npx nx affected --target=lint --parallel=3
-        npx nx affected --target=build -c production --parallel=3
-        npx nx run-many --target=test --projects=engine,shared,server-api --parallel=3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
 
-  agents:
-    name: Nx Cloud - Agents
-    secrets:
-      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.14.0
-    with:
-      number-of-agents: 3
+      - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js"
+
+      - run: npm ci
+
+      - uses: nrwl/nx-set-shas@v4
+
+      - run: npx nx affected --target=lint --parallel=3
+      - run: npx nx affected --target=build -c production --parallel=3
+      - run: npx nx run-many --target=test --projects=engine,shared,server-api --parallel=3

--- a/.github/workflows/build-cloud-nx.yml
+++ b/.github/workflows/build-cloud-nx.yml
@@ -21,12 +21,12 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js"
+      - run: npx nx-cloud start-ci-run --distribute-on="3 linux-large-js"
 
       - run: npm ci
 
       - uses: nrwl/nx-set-shas@v4
 
-      - run: npx nx affected --target=lint --parallel=3
-      - run: npx nx affected --target=build -c production --parallel=3
-      - run: npx nx run-many --target=test --projects=engine,shared,server-api --parallel=3
+      - run: npx nx affected --target=lint
+      - run: npx nx affected --target=build -c production
+      - run: npx nx run-many --target=test --projects=engine,shared,server-api

--- a/.github/workflows/build-cloud-nx.yml
+++ b/.github/workflows/build-cloud-nx.yml
@@ -21,12 +21,12 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - run: npx nx-cloud start-ci-run --distribute-on="3 linux-large-js"
+      - run: npx nx-cloud start-ci-run --distribute-on="3 linux-large-js" --agents
 
       - run: npm ci
 
       - uses: nrwl/nx-set-shas@v4
 
-      - run: npx nx affected --target=lint
-      - run: npx nx affected --target=build -c production
-      - run: npx nx run-many --target=test --projects=engine,shared,server-api
+      - run: npx nx affected --target=lint --agents
+      - run: npx nx affected --target=build -c production --agents
+      - run: npx nx run-many --target=test --projects=engine,shared,server-api --agents


### PR DESCRIPTION
## What does this PR do?

It changes the build cloud nx file to match the new updated template from [nx docs](https://nx.dev/ci/recipes/set-up/monorepo-ci-github-actions)