### PR TITLE
fix: long step name label overlapping the step node

### DIFF
--- a/packages/react-ui/src/app/builder/flow-canvas/nodes/step-node.tsx
+++ b/packages/react-ui/src/app/builder/flow-canvas/nodes/step-node.tsx
@@ -190,10 +190,9 @@ const ApStepNode = React.memo(({ data }: { data: ApNode['data'] }) => {
       {...(!openPieceSelector ? listeners : {})}
     >
       <div
-        className="absolute text-accent-foreground text-sm opacity-0 transition-all duration-300 group-hover:opacity-100 "
+        className="absolute text-accent-foreground text-sm opacity-0 transition-all duration-300 group-hover:opacity-100 left-full ml-3"
         style={{
           top: `${AP_NODE_SIZE.stepNode.height / 2 - 12}px`,
-          right: `-${AP_NODE_SIZE.stepNode.width / 5}px`,
         }}
       >
         {data.step?.name}


### PR DESCRIPTION
## What does this PR do?

Long step names grow into the step node. By using `left: 100%` instead of negative `right`, we ensure the label grows to the right.

<img width="1436" alt="Markup 2024-10-07 at 12 16 23" src="https://github.com/user-attachments/assets/0df8c996-0073-4cb5-bd53-de5021637a15">

Fixes # (issue)

