### PR TITLE
fix: svg piece logo rendering at 0x0

### DIFF
--- a/packages/react-ui/src/features/pieces/components/piece-icon.tsx
+++ b/packages/react-ui/src/features/pieces/components/piece-icon.tsx
@@ -58,7 +58,7 @@ const PieceIcon = React.memo(
               <ImageWithFallback
                 src={logoUrl}
                 alt={displayName}
-                className="object-contain"
+                className="object-contain w-full h-full"
                 fallback={<Skeleton className="rounded-full w-full h-full" />}
               />
             ) : (


### PR DESCRIPTION
## What does this PR do?

Currently, SVG logos are rendered as 0x0 images. This fix allows it to render while still keeping its size scaled to the parent div.

Before

<img width="856" alt="Screenshot on 2024-09-11 at 11-25-11" src="https://github.com/user-attachments/assets/ebe66f92-fd8c-4fbb-b17d-a946ddbec6b6">

After

<img width="860" alt="Screenshot on 2024-09-11 at 11-26-33" src="https://github.com/user-attachments/assets/6a0e130d-f692-4d99-8834-7fee4a004dcb">

Fixes # (issue)

