### PR TITLE
feat: improve piece selector experience 

### DIFF
--- a/packages/react-ui/src/app/builder/flow-canvas/nodes/step-node.tsx
+++ b/packages/react-ui/src/app/builder/flow-canvas/nodes/step-node.tsx
@@ -185,9 +185,9 @@ const ApStepNode = React.memo(({ data }: { data: ApNode['data'] }) => {
         setAllowCanvasPanning(true);
       }}
       key={data.step?.name}
-      ref={setNodeRef}
-      {...attributes}
-      {...listeners}
+      ref={openPieceSelector ? null : setNodeRef}
+      {...(!openPieceSelector ? attributes : {})}
+      {...(!openPieceSelector ? listeners : {})}
     >
       <div
         className="absolute text-accent-foreground text-sm opacity-0 transition-all duration-300 group-hover:opacity-100 "

--- a/packages/react-ui/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
+++ b/packages/react-ui/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
@@ -1,5 +1,6 @@
 import { MentionNodeAttrs } from '@tiptap/extension-mention';
 import { JSONContent } from '@tiptap/react';
+
 import { StepMetadata } from '@/features/pieces/lib/types';
 import {
   Action,

--- a/packages/react-ui/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
+++ b/packages/react-ui/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
@@ -1,7 +1,8 @@
-import { MentionNodeAttrs } from '@tiptap/extension-mention';
-import { JSONContent } from '@tiptap/react';
+import { MentionNodeAttrs, MentionNodeAttrs } from '@tiptap/extension-mention';
+import { JSONContent, JSONContent } from '@tiptap/react';
 
 import { StepMetadata } from '@/features/pieces/lib/pieces-hook';
+import { StepMetadata } from '@/features/pieces/lib/types';
 import {
   Action,
   Trigger,

--- a/packages/react-ui/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
+++ b/packages/react-ui/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
@@ -1,7 +1,5 @@
-import { MentionNodeAttrs, MentionNodeAttrs } from '@tiptap/extension-mention';
-import { JSONContent, JSONContent } from '@tiptap/react';
-
-import { StepMetadata } from '@/features/pieces/lib/pieces-hook';
+import { MentionNodeAttrs } from '@tiptap/extension-mention';
+import { JSONContent } from '@tiptap/react';
 import { StepMetadata } from '@/features/pieces/lib/types';
 import {
   Action,

--- a/packages/react-ui/src/app/builder/pieces-selector/index.tsx
+++ b/packages/react-ui/src/app/builder/pieces-selector/index.tsx
@@ -250,8 +250,6 @@ const PieceSelector = ({
     [metadata, selectedTag],
   );
 
-  const isSearching = !!debouncedQuery;
-
   return (
     <Popover
       open={open}
@@ -298,10 +296,15 @@ const PieceSelector = ({
         />
         <Separator orientation="horizontal" />
         <div className="flex overflow-y-auto max-h-[300px] h-[300px]">
-          <CardList className="w-[250px] min-w-[250px]" listClassName="gap-0">
-            {!isLoadingPieces &&
-              piecesMetadata &&
-              piecesMetadata.map((pieceMetadata) => (
+          {isLoadingPieces && (
+            <div className="flex flex-col gap-2">
+              <CardListItemSkeleton numberOfCards={2} withCircle={false} />
+            </div>
+          )}
+
+          {!isLoadingPieces && piecesMetadata && (
+            <CardList className="w-[250px] min-w-[250px]" listClassName="gap-0">
+              {piecesMetadata.map((pieceMetadata) => (
                 <div key={pieceSelectorUtils.toKey(pieceMetadata)}>
                   <CardListItem
                     className="flex-col p-3 gap-1 items-start"
@@ -326,7 +329,7 @@ const PieceSelector = ({
                     </div>
                   </CardListItem>
 
-                  {isSearching &&
+                  {debouncedQuery.length > 0 &&
                     (pieceMetadata.type === ActionType.PIECE ||
                       pieceMetadata.type === TriggerType.PIECE) && (
                       <div
@@ -344,26 +347,28 @@ const PieceSelector = ({
                 </div>
               ))}
 
-            {!isLoadingPieces &&
-              (!piecesMetadata || piecesMetadata.length === 0) && (
-                <div className="flex flex-col gap-2 items-center justify-center h-[300px] ">
-                  <SearchX className="w-10 h-10" />
-                  <div className="text-sm ">{t('No pieces found')}</div>
-                  <div className="text-sm ">
-                    {t('Try adjusting your search')}
+              {!isLoadingPieces &&
+                (!piecesMetadata || piecesMetadata.length === 0) && (
+                  <div className="flex flex-col gap-2 items-center justify-center h-[300px] ">
+                    <SearchX className="w-10 h-10" />
+                    <div className="text-sm ">{t('No pieces found')}</div>
+                    <div className="text-sm ">
+                      {t('Try adjusting your search')}
+                    </div>
+                    {showRequestPieceButton && (
+                      <Link
+                        to={`${supportUrl}/c/feature-requests/9`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Button className="h-8 px-2 ">Request Piece</Button>
+                      </Link>
+                    )}
                   </div>
-                  {showRequestPieceButton && (
-                    <Link
-                      to={`${supportUrl}/c/feature-requests/9`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Button className="h-8 px-2 ">Request Piece</Button>
-                    </Link>
-                  )}
-                </div>
-              )}
-          </CardList>
+                )}
+            </CardList>
+          )}
+
           <Separator orientation="vertical" className="h-full" />
           <ScrollArea className="h-full">
             <CardList className="w-[350px] min-w-[350px] h-full">

--- a/packages/react-ui/src/app/builder/pieces-selector/piece-selector-utils.ts
+++ b/packages/react-ui/src/app/builder/pieces-selector/piece-selector-utils.ts
@@ -2,6 +2,7 @@ import {
   PieceStepMetadata,
   StepMetadata,
 } from '@/features/pieces/lib/pieces-hook';
+import { PieceStepMetadata, StepMetadata } from '@/features/pieces/lib/types';
 import {
   Action,
   ActionType,

--- a/packages/react-ui/src/components/ui/card-list.tsx
+++ b/packages/react-ui/src/components/ui/card-list.tsx
@@ -9,13 +9,17 @@ import { Skeleton } from './skeleton';
 
 const CardList = forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ children, ...props }, ref) => (
+  React.HTMLAttributes<HTMLDivElement> & { listClassName?: string }
+>(({ children, className, listClassName, ...props }, ref) => (
   <ScrollArea
-    className="h-full overflow-auto"
+    className={`h-full overflow-auto ${className}`}
     viewPortClassName="[&>div]:h-full"
   >
-    <div ref={ref} className="flex flex-col gap-4 h-full w-full" {...props}>
+    <div
+      ref={ref}
+      className={cn('flex flex-col gap-4 h-full w-full', listClassName)}
+      {...props}
+    >
       {children}
     </div>
     <ScrollBar orientation="horizontal" />
@@ -24,7 +28,7 @@ const CardList = forwardRef<
 CardList.displayName = 'CardList';
 export { CardList };
 
-const cardItemListVariants = cva('flex items-center gap-4 w-full p-4 ', {
+const cardItemListVariants = cva('flex items-center gap-4 w-full py-4 px-2 ', {
   variants: {
     interactive: {
       true: 'cursor-pointer hover:bg-accent hover:text-accent-foreground',

--- a/packages/react-ui/src/components/ui/search-input.tsx
+++ b/packages/react-ui/src/components/ui/search-input.tsx
@@ -1,0 +1,23 @@
+import { Search } from 'lucide-react';
+import * as React from 'react';
+
+export type SearchInputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <div className="flex-grow flex  items-center gap-2 w-full rounded-md border border-input bg-background px-3   ring-offset-background focus-within:outline-none focus-within:ring-1 focus-within:ring-ring focus-within:ring-offset-1 first:disabled:cursor-not-allowed first:disabled:opacity-50 box-border">
+        <Search className="size-4 shrink-0 opacity-50"></Search>
+        <input
+          className="rounded-md bg-transparent  h-8 grow text-sm outline-none placeholder:text-muted-foreground"
+          type={type}
+          ref={ref}
+          {...props}
+        />
+      </div>
+    );
+  },
+);
+SearchInput.displayName = 'SearchInput';
+
+export { SearchInput };

--- a/packages/react-ui/src/components/ui/skeleton.tsx
+++ b/packages/react-ui/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn('animate-pulse rounded-md bg-muted', className)}
+      className={cn('animate-pulse rounded-md bg-muted/50', className)}
       {...props}
     />
   );

--- a/packages/react-ui/src/features/pieces/components/piece-icon-list.tsx
+++ b/packages/react-ui/src/features/pieces/components/piece-icon-list.tsx
@@ -8,7 +8,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '../../../components/ui/tooltip';
-import { piecesHooks, StepMetadata } from '../lib/pieces-hook';
+import { piecesHooks } from '../lib/pieces-hook';
+import { StepMetadata } from '../lib/types';
 
 import { PieceIcon } from './piece-icon';
 

--- a/packages/react-ui/src/features/pieces/components/piece-operations-suggestions.tsx
+++ b/packages/react-ui/src/features/pieces/components/piece-operations-suggestions.tsx
@@ -1,0 +1,56 @@
+import { GearIcon } from '@radix-ui/react-icons';
+
+import { CardListItem } from '@/components/ui/card-list';
+import { FlowOperationType } from '@activepieces/shared';
+
+import {
+  StepMetadata,
+  StepMetadataWithSuggestions,
+  ItemListMetadata,
+  PieceSelectorOperation,
+} from '../lib/types';
+
+type HandleSelectCallback = (
+  piece: StepMetadata | undefined,
+  item: ItemListMetadata,
+) => void;
+
+type PieceOperationSuggestionsProps = {
+  pieceMetadata: StepMetadataWithSuggestions;
+  handleSelectOperationSuggestion: HandleSelectCallback;
+  operation: PieceSelectorOperation;
+};
+
+const PieceOperationSuggestions = ({
+  pieceMetadata,
+  handleSelectOperationSuggestion,
+  operation,
+}: PieceOperationSuggestionsProps) => {
+  const suggestions =
+    operation.type === FlowOperationType.UPDATE_TRIGGER
+      ? pieceMetadata.suggestedTriggers
+      : pieceMetadata.suggestedActions;
+
+  return (
+    <>
+      <div className="mt-0.5" />
+      {suggestions?.map((suggestion) => (
+        <CardListItem
+          className="p-2 px-0 text-sm gap-2 items-start transition-transform duration-200 ease-in-out hover:scale-105 hover:font-bold"
+          key={suggestion.name}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleSelectOperationSuggestion(pieceMetadata, suggestion);
+          }}
+        >
+          <GearIcon className="w-2 mt-0.5" />
+          <span className="truncate" title={suggestion.displayName}>
+            {suggestion.displayName}
+          </span>
+        </CardListItem>
+      ))}
+    </>
+  );
+};
+
+export { PieceOperationSuggestions };

--- a/packages/react-ui/src/features/pieces/components/piece-operations-suggestions.tsx
+++ b/packages/react-ui/src/features/pieces/components/piece-operations-suggestions.tsx
@@ -1,22 +1,22 @@
-import { GearIcon } from '@radix-ui/react-icons';
-
 import { CardListItem } from '@/components/ui/card-list';
 import { FlowOperationType } from '@activepieces/shared';
 
 import {
   StepMetadata,
-  StepMetadataWithSuggestions,
-  ItemListMetadata,
+  ActionOrTriggerListItem,
   PieceSelectorOperation,
+  PieceStepMetadataWithSuggestions,
 } from '../lib/types';
 
+import { PieceIcon } from './piece-icon';
+
 type HandleSelectCallback = (
-  piece: StepMetadata | undefined,
-  item: ItemListMetadata,
+  piece: StepMetadata,
+  item: ActionOrTriggerListItem,
 ) => void;
 
 type PieceOperationSuggestionsProps = {
-  pieceMetadata: StepMetadataWithSuggestions;
+  pieceMetadata: PieceStepMetadataWithSuggestions;
   handleSelectOperationSuggestion: HandleSelectCallback;
   operation: PieceSelectorOperation;
 };
@@ -32,24 +32,29 @@ const PieceOperationSuggestions = ({
       : pieceMetadata.suggestedActions;
 
   return (
-    <>
-      <div className="mt-0.5" />
+    <div className="flex flex-col gap-2">
       {suggestions?.map((suggestion) => (
         <CardListItem
-          className="p-2 px-0 text-sm gap-2 items-start transition-transform duration-200 ease-in-out hover:scale-105 hover:font-bold"
+          className="p-3 px-0 text-sm gap-2 items-start "
           key={suggestion.name}
           onClick={(e) => {
             e.stopPropagation();
             handleSelectOperationSuggestion(pieceMetadata, suggestion);
           }}
         >
-          <GearIcon className="w-2 mt-0.5" />
-          <span className="truncate" title={suggestion.displayName}>
-            {suggestion.displayName}
-          </span>
+          <div className="opacity-0">
+            <PieceIcon
+              logoUrl={pieceMetadata.logoUrl}
+              displayName={pieceMetadata.displayName}
+              showTooltip={false}
+              size={'sm'}
+            ></PieceIcon>
+          </div>
+
+          <span title={suggestion.displayName}>{suggestion.displayName}</span>
         </CardListItem>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/packages/react-ui/src/features/pieces/components/piece-selector-card.tsx
+++ b/packages/react-ui/src/features/pieces/components/piece-selector-card.tsx
@@ -4,7 +4,7 @@ import { PieceIcon } from '@/features/pieces/components/piece-icon';
 import { cn } from '@/lib/utils';
 import { ActionType, TriggerType } from '@activepieces/shared';
 
-import { PieceStepMetadata, StepMetadata } from '../lib/pieces-hook';
+import { PieceStepMetadata, StepMetadata } from '../lib/types';
 
 type PieceCardInfoProps = {
   piece: StepMetadata;

--- a/packages/react-ui/src/features/pieces/lib/pieces-api.ts
+++ b/packages/react-ui/src/features/pieces/lib/pieces-api.ts
@@ -25,25 +25,25 @@ export const PRIMITIVE_STEP_METADATA = {
     displayName: 'Code',
     logoUrl: 'https://cdn.activepieces.com/pieces/code.svg',
     description: 'Powerful Node.js & TypeScript code with npm',
-    type: ActionType.CODE,
+    type: ActionType.CODE as const,
   },
   [ActionType.LOOP_ON_ITEMS]: {
     displayName: 'Loop on Items',
     logoUrl: 'https://cdn.activepieces.com/pieces/loop.svg',
     description: 'Iterate over a list of items',
-    type: ActionType.LOOP_ON_ITEMS,
+    type: ActionType.LOOP_ON_ITEMS as const,
   },
   [ActionType.BRANCH]: {
     displayName: 'Branch',
     logoUrl: 'https://cdn.activepieces.com/pieces/branch.svg',
     description: 'Branch',
-    type: ActionType.BRANCH,
+    type: ActionType.BRANCH as const,
   },
   [TriggerType.EMPTY]: {
     displayName: 'Empty Trigger',
     logoUrl: 'https://cdn.activepieces.com/pieces/empty-trigger.svg',
     description: 'Empty Trigger',
-    type: TriggerType.EMPTY,
+    type: TriggerType.EMPTY as const,
   },
 };
 

--- a/packages/react-ui/src/features/pieces/lib/pieces-api.ts
+++ b/packages/react-ui/src/features/pieces/lib/pieces-api.ts
@@ -18,7 +18,8 @@ import {
   TriggerType,
 } from '@activepieces/shared';
 
-import { PieceStepMetadata, StepMetadata } from './pieces-hook';
+import { PieceStepMetadata, StepMetadata } from './types';
+
 export const PRIMITIVE_STEP_METADATA = {
   [ActionType.CODE]: {
     displayName: 'Code',
@@ -76,6 +77,14 @@ export const piecesApi = {
       pieceVersion: piece.version,
       categories: piece.categories ?? [],
       packageType: piece.packageType,
+    };
+  },
+  mapToSuggestions(
+    piece: PieceMetadataModelSummary,
+  ): Pick<PieceMetadataModelSummary, 'suggestedActions' | 'suggestedTriggers'> {
+    return {
+      suggestedActions: piece.suggestedActions,
+      suggestedTriggers: piece.suggestedTriggers,
     };
   },
   async getMetadata(step: Action | Trigger): Promise<StepMetadata> {

--- a/packages/react-ui/src/features/pieces/lib/pieces-hook.ts
+++ b/packages/react-ui/src/features/pieces/lib/pieces-hook.ts
@@ -14,11 +14,7 @@ import {
 } from '@activepieces/shared';
 
 import { PRIMITIVE_STEP_METADATA, piecesApi } from './pieces-api';
-import {
-  PrimitiveStepMetadata,
-  StepMetadata,
-  StepMetadataWithSuggestions,
-} from './types';
+import { StepMetadata, StepMetadataWithSuggestions } from './types';
 
 type UsePieceProps = {
   name: string;
@@ -120,16 +116,17 @@ export const piecesHooks = {
           )
           .map((piece) => {
             const metadata = piecesApi.mapToMetadata(type, piece);
-            const suggestions = piecesApi.mapToSuggestions(piece);
 
-            return {
+            const res: StepMetadataWithSuggestions = {
               ...metadata,
-              ...suggestions,
+              suggestedActions: piece.suggestedActions,
+              suggestedTriggers: piece.suggestedTriggers,
             };
+            return res;
           });
         switch (type) {
           case 'action': {
-            const filtersPrimitive = [
+            const filtersPrimitive: StepMetadataWithSuggestions[] = [
               PRIMITIVE_STEP_METADATA[ActionType.CODE],
               PRIMITIVE_STEP_METADATA[ActionType.LOOP_ON_ITEMS],
               PRIMITIVE_STEP_METADATA[ActionType.BRANCH],
@@ -164,7 +161,7 @@ function stepMetadataQueryBuilder(step: Step) {
 
 function passSearch(
   searchQuery: string | undefined,
-  data: PrimitiveStepMetadata,
+  data: (typeof PRIMITIVE_STEP_METADATA)[keyof typeof PRIMITIVE_STEP_METADATA],
 ) {
   if (!searchQuery) {
     return true;

--- a/packages/react-ui/src/features/pieces/lib/types.ts
+++ b/packages/react-ui/src/features/pieces/lib/types.ts
@@ -23,8 +23,12 @@ export type PieceStepMetadata = BaseStepMetadata & {
   pieceType: PieceType;
 };
 
-export type PrimitiveStepMetadata = BaseStepMetadata & {
-  type: Omit<ActionType | TriggerType, ActionType.PIECE | TriggerType.PIECE>;
+type PrimitiveStepMetadata = BaseStepMetadata & {
+  type:
+    | ActionType.BRANCH
+    | ActionType.CODE
+    | ActionType.LOOP_ON_ITEMS
+    | TriggerType.EMPTY;
 };
 
 export type PieceStepMetadataWithSuggestions = PieceStepMetadata &
@@ -36,7 +40,7 @@ export type StepMetadataWithSuggestions =
 
 export type StepMetadata = PieceStepMetadata | PrimitiveStepMetadata;
 
-export type ItemListMetadata = {
+export type ActionOrTriggerListItem = {
   name: string;
   displayName: string;
   description: string;
@@ -58,5 +62,5 @@ export type PieceSelectorOperation =
 
 export type HandleSelectCallback = (
   piece: StepMetadata | undefined,
-  item: ItemListMetadata,
+  item: ActionOrTriggerListItem,
 ) => void;

--- a/packages/react-ui/src/features/pieces/lib/types.ts
+++ b/packages/react-ui/src/features/pieces/lib/types.ts
@@ -1,0 +1,62 @@
+import { PieceMetadataModelSummary } from '@activepieces/pieces-framework';
+import {
+  ActionType,
+  PackageType,
+  PieceType,
+  TriggerType,
+  FlowOperationType,
+  StepLocationRelativeToParent,
+} from '@activepieces/shared';
+
+type BaseStepMetadata = {
+  displayName: string;
+  logoUrl: string;
+  description: string;
+};
+
+export type PieceStepMetadata = BaseStepMetadata & {
+  type: ActionType.PIECE | TriggerType.PIECE;
+  pieceName: string;
+  pieceVersion: string;
+  categories: string[];
+  packageType: PackageType;
+  pieceType: PieceType;
+};
+
+export type PrimitiveStepMetadata = BaseStepMetadata & {
+  type: Omit<ActionType | TriggerType, ActionType.PIECE | TriggerType.PIECE>;
+};
+
+export type PieceStepMetadataWithSuggestions = PieceStepMetadata &
+  Pick<PieceMetadataModelSummary, 'suggestedActions' | 'suggestedTriggers'>;
+
+export type StepMetadataWithSuggestions =
+  | PieceStepMetadataWithSuggestions
+  | PrimitiveStepMetadata;
+
+export type StepMetadata = PieceStepMetadata | PrimitiveStepMetadata;
+
+export type ItemListMetadata = {
+  name: string;
+  displayName: string;
+  description: string;
+};
+
+export type PieceSelectorOperation =
+  | {
+      type: FlowOperationType.ADD_ACTION;
+      actionLocation: {
+        parentStep: string;
+        stepLocationRelativeToParent: StepLocationRelativeToParent;
+      };
+    }
+  | { type: FlowOperationType.UPDATE_TRIGGER }
+  | {
+      type: FlowOperationType.UPDATE_ACTION;
+      stepName: string;
+    };
+
+export type HandleSelectCallback = (
+  piece: StepMetadata | undefined,
+  item: ItemListMetadata,
+) => void;

--- a/packages/server/api/src/app/authentication/authentication-service/index.ts
+++ b/packages/server/api/src/app/authentication/authentication-service/index.ts
@@ -1,310 +1,313 @@
 import {
-  cryptoUtils,
-  logger,
-  SharedSystemProp,
-  system,
-} from '@activepieces/server-shared';
+    cryptoUtils,
+    logger,
+    SharedSystemProp,
+    system,
+} from '@activepieces/server-shared'
 import {
-  ActivepiecesError,
-  ApEnvironment,
-  ApFlagId,
-  AuthenticationResponse,
-  ErrorCode,
-  isNil,
-  PlatformRole,
-  Project,
-  TelemetryEventName,
-  User,
-  UserId,
-  UserStatus,
-} from '@activepieces/shared';
-import { QueryFailedError } from 'typeorm';
-import { flagService } from '../../flags/flag.service';
-import { telemetry } from '../../helper/telemetry.utils';
-import { userService } from '../../user/user-service';
-import { passwordHasher } from '../lib/password-hasher';
-import { authenticationServiceHooks as hooks } from './hooks';
-import { Provider } from './hooks/authentication-service-hooks';
+    ActivepiecesError,
+    ApEnvironment,
+    ApFlagId,
+    AuthenticationResponse,
+    ErrorCode,
+    isNil,
+    PlatformRole,
+    Project,
+    TelemetryEventName,
+    User,
+    UserId,
+    UserStatus,
+} from '@activepieces/shared'
+import { QueryFailedError } from 'typeorm'
+import { flagService } from '../../flags/flag.service'
+import { telemetry } from '../../helper/telemetry.utils'
+import { userService } from '../../user/user-service'
+import { passwordHasher } from '../lib/password-hasher'
+import { authenticationServiceHooks as hooks } from './hooks'
+import { Provider } from './hooks/authentication-service-hooks'
 
 export const authenticationService = {
-  async signUp(params: SignUpParams): Promise<AuthenticationResponse> {
-    await hooks.get().preSignUp(params);
-    const user = await createUser(params);
+    async signUp(params: SignUpParams): Promise<AuthenticationResponse> {
+        await hooks.get().preSignUp(params)
+        const user = await createUser(params)
 
-    return this.signUpResponse({
-      user,
-      referringUserId: params.referringUserId,
-    });
-  },
+        return this.signUpResponse({
+            user,
+            referringUserId: params.referringUserId,
+        })
+    },
 
-  async signIn(request: SignInParams): Promise<AuthenticationResponse> {
-    await hooks.get().preSignIn(request);
-    const user = await userService.getByPlatformAndEmail({
-      platformId: request.platformId,
-      email: request.email,
-    });
+    async signIn(request: SignInParams): Promise<AuthenticationResponse> {
+        await hooks.get().preSignIn(request)
+        const user = await userService.getByPlatformAndEmail({
+            platformId: request.platformId,
+            email: request.email,
+        })
 
-    assertUserIsAllowedToSignIn(user);
+        assertUserIsAllowedToSignIn(user)
 
-    await assertPasswordMatches({
-      requestPassword: request.password,
-      userPassword: user.password,
-    });
+        await assertPasswordMatches({
+            requestPassword: request.password,
+            userPassword: user.password,
+        })
 
-    return this.signInResponse({
-      user,
-    });
-  },
+        return this.signInResponse({
+            user,
+        })
+    },
 
-  async federatedAuthn(
-    params: FederatedAuthnParams
-  ): Promise<AuthenticationResponse> {
-    const existingUser = await userService.getByPlatformAndEmail({
-      platformId: params.platformId,
-      email: params.email,
-    });
-    if (existingUser) {
-      return this.signInResponse({
-        user: existingUser,
-      });
-    }
-    const newUser = {
-      email: params.email,
-      verified: params.verified,
-      firstName: params.firstName,
-      lastName: params.lastName,
-      trackEvents: true,
-      newsLetter: true,
-      password: await cryptoUtils.generateRandomPassword(),
-      platformId: params.platformId,
-    };
+    async federatedAuthn(
+        params: FederatedAuthnParams,
+    ): Promise<AuthenticationResponse> {
+        const existingUser = await userService.getByPlatformAndEmail({
+            platformId: params.platformId,
+            email: params.email,
+        })
+        if (existingUser) {
+            return this.signInResponse({
+                user: existingUser,
+            })
+        }
+        const newUser = {
+            email: params.email,
+            verified: params.verified,
+            firstName: params.firstName,
+            lastName: params.lastName,
+            trackEvents: true,
+            newsLetter: true,
+            password: await cryptoUtils.generateRandomPassword(),
+            platformId: params.platformId,
+        }
 
-    return this.signUp({
-      ...newUser,
-      provider: Provider.FEDERATED,
-    });
-  },
+        return this.signUp({
+            ...newUser,
+            provider: Provider.FEDERATED,
+        })
+    },
 
-  async signUpResponse({
-    user,
-    referringUserId,
-  }: SignUpResponseParams): Promise<AuthenticationResponse> {
-    const authnResponse = await hooks.get().postSignUp({
-      user,
-      referringUserId,
-    });
-    await flagService.save({ id: ApFlagId.USER_CREATED, value: true });
+    async signUpResponse({
+        user,
+        referringUserId,
+    }: SignUpResponseParams): Promise<AuthenticationResponse> {
+        const authnResponse = await hooks.get().postSignUp({
+            user,
+            referringUserId,
+        })
+        await flagService.save({ id: ApFlagId.USER_CREATED, value: true })
 
-    const userWithoutPassword = removePasswordPropFromUser(authnResponse.user);
+        const userWithoutPassword = removePasswordPropFromUser(authnResponse.user)
 
-    await sendTelemetry({
-      user,
-      project: authnResponse.project,
-    });
-    await saveNewsLetterSubscriber(user);
+        await sendTelemetry({
+            user,
+            project: authnResponse.project,
+        })
+        await saveNewsLetterSubscriber(user)
 
-    return {
-      ...userWithoutPassword,
-      token: authnResponse.token,
-      projectId: authnResponse.project.id,
-      projectRole: authnResponse.projectRole,
-    };
-  },
+        return {
+            ...userWithoutPassword,
+            token: authnResponse.token,
+            projectId: authnResponse.project.id,
+            projectRole: authnResponse.projectRole,
+        }
+    },
 
-  async signInResponse({
-    user,
-  }: SignInResponseParams): Promise<AuthenticationResponse> {
-    const authnResponse = await hooks.get().postSignIn({
-      user,
-    });
+    async signInResponse({
+        user,
+    }: SignInResponseParams): Promise<AuthenticationResponse> {
+        const authnResponse = await hooks.get().postSignIn({
+            user,
+        })
 
-    const userWithoutPassword = removePasswordPropFromUser(authnResponse.user);
+        const userWithoutPassword = removePasswordPropFromUser(authnResponse.user)
 
-    return {
-      ...userWithoutPassword,
-      token: authnResponse.token,
-      projectId: authnResponse.project.id,
-      projectRole: authnResponse.projectRole,
-    };
-  },
-};
+        return {
+            ...userWithoutPassword,
+            token: authnResponse.token,
+            projectId: authnResponse.project.id,
+            projectRole: authnResponse.projectRole,
+        }
+    },
+}
 
 const createUser = async (params: SignUpParams): Promise<User> => {
-  try {
-    const newUser: NewUser = {
-      email: params.email,
-      platformRole: PlatformRole.MEMBER,
-      verified: params.verified,
-      status: UserStatus.ACTIVE,
-      firstName: params.firstName,
-      lastName: params.lastName,
-      trackEvents: params.trackEvents,
-      newsLetter: params.newsLetter,
-      password: params.password,
-      platformId: params.platformId,
-    };
+    try {
+        const newUser: NewUser = {
+            email: params.email,
+            platformRole: PlatformRole.MEMBER,
+            verified: params.verified,
+            status: UserStatus.ACTIVE,
+            firstName: params.firstName,
+            lastName: params.lastName,
+            trackEvents: params.trackEvents,
+            newsLetter: params.newsLetter,
+            password: params.password,
+            platformId: params.platformId,
+        }
 
-    return await userService.create(newUser);
-  } catch (e: unknown) {
-    if (e instanceof QueryFailedError) {
-      logger.error(e);
-      throw new ActivepiecesError({
-        code: ErrorCode.EXISTING_USER,
-        params: {
-          email: params.email,
-          platformId: params.platformId,
-        },
-      });
+        return await userService.create(newUser)
     }
+    catch (e: unknown) {
+        if (e instanceof QueryFailedError) {
+            logger.error(e)
+            throw new ActivepiecesError({
+                code: ErrorCode.EXISTING_USER,
+                params: {
+                    email: params.email,
+                    platformId: params.platformId,
+                },
+            })
+        }
 
-    throw e;
-  }
-};
+        throw e
+    }
+}
 
 const assertUserIsAllowedToSignIn: (
-  user: User | null
+    user: User | null
 ) => asserts user is User = (user) => {
-  if (isNil(user)) {
-    throw new ActivepiecesError({
-      code: ErrorCode.INVALID_CREDENTIALS,
-      params: null,
-    });
-  }
-  if (user.status === UserStatus.INACTIVE) {
-    throw new ActivepiecesError({
-      code: ErrorCode.USER_IS_INACTIVE,
-      params: {
-        email: user.email,
-      },
-    });
-  }
-  if (!user.verified) {
-    throw new ActivepiecesError({
-      code: ErrorCode.EMAIL_IS_NOT_VERIFIED,
-      params: {
-        email: user.email,
-      },
-    });
-  }
-};
+    if (isNil(user)) {
+        throw new ActivepiecesError({
+            code: ErrorCode.INVALID_CREDENTIALS,
+            params: null,
+        })
+    }
+    if (user.status === UserStatus.INACTIVE) {
+        throw new ActivepiecesError({
+            code: ErrorCode.USER_IS_INACTIVE,
+            params: {
+                email: user.email,
+            },
+        })
+    }
+    if (!user.verified) {
+        throw new ActivepiecesError({
+            code: ErrorCode.EMAIL_IS_NOT_VERIFIED,
+            params: {
+                email: user.email,
+            },
+        })
+    }
+}
 
 const assertPasswordMatches = async ({
-  requestPassword,
-  userPassword,
-}: AssertPasswordsMatchParams): Promise<void> => {
-  const passwordMatches = await passwordHasher.compare(
     requestPassword,
-    userPassword
-  );
+    userPassword,
+}: AssertPasswordsMatchParams): Promise<void> => {
+    const passwordMatches = await passwordHasher.compare(
+        requestPassword,
+        userPassword,
+    )
 
-  if (!passwordMatches) {
-    throw new ActivepiecesError({
-      code: ErrorCode.INVALID_CREDENTIALS,
-      params: null,
-    });
-  }
-};
+    if (!passwordMatches) {
+        throw new ActivepiecesError({
+            code: ErrorCode.INVALID_CREDENTIALS,
+            params: null,
+        })
+    }
+}
 
 const removePasswordPropFromUser = (user: User): Omit<User, 'password'> => {
-  const { password: _, ...filteredUser } = user;
-  return filteredUser;
-};
+    const { password: _, ...filteredUser } = user
+    return filteredUser
+}
 
 const sendTelemetry = async ({
-  user,
-  project,
+    user,
+    project,
 }: SendTelemetryParams): Promise<void> => {
-  try {
-    await telemetry.identify(user, project.id);
+    try {
+        await telemetry.identify(user, project.id)
 
-    await telemetry.trackProject(project.id, {
-      name: TelemetryEventName.SIGNED_UP,
-      payload: {
-        userId: user.id,
-        email: user.email,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        projectId: project.id,
-      },
-    });
-  } catch (e) {
-    logger.warn({ name: 'AuthenticationService#sendTelemetry', error: e });
-  }
-};
+        await telemetry.trackProject(project.id, {
+            name: TelemetryEventName.SIGNED_UP,
+            payload: {
+                userId: user.id,
+                email: user.email,
+                firstName: user.firstName,
+                lastName: user.lastName,
+                projectId: project.id,
+            },
+        })
+    }
+    catch (e) {
+        logger.warn({ name: 'AuthenticationService#sendTelemetry', error: e })
+    }
+}
 
 async function saveNewsLetterSubscriber(user: User): Promise<void> {
-  const isPlatformUserOrNotSubscribed =
+    const isPlatformUserOrNotSubscribed =
     (!isNil(user.platformId) &&
       !flagService.isCloudPlatform(user.platformId)) ||
-    !user.newsLetter;
-  const environment = system.get(SharedSystemProp.ENVIRONMENT);
-  if (
-    isPlatformUserOrNotSubscribed ||
+    !user.newsLetter
+    const environment = system.get(SharedSystemProp.ENVIRONMENT)
+    if (
+        isPlatformUserOrNotSubscribed ||
     environment !== ApEnvironment.PRODUCTION
-  ) {
-    return;
-  }
-  try {
-    const response = await fetch(
-      'https://us-central1-activepieces-b3803.cloudfunctions.net/addContact',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email: user.email }),
-      }
-    );
-    return await response.json();
-  } catch (error) {
-    logger.warn(error);
-  }
+    ) {
+        return
+    }
+    try {
+        const response = await fetch(
+            'https://us-central1-activepieces-b3803.cloudfunctions.net/addContact',
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ email: user.email }),
+            },
+        )
+        return await response.json()
+    }
+    catch (error) {
+        logger.warn(error)
+    }
 }
 type SendTelemetryParams = {
-  user: User;
-  project: Project;
-};
+    user: User
+    project: Project
+}
 
-type NewUser = Omit<User, 'id' | 'created' | 'updated'>;
+type NewUser = Omit<User, 'id' | 'created' | 'updated'>
 
 type SignUpParams = {
-  email: string;
-  password: string;
-  firstName: string;
-  lastName: string;
-  trackEvents: boolean;
-  newsLetter: boolean;
-  verified: boolean;
-  platformId: string | null;
-  referringUserId?: string;
-  provider: Provider;
-};
+    email: string
+    password: string
+    firstName: string
+    lastName: string
+    trackEvents: boolean
+    newsLetter: boolean
+    verified: boolean
+    platformId: string | null
+    referringUserId?: string
+    provider: Provider
+}
 
 type SignInParams = {
-  email: string;
-  password: string;
-  platformId: string | null;
-  provider: Provider;
-};
+    email: string
+    password: string
+    platformId: string | null
+    provider: Provider
+}
 
 type AssertPasswordsMatchParams = {
-  requestPassword: string;
-  userPassword: string;
-};
+    requestPassword: string
+    userPassword: string
+}
 
 type FederatedAuthnParams = {
-  email: string;
-  verified: boolean;
-  firstName: string;
-  lastName: string;
-  platformId: string | null;
-};
+    email: string
+    verified: boolean
+    firstName: string
+    lastName: string
+    platformId: string | null
+}
 
 type SignUpResponseParams = {
-  user: User;
-  referringUserId?: UserId;
-};
+    user: User
+    referringUserId?: UserId
+}
 
 type SignInResponseParams = {
-  user: User;
-};
+    user: User
+}

--- a/packages/server/api/src/app/ee/authentication/federated-authn/federated-authn-service.ts
+++ b/packages/server/api/src/app/ee/authentication/federated-authn/federated-authn-service.ts
@@ -35,8 +35,8 @@ export const federatedAuthnService = {
         return authenticationService.federatedAuthn({
             email: idToken.email,
             verified: true,
-            firstName: idToken.firstName?? 'john',
-            lastName: idToken.lastName?? 'doe',
+            firstName: idToken.firstName ?? 'john',
+            lastName: idToken.lastName ?? 'doe',
             platformId: platformIdFromEmail,
         })
     },

--- a/packages/server/api/src/app/ee/authentication/saml-authn/authn-sso-saml-service.ts
+++ b/packages/server/api/src/app/ee/authentication/saml-authn/authn-sso-saml-service.ts
@@ -31,8 +31,8 @@ const getOrCreateUser = async (platformId: string, attributes: SamlAttributes): 
     }
     return userService.create({
         email,
-        firstName: attributes.firstName??'john',
-        lastName: attributes.lastName??'doe',
+        firstName: attributes.firstName ?? 'john',
+        lastName: attributes.lastName ?? 'doe',
         password: await cryptoUtils.generateRandomPassword(),
         trackEvents: true,
         newsLetter: false,

--- a/packages/server/api/src/app/pieces/piece-metadata-service/hooks/piece-filtering.ts
+++ b/packages/server/api/src/app/pieces/piece-metadata-service/hooks/piece-filtering.ts
@@ -13,7 +13,7 @@ const pieceFilterKeys = [{
     weight: 1,
 }]
 
-const suggestionLimit = 3
+const suggestionLimit = 10
 export const filterPiecesBasedUser = async ({
     searchQuery,
     pieces,


### PR DESCRIPTION
## What does this PR do?

The Angular version of the pieces search result included the suggestions (displayed as chips).
It was useful as the results included information such as:
- the action|trigger relevant to the search query
- the name of the piece

The Reactjs re-write no longer includes the suggestions and forces the user to perform an additional click on the piece name to reveal all available actions. To make matter worse, image that the list of available actions is very long and now the user needs to scroll down and find the search query relevant piece.

With this PR the piece search result view will list all piece suggestions together for any given piece (under with piece name), rendering the suggestions as clickable list items. This should simplify selection.

### Current UI: 

![Screenshot 2024-09-20 at 16 14 45](https://github.com/user-attachments/assets/a0ee7364-ab02-4229-93c2-9918b49b63e8)


### Suggested UI:

![Screenshot 2024-09-20 at 16 03 17](https://github.com/user-attachments/assets/f939cff9-44d4-471e-8861-e98cce7965e9)

