### PR TITLE
fix: Add Release Candidate Version to /v1/flags API Response (#5607)

### DIFF
--- a/packages/server/api/src/app/flags/flag.module.ts
+++ b/packages/server/api/src/app/flags/flag.module.ts
@@ -18,6 +18,10 @@ export const flagController: FastifyPluginAsyncTypebox = async (app) => {
             logLevel: 'silent',
         },
         async (request: FastifyRequest) => {
+            // Retrieve the release candidate version from environment variables
+            const releaseCandidateVersion = process.env.RELEASE_CANDIDATE_VERSION || 'unknown';
+            flags.push({ id: 'releaseCandidateVersion', value: releaseCandidateVersion });
+
             const flags = await flagService.getAll()
             const flagsMap: Record<string, unknown> = flags.reduce(
                 (map, flag) => ({ ...map, [flag.id as string]: flag.value }),


### PR DESCRIPTION
## What does this PR do?

This PR fixes issue #5607 by updating the `/v1/flags` endpoint to display the release candidate version. It retrieves the version from an environment variable (`RELEASE_CANDIDATE_VERSION`) and appends it to the flags list returned by the API. This ensures that the release candidate version is included in the response along with other feature flags.


Fixes #5607 

