### PR TITLE
fix(get-public-ip): resolve issue when Google DNS is blocked

### DIFF
--- a/packages/server/shared/src/lib/network-utils.ts
+++ b/packages/server/shared/src/lib/network-utils.ts
@@ -1,4 +1,5 @@
 import dns from 'node:dns/promises'
+import os from 'os'
 import { ApEnvironment, isNil } from '@activepieces/shared'
 import { FastifyRequest } from 'fastify'
 
@@ -12,20 +13,51 @@ type IpMetadata = {
 
 let ipMetadata: IpMetadata | undefined
 
+const getLocalIp = (): string | null => {
+    const networkInterfaces = os.networkInterfaces()
+    for (const interfaceName of Object.keys(networkInterfaces)) {
+        const networkInterface = networkInterfaces[interfaceName]
+        if (networkInterface) {
+            for (const iface of networkInterface) {
+                if (iface.family === 'IPv4' && !iface.internal) {
+                    return iface.address
+                }
+            }
+        }
+    }
+    return null
+}
+
 const getPublicIp = async (): Promise<IpMetadata> => {
     if (ipMetadata !== undefined) {
         return ipMetadata
     }
 
-    dns.setServers([GOOGLE_DNS])
+    try {
+        dns.setServers([GOOGLE_DNS])
 
-    const ipList = await dns.resolve(PUBLIC_IP_ADDRESS_QUERY, 'TXT')
+        const ipList = await dns.resolve(PUBLIC_IP_ADDRESS_QUERY, 'TXT')
 
-    ipMetadata = {
-        ip: ipList[0][0],
+        ipMetadata = {
+            ip: ipList[0][0],
+        }
+
+        return ipMetadata
     }
+    catch (error) {
+        const localIp = getLocalIp()
+        if (localIp) {
+            ipMetadata = {
+                ip: localIp,
+            }
+            return ipMetadata
+        }
 
-    return ipMetadata
+        ipMetadata = {
+            ip: 'Unknown',
+        }
+        return ipMetadata
+    }
 }
 
 const getPublicUrl = async (environment: ApEnvironment, frontendUrl: string): Promise<string> => {


### PR DESCRIPTION
Fix Get Public IP failed due to Google DNS is blocked

Issue (https://linear.app/activepieces/issue/AP-194/get-public-ip-failed-due-to-google-dns-is-blocked#customerRequest-ae20565f)
