### PR TITLE
fix: truncate long project names in switcher button

### DIFF
--- a/packages/react-ui/src/features/projects/components/project-switcher.tsx
+++ b/packages/react-ui/src/features/projects/components/project-switcher.tsx
@@ -65,7 +65,7 @@ function ProjectSwitcher() {
           aria-label="Select a project"
           className="w-[200px] justify-between"
         >
-          {currentProject?.displayName}
+          <span className="truncate">{currentProject?.displayName}</span>
           <CaretSortIcon className="ml-auto size-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>


### PR DESCRIPTION
## What does this PR do?

Before

<img width="828" alt="Screenshot on 2024-10-22 at 13-20-09" src="https://github.com/user-attachments/assets/12669732-486f-4db5-b1bc-65d8c0b637f9">

After

<img width="914" alt="Screenshot on 2024-10-22 at 13-16-31" src="https://github.com/user-attachments/assets/1482d9a3-e0d6-4f7d-87a7-85371df7d278">


Fixes # (issue)

