### PR TITLE
Update crop-image.action.ts

### DIFF
--- a/packages/pieces/community/image-helper/src/lib/actions/crop-image.action.ts
+++ b/packages/pieces/community/image-helper/src/lib/actions/crop-image.action.ts
@@ -30,6 +30,11 @@ export const cropImage = createAction({
       description: 'Determines the vertical size of the cropped area.',
       required: true,
     }),
+    resultFileName: Property.ShortText({
+      displayName: 'Result File Name',
+      description: 'Specifies the output file name for the cropped image (without extension).',
+      required: true,
+    }),
   },
   async run(context) {
     const image = await jimp.read(context.propsValue.image.data);
@@ -37,8 +42,10 @@ export const cropImage = createAction({
     
     const imageBuffer = await image.getBufferAsync(image.getMIME());
 
+    const fileName = context.propsValue.resultFileName + '.' + image.getExtension();
+
     const imageReference = await context.files.write({
-      fileName: 'image.' + image.getExtension(),
+      fileName: fileName,
       data: imageBuffer
     });
 


### PR DESCRIPTION
## What does this PR do?
fix: A bug fix

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #5303 
When users use this action, they can now provide a custom file name for the output image. The image will be saved with the specified name and the correct extension based on the image type.



