### PR TITLE
feat(spotify): get saved tracks action

### DIFF
--- a/packages/pieces/community/spotify/package.json
+++ b/packages/pieces/community/spotify/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-spotify",
-  "version": "0.3.4"
+  "version": "0.3.5"
 }

--- a/packages/pieces/community/spotify/src/index.ts
+++ b/packages/pieces/community/spotify/src/index.ts
@@ -15,7 +15,7 @@ export const spotify = createPiece({
   minimumSupportedRelease: '0.30.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/spotify.png',
   categories: [],
-  authors: ["JanHolger","kishanprmr","MoShizzle","abuaboud"],
+  authors: ["JanHolger","kishanprmr","MoShizzle","abuaboud","jerboa88"],
   actions: [
     ...actions,
     createCustomApiCallAction({

--- a/packages/pieces/community/spotify/src/lib/actions/get-saved-tracks.ts
+++ b/packages/pieces/community/spotify/src/lib/actions/get-saved-tracks.ts
@@ -1,0 +1,35 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { spotifyCommon, makeClient } from '../common';
+
+export default createAction({
+  name: 'get_saved_tracks',
+  displayName: 'Get Saved Tracks',
+  description: 'Retrieves the list of saved tracks for the current user',
+  auth: spotifyCommon.authentication,
+  props: {
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+    }),
+    all: Property.Checkbox({
+      displayName: 'All',
+      description: 'Fetches all items in a single request',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const client = makeClient({ auth });
+    if (propsValue.all) {
+      const items = await client.getAllSavedTracks();
+      return { total: items.length, items };
+    }
+    return await client.getSavedTracks({
+      limit: propsValue.limit,
+      offset: propsValue.offset,
+    });
+  },
+});

--- a/packages/pieces/community/spotify/src/lib/actions/index.ts
+++ b/packages/pieces/community/spotify/src/lib/actions/index.ts
@@ -9,6 +9,7 @@ import updatePlaylist from './update-playlist';
 import addPlaylistItems from './add-playlist-items';
 import removePlaylistItems from './remove-playlist-items';
 import getPlaylistItems from './get-playlist-items';
+import getSavedTracks from './get-saved-tracks';
 import reorderPlaylist from './reorder-playlist';
 import getPlaylists from './get-playlists';
 
@@ -21,6 +22,7 @@ export default [
   getPlaylists,
   getPlaylistInfo,
   getPlaylistItems,
+  getSavedTracks,
   createPlaylist,
   updatePlaylist,
   addPlaylistItems,

--- a/packages/pieces/community/spotify/src/lib/common/client.ts
+++ b/packages/pieces/community/spotify/src/lib/common/client.ts
@@ -201,6 +201,30 @@ export class SpotifyWebApi {
     return items;
   }
 
+  async getSavedTracks(
+    request?: PaginationRequest
+  ): Promise<Pagination<PlaylistItem>> {
+    return await this.makeRequest<Pagination<PlaylistItem>>(
+      HttpMethod.GET,
+      '/me/tracks',
+      prepareQuery(request)
+    );
+  }
+
+  async getAllSavedTracks(): Promise<PlaylistItem[]> {
+    const items: PlaylistItem[] = [];
+    let total = 99999;
+    while (items.length < total) {
+      const res = await this.getSavedTracks({
+        limit: 50,
+        offset: items.length,
+      });
+      total = res.total;
+      res.items.forEach((item) => items.push(item));
+    }
+    return items;
+  }
+
   async addItemsToPlaylist(id: string, request: PlaylistAddItemsRequest) {
     await this.makeRequest(
       HttpMethod.POST,

--- a/packages/pieces/community/spotify/src/lib/common/index.ts
+++ b/packages/pieces/community/spotify/src/lib/common/index.ts
@@ -3,7 +3,6 @@ import {
   OAuth2PropertyValue,
   PieceAuth,
   Property,
-  StaticPropsValue,
 } from '@activepieces/pieces-framework';
 import { SpotifyWebApi } from './client';
 
@@ -34,6 +33,7 @@ export const spotifyCommon = {
       'playlist-read-collaborative',
       'playlist-modify-private',
       'playlist-modify-public',
+      'user-library-read',
     ],
   }),
   device_id: (required = true) =>


### PR DESCRIPTION
## What does this PR do?

Add a new Action to the Spotify Piece for fetching a list of the user's saved tracks, as this can't be done with the existing 'Get Playlist Items' endpoint.

Closes #6462 

