### PR TITLE
feat(slack): add channel property for upload-file action

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.7.0"
+  "version": "0.7.1"
 }

--- a/packages/pieces/community/slack/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/slack/src/lib/actions/upload-file.ts
@@ -1,6 +1,9 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { slackAuth } from '../../index';
 import { WebClient } from '@slack/web-api';
+import {
+  slackChannel,
+} from '../common/props';
 
 export const uploadFile = createAction({
   auth: slackAuth,
@@ -20,14 +23,16 @@ export const uploadFile = createAction({
       displayName: 'Filename',
       required: false,
     }),
+    channel: slackChannel(false),
   },
   async run(context) {
     const token = context.auth.access_token;
-    const { file, title, filename } = context.propsValue;
+    const { file, title, filename, channel } = context.propsValue;
     const client = new WebClient(token);
     return await client.files.uploadV2({
       file_uploads: [{ file: file.data, filename: filename || file.filename }],
       title: title,
+      channel_id: channel,
     });
   },
 });


### PR DESCRIPTION
## What does this PR do?

The original piece slack upload-file action doesn't have a channel property. Yes, as stated in [here](https://slack.dev/node-slack-sdk/web-api/#upload-a-file), channel_id argument of slack files.upload function is optional:
"The channel_id and initial_comment aren't required, but the file either won't be shared to a channel or it won't be posted with a message if these aren't included.

In a successful response, the result.files contains an array of [shared files](https://api.slack.com/types/file). These files are "private" and available to just the token holder if no channel_id is included in the request, and are marked "public" when shared to a provided channel_id."

Unfortunately, an upload file by Activepieces slack app without shared to a channel is "private!" There is no way of a slack user to access that file😢 Thus, I think the slack piece upload-file action should provide a channel property such that an upload file can be shared to a channel. My PR adds the feature.