### PR TITLE
refactor: unified ai & db migration

### DIFF
--- a/docs/admin-console/manage-ai-providers.mdx
+++ b/docs/admin-console/manage-ai-providers.mdx
@@ -4,8 +4,6 @@ description: ""
 icon: "brain"
 ---
 
-<Snippet file="enterprise-feature.mdx" />
-
 You can configure the AI providers that you want to use in your flows.
 
 ## Manage AI Providers

--- a/packages/ee/shared/src/lib/billing/index.ts
+++ b/packages/ee/shared/src/lib/billing/index.ts
@@ -10,6 +10,7 @@ export type FlowPlanLimits = {
     connections: number
     teamMembers: number
     pieces: string[]
+    aiTokens: number
     piecesFilterType: PiecesFilterType
 }
 
@@ -21,6 +22,7 @@ export const DEFAULT_FREE_PLAN_LIMIT = {
     teamMembers: 100,
     connections: 1000,
     pieces: [],
+    aiTokens: 200,
     piecesFilterType: PiecesFilterType.NONE,
     minimumPollingInterval: 5,
 }

--- a/packages/engine/jest.config.ts
+++ b/packages/engine/jest.config.ts
@@ -1,5 +1,5 @@
 
-process.env.AP_EXECUTION_MODE = 'UNSANDBOXED';
+process.env.AP_EXECUTION_MODE = 'UNSANDBOXED'
 
 /* eslint-disable */
 export default {

--- a/packages/pieces/community/claude/src/lib/actions/send-prompt.ts
+++ b/packages/pieces/community/claude/src/lib/actions/send-prompt.ts
@@ -6,6 +6,7 @@ import {
 import Anthropic from '@anthropic-ai/sdk';
 import mime from 'mime-types';
 import { claudeAuth } from '../..';
+import { TextBlock } from '@anthropic-ai/sdk/resources';
 
 const billingIssueMessage = `Error Occurred: 429 \n
 
@@ -155,7 +156,7 @@ export const askClaude = createAction({
           messages: roles,
         });
 
-        response = req?.content[0].text?.trim();
+        response = (req?.content[0] as TextBlock).text?.trim();
 
         break; // Break out of the loop if the request is successful
       } catch (e: any) {

--- a/packages/pieces/community/common/src/lib/ai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/index.ts
@@ -1,7 +1,5 @@
 import { ServerContext } from '@activepieces/pieces-framework';
-import { anthropic } from './providers/anthropic';
-import { openai } from './providers/openai';
-import { AiProvider, AiProviders } from './providers';
+import { AiProvider, AI_PROVIDERS } from './providers';
 
 export type AI<SDK> = {
   provider: string;
@@ -90,7 +88,7 @@ export const AI = ({
   server: ServerContext;
 }): AI<unknown> => {
   const proxyUrl = `${server.apiUrl}v1/ai-providers/proxy/${provider}`;
-  const factory = AiProviders.find((p) => p.value === provider)?.factory;
+  const factory = AI_PROVIDERS.find((p) => p.value === provider)?.factory;
   const impl = factory?.({ proxyUrl, engineToken: server.token });
 
   if (!impl) {

--- a/packages/pieces/community/common/src/lib/ai/providers/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/providers/index.ts
@@ -2,12 +2,15 @@ import { Static, Type } from "@sinclair/typebox"
 import { anthropic } from "./anthropic"
 import { openai } from "./openai"
 import { authHeader } from "./utils"
+import { Property } from "@activepieces/pieces-framework"
+import { AiProviderWithoutSensitiveData, isNil, SeekPage } from "@activepieces/shared"
+import { httpClient, HttpMethod } from "../../http"
 
-export const AiProviders = [
+export const AI_PROVIDERS = [
   {
     logoUrl: 'https://cdn.activepieces.com/pieces/openai.png',
     defaultBaseUrl: 'https://api.openai.com',
-    label: 'OpenAI' as const, 
+    label: 'OpenAI' as const,
     value: 'openai' as const,
     models: [
       { label: 'gpt-4o', value: 'gpt-4o' },
@@ -46,9 +49,60 @@ export const AiProviders = [
   },
 ]
 
-export type AiProviderMetadata = typeof AiProviders[number]
+export const aiProps = {
+  provider: Property.Dropdown<AiProvider, true>({
+    displayName: 'Provider',
+    required: true,
+    refreshers: [],
+    options: async (_, ctx) => {
+      const providers = await httpClient.sendRequest<SeekPage<AiProviderWithoutSensitiveData>>({
+        method: HttpMethod.GET,
+        url: `${ctx.server.apiUrl}v1/ai-providers`,
+        headers: {
+          Authorization: `Bearer ${ctx.server.token}`,
+        },
+      })
+      if (providers.body.data.length === 0) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'No AI providers configured by the admin.',
+        }
+      }
+      return {
+        placeholder: 'Select AI Provider',
+        disabled: false,
+        options: providers.body.data.map((p) => ({
+          label: AI_PROVIDERS.find((f) => f.value === p.provider)?.label ?? 'Unknown Label',
+          value: p.provider as AiProvider,
+        })),
+      }
+    }
+  }),
+  model: Property.Dropdown({
+    displayName: 'Model',
+    required: true,
+    refreshers: ['provider'],
+    options: async ({ provider }) => {
+      if (isNil(provider)) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Select AI Provider',
+        }
+      }
+      const models = AI_PROVIDERS.find((p) => p.value === provider)?.models;
+      return {
+        disabled: isNil(models),
+        options: models ?? [],
+      };
+    },
+  }),
+}
 
-export const AiProvider = Type.Union(AiProviders.map(p => Type.Literal(p.value)))
+export type AiProviderMetadata = typeof AI_PROVIDERS[number]
+
+export const AiProvider = Type.Union(AI_PROVIDERS.map(p => Type.Literal(p.value)))
 
 export type AiProvider = Static<typeof AiProvider>
 

--- a/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
+++ b/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
@@ -56,7 +56,7 @@ export class AxiosHttpClient extends BaseHttpClient {
         );
         console.error(
           '[HttpClient#sendRequest] error, responseBody:',
-          e.response?.data
+          JSON.stringify(e.response?.data)
         );
 
         throw new HttpError(request.body, e);

--- a/packages/pieces/community/text-ai/src/index.ts
+++ b/packages/pieces/community/text-ai/src/index.ts
@@ -7,6 +7,7 @@ import { summarizeText } from './lib/actions/summarize-text';
 export const activepiecesAi = createPiece({
   displayName: 'Text AI',
   auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.32.1',
   categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
   logoUrl: 'https://cdn.activepieces.com/pieces/text-ai.svg',
   authors: ['anasbarg'],

--- a/packages/pieces/community/text-ai/src/index.ts
+++ b/packages/pieces/community/text-ai/src/index.ts
@@ -7,7 +7,7 @@ import { summarizeText } from './lib/actions/summarize-text';
 export const activepiecesAi = createPiece({
   displayName: 'Text AI',
   auth: PieceAuth.None(),
-  minimumSupportedRelease: '0.32.1',
+  minimumSupportedRelease: '0.32.0',
   categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
   logoUrl: 'https://cdn.activepieces.com/pieces/text-ai.svg',
   authors: ['anasbarg'],

--- a/packages/pieces/community/text-ai/src/lib/actions/ask-ai.ts
+++ b/packages/pieces/community/text-ai/src/lib/actions/ask-ai.ts
@@ -2,37 +2,17 @@ import {
   AI,
   AIChatMessage,
   AIChatRole,
-  AiProviders,
+  aiProps,
 } from '@activepieces/pieces-common';
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { isNil } from '@activepieces/shared';
 
 export const askAi = createAction({
   name: 'askAi',
   displayName: 'Ask AI',
   description: '',
   props: {
-    provider: Property.StaticDropdown({
-      displayName: 'Provider',
-      required: true,
-      options: {
-        disabled: false,
-        options: AiProviders,
-      },
-    }),
-    model: Property.Dropdown({
-      displayName: 'Model',
-      required: true,
-      refreshers: ['provider'],
-      async options(propsValue, ctx) {
-        const provider = propsValue['provider'];
-        const models = AiProviders.find((p) => p.value === provider)?.models;
-        return {
-          disabled: isNil(models),
-          options: models ?? [],
-        };
-      },
-    }),
+    provider: aiProps.provider,
+    model: aiProps.model,
     prompt: Property.LongText({
       displayName: 'Prompt',
       required: true,
@@ -55,9 +35,8 @@ export const askAi = createAction({
     }),
   },
   async run(context) {
-    const provider = context.propsValue.provider;
 
-    const ai = AI({ provider, server: context.server });
+    const ai = AI({ provider: context.propsValue.provider, server: context.server });
 
     const storage = context.store;
 

--- a/packages/pieces/community/text-ai/src/lib/actions/extract-structured-data.ts
+++ b/packages/pieces/community/text-ai/src/lib/actions/extract-structured-data.ts
@@ -1,37 +1,19 @@
 import {
   AI,
+  AI_PROVIDERS,
   AIChatRole,
   AIFunctionCallingPropDefinition,
-  AiProviders,
+  aiProps,
 } from '@activepieces/pieces-common';
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { isNil } from '@activepieces/shared';
 
 export const extractStructuredData = createAction({
   name: 'extractStructuredData',
   displayName: 'Extract Structured Data',
   description: '',
   props: {
-    provider: Property.StaticDropdown({
-      displayName: 'Provider',
-      required: true,
-      options: {
-        disabled: false,
-        options: AiProviders,
-      },
-    }),
-    model: Property.Dropdown({
-      displayName: 'Model',
-      required: true,
-      refreshers: ['provider'],
-      options: async ({ provider }) => {
-        const models = AiProviders.find((p) => p.value === provider)?.models;
-        return {
-          disabled: isNil(models),
-          options: models ?? [],
-        };
-      },
-    }),
+    provider: aiProps.provider,
+    model: aiProps.model,
     text: Property.LongText({
       displayName: 'Unstructured Text',
       required: true,

--- a/packages/pieces/community/text-ai/src/lib/actions/summarize-text.ts
+++ b/packages/pieces/community/text-ai/src/lib/actions/summarize-text.ts
@@ -1,32 +1,13 @@
-import { AI, AIChatRole, AiProviders } from '@activepieces/pieces-common';
+import { AI, AIChatRole, aiProps } from '@activepieces/pieces-common';
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { isNil } from '@activepieces/shared';
 
 export const summarizeText = createAction({
   name: 'summarizeText',
   displayName: 'Summarize Text',
   description: '',
   props: {
-    provider: Property.StaticDropdown({
-      displayName: 'Provider',
-      required: true,
-      options: {
-        disabled: false,
-        options: AiProviders,
-      },
-    }),
-    model: Property.Dropdown({
-      displayName: 'Model',
-      required: true,
-      refreshers: ['provider'],
-      options: async ({ provider }) => {
-        const models = AiProviders.find((p) => p.value === provider)?.models;
-        return {
-          disabled: isNil(models),
-          options: models ?? [],
-        };
-      },
-    }),
+    provider: aiProps.provider,
+    model: aiProps.model,
     text: Property.LongText({
       displayName: 'Text',
       required: true,

--- a/packages/react-ui/src/app/builder/run-details/index.tsx
+++ b/packages/react-ui/src/app/builder/run-details/index.tsx
@@ -36,7 +36,7 @@ function getMessage(run: FlowRun | null, retentionDays: number | null) {
   if (
     [FlowRunStatus.INTERNAL_ERROR, FlowRunStatus.TIMEOUT].includes(run.status)
   ) {
-    return t("There are no logs captured for this run.");
+    return t('There are no logs captured for this run.');
   }
   if (isNil(run.logsFileId)) {
     return t(
@@ -55,17 +55,17 @@ const FlowRunDetails = React.memo(() => {
     (state) => {
       const paths: StepPathWithName[] = state.run?.steps
         ? Object.keys(state.run.steps).map((stepName: string) => ({
-          stepName,
-          path: [],
-        }))
+            stepName,
+            path: [],
+          }))
         : [];
       const stepDetails =
         !isNil(state.selectedStep) && !isNil(state.run)
           ? builderSelectors.getStepOutputFromExecutionPath({
-            selectedPath: state.selectedStep,
-            executionState: state.run,
-            stepName: state.selectedStep.stepName,
-          })
+              selectedPath: state.selectedStep,
+              executionState: state.run,
+              stepName: state.selectedStep.stepName,
+            })
           : null;
       return [state.setLeftSidebar, state.run, paths, stepDetails];
     },

--- a/packages/react-ui/src/app/components/platform-admin-container.tsx
+++ b/packages/react-ui/src/app/components/platform-admin-container.tsx
@@ -6,7 +6,7 @@ import {
   Puzzle,
   UserCog,
   Workflow,
-  Wrench
+  Wrench,
 } from 'lucide-react';
 import { Navigate } from 'react-router-dom';
 
@@ -57,7 +57,6 @@ export function PlatformAdminContainer({
       to: '/platform/pieces',
       label: t('Pieces'),
       icon: Puzzle,
-      locked: isLocked(!platform.managePiecesEnabled),
     },
     {
       to: '/platform/templates',

--- a/packages/react-ui/src/app/components/platform-settings-layout.tsx
+++ b/packages/react-ui/src/app/components/platform-settings-layout.tsx
@@ -1,5 +1,5 @@
 import { t } from 'i18next';
-import { Brain, Key, Lock, Palette, ShieldPlus } from 'lucide-react';
+import { Key, Lock, Palette, ShieldPlus } from 'lucide-react';
 
 import SidebarLayout from '@/app/components/sidebar-layout';
 

--- a/packages/react-ui/src/app/router.tsx
+++ b/packages/react-ui/src/app/router.tsx
@@ -11,6 +11,7 @@ import { PageTitle } from '@/app/components/page-title';
 import PlatformSettingsLayout from '@/app/components/platform-settings-layout';
 import ProjectSettingsLayout from '@/app/components/project-settings-layout';
 import { EmbedPage } from '@/app/routes/embed';
+import AIProvidersPage from '@/app/routes/platform/ai-providers';
 import AnalyticsPage from '@/app/routes/platform/analytics';
 import { PlatformPiecesPage } from '@/app/routes/platform/pieces';
 import { ApiKeysPage } from '@/app/routes/platform/settings/api-keys';
@@ -44,6 +45,7 @@ import { FormPage } from './routes/forms';
 import IssuesPage from './routes/issues';
 import PlansPage from './routes/plans';
 import AuditLogsPage from './routes/platform/audit-logs';
+import { PlatformPiecesLayout } from './routes/platform/pieces/platform-pieces-layout';
 import ProjectsPage from './routes/platform/projects';
 import TemplatesPage from './routes/platform/templates';
 import UsersPage from './routes/platform/users';
@@ -56,8 +58,6 @@ import TeamPage from './routes/settings/team';
 import { SignInPage } from './routes/sign-in';
 import { SignUpPage } from './routes/sign-up';
 import { ShareTemplatePage } from './routes/templates/share-template';
-import AIProvidersPage from '@/app/routes/platform/ai-providers';
-import { PlatformPiecesLayout } from './routes/platform/pieces/platform-pieces-layout';
 
 const SettingsRerouter = () => {
   const { hash } = useLocation();
@@ -326,7 +326,7 @@ const routes = [
         <PlatformPiecesLayout>
           <PageTitle title="Platform Pieces">
             <PlatformPiecesPage />
-        </PageTitle>
+          </PageTitle>
         </PlatformPiecesLayout>
       </PlatformAdminContainer>
     ),
@@ -470,8 +470,8 @@ const ApRouter = () => {
   const router = useMemo(() => {
     return embedState.isEmbedded
       ? createMemoryRouter(routes, {
-        initialEntries: [window.location.pathname],
-      })
+          initialEntries: [window.location.pathname],
+        })
       : createBrowserRouter(routes);
   }, [embedState.isEmbedded]);
 

--- a/packages/react-ui/src/app/routes/platform/ai-providers/ai-provider-card.tsx
+++ b/packages/react-ui/src/app/routes/platform/ai-providers/ai-provider-card.tsx
@@ -1,73 +1,89 @@
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { platformHooks } from "@/hooks/platform-hooks";
-import { AuthHeader } from "@activepieces/pieces-common";
-import { AiProviderConfig } from "@activepieces/shared";
-import { t } from "i18next";
-import { Pencil, Trash } from "lucide-react";
-import { UpsertAIProviderDialog } from "./upsert-provider-dialog";
+import { t } from 'i18next';
+import { Pencil, Trash } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { platformHooks } from '@/hooks/platform-hooks';
 import type { AiProviderMetadata } from '@activepieces/pieces-common';
+import { AiProviderConfig } from '@activepieces/shared';
+
+import { UpsertAIProviderDialog } from './upsert-provider-dialog';
 
 type AIProviderCardProps = {
-    provider?: AiProviderConfig;
-    providerMetadata: AiProviderMetadata,
-    defaultBaseUrl?: string;
-    onDelete: () => void;
-    onSave: () => void;
-    isDeleting: boolean;
+  provider?: AiProviderConfig;
+  providerMetadata: AiProviderMetadata;
+  defaultBaseUrl?: string;
+  onDelete: () => void;
+  onSave: () => void;
+  isDeleting: boolean;
 };
 
 const AIProviderCard = ({
-    provider,
-    providerMetadata,
-    defaultBaseUrl,
-    onDelete,
-    isDeleting,
-    onSave,
+  provider,
+  providerMetadata,
+  defaultBaseUrl,
+  onDelete,
+  isDeleting,
+  onSave,
 }: AIProviderCardProps) => {
-    const { platform } = platformHooks.useCurrentPlatform();
-    const config: Omit<AiProviderConfig, "id"> & { id?: string } = provider ?? {
-        baseUrl: defaultBaseUrl ?? '',
-        provider: providerMetadata.value,
-        config: {
-            defaultHeaders: {},
-        },
-        created: new Date().toISOString(),
-        updated: new Date().toISOString(),
-        platformId: platform.id
-    }
-    return (
-        <Card className="w-full px-4 py-4">
-            <div className="flex w-full gap-2 justify-center items-center">
-                <div className="flex flex-col gap-2 text-center mr-2">
-                    <img src={providerMetadata.logoUrl}
-                        alt="icon"
-                        width={32}
-                        height={32}
-                    />
-                </div>
-                <div className="flex flex-grow flex-col">
-                    <div className="text-lg">{providerMetadata.label}</div>
-                    <div className="text-sm text-muted-foreground">
-                        {t('Configure credentials for {providerName} AI provider.', { providerName: providerMetadata.label })}
-                    </div>
-                </div>
-                <div className="flex flex-row justify-center items-center gap-1">
-                    <UpsertAIProviderDialog provider={config} providerMetadata={providerMetadata} onSave={onSave}>
-                        <Button variant={provider ? 'ghost' : "basic"} size={'sm'} >{provider ? <Pencil className="size-4" /> : t('Enable')}</Button>
-                    </UpsertAIProviderDialog>
-                    {provider && (
-                        <div className="gap-2 flex">
-                            <Button variant={'ghost'} size={'sm'} onClick={onDelete} loading={isDeleting} disabled={isDeleting}>
-                                <Trash className="size-4 text-destructive" />
-                            </Button>
-                        </div>
-                    )}
-                </div>
+  const { platform } = platformHooks.useCurrentPlatform();
+  const config: Omit<AiProviderConfig, 'id'> & { id?: string } = provider ?? {
+    baseUrl: defaultBaseUrl ?? '',
+    provider: providerMetadata.value,
+    config: {
+      defaultHeaders: {},
+    },
+    created: new Date().toISOString(),
+    updated: new Date().toISOString(),
+    platformId: platform.id,
+  };
+  return (
+    <Card className="w-full px-4 py-4">
+      <div className="flex w-full gap-2 justify-center items-center">
+        <div className="flex flex-col gap-2 text-center mr-2">
+          <img
+            src={providerMetadata.logoUrl}
+            alt="icon"
+            width={32}
+            height={32}
+          />
+        </div>
+        <div className="flex flex-grow flex-col">
+          <div className="text-lg">{providerMetadata.label}</div>
+          <div className="text-sm text-muted-foreground">
+            {t('Configure credentials for {providerName} AI provider.', {
+              providerName: providerMetadata.label,
+            })}
+          </div>
+        </div>
+        <div className="flex flex-row justify-center items-center gap-1">
+          <UpsertAIProviderDialog
+            provider={config}
+            providerMetadata={providerMetadata}
+            onSave={onSave}
+          >
+            <Button variant={provider ? 'ghost' : 'basic'} size={'sm'}>
+              {provider ? <Pencil className="size-4" /> : t('Enable')}
+            </Button>
+          </UpsertAIProviderDialog>
+          {provider && (
+            <div className="gap-2 flex">
+              <Button
+                variant={'ghost'}
+                size={'sm'}
+                onClick={onDelete}
+                loading={isDeleting}
+                disabled={isDeleting}
+              >
+                <Trash className="size-4 text-destructive" />
+              </Button>
             </div>
-        </Card>
-    );
+          )}
+        </div>
+      </div>
+    </Card>
+  );
 };
 
-AIProviderCard.displayName = 'AIProviderCard'
+AIProviderCard.displayName = 'AIProviderCard';
 export { AIProviderCard };

--- a/packages/react-ui/src/app/routes/platform/ai-providers/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/ai-providers/index.tsx
@@ -1,59 +1,64 @@
-import { AiProviders } from '@activepieces/pieces-common';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
-import { AIProviderCard } from './ai-provider-card';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { aiProviderApi } from '@/features/platform-admin-panel/lib/ai-provider-api';
-import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
+
 import { Skeleton } from '@/components/ui/skeleton';
+import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
+import { aiProviderApi } from '@/features/platform-admin-panel/lib/ai-provider-api';
+import { AI_PROVIDERS } from '@activepieces/pieces-common';
+
+import { AIProviderCard } from './ai-provider-card';
 
 export default function AIProvidersPage() {
-
-  const queryClient = useQueryClient()
-
-  const { data: providers, refetch, isLoading  } = useQuery({
+  const {
+    data: providers,
+    refetch,
+    isLoading,
+  } = useQuery({
     queryKey: ['ai-providers'],
     queryFn: () => aiProviderApi.list(),
-    networkMode: "online"
-  })
+  });
 
   const { mutate: deleteProvider, isPending: isDeleting } = useMutation({
     mutationFn: (provider: string) => aiProviderApi.delete(provider),
     onSuccess: () => {
-      refetch()
+      refetch();
     },
     onError: () => {
-      toast(INTERNAL_ERROR_TOAST)
-    }
-  })
+      toast(INTERNAL_ERROR_TOAST);
+    },
+  });
 
   return (
     <div className="flex flex-col w-full">
       <div className="mb-4 flex">
         <div className="flex justify-between flex-row w-full">
           <div className="flex flex-col gap-2">
-            <h1 className="text-3xl font-bold w-full">
-              {t('AI Providers')}
-            </h1>
+            <h1 className="text-3xl font-bold w-full">{t('AI Providers')}</h1>
           </div>
         </div>
       </div>
       <div className="flex flex-col gap-4">
-        {
-          AiProviders.map(metadata => {
-            const provider = providers?.data.find(c => c.provider === metadata.value)
-            return isLoading ? <Skeleton className="h-24 w-full" /> : <AIProviderCard
+        {AI_PROVIDERS.map((metadata) => {
+          const provider = providers?.data.find(
+            (c) => c.provider === metadata.value,
+          );
+          return isLoading ? (
+            <Skeleton className="h-24 w-full" />
+          ) : (
+            <AIProviderCard
               providerMetadata={metadata}
               defaultBaseUrl={provider?.baseUrl ?? metadata.defaultBaseUrl}
-              provider={provider ? { ...provider, config: { defaultHeaders: {} } } : undefined}
+              provider={
+                provider
+                  ? { ...provider, config: { defaultHeaders: {} } }
+                  : undefined
+              }
               isDeleting={isDeleting}
               onDelete={() => deleteProvider(metadata.value)}
-              onSave={() => {
-                queryClient.invalidateQueries({ queryKey: ['ai-providers'] })
-                refetch()
-              }}
+              onSave={() => refetch()}
             />
-          })
-        }
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/react-ui/src/app/routes/platform/pieces/platform-pieces-layout.tsx
+++ b/packages/react-ui/src/app/routes/platform/pieces/platform-pieces-layout.tsx
@@ -1,5 +1,5 @@
 import { t } from 'i18next';
-import { Brain, Puzzle, ShieldPlus } from 'lucide-react';
+import { Brain, Puzzle } from 'lucide-react';
 
 import SidebarLayout from '@/app/components/sidebar-layout';
 
@@ -22,9 +22,7 @@ interface PiecesLayoutProps {
   children: React.ReactNode;
 }
 
-export function PlatformPiecesLayout({
-  children,
-}: PiecesLayoutProps) {
+export function PlatformPiecesLayout({ children }: PiecesLayoutProps) {
   return (
     <SidebarLayout title={t('Pieces')} items={sidebarNavItems}>
       {children}

--- a/packages/react-ui/src/app/routes/platform/projects/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/projects/index.tsx
@@ -143,13 +143,18 @@ export default function ProjectsPage() {
             {
               accessorKey: 'ai-tokens',
               header: ({ column }) => (
-                <DataTableColumnHeader column={column} title={t('AI Credits')} />
+                <DataTableColumnHeader
+                  column={column}
+                  title={t('AI Credits')}
+                />
               ),
               cell: ({ row }) => {
                 return (
                   <div className="text-left">
                     {formatUtils.formatNumber(row.original.usage.aiTokens)} /{' '}
-                    {row.original.plan.aiTokens ? formatUtils.formatNumber(row.original.plan.aiTokens) : '-'}
+                    {row.original.plan.aiTokens
+                      ? formatUtils.formatNumber(row.original.plan.aiTokens)
+                      : '-'}
                   </div>
                 );
               },

--- a/packages/react-ui/src/app/routes/settings/general/index.tsx
+++ b/packages/react-ui/src/app/routes/settings/general/index.tsx
@@ -49,7 +49,7 @@ export default function GeneralPage() {
     Error,
     {
       displayName: string;
-      plan: { tasks: number, aiTokens?: number };
+      plan: { tasks: number; aiTokens?: number };
     }
   >({
     mutationFn: (request) => {
@@ -130,7 +130,11 @@ export default function GeneralPage() {
                     <Input
                       type="number"
                       {...field}
-                      onChange={(e) => field.onChange(e.target.value ? parseInt(e.target.value) : undefined)}
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value ? parseInt(e.target.value) : undefined,
+                        )
+                      }
                       id="plan.aiTokens"
                       placeholder={t('AI Credits')}
                       className="rounded-sm"

--- a/packages/react-ui/src/features/platform-admin-panel/lib/ai-provider-api.ts
+++ b/packages/react-ui/src/features/platform-admin-panel/lib/ai-provider-api.ts
@@ -2,17 +2,24 @@ import { api } from '@/lib/api';
 import {
   AiProviderConfig,
   AiProviderWithoutSensitiveData,
-  SeekPage
+  SeekPage,
 } from '@activepieces/shared';
 
 export const aiProviderApi = {
   list() {
-    return api.get<SeekPage<AiProviderWithoutSensitiveData>>('/v1/ai-providers');
+    return api.get<SeekPage<AiProviderWithoutSensitiveData>>(
+      '/v1/ai-providers',
+    );
   },
-  upsert(request: Omit<AiProviderWithoutSensitiveData, 'id' | 'created' | 'updated' | 'platformId'>) { 
+  upsert(
+    request: Omit<
+      AiProviderWithoutSensitiveData,
+      'id' | 'created' | 'updated' | 'platformId'
+    >,
+  ) {
     return api.post<AiProviderConfig>('/v1/ai-providers', request);
   },
   delete(provider: string) {
     return api.delete(`/v1/ai-providers/${provider}`);
-  }
+  },
 };

--- a/packages/server/api/src/app/ai/ai-provider-entity.ts
+++ b/packages/server/api/src/app/ai/ai-provider-entity.ts
@@ -44,9 +44,10 @@ export const AiProviderEntity = new EntitySchema<AiProviderSchema>({
     ],
     relations: {
         platform: {
-            type: 'one-to-one',
+            type: 'many-to-one',
             target: 'platform',
-            nullable: false,
+            cascade: true,
+            onDelete: 'CASCADE',
             joinColumn: {
                 name: 'platformId',
                 foreignKeyConstraintName: 'fk_ai_provider_platform_id',

--- a/packages/server/api/src/app/ai/ai-provider-proxy.ts
+++ b/packages/server/api/src/app/ai/ai-provider-proxy.ts
@@ -1,0 +1,95 @@
+import { PrincipalType } from '@activepieces/shared'
+import { FastifyPluginCallbackTypebox, Type } from '@fastify/type-provider-typebox'
+import { aiTokenLimit } from '../ee/project-plan/ai-token-limit'
+import { projectService } from '../project/project-service'
+import { projectUsageService } from '../project/usage/project-usage-service'
+import { aiProviderService } from './ai-provider.service'
+
+
+export const proxyController: FastifyPluginCallbackTypebox = (fastify, _opts, done) => {
+
+
+    fastify.all('/:provider/*', ProxyRequest, async (request, reply) => {
+        const { provider } = request.params
+        const { projectId } = request.principal
+
+        const platformId = await projectService.getPlatformId(projectId)
+        const aiProvider = await aiProviderService.getOrThrow({ platformId, provider })
+        await aiTokenLimit.exceededLimit({ projectId, tokensToConsume: 1 })
+
+        const url = buildUrl(aiProvider.baseUrl, request.params['*'])
+        try {
+            const response = await fetch(url, {
+                method: request.method,
+                headers: calculateHeaders(request.headers as Record<string, string | string[] | undefined>, aiProvider.config.defaultHeaders),
+                body: JSON.stringify(request.body),
+            })
+            const data = await response.json()
+            await projectUsageService.increaseUsage(projectId, 1, 'aiTokens')
+
+            await reply
+                .code(response.status)
+                .send(data)
+        }
+        catch (error) {
+            if (error instanceof Response) {
+                const errorData = await error.json()
+                await reply.code(error.status).send(errorData)
+            }
+            else {
+                await reply.code(500).send({ message: 'An unexpected error occurred in the proxy' })
+            }
+        }
+    })
+    done()
+}
+
+
+
+function buildUrl(baseUrl: string, path: string): string {
+    const url = new URL(path, baseUrl)
+    if (!['http:', 'https:'].includes(url.protocol)) {
+        throw new Error('Invalid protocol. Only HTTP and HTTPS are allowed.')
+    }
+    return url.toString()
+}
+
+const calculateHeaders = (
+    requestHeaders: Record<string, string | string[] | undefined>,
+    aiProviderDefaultHeaders: Record<string, string>,
+): [string, string][] => {
+    const cleanedHeaders = Object.entries(requestHeaders).reduce((acc, [key, value]) => {
+        if (
+            value !== undefined &&
+            !['authorization', 'Authorization', 'content-length', 'host'].includes(key) &&
+            !key.startsWith('x-')
+        ) {
+            acc[key as keyof typeof acc] = value
+        }
+        return acc
+    }, {} as Record<string, string | string[] | undefined>)
+
+    return Object.entries({
+        ...cleanedHeaders,
+        ...aiProviderDefaultHeaders,
+    })
+        .filter(([, value]) => value !== undefined)
+        .map(([key, value]) => [
+            key,
+            Array.isArray(value) ? value.join(',') : value!.toString(),
+        ])
+}
+
+const ProxyRequest = {
+    config: {
+        allowedPrincipals: [PrincipalType.ENGINE],
+    },
+    schema: {
+        tags: ['ai-providers'],
+        description: 'Proxy a request to a third party service',
+        params: Type.Object({
+            provider: Type.String(),
+            '*': Type.String(),
+        }),
+    },
+}

--- a/packages/server/api/src/app/database/database-connection.ts
+++ b/packages/server/api/src/app/database/database-connection.ts
@@ -137,6 +137,7 @@ export const databaseConnection = () => {
     return _databaseConnection
 }
 
+export const f = databaseConnection()
 export function APArrayContains<T extends ObjectLiteral>(
     columnName: string,
     values: string[],

--- a/packages/server/api/src/app/database/migration/postgres/1726445983043-AddAiProviderTable.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1726445983043-AddAiProviderTable.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class AddAiProvider1725927553607 implements MigrationInterface {
-    name = 'AddAiProvider1725927553607'
+export class AddAiProviderTable1726445983043 implements MigrationInterface {
+    name = 'AddAiProviderTable1726445983043'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
@@ -13,7 +13,6 @@ export class AddAiProvider1725927553607 implements MigrationInterface {
                 "config" json NOT NULL,
                 "baseUrl" character varying NOT NULL,
                 "provider" character varying NOT NULL,
-                CONSTRAINT "REL_04619a92ba6ba054cd41335a67" UNIQUE ("platformId", "provider"),
                 CONSTRAINT "PK_1046c2cb42f99614e1c7873744b" PRIMARY KEY ("id")
             )
         `)
@@ -22,9 +21,8 @@ export class AddAiProvider1725927553607 implements MigrationInterface {
         `)
         await queryRunner.query(`
             ALTER TABLE "ai_provider"
-            ADD CONSTRAINT "fk_ai_provider_platform_id" FOREIGN KEY ("platformId") REFERENCES "platform"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+            ADD CONSTRAINT "fk_ai_provider_platform_id" FOREIGN KEY ("platformId") REFERENCES "platform"("id") ON DELETE CASCADE ON UPDATE NO ACTION
         `)
-        await queryRunner.query(`ALTER TABLE "project_plan" ADD COLUMN "aiTokens" integer DEFAULT 1000;`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
@@ -32,12 +30,11 @@ export class AddAiProvider1725927553607 implements MigrationInterface {
             ALTER TABLE "ai_provider" DROP CONSTRAINT "fk_ai_provider_platform_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "idx_ai_provider_platform_id_provider"
+            DROP INDEX "public"."idx_ai_provider_platform_id_provider"
         `)
         await queryRunner.query(`
             DROP TABLE "ai_provider"
         `)
-        await queryRunner.query(`ALTER TABLE "project_plan" DROP COLUMN "aiTokens";`);
     }
 
 }

