### PR TITLE
feat: add optional validation check to OAuth2

### DIFF
--- a/packages/engine/src/lib/helper/piece-helper.ts
+++ b/packages/engine/src/lib/helper/piece-helper.ts
@@ -15,6 +15,7 @@ import {
     ExecutePropsOptions,
     ExecuteValidateAuthOperation,
     ExecuteValidateAuthResponse,
+    OAuth2ConnectionValueWithApp,
     SecretTextConnectionValue,
 } from '@activepieces/shared'
 import { EngineConstants } from '../handler/context/engine-constants'
@@ -113,6 +114,12 @@ export const pieceHelper = {
                 const con = params.auth as CustomAuthConnectionValue
                 return piece.auth.validate({
                     auth: con.props,
+                })
+            }
+            case PropertyType.OAUTH2: {
+                const con = params.auth as OAuth2ConnectionValueWithApp
+                return piece.auth.validate({
+                    auth: con,
                 })
             }
             default: {

--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -238,7 +238,7 @@ const validateConnectionValue = async (
                 pieceName: connection.pieceName,
                 props: connection.value.props,
             })
-            return oauth2Handler[connection.value.type].claim({
+            const auth = await oauth2Handler[connection.value.type].claim({
                 projectId,
                 pieceName: connection.pieceName,
                 request: {
@@ -253,6 +253,12 @@ const validateConnectionValue = async (
                     codeVerifier: connection.value.code_challenge,
                 },
             })
+            await engineValidateAuth({
+                pieceName: connection.pieceName,
+                projectId,
+                auth,
+            })
+            return auth
         }
         case AppConnectionType.CUSTOM_AUTH:
         case AppConnectionType.BASIC_AUTH:


### PR DESCRIPTION
## What does this PR do?

`PieceAuth.OAuth2` will now run the `validate` hook if you provide one. This allows you to run a sanity check before saving the token to the database. For example, many API endpoints provide a `whoami`-type endpoint.

This change brings OAuth2 in line with other auth types that support the validate hook.

In the validate hook, you have full access to the `auth` object, including `access_token` and `props`.

Fixes # (issue)

