### PR TITLE
feat(confluence): improve get-page-content to fetch recursive children

### DIFF
--- a/packages/pieces/community/confluence/package.json
+++ b/packages/pieces/community/confluence/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-confluence",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/packages/pieces/community/confluence/src/lib/actions/get-page-content.ts
+++ b/packages/pieces/community/confluence/src/lib/actions/get-page-content.ts
@@ -1,133 +1,145 @@
-import { createAction, Property, DynamicPropsValue } from '@activepieces/pieces-framework';
-import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import {
+	createAction,
+	Property,
+	DynamicPropsValue,
+	PiecePropValueSchema,
+} from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
 import { confluenceAuth } from '../..';
+import { confluenceApiCall } from '../common';
 
 interface ConfluencePage {
-  id: string;
-  title: string;
-  body: any;
-  children?: ConfluencePage[];
+	id: string;
+	title: string;
+	body: any;
+	children?: ConfluencePage[];
 }
 
-async function getPageWithContent(auth: any, domain: string, pageId: string): Promise<ConfluencePage> {
-  try {
-    const response = await httpClient.sendRequest<ConfluencePage>({
-      method: HttpMethod.GET,
-      url: `${domain}/wiki/api/v2/pages/${pageId}`,
-      queryParams: {
-        "body-format": "storage"
-      },
-      authentication: {
-        type: AuthenticationType.BASIC,
-        username: auth.username,
-        password: auth.password
-      }
-    });
-    return response.body;
-  } catch (error) {
-    throw new Error(`Failed to fetch page ${pageId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
-  }
+async function getPageWithContent(
+	auth: PiecePropValueSchema<typeof confluenceAuth>,
+	pageId: string,
+): Promise<ConfluencePage> {
+	try {
+		const response = await confluenceApiCall<ConfluencePage>({
+			domain: auth.confluenceDomain,
+			username: auth.username,
+			password: auth.password,
+			method: HttpMethod.GET,
+			resourceUri: `/pages/${pageId}`,
+			query: {
+				'body-format': 'storage',
+			},
+		});
+		return response;
+	} catch (error) {
+		throw new Error(
+			`Failed to fetch page ${pageId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+		);
+	}
 }
 
-async function getChildPages(auth: any, domain: string, parentId: string, currentDepth: number, maxDepth: number): Promise<ConfluencePage[]> {
-  if (currentDepth >= maxDepth) {
-    return [];
-  }
+async function getChildPages(
+	auth: PiecePropValueSchema<typeof confluenceAuth>,
+	parentId: string,
+	currentDepth: number,
+	maxDepth: number,
+): Promise<ConfluencePage[]> {
+	if (currentDepth >= maxDepth) {
+		return [];
+	}
 
-  try {
-    const childrenResponse = await httpClient.sendRequest<{ results: ConfluencePage[] }>({
-      method: HttpMethod.GET,
-      url: `${domain}/wiki/api/v2/pages/${parentId}/children`,
-      authentication: {
-        type: AuthenticationType.BASIC,
-        username: auth.username,
-        password: auth.password
-      },
-      headers: {
-        'Accept': 'application/json'
-      }
-    });
+	try {
+		const childrenResponse = await confluenceApiCall<{ results: ConfluencePage[] }>({
+			domain: auth.confluenceDomain,
+			username: auth.username,
+			password: auth.password,
+			method: HttpMethod.GET,
+			resourceUri: `/pages/${parentId}/children`,
+		});
 
-    const childPages = await Promise.all(
-      childrenResponse.body.results.map(async (childPage) => {
-        const pageWithContent = await getPageWithContent(auth, domain, childPage.id);
-        const children = await getChildPages(auth, domain, childPage.id, currentDepth + 1, maxDepth);
-        return {
-          ...pageWithContent,
-          children
-        };
-      })
-    );
+		const childPages = await Promise.all(
+			childrenResponse.results.map(async (childPage) => {
+				const pageWithContent = await getPageWithContent(auth, childPage.id);
+				const children = await getChildPages(auth, childPage.id, currentDepth + 1, maxDepth);
+				return {
+					...pageWithContent,
+					children,
+				};
+			}),
+		);
 
-    return childPages;
-  } catch (error) {
-    throw new Error(`Failed to fetch children for page ${parentId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
-  }
+		return childPages;
+	} catch (error) {
+		throw new Error(
+			`Failed to fetch children for page ${parentId}: ${
+				error instanceof Error ? error.message : 'Unknown error'
+			}`,
+		);
+	}
 }
 
 export const getPageContent = createAction({
-  name: 'getPageContent',
-  displayName: 'Get Page Content',
-  description: 'Get page content and optionally all its descendants',
-  auth: confluenceAuth,
-  props: {
-    pageId: Property.ShortText({
-      displayName: 'Page ID',
-      description: 'Get this from the page URL of your Confluence Cloud',
-      required: true
-    }),
-    includeDescendants: Property.Checkbox({
-      displayName: 'Include Descendants',
-      description: 'If checked, will fetch all child pages recursively',
-      required: false,
-      defaultValue: false
-    }),
-    dynamic: Property.DynamicProperties({
-      displayName: 'Dynamic Properties',
-      refreshers: ['includeDescendants'],
-      required: true,
-      props: async ({ includeDescendants }) => {
-        if (!includeDescendants) {
-          return {};
-        }
-        const fields: DynamicPropsValue = {
-          maxDepth: Property.Number({
-            displayName: 'Maximum Depth',
-            description: 'Maximum depth of child pages to fetch',
-            required: true,
-            defaultValue: 5
-          })
-        };
-        return fields;
-      }
-    })
-  },
-  async run(context) {
-    try {
-      const page = await getPageWithContent(
-        context.auth,
-        context.auth.confluenceDomain,
-        context.propsValue.pageId
-      );
+	name: 'getPageContent',
+	displayName: 'Get Page Content',
+	description: 'Get page content and optionally all its descendants',
+	auth: confluenceAuth,
+	props: {
+		pageId: Property.ShortText({
+			displayName: 'Page ID',
+			description: 'Get this from the page URL of your Confluence Cloud',
+			required: true,
+		}),
+		includeDescendants: Property.Checkbox({
+			displayName: 'Include Descendants ?',
+			description: 'If checked, will fetch all child pages recursively.',
+			required: false,
+			defaultValue: false,
+		}),
+		dynamic: Property.DynamicProperties({
+			displayName: 'Dynamic Properties',
+			refreshers: ['includeDescendants'],
+			required: true,
+			props: async ({ includeDescendants }) => {
+				if (!includeDescendants) {
+					return {};
+				}
+				const fields: DynamicPropsValue = {
+					maxDepth: Property.Number({
+						displayName: 'Maximum Depth',
+						description: 'Maximum depth of child pages to fetch.',
+						required: true,
+						defaultValue: 5,
+					}),
+				};
+				return fields;
+			},
+		}),
+	},
+	async run(context) {
+		try {
+			const page = await getPageWithContent(context.auth, context.propsValue.pageId);
 
-      if (!context.propsValue.includeDescendants) {
-        return page;
-      }
+			if (!context.propsValue.includeDescendants) {
+				return page;
+			}
 
-      const children = await getChildPages(
-        context.auth,
-        context.auth.confluenceDomain,
-        context.propsValue.pageId,
-        1,
-        context.propsValue.dynamic['maxDepth']
-      );
+			const children = await getChildPages(
+				context.auth,
+				context.propsValue.pageId,
+				1,
+				context.propsValue.dynamic['maxDepth'],
+			);
 
-      return {
-        ...page,
-        children
-      };
-    } catch (error) {
-      throw new Error(`Failed to fetch page ${context.propsValue.pageId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    }
-  },
+			return {
+				...page,
+				children,
+			};
+		} catch (error) {
+			throw new Error(
+				`Failed to fetch page ${context.propsValue.pageId}: ${
+					error instanceof Error ? error.message : 'Unknown error'
+				}`,
+			);
+		}
+	},
 });

--- a/packages/pieces/community/confluence/src/lib/actions/get-page-content.ts
+++ b/packages/pieces/community/confluence/src/lib/actions/get-page-content.ts
@@ -1,11 +1,74 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import { createAction, Property, DynamicPropsValue } from '@activepieces/pieces-framework';
 import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { confluenceAuth } from '../..';
+
+interface ConfluencePage {
+  id: string;
+  title: string;
+  body: any;
+  children?: ConfluencePage[];
+}
+
+async function getPageWithContent(auth: any, domain: string, pageId: string): Promise<ConfluencePage> {
+  try {
+    const response = await httpClient.sendRequest<ConfluencePage>({
+      method: HttpMethod.GET,
+      url: `${domain}/wiki/api/v2/pages/${pageId}`,
+      queryParams: {
+        "body-format": "storage"
+      },
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: auth.username,
+        password: auth.password
+      }
+    });
+    return response.body;
+  } catch (error) {
+    throw new Error(`Failed to fetch page ${pageId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+async function getChildPages(auth: any, domain: string, parentId: string, currentDepth: number, maxDepth: number): Promise<ConfluencePage[]> {
+  if (currentDepth >= maxDepth) {
+    return [];
+  }
+
+  try {
+    const childrenResponse = await httpClient.sendRequest<{ results: ConfluencePage[] }>({
+      method: HttpMethod.GET,
+      url: `${domain}/wiki/api/v2/pages/${parentId}/children`,
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: auth.username,
+        password: auth.password
+      },
+      headers: {
+        'Accept': 'application/json'
+      }
+    });
+
+    const childPages = await Promise.all(
+      childrenResponse.body.results.map(async (childPage) => {
+        const pageWithContent = await getPageWithContent(auth, domain, childPage.id);
+        const children = await getChildPages(auth, domain, childPage.id, currentDepth + 1, maxDepth);
+        return {
+          ...pageWithContent,
+          children
+        };
+      })
+    );
+
+    return childPages;
+  } catch (error) {
+    throw new Error(`Failed to fetch children for page ${parentId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
 
 export const getPageContent = createAction({
   name: 'getPageContent',
   displayName: 'Get Page Content',
-  description: 'Confluence Cloud REST API v2',
+  description: 'Get page content and optionally all its descendants',
   auth: confluenceAuth,
   props: {
     pageId: Property.ShortText({
@@ -13,20 +76,58 @@ export const getPageContent = createAction({
       description: 'Get this from the page URL of your Confluence Cloud',
       required: true
     }),
+    includeDescendants: Property.Checkbox({
+      displayName: 'Include Descendants',
+      description: 'If checked, will fetch all child pages recursively',
+      required: false,
+      defaultValue: false
+    }),
+    dynamic: Property.DynamicProperties({
+      displayName: 'Dynamic Properties',
+      refreshers: ['includeDescendants'],
+      required: true,
+      props: async ({ includeDescendants }) => {
+        if (!includeDescendants) {
+          return {};
+        }
+        const fields: DynamicPropsValue = {
+          maxDepth: Property.Number({
+            displayName: 'Maximum Depth',
+            description: 'Maximum depth of child pages to fetch',
+            required: true,
+            defaultValue: 5
+          })
+        };
+        return fields;
+      }
+    })
   },
   async run(context) {
-    const res = await httpClient.sendRequest<string[]>({
-      method: HttpMethod.GET,
-      url: `${context.auth.confluenceDomain}/wiki/api/v2/pages/${context.propsValue.pageId}`,
-      queryParams: {
-        "body-format": "storage"
-      },
-      authentication: {
-        type: AuthenticationType.BASIC,
-        username: context.auth.username,
-        password: context.auth.password
+    try {
+      const page = await getPageWithContent(
+        context.auth,
+        context.auth.confluenceDomain,
+        context.propsValue.pageId
+      );
+
+      if (!context.propsValue.includeDescendants) {
+        return page;
       }
-    });
-    return res.body;
+
+      const children = await getChildPages(
+        context.auth,
+        context.auth.confluenceDomain,
+        context.propsValue.pageId,
+        1,
+        context.propsValue.dynamic['maxDepth']
+      );
+
+      return {
+        ...page,
+        children
+      };
+    } catch (error) {
+      throw new Error(`Failed to fetch page ${context.propsValue.pageId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
   },
 });


### PR DESCRIPTION
## What does this PR do?

Fetches a page content and its children recursively. Children's page content is nested in `children` property

<img width="442" alt="Screenshot 2025-01-30 at 1 29 14 AM" src="https://github.com/user-attachments/assets/8a3ca885-d2f6-4ace-8572-44256cf2f35a" />

