### PR TITLE
remove public schema from migration file.

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1734418823028-CreateProjectReleaseTable.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1734418823028-CreateProjectReleaseTable.ts
@@ -48,7 +48,7 @@ export class CreateProjectReleaseTable1734418823028 implements MigrationInterfac
             ALTER TABLE "project_release" DROP CONSTRAINT "fk_project_release_project_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_project_release_project_id"
+            DROP INDEX "idx_project_release_project_id"
         `)
         await queryRunner.query(`
             DROP TABLE "project_release"


### PR DESCRIPTION
## What does this PR do?

Removes the reference to the public schema in a recent migration file.

