### PR TITLE
feat(teams): add scopes to retrieve list of users and presence

### DIFF
--- a/packages/pieces/community/microsoft-teams/package.json
+++ b/packages/pieces/community/microsoft-teams/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-microsoft-teams",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/pieces/community/microsoft-teams/src/index.ts
+++ b/packages/pieces/community/microsoft-teams/src/index.ts
@@ -23,6 +23,8 @@ export const microsoftTeamsAuth = PieceAuth.OAuth2({
     'ChannelMessage.Send',
     'Team.ReadBasic.All',
     'Chat.ReadWrite',
+    'User.ReadBasic.All',
+    'Presence.Read.All',
   ],
   authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
   tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',


### PR DESCRIPTION
## What does this PR do?

Add `User.ReadBasic.All` and `Presence.Read.All` scopes to microsoft-teams piece to retrieve list of users and their presence
