### PR TITLE
fix: project settings not visible on mobile

### DIFF
--- a/packages/react-ui/src/app/components/sidebar-layout.tsx
+++ b/packages/react-ui/src/app/components/sidebar-layout.tsx
@@ -59,7 +59,7 @@ export default function SidebarLayout({
   children,
 }: SidebarLayoutProps) {
   return (
-    <div className="w-full hidden md:block">
+    <div className="w-full md:block">
       <div className="space-y-0.5">
         <h2 className="text-3xl font-bold tracking-tight">{title}</h2>
       </div>


### PR DESCRIPTION
## What does this PR do?

On small viewports such as on a mobile device, the project settings is not visible. Even though the layout is not ideal, at least it's usable with this fix.

Fixes # (issue)

