### PR TITLE
feat: support attaching jira tickets to parent epic/task

### DIFF
--- a/packages/pieces/community/jira-cloud/package.json
+++ b/packages/pieces/community/jira-cloud/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-jira-cloud",
-  "version": "0.0.6"
+  "version": "0.0.7"
 }

--- a/packages/pieces/community/jira-cloud/src/lib/actions/create-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/create-issue.ts
@@ -52,7 +52,7 @@ export const createIssue = createAction({
     }),
     parentKey: Property.ShortText({
       displayName: 'Parent Key',
-      description: 'If this issue is a subtask, insert the parent issue key',
+      description: 'If you would like to attach the issue to a parent, insert the parent issue key',
       required: false,
     }),
   },

--- a/packages/pieces/community/jira-cloud/src/lib/actions/update-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/update-issue.ts
@@ -54,7 +54,7 @@ export const updateIssueAction = createAction({
 		}),
 		parentKey: Property.ShortText({
 			displayName: 'Parent Key',
-			description: 'If this issue is a subtask, insert the parent issue key',
+			description: 'If you would like to attach the issue to a parent, insert the parent issue key',
 			required: false,
 		}),
 	},

--- a/packages/pieces/community/jira-cloud/src/lib/common/index.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/common/index.ts
@@ -174,6 +174,10 @@ export async function createJiraIssue(data: CreateIssueParams) {
 			version: 1,
 		};
 
+	if (data.parentKey) {
+		fields.parent = { key: data.parentKey };
+	}
+
 	const response = await sendJiraRequest({
 		url: 'issue',
 		method: HttpMethod.POST,
@@ -207,6 +211,11 @@ export async function updateJiraIssue(data: UpdateIssueParams) {
 			type: 'doc',
 			version: 1,
 		};
+
+	if (data.parentKey) {
+		fields.parent = { key: data.parentKey };
+	}
+
 	const response = await sendJiraRequest({
 		url: `issue/${data.issueId}`,
 		method: HttpMethod.PUT,


### PR DESCRIPTION
Repro scenario 1:
1. Create a jira issue
2. Create a jira sub task and enter the issue as parent key
Expected:  sub task created and attached to the parent issue
Actual: error returned "Issue type is a sub-task but parent issue key or id not specified." 

Repro scenario 2:
1. Create a jira epic
2. Create a jira issue and enter the epic as parent key
Expected:  issue created and attached to the epic
Actual: issue created but not attached to the epic

<img width="606" alt="image" src="https://github.com/user-attachments/assets/7291230f-683b-4d76-90f1-e187d5d39a24">
