### PR TITLE
feat(linear): fix pagination bug

### DIFF
--- a/packages/pieces/community/linear/package.json
+++ b/packages/pieces/community/linear/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-linear",
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/packages/pieces/community/linear/src/lib/common/props.ts
+++ b/packages/pieces/community/linear/src/lib/common/props.ts
@@ -27,6 +27,7 @@ export const props = {
         do {
           const teams = await client.listTeams({
             orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,
+            first: 100,
             after: cursor,
           });
 
@@ -73,6 +74,7 @@ export const props = {
                 },
               },
             },
+            first: 100,
             after: cursor,
           };
           const statusList = await client.listIssueStates(filter);
@@ -114,6 +116,7 @@ export const props = {
         do {
           const labels = await client.listIssueLabels({
             orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,
+            first: 100,
             after: cursor,
           });
 
@@ -154,6 +157,7 @@ export const props = {
         do {
           const users = await client.listUsers({
             orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,
+            first: 100,
             after: cursor,
           });
 
@@ -261,6 +265,7 @@ export const props = {
         do {
           const projects = await client.listProjects({
             orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,
+            first: 100,
             after: cursor,
           });
 
@@ -303,6 +308,7 @@ export const props = {
             LinearDocument.Team_TemplatesQueryVariables,
             'id'
           > = {
+            first: 100,
             after: cursor,
             orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,
           };


### PR DESCRIPTION
## What does this PR do?

Dropdowns that use pagination are broken after the first load, i.e. once `after` is set - because `first` is mandatory in this case

https://relay.dev/graphql/connections.htm
