### PR TITLE
fix(image-helper): add custom file name property

### DIFF
--- a/packages/pieces/community/image-helper/package.json
+++ b/packages/pieces/community/image-helper/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-image-helper",
-  "version": "0.0.8"
+  "version": "0.1.0"
 }

--- a/packages/pieces/community/image-helper/src/lib/actions/compress-image.actions.ts
+++ b/packages/pieces/community/image-helper/src/lib/actions/compress-image.actions.ts
@@ -12,37 +12,47 @@ export const compressImage = createAction({
     }),
     quality: Property.StaticDropdown({
       displayName: 'Quality',
-      description: 'Specifies the quality of the image after compression (0-100).',
+      description:
+        'Specifies the quality of the image after compression (0-100).',
       required: true,
       options: {
-        options:[
-          {label: 'High Quality', value: 90},
-          {label: 'Lossy Quality', value: 60}
-        ]
-      }
+        options: [
+          { label: 'High Quality', value: 90 },
+          { label: 'Lossy Quality', value: 60 },
+        ],
+      },
     }),
     format: Property.StaticDropdown({
       displayName: 'Format',
       description: 'Specifies the format of the image after compression.',
       required: true,
       options: {
-        options:[
-          {label: 'JPG', value: 'jpg'},
-          {label: 'PNG', value: 'png'}
-        ]
-      }
+        options: [
+          { label: 'JPG', value: 'jpg' },
+          { label: 'PNG', value: 'png' },
+        ],
+      },
+    }),
+    resultFileName: Property.ShortText({
+      displayName: 'Result File Name',
+      description:
+        'Specifies the output file name for the result image (without extension).',
+      required: false,
     }),
   },
   async run(context) {
     const image = await jimp.read(context.propsValue.image.data);
-    
+
     image.quality(context.propsValue.quality);
-    
+
     const imageBuffer = await image.getBufferAsync(image.getMIME());
 
     const imageReference = await context.files.write({
-      fileName: 'image.' + context.propsValue.format,
-      data: imageBuffer
+      fileName:
+        (context.propsValue.resultFileName ?? 'image') +
+        '.' +
+        context.propsValue.format,
+      data: imageBuffer,
     });
 
     return imageReference;

--- a/packages/pieces/community/image-helper/src/lib/actions/crop-image.action.ts
+++ b/packages/pieces/community/image-helper/src/lib/actions/crop-image.action.ts
@@ -12,12 +12,14 @@ export const cropImage = createAction({
     }),
     left: Property.Number({
       displayName: 'Left',
-      description: 'Specifies the horizontal position, indicating where the cropping starts from the left side of the image.',
+      description:
+        'Specifies the horizontal position, indicating where the cropping starts from the left side of the image.',
       required: true,
     }),
     top: Property.Number({
       displayName: 'Top',
-      description: 'Represents the vertical position, indicating the starting point from the top of the image.',
+      description:
+        'Represents the vertical position, indicating the starting point from the top of the image.',
       required: true,
     }),
     width: Property.Number({
@@ -32,21 +34,30 @@ export const cropImage = createAction({
     }),
     resultFileName: Property.ShortText({
       displayName: 'Result File Name',
-      description: 'Specifies the output file name for the cropped image (without extension).',
-      required: true,
+      description:
+        'Specifies the output file name for the cropped image (without extension).',
+      required: false,
     }),
   },
   async run(context) {
     const image = await jimp.read(context.propsValue.image.data);
-    await image.crop(context.propsValue.left, context.propsValue.top, context.propsValue.width, context.propsValue.height);
-    
+    await image.crop(
+      context.propsValue.left,
+      context.propsValue.top,
+      context.propsValue.width,
+      context.propsValue.height
+    );
+
     const imageBuffer = await image.getBufferAsync(image.getMIME());
 
-    const fileName = context.propsValue.resultFileName + '.' + image.getExtension();
+    const fileName =
+      (context.propsValue.resultFileName ?? 'image') +
+      '.' +
+      image.getExtension();
 
     const imageReference = await context.files.write({
       fileName: fileName,
-      data: imageBuffer
+      data: imageBuffer,
     });
 
     return imageReference;

--- a/packages/pieces/community/image-helper/src/lib/actions/crop-image.action.ts
+++ b/packages/pieces/community/image-helper/src/lib/actions/crop-image.action.ts
@@ -30,6 +30,11 @@ export const cropImage = createAction({
       description: 'Determines the vertical size of the cropped area.',
       required: true,
     }),
+    resultFileName: Property.ShortText({
+      displayName: 'Result File Name',
+      description: 'Specifies the output file name for the cropped image (without extension).',
+      required: true,
+    }),
   },
   async run(context) {
     const image = await jimp.read(context.propsValue.image.data);
@@ -37,8 +42,10 @@ export const cropImage = createAction({
     
     const imageBuffer = await image.getBufferAsync(image.getMIME());
 
+    const fileName = context.propsValue.resultFileName + '.' + image.getExtension();
+
     const imageReference = await context.files.write({
-      fileName: 'image.' + image.getExtension(),
+      fileName: fileName,
       data: imageBuffer
     });
 

--- a/packages/pieces/community/image-helper/src/lib/actions/resize-Image.action.ts
+++ b/packages/pieces/community/image-helper/src/lib/actions/resize-Image.action.ts
@@ -24,19 +24,31 @@ export const resizeImage = createAction({
       displayName: 'Maintain aspect ratio for height',
       required: false,
       defaultValue: false,
-    })
+    }),
+    resultFileName: Property.ShortText({
+      displayName: 'Result File Name',
+      description:
+        'Specifies the output file name for the result image (without extension).',
+      required: false,
+    }),
   },
   async run(context) {
     const image = await jimp.read(context.propsValue.image.data);
-    await image.resize(context.propsValue.width, (context.propsValue.aspectRatio ? jimp.AUTO : context.propsValue.height));
-    
+    await image.resize(
+      context.propsValue.width,
+      context.propsValue.aspectRatio ? jimp.AUTO : context.propsValue.height
+    );
+
     const imageBuffer = await image.getBufferAsync(image.getMIME());
 
     const imageReference = await context.files.write({
-      fileName: 'image.' + image.getExtension(),
-      data: imageBuffer
+      fileName:
+        (context.propsValue.resultFileName ?? 'image') +
+        '.' +
+        image.getExtension(),
+      data: imageBuffer,
     });
-  
+
     return imageReference;
   },
 });

