### PR TITLE
fix: tab order of the sign in field

### DIFF
--- a/packages/react-ui/src/features/authentication/components/sign-in-form.tsx
+++ b/packages/react-ui/src/features/authentication/components/sign-in-form.tsx
@@ -105,6 +105,7 @@ const SignInForm: React.FC = () => {
                 type="text"
                 placeholder={'email@example.com'}
                 className="rounded-sm"
+                tabIndex={1}
               />
               <FormMessage />
             </FormItem>
@@ -133,6 +134,7 @@ const SignInForm: React.FC = () => {
                 type="password"
                 placeholder={'********'}
                 className="rounded-sm"
+                tabIndex={2}
               />
               <FormMessage />
             </FormItem>
@@ -146,6 +148,7 @@ const SignInForm: React.FC = () => {
         <Button
           loading={isPending}
           onClick={(e) => form.handleSubmit(onSubmit)(e)}
+          tabIndex={3}
         >
           {t('Sign in')}
         </Button>


### PR DESCRIPTION
## What does this PR do?

Fixing an annoyance where tabbing from username field will go to Forget password? link first. Now it goes from username field, to password, to sign in button.

Fixes # (issue)

