### PR TITLE
feat(instasent): add instant parameter to add/update contact action

### DIFF
--- a/packages/pieces/community/instasent/package.json
+++ b/packages/pieces/community/instasent/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-instasent",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/pieces/community/instasent/src/index.ts
+++ b/packages/pieces/community/instasent/src/index.ts
@@ -11,8 +11,16 @@ export const getBaseUrl = (auth: { projectId: string, datasourceId: string }) =>
     return `${BASE_URL}/project/${auth.projectId}/datasource/${auth.datasourceId}`;
 };
 
+const authDescriptionMarkdown = `
+## Obtain your auth data
+1. Go to https://dashboard.instasent.com
+2. Access to your project
+3. Create an Activepieces data source
+4. Copy the auth parameters and paste them in the fields below
+`;
+
 export const instasentAuth = PieceAuth.CustomAuth({
-    description: 'Authentication for Instasent',
+    description: authDescriptionMarkdown,
     props: {
         projectId: PieceAuth.SecretText({
             displayName: 'Project ID',

--- a/packages/pieces/community/instasent/src/lib/actions/add-or-update-contact.ts
+++ b/packages/pieces/community/instasent/src/lib/actions/add-or-update-contact.ts
@@ -90,17 +90,24 @@ export const addOrUpdateContact = createAction({
                     throw new Error('Failed to load contact properties');
                 }
             }
+        }),
+        instant: Property.Checkbox({
+            displayName: 'Instant',
+            description: 'Process contact immediately instead of queuing. Only enable this when you need to add an event for this contact in the next step. Not recommended for high-volume operations.',
+            required: false,
+            defaultValue: false
         })
     },
 
     async run(context) {
         const contact = context.propsValue.contact;
+        const instant = context.propsValue.instant;
         const auth = context.auth as InstasentAuthType;
         const baseUrl = getBaseUrl({ projectId: auth.projectId, datasourceId: auth.datasourceId });
 
         const response = await httpClient.sendRequest({
             method: HttpMethod.POST,
-            url: `${baseUrl}/stream/contacts`,
+            url: `${baseUrl}/stream/contacts${instant ? '?_sync' : ''}`,
             headers: {
                 'Authorization': `Bearer ${auth.apiKey}`,
                 'Content-Type': 'application/json'


### PR DESCRIPTION
Added a new instant parameter that allows immediate contact creation/update instead of queueing. This is useful for scenarios where users need to add events right after creating/updating a contact.

Changes:
- Added instant checkbox property
- Modified endpoint URL to include ?_sync parameter when instant is enabled