### PR TITLE
feat(metabase): allow full question id

### DIFF
--- a/packages/pieces/community/metabase/package.json
+++ b/packages/pieces/community/metabase/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-metabase",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/packages/pieces/community/metabase/src/lib/actions/get-question.ts
+++ b/packages/pieces/community/metabase/src/lib/actions/get-question.ts
@@ -27,15 +27,16 @@ export const getQuestion = createAction({
     }),
   },
   async run({ auth, propsValue }) {
+    const questionId = propsValue.questionId.split('-')[0];
     const card = await queryMetabaseApi(
-      { endpoint: `card/${propsValue.questionId}`, method: HttpMethod.GET },
+      { endpoint: `card/${questionId}`, method: HttpMethod.GET },
       auth
     );
     const parameters = card['parameters'] as MetabaseParam[];
 
     const response = await queryMetabaseApi(
       {
-        endpoint: `card/${propsValue.questionId}/query`,
+        endpoint: `card/${questionId}/query`,
         method: HttpMethod.POST,
         body: {
           collection_preview: false,


### PR DESCRIPTION
## What does this PR do?

Allow using full path parameter of a metabase question, e.g. `1234-my-awesome-question` instead of just the ID, e.g. `1234` - in order to avoid surprises for flow builders
