### PR TITLE
feat(krisp-call): new outbound sms/mms trigger

### DIFF
--- a/packages/pieces/community/krisp-call/package.json
+++ b/packages/pieces/community/krisp-call/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-krisp-call",
-  "version": "0.0.3"
+  "version": "0.0.4"
 }

--- a/packages/pieces/community/krisp-call/src/lib/triggers/index.ts
+++ b/packages/pieces/community/krisp-call/src/lib/triggers/index.ts
@@ -58,6 +58,19 @@ export const triggers = [
             callRecording: "http://example.com/recording.mp3",
         },
     },
+    {
+        name: 'OutboundSMS/MMS',
+        displayName: 'Outbound MMS/SMS',
+        description: 'Trigger when a new MMS/SMS is sent.',
+        action: 'outbound_sms_or_mms',
+        sampleData: {
+            "id": "YiW2nyxqtJPYqkRKbrcJQ7",
+            "from_number": "+16466813538",
+            "to_number": "+12517327005",
+            "content": "Last testing",
+            "media_link": "https://api.twilio.com/2010-04-01/Accounts/LINK/Media/SOMETHING"
+        },
+    },
 ].map(trigger => {
     return createTrigger({
         name: trigger.name,


### PR DESCRIPTION
What does this PR do?
This PR introduces a outbound sms/mms  trigger for the krisp-call pieces. It adds functionality to monitor and record outbound sms /mms, enhancing the system's ability to log and track call activities effectively.

Fixes

Fixes # (link to the issue, if applicable).
Motivation and Context
The addition of the outbound sms/mms trigger is crucial for improving sms or mms analytics and debugging capabilities. By capturing detailed call events, this update will enable better monitoring and reporting of sms/mms activities within the krisp-call module.

Dependencies
No additional dependencies are required for this change (or list any required).