### PR TITLE
feat: added flow context to PropertyContext for use in DynamicProperties

### DIFF
--- a/packages/engine/src/lib/handler/piece-executor.ts
+++ b/packages/engine/src/lib/handler/piece-executor.ts
@@ -75,6 +75,12 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
                 flowId: constants.flowId,
                 engineToken: constants.engineToken,
             }),
+            flow: {
+                id: constants.flowId,
+                version: {
+                    id: constants.flowVersionId,
+                },
+            },
             auth: processedInput[AUTHENTICATION_PROPERTY_NAME],
             files: createFilesService({
                 apiUrl: constants.internalApiUrl,

--- a/packages/engine/src/lib/handler/piece-executor.ts
+++ b/packages/engine/src/lib/handler/piece-executor.ts
@@ -75,10 +75,12 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
                 flowId: constants.flowId,
                 engineToken: constants.engineToken,
             }),
-            flow: {
-                id: constants.flowId,
-                version: {
-                    id: constants.flowVersionId,
+            flows: {
+                current: {
+                    id: constants.flowId,
+                    version: {
+                        id: constants.flowVersionId,
+                    },
                 },
             },
             auth: processedInput[AUTHENTICATION_PROPERTY_NAME],

--- a/packages/engine/src/lib/helper/piece-helper.ts
+++ b/packages/engine/src/lib/helper/piece-helper.ts
@@ -42,10 +42,12 @@ export const pieceHelper = {
             })
             const ctx = {
                 searchValue,
-                flow: {
-                    id: params.flowVersion.flowId,
-                    version: {
-                        id: params.flowVersion.id,
+                flows: {
+                    current: {
+                        id: params.flowVersion.flowId,
+                        version: {
+                            id: params.flowVersion.id,
+                        },
                     },
                 },
                 server: {

--- a/packages/engine/src/lib/helper/piece-helper.ts
+++ b/packages/engine/src/lib/helper/piece-helper.ts
@@ -42,6 +42,12 @@ export const pieceHelper = {
             })
             const ctx = {
                 searchValue,
+                flow: {
+                    id: params.flowVersion.flowId,
+                    version: {
+                        id: params.flowVersion.id,
+                    },
+                },
                 server: {
                     token: params.engineToken,
                     apiUrl: constants.internalApiUrl,

--- a/packages/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/engine/src/lib/helper/trigger-helper.ts
@@ -69,10 +69,12 @@ export const triggerHelper = {
                     failureCount: request.failureCount ?? 0,
                 }
             },
-            flow: {
-                id: params.flowVersion.flowId,
-                version: {
-                    id: params.flowVersion.id,
+            flows: {
+                current: {
+                    id: params.flowVersion.flowId,
+                    version: {
+                        id: params.flowVersion.id,
+                    },
                 },
             },
             webhookUrl: params.webhookUrl,

--- a/packages/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/engine/src/lib/helper/trigger-helper.ts
@@ -69,6 +69,12 @@ export const triggerHelper = {
                     failureCount: request.failureCount ?? 0,
                 }
             },
+            flow: {
+                id: params.flowVersion.flowId,
+                version: {
+                    id: params.flowVersion.id,
+                },
+            },
             webhookUrl: params.webhookUrl,
             auth: processedInput[AUTHENTICATION_PROPERTY_NAME],
             propsValue: processedInput,

--- a/packages/pieces/community/framework/src/lib/context.ts
+++ b/packages/pieces/community/framework/src/lib/context.ts
@@ -19,7 +19,7 @@ type BaseContext<
   PieceAuth extends PieceAuthProperty,
   Props extends InputPropertyMap
 > = {
-  flow: FlowContext;
+  flows: FlowContext;
   auth: PiecePropValueSchema<PieceAuth>;
   propsValue: StaticPropsValue<Props>;
   store: Store;
@@ -96,15 +96,17 @@ export type PauseHook = (params: {
 }) => void;
 
 export type FlowContext = {
-  id: string;
-  version: {
+  current: {
     id: string;
-  };
+    version: {
+      id: string;
+    };
+  }
 }
 
 export type PropertyContext = {
   server: ServerContext;
-  flow: FlowContext;
+  flows: FlowContext;
   project: {
     id: ProjectId;
     externalId: () => Promise<string | undefined>;

--- a/packages/pieces/community/framework/src/lib/context.ts
+++ b/packages/pieces/community/framework/src/lib/context.ts
@@ -19,6 +19,7 @@ type BaseContext<
   PieceAuth extends PieceAuthProperty,
   Props extends InputPropertyMap
 > = {
+  flow: FlowContext;
   auth: PiecePropValueSchema<PieceAuth>;
   propsValue: StaticPropsValue<Props>;
   store: Store;
@@ -94,14 +95,16 @@ export type PauseHook = (params: {
   pauseMetadata: DelayPauseMetadata | Omit<WebhookPauseMetadata, 'requestId'>
 }) => void;
 
+export type FlowContext = {
+  id: string;
+  version: {
+    id: string;
+  };
+}
+
 export type PropertyContext = {
   server: ServerContext;
-  flow: {
-    id: string;
-    version: {
-      id: string;
-    };
-  };
+  flow: FlowContext;
   project: {
     id: ProjectId;
     externalId: () => Promise<string | undefined>;

--- a/packages/pieces/community/framework/src/lib/context.ts
+++ b/packages/pieces/community/framework/src/lib/context.ts
@@ -96,6 +96,12 @@ export type PauseHook = (params: {
 
 export type PropertyContext = {
   server: ServerContext;
+  flow: {
+    id: string;
+    version: {
+      id: string;
+    };
+  };
   project: {
     id: ProjectId;
     externalId: () => Promise<string | undefined>;


### PR DESCRIPTION
## What does this PR do?

This PR adds the flow and flow version ID to the PropertyContext. This can be useful if you want to do things dynamically with the flow ID. In my case I want to build an email address that contains the flow ID.

As discussed on Discord: https://discord.com/channels/966798490984382485/1060469824104439838/1268137709818478685