--- a/packages/pieces/community/image-helper/src/lib/actions/rotate-image.action.ts
+++ b/packages/pieces/community/image-helper/src/lib/actions/rotate-image.action.ts
@@ -12,15 +12,22 @@ export const rotateImage = createAction({
     }),
     degree: Property.StaticDropdown({
       displayName: 'Degree',
-      description: 'Specifies the degree of clockwise rotation applied to the image.',
+      description:
+        'Specifies the degree of clockwise rotation applied to the image.',
       required: true,
       options: {
         options: [
           { value: 90, label: '90°' },
           { value: 180, label: '180°' },
           { value: 270, label: '270°' },
-        ]
-      }
+        ],
+      },
+    }),
+    resultFileName: Property.ShortText({
+      displayName: 'Result File Name',
+      description:
+        'Specifies the output file name for the result image (without extension).',
+      required: false,
     }),
   },
   async run(context) {
@@ -30,8 +37,11 @@ export const rotateImage = createAction({
     const imageBuffer = await image.getBufferAsync(image.getMIME());
 
     const imageReference = await context.files.write({
-      fileName: 'image.' + image.getExtension(),
-      data: imageBuffer
+      fileName:
+        (context.propsValue.resultFileName ?? 'image') +
+        '.' +
+        image.getExtension(),
+      data: imageBuffer,
     });
 
     return imageReference;


### PR DESCRIPTION

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
When users use this action, they can now provide a custom file name for the output image. The image will be saved with the specified name and the correct extension based on the image type.

Fixes #5303 
Changes Made:
New Property: **resultFileName**
Added a **resultFileName** property using **Property.ShortText**

Dynamic File Naming:
The file name used in **context.files.write** is now generated dynamically using the value provided in **resultFileName** and the image extension.

