### PR TITLE
feat: support proxy binary data

### DIFF
--- a/packages/server/api/src/app/ai/ai-provider-proxy.ts
+++ b/packages/server/api/src/app/ai/ai-provider-proxy.ts
@@ -59,7 +59,7 @@ export const proxyController: FastifyPluginCallbackTypebox = (
             const data = responseContentType?.includes('application/json')
                 ? await response.json()
                 : responseContentType?.includes('application/octet-stream')
-                    ? await response.blob()
+                    ? await Buffer.from(await response.arrayBuffer())
                     : responseContentType?.includes('audio/') || responseContentType?.includes('video/') || responseContentType?.includes('image/')
                         ? Buffer.from(await response.arrayBuffer())
                         : await response.text()


### PR DESCRIPTION
## What does this PR do?

The proxy now serializes the response based on the original response `content-type` header supporting binary data.
