### PR TITLE
fix(nocoDB): added compatibility with self-hosted versions

### DIFF
--- a/packages/pieces/community/crypto/package.json
+++ b/packages/pieces/community/crypto/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-crypto",
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/packages/pieces/community/crypto/src/index.ts
+++ b/packages/pieces/community/crypto/src/index.ts
@@ -11,7 +11,7 @@ export const Crypto = createPiece({
   minimumSupportedRelease: '0.30.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/crypto.png',
   categories: [PieceCategory.CORE],
-  authors: ['AbdullahBitar', 'kishanprmr', 'abuaboud', 'matthieu-lombard'],
+  authors: ['AbdullahBitar', 'kishanprmr', 'abuaboud', 'matthieu-lombard', 'antonyvigouret'],
   actions: [hashText, hmacSignature, generatePassword],
   triggers: [],
 });

--- a/packages/pieces/community/crypto/src/lib/actions/hash-text.ts
+++ b/packages/pieces/community/crypto/src/lib/actions/hash-text.ts
@@ -15,6 +15,7 @@ export const hashText = createAction({
           { label: 'MD5', value: 'md5' },
           { label: 'SHA256', value: 'sha256' },
           { label: 'SHA512', value: 'sha512' },
+          { label: 'SHA3-512', value: 'sha3-512' },
         ],
       },
     }),

