### PR TITLE
fix: error logging in pieces-builder

### DIFF
--- a/packages/server/api/src/app/pieces/piece-metadata-service/pieces-builder.ts
+++ b/packages/server/api/src/app/pieces/piece-metadata-service/pieces-builder.ts
@@ -29,7 +29,7 @@ async function handleFileChange(piecePackageName: string, io: Server): Promise<v
         io.emit(WebsocketClientEvent.REFRESH_PIECE)
     }
     catch (error) {
-        logger.info(chalk.red.bold('Failed to run build process...'), error)
+        logger.info(error, chalk.red.bold('Failed to run build process...'))
     }
     finally {
         mutex.release()


### PR DESCRIPTION
## What does this PR do?

It fixes incorrect usage of pino, caught error was not shown.
