### PR TITLE
fix: uncontrolled to controlled input warning in SignInForm component

### DIFF
--- a/packages/react-ui/src/features/authentication/components/sign-in-form.tsx
+++ b/packages/react-ui/src/features/authentication/components/sign-in-form.tsx
@@ -38,6 +38,10 @@ type SignInSchema = Static<typeof SignInSchema>;
 const SignInForm: React.FC = () => {
   const form = useForm<SignInSchema>({
     resolver: typeboxResolver(SignInSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
     mode: 'onChange',
   });
 


### PR DESCRIPTION
## What does this PR do?

Fixes a warning on local-dev indicating that an input element is switching from uncontrolled to controlled state by providing a `defaultValues` object to useForm hook which ensures all form input values are initialized.

![Screenshot 2024-10-07 at 09 56 30](https://github.com/user-attachments/assets/3bd13854-d9f0-41ff-b4f3-88e0141dfe86)


Reference material [here](https://react.dev/reference/react-dom/components/input#controlling-an-input-with-a-state-variable).