### PR TITLE
fix(google-drive): files could not be moved

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.31"
+  "version": "0.5.32"
 }

--- a/packages/pieces/community/google-drive/src/lib/action/move-file.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/move-file.ts
@@ -30,6 +30,7 @@ export const moveFileAction = createAction({
     const file = await drive.files.get({
       fileId,
       supportsAllDrives: context.propsValue.include_team_drives,
+      fields: 'id,parents',
     });
 
     const response = await drive.files.update({


### PR DESCRIPTION
## What does this PR do?

`parents` is not returned by default by the `files.get` endpoint, so we were always passing `undefined` to the `files.update` call - leading to a 400 error when trying to move the file to a subdirectory (and probably to any directory)