--- a/packages/server/api/src/app/database/migration/postgres/1726446092010-AddAiTokensForProjectPlan.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1726446092010-AddAiTokensForProjectPlan.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddAiTokensForProjectPlan1726446092010 implements MigrationInterface {
+    name = 'AddAiTokensForProjectPlan1726446092010'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "project_plan"
+            ADD COLUMN "aiTokens" integer
+        `)
+        await queryRunner.query(`
+            UPDATE "project_plan"
+            SET "aiTokens" = 0
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "project_plan"
+            ALTER COLUMN "aiTokens" SET NOT NULL
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "project_plan" DROP COLUMN "aiTokens"
+        `)
+    }
+
+}

--- a/packages/server/api/src/app/database/migration/sqlite/1726446345221-AddAiProviderSqlite.ts
+++ b/packages/server/api/src/app/database/migration/sqlite/1726446345221-AddAiProviderSqlite.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class AddAiProviderSqlite1725930375719 implements MigrationInterface {
-    name = 'AddAiProviderSqlite1725930375719'
+export class AddAiProviderSqlite1726446345221 implements MigrationInterface {
+    name = 'AddAiProviderSqlite1726446345221'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
@@ -13,23 +13,17 @@ export class AddAiProviderSqlite1725930375719 implements MigrationInterface {
                 "config" text NOT NULL,
                 "baseUrl" varchar NOT NULL,
                 "provider" varchar NOT NULL,
-                CONSTRAINT "REL_04619a92ba6ba054cd41335a67" UNIQUE ("platformId"),
-                CONSTRAINT "fk_ai_provider_platform_id" FOREIGN KEY ("platformId") REFERENCES "platform" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+                CONSTRAINT "fk_ai_provider_platform_id" FOREIGN KEY ("platformId") REFERENCES "platform" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
             )
         `)
