### PR TITLE
fix: update error status on Dust piece to match changes in the API

### DIFF
--- a/packages/pieces/community/dust/src/lib/common.ts
+++ b/packages/pieces/community/dust/src/lib/common.ts
@@ -89,7 +89,7 @@ export async function getConversationContent(
   let retries = 0;
   const maxRetries = timeout / 10;
   while (
-    !['succeeded', 'errored'].includes(
+    !['succeeded', 'failed'].includes(
       getConversationStatus(conversation.body)
     ) &&
     retries < maxRetries


### PR DESCRIPTION
## What does this PR do?

The API for Dust changed, and the error status changed from `errored` to `failed`. Because of this, the pieces are timing out and never resolve. This ensures it resolve with a proper failure instead of a time-out.