### PR TITLE
feat(slack): set user's status, find user by slack handle  actions and make channel optional for trigger

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.6.3"
+  "version": "0.7.0"
 }

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -23,6 +23,8 @@ import { createChannelAction } from './lib/actions/create-channel';
 import { channelCreated } from './lib/triggers/new-channel';
 import { addRectionToMessageAction } from './lib/actions/add-reaction-to-message';
 import { getChannelHistory } from './lib/actions/get-channel-history';
+import { findUserByHandleAction } from './lib/actions/find-user-by-handle';
+import { setUserStatusAction } from './lib/actions/set-user-status';
 
 export const slackAuth = PieceAuth.OAuth2({
   description: '',
@@ -104,10 +106,12 @@ export const slack = createPiece({
     uploadFile,
     searchMessages,
     findUserByEmailAction,
+    findUserByHandleAction,
     updateMessage,
     createChannelAction,
     updateProfileAction,
     getChannelHistory,
+    setUserStatusAction,
     createCustomApiCallAction({
       baseUrl: () => {
         return 'https://slack.com/api';

--- a/packages/pieces/community/slack/src/lib/actions/find-user-by-handle.ts
+++ b/packages/pieces/community/slack/src/lib/actions/find-user-by-handle.ts
@@ -1,0 +1,35 @@
+import { slackAuth } from '../../';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { UsersListResponse, WebClient } from '@slack/web-api';
+
+export const findUserByHandleAction = createAction({
+  auth: slackAuth,
+  name: 'slack-find-user-by-handle',
+  displayName: 'Find User by Handle',
+  description: 'Finds a user by matching against their Slack handle.',
+  props: {
+    handle: Property.ShortText({
+      displayName: 'Handle',
+      description: 'User handle (display name), without the leading @',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const handle = propsValue.handle.replace('@', '');
+    const client = new WebClient(auth.access_token);
+    for await (const page of client.paginate('users.list', {
+      limit: 1000, // Only limits page size, not total number of results
+    })) {
+      const response = page as UsersListResponse;
+      if (response.members) {
+        const matchedMember = response.members.find(
+          (member) => member.profile?.display_name === handle
+        );
+        if (matchedMember) {
+          return matchedMember;
+        }
+      }
+    }
+    throw new Error(`Could not find user with handle @${handle}`);
+  },
+});

--- a/packages/pieces/community/slack/src/lib/actions/set-user-status.ts
+++ b/packages/pieces/community/slack/src/lib/actions/set-user-status.ts
@@ -1,0 +1,42 @@
+import { slackAuth } from '../../';
+import {
+  createAction,
+  Property,
+  Validators,
+} from '@activepieces/pieces-framework';
+import { WebClient } from '@slack/web-api';
+
+export const setUserStatusAction = createAction({
+  auth: slackAuth,
+  name: 'slack-set-user-status',
+  displayName: 'Set User Status',
+  description: "Sets a user's custom status",
+  props: {
+    text: Property.ShortText({
+      displayName: 'Text',
+      required: true,
+      validators: [Validators.maxLength(100)],
+    }),
+    emoji: Property.ShortText({
+      displayName: 'Emoji',
+      required: false,
+      description:
+        'Emoji shortname (standard or custom), e.g. :tada: or :train:',
+    }),
+    expiration: Property.Number({
+      displayName: 'Expires at',
+      description: 'Unix timestamp - if not set, the status will not expire',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const client = new WebClient(auth.data['authed_user']?.access_token);
+    return await client.users.profile.set({
+      profile: {
+        status_text: propsValue.text,
+        status_emoji: propsValue.emoji,
+        status_expiration: propsValue.expiration,
+      },
+    });
+  },
+});

--- a/packages/pieces/community/slack/src/lib/common/props.ts
+++ b/packages/pieces/community/slack/src/lib/common/props.ts
@@ -1,8 +1,5 @@
 import { OAuth2PropertyValue, Property } from '@activepieces/pieces-framework';
-import {
-  UsersListResponse,
-  WebClient,
-} from '@slack/web-api';
+import { UsersListResponse, WebClient } from '@slack/web-api';
 
 export const slackInfo = Property.MarkDown({
   value: `
@@ -10,9 +7,9 @@ export const slackInfo = Property.MarkDown({
 	  1. Type /invite in the channel's chat.
 	  2. Click on Add apps to this channel.
 	  3. Search for and add the bot.
-    
+
     **Note**: If you can't find the channel in the dropdown list (which fetches up to 2000 channels), please click on the **(X)** and type the name directly.
-  `
+  `,
 });
 export const slackChannel = <R extends boolean>(required: R) =>
   Property.Dropdown<string, R>({
@@ -127,3 +124,4 @@ export const actions = Property.Array({
   displayName: 'Action Buttons',
   required: true,
 });
+

--- a/packages/pieces/community/slack/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-message.ts
@@ -39,7 +39,7 @@ export const newMessage = createTrigger({
   description: 'Triggers when a new message is received',
   props: {
     info: slackInfo,
-    channel: slackChannel(true),
+    channel: slackChannel(false),
   },
   type: TriggerStrategy.APP_WEBHOOK,
   sampleData: sampleData,
@@ -57,6 +57,9 @@ export const newMessage = createTrigger({
   },
 
   test: async (context) => {
+    if (!context.propsValue.channel) {
+      return [sampleData];
+    }
     const client = new WebClient(context.auth.access_token);
     const response = await client.conversations.history({
       channel: context.propsValue.channel,
@@ -77,7 +80,10 @@ export const newMessage = createTrigger({
 
   run: async (context) => {
     const payloadBody = context.payload.body as PayloadBody;
-    if (payloadBody.event.channel === context.propsValue.channel) {
+    if (
+      !context.propsValue.channel ||
+      payloadBody.event.channel === context.propsValue.channel
+    ) {
       return [payloadBody.event];
     }
 


### PR DESCRIPTION
## What does this PR do?

- add action to set the connected user's status
- add action to find a user by Slack handle
- make channel optional for "new message" trigger (to receive messages on **all** public channels)

ANNOUNCEMENT=true