### PR TITLE
feat(file-helper): Add Encoding property to createFile action

### DIFF
--- a/packages/pieces/community/file-helper/package.json
+++ b/packages/pieces/community/file-helper/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-file-helper",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/packages/pieces/community/file-helper/src/lib/actions/create-file.ts
+++ b/packages/pieces/community/file-helper/src/lib/actions/create-file.ts
@@ -4,15 +4,62 @@ export const createFile = createAction({
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
   name: 'createFile',
   displayName: 'Create file',
-  description: 'Create file from UTF-8 content',
+  description: 'Create file from content',
   props: {
     content: Property.LongText({ displayName: 'Content', required: true }),
     fileName: Property.ShortText({ displayName: 'File name', required: true }),
+    encoding: Property.StaticDropdown({
+      displayName: 'Encoding',
+      required: true,
+      defaultValue: 'utf8',
+      options: {
+        // Checkout https://nodejs.org/api/buffer.html#buffers-and-character-encodings
+        options: [
+          {
+            value: 'ascii',
+            label: 'ASCII',
+          },
+          {
+            value: 'utf8',
+            label: 'UTF-8',
+          },
+          {
+            value: 'utf16le',
+            label: 'UTF-16LE',
+          },
+          {
+            value: 'ucs2',
+            label: 'UCS-2',
+          },
+          {
+            value: 'base64',
+            label: 'Base64',
+          },
+          {
+            value: 'base64url',
+            label: 'Base64 URL',
+          },
+          {
+            value: 'latin1',
+            label: 'Latin1',
+          },
+          {
+            value: 'binary',
+            label: 'Binary',
+          },
+          {
+            value: 'hex',
+            label: 'Hex',
+          },
+        ],
+      },
+    }),
+
   },
   async run({ propsValue, files }) {
     const fileUrl = await files.write({
       fileName: propsValue.fileName,
-      data: Buffer.from(propsValue.content, 'utf-8'),
+      data: Buffer.from(propsValue.content, propsValue.encoding as BufferEncoding),
     });
     return { fileName: propsValue.fileName, url: fileUrl };
   },

--- a/packages/pieces/community/file-helper/src/lib/actions/create-file.ts
+++ b/packages/pieces/community/file-helper/src/lib/actions/create-file.ts
@@ -57,9 +57,10 @@ export const createFile = createAction({
 
   },
   async run({ propsValue, files }) {
+    const encoding = propsValue.encoding as BufferEncoding ?? 'utf8';
     const fileUrl = await files.write({
       fileName: propsValue.fileName,
-      data: Buffer.from(propsValue.content, propsValue.encoding as BufferEncoding),
+      data: Buffer.from(propsValue.content, encoding),
     });
     return { fileName: propsValue.fileName, url: fileUrl };
   },


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds an encoding property to the `createFile` action. We need this to convert base64 to a file. The default is still utf8, so no flows should break because of this PR.

Fixes # (issue)

ANNOUNCEMENT=true

