### PR TITLE
feat: generic service proxy for external services

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
 			]
 		}
 	},
-	"forwardPorts": [3000, 4200],
+	"forwardPorts": [3000, 4200, 5432],
 	"postAttachCommand": "/bin/bash .devcontainer/setup.sh",
 	"hostRequirements": {
   	  "cpus": 4,

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     network_mode: service:redis
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
 
   redis:
     image: redis:7.0.7

--- a/packages/pieces/community/activepieces-ai/.eslintrc.json
+++ b/packages/pieces/community/activepieces-ai/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/activepieces-ai/README.md
+++ b/packages/pieces/community/activepieces-ai/README.md
@@ -1,0 +1,7 @@
+# pieces-activepieces-ai
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-activepieces-ai` to build the library.

--- a/packages/pieces/community/activepieces-ai/package.json
+++ b/packages/pieces/community/activepieces-ai/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-activepieces-ai",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/activepieces-ai/project.json
+++ b/packages/pieces/community/activepieces-ai/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-activepieces-ai",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/activepieces-ai/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/activepieces-ai",
+        "tsConfig": "packages/pieces/community/activepieces-ai/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/activepieces-ai/package.json",
+        "main": "packages/pieces/community/activepieces-ai/src/index.ts",
+        "assets": [
+          "packages/pieces/community/activepieces-ai/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/activepieces-ai/src/index.ts
+++ b/packages/pieces/community/activepieces-ai/src/index.ts
@@ -1,0 +1,12 @@
+
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { askAi } from "./lib/actions/ask-ai";
+
+export const activepiecesAi = createPiece({
+  displayName: "AI",
+  auth: PieceAuth.None(),
+  logoUrl: "https://cdn.activepieces.com/pieces/activepieces-ai.png",
+  authors: [],
+  actions: [askAi],
+  triggers: [],
+});

--- a/packages/pieces/community/activepieces-ai/src/lib/actions/ask-ai.ts
+++ b/packages/pieces/community/activepieces-ai/src/lib/actions/ask-ai.ts
@@ -1,0 +1,103 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { AI, AIChatMessage, AIChatRole } from '@activepieces/pieces-common';
+
+export const askAi = createAction({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'askAi',
+  displayName: 'Ask AI',
+  description: '',
+  props: {
+    model: Property.StaticDropdown({
+      displayName: 'Model',
+      required: true,
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'gpt-3.5-turbo',
+            value: 'gpt-3.5-turbo',
+          },
+          {
+            label: 'gpt-4o',
+            value: 'gpt-4o',
+          },
+        ],
+      },
+    }),
+    prompt: Property.LongText({
+      displayName: 'Prompt',
+      required: true,
+    }),
+    conversationKey: Property.ShortText({
+      displayName: 'Conversation Key',
+      required: true,
+    }),
+    creativity: Property.Number({
+      displayName: 'Creativity',
+      required: false,
+      description: 'Controls the creativity of the AI response. A higher value will make the AI more creative and a lower value will make it more deterministic.',
+    }),
+    maxTokens: Property.Number({
+      displayName: 'Max Tokens',
+      required: false,
+    }),
+    provider: Property.StaticDropdown({
+      displayName: 'Provider',
+      required: true,
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'OpenAI',
+            value: 'openai',
+          },
+          {
+            label: 'Anthropic',
+            value: 'anthropic',
+          },
+        ],
+      },
+    })
+  },
+  async run(context) {
+    const provider = context.propsValue.provider
+
+    if (provider === 'openai' || provider === 'anthropic') {
+      const ai = AI({ provider, server: context.server })
+
+      const storage = context.store
+
+      const conversationKey = `ask-ai-conversation:${context.propsValue.conversationKey}`
+
+      const conversation = await storage.get<{ messages: AIChatMessage[] }>(conversationKey) ?? { messages: [] }
+
+      if (!conversation) {
+        await storage.put(conversationKey, { messages: [] })
+      }
+
+      const response = await ai.chat.text({
+        model: context.propsValue.model,
+        messages: [
+          ...conversation.messages,
+          {
+            role: AIChatRole.USER,
+            content: context.propsValue.prompt,
+          },
+        ],
+        creativity: context.propsValue.creativity,
+        maxTokens: context.propsValue.maxTokens,
+      })
+
+      conversation.messages.push({
+        role: AIChatRole.ASSISTANT,
+        content: response.choices[0].content,
+      })
+
+      await storage.put(conversationKey, conversation)
+
+      return response
+    }
+
+    throw new Error(`AI provider ${provider} not supported`)
+  },
+});

--- a/packages/pieces/community/activepieces-ai/tsconfig.json
+++ b/packages/pieces/community/activepieces-ai/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/activepieces-ai/tsconfig.lib.json
+++ b/packages/pieces/community/activepieces-ai/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/common/src/index.ts
+++ b/packages/pieces/community/common/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/authentication';
 export * from './lib/helpers';
 export * from './lib/http';
 export * from './lib/polling';
+export * from './lib/ai';

--- a/packages/pieces/community/common/src/lib/ai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/index.ts
@@ -32,7 +32,6 @@ export interface AIChatCompletion {
 }
 
 export interface AIChatCompletionChoice {
-  index: number;
   message: AIChatMessage;
   finishReason: string;
 }

--- a/packages/pieces/community/common/src/lib/ai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/index.ts
@@ -1,18 +1,19 @@
-export interface AI<P extends string, ChatModel extends string> {
-  provider: P;
-  chat: AIChat<ChatModel>;
+export interface AI<SDK> {
+  provider: string;
+  chat: AIChat;
+  underlying: SDK;
 }
 
-export interface AIChat<ChatModel extends string> {
-  completions: AIChatCompletions<ChatModel>;
+export interface AIChat {
+  completions: AIChatCompletions;
 }
 
-export interface AIChatCompletions<ChatModel extends string> {
-  create: (params: AIChatCompletionsCreateParams<ChatModel>) => Promise<AIChatCompletion>;
+export interface AIChatCompletions {
+  create: (params: AIChatCompletionsCreateParams) => Promise<AIChatCompletion>;
 }
 
-export interface AIChatCompletionsCreateParams<ChatModel> {
-  model: ChatModel;
+export interface AIChatCompletionsCreateParams {
+  model: string;
   messages: AIChatMessage[];
   temperature?: number;
   maxTokens?: number;
@@ -24,16 +25,10 @@ export interface AIChatCompletionsCreateParams<ChatModel> {
 
 export interface AIChatCompletion {
   id: string;
-  object: string;
   created: number;
   model: string;
-  choices: AIChatCompletionChoice[];
-  usage: AIChatCompletionUsage;
-}
-
-export interface AIChatCompletionChoice {
-  message: AIChatMessage;
-  finishReason: string;
+  choices: AIChatMessage[];
+  usage?: AIChatCompletionUsage;
 }
 
 export interface AIChatCompletionUsage {

--- a/packages/pieces/community/common/src/lib/ai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/index.ts
@@ -1,0 +1,55 @@
+export interface AI<P extends string, ChatModel extends string> {
+  provider: P;
+  chat: AIChat<ChatModel>;
+}
+
+export interface AIChat<ChatModel extends string> {
+  completions: AIChatCompletions<ChatModel>;
+}
+
+export interface AIChatCompletions<ChatModel extends string> {
+  create: (params: AIChatCompletionsCreateParams<ChatModel>) => Promise<AIChatCompletion>;
+}
+
+export interface AIChatCompletionsCreateParams<ChatModel> {
+  model: ChatModel;
+  messages: AIChatMessage[];
+  temperature?: number;
+  maxTokens?: number;
+  topP?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  stop?: string[];
+}
+
+export interface AIChatCompletion {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: AIChatCompletionChoice[];
+  usage: AIChatCompletionUsage;
+}
+
+export interface AIChatCompletionChoice {
+  index: number;
+  message: AIChatMessage;
+  finishReason: string;
+}
+
+export interface AIChatCompletionUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+export interface AIChatMessage {
+  role: AIChatRole;
+  content: string;
+}
+
+export enum AIChatRole {
+  SYSTEM = 'system',
+  USER = 'user',
+  ASSISTANT = 'assistant',
+}

--- a/packages/pieces/community/common/src/lib/ai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/index.ts
@@ -1,29 +1,26 @@
-export interface AI<SDK> {
+export type AI<SDK> = {
   provider: string;
   chat: AIChat;
   underlying: SDK;
 }
 
-export interface AIChat {
-  completions: AIChatCompletions;
+export type AIChat = {
+  text: (params: AIChatCompletionsCreateParams) => Promise<AIChatCompletion>;
 }
 
-export interface AIChatCompletions {
-  create: (params: AIChatCompletionsCreateParams) => Promise<AIChatCompletion>;
-}
-
-export interface AIChatCompletionsCreateParams {
+export type AIChatCompletionsCreateParams = {
   model: string;
   messages: AIChatMessage[];
   temperature?: number;
   maxTokens?: number;
   topP?: number;
+  topK?: number;
   frequencyPenalty?: number;
   presencePenalty?: number;
   stop?: string[];
 }
 
-export interface AIChatCompletion {
+export type AIChatCompletion = {
   id: string;
   created: number;
   model: string;
@@ -31,13 +28,13 @@ export interface AIChatCompletion {
   usage?: AIChatCompletionUsage;
 }
 
-export interface AIChatCompletionUsage {
+export type AIChatCompletionUsage = {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
 }
 
-export interface AIChatMessage {
+export type AIChatMessage = {
   role: AIChatRole;
   content: string;
 }

--- a/packages/pieces/community/common/src/lib/ai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/index.ts
@@ -1,3 +1,7 @@
+import { ServerContext } from '@activepieces/pieces-framework';
+import { anthropic } from './providers/anthropic';
+import { openai } from './providers/openai';
+
 export type AI<SDK> = {
   provider: string;
   chat: AIChat;
@@ -11,12 +15,8 @@ export type AIChat = {
 export type AIChatCompletionsCreateParams = {
   model: string;
   messages: AIChatMessage[];
-  temperature?: number;
+  creativity?: number;
   maxTokens?: number;
-  topP?: number;
-  topK?: number;
-  frequencyPenalty?: number;
-  presencePenalty?: number;
   stop?: string[];
 }
 
@@ -43,4 +43,18 @@ export enum AIChatRole {
   SYSTEM = 'system',
   USER = 'user',
   ASSISTANT = 'assistant',
+}
+
+export const AI = ({
+  provider,
+  server
+}: { provider: "openai" | "anthropic", server: ServerContext }) => {
+  switch (provider) {
+    case 'openai':
+      return openai({ serverUrl: server.apiUrl, engineToken: server.token })
+    case 'anthropic':
+      return anthropic({ serverUrl: server.apiUrl, engineToken: server.token })
+    default:
+      throw new Error(`AI provider ${provider} not supported`)
+  }
 }

--- a/packages/pieces/community/common/src/lib/ai/providers/anthropic/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/providers/anthropic/index.ts
@@ -11,6 +11,9 @@ export const anthropic = ({
   const sdk = new Anthropic({
     apiKey: engineToken,
     baseURL: `${proxyUrl}${anthropicEndpoint}`,
+    defaultHeaders: {
+      'X-AP-TOTAL-USAGE-BODY-PATH': 'usage.total_tokens',
+    },
   })
   return {
     underlying: sdk,
@@ -24,9 +27,7 @@ export const anthropic = ({
             role: message.role === 'user' ? 'user' : 'assistant',
             content: message.content,
           })),
-          temperature: params.temperature,
-          top_k: params.topK,
-          top_p: params.topP,
+          temperature: Math.tanh(params.creativity ?? 100),
           stop_sequences: params.stop,
           system: concatenatedSystemMessage,
           stream: false,

--- a/packages/pieces/community/common/src/lib/ai/providers/anthropic/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/providers/anthropic/index.ts
@@ -1,0 +1,18 @@
+import { AI } from "../..";
+
+type AnthropicChatModel =
+  | "claude-3-5-sonnet-20240620"
+  | "claude-3-opus-20240229"
+  | "claude-3-sonnet-20240229"
+  | "claude-3-haiku-20240307"
+
+export const anthropic: AI<"ANTHROPIC", AnthropicChatModel> = {
+  provider: "ANTHROPIC",
+  chat: {
+    completions: {
+      create: async (params) => {
+        throw new Error("Method not implemented.");
+      },
+    },
+  },
+};

--- a/packages/pieces/community/common/src/lib/ai/providers/anthropic/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/providers/anthropic/index.ts
@@ -1,18 +1,52 @@
-import { AI } from "../..";
+import { AI, AIChatRole } from "../..";
+import Anthropic from '@anthropic-ai/sdk';
 
-type AnthropicChatModel =
-  | "claude-3-5-sonnet-20240620"
-  | "claude-3-opus-20240229"
-  | "claude-3-sonnet-20240229"
-  | "claude-3-haiku-20240307"
 
-export const anthropic: AI<"ANTHROPIC", AnthropicChatModel> = {
-  provider: "ANTHROPIC",
-  chat: {
-    completions: {
-      create: async (params) => {
-        throw new Error("Method not implemented.");
+export const anthropic = ({
+  serverUrl,
+  engineToken,
+}: { serverUrl: string, engineToken: string }): AI<Anthropic> => {
+  const anthropicEndpoint = '/v1/chat/completions';
+  const proxyUrl = `${serverUrl}v1/proxy/anthropic`
+  const sdk = new Anthropic({
+    apiKey: engineToken,
+    baseURL: `${proxyUrl}${anthropicEndpoint}`,
+  })
+  return {
+    underlying: sdk,
+    provider: "ANTHROPIC" as const,
+    chat: {
+      completions: {
+        create: async (params) => {
+          const completion = await sdk.messages.create({
+            model: params.model,
+            messages: params.messages.map((message) => ({
+              role: message.role === 'user' ? 'user' : 'assistant',
+              content: message.content,
+            })),
+            temperature: params.temperature,
+            top_p: params.topP,
+            max_tokens: params.maxTokens ?? 2000,
+          })
+
+          return {
+            choices: completion.content.map(choice => {
+              return {
+                content: choice.text,
+                role: AIChatRole.ASSISTANT,
+              }
+            }),
+            created: new Date().getTime(),
+            id: completion.id,
+            model: completion.model,
+            usage: {
+              completionTokens: completion.usage.output_tokens,
+              promptTokens: completion.usage.input_tokens,
+              totalTokens: completion.usage.output_tokens + completion.usage.input_tokens,
+            },
+          }
+        },
       },
     },
-  },
+  }
 };

--- a/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
@@ -37,7 +37,16 @@ export const openai = ({
             'Content-Type': 'application/json',
             Authorization: `Bearer ${engineToken}`,
           },
-          body: params,
+          body: {
+            model: params.model,
+            messages: params.messages,
+            temperature: params.temperature,
+            max_tokens: params.maxTokens,
+            top_p: params.topP,
+            frequency_penalty: params.frequencyPenalty,
+            presence_penalty: params.presencePenalty,
+            stop: params.stop,
+          },
         });
 
         const choices = (response.body.choices as Array<{ message: { role: string, content: string }, finish_reason: string }>)
@@ -45,7 +54,6 @@ export const openai = ({
         return {
           choices: choices.map((choice) => {
             return {
-              index: 0,
               message: {
                 role: choice.message.role as AIChatRole,
                 content: choice.message.content,

--- a/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
@@ -18,40 +18,36 @@ export const openai = ({
     underlying: sdk,
     provider: "OPENAI" as const,
     chat: {
-      completions: {
-        create: async (params) => {
-          const completion = await sdk.chat.completions.create({
-            model: params.model,
-            messages: params.messages.map((message) => ({
-              role: message.role === 'user' ? 'user' : 'assistant',
-              content: message.content,
-            })),
-            temperature: params.temperature,
-            max_tokens: params.maxTokens,
-            top_p: params.topP,
-            frequency_penalty: params.frequencyPenalty,
-            presence_penalty: params.presencePenalty,
-            stop: params.stop,
-          })
+      text: async (params) => {
+        const completion = await sdk.chat.completions.create({
+          model: params.model,
+          messages: params.messages.map((message) => ({
+            role: message.role === 'user' ? 'user' : 'assistant',
+            content: message.content,
+          })),
+          temperature: params.temperature,
+          max_tokens: params.maxTokens,
+          top_p: params.topP,
+          frequency_penalty: params.frequencyPenalty,
+          presence_penalty: params.presencePenalty,
+          stop: params.stop,
+        })
 
-          return {
-            choices: completion.choices.map((choice) => {
-              return {
-                role: AIChatRole.ASSISTANT,
-                content: choice.message.content ?? "",
-              }
-            }),
-            created: completion.created,
-            id: completion.id,
-            model: completion.model,
-            usage: completion.usage && {
-              completionTokens: completion.usage.completion_tokens,
-              promptTokens: completion.usage.prompt_tokens,
-              totalTokens: completion.usage.total_tokens,
-            },
-          }
-        },
-      },
+        return {
+          choices: completion.choices.map((choice) => ({
+            role: AIChatRole.ASSISTANT,
+            content: choice.message.content ?? "",
+          })),
+          created: completion.created,
+          id: completion.id,
+          model: completion.model,
+          usage: completion.usage && {
+            completionTokens: completion.usage.completion_tokens,
+            promptTokens: completion.usage.prompt_tokens,
+            totalTokens: completion.usage.total_tokens,
+          },
+        }
+      }
     },
   }
 };

--- a/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
@@ -6,7 +6,7 @@ export const openai = ({
   engineToken,
 }: { serverUrl: string, engineToken: string }): AI<OpenAI> => {
   const openaiEndpoint = '/v1/chat/completions';
-  const proxyUrl = `${serverUrl}v1/proxy/openai`
+  const proxyUrl = `${serverUrl}api/v1/proxy/openai`
   const sdk = new OpenAI({
     apiKey: engineToken,
     baseURL: `${proxyUrl}${openaiEndpoint}`,
@@ -16,7 +16,7 @@ export const openai = ({
   });
   return {
     underlying: sdk,
-    provider: "OPENAI" as const,
+    provider: "OPENAI",
     chat: {
       text: async (params) => {
         const completion = await sdk.chat.completions.create({
@@ -25,11 +25,8 @@ export const openai = ({
             role: message.role === 'user' ? 'user' : 'assistant',
             content: message.content,
           })),
-          temperature: params.temperature,
+          temperature: Math.tanh(params.creativity ?? 100),
           max_tokens: params.maxTokens,
-          top_p: params.topP,
-          frequency_penalty: params.frequencyPenalty,
-          presence_penalty: params.presencePenalty,
           stop: params.stop,
         })
 

--- a/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
@@ -1,0 +1,69 @@
+import { AI, AIChatRole } from "../..";
+import { httpClient, HttpMethod } from "../../../http";
+
+export type OpenAIChatModel =
+  | "gpt-3.5-turbo-instruct"
+  | "gpt-3.5-turbo-1106"
+  | "gpt-3.5-turbo"
+  | "gpt-3.5-turbo-0125"
+  | "gpt-4-0613"
+  | "gpt-4"
+  | "gpt-4-1106-preview"
+  | "gpt-4-0125-preview"
+  | "gpt-4-turbo-preview"
+  | "gpt-4-turbo-2024-04-09"
+  | "gpt-4-turbo"
+  | "gpt-4o-mini-2024-07-18"
+  | "gpt-4o-mini"
+  | "chatgpt-4o-latest"
+  | "gpt-4o-2024-08-06"
+  | "gpt-4o-2024-05-13"
+  | "gpt-4o"
+
+export const openai = ({
+  serverUrl,
+  engineToken,
+}: { serverUrl: string, engineToken: string }): AI<"OPENAI", OpenAIChatModel> => ({
+  provider: "OPENAI",
+  chat: {
+    completions: {
+      create: async (params) => {
+        const openaiEndpoint = '/v1/chat/completions';
+        const proxyUrl = `${serverUrl}v1/proxy/openai`
+        const response = await httpClient.sendRequest({
+          method: HttpMethod.POST,
+          url: `${proxyUrl}${openaiEndpoint}`,
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${engineToken}`,
+          },
+          body: params,
+        });
+
+        const choices = (response.body.choices as Array<{ message: { role: string, content: string }, finish_reason: string }>)
+
+        return {
+          choices: choices.map((choice) => {
+            return {
+              index: 0,
+              message: {
+                role: choice.message.role as AIChatRole,
+                content: choice.message.content,
+              },
+              finishReason: choice.finish_reason,
+            }
+          }),
+          created: response.body.created,
+          id: response.body.id,
+          model: response.body.model,
+          object: "chat.completion",
+          usage: {
+            completionTokens: response.body.usage.completion_tokens,
+            promptTokens: response.body.usage.prompt_tokens,
+            totalTokens: response.body.usage.total_tokens,
+          },
+        }
+      },
+    },
+  },
+});

