### PR TITLE
fix: remove all references to the public schema in migration files

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1676238396411-initialize-schema.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1676238396411-initialize-schema.ts
@@ -182,32 +182,32 @@ export class initializeSchema1676238396411 implements MigrationInterface {
             'ALTER TABLE "collection" DROP CONSTRAINT "fk_collection_project_id"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_app_connection_project_id_and_name"',
+            'DROP INDEX "idx_app_connection_project_id_and_name"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_app_connection_project_id_and_app_name_and_name"',
+            'DROP INDEX "idx_app_connection_project_id_and_app_name_and_name"',
         )
         await queryRunner.query('DROP TABLE "app_connection"')
         await queryRunner.query('DROP TABLE "user"')
         await queryRunner.query('DROP TABLE "store-entry"')
-        await queryRunner.query('DROP INDEX "public"."idx_project_owner_id"')
+        await queryRunner.query('DROP INDEX "idx_project_owner_id"')
         await queryRunner.query('DROP TABLE "project"')
-        await queryRunner.query('DROP INDEX "public"."idx_run_project_id"')
+        await queryRunner.query('DROP INDEX "idx_run_project_id"')
         await queryRunner.query('DROP TABLE "flow_run"')
-        await queryRunner.query('DROP INDEX "public"."idx_instance_collection_id"')
-        await queryRunner.query('DROP INDEX "public"."idx_instance_project_id"')
+        await queryRunner.query('DROP INDEX "idx_instance_collection_id"')
+        await queryRunner.query('DROP INDEX "idx_instance_project_id"')
         await queryRunner.query('DROP TABLE "instance"')
-        await queryRunner.query('DROP INDEX "public"."idx_flow_version_flow_id"')
+        await queryRunner.query('DROP INDEX "idx_flow_version_flow_id"')
         await queryRunner.query('DROP TABLE "flow_version"')
-        await queryRunner.query('DROP INDEX "public"."idx_flow_collection_id"')
+        await queryRunner.query('DROP INDEX "idx_flow_collection_id"')
         await queryRunner.query('DROP TABLE "flow"')
         await queryRunner.query('DROP TABLE "flag"')
         await queryRunner.query('DROP TABLE "file"')
         await queryRunner.query(
-            'DROP INDEX "public"."idx_collection_version_collection_id"',
+            'DROP INDEX "idx_collection_version_collection_id"',
         )
         await queryRunner.query('DROP TABLE "collection_version"')
-        await queryRunner.query('DROP INDEX "public"."idx_collection_project_id"')
+        await queryRunner.query('DROP INDEX "idx_collection_project_id"')
         await queryRunner.query('DROP TABLE "collection"')
     }
 }

