### PR TITLE
chore(talkable): removed 'no error on failure' checkbox property

### DIFF
--- a/packages/pieces/community/talkable/package.json
+++ b/packages/pieces/community/talkable/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-talkable",
-  "version": "0.0.14"
+  "version": "0.0.15"
 }

--- a/packages/pieces/community/talkable/src/lib/actions/coupons/find-coupon.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/coupons/find-coupon.ts
@@ -13,10 +13,6 @@ export const findCoupon = createAction({
       description: undefined,
       required: true,
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -32,12 +28,6 @@ export const findCoupon = createAction({
         body: {
           site_slug: site,
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return couponInfoResponse.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/loyalty/get-loyalty-redeem-actions.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/loyalty/get-loyalty-redeem-actions.ts
@@ -13,10 +13,6 @@ export const getLoyaltyRedeemActions = createAction({
       description: undefined,
       required: true,
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -32,12 +28,6 @@ export const getLoyaltyRedeemActions = createAction({
         body: {
           site_slug: site,
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return getLoyaltyRedeemActionsResponse.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/origins/create-event.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/create-event.ts
@@ -116,16 +116,12 @@ export const createEvent = createAction({
     }),
     items: Property.Json({
       displayName: 'Items',
-      description: undefined,
+      description: "You can pass items with event",
       required: false,
       defaultValue: [
         { price: 10, quantity: 1, product_id: 'SKU1' },
         { price: 20, quantity: 1, product_id: 'SKU2' },
       ],
-    }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
     }),
   },
   async run(context) {
@@ -143,12 +139,6 @@ export const createEvent = createAction({
           site_slug: site,
           data: context.propsValue,
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return createEventResponse.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/origins/create-events-batch.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/create-events-batch.ts
@@ -55,10 +55,6 @@ export const createEventsBatch = createAction({
         },
       ],
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -76,12 +72,6 @@ export const createEventsBatch = createAction({
           data: context.propsValue.events,
           create_offers: context.propsValue.create_offers,
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return createEventsBatch.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/origins/create-purchase.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/create-purchase.ts
@@ -111,16 +111,12 @@ export const createPurchase = createAction({
     }),
     items: Property.Json({
       displayName: 'Items',
-      description: undefined,
+      description: "You can pass items with purchase",
       required: false,
       defaultValue: [
         { price: 10, quantity: 1, product_id: 'SKU1' },
         { price: 20, quantity: 1, product_id: 'SKU2' },
       ],
-    }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
     }),
   },
   async run(context) {
@@ -138,12 +134,6 @@ export const createPurchase = createAction({
           site_slug: site,
           data: context.propsValue,
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return createPurchaseResponse.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/origins/create-purchases-batch.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/create-purchases-batch.ts
@@ -54,10 +54,6 @@ export const createPurchasesBatch = createAction({
         },
       ],
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -75,12 +71,6 @@ export const createPurchasesBatch = createAction({
           data: context.propsValue.purchases,
           create_offers: context.propsValue.create_offers,
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return createPurchasesBatch.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/origins/refund.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/refund.ts
@@ -23,10 +23,6 @@ export const refund = createAction({
       description: undefined,
       required: false,
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -47,12 +43,6 @@ export const refund = createAction({
             refund_subtotal,
           },
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return refundResponse.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/people/anonymize-person.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/people/anonymize-person.ts
@@ -13,10 +13,6 @@ export const anonymizePerson = createAction({
       description: undefined,
       required: true,
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -32,12 +28,6 @@ export const anonymizePerson = createAction({
         body: {
           site_slug: site,
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return personAnonymizeResponse.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/people/find-person.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/people/find-person.ts
@@ -46,10 +46,6 @@ export const findPerson = createAction({
         ],
       },
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -65,12 +61,6 @@ export const findPerson = createAction({
         body: {
           site_slug: site,
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return personInfoResponse.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/people/unsubscribe-person.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/people/unsubscribe-person.ts
@@ -13,10 +13,6 @@ export const unsubscribePerson = createAction({
       description: undefined,
       required: true,
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -32,12 +28,6 @@ export const unsubscribePerson = createAction({
         body: {
           site_slug: site,
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return personUnsubscribeResponse.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/people/update-person.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/people/update-person.ts
@@ -58,10 +58,6 @@ export const updatePerson = createAction({
       description: undefined,
       required: false,
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -100,12 +96,6 @@ export const updatePerson = createAction({
             unsubscribed_at,
           },
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return personUpdateResponse.body;
   },

--- a/packages/pieces/community/talkable/src/lib/actions/referrals/update_referral_status.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/referrals/update_referral_status.ts
@@ -25,10 +25,6 @@ export const updateReferralStatus = createAction({
         ],
       },
     }),
-    failsafe: Property.Checkbox({
-      displayName: 'No Error On Failure',
-      required: false,
-    }),
   },
   async run(context) {
     const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
@@ -45,12 +41,6 @@ export const updateReferralStatus = createAction({
           site_slug: site,
           status: context.propsValue['status'], // we have only one status so it's hardcoded
         },
-      })
-      .catch((error) => {
-        if (context.propsValue.failsafe) {
-          return error.errorMessage();
-        }
-        throw error;
       });
     return updateReferralStatusResponse.body;
   },


### PR DESCRIPTION
Removed the 'No Error on Failure' checkbox because it is now included by default for all pieces. 

![image](https://github.com/user-attachments/assets/149269c1-473f-41ef-94a3-f4dc776cb3da)

I've removed the extra checkbox to avoid duplication and maintain a clean interface.

## What does this PR do?
Cleanup