--- a/packages/server/api/src/app/database/database-connection.ts
+++ b/packages/server/api/src/app/database/database-connection.ts
@@ -46,6 +46,7 @@ import { WebhookSimulationEntity } from '../webhooks/webhook-simulation/webhook-
 import { WorkerMachineEntity } from '../workers/machine/machine-entity'
 import { createPostgresDataSource } from './postgres-connection'
 import { createSqlLiteDataSource } from './sqlite-connection'
+import { ProxyConfigEntity } from '../proxy/proxy-config-entity'
 
 const databaseType = system.get(AppSystemProp.DB_TYPE)
 
@@ -75,6 +76,7 @@ function getEntities(): EntitySchema<unknown>[] {
         AlertEntity,
         UserInvitationEntity,
         WorkerMachineEntity,
+        ProxyConfigEntity,
     ]
 
     switch (edition) {
@@ -163,3 +165,6 @@ export function APArrayContains<T extends ObjectLiteral>(
             throw new Error(`Unsupported database type: ${databaseType}`)
     }
 }
+
+// Uncomment the below line when running `nx db-migration server-api name=<MIGRATION_NAME>` and recomment it after the migration is generated
+// export const exportedConnection = databaseConnection()

--- a/packages/server/api/src/app/database/migration/common/1724777988812-CreateProxyConfig.ts
+++ b/packages/server/api/src/app/database/migration/common/1724777988812-CreateProxyConfig.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateProxyConfig1724777988812 implements MigrationInterface {
+    name = 'CreateProxyConfig1724777988812'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "proxy_config" (
+                "id" character varying(21) NOT NULL,
+                "created" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updated" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "defaultHeaders" json NOT NULL,
+                "baseUrl" character varying NOT NULL,
+                "provider" character varying NOT NULL,
+                "project_id" character varying(21),
+                "platform_id" character varying(21) NOT NULL,
+                CONSTRAINT "PK_2ecf3b46f1e0c88c1e336e74b4e" PRIMARY KEY ("id")
+            )
+        `);
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_proxy_config_platform_project_provider_unique" ON "proxy_config" ("platform_id", "project_id", "provider") WHERE project_id IS NOT NULL
+        `);
+        await queryRunner.query(`CREATE UNIQUE INDEX "idx_proxy_config_platform_provider_unique" ON "proxy_config" ("platform_id", "provider") WHERE project_id IS NULL`)
+        await queryRunner.query(`
+            ALTER TABLE "proxy_config"
+            ADD CONSTRAINT "fk_proxy_config_project_id" FOREIGN KEY ("project_id") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "proxy_config"
+            ADD CONSTRAINT "fk_proxy_config_platform_id" FOREIGN KEY ("platform_id") REFERENCES "platform"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "proxy_config" DROP CONSTRAINT "fk_proxy_config_platform_id"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "proxy_config" DROP CONSTRAINT "fk_proxy_config_project_id"
+        `);
+        await queryRunner.query(`DROP INDEX "public"."idx_proxy_config_platform_project_provider_unique"`)
+        await queryRunner.query(`
+            DROP TABLE "proxy_config"
+        `);
+    }
+
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -141,6 +141,7 @@ import { AddUserInvitation1717960689650 } from './migration/postgres/17179606896
 import { ModifyProjectMembers1717961669938 } from './migration/postgres/1717961669938-ModifyProjectMembers'
 import { AddWorkerMachine1720101280025 } from './migration/postgres/1720101280025-AddWorkerMachine'
 import { MigrateAuditEventSchema1723489038729 } from './migration/postgres/1723489038729-MigrateAuditEventSchema'
