### PR TITLE
feat(metabase): raise error when question fails

### DIFF
--- a/packages/pieces/community/metabase/package.json
+++ b/packages/pieces/community/metabase/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-metabase",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/packages/pieces/community/metabase/src/lib/actions/get-question.ts
+++ b/packages/pieces/community/metabase/src/lib/actions/get-question.ts
@@ -33,7 +33,7 @@ export const getQuestion = createAction({
     );
     const parameters = card['parameters'] as MetabaseParam[];
 
-    return queryMetabaseApi(
+    const response = await queryMetabaseApi(
       {
         endpoint: `card/${propsValue.questionId}/query`,
         method: HttpMethod.POST,
@@ -59,5 +59,10 @@ export const getQuestion = createAction({
       },
       auth
     );
+    if (response.error) {
+      throw new Error(response.error);
+    } else {
+      return response;
+    }
   },
 });


### PR DESCRIPTION
## What does this PR do?

We want to raise an error when a metabase query (called question in metabase) fails.

Announcement=true