### PR TITLE
feat(google-drive): add includeTrashed option to googleDriveListFiles action

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.6.0"
+  "version": "0.5.33"
 }

--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.32"
+  "version": "0.6.0"
 }

--- a/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
@@ -1,6 +1,7 @@
 import { HttpMethod, httpClient } from '@activepieces/pieces-common';
 import { googleDriveAuth } from '../../index';
 import { Property, createAction } from "@activepieces/pieces-framework";
+import querystring from 'querystring';
 
 export const googleDriveListFiles = createAction({
   auth: googleDriveAuth,
@@ -13,21 +14,36 @@ export const googleDriveListFiles = createAction({
       description: 'Folder ID coming from | New Folder -> id | (or any other source)',
       required: true,
     }),
+    includeTrashed: Property.Checkbox({
+      displayName: 'Include Trashed',
+      description: 'Include new files that have been trashed.',
+      required: false,
+      defaultValue: false
+    }),
   },
   async run(context) {
-
     const result = {
       'type': 'drive#fileList',
       'incompleteSearch': false,
-       'files': [] as unknown[],
-       
+      'files': [] as unknown[],
     }
 
-    
+    let q = `'${context.propsValue.folderId}' in parents`;
+
+    // When include_trashed is false, we add a filter to exclude trashed files.
+    // By default, Google Drive API returns trashed files as well.
+    if (!context.propsValue.includeTrashed) {
+      q += ' and trashed=false';
+    }
+
+    const params: Record<string, string> = {
+      q: q,
+      fields: 'files(id,kind,mimeType,name,trashed)',
+    }
 
     let response = await httpClient.sendRequest({
       method: HttpMethod.GET,
-      url: `https://www.googleapis.com/drive/v3/files?q='${context.propsValue.folderId}'+in+parents`,
+      url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
       headers: {
         Authorization: `Bearer ${context.auth.access_token}`,
       },
@@ -36,9 +52,10 @@ export const googleDriveListFiles = createAction({
     result.files = [...response.body.files];
     while(response.body.nextPageToken)
     {
+      params.pageToken = response.body.nextPageToken;
       response = await httpClient.sendRequest({
         method: HttpMethod.GET,
-        url: `https://www.googleapis.com/drive/v3/files?pageToken=${response.body.nextPageToken}&q='${context.propsValue.folderId}'+in+parents`,
+        url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
         headers: {
           Authorization: `Bearer ${context.auth.access_token}`,
         },


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds the `includeTrashed` option to the `googleDriveListFiles` action. The minor version of the Piece has been updated, since  `includeTrashed` now defaults to false, which is a breaking change. It now also returns the `trashed` field, so the user knows which files are trashed.

Fixes # (issue)

