### PR TITLE
feat(mysql): Allow MySQL Piece Authentication Without Specifying a Database for ‘Execute Query’ Action

### DIFF
--- a/packages/pieces/community/mysql/package.json
+++ b/packages/pieces/community/mysql/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-mysql",
-  "version": "0.1.6"
+  "version": "0.1.7"
 }

--- a/packages/pieces/community/mysql/src/index.ts
+++ b/packages/pieces/community/mysql/src/index.ts
@@ -31,8 +31,8 @@ export const mysqlAuth = PieceAuth.CustomAuth({
     }),
     database: Property.ShortText({
       displayName: 'Database',
-      description: 'The name of the database to use',
-      required: true,
+      description: 'The name of the database to use. Required if you are not using the "Execute Query" Action',
+      required: false,
     }),
   },
   required: true,


### PR DESCRIPTION
## What does this PR do?

This pull request removes the requirement for the database field during authentication in the MySQL piece. By making the database field optional, users can now authenticate without specifying a database when using the “Execute Query” action. This enhancement facilitates access to multiple databases on a single MySQL server using a single set of credentials, eliminating the need to manage multiple authentications dynamically.


## Changes Made:

1. Removed the required property from the database field in the authentication settings.
2. Updated the database field description from: “The name of the database to use” to “The name of the database to use. Required if you are not using the ‘Execute Query’ Action”.

## Testing Conducted:

We have thoroughly tested other actions that require the database to be defined, including:
	•	getTables
	•	insertRow
	•	updateRows
	•	deleteRows
	•	selectRows

In all cases where the database was not specified, clear and informative error messages were displayed, indicating that no database was selected. This ensures that users are appropriately notified when a required database specification is missing for these actions.

By implementing this change, we enhance the flexibility of the MySQL piece, particularly benefiting scenarios involving multiple databases, without impacting the existing functionality of other actions that depend on a specified database.