### PR TITLE
fix(chargekeep): updating authentication to customAuth with static dropdown

### DIFF
--- a/packages/pieces/community/chargekeep/package.json
+++ b/packages/pieces/community/chargekeep/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-chargekeep",
-  "version": "0.0.1"
+  "version": "0.1.0"
 }

--- a/packages/pieces/community/chargekeep/src/index.ts
+++ b/packages/pieces/community/chargekeep/src/index.ts
@@ -25,17 +25,17 @@ export const chargekeepAuth = PieceAuth.CustomAuth({
   props: {
     base_url: Property.StaticDropdown({
       displayName: 'Base URL',
-      description: 'Select the base URL',
+      description: 'Select the base environment URL',
       required: true,
       options: {
         disabled: false,
         options: [
           {
-            label: 'CRM (Live App)',
+            label: 'ChargeKeep Live (crm.chargekeep.com)',
             value: 'https://crm.chargekeep.com',
           },
           {
-            label: 'BETA',
+            label: 'ChargeKeep Beta (beta.chargekeep.com)',
             value: 'https://beta.chargekeep.com',
           },
         ],

--- a/packages/pieces/community/chargekeep/src/index.ts
+++ b/packages/pieces/community/chargekeep/src/index.ts
@@ -1,4 +1,8 @@
-import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import {
+  createPiece,
+  PieceAuth,
+  Property,
+} from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import { addOrUpdateContactExtended } from './lib/actions/add-or-update-contact-extended';
 import { addOrUpdateContact } from './lib/actions/add-or-update-contact';
@@ -11,14 +15,38 @@ import { newSubscription } from './lib/triggers/new-subscription';
 const markdownDescription = `
   Follow these instructions to get your Chargekeep API Key:
 
-  1. Visit the following website: https://beta.chargekeep.com/
+  1. Visit the following website: https://crm.chargekeep.com/ or the beta website: https://beta.chargekeep.com
   2. Once on the website, locate and click on the admin to obtain your chargekeep API Key.
 `;
 
-export const chargekeepAuth = PieceAuth.SecretText({
+export const chargekeepAuth = PieceAuth.CustomAuth({
   description: markdownDescription,
-  displayName: 'API Key',
   required: true,
+  props: {
+    base_url: Property.StaticDropdown({
+      displayName: 'Base URL',
+      description: 'Select the base URL',
+      required: true,
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'CRM (Live App)',
+            value: 'https://crm.chargekeep.com',
+          },
+          {
+            label: 'BETA',
+            value: 'https://beta.chargekeep.com',
+          },
+        ],
+      },
+    }),
+    api_key: PieceAuth.SecretText({
+      displayName: 'Secret API Key',
+      description: 'Enter the API Key',
+      required: true,
+    }),
+  },
 });
 
 export const chargekeep = createPiece({

--- a/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact-extended.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact-extended.ts
@@ -1263,9 +1263,9 @@ export const addOrUpdateContactExtended = createAction({
 
     const res = await httpClient.sendRequest({
       method: HttpMethod.POST,
-      url: 'https://beta.chargekeep.com/api/services/CRM/Import/ImportContact',
+      url: `${context.auth.base_url}/api/services/CRM/Import/ImportContact`,
       headers: {
-        'api-key': context.auth, // Pass API key in headers
+        'api-key': context.auth.api_key, // Pass API key in headers
         'Content-Type': 'application/json',
       },
       body: {

--- a/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact-extended.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact-extended.ts
@@ -72,7 +72,7 @@ export const addOrUpdateContactExtended = createAction({
       displayName: 'Contact ID',
       description: 'Sperse Contact ID. Will be used for looking a client',
       defaultValue: 0,
-      required: true,
+      required: false,
     }),
     contactXref: Property.ShortText({
       displayName: 'Contact XREF',
@@ -280,32 +280,32 @@ export const addOrUpdateContactExtended = createAction({
       required: false,
     }),
     // email
-    email1: Property.ShortText({
+    email1: Property.LongText({
       displayName: 'Personal Email',
       description: "The contact's personal email.",
       required: false,
     }),
-    email2: Property.ShortText({
+    email2: Property.LongText({
       displayName: 'Alternative Personal email',
       description: "The contact's alternative personal email.",
       required: false,
     }),
-    email3: Property.ShortText({
+    email3: Property.LongText({
       displayName: 'Other Personal email',
       description: "The contact's additional email.",
       required: false,
     }),
-    workEmail1: Property.ShortText({
+    workEmail1: Property.LongText({
       displayName: 'Work Email',
       description: "The contact's work email.",
       required: false,
     }),
-    workEmail2: Property.ShortText({
+    workEmail2: Property.LongText({
       displayName: 'Alternative Work Email',
       description: "The contact's alternative work email.",
       required: false,
     }),
-    workEmail3: Property.ShortText({
+    workEmail3: Property.LongText({
       displayName: 'Other Work Email',
       description: "The contact's other work email.",
       required: false,
@@ -352,17 +352,17 @@ export const addOrUpdateContactExtended = createAction({
       required: false,
     }),
     // home address
-    home_street: Property.ShortText({
+    home_street: Property.LongText({
       displayName: 'Home Street',
       description:
         "The contact's full street address (can include apartment or unit number).",
       required: false,
     }),
-    home_addressLine2: Property.ShortText({
+    home_addressLine2: Property.LongText({
       displayName: 'Address 2',
       required: false,
     }),
-    home_city: Property.ShortText({
+    home_city: Property.LongText({
       displayName: 'City',
       description: "The contact's city of residence.",
       required: false,
@@ -393,16 +393,16 @@ export const addOrUpdateContactExtended = createAction({
       required: false,
     }),
     // work address
-    work_street: Property.ShortText({
+    work_street: Property.LongText({
       displayName: 'Work Street',
       description: "The contact's work address.",
       required: false,
     }),
-    work_addressLine2: Property.ShortText({
+    work_addressLine2: Property.LongText({
       displayName: 'Address 2',
       required: false,
     }),
-    work_city: Property.ShortText({
+    work_city: Property.LongText({
       displayName: 'City',
       description: "The contact's work city.",
       required: false,
@@ -534,7 +534,7 @@ export const addOrUpdateContactExtended = createAction({
       required: false,
     }),
     // business info
-    companyName: Property.ShortText({
+    companyName: Property.LongText({
       displayName: 'Company Name',
       description:
         "Name of the contact's company (This field is mandatory if the First Name and Last Name fields are empty).",
@@ -622,7 +622,7 @@ export const addOrUpdateContactExtended = createAction({
       description: 'Valid date format YYYY-MM-DD or MM-DD-YYYY',
       required: false,
     }),
-    ein: Property.ShortText({
+    ein: Property.LongText({
       displayName: 'EIN',
       required: false,
     }),
@@ -643,11 +643,11 @@ export const addOrUpdateContactExtended = createAction({
       displayName: 'Company Phone Extention',
       required: false,
     }),
-    companyFaxNumber: Property.ShortText({
+    companyFaxNumber: Property.LongText({
       displayName: 'Company Fax Number',
       required: false,
     }),
-    companyEmail: Property.ShortText({
+    companyEmail: Property.LongText({
       displayName: 'Company Email',
       required: false,
     }),
@@ -700,11 +700,11 @@ export const addOrUpdateContactExtended = createAction({
       required: false,
     }),
     // company full Address
-    company_street: Property.ShortText({
+    company_street: Property.LongText({
       displayName: 'Company Street',
       required: false,
     }),
-    company_addressLine2: Property.ShortText({
+    company_addressLine2: Property.LongText({
       displayName: 'Address 2',
       required: false,
     }),
@@ -724,7 +724,7 @@ export const addOrUpdateContactExtended = createAction({
       displayName: 'Company Zip Code',
       required: false,
     }),
-    company_countryName: Property.ShortText({
+    company_countryName: Property.LongText({
       displayName: 'Company Country Name',
       required: false,
     }),
@@ -758,7 +758,7 @@ export const addOrUpdateContactExtended = createAction({
       displayName: 'Google Click ID',
       required: false,
     }),
-    refererURL: Property.ShortText({
+    refererURL: Property.LongText({
       displayName: 'Referer URL',
       description:
         'The webpage where the contact clicked a link that sent them to your website.',
@@ -772,7 +772,7 @@ export const addOrUpdateContactExtended = createAction({
       displayName: 'Application ID',
       required: false,
     }),
-    ipAddress: Property.ShortText({
+    ipAddress: Property.LongText({
       displayName: 'IP Address',
       required: false,
     }),
@@ -784,7 +784,7 @@ export const addOrUpdateContactExtended = createAction({
       displayName: 'Site ID',
       required: false,
     }),
-    siteUrl: Property.ShortText({
+    siteUrl: Property.LongText({
       displayName: 'Site URL',
       required: false,
     }),
@@ -793,7 +793,7 @@ export const addOrUpdateContactExtended = createAction({
       description: 'Valid date format YYYY-MM-DD HH:MM:SS',
       required: false,
     }),
-    entryUrl: Property.ShortText({
+    entryUrl: Property.LongText({
       displayName: 'Entry URL',
       description:
         'The first page of visit through which the contact visited your website.',
@@ -818,56 +818,56 @@ export const addOrUpdateContactExtended = createAction({
       required: false,
     }),
     // UtmParameters
-    utmSource: Property.ShortText({
+    utmSource: Property.LongText({
       displayName: 'UTM Source',
       required: false,
     }),
-    utmMedium: Property.ShortText({
+    utmMedium: Property.LongText({
       displayName: 'UTM Medium',
       required: false,
     }),
-    utmCampaign: Property.ShortText({
+    utmCampaign: Property.LongText({
       displayName: 'UTM Campaign',
       required: false,
     }),
-    utmTerm: Property.ShortText({
+    utmTerm: Property.LongText({
       displayName: 'UTM Term',
       required: false,
     }),
-    utmContent: Property.ShortText({
+    utmContent: Property.LongText({
       displayName: 'UTM Content',
       required: false,
     }),
-    utmKeyword: Property.ShortText({
+    utmKeyword: Property.LongText({
       displayName: 'UTM Keyword',
       required: false,
     }),
-    utmAdGroup: Property.ShortText({
+    utmAdGroup: Property.LongText({
       displayName: 'UTM AdGroup',
       required: false,
     }),
-    utmName: Property.ShortText({
+    utmName: Property.LongText({
       displayName: 'UTM Name',
       required: false,
     }),
     // requestCustomInfo
-    requestCustomField1: Property.ShortText({
+    requestCustomField1: Property.LongText({
       displayName: 'Request Custom Field 1',
       required: false,
     }),
-    requestCustomField2: Property.ShortText({
+    requestCustomField2: Property.LongText({
       displayName: 'Request Custom Field 2',
       required: false,
     }),
-    requestCustomField3: Property.ShortText({
+    requestCustomField3: Property.LongText({
       displayName: 'Request Custom Field 3',
       required: false,
     }),
-    requestCustomField4: Property.ShortText({
+    requestCustomField4: Property.LongText({
       displayName: 'Request Custom Field 4',
       required: false,
     }),
-    requestCustomField5: Property.ShortText({
+    requestCustomField5: Property.LongText({
       displayName: 'Request Custom Field 5',
       required: false,
     }),

--- a/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact.ts
@@ -346,9 +346,9 @@ export const addOrUpdateContact = createAction({
 
     const res = await httpClient.sendRequest({
       method: HttpMethod.POST,
-      url: 'https://beta.chargekeep.com/api/services/CRM/Import/ImportContact',
+      url: `${context.auth.base_url}/api/services/CRM/Import/ImportContact`,
       headers: {
-        'api-key': context.auth, // Pass API key in headers
+        'api-key': context.auth.api_key, // Pass API key in headers
         'Content-Type': 'application/json',
       },
       body: {

--- a/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact.ts
@@ -55,7 +55,7 @@ export const addOrUpdateContact = createAction({
       displayName: 'Contact ID',
       description: 'Sperse Contact ID. Will be used for looking a client',
       defaultValue: 0,
-      required: true,
+      required: false,
     }),
     // fullname
     fullName: Property.ShortText({
@@ -132,17 +132,17 @@ export const addOrUpdateContact = createAction({
       required: false,
     }),
     // email
-    workEmail1: Property.ShortText({
+    workEmail1: Property.LongText({
       displayName: 'Work Email',
       description: "The contact's work email.",
       required: false,
     }),
-    email1: Property.ShortText({
+    email1: Property.LongText({
       displayName: 'Personal Email',
       description: "The contact's personal email.",
       required: false,
     }),
-    email2: Property.ShortText({
+    email2: Property.LongText({
       displayName: 'Other email',
       description: "The contact's additional email.",
       required: false,

--- a/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-subscription.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-subscription.ts
@@ -92,9 +92,9 @@ export const addOrUpdateSubscription = createAction({
 
     const res = await httpClient.sendRequest({
       method: HttpMethod.PUT,
-      url: 'https://beta.chargekeep.com/api/services/CRM/OrderSubscription/Update',
+      url: `${context.auth.base_url}/api/services/CRM/OrderSubscription/Update`,
       headers: {
-        'api-key': context.auth, // Pass API key in headers
+        'api-key': context.auth.api_key, // Pass API key in headers
         'Content-Type': 'application/json',
       },
       body: {

--- a/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-subscription.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-subscription.ts
@@ -11,7 +11,7 @@ export const addOrUpdateSubscription = createAction({
     contactId: Property.Number({
       displayName: 'Contact ID',
       defaultValue: 0,
-      required: true,
+      required: false,
     }),
     productId: Property.Number({
       displayName: 'Product ID',

--- a/packages/pieces/community/chargekeep/src/lib/actions/create-invoice.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/create-invoice.ts
@@ -449,9 +449,9 @@ export const createInvoice = createAction({
 
     const res = await httpClient.sendRequest({
       method: HttpMethod.POST,
-      url: 'https://beta.chargekeep.com/api/services/CRM/Import/ImportInvoice',
+      url: `${context.auth.base_url}/api/services/CRM/Import/ImportInvoice`,
       headers: {
-        'api-key': context.auth, // Pass API key in headers
+        'api-key': context.auth.api_key, // Pass API key in headers
         'Content-Type': 'application/json',
       },
       body: {

--- a/packages/pieces/community/chargekeep/src/lib/actions/create-invoice.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/create-invoice.ts
@@ -176,11 +176,11 @@ export const createInvoice = createAction({
       displayName: 'Zip',
       required: false,
     }),
-    bAddress1: Property.ShortText({
+    bAddress1: Property.LongText({
       displayName: 'Billing Address 1',
       required: false,
     }),
-    bAddress2: Property.ShortText({
+    bAddress2: Property.LongText({
       displayName: 'Billing Address 2',
       required: false,
     }),
@@ -225,20 +225,20 @@ export const createInvoice = createAction({
       displayName: 'Zip',
       required: false,
     }),
-    sAddress1: Property.ShortText({
+    sAddress1: Property.LongText({
       displayName: 'Shipping Address 1',
       required: false,
     }),
-    sAddress2: Property.ShortText({
+    sAddress2: Property.LongText({
       displayName: 'Shipping Address 2',
       required: false,
     }),
     //
-    note: Property.ShortText({
+    note: Property.LongText({
       displayName: 'Invoice Note',
       required: false,
     }),
-    invoiceDescription: Property.ShortText({
+    invoiceDescription: Property.LongText({
       displayName: 'Invoice Description',
       required: true,
     }),

--- a/packages/pieces/community/chargekeep/src/lib/common/common.ts
+++ b/packages/pieces/community/chargekeep/src/lib/common/common.ts
@@ -1,15 +1,15 @@
 import { HttpMethod, httpClient } from '@activepieces/pieces-common';
 
 export const chargekeepCommon = {
-  baseUrl: 'https://beta.chargekeep.com',
   subscribeWebhook: async (
     eventName: string,
-    webhookUrl: string,
-    apiKey: string
+    baseUrl: string,
+    apiKey: string,
+    webhookUrl: string
   ) => {
     const request = {
       method: HttpMethod.POST,
-      url: `${chargekeepCommon.baseUrl}/api/services/Platform/Event/Subscribe`,
+      url: `${baseUrl}/api/services/Platform/Event/Subscribe`,
       headers: {
         'api-key': apiKey,
         'Content-Type': 'application/json',
@@ -27,10 +27,14 @@ export const chargekeepCommon = {
     return webhookId;
   },
 
-  unsubscribeWebhook: async (webhookId: number, apiKey: string) => {
+  unsubscribeWebhook: async (
+    baseUrl: string,
+    apiKey: string,
+    webhookId: number
+  ) => {
     const request = {
       method: HttpMethod.POST,
-      url: `${chargekeepCommon.baseUrl}/api/services/Platform/Event/Unsubscribe?id=${webhookId}`,
+      url: `${baseUrl}/api/services/Platform/Event/Unsubscribe?id=${webhookId}`,
       headers: {
         'api-key': apiKey,
         'Content-Type': 'application/json',

--- a/packages/pieces/community/chargekeep/src/lib/triggers/new-lead.ts
+++ b/packages/pieces/community/chargekeep/src/lib/triggers/new-lead.ts
@@ -200,8 +200,9 @@ export const newLead = createTrigger({
   async onEnable(context) {
     const webhookId = await chargekeepCommon.subscribeWebhook(
       'LeadCreated',
-      context.webhookUrl,
-      context.auth
+      context.auth.base_url,
+      context.auth.api_key,
+      context.webhookUrl
     );
 
     await context.store?.put<WebhookInformation>('_new_lead_trigger', {
@@ -216,8 +217,9 @@ export const newLead = createTrigger({
 
     if (response !== null && response !== undefined) {
       await chargekeepCommon.unsubscribeWebhook(
-        response.webhookId,
-        context.auth
+        context.auth.base_url,
+        context.auth.api_key,
+        response.webhookId
       );
     }
   },

--- a/packages/pieces/community/chargekeep/src/lib/triggers/new-payment.ts
+++ b/packages/pieces/community/chargekeep/src/lib/triggers/new-payment.ts
@@ -53,8 +53,9 @@ export const newPayment = createTrigger({
   async onEnable(context) {
     const webhookId = await chargekeepCommon.subscribeWebhook(
       'Payment.Created',
-      context.webhookUrl,
-      context.auth
+      context.auth.base_url,
+      context.auth.api_key,
+      context.webhookUrl
     );
 
     await context.store?.put<WebhookInformation>('_new_payment_trigger', {
@@ -69,8 +70,9 @@ export const newPayment = createTrigger({
 
     if (response !== null && response !== undefined) {
       await chargekeepCommon.unsubscribeWebhook(
-        response.webhookId,
-        context.auth
+        context.auth.base_url,
+        context.auth.api_key,
+        response.webhookId
       );
     }
   },

--- a/packages/pieces/community/chargekeep/src/lib/triggers/new-subscription.ts
+++ b/packages/pieces/community/chargekeep/src/lib/triggers/new-subscription.ts
@@ -22,8 +22,9 @@ export const newSubscription = createTrigger({
   async onEnable(context) {
     const webhookId = await chargekeepCommon.subscribeWebhook(
       'Subscription.CreatedOrUpdated',
-      context.webhookUrl,
-      context.auth
+      context.auth.base_url,
+      context.auth.api_key,
+      context.webhookUrl
     );
 
     await context.store?.put<WebhookInformation>('_new_subscription_trigger', {
@@ -38,8 +39,9 @@ export const newSubscription = createTrigger({
 
     if (response !== null && response !== undefined) {
       await chargekeepCommon.unsubscribeWebhook(
-        response.webhookId,
-        context.auth
+        context.auth.base_url,
+        context.auth.api_key,
+        response.webhookId
       );
     }
   },


### PR DESCRIPTION
## What does this PR do?

This pull request involves changes made to chargekeep's authentication which now involves a customAuth with a static dropdown with options to select base environment URL (https://crm.chargekeep.com/ or https://beta.chargekeep.com/) and then the secret key field. Finally, making changes to the actions and triggers, to make use of the base_url selected in the connection, as well as the secret key provided, to make the api calls.

