### PR TITLE
fix(chargekeep): update gender input, and add helper function for default date

### DIFF
--- a/packages/pieces/community/chargekeep/package.json
+++ b/packages/pieces/community/chargekeep/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-chargekeep",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact-extended.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact-extended.ts
@@ -181,10 +181,22 @@ export const addOrUpdateContactExtended = createAction({
       required: false,
     }),
     // personal info
-    gender: Property.ShortText({
+    gender: Property.StaticDropdown({
       displayName: 'Gender',
-      description: 'Possible values are Male and Female',
       required: false,
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'Male',
+            value: 'Male',
+          },
+          {
+            label: 'Female',
+            value: 'Female',
+          },
+        ],
+      },
     }),
     dob: Property.ShortText({
       displayName: 'Date of Birth',

--- a/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/add-or-update-contact.ts
@@ -94,10 +94,22 @@ export const addOrUpdateContact = createAction({
       required: false,
     }),
     // personal info
-    gender: Property.ShortText({
+    gender: Property.StaticDropdown({
       displayName: 'Gender',
-      description: 'Possible values are Male and Female',
       required: false,
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'Male',
+            value: 'Male',
+          },
+          {
+            label: 'Female',
+            value: 'Female',
+          },
+        ],
+      },
     }),
     dob: Property.ShortText({
       displayName: 'Date of Birth',

--- a/packages/pieces/community/chargekeep/src/lib/actions/create-invoice.ts
+++ b/packages/pieces/community/chargekeep/src/lib/actions/create-invoice.ts
@@ -2,6 +2,11 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { chargekeepAuth } from '../..';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 
+// Helper function to get current date in the required format
+const getCurrentDateInISOFormat = () => {
+  return new Date().toISOString(); // Returns current date in format: YYYY-MM-DDTHH:MM:SSZ
+};
+
 export const createInvoice = createAction({
   name: 'createInvoice',
   displayName: 'Create Invoice',
@@ -53,12 +58,13 @@ export const createInvoice = createAction({
     }),
     date: Property.DateTime({
       displayName: 'Date of the Invoice',
-      description: 'should be like this : 2024-06-11T11:11:41Z',
+      description: 'should be like this: 2024-06-11T11:11:41Z',
+      defaultValue: getCurrentDateInISOFormat(),
       required: true,
     }),
     dueDate: Property.DateTime({
       displayName: 'Due Date of the Invoice',
-      description: 'should be like this : 2024-06-11T11:11:41Z',
+      description: 'should be like this: 2024-06-11T11:11:41Z',
       required: true,
     }),
     currencyId: Property.StaticDropdown({
@@ -338,7 +344,8 @@ export const createInvoice = createAction({
     // transactions
     transactionDate: Property.DateTime({
       displayName: 'Transaction Date',
-      description: 'should be like this : 2024-06-11T11:11:41Z',
+      description: 'should be like this: 2024-06-11T11:11:41Z',
+      defaultValue: getCurrentDateInISOFormat(),
       required: true,
     }),
     transactionDescription: Property.ShortText({


### PR DESCRIPTION
## What does this PR do?
This pull request contains updates to the chargekeep module, including fixes to the gender input field and a new helper function.

### Detailed Changes
 - Replaced the previous gender input field with a static dropdown for a more standardized and controlled user input experience.
 - Introduced a helper function to set default current dates, improving date handling and reducing redundant code.

### Notes
- Review the changes to the gender input field to ensure the dropdown behaves as expected.
- Verify that the new helper function for default dates works as intended across all relevant parts of the application.

Your feedback and approval are appreciated.
