### PR TITLE
docs: removed stacksnap from overview docs

### DIFF
--- a/docs/install/overview.mdx
+++ b/docs/install/overview.mdx
@@ -60,10 +60,6 @@ Deploy Activepieces as a single Docker container using the SQLite database.
       Easily install on RepoCloud using this template, maintained by the community.
     </Card>
 
-    <Card title="AWS (StackSnap)" icon="cloud" color="#805ac3" href="https://klo.dev/stacksnap/apps/activepieces">
-      1-Click Install on AWS with the StackSnap template, maintained by the community.
-    </Card>
-
   <Card title="Zeabur" icon={
     <svg viewBox="0 0 294 229" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M113.865 144.888H293.087V229H0V144.888H82.388L195.822 84.112H0V0H293.087V84.112L113.865 144.888Z" fill="black"/>


### PR DESCRIPTION
Hey all, we're closing down StackSnap, this PR removes instructions for using it.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