--- a/packages/server/api/src/app/database/migration/postgres/1677286751592-billing.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1677286751592-billing.ts
@@ -7,7 +7,7 @@ export class billing1677286751592 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         logger.info('Running migration billing1677286751592')
         await queryRunner.query(
-            'DROP INDEX "public"."idx_app_connection_project_id_and_app_name_and_name"',
+            'DROP INDEX "idx_app_connection_project_id_and_app_name_and_name"',
         )
         await queryRunner.query(
             'CREATE TABLE "project_plan" ("id" character varying(21) NOT NULL, "created" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "projectId" character varying(21) NOT NULL, "name" character varying NOT NULL, "stripeCustomerId" character varying NOT NULL, "stripeSubscriptionId" character varying NOT NULL, "tasks" integer NOT NULL, "subscriptionStartDatetime" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "REL_4f52e89612966d95843e4158bb" UNIQUE ("projectId"), CONSTRAINT "PK_759d33fce71c95de832df935841" PRIMARY KEY ("id"))',
@@ -42,13 +42,13 @@ export class billing1677286751592 implements MigrationInterface {
             'ALTER TABLE "project_plan" DROP CONSTRAINT "fk_project_plan_project_id"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_project_usage_project_id"',
+            'DROP INDEX "idx_project_usage_project_id"',
         )
         await queryRunner.query('DROP TABLE "project_usage"')
         await queryRunner.query(
-            'DROP INDEX "public"."idx_plan_stripe_customer_id"',
+            'DROP INDEX "idx_plan_stripe_customer_id"',
         )
-        await queryRunner.query('DROP INDEX "public"."idx_plan_project_id"')
+        await queryRunner.query('DROP INDEX "idx_plan_project_id"')
         await queryRunner.query('DROP TABLE "project_plan"')
         await queryRunner.query(
             'CREATE UNIQUE INDEX "idx_app_connection_project_id_and_app_name_and_name" ON "app_connection" ("name", "appName", "projectId") ',

--- a/packages/server/api/src/app/database/migration/postgres/1677894800372-product-embed.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1677894800372-product-embed.ts
@@ -45,11 +45,11 @@ export class productEmbed1677894800372 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            'DROP INDEX "public"."idx_connection_key_project_id"',
+            'DROP INDEX "idx_connection_key_project_id"',
         )
         await queryRunner.query('DROP TABLE "connection_key"')
         await queryRunner.query(
-            'DROP INDEX "public"."idx_app_credentials_projectId_appName"',
+            'DROP INDEX "idx_app_credentials_projectId_appName"',
         )
         await queryRunner.query('DROP TABLE "app_credential"')
         await queryRunner.query(

--- a/packages/server/api/src/app/database/migration/postgres/1678382946390-add-event-routing.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1678382946390-add-event-routing.ts
@@ -21,10 +21,10 @@ export class addEventRouting1678382946390 implements MigrationInterface {
     public async down(queryRunner: QueryRunner): Promise<void> {
         logger.info('Rolling Back migration addEventRouting1678382946390')
         await queryRunner.query(
-            'DROP INDEX "public"."idx_app_event_project_id_appName_identifier_value_event"',
+            'DROP INDEX "idx_app_event_project_id_appName_identifier_value_event"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_app_event_routing_flow_id"',
+            'DROP INDEX "idx_app_event_routing_flow_id"',
         )
         await queryRunner.query('DROP TABLE "app_event_routing"')
         logger.info('Finished Rolling Back migration addEventRouting1678382946390')

--- a/packages/server/api/src/app/database/migration/postgres/1678492809093-removeCollectionVersion.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1678492809093-removeCollectionVersion.ts
@@ -26,13 +26,13 @@ implements MigrationInterface {
             'ALTER TABLE "collection" ADD "displayName" character varying',
         )
         const collections = await queryRunner.query(
-            'SELECT * FROM public.collection',
+            'SELECT * FROM collection',
         )
 
         for (let i = 0; i < collections.length; ++i) {
             let currentCollection = collections[i]
             const latestCollectionVersionQuery = `
-                SELECT * FROM public.collection_version
+                SELECT * FROM collection_version
                 WHERE "collectionId" = '${currentCollection.id}'
                 ORDER BY created DESC
                 LIMIT 1
@@ -52,7 +52,7 @@ implements MigrationInterface {
             }
 
             const updateCollectionQuery = `
-                UPDATE public.collection
+                UPDATE collection
                 SET displayName = '${displayName}'
                 WHERE id = '${currentCollection.id}'
             `

--- a/packages/server/api/src/app/database/migration/postgres/1678621361185-addtriggerevents.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1678621361185-addtriggerevents.ts
@@ -28,7 +28,7 @@ export class addtriggerevents1678621361185 implements MigrationInterface {
         await queryRunner.query(
             'ALTER TABLE "trigger_event" DROP CONSTRAINT "fk_trigger_event_project_id"',
         )
-        await queryRunner.query('DROP INDEX "public"."idx_trigger_event_flow_id"')
+        await queryRunner.query('DROP INDEX "idx_trigger_event_flow_id"')
         await queryRunner.query('DROP TABLE "trigger_event"')
     }
 }

--- a/packages/server/api/src/app/database/migration/postgres/1680698259291-create-webhook-simulation-schema.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1680698259291-create-webhook-simulation-schema.ts
@@ -15,7 +15,7 @@ implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            'DROP INDEX "public"."idx_webhook_simulation_flow_id"',
+            'DROP INDEX "idx_webhook_simulation_flow_id"',
         )
         await queryRunner.query('DROP TABLE "webhook_simulation"')
     }

--- a/packages/server/api/src/app/database/migration/postgres/1680986182074-RemoveCollections.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1680986182074-RemoveCollections.ts
@@ -47,7 +47,7 @@ export class RemoveCollections1680986182074 implements MigrationInterface {
         await queryRunner.query(
             'ALTER TABLE "flow_run" DROP CONSTRAINT "fk_flow_run_collection_id"',
         )
-        await queryRunner.query('DROP INDEX "public"."idx_flow_collection_id"')
+        await queryRunner.query('DROP INDEX "idx_flow_collection_id"')
         await queryRunner.query(
             'ALTER TABLE "store-entry" RENAME COLUMN "collectionId" TO "projectId"',
         )
@@ -145,8 +145,8 @@ export class RemoveCollections1680986182074 implements MigrationInterface {
         await queryRunner.query(
             'ALTER TABLE "flow_instance" DROP CONSTRAINT "fk_flow_instance_flow"',
         )
-        await queryRunner.query('DROP INDEX "public"."idx_flow_folder_id"')
-        await queryRunner.query('DROP INDEX "public"."idx_flow_project_id"')
+        await queryRunner.query('DROP INDEX "idx_flow_folder_id"')
+        await queryRunner.query('DROP INDEX "idx_flow_project_id"')
         await queryRunner.query(
             'ALTER TABLE "flow" ALTER COLUMN "projectId" DROP NOT NULL',
         )
@@ -163,10 +163,10 @@ export class RemoveCollections1680986182074 implements MigrationInterface {
         await queryRunner.query(
             'ALTER TABLE "flow" ADD "collectionId" character varying(21) NOT NULL',
         )
-        await queryRunner.query('DROP INDEX "public"."idx_folder_project_id"')
+        await queryRunner.query('DROP INDEX "idx_folder_project_id"')
         await queryRunner.query('DROP TABLE "folder"')
         await queryRunner.query(
-            'DROP INDEX "public"."idx_flow_instance_project_id_flow_id"',
+            'DROP INDEX "idx_flow_instance_project_id_flow_id"',
         )
         await queryRunner.query('DROP TABLE "flow_instance"')
         await queryRunner.query(

--- a/packages/server/api/src/app/database/migration/postgres/1681019096716-StoreAllPeriods.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1681019096716-StoreAllPeriods.ts
@@ -10,7 +10,7 @@ export class StoreAllPeriods1681019096716 implements MigrationInterface {
             'ALTER TABLE "project_usage" DROP CONSTRAINT "REL_c407fc9b2bfb44515af69d575a"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_project_usage_project_id"',
+            'DROP INDEX "idx_project_usage_project_id"',
         )
         await queryRunner.query(
             'CREATE INDEX "idx_project_usage_project_id" ON "project_usage" ("projectId") ',
@@ -23,7 +23,7 @@ export class StoreAllPeriods1681019096716 implements MigrationInterface {
             'ALTER TABLE "project_usage" ADD CONSTRAINT "REL_c407fc9b2bfb44515af69d575a" UNIQUE ("projectId")',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_project_usage_project_id"',
+            'DROP INDEX "idx_project_usage_project_id"',
         )
         await queryRunner.query(
             'CREATE UNIQUE INDEX "idx_project_usage_project_id" ON "project_usage" ("projectId") ',

--- a/packages/server/api/src/app/database/migration/postgres/1683199709317-list-flow-runs-indices.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1683199709317-list-flow-runs-indices.ts
@@ -4,7 +4,7 @@ export class ListFlowRunsIndices1683199709317 implements MigrationInterface {
     name = 'ListFlowRunsIndices1683199709317'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query('DROP INDEX "public"."idx_run_project_id"')
+        await queryRunner.query('DROP INDEX "idx_run_project_id"')
         await queryRunner.query(
             'CREATE INDEX "idx_run_project_id_environment_created_desc" ON "flow_run" ("projectId", "environment", "created" DESC) ',
         )
@@ -21,16 +21,16 @@ export class ListFlowRunsIndices1683199709317 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            'DROP INDEX "public"."idx_run_project_id_flow_id_environment_status_created_desc"',
+            'DROP INDEX "idx_run_project_id_flow_id_environment_status_created_desc"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_run_project_id_flow_id_environment_created_desc"',
+            'DROP INDEX "idx_run_project_id_flow_id_environment_created_desc"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_run_project_id_environment_status_created_desc"',
+            'DROP INDEX "idx_run_project_id_environment_status_created_desc"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_run_project_id_environment_created_desc"',
+            'DROP INDEX "idx_run_project_id_environment_created_desc"',
         )
         await queryRunner.query(
             'CREATE INDEX "idx_run_project_id" ON "flow_run" ("projectId") ',

--- a/packages/server/api/src/app/database/migration/postgres/1685537054805-piece-metadata.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1685537054805-piece-metadata.ts
@@ -21,7 +21,7 @@ export class PieceMetadata1685537054805 implements MigrationInterface {
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query('DROP COLLATION en_natural')
         await queryRunner.query(
-            'DROP INDEX "public"."idx_piece_metadata_name_version"',
+            'DROP INDEX "idx_piece_metadata_name_version"',
         )
         await queryRunner.query('DROP TABLE "piece_metadata"')
 

--- a/packages/server/api/src/app/database/migration/postgres/1686090319016-AddProjectIdToPieceMetadata.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1686090319016-AddProjectIdToPieceMetadata.ts
@@ -8,7 +8,7 @@ implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         logger.info('[AddProjectIdToPieceMetadata1686090319016] up')
         await queryRunner.query(
-            'DROP INDEX "public"."idx_piece_metadata_name_version"',
+            'DROP INDEX "idx_piece_metadata_name_version"',
         )
         await queryRunner.query(
             'ALTER TABLE "piece_metadata" ADD "projectId" character varying',
@@ -27,7 +27,7 @@ implements MigrationInterface {
             'ALTER TABLE "piece_metadata" DROP CONSTRAINT "fk_piece_metadata_project_id"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_piece_metadata_name_project_id_version"',
+            'DROP INDEX "idx_piece_metadata_name_project_id_version"',
         )
         await queryRunner.query(
             'ALTER TABLE "piece_metadata" DROP COLUMN "projectId"',

--- a/packages/server/api/src/app/database/migration/postgres/1693004806926-AddFileToPostgres.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1693004806926-AddFileToPostgres.ts
@@ -26,7 +26,7 @@ export class AddFileToPostgres1693004806926 implements MigrationInterface {
             'ALTER TABLE "step_file" DROP CONSTRAINT "fk_step_file_project_id"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."step_file_project_id_flow_id_step_name_name"',
+            'DROP INDEX "step_file_project_id_flow_id_step_name_name"',
         )
         await queryRunner.query('DROP TABLE "step_file"')
     }

--- a/packages/server/api/src/app/database/migration/postgres/1698700720482-managed-authn-initial.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1698700720482-managed-authn-initial.ts
@@ -25,10 +25,10 @@ export class ManagedAuthnInitial1698700720482 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_user_external_id"
+            DROP INDEX "idx_user_external_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_platform_id_external_id"
+            DROP INDEX "idx_project_platform_id_external_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "user" DROP COLUMN "externalId"

--- a/packages/server/api/src/app/database/migration/postgres/1699221414907-AddOAuth2AppEntiity.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1699221414907-AddOAuth2AppEntiity.ts
@@ -38,7 +38,7 @@ export class AddOAuth2AppEntiity1699221414907 implements MigrationInterface {
             ALTER TABLE "oauth_app" DROP CONSTRAINT "fk_oauth_app_platform_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_oauth_app_platformId_pieceName"
+            DROP INDEX "idx_oauth_app_platformId_pieceName"
         `)
         await queryRunner.query(`
             DROP TABLE "oauth_app"

--- a/packages/server/api/src/app/database/migration/postgres/1699901161457-add-platform-id-to-user.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1699901161457-add-platform-id-to-user.ts
@@ -6,7 +6,7 @@ export class AddPlatformIdToUser1699901161457 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_user_external_id"
+            DROP INDEX "idx_user_external_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "user"
@@ -27,10 +27,10 @@ export class AddPlatformIdToUser1699901161457 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_user_platform_id_external_id"
+            DROP INDEX "idx_user_platform_id_external_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_user_platform_id_email"
+            DROP INDEX "idx_user_platform_id_email"
         `)
         await queryRunner.query(`
             ALTER TABLE "user"

--- a/packages/server/api/src/app/database/migration/postgres/1700396157624-add-otp-entity.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1700396157624-add-otp-entity.ts
@@ -40,7 +40,7 @@ export class AddOtpEntity1700396157624 implements MigrationInterface {
             ALTER TABLE "otp" DROP CONSTRAINT "fk_otp_user_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_otp_user_id_type"
+            DROP INDEX "idx_otp_user_id_type"
         `)
         await queryRunner.query(`
             DROP TABLE "otp"

--- a/packages/server/api/src/app/database/migration/postgres/1700751925992-MakeStripeCustomerIdNullable.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1700751925992-MakeStripeCustomerIdNullable.ts
@@ -17,7 +17,7 @@ implements MigrationInterface {
             ALTER COLUMN "stripeCustomerId" DROP NOT NULL
         `)
         await queryRunner.query(`
-        DROP INDEX "public"."idx_plan_stripe_customer_id"
+        DROP INDEX "idx_plan_stripe_customer_id"
     `)
         logger.info('MakeStripeCustomerIdNullable1700751925992 finished')
     }

--- a/packages/server/api/src/app/database/migration/postgres/1701647565290-ModifyProjectMembersAndRemoveUserId.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1701647565290-ModifyProjectMembersAndRemoveUserId.ts
@@ -26,7 +26,7 @@ implements MigrationInterface {
             UPDATE "project_member" SET "email" = "user"."email", "platformId" = "user"."platformId" FROM "user" WHERE "project_member"."userId" = "user"."id"
         `)
         await queryRunner.query(`
-            UPDATE user SET "email" = CONCAT("email", 'deleted') WHERE "status" = 'INVITED';
+            UPDATE "user" SET "email" = CONCAT("email", 'deleted') WHERE "status" = 'INVITED';
         `)
         await queryRunner.query(`
             ALTER TABLE "project_member"

--- a/packages/server/api/src/app/database/migration/postgres/1701647565290-ModifyProjectMembersAndRemoveUserId.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1701647565290-ModifyProjectMembersAndRemoveUserId.ts
@@ -26,7 +26,7 @@ implements MigrationInterface {
             UPDATE "project_member" SET "email" = "user"."email", "platformId" = "user"."platformId" FROM "user" WHERE "project_member"."userId" = "user"."id"
         `)
         await queryRunner.query(`
-            UPDATE public.user SET "email" = CONCAT("email", 'deleted') WHERE "status" = 'INVITED';
+            UPDATE user SET "email" = CONCAT("email", 'deleted') WHERE "status" = 'INVITED';
         `)
         await queryRunner.query(`
             ALTER TABLE "project_member"
@@ -37,7 +37,7 @@ implements MigrationInterface {
             ALTER TABLE "project_member" DROP CONSTRAINT "fk_project_member_user_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_member_project_id_user_id"
+            DROP INDEX "idx_project_member_project_id_user_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "project_member" DROP COLUMN "userId"
@@ -49,7 +49,7 @@ implements MigrationInterface {
             return
         }
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_member_project_id_email_platform_id"
+            DROP INDEX "idx_project_member_project_id_email_platform_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "project_member" DROP COLUMN "platformId"

--- a/packages/server/api/src/app/database/migration/postgres/1704503804056-AddGitRepoMigrationPostgres.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1704503804056-AddGitRepoMigrationPostgres.ts
@@ -40,7 +40,7 @@ implements MigrationInterface {
             ALTER TABLE "git_repo" DROP CONSTRAINT "fk_git_repo_project_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_git_repo_project_id"
+            DROP INDEX "idx_git_repo_project_id"
         `)
         await queryRunner.query(`
             DROP TABLE "git_repo"

--- a/packages/server/api/src/app/database/migration/postgres/1705586178452-RemoveUniqueonAppNameAppCredentials.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1705586178452-RemoveUniqueonAppNameAppCredentials.ts
@@ -11,7 +11,7 @@ implements MigrationInterface {
             return
         }
         await queryRunner.query(`
-            DROP INDEX "public"."idx_app_credentials_projectId_appName"
+            DROP INDEX "idx_app_credentials_projectId_appName"
         `)
     }
 

--- a/packages/server/api/src/app/database/migration/postgres/1705969874745-MakePlatformNotNullable.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1705969874745-MakePlatformNotNullable.ts
@@ -13,7 +13,7 @@ export class MakePlatformNotNullable1705969874745 implements MigrationInterface 
             ALTER TABLE "project" DROP COLUMN "type"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_platform_id_external_id"
+            DROP INDEX "idx_project_platform_id_external_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "project"
@@ -37,7 +37,7 @@ export class MakePlatformNotNullable1705969874745 implements MigrationInterface 
             ALTER TABLE "project" DROP CONSTRAINT "fk_project_platform_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_platform_id_external_id"
+            DROP INDEX "idx_project_platform_id_external_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "project"

--- a/packages/server/api/src/app/database/migration/postgres/1707614902283-AddAuditEvents.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1707614902283-AddAuditEvents.ts
@@ -61,7 +61,7 @@ export class AddAuditEvents1707614902283 implements MigrationInterface {
             ALTER TABLE "audit_event" DROP CONSTRAINT "FK_8188cdbf5c16c58d431efddd451"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."audit_event_platform_id_project_id_user_id_idx"
+            DROP INDEX "audit_event_platform_id_project_id_user_id_idx"
         `)
         await queryRunner.query(`
             DROP TABLE "audit_event"

--- a/packages/server/api/src/app/database/migration/postgres/1708515756040-create-activity-table.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1708515756040-create-activity-table.ts
@@ -41,7 +41,7 @@ export class CreateActivityTable1708515756040 implements MigrationInterface {
             ALTER TABLE "activity" DROP CONSTRAINT "fk_activity_project_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_activity_project_id_created_desc"
+            DROP INDEX "idx_activity_project_id_created_desc"
         `)
         await queryRunner.query(`
             DROP TABLE "activity"

--- a/packages/server/api/src/app/database/migration/postgres/1708811745694-AddProjectBilling.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1708811745694-AddProjectBilling.ts
@@ -41,7 +41,7 @@ export class AddProjectBilling1708811745694 implements MigrationInterface {
             ALTER TABLE "project_billing" DROP CONSTRAINT "fk_project_stripe_project_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_stripe_project_id"
+            DROP INDEX "idx_stripe_project_id"
         `)
         await queryRunner.query(`
             DROP TABLE "project_billing"

--- a/packages/server/api/src/app/database/migration/postgres/1709500213947-add-user-email-to-referral.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1709500213947-add-user-email-to-referral.ts
@@ -46,7 +46,7 @@ export class AddUserEmailToReferral1709500213947 implements MigrationInterface {
             ALTER TABLE "referal" DROP CONSTRAINT "fk_referral_referring_user_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_referral_referring_user_id"
+            DROP INDEX "idx_referral_referring_user_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "referal"
@@ -84,7 +84,7 @@ export class AddUserEmailToReferral1709500213947 implements MigrationInterface {
             ALTER TABLE "referal" DROP CONSTRAINT "fk_referral_referred_user_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_referral_referring_user_id"
+            DROP INDEX "idx_referral_referring_user_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "referal"

--- a/packages/server/api/src/app/database/migration/postgres/1709505632771-SetNotNullOnPlatform.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1709505632771-SetNotNullOnPlatform.ts
@@ -5,7 +5,7 @@ export class SetNotNullOnPlatform1709505632771 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_platform_id_external_id"
+            DROP INDEX "idx_project_platform_id_external_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "project"
@@ -19,7 +19,7 @@ export class SetNotNullOnPlatform1709505632771 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_platform_id_external_id"
+            DROP INDEX "idx_project_platform_id_external_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "project"

--- a/packages/server/api/src/app/database/migration/postgres/1712107871405-AddPieceTags.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1712107871405-AddPieceTags.ts
@@ -55,7 +55,7 @@ export class AddPieceTags1712107871405 implements MigrationInterface {
             ALTER TABLE "tag" DROP CONSTRAINT "FK_9dec09e187398715b7f1e32a6cb"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."tag_platformId"
+            DROP INDEX "tag_platformId"
         `)
         await queryRunner.query(`
             DROP TABLE "piece_tag"

--- a/packages/server/api/src/app/database/migration/postgres/1712279318440-PiecesProjectLimits.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1712279318440-PiecesProjectLimits.ts
@@ -69,7 +69,7 @@ export class PiecesProjectLimits1712279318440 implements MigrationInterface {
             ALTER TABLE "project_plan" DROP COLUMN "piecesFilterType"
         `)
         await queryRunner.query(`
-            DROP TYPE "public"."project_plan_piecesfiltertype_enum"
+            DROP TYPE "project_plan_piecesfiltertype_enum"
         `)
         await queryRunner.query(`
             ALTER TABLE "project_plan" DROP COLUMN "pieces"

--- a/packages/server/api/src/app/database/migration/postgres/1713221809186-RemoveUniqueEmailOnUser.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1713221809186-RemoveUniqueEmailOnUser.ts
@@ -5,7 +5,7 @@ export class RemoveUniqueEmailOnUser1713221809186 implements MigrationInterface 
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_user_partial_unique_email_platform_id_is_null"
+            DROP INDEX "idx_user_partial_unique_email_platform_id_is_null"
         `)
     }
 

--- a/packages/server/api/src/app/database/migration/postgres/1713302610746-AddPlatformRoleToUser.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1713302610746-AddPlatformRoleToUser.ts
@@ -34,10 +34,10 @@ export class AddPlatformRoleToUser1713302610746 implements MigrationInterface {
      `)
 
         await queryRunner.query(`
-            DROP INDEX "public"."idx_user_platform_id_external_id"
+            DROP INDEX "idx_user_platform_id_external_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_user_platform_id_email"
+            DROP INDEX "idx_user_platform_id_email"
         `)
         await queryRunner.query(`
             ALTER TABLE "user"
@@ -69,10 +69,10 @@ export class AddPlatformRoleToUser1713302610746 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_user_platform_id_external_id"
+            DROP INDEX "idx_user_platform_id_external_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_user_platform_id_email"
+            DROP INDEX "idx_user_platform_id_email"
         `)
         await queryRunner.query(`
             ALTER TABLE "user"

--- a/packages/server/api/src/app/database/migration/postgres/1713643694049-AddUniqueNameToFolder.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1713643694049-AddUniqueNameToFolder.ts
@@ -16,7 +16,7 @@ export class AddUniqueNameToFolder1713643694049 implements MigrationInterface {
             )
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_folder_project_id"
+            DROP INDEX "idx_folder_project_id"
         `)
         await queryRunner.query(`
             CREATE UNIQUE INDEX "idx_folder_project_id_display_name" ON "folder" ("projectId", "displayName")
@@ -25,7 +25,7 @@ export class AddUniqueNameToFolder1713643694049 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_folder_project_id_display_name"
+            DROP INDEX "idx_folder_project_id_display_name"
         `)
         await queryRunner.query(`
             CREATE INDEX "idx_folder_project_id" ON "folder" ("projectId")

--- a/packages/server/api/src/app/database/migration/postgres/1714249840058-UnifyEnterpriseWithCloud.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1714249840058-UnifyEnterpriseWithCloud.ts
@@ -16,7 +16,7 @@ export class UnifyEnterpriseWithCloud1714249840058 implements MigrationInterface
             ALTER TABLE "app_credential" DROP CONSTRAINT "FK_d82bfb4c7432a69dc2419083a0e"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_app_credentials_projectId_appName"
+            DROP INDEX "idx_app_credentials_projectId_appName"
         `)
         await queryRunner.query(`
             ALTER TABLE "connection_key"

--- a/packages/server/api/src/app/database/migration/postgres/1714904516114-AddIssueEntityPostgres.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1714904516114-AddIssueEntityPostgres.ts
@@ -58,10 +58,10 @@ export class AddIssueEntityPostgres1714904516114 implements MigrationInterface {
             ALTER TABLE "platform" DROP COLUMN "flowIssuesEnabled"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_issue_project_id_flow_id"
+            DROP INDEX "idx_issue_project_id_flow_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_issue_flow_id"
+            DROP INDEX "idx_issue_flow_id"
         `)
         await queryRunner.query(`
             DROP TABLE "issue"

--- a/packages/server/api/src/app/database/migration/postgres/1717961669938-ModifyProjectMembers.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1717961669938-ModifyProjectMembers.ts
@@ -8,7 +8,7 @@ export class ModifyProjectMembers1717961669938 implements MigrationInterface {
         const projectMembers = await queryRunner.query('SELECT * FROM project_member WHERE status = \'ACTIVE\'')
         await queryRunner.query('TRUNCATE TABLE project_member CASCADE')
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_member_project_id_email_platform_id"
+            DROP INDEX "idx_project_member_project_id_email_platform_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "project_member" DROP COLUMN "status"
@@ -38,7 +38,7 @@ export class ModifyProjectMembers1717961669938 implements MigrationInterface {
             if (projectMember.role === 'EXTERNAL_CUSTOMER') {
                 projectMember.role = 'OPERATOR'
             }
-            const user = await queryRunner.query(`SELECT * FROM "public"."user" WHERE email = '${projectMember.email}' AND "platformId" = '${projectMember.platformId}'`)
+            const user = await queryRunner.query(`SELECT * FROM "user" WHERE email = '${projectMember.email}' AND "platformId" = '${projectMember.platformId}'`)
             if (user.length === 0) {
                 // Skip if user not found
                 continue
@@ -58,7 +58,7 @@ export class ModifyProjectMembers1717961669938 implements MigrationInterface {
             ALTER TABLE "project_member" DROP CONSTRAINT "fk_project_member_user_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_member_project_id_user_id_platform_id"
+            DROP INDEX "idx_project_member_project_id_user_id_platform_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "project_member" DROP COLUMN "platformId"
@@ -82,7 +82,7 @@ export class ModifyProjectMembers1717961669938 implements MigrationInterface {
             CREATE UNIQUE INDEX "idx_project_member_project_id_email_platform_id" ON "project_member" ("projectId", "email", "platformId")
         `)
         for (const projectMember of projectMembers) {
-            const user = await queryRunner.query(`SELECT * FROM "public.user" WHERE id = '${projectMember.userId}'`)
+            const user = await queryRunner.query(`SELECT * FROM "user" WHERE id = '${projectMember.userId}'`)
             await queryRunner.query(`
             INSERT INTO "project_member" ("id", "created", "updated", "projectId", "platformId", "email", "status", "role")
             VALUES ('${projectMember.id}','${dayjs(projectMember.created).toISOString()}', '${dayjs(projectMember.updated).toISOString()}', '${projectMember.projectId}', '${projectMember.platformId}', '${user.email}', '${projectMember.status}', '${projectMember.role}')

--- a/packages/server/api/src/app/database/migration/postgres/1723489038729-MigrateAuditEventSchema.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1723489038729-MigrateAuditEventSchema.ts
@@ -5,7 +5,7 @@ export class MigrateAuditEventSchema1723489038729 implements MigrationInterface 
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."audit_event_platform_id_project_id_user_id_idx"
+            DROP INDEX "audit_event_platform_id_project_id_user_id_idx"
         `)
         await queryRunner.query(`
             ALTER TABLE "audit_event"
@@ -22,7 +22,7 @@ export class MigrateAuditEventSchema1723489038729 implements MigrationInterface 
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."audit_event_platform_id_project_id_user_id_idx"
+            DROP INDEX "audit_event_platform_id_project_id_user_id_idx"
         `)
         await queryRunner.query(`
             ALTER TABLE "audit_event"

--- a/packages/server/api/src/app/ee/database/migrations/postgres/1685538145476-addTemplates.ts
+++ b/packages/server/api/src/app/ee/database/migrations/postgres/1685538145476-addTemplates.ts
@@ -24,8 +24,8 @@ export class AddTemplates1685538145476 implements MigrationInterface {
         if (isNotOneOfTheseEditions([ApEdition.ENTERPRISE, ApEdition.CLOUD])) {
             return
         }
-        await queryRunner.query('DROP INDEX "public"."idx_flow_template_pieces"')
-        await queryRunner.query('DROP INDEX "public"."idx_flow_template_tags"')
+        await queryRunner.query('DROP INDEX "idx_flow_template_pieces"')
+        await queryRunner.query('DROP INDEX "idx_flow_template_tags"')
         await queryRunner.query('DROP TABLE "flow_template"')
     }
 }

--- a/packages/server/api/src/app/ee/database/migrations/postgres/1689177797092-AddProjectMembers.ts
+++ b/packages/server/api/src/app/ee/database/migrations/postgres/1689177797092-AddProjectMembers.ts
@@ -22,7 +22,7 @@ export class AddProjectMembers1689177797092 implements MigrationInterface {
             return
         }
         await queryRunner.query(
-            'DROP INDEX "public"."idx_project_member_project_id_user_id"',
+            'DROP INDEX "idx_project_member_project_id_user_id"',
         )
         await queryRunner.query('DROP TABLE "project_member"')
     }

--- a/packages/server/api/src/app/ee/database/migrations/postgres/1690459469381-AddReferral.ts
+++ b/packages/server/api/src/app/ee/database/migrations/postgres/1690459469381-AddReferral.ts
@@ -34,7 +34,7 @@ export class AddReferral1690459469381 implements MigrationInterface {
             'ALTER TABLE "referal" DROP CONSTRAINT "fk_referral_referred_user_id"',
         )
         await queryRunner.query(
-            'DROP INDEX "public"."idx_referral_referring_user_id"',
+            'DROP INDEX "idx_referral_referring_user_id"',
         )
         await queryRunner.query('DROP TABLE "referal"')
     }

--- a/packages/server/api/src/app/ee/database/migrations/postgres/1698077078271-AddCustomDomain.ts
+++ b/packages/server/api/src/app/ee/database/migrations/postgres/1698077078271-AddCustomDomain.ts
@@ -37,7 +37,7 @@ export class AddCustomDomain1698077078271 implements MigrationInterface {
             ALTER TABLE "custom_domain" DROP CONSTRAINT "fk_custom_domain_platform_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."custom_domain_domain_unique"
+            DROP INDEX "custom_domain_domain_unique"
         `)
         await queryRunner.query(`
             DROP TABLE "custom_domain"


### PR DESCRIPTION
## What does this PR do?

Several migration files reference the `public` schema while others did not. This is inconsistent with the rest of the application and creates challenges with Activepieces is not being run in the `public` schema. 

Fixes #[4350](https://github.com/activepieces/activepieces/issues/4350) 
