### PR TITLE
fix(spotify): spotify offset labels

### DIFF
--- a/packages/pieces/community/spotify/package.json
+++ b/packages/pieces/community/spotify/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-spotify",
-  "version": "0.3.5"
+  "version": "0.3.6"
 }

--- a/packages/pieces/community/spotify/src/lib/actions/get-playlist-items.ts
+++ b/packages/pieces/community/spotify/src/lib/actions/get-playlist-items.ts
@@ -9,7 +9,7 @@ export default createAction({
   props: {
     playlist_id: spotifyCommon.playlist_id(true),
     offset: Property.Number({
-      displayName: 'Limit',
+      displayName: 'Offset',
       required: false,
     }),
     limit: Property.Number({

--- a/packages/pieces/community/spotify/src/lib/actions/get-playlists.ts
+++ b/packages/pieces/community/spotify/src/lib/actions/get-playlists.ts
@@ -8,7 +8,7 @@ export default createAction({
   auth: spotifyCommon.authentication,
   props: {
     offset: Property.Number({
-      displayName: 'Limit',
+      displayName: 'Offset',
       required: false,
     }),
     limit: Property.Number({


### PR DESCRIPTION
## What does this PR do?

Fix incorrect labels for 'Offset' fields for certain Spotify Actions.

Fixes #6460 

