### PR TITLE
chore(ci): remove unused ENVIRONMENT build-arg

### DIFF
--- a/.github/workflows/automate-deploy.yml
+++ b/.github/workflows/automate-deploy.yml
@@ -31,8 +31,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          build-args: |
-            ENVIRONMENT=cloud
           platforms: |
             linux/amd64
           push: true

--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -25,8 +25,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          build-args: |
-            ENVIRONMENT=cloud
           platforms: |
             linux/amd64
           push: true

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -42,8 +42,6 @@ jobs:
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
           context: .
           file: ./Dockerfile
-          args: |
-            ENVIRONMENT=standard
           platforms: |
             linux/amd64
             linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,6 @@ jobs:
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
           context: .
           file: ./Dockerfile
-          args: |
-            ENVIRONMENT=standard
           platforms: |
             linux/amd64
             linux/arm64


### PR DESCRIPTION
## What does this PR do?

Removes the `ENVIRONMENT` Docker arg. Previously, you could pass `cloud` or `standard`, where it was used to copy the appropriate nginx.{$ENVIRONMENT}.conf file. That was removed in https://github.com/activepieces/activepieces/pull/3379 but the GitHub Actions still referenced it.

Fixes # (issue)