--- a/packages/pieces/community/nocodb/package.json
+++ b/packages/pieces/community/nocodb/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-nocodb",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/pieces/community/nocodb/src/lib/actions/create-record.ts
+++ b/packages/pieces/community/nocodb/src/lib/actions/create-record.ts
@@ -8,13 +8,14 @@ export const createRecordAction = createAction({
 	displayName: 'Create a Record',
 	description: 'Creates a new record in the given table.',
 	props: {
+		version: nocodbCommon.version,
 		workspaceId: nocodbCommon.workspaceId,
 		baseId: nocodbCommon.baseId,
 		tableId: nocodbCommon.tableId,
 		tableColumns: nocodbCommon.tableColumns,
 	},
 	async run(context) {
-		const { tableId, tableColumns } = context.propsValue;
+		const { tableId, tableColumns, version } = context.propsValue;
 		const recordInput: DynamicPropsValue = {};
 
 		Object.entries(tableColumns).forEach(([key, value]) => {
@@ -26,6 +27,6 @@ export const createRecordAction = createAction({
 		});
 
 		const client = makeClient(context.auth);
-		return await client.createRecord(tableId, recordInput);
+		return await client.createRecord(tableId, recordInput, Number(version));
 	},
 });

--- a/packages/pieces/community/nocodb/src/lib/actions/delete-record.ts
+++ b/packages/pieces/community/nocodb/src/lib/actions/delete-record.ts
@@ -8,6 +8,7 @@ export const deleteRecordAction = createAction({
 	displayName: 'Delete a Record',
 	description: 'Deletes a record with the given Record ID.',
 	props: {
+		version: nocodbCommon.version,
 		workspaceId: nocodbCommon.workspaceId,
 		baseId: nocodbCommon.baseId,
 		tableId: nocodbCommon.tableId,
@@ -17,9 +18,9 @@ export const deleteRecordAction = createAction({
 		}),
 	},
 	async run(context) {
-		const { tableId, recordId } = context.propsValue;
+		const { tableId, recordId, version } = context.propsValue;
 
 		const client = makeClient(context.auth);
-		return await client.deleteRecord(tableId, recordId);
+		return await client.deleteRecord(tableId, recordId, Number(version));
 	},
 });

--- a/packages/pieces/community/nocodb/src/lib/actions/get-record.ts
+++ b/packages/pieces/community/nocodb/src/lib/actions/get-record.ts
@@ -8,6 +8,7 @@ export const getRecordAction = createAction({
 	displayName: 'Get a Record',
 	description: 'Gets a record by the Record ID.',
 	props: {
+		version: nocodbCommon.version,
 		workspaceId: nocodbCommon.workspaceId,
 		baseId: nocodbCommon.baseId,
 		tableId: nocodbCommon.tableId,
@@ -17,9 +18,9 @@ export const getRecordAction = createAction({
 		}),
 	},
 	async run(context) {
-		const { tableId, recordId } = context.propsValue;
+		const { tableId, recordId, version } = context.propsValue;
 
 		const client = makeClient(context.auth);
-		return await client.getRecord(tableId, recordId);
+		return await client.getRecord(tableId, recordId, Number(version));
 	},
 });

--- a/packages/pieces/community/nocodb/src/lib/actions/search-records.ts
+++ b/packages/pieces/community/nocodb/src/lib/actions/search-records.ts
@@ -8,6 +8,7 @@ export const searchRecordsAction = createAction({
 	displayName: 'Search Records',
 	description: 'Returns a list of records matching the where condition.',
 	props: {
+		version: nocodbCommon.version,
 		workspaceId: nocodbCommon.workspaceId,
 		baseId: nocodbCommon.baseId,
 		tableId: nocodbCommon.tableId,
@@ -30,7 +31,7 @@ export const searchRecordsAction = createAction({
 		}),
 	},
 	async run(context) {
-		const { tableId, columnId, limit, whereCondition, sort } = context.propsValue;
+		const { tableId, columnId, limit, whereCondition, sort, version } = context.propsValue;
 
 		const client = makeClient(context.auth);
 		const response = await client.listRecords(tableId, {
@@ -39,7 +40,7 @@ export const searchRecordsAction = createAction({
 			sort,
 			offset: 0,
 			limit,
-		});
+		}, Number(version));
 		return response.list;
 	},
 });

--- a/packages/pieces/community/nocodb/src/lib/actions/update-record.ts
+++ b/packages/pieces/community/nocodb/src/lib/actions/update-record.ts
@@ -8,6 +8,7 @@ export const updateRecordAction = createAction({
 	displayName: 'Update a Record',
 	description: 'Updates an existing record with the given Record ID.',
 	props: {
+		version: nocodbCommon.version,
 		workspaceId: nocodbCommon.workspaceId,
 		baseId: nocodbCommon.baseId,
 		tableId: nocodbCommon.tableId,
@@ -18,7 +19,7 @@ export const updateRecordAction = createAction({
 		tableColumns: nocodbCommon.tableColumns,
 	},
 	async run(context) {
-		const { tableId, recordId, tableColumns } = context.propsValue;
+		const { tableId, recordId, tableColumns, version } = context.propsValue;
 		const recordInput: DynamicPropsValue = {
 			Id: recordId,
 		};
@@ -32,6 +33,6 @@ export const updateRecordAction = createAction({
 		});
 
 		const client = makeClient(context.auth);
-		return await client.updateRecord(tableId, recordInput);
+		return await client.updateRecord(tableId, recordInput, Number(version));
 	},
 });

--- a/packages/pieces/community/nocodb/src/lib/common/client.ts
+++ b/packages/pieces/community/nocodb/src/lib/common/client.ts
@@ -52,59 +52,100 @@ export class NocoDBClient {
 		);
 	}
 
-	async listBases(workspaceId: string): Promise<ListAPIResponse<BaseResponse>> {
-		return await this.makeRequest<ListAPIResponse<BaseResponse>>(
-			HttpMethod.GET,
-			`/v1/workspaces/${workspaceId}/bases/`,
-		);
+	async listBases(workspaceId?: string, version: number = 3): Promise<ListAPIResponse<BaseResponse>> {
+		try {
+			if (workspaceId && workspaceId !== 'none') {
+				// Cloud version
+				const endpoint = `/v1/workspaces/${workspaceId}/bases/`;
+				return await this.makeRequest<ListAPIResponse<BaseResponse>>(
+					HttpMethod.GET,
+					endpoint,
+				);
+			} else {
+				// Self-hosted version
+				const endpoint = version === 3 ? '/v2/meta/bases/' : '/v1/db/meta/projects/';
+				return await this.makeRequest<ListAPIResponse<BaseResponse>>(
+					HttpMethod.GET,
+					endpoint,
+				);
+			}
+		} catch (error) {
+			throw error;
+		}
 	}
 
-	async listTables(baseId: string): Promise<ListAPIResponse<TableResponse>> {
+	async listTables(baseId: string, version: number = 3): Promise<ListAPIResponse<TableResponse>> {
+		const endpoint = version === 3
+			? `/v2/meta/bases/${baseId}/tables`
+			: `/v1/db/meta/projects/${baseId}/tables`;
 		return await this.makeRequest<ListAPIResponse<TableResponse>>(
 			HttpMethod.GET,
-			`/v2/meta/bases/${baseId}/tables/`,
+			endpoint,
 		);
 	}
 
-	async getTable(tableId: string): Promise<GetTableResponse> {
-		return await this.makeRequest<GetTableResponse>(HttpMethod.GET, `/v2/meta/tables/${tableId}/`);
+	async getTable(tableId: string, version: number = 3): Promise<GetTableResponse> {
+		const endpoint = version === 3
+			? `/v2/meta/tables/${tableId}/`
+			: `/v1/db/meta/tables/${tableId}/`;
+		return await this.makeRequest<GetTableResponse>(HttpMethod.GET, endpoint);
 	}
 
-	async createRecord(tableId: string, recordInput: Record<string, any>) {
+	async createRecord(tableId: string, recordInput: Record<string, any>, version: number = 3) {
+		const endpoint = version === 3
+			? `/v2/tables/${tableId}/records`
+			: `/v1/db/data/noco/${tableId}`;
 		return await this.makeRequest(
 			HttpMethod.POST,
-			`/v2/tables/${tableId}/records/`,
+			endpoint,
 			undefined,
-			recordInput,
+			recordInput
 		);
 	}
 
-	async getRecord(tableId: string, recordId: number) {
-		return await this.makeRequest(HttpMethod.GET, `/v2/tables/${tableId}/records/${recordId}`);
+	async getRecord(tableId: string, recordId: number, version: number = 3) {
+		const endpoint = version === 3
+			? `/v2/tables/${tableId}/records/${recordId}`
+			: `/v1/db/data/noco/${tableId}/${recordId}`;
+		return await this.makeRequest(HttpMethod.GET, endpoint);
 	}
 
-	async updateRecord(tableId: string, recordInput: Record<string, any>) {
+	async updateRecord(tableId: string, recordInput: Record<string, any>, version: number = 3) {
+		const endpoint = version === 3
+			? `/v2/tables/${tableId}/records/`
+			: `/v1/db/data/noco/${tableId}`;
 		return await this.makeRequest(
 			HttpMethod.PATCH,
-			`/v2/tables/${tableId}/records/`,
+			endpoint,
 			undefined,
 			recordInput,
 		);
 	}
 
-	async deleteRecord(tableId: string, recordId: number) {
-		return await this.makeRequest(HttpMethod.DELETE, `/v2/tables/${tableId}/records/`, undefined, {
-			Id: recordId,
-		});
+	async deleteRecord(tableId: string, recordId: number, version: number = 3) {
+		const endpoint = version === 3
+			? `/v2/tables/${tableId}/records/`
+			: `/v1/db/data/noco/${tableId}/${recordId}`;
+		const body = version === 3 ? { Id: recordId } : undefined;
+		return await this.makeRequest(
+			HttpMethod.DELETE,
+			endpoint,
+			undefined,
+			body
+		);
 	}
 
 	async listRecords(
 		tableId: string,
 		params: ListRecordsParams,
+		version: number = 3
 	): Promise<ListAPIResponse<Record<string, any>>> {
+		const endpoint = version === 3
+			? `/v2/tables/${tableId}/records/`
+			: `/v1/db/data/noco/${tableId}`;
 		return await this.makeRequest<ListAPIResponse<Record<string, any>>>(
 			HttpMethod.GET,
-			`/v2/tables/${tableId}/records/`,
+			endpoint,
 			params,
 		);
 	}

--- a/packages/pieces/community/nocodb/src/lib/common/index.ts
+++ b/packages/pieces/community/nocodb/src/lib/common/index.ts
@@ -7,10 +7,24 @@ export function makeClient(auth: PiecePropValueSchema<typeof nocodbAuth>) {
 }
 
 export const nocodbCommon = {
+	version: Property.StaticDropdown({
+		displayName: 'API Version',
+		description: 'Version of NocoDB API to use',
+		required: true,
+		defaultValue: 3,
+		options: {
+			options: [
+				{ label: 'Before v0.90.0', value: 1 },
+				{ label: 'v0.90.0 to v0.199.0', value: 2 },
+				{ label: 'v0.200.0 Onwards', value: 3 }
+			]
+		}
+	}),
 	workspaceId: Property.Dropdown({
 		displayName: 'Workspace ID',
 		refreshers: [],
-		required: true,
+		required: false,
+		description: 'Only required for cloud instances. Leave empty for self-hosted instances.',
 		options: async ({ auth }) => {
 			if (!auth) {
 				return {
@@ -36,37 +50,46 @@ export const nocodbCommon = {
 	}),
 	baseId: Property.Dropdown({
 		displayName: 'Base ID',
-		refreshers: ['workspaceId'],
+		refreshers: ['workspaceId', 'version'],
 		required: true,
-		options: async ({ auth, workspaceId }) => {
-			if (!auth || !workspaceId) {
+		options: async ({ auth, workspaceId, version }) => {
+			if (!auth) {
 				return {
 					disabled: true,
-					placeholder: 'Please connect your account first and select workspace.',
+					placeholder: 'Please connect your account first.',
 					options: [],
 				};
 			}
 
-			const client = makeClient(auth as PiecePropValueSchema<typeof nocodbAuth>);
-			const response = await client.listBases(workspaceId as string);
+			try {
+				const client = makeClient(auth as PiecePropValueSchema<typeof nocodbAuth>);
+				const response = await client.listBases(workspaceId as string || undefined, Number(version));
 
-			return {
-				disabled: false,
-				options: response.list.map((base) => {
-					return {
-						label: base.title,
-						value: base.id,
-					};
-				}),
-			};
+				return {
+					disabled: false,
+					options: response.list.map((base) => {
+						return {
+							label: base.title,
+							value: base.id,
+						};
+					}),
+				};
+			} catch (error) {
+				console.error('Error fetching bases:', error);
+				return {
+					disabled: true,
+					placeholder: 'Error fetching bases. Please check your connection and version.',
+					options: [],
+				};
+			}
 		},
 	}),
 	tableId: Property.Dropdown({
 		displayName: 'Table ID',
 		refreshers: ['workspaceId', 'baseId'],
 		required: true,
-		options: async ({ auth, workspaceId, baseId }) => {
-			if (!auth || !workspaceId || !baseId) {
+		options: async ({ auth, baseId, version }) => {
+			if (!auth || !baseId) {
 				return {
 					disabled: true,
 					placeholder: 'Please connect your account first and select base.',
@@ -75,7 +98,7 @@ export const nocodbCommon = {
 			}
 
 			const client = makeClient(auth as PiecePropValueSchema<typeof nocodbAuth>);
-			const response = await client.listTables(baseId as string);
+			const response = await client.listTables(baseId as string, Number(version));
 
 			return {
 				disabled: false,
@@ -94,8 +117,8 @@ export const nocodbCommon = {
 			'Allows you to specify the fields that you wish to include in your API response. By default, all the fields are included in the response.',
 		refreshers: ['workspaceId', 'baseId', 'tableId'],
 		required: false,
-		options: async ({ auth, workspaceId, baseId, tableId }) => {
-			if (!auth || !workspaceId || !baseId || !tableId) {
+		options: async ({ auth, baseId, tableId, version }) => {
+			if (!auth || !baseId || !tableId) {
 				return {
 					disabled: true,
 					placeholder: 'Please connect your account first and select base.',
@@ -104,7 +127,7 @@ export const nocodbCommon = {
 			}
 
 			const client = makeClient(auth as PiecePropValueSchema<typeof nocodbAuth>);
-			const response = await client.getTable(tableId as unknown as string);
+			const response = await client.getTable(tableId as unknown as string, Number(version));
 
 			return {
 				disabled: false,
@@ -121,14 +144,14 @@ export const nocodbCommon = {
 		displayName: 'Table Columns',
 		refreshers: ['tableId'],
 		required: true,
-		props: async ({ auth, tableId }) => {
+		props: async ({ auth, tableId, version }) => {
 			if (!auth) return {};
 			if (!tableId) return {};
 
 			const fields: DynamicPropsValue = {};
 
 			const client = makeClient(auth as PiecePropValueSchema<typeof nocodbAuth>);
-			const response = await client.getTable(tableId as unknown as string);
+			const response = await client.getTable(tableId as unknown as string, Number(version));
 
 			for (const column of response.columns) {
 				switch (column.uidt) {


### PR DESCRIPTION
## What does this PR do?

This PR fixes compatibility issues with self-hosted versions of NocoDB by addressing the following:

Removes dependency on workspaces: Self-hosted versions of NocoDB do not support the workspace function, so this update eliminates the necessity of having a workspace to retrieve a base.

Adds API version selection: Users can now select which version of the NocoDB API they are using, ensuring compatibility with various versions.

Fixes # ( added compatibility with self-hosted versions)