+import { CreateProxyConfig1724777988812 } from './migration/common/1724777988812-CreateProxyConfig'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -232,6 +233,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
         AddPremiumPiecesColumnPostgres1717370717678,
         AddWorkerMachine1720101280025,
         ChangeEventRoutingConstraint1723549873495,
+        CreateProxyConfig1724777988812
     ]
 
     const edition = system.getEdition()

--- a/packages/server/api/src/app/database/sqlite-connection.ts
+++ b/packages/server/api/src/app/database/sqlite-connection.ts
@@ -51,6 +51,7 @@ import { AddAlertsEntitySqlite1717239613259 } from './migration/sqlite/171723961
 import { AddPremiumPiecesColumnSqlite1717443603235 } from './migration/sqlite/1717443603235-AddPremiumPiecesColumnSqlite'
 import { AddUserInvitationSqlite1717943564437 } from './migration/sqlite/1717943564437-AddUserInvitationSqlite'
 import { AddWorkerMachineSqlite1720100928449 } from './migration/sqlite/1720100928449-AddWorkerMachineSqlite'
+import { CreateProxyConfig1724777988812 } from './migration/common/1724777988812-CreateProxyConfig'
 
 const getSqliteDatabaseFilePath = (): string => {
     const apConfigDirectoryPath = system.getOrThrow(AppSystemProp.CONFIG_PATH)
@@ -120,6 +121,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
         AddPremiumPiecesColumnSqlite1717443603235,
         AddWorkerMachineSqlite1720100928449,
         ChangeEventRoutingConstraint1723549873495,
+        CreateProxyConfig1724777988812
     ]
     const edition = system.getEdition()
     if (edition !== ApEdition.COMMUNITY) {

--- a/packages/server/api/src/app/proxy/platform-proxy-config-service.ts
+++ b/packages/server/api/src/app/proxy/platform-proxy-config-service.ts
@@ -1,0 +1,52 @@
+import { apId, PlatformId, ProxyConfig } from "@activepieces/shared";
+import { repoFactory } from "../core/db/repo-factory";
+import { ProxyConfigEntity } from "./proxy-config-entity";
+
+
+const repo = repoFactory(ProxyConfigEntity)
+
+export const platformProxyConfigService = {
+
+  async get(platformId: PlatformId, provider: string): Promise<ProxyConfig | null> {
+    const builder = repo().createQueryBuilder()
+    return builder.where({
+      platformId,
+      projectId: null,
+      provider,
+    }).getOne()
+  },
+
+  async create(platformId: PlatformId, proxyConfig: ProxyConfig): Promise<ProxyConfig> {
+    
+    const existingProxyConfig = await platformProxyConfigService.get(platformId, proxyConfig.provider)
+    if (existingProxyConfig) {
+      return existingProxyConfig
+    }
+
+    return repo().save({ ...proxyConfig, platformId, projectId: null, id: apId() })
+  },
+
+  async upsert(platformId: PlatformId, proxyConfig: ProxyConfig): Promise<ProxyConfig> {
+    return repo().save({ ...proxyConfig, platformId, projectId: null })
+  },
+
+  async delete(platformId: PlatformId, provider: string): Promise<void> {
+    const builder = repo().createQueryBuilder()
+    
+    await builder.delete().where({
+      platformId,
+      projectId: null,
+      provider,
+    }).execute()
+  },
+
+  async list(platformId: PlatformId): Promise<ProxyConfig[]> {
+    const builder = repo().createQueryBuilder()
+
+    
+    return builder.where({
+      platformId,
+      projectId: null,
+    }).getMany()
+  },
+}

--- a/packages/server/api/src/app/proxy/project-proxy-config-service.ts
+++ b/packages/server/api/src/app/proxy/project-proxy-config-service.ts
@@ -1,0 +1,65 @@
+import { apId, ProjectId, ProxyConfig } from "@activepieces/shared";
+import { repoFactory } from "../core/db/repo-factory";
+import { ProxyConfigEntity } from "./proxy-config-entity";
+import { projectService } from "../project/project-service";
+import { platformProxyConfigService } from "./platform-proxy-config-service";
+
+
+const repo = repoFactory(ProxyConfigEntity)
+
+export const projectProxyConfigService = {
+
+  async get(projectId: ProjectId, provider: string): Promise<ProxyConfig | null> {
+    const builder = repo().createQueryBuilder()
+
+    const platform = await projectService.getOneOrThrow(projectId)
+
+    const projectProxyConfig = await builder.where({
+      platformId: platform.id,
+      projectId,
+      provider,
+    }).getOne()
+
+    if (projectProxyConfig) {
+      return projectProxyConfig
+    }
+
+    return platformProxyConfigService.get(platform.id, provider)
+  },
+
+  async create(projectId: ProjectId, proxyConfig: ProxyConfig): Promise<ProxyConfig> {
+    const platformId = await projectService.getOneOrThrow(projectId)
+    const existingProxyConfig = await projectProxyConfigService.get(projectId, proxyConfig.provider)
+    if (existingProxyConfig) {
+      return existingProxyConfig
+    }
+
+    return repo().save({ ...proxyConfig, platformId, projectId, id: apId() })
+  },
+
+  async upsert(projectId: ProjectId, proxyConfig: ProxyConfig): Promise<ProxyConfig> {
+    const platformId = await projectService.getOneOrThrow(projectId)
+    return repo().save({ ...proxyConfig, platformId, projectId })
+  },
+
+  async delete(projectId: ProjectId, provider: string): Promise<void> {
+    const builder = repo().createQueryBuilder()
+    const platformId = await projectService.getOneOrThrow(projectId)
+
+    await builder.delete().where({
+      platformId,
+      projectId,
+      provider,
+    }).execute()
+  },
+
+  async list(projectId: ProjectId): Promise<ProxyConfig[]> {
+    const builder = repo().createQueryBuilder()
+
+    const platformId = await projectService.getOneOrThrow(projectId)
+    return builder.where({
+      platformId,
+      projectId,
+    }).getMany()
+  },
+}

--- a/packages/server/api/src/app/proxy/proxy-config-entity.ts
+++ b/packages/server/api/src/app/proxy/proxy-config-entity.ts
@@ -1,0 +1,53 @@
+import { Platform, Project, ProxyConfig } from '@activepieces/shared'
+import { EntitySchema } from 'typeorm'
+import { BaseColumnSchemaPart, JSON_COLUMN_TYPE } from '../database/database-common'
+
+export type ProxySchema = ProxyConfig & {
+    project: Project | null,
+    platform: Platform
+}
+
+
+export const ProxyConfigEntity = new EntitySchema<ProxySchema>({
+    name: 'proxy_config',
+    columns: {
+        ...BaseColumnSchemaPart,
+        defaultHeaders: {
+            type: JSON_COLUMN_TYPE,
+            nullable: false,
+        },
+        baseUrl: {
+            type: String,
+            nullable: false,
+        },
+        provider: {
+            type: String,
+            nullable: false,
+        }
+    },
+    indices: [
+        { name: 'idx_proxy_config_provider', columns: ['provider'] },
+        { name: 'idx_proxy_config_project_id', columns: ['project'] },
+        { name: 'idx_proxy_config_platform_id', columns: ['platform'] },
+    ],
+    relations: {
+        project: {
+            type: "one-to-one",
+            target: "project",
+            nullable: true,
+            joinColumn: {
+                name: "project_id",
+                foreignKeyConstraintName: "fk_proxy_config_project_id",
+            },
+        },
+        platform: {
+            type: "one-to-one",
+            target: "platform",
+            nullable: false,
+            joinColumn: {
+                name: "platform_id",
+                foreignKeyConstraintName: "fk_proxy_config_platform_id",
+            },
+        },
+    },
+})

--- a/packages/server/api/src/app/proxy/proxy-module.ts
+++ b/packages/server/api/src/app/proxy/proxy-module.ts
@@ -1,0 +1,67 @@
+import { FastifyPluginAsyncTypebox, FastifyPluginCallbackTypebox, Type } from '@fastify/type-provider-typebox'
+import { projectProxyConfigService } from './project-proxy-config-service'
+import { Permission, PrincipalType } from '@activepieces/shared'
+import { StatusCodes } from 'http-status-codes'
+import axios from 'axios'
+
+export const projectModule: FastifyPluginAsyncTypebox = async (app) => {
+  await app.register(projectProxyController, { prefix: '/v1/proxy' })
+}
+
+
+const ProxyRequest = {
+  config: {
+    allowedPrincipals: [PrincipalType.USER, PrincipalType.SERVICE, PrincipalType.ENGINE],
+  },
+  schema: {
+    tags: ['proxy'],
+    description: 'Proxy a request to a third party service',
+    params: Type.Object({
+      provider: Type.String(),
+    }),
+    response: {
+      [StatusCodes.OK]: Type.Unknown(),
+    }
+  },
+}
+
+export const projectProxyController: FastifyPluginCallbackTypebox = (
+  fastify,
+  _opts,
+  done,
+) => {
+  fastify.all('/:provider/*', ProxyRequest, async (request, reply) => {
+    try {
+      const projectId = request.principal.projectId
+
+      const config = await projectProxyConfigService.get(projectId, request.params.provider)
+
+      if (!config) {
+        reply.code(404).send({ error: 'Proxy config not found' });
+        return
+      }
+
+      const targetUrl = `${config.baseUrl}${request.url.replace('/proxy', '')}`;
+
+      const response = await axios.request({
+        method: request.method,
+        url: targetUrl,
+        headers: {
+          ...config.defaultHeaders,
+          ...request.headers,
+        },
+        data: request.body,
+        responseType: "json",
+        timeout: 5 * 60 * 1000, // 5 minutes since most LLMs are slow
+      })
+
+      const data = await response.data
+      reply.code(response.status).send(data);
+    } catch (error) {
+      fastify.log.error(error);
+      reply.code(500).send({ error: 'Proxy error' });
+    }
+  })
+
+  done()
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -100,6 +100,7 @@ export * from './lib/support-url'
 export * from './lib/license-keys'
 export * from './lib/invitations'
 export * from './lib/workers'
+export * from './lib/proxy'
 
 // Look at https://github.com/sinclairzx81/typebox/issues/350
 import { TypeSystemPolicy } from '@sinclair/typebox/system'

--- a/packages/shared/src/lib/proxy/index.ts
+++ b/packages/shared/src/lib/proxy/index.ts
@@ -1,0 +1,11 @@
+import { Static, Type } from "@sinclair/typebox";
+import { BaseModelSchema } from "../common";
+
+export const ProxyConfig = Type.Object({
+  ...BaseModelSchema,
+  defaultHeaders: Type.Record(Type.String(), Type.String()),
+  baseUrl: Type.String(),
+  provider: Type.String(),
+})
+
+export type ProxyConfig = Static<typeof ProxyConfig>;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,6 +27,9 @@
       "@activepieces/piece-activepieces": [
         "packages/pieces/community/activepieces/src/index.ts"
       ],
+      "@activepieces/piece-activepieces-ai": [
+        "packages/pieces/community/activepieces-ai/src/index.ts"
+      ],
       "@activepieces/piece-actualbudget": [
         "packages/pieces/community/actualbudget/src/index.ts"
       ],
@@ -36,6 +39,7 @@
       "@activepieces/piece-afforai": [
         "packages/pieces/community/afforai/src/index.ts"
       ],
+      "@activepieces/piece-ai": ["packages/pieces/community/ai/src/index.ts"],
       "@activepieces/piece-airtable": [
         "packages/pieces/community/airtable/src/index.ts"
       ],
@@ -59,6 +63,9 @@
       ],
       "@activepieces/piece-asana": [
         "packages/pieces/community/asana/src/index.ts"
+      ],
+      "@activepieces/piece-ask-ai": [
+        "packages/pieces/community/ask-ai/src/index.ts"
       ],
       "@activepieces/piece-azure-openai": [
         "packages/pieces/community/azure-openai/src/index.ts"


### PR DESCRIPTION
## What does this PR do?

Introduces a `/api/v1/proxy/:provider/*` endpoint to proxy requests to external services which will help abstracting away auth and service-specific request configurations.

