### PR TITLE
fix: show non-empty page on approval

### DIFF
--- a/packages/server/api/src/app/flows/flow-run/flow-run-controller.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-controller.ts
@@ -58,7 +58,7 @@ export const flowRunController: FastifyPluginCallbackTypebox = (
         },
     )
 
-    app.all('/:id/requests/:requestId', ResumeFlowRunRequest, async (req) => {
+    app.all('/:id/requests/:requestId', ResumeFlowRunRequest, async (req, reply) => {
         const headers = req.headers as Record<string, string>
         const queryParams = req.query as Record<string, string>
         await flowRunService.addToQueue({
@@ -72,6 +72,9 @@ export const flowRunController: FastifyPluginCallbackTypebox = (
             checkRequestId: true,
             progressUpdateType: ProgressUpdateType.TEST_FLOW,
             executionType: ExecutionType.RESUME,
+        })
+        await reply.send({
+            message: 'Your response has been recorded. You can close this page now.',
         })
     })
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes empty page when user clicks an approval link.

Before:
<img width="1004" alt="Screenshot 2024-10-10 at 5 00 02 PM" src="https://github.com/user-attachments/assets/d6b74f76-d35c-4cb0-8ade-8bc62f31380c">

After:
<img width="923" alt="Screenshot 2024-10-10 at 5 25 42 PM" src="https://github.com/user-attachments/assets/c3c4b420-1f59-47ed-b39e-177db4719183">
