### PR TITLE
fix: symlink permissions error on windows

### DIFF
--- a/packages/server/shared/src/lib/package-manager.ts
+++ b/packages/server/shared/src/lib/package-manager.ts
@@ -124,7 +124,7 @@ const replaceRelativeSystemLinkWithAbsolute = async (filePath: string) => {
             const realPath = await fs.realpath(filePath)
             logger.info({ realPath, filePath }, '[link]')
             await fs.unlink(filePath)
-            await fs.symlink(realPath, filePath, 'dir')
+            await fs.symlink(realPath, filePath, 'junction')
         }
     }
     catch (error) {


### PR DESCRIPTION
## What does this PR do?

Fixes a symlink permission error when developing a piece on Windows. See for example https://github.com/nodejs/node/issues/18518#issuecomment-513866491.
