### PR TITLE
fix(google-sheets): "cannot read properties of null" error when using…

### DIFF
--- a/packages/pieces/community/google-sheets/package.json
+++ b/packages/pieces/community/google-sheets/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.11.9"
+  "version": "0.11.10"
 }

--- a/packages/pieces/community/google-sheets/src/lib/triggers/new-or-updated-row.trigger.ts
+++ b/packages/pieces/community/google-sheets/src/lib/triggers/new-or-updated-row.trigger.ts
@@ -205,7 +205,9 @@ export const newOrUpdatedRowTrigger = createTrigger({
 				continue;
 			}
 
-			const oldRowHash = row < oldValuesHashes.length ? oldValuesHashes[row] : undefined;
+			const oldRowHash = !isNil(oldValuesHashes) && row < oldValuesHashes.length
+				? oldValuesHashes[row]
+				: undefined;
 
 			if (oldRowHash === undefined || oldRowHash != currentRowHash) {
 				const formattedValues: any = {};


### PR DESCRIPTION
Updated the earlier fix to handle possible scenarios where `oldValuesHashes` is null or undefined. This ensures that when we try to read it's length, we don't get any errors. 