### PR TITLE
fix: handle case when input.auth is undefined

### DIFF
--- a/packages/engine/src/lib/handler/piece-executor.ts
+++ b/packages/engine/src/lib/handler/piece-executor.ts
@@ -49,7 +49,7 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
 
         stepOutput.input = censoredInput
 
-        const { processedInput, errors } = await constants.variableService.applyProcessorsAndValidators(resolvedInput, pieceAction.props, piece.auth)
+        const { processedInput, errors } = await constants.variableService.applyProcessorsAndValidators(resolvedInput, pieceAction.props, piece.auth, pieceAction.requireAuth)
         if (Object.keys(errors).length > 0) {
             throw new Error(JSON.stringify(errors))
         }

--- a/packages/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/engine/src/lib/helper/trigger-helper.ts
@@ -40,7 +40,7 @@ export const triggerHelper = {
             apiUrl: constants.internalApiUrl,
             projectId: params.projectId,
             engineToken: params.engineToken,
-        }).applyProcessorsAndValidators(resolvedInput, trigger.props, piece.auth)
+        }).applyProcessorsAndValidators(resolvedInput, trigger.props, piece.auth, trigger.requireAuth)
 
         if (Object.keys(errors).length > 0) {
             throw new Error(JSON.stringify(errors))

--- a/packages/engine/src/lib/variables/variable-service.ts
+++ b/packages/engine/src/lib/variables/variable-service.ts
@@ -212,7 +212,7 @@ export class VariableService {
         const processedInput = { ...resolvedInput }
         const errors: VariableValidationError = {}
 
-        const isAuthenticationProperty = auth && (auth.type === PropertyType.CUSTOM_AUTH || auth.type === PropertyType.OAUTH2) && !isNil(auth.props)
+        const isAuthenticationProperty = auth && (auth.type === PropertyType.CUSTOM_AUTH || auth.type === PropertyType.OAUTH2) && !isNil(auth.props) && !isNil(resolvedInput[AUTHENTICATION_PROPERTY_NAME])
         if (isAuthenticationProperty) {
             const { processedInput: authProcessedInput, errors: authErrors } = await this.applyProcessorsAndValidators(
                 resolvedInput[AUTHENTICATION_PROPERTY_NAME],

--- a/packages/engine/src/lib/variables/variable-service.ts
+++ b/packages/engine/src/lib/variables/variable-service.ts
@@ -208,16 +208,18 @@ export class VariableService {
         resolvedInput: StaticPropsValue<PiecePropertyMap>,
         props: InputPropertyMap,
         auth: PieceAuthProperty | undefined,
+        requireAuth: boolean,
     ): Promise<{ processedInput: StaticPropsValue<PiecePropertyMap>, errors: VariableValidationError }> {
         const processedInput = { ...resolvedInput }
         const errors: VariableValidationError = {}
 
-        const isAuthenticationProperty = auth && (auth.type === PropertyType.CUSTOM_AUTH || auth.type === PropertyType.OAUTH2) && !isNil(auth.props) && !isNil(resolvedInput[AUTHENTICATION_PROPERTY_NAME])
+        const isAuthenticationProperty = auth && (auth.type === PropertyType.CUSTOM_AUTH || auth.type === PropertyType.OAUTH2) && !isNil(auth.props) && requireAuth
         if (isAuthenticationProperty) {
             const { processedInput: authProcessedInput, errors: authErrors } = await this.applyProcessorsAndValidators(
                 resolvedInput[AUTHENTICATION_PROPERTY_NAME],
                 auth.props,
                 undefined,
+                requireAuth,
             )
             processedInput.auth = authProcessedInput
             if (Object.keys(authErrors).length > 0) {

--- a/packages/engine/test/services/variable-service.test.ts
+++ b/packages/engine/test/services/variable-service.test.ts
@@ -300,7 +300,7 @@ describe('Variable Service', () => {
                 required: true,
             }),
         }
-        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None())
+        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None(), false)
         expect(processedInput).toEqual({
             base64: null,
             base64WithMime: new ApFile('unknown.png', Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAiAAAAC4CAYAAADaI1cbAAA0h0lEQVR4AezdA5AlPx7A8Zxt27Z9r5PB2SidWTqbr26S9Hr/tm3btu3723eDJD3r15ec17vzXr+Z', 'base64'), 'png'),
@@ -321,8 +321,9 @@ describe('Variable Service', () => {
                 displayName: 'File',
                 required: true,
             }),
+        
         }
-        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None())
+        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None(), false)
         expect(processedInput.file).toBeDefined()
         expect(processedInput.file.extension).toBe('svg')
         expect(processedInput.file.filename).toBe('logo.svg')
@@ -350,7 +351,7 @@ describe('Variable Service', () => {
                 required: false,
             }),
         }
-        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None())
+        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None(), false)
 
         expect(processedInput.file).toBeDefined()
         expect(processedInput.file.extension).toBe('html')
@@ -373,13 +374,13 @@ describe('Variable Service', () => {
                 age: '12',
             },
         }
-        const props = {
+  
+        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, {
             price: Property.Number({
                 displayName: 'Price',
                 required: true,
             }),
-        }
-        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.CustomAuth({
+        }, PieceAuth.CustomAuth({
             required: true,
             props: {
                 age: Property.Number({
@@ -387,7 +388,7 @@ describe('Variable Service', () => {
                     required: true,
                 }),
             },
-        }))
+        }), true)
 
         expect(processedInput).toEqual({
             auth: {
@@ -411,7 +412,7 @@ describe('Variable Service', () => {
         const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.CustomAuth({
             required: true,
             props: {},
-        }))
+        }), false)
 
         expect(processedInput).toEqual({
             price: 0,
@@ -465,7 +466,7 @@ describe('Variable Service', () => {
                     required: true,
                 }),
             },
-        }))
+        }), true)
         expect(processedInput).toEqual({
             price: NaN,
             emptyStringNumber: NaN,
@@ -550,7 +551,7 @@ describe('Variable Service', () => {
                 required: true,
             }),
         }
-        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None())
+        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None(), false)
         expect(processedInput).toEqual({
             Asana1: '2012-02-22T02:06:58.147Z',
             Asana2: '2012-02-22T00:00:00.000Z',
@@ -597,7 +598,7 @@ describe('Variable Service', () => {
                 required: true,
             }),
         }
-        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None())
+        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None(), false)
 
         expect(processedInput).toEqual({
             invalidDateString: undefined,
@@ -638,7 +639,7 @@ describe('Variable Service', () => {
                     validators: [Validators.email],
                 }),
             },
-        }))
+        }), true)
         expect(errors).toEqual({
             email: ['Invalid Email format: ap@dev&com'],
             auth: {
@@ -658,7 +659,7 @@ describe('Variable Service', () => {
                 validators: [Validators.url, Validators.oneOf(['activepieces.com', 'www.activepieces.com'])],
             }),
         }
-        const { errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None())
+        const { errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None(), false)
         expect(errors).toEqual({
             text: [
                 'The value: activepiecescom. is not a valid URL',
@@ -690,7 +691,7 @@ describe('Variable Service', () => {
                 validators: [Validators.maxLength(10)],
             }),
         }
-        const { errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None())
+        const { errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None(), false)
         expect(errors).toEqual({
             text1: ['The value: short must be at least 10 characters'],
             text2: ['The value: short1234678923145678 must be less than 10 characters'],
@@ -724,7 +725,7 @@ describe('Variable Service', () => {
                 validators: [Validators.minValue(10)],
             }),
         }
-        const { errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None())
+        const { errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.None(), false)
         expect(errors).toEqual({
             value1: ['The value: 40 must be 2 or less', 'The 40 is not a valid value, valid choices are: 1,2'],
             value2: ['The value: 4 must be at least 5 and less than or equal 10'],

--- a/packages/engine/test/services/variable-service.test.ts
+++ b/packages/engine/test/services/variable-service.test.ts
@@ -397,6 +397,27 @@ describe('Variable Service', () => {
         })
         expect(errors).toEqual({})
     })
+    
+    it('should not error if auth configured, but no auth provided in input', async () => {
+        const input = {
+            price: '0',
+        }
+        const props = {
+            price: Property.Number({
+                displayName: 'Price',
+                required: true,
+            }),
+        }
+        const { processedInput, errors } = await variableService.applyProcessorsAndValidators(input, props, PieceAuth.CustomAuth({
+            required: true,
+            props: {},
+        }))
+
+        expect(processedInput).toEqual({
+            price: 0,
+        })
+        expect(errors).toEqual({})
+    })
 
     it('should return errors for invalid number', async () => {
         const input = {

--- a/packages/pieces/community/framework/package.json
+++ b/packages/pieces/community/framework/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.7.34",
+  "version": "0.7.35",
   "type": "commonjs"
 }

--- a/packages/pieces/community/framework/src/lib/trigger/trigger.ts
+++ b/packages/pieces/community/framework/src/lib/trigger/trigger.ts
@@ -57,6 +57,7 @@ type BaseTriggerParams<
   name: string
   displayName: string
   description: string
+  requireAuth?: boolean
   auth?: PieceAuth
   props: TriggerProps
   type: TS
@@ -95,6 +96,7 @@ export class ITrigger<
     public readonly name: string,
     public readonly displayName: string,
     public readonly description: string,
+    public readonly requireAuth: boolean,
     public readonly props: TriggerProps,
     public readonly type: TS,
     public readonly handshakeConfiguration: WebhookHandshakeConfiguration,
@@ -128,6 +130,7 @@ export const createTrigger = <
         params.name,
         params.displayName,
         params.description,
+        params.requireAuth ?? true,
         params.props,
         params.type,
         params.handshakeConfiguration ?? { strategy: WebhookHandshakeStrategy.NONE },
@@ -146,6 +149,7 @@ export const createTrigger = <
         params.name,
         params.displayName,
         params.description,
+        params.requireAuth ?? true,
         params.props,
         params.type,
         { strategy: WebhookHandshakeStrategy.NONE },
@@ -164,6 +168,7 @@ export const createTrigger = <
         params.name,
         params.displayName,
         params.description,
+        params.requireAuth ?? true,
         params.props,
         params.type,
         { strategy: WebhookHandshakeStrategy.NONE },


### PR DESCRIPTION
## What does this PR do?

If you have auth configured on a piece, but have an action where auth is not defined _and_ `requireAuth: false`, the action is executed with input that is without an `auth` attribute. Executing the action will result in an exception

```
TypeError: Cannot convert undefined or null to object
```

Fixes # (issue)

