### PR TITLE
feat(google-sheets): allow using headers as keys

### DIFF
--- a/packages/pieces/community/google-sheets/package.json
+++ b/packages/pieces/community/google-sheets/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.10.12"
+  "version": "0.11.0"
 }

--- a/packages/pieces/community/google-sheets/package.json
+++ b/packages/pieces/community/google-sheets/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.10.11"
+  "version": "0.10.12"
 }

--- a/packages/pieces/community/google-sheets/src/lib/actions/find-row-by-num.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/find-row-by-num.ts
@@ -16,6 +16,7 @@ export const findRowByNumAction = createAction({
       description: 'The row number to get from the sheet',
       required: true,
     }),
+    headersAsKeys: googleSheetsCommon.headersAsKeys,
   },
   async run({ propsValue, auth }) {
     const sheetName = await googleSheetsCommon.findSheetName(
@@ -30,6 +31,7 @@ export const findRowByNumAction = createAction({
       spreadSheetId: propsValue['spreadsheet_id'],
       rowIndex_s: propsValue['rowNumber'],
       rowIndex_e: propsValue['rowNumber'],
+      headersAsKeys: propsValue['headersAsKeys'],
     });
     return row[0];
   },

--- a/packages/pieces/community/google-sheets/src/lib/actions/get-rows.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/get-rows.ts
@@ -22,6 +22,7 @@ async function getRows(
   memKey: string,
   groupSize: number,
   startRow: number,
+  headersAsKeys: boolean,
   testing: boolean
 ) {
   const sheetName = await googleSheetsCommon.findSheetName(
@@ -58,6 +59,7 @@ async function getRows(
     spreadSheetId: spreadsheetId,
     rowIndex_s: startingRow,
     rowIndex_e: endRow - 1,
+    headersAsKeys: headersAsKeys,
   });
 
   if (row.length == 0) {
@@ -111,6 +113,7 @@ export const getRowsAction = createAction({
       defaultValue: 1,
       validators: [Validators.minValue(1)],
     }),
+    headersAsKeys: googleSheetsCommon.headersAsKeys,
   },
   async run({ store, auth, propsValue }) {
     try {
@@ -122,6 +125,7 @@ export const getRowsAction = createAction({
         propsValue['memKey'],
         propsValue['groupSize'],
         propsValue['startRow'],
+        propsValue['headersAsKeys'],
         false
       );
     } catch (error) {
@@ -142,6 +146,7 @@ export const getRowsAction = createAction({
         propsValue['memKey'],
         propsValue['groupSize'],
         propsValue['startRow'],
+        propsValue['headersAsKeys'],
         true
       );
     } catch (error) {

--- a/packages/pieces/community/google-sheets/src/lib/actions/insert-multiple-rows.action.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/insert-multiple-rows.action.ts
@@ -1,127 +1,144 @@
 import { googleSheetsAuth } from '../../';
 import {
-	createAction,
-	DynamicPropsValue,
-	OAuth2PropertyValue,
-	Property,
+  createAction,
+  DynamicPropsValue,
+  OAuth2PropertyValue,
+  Property,
 } from '@activepieces/pieces-framework';
 import {
-    Dimension,
-    getHeaders,
-    googleSheetsCommon,
-    labelToColumn,
-    ValueInputOption,
+  Dimension,
+  getHeaders,
+  googleSheetsCommon,
+  ValueInputOption,
 } from '../common/common';
-import { getAccessTokenOrThrow } from '@activepieces/pieces-common';
 import { getWorkSheetName } from '../triggers/helpers';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'googleapis-common';
 
 export const insertMultipleRowsAction = createAction({
-	auth: googleSheetsAuth,
-	name: 'google-sheets-insert-multiple-rows',
-	displayName: 'Insert Multiple Rows',
-	description: 'Add one or more new rows in a specific spreadsheet.',
-	props: {
-		spreadsheet_id: googleSheetsCommon.spreadsheet_id,
-		include_team_drives: googleSheetsCommon.include_team_drives,
-		sheet_id: googleSheetsCommon.sheet_id,
-		as_string: Property.Checkbox({
-			displayName: 'As String',
-			description:
-				'Inserted values that are dates and formulas will be entered as strings and have no effect',
-			required: false,
-		}),
-		values: Property.DynamicProperties({
-			displayName: 'Values',
-			description: 'The values to insert.',
-			required: true,
-			refreshers: ['sheet_id', 'spreadsheet_id'],
-			props: async ({ auth, sheet_id, spreadsheet_id }) => {
-				if (
-					!auth ||
-					(spreadsheet_id ?? '').toString().length === 0 ||
-					(sheet_id ?? '').toString().length === 0
-				) {
-					return {};
-				}
+  auth: googleSheetsAuth,
+  name: 'google-sheets-insert-multiple-rows',
+  displayName: 'Insert Multiple Rows',
+  description: 'Add one or more new rows in a specific spreadsheet.',
+  props: {
+    spreadsheet_id: googleSheetsCommon.spreadsheet_id,
+    include_team_drives: googleSheetsCommon.include_team_drives,
+    sheet_id: googleSheetsCommon.sheet_id,
+    as_string: Property.Checkbox({
+      displayName: 'As String',
+      description:
+        'Inserted values that are dates and formulas will be entered as strings and have no effect',
+      required: false,
+    }),
+    values: Property.DynamicProperties({
+      displayName: 'Values',
+      description: 'The values to insert.',
+      required: true,
+      refreshers: ['sheet_id', 'spreadsheet_id'],
+      props: async ({ auth, sheet_id, spreadsheet_id }) => {
+        if (
+          !auth ||
+          (spreadsheet_id ?? '').toString().length === 0 ||
+          (sheet_id ?? '').toString().length === 0
+        ) {
+          return {};
+        }
 
-				const fields: DynamicPropsValue = {};
+        const fields: DynamicPropsValue = {};
 
-				const sheetId = Number(sheet_id)
+        const sheetId = Number(sheet_id);
 
-				const authentication = auth as OAuth2PropertyValue;
-				const values = await googleSheetsCommon.getValues(
-					spreadsheet_id as unknown as string,
-					getAccessTokenOrThrow(authentication),
-					sheetId,
-				);
+        const authentication = auth as OAuth2PropertyValue;
 
-				const firstRow = values?.[0]?.values ?? [];
-				const columns: {
-					[key: string]: any;
-				} = {};
-				for (const key in firstRow) {
-					columns[key] = Property.ShortText({
-						displayName: firstRow[key].toString(),
-						description: firstRow[key].toString(),
-						required: false,
-						defaultValue: '',
-					});
-				}
+        const sheetName = await getWorkSheetName(
+          authentication,
+          spreadsheet_id as unknown as string,
+          sheetId
+        );
+        const headers = await getHeaders({
+          accessToken: authentication.access_token,
+          sheetName: sheetName,
+          spreadSheetId: spreadsheet_id as unknown as string,
+        });
 
-				fields['values'] = Property.Array({
-					displayName: 'Values',
-					required: false,
-					properties: columns,
-				});
+        const columns: {
+          [key: string]: any;
+        } = {};
+        for (const header of headers) {
+          columns[header] = Property.ShortText({
+            displayName: header.toString(),
+            description: header.toString(),
+            required: false,
+            defaultValue: '',
+          });
+        }
 
-				return fields;
-			},
-		}),
-	},
+        fields['values'] = Property.Array({
+          displayName: 'Values',
+          required: false,
+          properties: columns,
+        });
 
-	async run(context) {
-		const spreadSheetId = context.propsValue.spreadsheet_id;
-		const sheetId = context.propsValue.sheet_id;
-		const rowValuesInput: Record<string,string>[] = context.propsValue.values['values'];
-		const sheetName = await getWorkSheetName(context.auth, spreadSheetId, sheetId);
-		const headers =  await getHeaders({
-			accessToken: context.auth['access_token'],
-			sheetName: sheetName,
-			spreadSheetId: spreadSheetId,
-		});
+        return fields;
+      },
+    }),
+  },
 
-		const formattedValues=rowValuesInput.map(row=>{
-		  return  Object.keys(row).reduce((acc,column)=>{
-				const columnIndexInHeaders = headers.findIndex(header=> header === column);
-					if(columnIndexInHeaders > -1)
-					{
-						acc[columnIndexInHeaders]=row[column];
-					}
-					else {
-						acc[labelToColumn(column)]=row[column];
-					}
-				return acc;
-			},[] as string[])
-		})
+  async run(context) {
+    const spreadSheetId = context.propsValue.spreadsheet_id;
+    const sheetId = context.propsValue.sheet_id;
+    const rowValuesInput: Record<string, string>[] =
+      context.propsValue.values['values'];
 
-		const authClient = new OAuth2Client();
-		authClient.setCredentials(context.auth);
+    const sheetName = await getWorkSheetName(
+      context.auth,
+      spreadSheetId,
+      sheetId
+    );
+    const headers = await getHeaders({
+      accessToken: context.auth['access_token'],
+      sheetName: sheetName,
+      spreadSheetId: spreadSheetId,
+    });
 
-		const sheets = google.sheets({ version: 'v4', auth: authClient });
+    let formattedValues;
 
-		const response = await sheets.spreadsheets.values.append({
-			range: sheetName + '!A:A',
-			spreadsheetId: spreadSheetId,
-			valueInputOption: context.propsValue.as_string
-				? ValueInputOption.RAW
-				: ValueInputOption.USER_ENTERED,
-			requestBody: {
-				values: formattedValues,
-				majorDimension: Dimension.ROWS,
-			},
-		});
-		return response.data;
-	},
+    if (isArrayOfArrays(rowValuesInput)) {
+      formattedValues = rowValuesInput as any[];
+    } else {
+      formattedValues = rowValuesInput.map((row) => {
+        return Object.keys(row).reduce((acc, column) => {
+          const columnIndexInHeaders = headers.findIndex(
+            (header) => header === column
+          );
+          if (columnIndexInHeaders > -1) {
+            acc[columnIndexInHeaders] = row[column];
+          }
+          return acc;
+        }, [] as string[]);
+      });
+    }
+
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const sheets = google.sheets({ version: 'v4', auth: authClient });
+
+    const response = await sheets.spreadsheets.values.append({
+      range: sheetName + '!A:A',
+      spreadsheetId: spreadSheetId,
+      valueInputOption: context.propsValue.as_string
+        ? ValueInputOption.RAW
+        : ValueInputOption.USER_ENTERED,
+      requestBody: {
+        values: formattedValues,
+        majorDimension: Dimension.ROWS,
+      },
+    });
+    return response.data;
+  },
 });
+
+function isArrayOfArrays(value: any): boolean {
+  return Array.isArray(value) && value.every((item) => Array.isArray(item));
+}

--- a/packages/pieces/community/google-sheets/src/lib/actions/insert-row.action.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/insert-row.action.ts
@@ -1,10 +1,8 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import {
   Dimension,
-  getHeaders,
   googleSheetsCommon,
   objectToArray,
-  objectWithHeadersAsKeysToArray,
   stringifyArray,
   ValueInputOption,
 } from '../common/common';
@@ -33,38 +31,23 @@ export const insertRowAction = createAction({
       defaultValue: false,
     }),
     values: googleSheetsCommon.values,
-    headersAsKeys: googleSheetsCommon.headersAsKeysForInsert,
   },
   async run({ propsValue, auth }) {
+    const values = propsValue['values'];
     const sheetName = await googleSheetsCommon.findSheetName(
       auth['access_token'],
       propsValue['spreadsheet_id'],
       propsValue['sheet_id']
     );
-
-    const values = propsValue['values'];
     let formattedValues;
-    if (propsValue.first_row_headers || propsValue.headersAsKeys) {
-      if (propsValue.headersAsKeys) {
-        const headers = await getHeaders({
-          accessToken: auth['access_token'],
-          sheetName: sheetName,
-          spreadSheetId: propsValue['spreadsheet_id'],
-        });
-        formattedValues = await objectWithHeadersAsKeysToArray(headers, values['values']);
-      } else {
-        formattedValues = objectToArray(values);
-      }
-
-      // To prevent undefined values from being completely removed,
-      // we have to replace it with empty strings.
+    if (propsValue.first_row_headers) {
+      formattedValues = objectToArray(values);
       for (let i = 0; i < formattedValues.length; i++) {
         if (isNil(formattedValues[i])) formattedValues[i] = '';
       }
     } else {
       formattedValues = values['values'];
     }
-
     const res = await googleSheetsCommon.appendGoogleSheetValues({
       accessToken: auth['access_token'],
       majorDimension: Dimension.COLUMNS,

--- a/packages/pieces/community/google-sheets/src/lib/common/common.ts
+++ b/packages/pieces/community/google-sheets/src/lib/common/common.ts
@@ -98,15 +98,9 @@ export const googleSheetsCommon = {
     },
   }),
   headersAsKeys: Property.Checkbox({
-    displayName: 'Use headers as keys?',
-    description: 'Use headers as keys in the result (instead of A, B, C...)',
+    displayName: 'Use headers as Value Names',
+    description: 'Use headers as value names in the result (instead of A, B, C)',
     required: true,
-    defaultValue: false,
-  }),
-  headersAsKeysForInsert: Property.Checkbox({
-    displayName: 'Use headers as keys?',
-    description: 'The provided dynamic values are using headers as object keys (instead of A, B, C...)',
-    required: false,
     defaultValue: false,
   }),
   values: Property.DynamicProperties({
@@ -332,7 +326,7 @@ export async function getGoogleSheetRows(params: {
   for (let i = 0; i < response.body.values.length; i++) {
     const values: any = {};
     for (let j = 0; j < response.body.values[i].length; j++) {
-      const key = params.headersAsKeys ? headers[j] : columnToLabel(j);
+      const key = params.headersAsKeys ? headers[j] || columnToLabel(j)  : columnToLabel(j);
       if (Object.prototype.hasOwnProperty.call(values, key)) {
         throw new Error(`Duplicate column name "${key}"`);
       }


### PR DESCRIPTION
## What does this PR do?

This adds an option to the google sheet actions that allows getting or inserting objects where the sheet header is used as a key (instead of A, B, C...).

This allows for a better and easier compatibility with any other piece that deals with natural objects (DBs, code...).

I made this an optional setting to keep the backward compatibility and not break existing code.

As for the insert actions, I looked for a way to only show the new setting if the inserted data is defined as a custom/dynamic (because that would make more sense and be more intuitive), but I didn't find a way to do that, so it's always shown currently.