### PR TITLE
feat: add customizable expiry date (in seconds) to user invitations and include in request payload

### DIFF
--- a/packages/server/api/src/app/user-invitations/user-invitation.entity.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.entity.ts
@@ -33,6 +33,10 @@ export const UserInvitationEntity = new EntitySchema<UserInvitation>({
             type: String,
             nullable: false,
         },
+        invitationExpirySeconds: {
+            type: Number,
+            nullable: true,
+        },
     },
     indices: [
         {

--- a/packages/server/api/src/app/user-invitations/user-invitation.entity.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.entity.ts
@@ -33,10 +33,6 @@ export const UserInvitationEntity = new EntitySchema<UserInvitation>({
             type: String,
             nullable: false,
         },
-        invitationExpirySeconds: {
-            type: Number,
-            nullable: true,
-        },
     },
     indices: [
         {

--- a/packages/server/api/src/app/user-invitations/user-invitation.module.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.module.ts
@@ -35,7 +35,7 @@ const invitationController: FastifyPluginAsyncTypebox = async (
 
     app.post('/', CreateUserInvitationRequestParams, async (request, reply) => {
         await assertPermission(app, request, reply, request.body.projectId ?? undefined, request.body.type)
-        const { email, platformRole, projectRole, type } = request.body
+        const { email, platformRole, projectRole, type, invitationExpirySeconds } = request.body
         if (type === InvitationType.PROJECT) {
             await projectMembersLimit.limit({
                 projectId: request.principal.projectId,
@@ -51,6 +51,7 @@ const invitationController: FastifyPluginAsyncTypebox = async (
             platformRole: type === InvitationType.PROJECT ? null : platformRole ?? null,
             projectId: type === InvitationType.PLATFORM ? null : request.body.projectId ?? null,
             projectRole: type === InvitationType.PLATFORM ? null : projectRole ?? null,
+            invitationExpirySeconds: invitationExpirySeconds ?? 24 * 60 * 60,
         })
         await reply.status(StatusCodes.CREATED).send(invitation)
     })
@@ -122,6 +123,7 @@ const ListUserInvitationsRequestParams = {
     config: {
         allowedPrincipals: [PrincipalType.USER, PrincipalType.SERVICE],
         permission: Permission.READ_INVITATION,
+        scope: EndpointScope.PLATFORM,
     },
     schema: {
         tags: ['user-invitations'],
@@ -136,6 +138,7 @@ const ListUserInvitationsRequestParams = {
 const AcceptUserInvitationRequestParams = {
     config: {
         allowedPrincipals: ALL_PRINCIPAL_TYPES,
+        scope: EndpointScope.PLATFORM,
     },
     schema: {
         body: AcceptUserInvitationRequest,
@@ -145,6 +148,7 @@ const AcceptUserInvitationRequestParams = {
 const DeleteInvitationRequestParams = {
     config: {
         allowedPrincipals: [PrincipalType.USER, PrincipalType.SERVICE],
+        scope: EndpointScope.PLATFORM,
     },
     schema: {
         tags: ['user-invitations'],

--- a/packages/server/api/src/app/user-invitations/user-invitation.module.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.module.ts
@@ -51,7 +51,7 @@ const invitationController: FastifyPluginAsyncTypebox = async (
             platformRole: type === InvitationType.PROJECT ? null : platformRole ?? null,
             projectId: type === InvitationType.PLATFORM ? null : request.body.projectId ?? null,
             projectRole: type === InvitationType.PLATFORM ? null : projectRole ?? null,
-            invitationExpirySeconds: invitationExpirySeconds ?? 24 * 60 * 60,
+            invitationExpirySeconds,
         })
         await reply.status(StatusCodes.CREATED).send(invitation)
     })

--- a/packages/server/api/src/app/user-invitations/user-invitation.service.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.service.ts
@@ -1,7 +1,7 @@
 
 import { ActivepiecesError, apId, assertEqual, assertNotNullOrUndefined, ErrorCode, InvitationStatus, InvitationType, isNil, Platform, PlatformRole, ProjectMemberRole, SeekPage, spreadIfDefined, UserInvitation, UserInvitationWithLink } from '@activepieces/shared'
 import dayjs from 'dayjs'
-import { IsNull, MoreThanOrEqual } from 'typeorm'
+import { IsNull } from 'typeorm'
 import { repoFactory } from '../core/db/repo-factory'
 import { smtpEmailSender } from '../ee/helper/email/email-sender/smtp-email-sender'
 import { emailService } from '../ee/helper/email/email-service'
@@ -15,7 +15,6 @@ import { userService } from '../user/user-service'
 import { UserInvitationEntity } from './user-invitation.entity'
 
 const repo = repoFactory(UserInvitationEntity)
-const INVITATION_EXPIREY_DAYS = 1
 
 export const userInvitationsService = {
     async countByProjectId(projectId: string): Promise<number> {
@@ -32,16 +31,21 @@ export const userInvitationsService = {
             return
         }
         const platform = await platformService.getOneOrThrow(platformId)
-        const ONE_DAY_AGO = dayjs().subtract(INVITATION_EXPIREY_DAYS, 'day').toISOString()
         const invitations = await repo().findBy([
             {
                 email,
                 platformId,
                 status: InvitationStatus.ACCEPTED,
-                created: MoreThanOrEqual(ONE_DAY_AGO),
             },
         ])
         for (const invitation of invitations) {
+            const expiryDate = dayjs(invitation.created).add(invitation.invitationExpirySeconds, 'seconds')
+            if (expiryDate.isBefore(dayjs())) {
+                await repo().delete({
+                    id: invitation.id,
+                })
+                continue
+            }
             switch (invitation.type) {
                 case InvitationType.PLATFORM: {
                     assertNotNullOrUndefined(invitation.platformRole, 'platformRole')
@@ -65,9 +69,6 @@ export const userInvitationsService = {
                     break
                 }
             }
-            await repo().delete({
-                id: invitation.id,
-            })
         }
     },
     async create({
@@ -77,6 +78,7 @@ export const userInvitationsService = {
         type,
         projectRole,
         platformRole,
+        invitationExpirySeconds,
     }: CreateParams): Promise<UserInvitationWithLink> {
         const invitation = await repo().findOneBy({
             email,
@@ -98,6 +100,7 @@ export const userInvitationsService = {
             projectRole: type === InvitationType.PLATFORM ? undefined : projectRole!,
             platformRole: type === InvitationType.PROJECT ? undefined : platformRole!,
             projectId: type === InvitationType.PLATFORM ? undefined : projectId!,
+            invitationExpirySeconds: invitationExpirySeconds ?? 24 * 60 * 60,
         }, ['email', 'platformId', 'projectId'])
 
         const userInvitation = await this.getOneOrThrow({
@@ -199,7 +202,7 @@ async function generateInvitationLink(userInvitation: UserInvitation): Promise<s
         payload: {
             id: userInvitation.id,
         },
-        expiresInSeconds: INVITATION_EXPIREY_DAYS * 24 * 60 * 60,
+        expiresInSeconds: userInvitation.invitationExpirySeconds,
         key: await jwtUtils.getJwtSecret(),
     })
 
@@ -278,6 +281,7 @@ export type CreateParams = {
     projectId: string | null
     type: InvitationType
     projectRole: ProjectMemberRole | null
+    invitationExpirySeconds: number | null
 }
 
 export type DeleteParams = {

--- a/packages/shared/src/lib/invitations/index.ts
+++ b/packages/shared/src/lib/invitations/index.ts
@@ -22,6 +22,7 @@ export const UserInvitation = Type.Object({
     platformRole: NullableEnum(Type.Enum(PlatformRole)),
     projectId: Nullable(Type.String()),
     projectRole: NullableEnum(Type.Enum(ProjectMemberRole)),
+    invitationExpirySeconds: Type.Number(),
 })
 
 export type UserInvitation = Static<typeof UserInvitation>
@@ -38,6 +39,7 @@ export const SendUserInvitationRequest = Type.Object({
     platformRole: Type.Optional(Type.Enum(PlatformRole)),
     projectId: Nullable(Type.String()),
     projectRole: Type.Optional(Type.Enum(ProjectMemberRole)),
+    invitationExpirySeconds: Type.Optional(Type.Number()),
 })
 
 export type SendUserInvitationRequest = Static<typeof SendUserInvitationRequest>


### PR DESCRIPTION
This PR introduces a new feature for customizing user invitation expiry dates. The expiry date is now set in seconds and included in the request payload when sending an invitation (it's not required & by default, it stays for a day).

in the body of the request
```
{
   ....,
   ....,
   ....,
   "invitationExpirySeconds" : 24 * 60 * 60        //One Day
}