### PR TITLE
fix: remove public schema reference from migration files

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1730123432651-AddConnectionOwner.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1730123432651-AddConnectionOwner.ts
@@ -25,7 +25,7 @@ export class AddConnectionOwner1730123432651 implements MigrationInterface {
                     AND data->'connection' IS NOT NULL
                     AND data->'connection'->>'id' IS NOT NULL
                     AND "userId" IS NOT NULL
-                    AND "userId" IN (SELECT id FROM public.user)
+                    AND "userId" IN (SELECT id FROM "user")
                     ORDER BY (data->'connection'->>'id')::text, created DESC
                 )
                 UPDATE app_connection

--- a/packages/server/api/src/app/database/migration/postgres/1731711188507-AddAuditLogIndicies.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1731711188507-AddAuditLogIndicies.ts
@@ -9,7 +9,7 @@ export class AddAuditLogIndicies1731711188507 implements MigrationInterface {
             name: this.name,
         }, 'up')
         await queryRunner.query(`
-            DROP INDEX CONCURRENTLY IF EXISTS "public"."audit_event_platform_id_project_id_user_id_idx"
+            DROP INDEX CONCURRENTLY IF EXISTS "audit_event_platform_id_project_id_user_id_idx"
         `)
         await queryRunner.query(`
             CREATE INDEX CONCURRENTLY IF NOT EXISTS "audit_event_platform_id_project_id_user_id_action_idx" ON "audit_event" ("platformId", "projectId", "userId", "action")
@@ -27,13 +27,13 @@ export class AddAuditLogIndicies1731711188507 implements MigrationInterface {
             name: this.name,
         }, 'down')
         await queryRunner.query(`
-            DROP INDEX CONCURRENTLY IF EXISTS "public"."audit_event_platform_id_action_idx"
+            DROP INDEX CONCURRENTLY IF EXISTS "audit_event_platform_id_action_idx"
         `)
         await queryRunner.query(`
-            DROP INDEX CONCURRENTLY IF EXISTS "public"."audit_event_platform_id_user_id_action_idx"
+            DROP INDEX CONCURRENTLY IF EXISTS "audit_event_platform_id_user_id_action_idx"
         `)
         await queryRunner.query(`
-            DROP INDEX CONCURRENTLY IF EXISTS "public"."audit_event_platform_id_project_id_user_id_action_idx"
+            DROP INDEX CONCURRENTLY IF EXISTS "audit_event_platform_id_project_id_user_id_action_idx"
         `)
         await queryRunner.query(`
             CREATE INDEX CONCURRENTLY IF NOT EXISTS "audit_event_platform_id_project_id_user_id_idx" ON "audit_event" ("platformId", "projectId", "userId")


### PR DESCRIPTION
## What does this PR do?

A few of the migration files had references to the public schema. For any deployments running Activepieces in another schema this causes the app to not start due to the migrations failing during startup. 
