### PR TITLE
fix(dark): piece icons and switch

### DIFF
--- a/packages/react-ui/src/components/ui/switch.tsx
+++ b/packages/react-ui/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-white',
       className,
     )}
     {...props}

--- a/packages/react-ui/src/features/pieces/components/piece-icon.tsx
+++ b/packages/react-ui/src/features/pieces/components/piece-icon.tsx
@@ -7,6 +7,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 
 const pieceIconVariants = cva('flex items-center justify-center  ', {
   variants: {
@@ -45,7 +46,12 @@ const PieceIcon = React.memo(
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className={pieceIconVariants({ border, size, circle })}>
+          <div
+            className={cn(
+              pieceIconVariants({ border, size, circle }),
+              'dark:bg-foreground',
+            )}
+          >
             {logoUrl ? (
               <img src={logoUrl} className="object-contain" alt={displayName} />
             ) : (


### PR DESCRIPTION
## What does this PR do?
Improve dark mode for switches and piece icons.

Before: 
![image](https://github.com/user-attachments/assets/aa2073c1-08eb-4340-a112-128953e29d55)

After:
![image](https://github.com/user-attachments/assets/75bfb2b3-757b-4fb5-851e-b4f5e3775ee8)



