### PR TITLE
feat: add optional extra props for custom API call

### DIFF
--- a/packages/pieces/community/common/package.json
+++ b/packages/pieces/community/common/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "type": "commonjs"
 }

--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.7.8"
+  "version": "0.7.9"
 }

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -3,6 +3,7 @@ import {
   OAuth2PropertyValue,
   PieceAuth,
   createPiece,
+  Property,
 } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import crypto from 'node:crypto';
@@ -124,10 +125,28 @@ export const slack = createPiece({
         return 'https://slack.com/api';
       },
       auth: slackAuth,
-      authMapping: async (auth) => {
-        return {
-          Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
-        };
+      authMapping: async (auth, propsValue) => {
+        if (propsValue.useUserToken) {
+          return {
+            Authorization: `Bearer ${
+              (auth as OAuth2PropertyValue).data['authed_user']?.access_token
+            }`,
+          };
+        } else {
+          return {
+            Authorization: `Bearer ${
+              (auth as OAuth2PropertyValue).access_token
+            }`,
+          };
+        }
+      },
+      extraProps: {
+        useUserToken: Property.Checkbox({
+          displayName: 'Use user token',
+          description: 'Use user token instead of bot token',
+          required: true,
+          defaultValue: false,
+        }),
       },
     }),
   ],


### PR DESCRIPTION
## What does this PR do?

1. add optional `extraProps` to `createCustomApiCallAction` helper and pass it to `authMapping`
2. update Slack piece: add "Use user token" checkbox to be able to call methods that require a user token (instead of a bot token) or behave differently