-
         await queryRunner.query(`
             CREATE UNIQUE INDEX "idx_ai_provider_platform_id_provider" ON "ai_provider" ("platformId", "provider")
         `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
-            DROP INDEX "idx_ai_provider_platform_id_provider"
-        `)
-        await queryRunner.query(`
-            DROP TABLE "temporary_ai_provider"
-        `)
+        await queryRunner.query('DROP INDEX "idx_ai_provider_platform_id_provider"')
+        await queryRunner.query('DROP TABLE "ai_provider"')
     }
 
 }

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -145,7 +145,8 @@ import { MigrateAuditEventSchema1723489038729 } from './migration/postgres/17234
 import { AddAnalyticsToPlatform1725113652923 } from './migration/postgres/1725113652923-AddAnalyticsToPlatform'
 import { LogFileRelationWithFlowRun1725639666232 } from './migration/postgres/1725639666232-LogFileRelationWithFlowRun'
 import { AddLogsFileIdIndex1725699690971 } from './migration/postgres/1725699690971-AddLogsFileIdIndex'
-import { AddAiProvider1725927553607 } from './migration/postgres/1725927553607-AddAiProvider'
+import { AddAiProviderTable1726445983043 } from './migration/postgres/1726445983043-AddAiProviderTable'
+import { AddAiTokensForProjectPlan1726446092010 } from './migration/postgres/1726446092010-AddAiTokensForProjectPlan'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -241,7 +242,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
         RemoveUniqueConstraintOnStepFile1725570317713,
         LogFileRelationWithFlowRun1725639666232,
         AddLogsFileIdIndex1725699690971,
-        AddAiProvider1725927553607,
+        AddAiProviderTable1726445983043,
     ]
 
     const edition = system.getEdition()
@@ -315,6 +316,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
                 // New Migration After Unifying
                 ModifyProjectMembers1717961669938,
                 MigrateAuditEventSchema1723489038729,
+                AddAiTokensForProjectPlan1726446092010,
             )
             break
         case ApEdition.COMMUNITY:

--- a/packages/server/api/src/app/database/sqlite-connection.ts
+++ b/packages/server/api/src/app/database/sqlite-connection.ts
@@ -4,7 +4,6 @@ import { AppSystemProp, SharedSystemProp, system } from '@activepieces/server-sh
 import { ApEdition, ApEnvironment } from '@activepieces/shared'
 import { DataSource, MigrationInterface } from 'typeorm'
 import { commonProperties } from './database-connection'
-import { AddAiProviderSqlite1725930375719 } from './migration/sqlite/1725930375719-AddAiProviderSqlite'
 import { AddPieceTypeAndPackageTypeToFlowVersion1696245170061 } from './migration/common/1696245170061-add-piece-type-and-package-type-to-flow-version'
 import { StoreCodeInsideFlow1697969398200 } from './migration/common/1697969398200-store-code-inside-flow'
 import { UpdateUserStatusRenameShadowToInvited1699818680567 } from './migration/common/1699818680567-update-user-status-rename-shadow-to-invited'
@@ -56,6 +55,7 @@ import { AddWorkerMachineSqlite1720100928449 } from './migration/sqlite/17201009
 import { AddAnalyticsToPlatformSqlite1725151368300 } from './migration/sqlite/1725151368300-AddAnalyticsToPlatformSqlite'
 import { LogFileRelationWithFlowRunSqlite1725637505836 } from './migration/sqlite/1725637505836-LogFileRelationWithFlowRunSqlite'
 import { AddLogsFileIdIndexSqlite1725699920020 } from './migration/sqlite/1725699920020-AddLogsFileIdIndexSqlite'
+import { AddAiProviderSqlite1726446345221 } from './migration/sqlite/1726446345221-AddAiProviderSqlite'
 
 const getSqliteDatabaseFilePath = (): string => {
     const apConfigDirectoryPath = system.getOrThrow(AppSystemProp.CONFIG_PATH)
@@ -129,7 +129,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
         RemoveUniqueConstraintOnStepFile1725570317713,
         LogFileRelationWithFlowRunSqlite1725637505836,
         AddLogsFileIdIndexSqlite1725699920020,
-        AddAiProviderSqlite1725930375719,
+        AddAiProviderSqlite1726446345221,
     ]
     const edition = system.getEdition()
     if (edition !== ApEdition.COMMUNITY) {

--- a/packages/server/api/src/app/ee/flow-run/cloud-flow-run-hooks.ts
+++ b/packages/server/api/src/app/ee/flow-run/cloud-flow-run-hooks.ts
@@ -16,9 +16,10 @@ export const platformRunHooks: FlowRunHooks = {
     }): Promise<void> {
         const edition = system.getEdition()
         if ([ApEdition.CLOUD, ApEdition.ENTERPRISE].includes(edition)) {
-            const consumedTasks = await projectUsageService.increaseTasks(
+            const consumedTasks = await projectUsageService.increaseUsage(
                 projectId,
                 tasks,
+                'tasks',
             )
             await sendAlertsIfNeeded({
                 projectId,

--- a/packages/server/api/src/app/ee/project-plan/ai-token-limit.ts
+++ b/packages/server/api/src/app/ee/project-plan/ai-token-limit.ts
@@ -6,8 +6,7 @@ import {
 import { projectUsageService } from '../../project/usage/project-usage-service'
 import { projectLimitsService } from './project-plan.service'
 
-
-async function exceededLimit({ projectId }: { projectId: ProjectId }): Promise<boolean> {
+async function exceededLimit({ projectId, tokensToConsume }: { projectId: ProjectId, tokensToConsume: number }): Promise<boolean> {
     const edition = system.getEdition()
 
     if (![ApEdition.CLOUD, ApEdition.ENTERPRISE].includes(edition)) {
@@ -19,8 +18,8 @@ async function exceededLimit({ projectId }: { projectId: ProjectId }): Promise<b
         if (!projectPlan) {
             return false
         }
-        const consumedTasks = await projectUsageService.increaseUsage(projectId, 0, 'tasks')
-        return consumedTasks >= projectPlan.tasks
+        const consumedTokens = await projectUsageService.increaseUsage(projectId, tokensToConsume, 'aiTokens')
+        return consumedTokens > projectPlan.aiTokens
     }
     catch (e) {
         exceptionHandler.handle(e)
@@ -28,6 +27,6 @@ async function exceededLimit({ projectId }: { projectId: ProjectId }): Promise<b
     }
 }
 
-export const tasksLimit = {
+export const aiTokenLimit = {
     exceededLimit,
 }

--- a/packages/server/api/src/app/ee/project-plan/project-plan.entity.ts
+++ b/packages/server/api/src/app/ee/project-plan/project-plan.entity.ts
@@ -41,8 +41,6 @@ export const ProjectPlanEntity = new EntitySchema<ProjectPlanSchema>({
         },
         aiTokens: {
             type: Number,
-            default: 1000,
-            nullable: true,
         },
     },
     indices: [

--- a/packages/server/api/src/app/ee/project-plan/project-plan.service.ts
+++ b/packages/server/api/src/app/ee/project-plan/project-plan.service.ts
@@ -10,7 +10,7 @@ const projectPlanRepo = repoFactory<ProjectPlan>(ProjectPlanEntity)
 
 export const projectLimitsService = {
     async upsert(
-        planLimits: Partial<FlowPlanLimits & { aiTokens?: number }>,
+        planLimits: Partial<FlowPlanLimits>,
         projectId: string,
     ): Promise<ProjectPlan> {
         const existingPlan = await projectPlanRepo().findOneBy({ projectId })
@@ -77,7 +77,8 @@ async function createDefaultPlan(projectId: string, flowPlanLimit: FlowPlanLimit
         tasks: flowPlanLimit.tasks,
         teamMembers: flowPlanLimit.teamMembers,
         minimumPollingInterval: flowPlanLimit.minimumPollingInterval,
-        connections: flowPlanLimit.connections,
+        connections: flowPlanLimit.connections, 
+        aiTokens: flowPlanLimit.aiTokens,
         name: flowPlanLimit.nickname,
     }, ['projectId'])
 

--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -18,6 +18,7 @@ export const errorHandler = async (
             [ErrorCode.PERMISSION_DENIED]: StatusCodes.FORBIDDEN,
             [ErrorCode.ENTITY_NOT_FOUND]: StatusCodes.NOT_FOUND,
             [ErrorCode.EXISTING_USER]: StatusCodes.CONFLICT,
+            [ErrorCode.PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER]: StatusCodes.NOT_IMPLEMENTED,
             [ErrorCode.EXISTING_ALERT_CHANNEL]: StatusCodes.CONFLICT,
             [ErrorCode.FLOW_IN_USE]: StatusCodes.CONFLICT,
             [ErrorCode.AUTHORIZATION]: StatusCodes.FORBIDDEN,

--- a/packages/server/api/src/app/project/usage/project-usage-service.ts
+++ b/packages/server/api/src/app/project/usage/project-usage-service.ts
@@ -1,27 +1,35 @@
 import { SharedSystemProp, system } from '@activepieces/server-shared'
-import { ApEnvironment, ProjectUsage } from '@activepieces/shared'
+import { ApEdition, ApEnvironment, ProjectUsage } from '@activepieces/shared'
 import { getRedisConnection } from '../../database/redis-connection'
 import { projectMemberService } from '../../ee/project-members/project-member.service'
 import { apDayjs } from '../../helper/dayjs-helper'
 import { userInvitationsService } from '../../user-invitations/user-invitation.service'
 import { projectService } from '../project-service'
 
+type UsageType = 'tasks' | 'aiTokens'
+
+const environment = system.get(SharedSystemProp.ENVIRONMENT)
+
+const redisKeys: Record<UsageType, (projectId: string, startBillingPeriod: string) => string> = {
+    'tasks': (projectId: string, startBillingPeriod: string) => `project-usage:${projectId}:${startBillingPeriod}`,
+    'aiTokens': (projectId: string, startBillingPeriod: string) => `project-ai-tokens-usage:${projectId}:${startBillingPeriod}`,
+}
+
 export const projectUsageService = {
     async getUsageForBillingPeriod(projectId: string, startBillingPeriod: string): Promise<ProjectUsage> {
-        const flowTasks = await getTasksUsage(projectId, getCurrentingStartPeriod(startBillingPeriod))
+        const flowTasks = await getUsage(projectId, getCurrentingStartPeriod(startBillingPeriod), 'tasks')
         const teamMembers = await projectMemberService.countTeamMembers(projectId) + await userInvitationsService.countByProjectId(projectId)
-        const aiTokens = await getAITokensUsage(projectId, getCurrentingStartPeriod(startBillingPeriod))
+        const aiTokens = await getUsage(projectId, getCurrentingStartPeriod(startBillingPeriod), 'aiTokens')
         return {
             tasks: flowTasks,
             teamMembers,
             aiTokens,
         }
     },
-    increaseTasks,
+    increaseUsage,
     getCurrentingStartPeriod,
     getCurrentingEndPeriod,
-    increaseAITokens,
-    getAITokensUsage,
+    getUsage,
 }
 
 function getCurrentingStartPeriod(datetime: string): string {
@@ -36,63 +44,25 @@ function getCurrentingEndPeriod(datetime: string): string {
     return apDayjs(getCurrentingStartPeriod(datetime)).add(30, 'days').toISOString()
 }
 
-async function increaseTasks(projectId: string, incrementBy: number): Promise<number> {
-    const project = await projectService.getOneOrThrow(projectId)
-    const startBillingPeriod = getCurrentingStartPeriod(project.created)
-    return incrementOrCreateRedisRecord(projectId, startBillingPeriod, incrementBy)
-}
-
-async function incrementOrCreateRedisRecord(projectId: string, startBillingPeriod: string, incrementBy: number): Promise<number> {
-    const environment = system.get(SharedSystemProp.ENVIRONMENT)
+async function increaseUsage(projectId: string, incrementBy: number, usageType: UsageType): Promise<number> {
+    const edition = system.getEdition()
+    if (edition === ApEdition.COMMUNITY) {
+        return 0
+    }
     if (environment === ApEnvironment.TESTING) {
         return 0
     }
-    const key = constructUsageKey(projectId, startBillingPeriod)
+    const project = await projectService.getOneOrThrow(projectId)
+    const startBillingPeriod = getCurrentingStartPeriod(project.created)
+    const key = redisKeys[usageType](projectId, startBillingPeriod)
     return getRedisConnection().incrby(key, incrementBy)
 }
 
-async function getTasksUsage(projectId: string, startBillingPeriod: string): Promise<number> {
-    const environment = system.get(SharedSystemProp.ENVIRONMENT)
+async function getUsage(projectId: string, startBillingPeriod: string, usageType: UsageType): Promise<number> {
     if (environment === ApEnvironment.TESTING) {
         return 0
     }
-    const key = constructUsageKey(projectId, startBillingPeriod)
+    const key = redisKeys[usageType](projectId, startBillingPeriod)
     const value = await getRedisConnection().get(key)
     return Number(value) || 0
-}
-
-
-async function increaseAITokens(projectId: string, incrementBy: number): Promise<number> {
-    const project = await projectService.getOneOrThrow(projectId)
-    const startBillingPeriod = getCurrentingStartPeriod(project.created)
-    return incrementOrCreateAITokensRedisRecord(projectId, startBillingPeriod, incrementBy)
-}
-
-async function incrementOrCreateAITokensRedisRecord(projectId: string, startBillingPeriod: string, incrementBy: number): Promise<number> {
-    const environment = system.get(SharedSystemProp.ENVIRONMENT)
-    if (environment === ApEnvironment.TESTING) {
-        return 0
-    }
-    const key = constructAITokensUsageKey(projectId, startBillingPeriod)
-    return getRedisConnection().incrby(key, incrementBy)
-}
-
-async function getAITokensUsage(projectId: string, startBillingPeriod?: string): Promise<number> {
-    const environment = system.get(SharedSystemProp.ENVIRONMENT)
-    if (environment === ApEnvironment.TESTING) {
-        return 0
-    }
-    const project = await projectService.getOneOrThrow(projectId)
-    const period = startBillingPeriod ?? getCurrentingStartPeriod(project.created)
-    const key = constructAITokensUsageKey(projectId, period)
-    const value = await getRedisConnection().get(key)
-    return Number(value) || 0
-}
-
-function constructUsageKey(projectId: string, startBillingPeriod: string): string {
-    return `project-usage:${projectId}:${startBillingPeriod}`
-}
-
-function constructAITokensUsageKey(projectId: string, startBillingPeriod: string): string {
-    return `project-ai-tokens-usage:${projectId}:${startBillingPeriod}`
 }

--- a/packages/shared/src/lib/ai/index.ts
+++ b/packages/shared/src/lib/ai/index.ts
@@ -1,25 +1,25 @@
-import { Static, Type } from "@sinclair/typebox";
-import { BaseModelSchema } from "../common";
+import { Static, Type } from '@sinclair/typebox'
+import { BaseModelSchema } from '../common'
 
 
 export const AiProviderConfig = Type.Object({
-  ...BaseModelSchema,
-  config: Type.Object({
-    defaultHeaders: Type.Record(Type.String(), Type.String()),
-  }),
-  baseUrl: Type.String({
-    pattern: '^https?://.+$',
-  }),
-  provider: Type.String({ minLength: 1 }),
-  platformId: Type.String(),
+    ...BaseModelSchema,
+    config: Type.Object({
+        defaultHeaders: Type.Record(Type.String(), Type.String()),
+    }),
+    baseUrl: Type.String({
+        pattern: '^https?://.+$',
+    }),
+    provider: Type.String({ minLength: 1 }),
+    platformId: Type.String(),
 })
 
-export type AiProviderConfig = Static<typeof AiProviderConfig>;
+export type AiProviderConfig = Static<typeof AiProviderConfig>
 
 export const AiProviderWithoutSensitiveData = Type.Composite([Type.Omit(AiProviderConfig, ['config']),
-Type.Object({
-  config: Type.Object({
-  }),
-}),
+    Type.Object({
+        config: Type.Object({
+        }),
+    }),
 ])
 export type AiProviderWithoutSensitiveData = Static<typeof AiProviderWithoutSensitiveData>

--- a/packages/shared/src/lib/common/activepieces-error.ts
+++ b/packages/shared/src/lib/common/activepieces-error.ts
@@ -63,6 +63,7 @@ export type ApErrorParams =
     | ActivationKeyNotFoundParams
     | ActivationKeyNotAlreadyActivated
     | EmailAlreadyHasActivationKey
+    | ProviderProxyConfigNotFoundParams
 
 export type BaseErrorParams<T, V> = {
     code: T
@@ -323,10 +324,16 @@ ErrorCode.INVALID_APP_CONNECTION,
 export type QuotaExceededParams = BaseErrorParams<
 ErrorCode.QUOTA_EXCEEDED,
 {
-    metric: 'tasks' | 'team-members'
+    metric: 'tasks' | 'team-members' | 'ai-tokens'
     quota?: number
 }
 >
+
+export type ProviderProxyConfigNotFoundParams = BaseErrorParams<
+ErrorCode.PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER,
+{
+    provider: string
+}>
 
 export type FeatureDisabledErrorParams = BaseErrorParams<
 ErrorCode.FEATURE_DISABLED,
@@ -375,6 +382,7 @@ export type EmailAlreadyHasActivationKey = BaseErrorParams<ErrorCode.EMAIL_ALREA
 export enum ErrorCode {
     AUTHENTICATION = 'AUTHENTICATION',
     AUTHORIZATION = 'AUTHORIZATION',
+    PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER = 'PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER',
     CONFIG_NOT_FOUND = 'CONFIG_NOT_FOUND',
     DOMAIN_NOT_ALLOWED = 'DOMAIN_NOT_ALLOWED',
     EMAIL_IS_NOT_VERIFIED = 'EMAIL_IS_NOT_VERIFIED',

--- a/packages/shared/src/lib/project/project.ts
+++ b/packages/shared/src/lib/project/project.ts
@@ -50,7 +50,7 @@ export const ProjectPlan = Type.Object({
     connections: Type.Number(),
     teamMembers: Type.Number(),
     tasks: Type.Number(),
-    aiTokens: Type.Optional(Type.Number()),
+    aiTokens: Type.Number(),
 })
 
 export type ProjectPlan = Static<typeof ProjectPlan>


### PR DESCRIPTION
## What does this PR do?

- Removed the Credits Criteria label.
- Regenerated the AI provider database schema table, split the project_limit feature into a separate migration, and added it for enterprise migration.
- Error handling in the proxy now returns the original error.
- Instead of returning a status and custom message format, I made `ActivepiecesError` throw an error, which is handled globally.
- Refactored the project usage class, as it was the same as tasks, so I unified the methods and created an abstraction on the key.
- Providers should be a dynamic dropdown; otherwise, the user could select an unsupported provider. I made it fetch the list from the backend to ensure only supported providers are shown.
- Moved the dropdown props to the common library since they were duplicated across the three actions.
- Refactored the proxy class by splitting it into multiple declarative functions.