### PR TITLE
fix(date-helper): extend dayjs with advancedFormat to support X format

### DIFF
--- a/packages/pieces/community/date-helper/package.json
+++ b/packages/pieces/community/date-helper/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-date-helper",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/packages/pieces/community/date-helper/src/lib/actions/add-subtract-date.ts
+++ b/packages/pieces/community/date-helper/src/lib/actions/add-subtract-date.ts
@@ -1,5 +1,6 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import {
   optionalTimeFormats,
   parseDate,
@@ -7,6 +8,8 @@ import {
   timeFormatDescription,
   timeParts,
 } from '../common';
+
+dayjs.extend(advancedFormat);
 
 export const addSubtractDateAction = createAction({
   name: 'add_subtract_date',

--- a/packages/pieces/community/date-helper/src/lib/actions/date-difference.ts
+++ b/packages/pieces/community/date-helper/src/lib/actions/date-difference.ts
@@ -1,6 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import {
   optionalTimeFormats,
   timeFormat,
@@ -10,6 +11,7 @@ import {
 } from '../common';
 
 dayjs.extend(duration);
+dayjs.extend(advancedFormat);
 
 export const dateDifferenceAction = createAction({
   name: 'date_difference',

--- a/packages/pieces/community/date-helper/src/lib/actions/extract-date-parts.ts
+++ b/packages/pieces/community/date-helper/src/lib/actions/extract-date-parts.ts
@@ -1,5 +1,4 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
-import dayjs from 'dayjs';
 import {
   optionalTimeFormats,
   timeFormat,

--- a/packages/pieces/community/date-helper/src/lib/actions/format-date.ts
+++ b/packages/pieces/community/date-helper/src/lib/actions/format-date.ts
@@ -8,10 +8,11 @@ import {
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
-
+dayjs.extend(advancedFormat);
 
 export const formatDateAction = createAction({
   name: 'format_date',

--- a/packages/pieces/community/date-helper/src/lib/actions/get-current-date.ts
+++ b/packages/pieces/community/date-helper/src/lib/actions/get-current-date.ts
@@ -2,6 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import {
   optionalTimeFormats,
   timeFormat,
@@ -11,6 +12,7 @@ import {
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
+dayjs.extend(advancedFormat);
 
 export const getCurrentDate = createAction({
   name: 'get_current_date',

--- a/packages/pieces/community/date-helper/src/lib/actions/next-day-of-week.ts
+++ b/packages/pieces/community/date-helper/src/lib/actions/next-day-of-week.ts
@@ -12,9 +12,11 @@ import {
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
+dayjs.extend(advancedFormat);
 
 export const nextDayofWeek = createAction({
   name: 'next_day_of_week',

--- a/packages/pieces/community/date-helper/src/lib/actions/next-day-of-year.ts
+++ b/packages/pieces/community/date-helper/src/lib/actions/next-day-of-year.ts
@@ -12,9 +12,11 @@ import {
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
+dayjs.extend(advancedFormat);
 
 export const nextDayofYear = createAction({
   name: 'next_day_of_year',


### PR DESCRIPTION
## What does this PR do?

It was missing the unix epoch format, `X`. When running against 0.1.0 of date-helper piece, the result is just X

Fixes # (issue)

