### PR TITLE
fix(dropbox): fix support of accented characters in path property

### DIFF
--- a/packages/pieces/community/dropbox/package.json
+++ b/packages/pieces/community/dropbox/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-dropbox",
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/packages/pieces/community/dropbox/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/dropbox/src/lib/actions/upload-file.ts
@@ -48,7 +48,8 @@ export const dropboxUploadFile = createAction({
 
     const params = {
       autorename: context.propsValue.autorename,
-      path: context.propsValue.path,
+      // For information about Dropbox JSON encoding, see https://www.dropbox.com/developers/reference/json-encoding
+      path: context.propsValue.path.replace(/[\u007f-\uffff]/g, (c) => '\\u'+('000'+c.charCodeAt(0).toString(16)).slice(-4)),
       mode: 'add',
       mute: context.propsValue.mute,
       strict_conflict: context.propsValue.strict_conflict,


### PR DESCRIPTION
## What does this PR do?

It is currently impossible to upload a file in Dropbox using AP if its path contains accented characters.

Dropbox's API does not support UTF-8 characters so they need be encoded a specific way. The encoding code can be found here https://www.dropbox.com/developers/reference/json-encoding

This changes applies the proposed JS code to the `path` property.
