### PR TITLE
docs: fix two minor typos in docs

### DIFF
--- a/docs/embedding/overview.mdx
+++ b/docs/embedding/overview.mdx
@@ -22,6 +22,6 @@ The embedding process involves the following steps:
 
 
 <Tip>
-Incase, you need to gather connections in custom place in your application. You can do this with the SDK. Find more info [here](./embed-connections.mdx).
+In case, you need to gather connections in custom place in your application. You can do this with the SDK. Find more info [here](./embed-connections.mdx).
 </Tip>
 

--- a/docs/install/options/elestio.mdx
+++ b/docs/install/options/elestio.mdx
@@ -3,6 +3,6 @@ title: "Elestio"
 description: "Run Activepieces with Elestio 1-Click Install"
 ---
 
-You can deploy Activepieces on Elestio using one-click deployment. Elestio handles version updates, maintenance, securtiy, backups, etc. So go ahead and click below to deploy and start using.
+You can deploy Activepieces on Elestio using one-click deployment. Elestio handles version updates, maintenance, security, backups, etc. So go ahead and click below to deploy and start using.
 
 [![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/activepieces)


### PR DESCRIPTION
As mentioned in title, two small typos are fixed on docs. @AshrafSam promised an activepieces hoodie for this
