### PR TITLE
fix: stop opening piece settings when trigger is of type empty

### DIFF
--- a/packages/react-ui/src/app/builder/builder-hooks.ts
+++ b/packages/react-ui/src/app/builder/builder-hooks.ts
@@ -161,7 +161,7 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
       canExitRun: initialState.canExitRun,
       activeDraggingStep: null,
       allowCanvasPanning: true,
-      rightSidebar: initiallySelectedStep
+      rightSidebar: initiallySelectedStep && (initiallySelectedStep !== 'trigger' || initialState.flowVersion.trigger.type !== TriggerType.EMPTY)
         ? RightSideBarType.PIECE_SETTINGS
         : RightSideBarType.NONE,
       refreshPieceFormSettings: false,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

