### PR TITLE
fix: facebook pages markdown rendering

### DIFF
--- a/packages/pieces/community/facebook-pages/package.json
+++ b/packages/pieces/community/facebook-pages/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-facebook-pages",
-  "version": "0.1.7"
+  "version": "0.1.8"
 }

--- a/packages/pieces/community/facebook-pages/src/index.ts
+++ b/packages/pieces/community/facebook-pages/src/index.ts
@@ -12,7 +12,8 @@ To Obtain a Client ID and Client Secret:
 2. Register for a Facebook Developer account.
 3. Once login, click "Make a new app" button.
 4. Select "Other" for use cases.
-5. Choose "Business" as the type of app. 6. Provide application details: custom name and associated email.
+5. Choose "Business" as the type of app. 
+6. Provide application details: custom name and associated email.
 7. Once your application is created, you need to add a new "product".
 8. Configure a new product of type "Facebook Login Settings".
 9. Default settings should be fine, you only need to provide the Redirect URL in "Valid OAuth Redirect URIs" and your domain name in "Allowed Domains for the JavaScript SDK".


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Issue:

In the below screenshot, the numbering in the markdown is affected due to a missing newline. 

<img width="708" alt="Screenshot 2024-10-24 at 10 49 31" src="https://github.com/user-attachments/assets/9cdbd688-54bf-4439-9571-ef2342e38e8c">

Fixes # (issue)

This PR resolves the above issue by adding a new line to the markdown.

