### PR TITLE
fix: allow context.run.stop() to be called without params

### DIFF
--- a/packages/engine/src/lib/handler/piece-executor.ts
+++ b/packages/engine/src/lib/handler/piece-executor.ts
@@ -177,9 +177,9 @@ const createConnectionManager = ({ engineToken, projectId, hookResponse, apiUrl 
 }
 
 function createStopHook(hookResponse: HookResponse): StopHook {
-    return (req: StopHookParams) => {
+    return (req?: StopHookParams) => {
         hookResponse.stopped = true
-        hookResponse.stopResponse = req
+        hookResponse.stopResponse = req ?? { response: {} }
     }
 }
 

--- a/packages/pieces/community/framework/src/lib/context.ts
+++ b/packages/pieces/community/framework/src/lib/context.ts
@@ -87,7 +87,7 @@ export type StopHookParams = {
   response: StopResponse;
 };
 
-export type StopHook = (params: StopHookParams) => void;
+export type StopHook = (params?: StopHookParams) => void;
 
 export type PauseHookParams = {
   pauseMetadata: PauseMetadata;


### PR DESCRIPTION
## What does this PR do?

In the [Flow Control documentation](https://www.activepieces.com/docs/developers/piece-reference/flow-control), it says Stop Flow can be called without a Response.

```ts
context.run.stop();
```

This PR makes this possible. Previously, you still had to call it with at least an empty response.

```ts
context.run.stop({
  response: {}
});
```
Fixes # (issue)

