### PR TITLE
feat(file-helper): added an action to convert the encoding

### DIFF
--- a/packages/pieces/community/file-helper/package.json
+++ b/packages/pieces/community/file-helper/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-file-helper",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/packages/pieces/community/file-helper/src/index.ts
+++ b/packages/pieces/community/file-helper/src/index.ts
@@ -2,6 +2,7 @@ import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import { readFileAction } from './lib/actions/read-file';
 import { createFile } from './lib/actions/create-file';
+import { changeFileEncoding } from './lib/actions/change-file-encoding';
 
 export const filesHelper = createPiece({
   displayName: 'Files Helper',
@@ -10,7 +11,7 @@ export const filesHelper = createPiece({
   minimumSupportedRelease: '0.9.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/file-piece.svg',
   categories: [PieceCategory.CORE],
-  authors: ['kishanprmr', 'MoShizzle', 'abuaboud'],
-  actions: [readFileAction, createFile],
+  authors: ['kishanprmr', 'MoShizzle', 'abuaboud', 'Seb-C'],
+  actions: [readFileAction, createFile, changeFileEncoding],
   triggers: [],
 });

--- a/packages/pieces/community/file-helper/src/lib/actions/change-file-encoding.ts
+++ b/packages/pieces/community/file-helper/src/lib/actions/change-file-encoding.ts
@@ -1,0 +1,46 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import mime from 'mime-types';
+import { encodings } from '../common/encodings';
+
+export const changeFileEncoding = createAction({
+  name: 'change_file_encoding',
+  displayName: 'Change File Encoding',
+  description: 'Changes the encoding of a file',
+  props: {
+    inputFile: Property.File({
+      displayName: 'Source file',
+      required: true,
+    }),
+    inputEncoding: Property.StaticDropdown({
+      displayName: 'Source encoding',
+      required: true,
+      options: {
+        options: encodings,
+      },
+    }),
+    outputFileName: Property.ShortText({
+      displayName: 'Output file name',
+      required: true,
+    }),
+    outputEncoding: Property.StaticDropdown({
+      displayName: 'Output encoding',
+      required: true,
+      options: {
+        options: encodings,
+      },
+    }),
+  },
+  async run(context) {
+    const inputFile = context.propsValue.inputFile.data;
+    const inputEncoding = context.propsValue.inputEncoding as BufferEncoding;
+    const outputFileName = context.propsValue.outputFileName;
+    const outputEncoding = context.propsValue.outputEncoding as BufferEncoding;
+
+    const output = Buffer.from(inputFile.toString(), inputEncoding).toString(outputEncoding);
+
+    return context.files.write({
+      fileName: outputFileName,
+      data: Buffer.from(output),
+    });
+  },
+});

--- a/packages/pieces/community/file-helper/src/lib/actions/create-file.ts
+++ b/packages/pieces/community/file-helper/src/lib/actions/create-file.ts
@@ -1,4 +1,5 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
+import { encodings } from '../common/encodings';
 
 export const createFile = createAction({
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
@@ -13,45 +14,7 @@ export const createFile = createAction({
       required: true,
       defaultValue: 'utf8',
       options: {
-        // Checkout https://nodejs.org/api/buffer.html#buffers-and-character-encodings
-        options: [
-          {
-            value: 'ascii',
-            label: 'ASCII',
-          },
-          {
-            value: 'utf8',
-            label: 'UTF-8',
-          },
-          {
-            value: 'utf16le',
-            label: 'UTF-16LE',
-          },
-          {
-            value: 'ucs2',
-            label: 'UCS-2',
-          },
-          {
-            value: 'base64',
-            label: 'Base64',
-          },
-          {
-            value: 'base64url',
-            label: 'Base64 URL',
-          },
-          {
-            value: 'latin1',
-            label: 'Latin1',
-          },
-          {
-            value: 'binary',
-            label: 'Binary',
-          },
-          {
-            value: 'hex',
-            label: 'Hex',
-          },
-        ],
+        options: encodings,
       },
     }),
 

--- a/packages/pieces/community/file-helper/src/lib/common/encodings.ts
+++ b/packages/pieces/community/file-helper/src/lib/common/encodings.ts
@@ -1,0 +1,39 @@
+// Checkout https://nodejs.org/api/buffer.html#buffers-and-character-encodings
+export const encodings = [
+  {
+    value: 'ascii',
+    label: 'ASCII',
+  },
+  {
+    value: 'utf8',
+    label: 'UTF-8',
+  },
+  {
+    value: 'utf16le',
+    label: 'UTF-16LE',
+  },
+  {
+    value: 'ucs2',
+    label: 'UCS-2',
+  },
+  {
+    value: 'base64',
+    label: 'Base64',
+  },
+  {
+    value: 'base64url',
+    label: 'Base64 URL',
+  },
+  {
+    value: 'latin1',
+    label: 'Latin1',
+  },
+  {
+    value: 'binary',
+    label: 'Binary',
+  },
+  {
+    value: 'hex',
+    label: 'Hex',
+  },
+];


### PR DESCRIPTION
## What does this PR do?

This adds an action that allows converting the encoding of a file.

I needed that because it is not possible to do that within the `code` action itself, since I could not import any node or browser package from it.