### PR TITLE
chore: add sentry tracing to ai proxy

### DIFF
--- a/packages/server/shared/src/lib/exception-handler.ts
+++ b/packages/server/shared/src/lib/exception-handler.ts
@@ -24,11 +24,13 @@ export const initializeSentry = () => {
     }
 }
 
+export const sentry = sentryDsn ? Sentry : null
+
 export const exceptionHandler = {
-    handle: (e: unknown): void => {
+    handle: (e: unknown, context?: any): void => {
         logger.error(e)
         if (sentryDsn) {
-            Sentry.captureException(e)
+            Sentry.captureException(e, context)
         }
     },
 }


### PR DESCRIPTION
## What does this PR do?

This adds temporary tracing to the AI proxy. Will refactor it soon to a `Tracer` interface to hide Sentry as an implementation detail instead of exposing it this way.