### PR TITLE
docs: remove easypanel warning

### DIFF
--- a/docs/install/options/easypanel.mdx
+++ b/docs/install/options/easypanel.mdx
@@ -3,10 +3,6 @@ title: "Easypanel"
 description: "Run Activepieces with Easypanel 1-Click Install"
 ---
 
-<Warning>
-The maintainer of EasyPanel is no longer accepting template changes. The docker image used in the template is outdated. To avoid any problems, make sure to upgrade to the latest version of Activepieces after installation by changing the docker image version.
-</Warning>
-
 Easypanel is a modern server control panel. If you [run Easypanel](https://easypanel.io/docs) on your server, you can deploy Activepieces with 1 click on it.
 
 <a target="_blank" rel="noopener" href="https://easypanel.io/docs/templates/activepieces">![Deploy to Easypanel](https://easypanel.io/img/deploy-on-easypanel-40.svg)</a>


### PR DESCRIPTION
This warning should be removed as Easypanel supports [the latest version of ActivePieces](https://easypanel.io/docs/templates/activepieces#options)