### PR TITLE
feat(dust): allow creation of empty conversations

### DIFF
--- a/packages/pieces/community/dust/package.json
+++ b/packages/pieces/community/dust/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-dust",
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/packages/pieces/community/dust/src/lib/common.ts
+++ b/packages/pieces/community/dust/src/lib/common.ts
@@ -104,7 +104,7 @@ export async function getConversationContent(
   if (conversationStatus != 'succeeded') {
     if (retries >= maxRetries) {
       throw new Error(
-        `Could not load conversation ${conversationId} after ${timeout}s - consider increasing timeout value`
+        `Could not load conversation ${conversationId} after ${timeout}s - ${conversationStatus} - consider increasing timeout value`
       );
     } else {
       throw new Error(


### PR DESCRIPTION
## What does this PR do?

Allow creation of empty conversations, i.e. placeholders before adding fragments (files) and a query later