### PR TITLE
feat(Activepieces): add base url and api key secret

### DIFF
--- a/packages/pieces/community/activepieces/package.json
+++ b/packages/pieces/community/activepieces/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-activepieces",
-  "version": "0.0.5"
+  "version": "0.1.0"
 }

--- a/packages/pieces/community/activepieces/src/index.ts
+++ b/packages/pieces/community/activepieces/src/index.ts
@@ -1,4 +1,8 @@
-import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import {
+  createPiece,
+  PieceAuth,
+  Property,
+} from '@activepieces/pieces-framework';
 import { createProject } from './lib/actions/create-project';
 import { createProjectMember } from './lib/actions/create-project-member';
 import { listProject } from './lib/actions/list-project';
@@ -13,10 +17,20 @@ Activepieces Platform API is available under the Platform Edition.
 You can get your API Key from the Platform Dashboard.
 `;
 
-export const activePieceAuth = PieceAuth.SecretText({
-  displayName: 'API Key',
+export const activePieceAuth = PieceAuth.CustomAuth({
   description: markdown,
   required: true,
+  props: {
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API Key',
+      required: true,
+    }),
+    baseApiUrl: Property.ShortText({
+      displayName: 'Base URL',
+      required: true,
+      defaultValue: 'https://cloud.activepieces.com/api/v1',
+    }),
+  },
 });
 
 export const activepieces = createPiece({
@@ -26,7 +40,7 @@ export const activepieces = createPiece({
   auth: activePieceAuth,
   minimumSupportedRelease: '0.9.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/activepieces.png',
-  authors: ["doskyft","abuaboud"],
+  authors: ['doskyft', 'abuaboud', 'AdamSelene'],
   actions: [
     createProject,
     updateProject,
@@ -37,7 +51,3 @@ export const activepieces = createPiece({
   ],
   triggers: [],
 });
-
-export const config = {
-  baseApiUrl: 'https://cloud.activepieces.com/api/v1',
-};

--- a/packages/pieces/community/activepieces/src/index.ts
+++ b/packages/pieces/community/activepieces/src/index.ts
@@ -21,14 +21,14 @@ export const activePieceAuth = PieceAuth.CustomAuth({
   description: markdown,
   required: true,
   props: {
-    apiKey: PieceAuth.SecretText({
-      displayName: 'API Key',
-      required: true,
-    }),
     baseApiUrl: Property.ShortText({
       displayName: 'Base URL',
       required: true,
       defaultValue: 'https://cloud.activepieces.com/api/v1',
+    }),
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API Key',
+      required: true,
     }),
   },
 });

--- a/packages/pieces/community/activepieces/src/lib/actions/create-project-member.ts
+++ b/packages/pieces/community/activepieces/src/lib/actions/create-project-member.ts
@@ -4,7 +4,7 @@ import {
   httpClient,
   HttpMethod,
 } from '@activepieces/pieces-common';
-import { activePieceAuth, config } from '../../index';
+import { activePieceAuth } from '../../index';
 
 export const createProjectMember = createAction({
   name: 'create_project_member',
@@ -63,10 +63,10 @@ export const createProjectMember = createAction({
   async run({ propsValue, auth }) {
     const response = await httpClient.sendRequest<string[]>({
       method: HttpMethod.POST,
-      url: `${config.baseApiUrl}/project-members`,
+      url: `${auth.baseApiUrl}/project-members`,
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: auth,
+        token: auth.apiKey,
       },
       body: {
         email: propsValue['email'],

--- a/packages/pieces/community/activepieces/src/lib/actions/create-project.ts
+++ b/packages/pieces/community/activepieces/src/lib/actions/create-project.ts
@@ -4,7 +4,7 @@ import {
   httpClient,
   HttpMethod,
 } from '@activepieces/pieces-common';
-import { activePieceAuth, config } from '../../index';
+import { activePieceAuth } from '../../index';
 
 export const createProject = createAction({
   name: 'create_project',
@@ -21,10 +21,10 @@ export const createProject = createAction({
   async run({ propsValue, auth }) {
     const response = await httpClient.sendRequest<string[]>({
       method: HttpMethod.POST,
-      url: `${config.baseApiUrl}/projects`,
+      url: `${auth.baseApiUrl}/projects`,
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: auth,
+        token: auth.apiKey,
       },
       body: {
         displayName: propsValue['display_name'],

--- a/packages/pieces/community/activepieces/src/lib/actions/delete-project-member.ts
+++ b/packages/pieces/community/activepieces/src/lib/actions/delete-project-member.ts
@@ -4,7 +4,7 @@ import {
   httpClient,
   HttpMethod,
 } from '@activepieces/pieces-common';
-import { activePieceAuth, config } from '../../index';
+import { activePieceAuth } from '../../index';
 
 export const deleteProjectMember = createAction({
   name: 'delete_project_member',
@@ -20,10 +20,10 @@ export const deleteProjectMember = createAction({
   async run({ propsValue, auth }) {
     const response = await httpClient.sendRequest<string[]>({
       method: HttpMethod.DELETE,
-      url: `${config.baseApiUrl}/project-members/${propsValue['id']}`,
+      url: `${auth.baseApiUrl}/project-members/${propsValue['id']}`,
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: auth,
+        token: auth.apiKey,
       },
     });
 

--- a/packages/pieces/community/activepieces/src/lib/actions/list-project-member.ts
+++ b/packages/pieces/community/activepieces/src/lib/actions/list-project-member.ts
@@ -4,7 +4,7 @@ import {
   httpClient,
   HttpMethod,
 } from '@activepieces/pieces-common';
-import { activePieceAuth, config } from '../../index';
+import { activePieceAuth } from '../../index';
 
 export const listProjectMember = createAction({
   name: 'list_project_member',
@@ -20,10 +20,10 @@ export const listProjectMember = createAction({
   async run({ propsValue, auth }) {
     const response = await httpClient.sendRequest<string[]>({
       method: HttpMethod.GET,
-      url: `${config.baseApiUrl}/project-members`,
+      url: `${auth.baseApiUrl}/project-members`,
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: auth,
+        token: auth.apiKey,
       },
       queryParams: {
         projectId: propsValue['project_id'],

--- a/packages/pieces/community/activepieces/src/lib/actions/list-project.ts
+++ b/packages/pieces/community/activepieces/src/lib/actions/list-project.ts
@@ -4,7 +4,7 @@ import {
   httpClient,
   HttpMethod,
 } from '@activepieces/pieces-common';
-import { activePieceAuth, config } from '../../index';
+import { activePieceAuth } from '../../index';
 
 export const listProject = createAction({
   name: 'list_project',
@@ -15,10 +15,10 @@ export const listProject = createAction({
   async run({ auth }) {
     const response = await httpClient.sendRequest<string[]>({
       method: HttpMethod.GET,
-      url: `${config.baseApiUrl}/projects`,
+      url: `${auth.baseApiUrl}/projects`,
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: auth,
+        token: auth.apiKey,
       },
     });
 

--- a/packages/pieces/community/activepieces/src/lib/actions/update-project.ts
+++ b/packages/pieces/community/activepieces/src/lib/actions/update-project.ts
@@ -4,7 +4,7 @@ import {
   httpClient,
   HttpMethod,
 } from '@activepieces/pieces-common';
-import { activePieceAuth, config } from '../../index';
+import { activePieceAuth } from '../../index';
 
 export const updateProject = createAction({
   name: 'update_project',
@@ -53,10 +53,10 @@ export const updateProject = createAction({
   async run({ propsValue, auth }) {
     const response = await httpClient.sendRequest<string[]>({
       method: HttpMethod.POST,
-      url: `${config.baseApiUrl}/projects/${propsValue['id']}`,
+      url: `${auth.baseApiUrl}/projects/${propsValue['id']}`,
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: auth,
+        token: auth.apiKey,
       },
       body: {
         displayName: propsValue['display_name'],


### PR DESCRIPTION
This is a pr from @AdamSelene, https://github.com/activepieces/activepieces/pull/5710, but I needed to modify properties' order in the piece auth prop.