### PR TITLE
feat(clickup): add markdown description option for create task action

### DIFF
--- a/packages/pieces/community/clickup/package.json
+++ b/packages/pieces/community/clickup/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-clickup",
-  "version": "0.5.12"
+  "version": "0.5.13"
 }

--- a/packages/pieces/community/clickup/src/lib/actions/tasks/create-task.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/tasks/create-task.ts
@@ -21,24 +21,31 @@ export const createClickupTask = createAction({
       'ID of assignee for Clickup Task'
     ),
     name: Property.ShortText({
-      description: 'The name of the task to create',
-      displayName: 'Task Name',
+      description: 'The name of task',
+      displayName: 'Name',
       required: true,
     }),
     description: Property.LongText({
-      description: 'The description of the task to create',
-      displayName: 'Task Description',
+      description: 'The description of task',
+      displayName: 'Description',
       required: false,
     }),
     markdown_description: Property.LongText({
-      description: 'The description of the task to create (in markdown)',
-      displayName: 'Task Description (Markdown)',
+      displayName: 'Markdown Description',
+      description: 'The description of task with markdown formatting',
       required: false,
     }),
   },
   async run(configValue) {
-    const { list_id, name, description, status_id, priority_id, assignee_id } =
-      configValue.propsValue;
+    const {
+      list_id,
+      name,
+      description,
+      status_id,
+      priority_id,
+      assignee_id,
+      markdown_description,
+    } = configValue.propsValue;
     const response = await callClickUpApi(
       HttpMethod.POST,
       `list/${list_id}/task`,
@@ -46,6 +53,7 @@ export const createClickupTask = createAction({
       {
         name,
         description,
+        markdown_description,
         status: status_id,
         priority: priority_id,
         assignees: assignee_id,

--- a/packages/pieces/community/clickup/src/lib/actions/tasks/create-task.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/tasks/create-task.ts
@@ -28,7 +28,7 @@ export const createClickupTask = createAction({
     description: Property.LongText({
       description: 'The description of the task to create',
       displayName: 'Task Description',
-      required: true,
+      required: false,
     }),
     markdown_description: Property.LongText({
       description: 'The description of the task to create (in markdown)',

--- a/packages/pieces/community/clickup/src/lib/actions/tasks/create-task.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/tasks/create-task.ts
@@ -30,6 +30,11 @@ export const createClickupTask = createAction({
       displayName: 'Task Description',
       required: true,
     }),
+    markdown_description: Property.LongText({
+      description: 'The description of the task to create (in markdown)',
+      displayName: 'Task Description (Markdown)',
+      required: false,
+    }),
   },
   async run(configValue) {
     const { list_id, name, description, status_id, priority_id, assignee_id } =


### PR DESCRIPTION
According to [this](https://clickup.com/api/developer-portal/tasks/#using-markdown-in-the-task-description) section of the ClickUp API Docs, we can use `markdown_description` to apply github-style markdown syntax to customize the description. 

I'm not sure if `markdown_description` will overwrite `description` or the other way around. Either way, I made the `description` property optional since it's not required by the ClickUp API. This way the consumer of this piece can choose if they want to use `description` or `markdown_description`