### PR TITLE
feat: add basic confluence integration

### DIFF
--- a/packages/pieces/community/confluence/.eslintrc.json
+++ b/packages/pieces/community/confluence/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/confluence/README.md
+++ b/packages/pieces/community/confluence/README.md
@@ -1,0 +1,7 @@
+# pieces-confluence
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-confluence` to build the library.

--- a/packages/pieces/community/confluence/package.json
+++ b/packages/pieces/community/confluence/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-confluence",
+  "version": "0.1.0"
+}

--- a/packages/pieces/community/confluence/project.json
+++ b/packages/pieces/community/confluence/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-confluence",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/confluence/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/confluence",
+        "tsConfig": "packages/pieces/community/confluence/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/confluence/package.json",
+        "main": "packages/pieces/community/confluence/src/index.ts",
+        "assets": [
+          "packages/pieces/community/confluence/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/confluence/src/index.ts
+++ b/packages/pieces/community/confluence/src/index.ts
@@ -1,0 +1,36 @@
+import { createPiece, PieceAuth, Property } from "@activepieces/pieces-framework";
+import { getPageContent } from "./lib/actions/get-page-content";
+import { PieceCategory } from "@activepieces/shared";
+
+export const confluenceAuth = PieceAuth.CustomAuth({
+  description: 'Please refer to this guide to get your api credentials: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account',
+  required: true,
+  props: {
+    username: PieceAuth.SecretText({
+      displayName: 'Account Email',
+      required: true,
+      description: 'Account email for basic auth',
+    }),
+    password: PieceAuth.SecretText({
+      displayName: 'API token',
+      required: true,
+      description: 'API token for basic auth',
+    }),
+    confluenceDomain: Property.ShortText({
+      displayName: 'Confluence Domain',
+      required: true,
+      description: 'Example value - https://your-domain.atlassian.net',
+    }),
+  },
+});
+
+export const confluence = createPiece({
+  displayName: "Confluence",
+  auth: confluenceAuth,
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: "https://cdn.activepieces.com/pieces/confluence.png",
+  authors: ["geekyme"],
+  actions: [getPageContent],
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  triggers: [],
+});

--- a/packages/pieces/community/confluence/src/lib/actions/get-page-content.ts
+++ b/packages/pieces/community/confluence/src/lib/actions/get-page-content.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { confluenceAuth } from '../..';
+
+export const getPageContent = createAction({
+  name: 'getPageContent',
+  displayName: 'Get Page Content',
+  description: 'Confluence Cloud REST API v2',
+  auth: confluenceAuth,
+  props: {
+    pageId: Property.ShortText({
+      displayName: 'Page ID',
+      description: 'Get this from the page URL of your Confluence Cloud',
+      required: true
+    }),
+  },
+  async run(context) {
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.GET,
+      url: `${context.auth.confluenceDomain}/wiki/api/v2/pages/${context.propsValue.pageId}`,
+      queryParams: {
+        "body-format": "storage"
+      },
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: context.auth.username,
+        password: context.auth.password
+      }
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/confluence/tsconfig.json
+++ b/packages/pieces/community/confluence/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/confluence/tsconfig.lib.json
+++ b/packages/pieces/community/confluence/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -127,6 +127,9 @@
       "@activepieces/piece-clockodo": [
         "packages/pieces/community/clockodo/src/index.ts"
       ],
+      "@activepieces/piece-confluence": [
+        "packages/pieces/community/confluence/src/index.ts"
+      ],
       "@activepieces/piece-connections": [
         "packages/pieces/community/connections/src/index.ts"
       ],


### PR DESCRIPTION
## Add Confluence Integration to Activepieces
This PR adds confluence to activepieces. The authentication uses a Custom Auth which accepts the account email, the api token tagged to that email, and the confluence domain.

Please follow the atlassian guidelines to add the logo to your CDN. https://atlassian.design/foundations/logos. 

### Actions
The integration includes the following actions:

- Get Page Content

### Screenshots

Connecting / reconnecting credentials:
<img width="749" alt="Screenshot 2024-10-18 at 10 32 11 PM" src="https://github.com/user-attachments/assets/9e639fe5-0022-42a4-a55c-9548437015e5">

Get Page Content
<img width="906" alt="Screenshot 2024-10-18 at 10 27 52 PM" src="https://github.com/user-attachments/assets/ddf84a13-a3c4-4519-9f1b-71870da3c3ee">
