### PR TITLE
fix(connections-table): pagination / data loading

### DIFF
--- a/packages/ui/feature-dashboard/src/lib/pages/connections-table/connections-table.datasource.ts
+++ b/packages/ui/feature-dashboard/src/lib/pages/connections-table/connections-table.datasource.ts
@@ -85,7 +85,11 @@ export class ConnectionsTableDataSource extends DataSource<any> {
             .getPieceMetadata(item.pieceName, undefined)
             .pipe(
               take(1),
-              map((metadata) => metadata.logoUrl)
+              map((metadata) => metadata.logoUrl),
+              catchError((err) => {
+                console.error(err);
+                return of('');
+              })
             )
         );
         return forkJoin(logos).pipe(


### PR DESCRIPTION
## What does this PR do?

Fix connection table pagination or data loading when piece metadata does not load.

Fixes https://github.com/activepieces/activepieces/issues/5241

