### PR TITLE
feat(dust): add mime type after breaking API change

### DIFF
--- a/packages/pieces/community/dust/package.json
+++ b/packages/pieces/community/dust/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-dust",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/packages/pieces/community/dust/src/lib/actions/add-fragment-to-conversation.ts
+++ b/packages/pieces/community/dust/src/lib/actions/add-fragment-to-conversation.ts
@@ -6,6 +6,7 @@ import {
   HttpMethod,
   HttpRequest,
 } from '@activepieces/pieces-common';
+import mime from 'mime-types';
 
 export const addFragmentToConversation = createAction({
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
@@ -26,6 +27,11 @@ export const addFragmentToConversation = createAction({
     }),
   },
   async run({ auth, propsValue }) {
+    const mimeType = propsValue.fragmentName
+      ? mime.lookup(propsValue.fragmentName) ||
+        mime.lookup(propsValue.fragment.filename)
+      : mime.lookup(propsValue.fragment.filename);
+
     const request: HttpRequest = {
       method: HttpMethod.POST,
       url: `${DUST_BASE_URL}/${auth.workspaceId}/assistant/conversations/${propsValue.conversationId}/content_fragments`,
@@ -37,7 +43,7 @@ export const addFragmentToConversation = createAction({
         {
           content: propsValue.fragment.data.toString('utf-8'),
           title: propsValue.fragmentName || propsValue.fragment.filename,
-          contentType: 'file_attachment',
+          contentType: mimeType || 'text/plain',
           context: null,
           url: null,
         },

--- a/packages/pieces/community/dust/src/lib/actions/create-conversation.ts
+++ b/packages/pieces/community/dust/src/lib/actions/create-conversation.ts
@@ -13,6 +13,7 @@ import {
   timeoutProp,
 } from '../common';
 import { dustAuth } from '../..';
+import mime from 'mime-types';
 
 export const createConversation = createAction({
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
@@ -49,10 +50,14 @@ export const createConversation = createAction({
       },
     };
     if (propsValue.fragment) {
+      const mimeType = propsValue.fragmentName
+        ? mime.lookup(propsValue.fragmentName) ||
+          mime.lookup(propsValue.fragment.filename)
+        : mime.lookup(propsValue.fragment.filename);
       payload['contentFragment'] = {
         title: propsValue.fragmentName || propsValue.fragment.filename,
         content: propsValue.fragment.data.toString('utf-8'),
-        contentType: 'file_attachment',
+        contentType: mimeType || 'text/plain',
         context: null,
         url: null,
       };


### PR DESCRIPTION
## What does this PR do?

Dust.tt made a breaking change to their API - we now must provide a proper mime type