### PR TITLE
feat(google-sheets): action to replace all rows at once

### DIFF
--- a/packages/pieces/community/google-sheets/src/index.ts
+++ b/packages/pieces/community/google-sheets/src/index.ts
@@ -8,6 +8,7 @@ import { findRowsAction } from './lib/actions/find-rows';
 import { getRowsAction } from './lib/actions/get-rows';
 import { insertRowAction } from './lib/actions/insert-row.action';
 import { updateRowAction } from './lib/actions/update-row';
+import { replaceRowsAction } from './lib/actions/replace-rows';
 import { googleSheetsCommon } from './lib/common/common';
 import { newRowAddedTrigger } from './lib/triggers/new-row-added-webhook';
 import { newOrUpdatedRowTrigger } from './lib/triggers/new-or-updated-row.trigger';
@@ -53,6 +54,7 @@ export const googleSheets = createPiece({
 		clearSheetAction,
 		findRowByNumAction,
 		getRowsAction,
+		replaceRowsAction,
 		createCustomApiCallAction({
 			auth: googleSheetsAuth,
 			baseUrl: () => {

--- a/packages/pieces/community/google-sheets/src/lib/actions/clear-sheet.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/clear-sheet.ts
@@ -11,12 +11,7 @@ export const clearSheetAction = createAction({
     spreadsheet_id: googleSheetsCommon.spreadsheet_id,
     include_team_drives: googleSheetsCommon.include_team_drives,
     sheet_id: googleSheetsCommon.sheet_id,
-    is_first_row_headers: Property.Checkbox({
-      displayName: 'Is First row Headers?',
-      description: 'If the first row is headers',
-      required: true,
-      defaultValue: true,
-    }),
+    is_first_row_headers: googleSheetsCommon.first_row_headers,
   },
   async run({ propsValue, auth }) {
     await googleSheetsCommon.findSheetName(

--- a/packages/pieces/community/google-sheets/src/lib/actions/find-row-by-num.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/find-row-by-num.ts
@@ -16,6 +16,7 @@ export const findRowByNumAction = createAction({
       description: 'The row number to get from the sheet',
       required: true,
     }),
+    headersAsKeys: googleSheetsCommon.headersAsKeys,
   },
   async run({ propsValue, auth }) {
     const sheetName = await googleSheetsCommon.findSheetName(
@@ -30,6 +31,7 @@ export const findRowByNumAction = createAction({
       spreadSheetId: propsValue['spreadsheet_id'],
       rowIndex_s: propsValue['rowNumber'],
       rowIndex_e: propsValue['rowNumber'],
+      headersAsKeys: propsValue['headersAsKeys'],
     });
     return row[0];
   },

--- a/packages/pieces/community/google-sheets/src/lib/actions/get-rows.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/get-rows.ts
@@ -22,6 +22,7 @@ async function getRows(
   memKey: string,
   groupSize: number,
   startRow: number,
+  headersAsKeys: boolean,
   testing: boolean
 ) {
   const sheetName = await googleSheetsCommon.findSheetName(
@@ -58,6 +59,7 @@ async function getRows(
     spreadSheetId: spreadsheetId,
     rowIndex_s: startingRow,
     rowIndex_e: endRow - 1,
+    headersAsKeys: headersAsKeys,
   });
 
   if (row.length == 0) {
@@ -111,6 +113,7 @@ export const getRowsAction = createAction({
       defaultValue: 1,
       validators: [Validators.minValue(1)],
     }),
+    headersAsKeys: googleSheetsCommon.headersAsKeys,
   },
   async run({ store, auth, propsValue }) {
     try {
@@ -122,6 +125,7 @@ export const getRowsAction = createAction({
         propsValue['memKey'],
         propsValue['groupSize'],
         propsValue['startRow'],
+        propsValue['headersAsKeys'],
         false
       );
     } catch (error) {
@@ -142,6 +146,7 @@ export const getRowsAction = createAction({
         propsValue['memKey'],
         propsValue['groupSize'],
         propsValue['startRow'],
+        propsValue['headersAsKeys'],
         true
       );
     } catch (error) {

--- a/packages/pieces/community/google-sheets/src/lib/actions/insert-multiple-rows.action.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/insert-multiple-rows.action.ts
@@ -1,10 +1,5 @@
 import { googleSheetsAuth } from '../../';
-import {
-	createAction,
-	DynamicPropsValue,
-	OAuth2PropertyValue,
-	Property,
-} from '@activepieces/pieces-framework';
+import { createAction } from '@activepieces/pieces-framework';
 import {
     Dimension,
     getHeaders,
@@ -13,7 +8,6 @@ import {
     objectWithHeadersAsKeysToArray,
     ValueInputOption,
 } from '../common/common';
-import { getAccessTokenOrThrow } from '@activepieces/pieces-common';
 import { getWorkSheetName } from '../triggers/helpers';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'googleapis-common';
@@ -27,59 +21,8 @@ export const insertMultipleRowsAction = createAction({
 		spreadsheet_id: googleSheetsCommon.spreadsheet_id,
 		include_team_drives: googleSheetsCommon.include_team_drives,
 		sheet_id: googleSheetsCommon.sheet_id,
-		as_string: Property.Checkbox({
-			displayName: 'As String',
-			description:
-				'Inserted values that are dates and formulas will be entered as strings and have no effect',
-			required: false,
-		}),
-		values: Property.DynamicProperties({
-			displayName: 'Values',
-			description: 'The values to insert.',
-			required: true,
-			refreshers: ['sheet_id', 'spreadsheet_id'],
-			props: async ({ auth, sheet_id, spreadsheet_id }) => {
-				if (
-					!auth ||
-					(spreadsheet_id ?? '').toString().length === 0 ||
-					(sheet_id ?? '').toString().length === 0
-				) {
-					return {};
-				}
-
-				const fields: DynamicPropsValue = {};
-
-				const sheetId = Number(sheet_id)
-
-				const authentication = auth as OAuth2PropertyValue;
-				const values = await googleSheetsCommon.getValues(
-					spreadsheet_id as unknown as string,
-					getAccessTokenOrThrow(authentication),
-					sheetId,
-				);
-
-				const firstRow = values?.[0]?.values ?? [];
-				const columns: {
-					[key: string]: any;
-				} = {};
-				for (const key in firstRow) {
-					columns[key] = Property.ShortText({
-						displayName: firstRow[key].toString(),
-						description: firstRow[key].toString(),
-						required: false,
-						defaultValue: '',
-					});
-				}
-
-				fields['values'] = Property.Array({
-					displayName: 'Values',
-					required: false,
-					properties: columns,
-				});
-
-				return fields;
-			},
-		}),
+		as_string: googleSheetsCommon.as_string,
+		values: googleSheetsCommon.valuesForMultipleRows,
         headersAsKeys: googleSheetsCommon.headersAsKeysForInsert,
 	},
 

--- a/packages/pieces/community/google-sheets/src/lib/actions/insert-row.action.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/insert-row.action.ts
@@ -20,19 +20,9 @@ export const insertRowAction = createAction({
     spreadsheet_id: googleSheetsCommon.spreadsheet_id,
     include_team_drives: googleSheetsCommon.include_team_drives,
     sheet_id: googleSheetsCommon.sheet_id,
-    as_string: Property.Checkbox({
-      displayName: 'As String',
-      description:
-        'Inserted values that are dates and formulas will be entered strings and have no effect',
-      required: false,
-    }),
-    first_row_headers: Property.Checkbox({
-      displayName: 'Does the first row contain headers?',
-      description: 'If the first row is headers',
-      required: true,
-      defaultValue: false,
-    }),
-    values: googleSheetsCommon.values,
+    as_string: googleSheetsCommon.as_string,
+    first_row_headers: googleSheetsCommon.first_row_headers,
+    values: googleSheetsCommon.valuesForOneRow,
     headersAsKeys: googleSheetsCommon.headersAsKeysForInsert,
   },
   async run({ propsValue, auth }) {

--- a/packages/pieces/community/google-sheets/src/lib/actions/replace-rows.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/replace-rows.ts
@@ -1,0 +1,115 @@
+import { googleSheetsAuth } from '../../';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+    Dimension,
+    getHeaders,
+    googleSheetsCommon,
+    objectToArray,
+    objectWithHeadersAsKeysToArray,
+    ValueInputOption,
+} from '../common/common';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const replaceRowsAction = createAction({
+  auth: googleSheetsAuth,
+  name: 'replace_rows',
+  displayName: 'Replace all rows',
+  description: 'Replace all the data rows with the provided list',
+  props: {
+    spreadsheet_id: googleSheetsCommon.spreadsheet_id,
+    include_team_drives: googleSheetsCommon.include_team_drives,
+    sheet_id: googleSheetsCommon.sheet_id,
+    as_string: googleSheetsCommon.as_string,
+    first_row_headers: googleSheetsCommon.first_row_headers,
+    values: googleSheetsCommon.valuesForMultipleRows,
+    headersAsKeys: googleSheetsCommon.headersAsKeysForInsert,
+  },
+
+  async run(context) {
+    const spreadSheetId = context.propsValue.spreadsheet_id;
+    const sheetId = context.propsValue.sheet_id;
+    const accessToken = context.auth['access_token'] ?? '';
+
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const sheetsClient = google.sheets({ version: 'v4', auth: authClient });
+    const sheets = (await sheetsClient.spreadsheets.get({ spreadsheetId: spreadSheetId })).data.sheets;
+    const sheet = sheets?.find((f) => f.properties?.sheetId == sheetId);
+    const currentRows = sheet?.properties?.gridProperties?.rowCount;
+    const sheetName = sheet?.properties?.title;
+    if (!currentRows || !sheetName) {
+      throw Error(`Sheet with ID ${sheetId} not found in spreadsheet ${spreadSheetId}`);
+    }
+
+    const headers = context.propsValue.headersAsKeys
+      ? await getHeaders({ accessToken, sheetName, spreadSheetId })
+      : [];
+
+    const formattedValues = [];
+    for (const rowInput of context.propsValue.values['values']) {
+      formattedValues.push(
+        context.propsValue.headersAsKeys
+          ? await objectWithHeadersAsKeysToArray(headers, rowInput)
+          : objectToArray(rowInput)
+      );
+    }
+
+    const headerRows = context.propsValue.first_row_headers ? 1 : 0;
+    const requiredRows = formattedValues.length + headerRows;
+
+    if (requiredRows > currentRows) {
+      // Add the required rows to match the size of the data that will be inserted
+      await sheetsClient.spreadsheets.batchUpdate({
+        spreadsheetId: spreadSheetId,
+        requestBody: {
+          requests: [
+            {
+              insertDimension: {
+                inheritFromBefore: true,
+                range: {
+                  sheetId: sheetId,
+                  dimension: "ROWS",
+                  startIndex: currentRows,
+                  endIndex: requiredRows,
+                },
+              },
+            }
+          ],
+        }
+      });
+    } else if (requiredRows < currentRows) {
+      // Remove existing rows to match the size of the data that will be inserted
+      await sheetsClient.spreadsheets.batchUpdate({
+        spreadsheetId: spreadSheetId,
+        requestBody: {
+          requests: [
+            {
+              deleteDimension: {
+                range: {
+                  sheetId: sheetId,
+                  dimension: "ROWS",
+                  startIndex: requiredRows,
+                },
+              },
+            }
+          ],
+        }
+      });
+    }
+
+    // Put the data into the cells, replacing both existing data and empty cells
+    return await sheetsClient.spreadsheets.values.update({
+      range: sheetName + `!A${headerRows + 1}`,
+      spreadsheetId: spreadSheetId,
+      valueInputOption: context.propsValue.as_string
+        ? ValueInputOption.RAW
+        : ValueInputOption.USER_ENTERED,
+      requestBody: {
+        values: formattedValues,
+        majorDimension: Dimension.ROWS,
+      },
+    });
+  },
+});

--- a/packages/pieces/community/google-sheets/src/lib/actions/update-row.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/update-row.ts
@@ -21,13 +21,8 @@ export const updateRowAction = createAction({
       description: 'The row number to update',
       required: true,
     }),
-    first_row_headers: Property.Checkbox({
-      displayName: 'Does the first row contain headers?',
-      description: 'If the first row is headers',
-      required: true,
-      defaultValue: false,
-    }),
-    values: googleSheetsCommon.values,
+    first_row_headers: googleSheetsCommon.first_row_headers,
+    values: googleSheetsCommon.valuesForOneRow,
   },
   async run(context) {
     const spreadSheetId = context.propsValue.spreadsheet_id;


### PR DESCRIPTION
## What does this PR do?

This is a google-sheets action that allows to replace at once the whole content of a spreadsheet (except the headers) with the given data-set. It also resizes the sheet (number of rows) appropriately.

This is necessary because it's difficult to do otherwise. The alternative is to use "clear rows" + "insert multiple rows", but this is more difficult to use and has side effects (for example, we cannot clear the rows when the headers are frozen).

:warning: Please note that since there are inter-dependencies between my two PRs, I based this one on the same branch than https://github.com/activepieces/activepieces/pull/5981.