### PR TITLE
feat: add multi-query transaction support to snowflake piece

### DIFF
--- a/packages/pieces/community/snowflake/package.json
+++ b/packages/pieces/community/snowflake/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-snowflake",
-  "version": "0.0.9"
+  "version": "0.1.0"
 }

--- a/packages/pieces/community/snowflake/src/index.ts
+++ b/packages/pieces/community/snowflake/src/index.ts
@@ -3,7 +3,7 @@ import {
   PieceAuth,
   Property,
 } from '@activepieces/pieces-framework';
-import { runQuery } from './lib/actions/run-query';
+import { runQueries } from './lib/actions/run-query';
 import { PieceCategory } from '@activepieces/shared';
 import { insertRowAction } from './lib/actions/insert-row';
 
@@ -53,7 +53,7 @@ export const snowflake = createPiece({
   minimumSupportedRelease: '0.27.1',
   logoUrl: 'https://cdn.activepieces.com/pieces/snowflake.png',
   categories: [PieceCategory.DEVELOPER_TOOLS],
-  authors: ['AdamSelene', 'abuaboud'],
-  actions: [runQuery, insertRowAction],
+  authors: ['AdamSelene', 'abuaboud', 'valentin-mourtialon'],
+  actions: [runQueries, insertRowAction],
   triggers: [],
 });


### PR DESCRIPTION
## What does this PR do?

Adds support for executing multiple SQL queries within a single transaction in the Snowflake piece.

The action returns the result of the last executed query and ensures atomicity by rolling back all changes if any query fails.


