### PR TITLE
feat: add store to property context

### DIFF
--- a/packages/engine/src/lib/helper/piece-helper.ts
+++ b/packages/engine/src/lib/helper/piece-helper.ts
@@ -21,6 +21,7 @@ import {
 import { EngineConstants } from '../handler/context/engine-constants'
 import { FlowExecutorContext } from '../handler/context/flow-execution-context'
 import { createFlowsContext } from '../services/flows.service'
+import { createContextStore } from '../services/storage.service'
 import { variableService } from '../variables/variable-service'
 import { pieceLoader } from './piece-loader'
 
@@ -54,6 +55,12 @@ export const pieceHelper = {
                     externalId: constants.externalProjectId,
                 },
                 flows: createFlowsContext(constants),
+                store: createContextStore({
+                    apiUrl: constants.internalApiUrl,
+                    prefix: '',
+                    flowId: constants.flowId,
+                    engineToken: params.engineToken,
+                }),
             }
 
             if (property.type === PropertyType.DYNAMIC) {

--- a/packages/pieces/community/framework/src/lib/context.ts
+++ b/packages/pieces/community/framework/src/lib/context.ts
@@ -117,6 +117,7 @@ export type PropertyContext = {
   };
   searchValue?: string;
   flows: FlowsContext;
+  store: Store;
 };
 
 export type ServerContext = {


### PR DESCRIPTION
## What does this PR do?

Currently, when you define a `Property.DynamicProperties`, the `ctx` you get yielded doesn't have access to the store. This PR adds the store so that you can use it while creating the dynamic properties.

Fixes # (issue)

