### PR TITLE
feat(core): add pieceConfig mechanism

### DIFF
--- a/packages/pieces/community/framework/src/lib/context.ts
+++ b/packages/pieces/community/framework/src/lib/context.ts
@@ -143,6 +143,7 @@ export type BaseActionContext<
   generateResumeUrl: (params: {
     queryParams: Record<string, string>
   }) => string;
+  pieceConfig: object;
 };
 
 type BeginExecutionActionContext<

--- a/packages/pieces/community/http/src/lib/actions/send-http-request-action.ts
+++ b/packages/pieces/community/http/src/lib/actions/send-http-request-action.ts
@@ -197,7 +197,7 @@ export const httpSendRequestAction = createAction({
         } else {
           proxyUrl = `http://${proxySettings.proxy_host}:${proxySettings.proxy_port}`;
         }
-  
+
         const httpsAgent = new HttpsProxyAgent(proxyUrl)
         const axiosClient = axios.create({
           httpsAgent,

--- a/packages/server/shared/src/lib/system/system-prop.ts
+++ b/packages/server/shared/src/lib/system/system-prop.ts
@@ -16,7 +16,7 @@ export enum AppSystemProp {
     ENCRYPTION_KEY = 'ENCRYPTION_KEY',
     EXECUTION_DATA_RETENTION_DAYS = 'EXECUTION_DATA_RETENTION_DAYS',
     JWT_SECRET = 'JWT_SECRET',
-    
+
     /**
      * @deprecated this now can be done from the platform admin page.
      */
@@ -95,7 +95,7 @@ export enum SharedSystemProp  {
     MAX_FILE_SIZE_MB = 'MAX_FILE_SIZE_MB',
 
     FRONTEND_URL = 'FRONTEND_URL',
-        
+
     // These are shared as the app is using the engine as a dependency for now.
     CACHE_PATH = 'CACHE_PATH',
     EXECUTION_MODE = 'EXECUTION_MODE',
@@ -103,6 +103,7 @@ export enum SharedSystemProp  {
     SANDBOX_MEMORY_LIMIT = 'SANDBOX_MEMORY_LIMIT',
     SANDBOX_PROPAGATED_ENV_VARS = 'SANDBOX_PROPAGATED_ENV_VARS',
     PIECES_SOURCE = 'PIECES_SOURCE',
+    PIECES_CONFIG = 'PIECES_CONFIG',
     ENGINE_EXECUTABLE_PATH = 'ENGINE_EXECUTABLE_PATH',
     ENRICH_ERROR_CONTEXT = 'ENRICH_ERROR_CONTEXT',
 
@@ -112,13 +113,14 @@ export enum SharedSystemProp  {
     LOKI_URL = 'LOKI_URL',
     LOKI_USERNAME = 'LOKI_USERNAME',
 
+
 }
 
 export enum WorkerSystemProps {
     FLOW_WORKER_CONCURRENCY = 'FLOW_WORKER_CONCURRENCY',
     SCHEDULED_WORKER_CONCURRENCY = 'SCHEDULED_WORKER_CONCURRENCY',
     SCHEDULED_POLLING_COUNT = 'SCHEDULED_POLLING_COUNT',
-    
+
     // TODO: This is currently undocumented and used for testing purposes. Please document or remove as necessary.
     POLLING_POOL_SIZE = 'POLLING_POOL_SIZE',
     WORKER_TOKEN = 'WORKER_TOKEN',

--- a/packages/server/shared/src/lib/system/system.ts
+++ b/packages/server/shared/src/lib/system/system.ts
@@ -82,7 +82,7 @@ const systemPropDefaultValues: Partial<Record<SystemProp, string>> = {
     [AppSystemProp.MAX_CONCURRENT_JOBS_PER_PROJECT]: '100',
     [AppSystemProp.PROJECT_RATE_LIMITER_ENABLED]: 'false',
     [AppSystemProp.DEV_PIECES]: '',
-
+    [SharedSystemProp.PIECES_CONFIG]: '{}',
 }
 
 export const system = {

--- a/packages/server/worker/src/lib/engine/isolate/sandbox/isolate-sandbox.ts
+++ b/packages/server/worker/src/lib/engine/isolate/sandbox/isolate-sandbox.ts
@@ -199,6 +199,7 @@ export class IsolateSandbox {
             AP_PAUSED_FLOW_TIMEOUT_DAYS: system.getOrThrow(SharedSystemProp.PAUSED_FLOW_TIMEOUT_DAYS),
             AP_BASE_CODE_DIRECTORY: IsolateSandbox.sandboxCodesCachePath,
             AP_MAX_FILE_SIZE_MB: system.getOrThrow(SharedSystemProp.MAX_FILE_SIZE_MB),
+            AP_PIECES_CONFIG: system.getOrThrow(SharedSystemProp.PIECES_CONFIG),
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

- add `AP_PIECES_CONFIG` env var to store piece-specific configuration - e.g. `{"@activepieces/piece-http": {"someKey": "someValue"}}`
- inject `pieceConfig` in actions' `run()` method