### PR TITLE
fix: empty variable on resolving with v8 isolate

### DIFF
--- a/packages/engine/src/lib/core/code/v8-isolate-code-sandbox.ts
+++ b/packages/engine/src/lib/core/code/v8-isolate-code-sandbox.ts
@@ -13,7 +13,7 @@ const getIvm = () => {
     }
     return ivmCache as typeof import('isolated-vm')
 }
-  
+
 /**
  * Runs code in a V8 Isolate sandbox
  */
@@ -48,9 +48,10 @@ export const v8IsolateCodeSandbox: CodeSandbox = {
         const isolate = new ivm.Isolate({ memoryLimit: ONE_HUNDRED_TWENTY_EIGHT_MEGABYTES })
 
         try {
+            // It is to avoid strucutedClone issue of proxy objects / functions, It will throw cannot be cloned error.
             const isolateContext = await initIsolateContext({
                 isolate,
-                codeContext: scriptContext,
+                codeContext: JSON.parse(JSON.stringify(scriptContext)),
             })
 
             return await executeIsolate({

--- a/packages/engine/src/lib/variables/variable-service.ts
+++ b/packages/engine/src/lib/variables/variable-service.ts
@@ -131,7 +131,7 @@ export class VariableService {
             return result ?? ''
         }
         catch (exception) {
-            console.error('[evalInScope] Error evaluating variable', exception)
+            console.warn('[evalInScope] Error evaluating variable', exception)
             return ''
         }
     }

--- a/packages/react-ui/src/features/projects/components/project-switcher.tsx
+++ b/packages/react-ui/src/features/projects/components/project-switcher.tsx
@@ -33,7 +33,7 @@ function ProjectSwitcher() {
   const sortedProjects = projects?.sort((a, b) => {
     return a.displayName.localeCompare(b.displayName);
   });
-  
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>


### PR DESCRIPTION
## What does this PR do?

If the context contains a function, we cannot determine how it could be possible for a piece to return functions in the output.

It will trigger a "cannot be cloned" error since V8 isolates use `structuredClone`. We sanitize it using `JSON.stringify` and `JSON.parse`.
