### PR TITLE
fix(customerio): don't send customer identifier as event id

### DIFF
--- a/packages/pieces/community/customer-io/package.json
+++ b/packages/pieces/community/customer-io/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-customer-io",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/packages/pieces/community/customer-io/src/lib/actions/create_event.ts
+++ b/packages/pieces/community/customer-io/src/lib/actions/create_event.ts
@@ -9,14 +9,14 @@ export const createEvent = createAction({
   displayName: 'Create Event',
   description: 'Create an event in Customer.io',
   props: {
-    customer_email: Property.ShortText({
-      displayName: 'Customer Email',
-      description: 'Customer Email',
+    customer_identifier: Property.ShortText({
+      displayName: 'Customer identifier',
+      description: 'The unique value representing a person. You may identify a person by id, email address, or the cio_id (when updating people), depending on your workspace settings',
       required: true,
     }),
     event_name: Property.ShortText({
       displayName: 'Event Name',
-      description: 'Event Name',
+      description: 'The name of the event. This is how you\'ll reference the event in campaigns or segments',
       required: true,
     }),
     body_type: Property.StaticDropdown({
@@ -84,7 +84,7 @@ export const createEvent = createAction({
       Authorization: `Basic ${basic_track_api}`,
       'Content-Type': 'application/json',
     }
-    const encoded_email = encodeURIComponent(context.propsValue.customer_email);
+    const encoded_email = encodeURIComponent(context.propsValue.customer_identifier);
     const url = customerIOCommon[context.auth.region || 'us'].trackUrl + 'customers/' + encoded_email + '/events';
 
     const httprequestdata = {
@@ -93,7 +93,6 @@ export const createEvent = createAction({
       headers,
       body: {
         name: context.propsValue.event_name,
-        id: context.propsValue.customer_email,
         data: body ? body['data'] : {},
       },
     }


### PR DESCRIPTION
## What does this PR do?

We don't want to send the customer identifier (email or ID) as event ID because CustomerIO would treat it as a duplicate

https://docs.customer.io/api/track/#operation/track

> An identifier used to deduplicate events. This value must be a ULID. If an event has the same value as an event we previously received, we won't show or process the duplicate. Note - our Python and Ruby libraries do not pass this id.
> An identifier used to deduplicate events. This value must be a [ULID](https://github.com/ulid/spec). If an event has the same value as an event we previously received, we won't show or process the duplicate. Note - our Python and Ruby libraries do not pass this id.
