### PR TITLE
feat: Adding support for syncing specific pieces

### DIFF
--- a/packages/cli/src/lib/commands/build-piece.ts
+++ b/packages/cli/src/lib/commands/build-piece.ts
@@ -1,14 +1,10 @@
 import { Command } from "commander";
-import { buildPiece, findPieceSourceDirectory } from "../utils/piece-utils";
+import { buildPiece, findPiece } from '../utils/piece-utils';
 import chalk from "chalk";
 
 async function buildPieces(pieceName: string) {
-    const piecesFolder = await findPieceSourceDirectory(pieceName);
-    if (!piecesFolder) {
-        console.error(chalk.red(`Piece '${pieceName}' not found.`));
-        process.exit(1);
-    }
-    const { outputFolder } = await buildPiece(piecesFolder);
+    const pieceFolder = await findPiece(pieceName);
+    const { outputFolder } = await buildPiece(pieceFolder);
     console.info(chalk.green(`Piece '${pieceName}' built and packed successfully at ${outputFolder}.`));
 }
 

--- a/packages/cli/src/lib/commands/create-action.ts
+++ b/packages/cli/src/lib/commands/create-action.ts
@@ -2,11 +2,7 @@ import { writeFile } from 'node:fs/promises';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import inquirer from 'inquirer';
-import {
-  displayNameToCamelCase,
-  displayNameToKebabCase,
-  findPiece
-} from '../utils/piece-utils';
+import { displayNameToCamelCase, displayNameToKebabCase, findPiece } from '../utils/piece-utils';
 import { checkIfFileExists, makeFolderRecursive } from '../utils/files';
 import { join } from 'node:path';
 

--- a/packages/cli/src/lib/commands/create-action.ts
+++ b/packages/cli/src/lib/commands/create-action.ts
@@ -2,7 +2,11 @@ import { writeFile } from 'node:fs/promises';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import inquirer from 'inquirer';
-import { displayNameToCamelCase, findPieceSourceDirectory, displayNameToKebabCase } from '../utils/piece-utils';
+import {
+  displayNameToCamelCase,
+  displayNameToKebabCase,
+  findPiece
+} from '../utils/piece-utils';
 import { checkIfFileExists, makeFolderRecursive } from '../utils/files';
 import { join } from 'node:path';
 
@@ -24,13 +28,6 @@ export const ${camelCase} = createAction({
 
   return actionTemplate
 }
-const checkIfPieceExists = async (pieceName: string) => {
-  const path = await findPieceSourceDirectory(pieceName);
-  if (!path) {
-    console.log(chalk.red(`🚨 Piece ${pieceName} not found`));
-    process.exit(1);
-  }
-};
 
 const checkIfActionExists = async (actionPath: string) => {
   if (await checkIfFileExists(actionPath)) {
@@ -41,11 +38,9 @@ const checkIfActionExists = async (actionPath: string) => {
 const createAction = async (pieceName: string, displayActionName: string, actionDescription: string) => {
   const actionTemplate = createActionTemplate(displayActionName, actionDescription)
   const actionName = displayNameToKebabCase(displayActionName)
-  const path = await findPieceSourceDirectory(pieceName);
-  await checkIfPieceExists(pieceName);
-  console.log(chalk.blue(`Piece path: ${path}`))
-
-  const actionsFolder = join(path, 'src', 'lib', 'actions')
+  const pieceFolder = await findPiece(pieceName);
+  console.log(chalk.blue(`Piece path: ${pieceFolder}`))
+  const actionsFolder = join(pieceFolder, 'src', 'lib', 'actions')
   const actionPath = join(actionsFolder, `${actionName}.ts`)
   await checkIfActionExists(actionPath)
 

--- a/packages/cli/src/lib/commands/create-piece.ts
+++ b/packages/cli/src/lib/commands/create-piece.ts
@@ -38,6 +38,14 @@ const validatePackageName = async (packageName: string) => {
   }
 };
 
+const checkIfPieceExists = async (pieceName: string) => {
+  const pieceFolder = await findPiece(pieceName);
+  if (pieceFolder) {
+    console.log(chalk.red(`🚨 Piece already exists at ${pieceFolder}`));
+    process.exit(1);
+  }
+};
+
 const nxGenerateNodeLibrary = async (
   pieceName: string,
   packageName: string,
@@ -165,7 +173,7 @@ export const createPiece = async (
 ) => {
   await validatePieceName(pieceName);
   await validatePackageName(packageName);
-  await findPiece(pieceName);
+  await checkIfPieceExists(pieceName);
   await nxGenerateNodeLibrary(pieceName, packageName, pieceType);
   await setupGeneratedLibrary(pieceName, pieceType);
   console.log(chalk.green('✨  Done!'));

--- a/packages/cli/src/lib/commands/create-piece.ts
+++ b/packages/cli/src/lib/commands/create-piece.ts
@@ -10,7 +10,7 @@ import {
   writePackageEslint,
   writeProjectJson,
 } from '../utils/files';
-import { findPieceSourceDirectory } from '../utils/piece-utils';
+import { findPiece } from '../utils/piece-utils';
 
 const validatePieceName = async (pieceName: string) => {
   console.log(chalk.yellow('Validating piece name....'));
@@ -34,14 +34,6 @@ const validatePackageName = async (packageName: string) => {
         `🚨 Invalid package name: ${packageName}. Package names can only contain lowercase letters, numbers, and hyphens.`
       )
     );
-    process.exit(1);
-  }
-};
-
-const checkIfPieceExists = async (pieceName: string) => {
-  const path = await findPieceSourceDirectory(pieceName);
-  if (path) {
-    console.log(chalk.red(`🚨 Piece already exists at ${path}`));
     process.exit(1);
   }
 };
@@ -92,7 +84,7 @@ const generateIndexTsFile = async (pieceName: string, pieceType: string) => {
 
   const indexTemplate = `
     import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
-    
+
     export const ${pieceNameCamelCase} = createPiece({
       displayName: "${capitalizeFirstLetter(pieceName)}",
       auth: PieceAuth.None(),
@@ -173,7 +165,7 @@ export const createPiece = async (
 ) => {
   await validatePieceName(pieceName);
   await validatePackageName(packageName);
-  await checkIfPieceExists(pieceName);
+  await findPiece(pieceName);
   await nxGenerateNodeLibrary(pieceName, packageName, pieceType);
   await setupGeneratedLibrary(pieceName, pieceType);
   console.log(chalk.green('✨  Done!'));

--- a/packages/cli/src/lib/commands/create-trigger.ts
+++ b/packages/cli/src/lib/commands/create-trigger.ts
@@ -4,7 +4,12 @@ import inquirer from 'inquirer';
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { checkIfFileExists, makeFolderRecursive } from '../utils/files';
-import { displayNameToCamelCase, displayNameToKebabCase, findPieceSourceDirectory } from '../utils/piece-utils';
+import {
+  customPiecePath,
+  displayNameToCamelCase,
+  displayNameToKebabCase, findPiece,
+  findPieces,
+} from '../utils/piece-utils';
 
 function createTriggerTemplate(displayName: string, description: string, technique: string) {
     const camelCase = displayNameToCamelCase(displayName)
@@ -82,14 +87,6 @@ export const ${camelCase} = createTrigger({
 
     return triggerTemplate
 }
-const checkIfPieceExists = async (pieceName: string) => {
-    const path = await findPieceSourceDirectory(pieceName);
-    if (!path) {
-        console.log(chalk.red(`🚨 Piece ${pieceName} not found`));
-        process.exit(1);
-    }
-};
-
 const checkIfTriggerExists = async (triggerPath: string) => {
     if (await checkIfFileExists(triggerPath)) {
         console.log(chalk.red(`🚨 Trigger already exists at ${triggerPath}`));
@@ -99,11 +96,10 @@ const checkIfTriggerExists = async (triggerPath: string) => {
 const createTrigger = async (pieceName: string, displayTriggerName: string, triggerDescription: string, triggerTechnique: string) => {
     const triggerTemplate = createTriggerTemplate(displayTriggerName, triggerDescription, triggerTechnique)
     const triggerName = displayNameToKebabCase(displayTriggerName)
-    const path = await findPieceSourceDirectory(pieceName);
-    await checkIfPieceExists(pieceName);
-    console.log(chalk.blue(`Piece path: ${path}`))
+    const pieceFolder = await findPiece(pieceName);
+    console.log(chalk.blue(`Piece path: ${pieceFolder}`))
 
-    const triggersFolder = join(path, 'src', 'lib', 'triggers')
+    const triggersFolder = join(pieceFolder, 'src', 'lib', 'triggers')
     const triggerPath = join(triggersFolder, `${triggerName}.ts`)
     await checkIfTriggerExists(triggerPath)
 

--- a/packages/cli/src/lib/commands/publish-piece.ts
+++ b/packages/cli/src/lib/commands/publish-piece.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { publishPieceFromFolder, findPieceSourceDirectory } from "../utils/piece-utils";
+import { publishPieceFromFolder, findPiece } from '../utils/piece-utils';
 import chalk from "chalk";
 import inquirer from 'inquirer';
 import * as dotenv from 'dotenv';
@@ -7,11 +7,7 @@ import * as dotenv from 'dotenv';
 dotenv.config({path: 'packages/server/api/.env'});
 
 async function publishPieces(apiUrl: string, apiKey: string, pieceName: string) {
-    const piecesFolder = await findPieceSourceDirectory (pieceName);
-    if (piecesFolder.length === 0) {
-        console.error(chalk.red(`Piece '${pieceName}' not found.`));
-        process.exit(1);
-    }
+    const piecesFolder = await findPiece(pieceName);
     await publishPieceFromFolder(piecesFolder, apiUrl, apiKey);
 }
 

--- a/packages/cli/src/lib/commands/sync-pieces.ts
+++ b/packages/cli/src/lib/commands/sync-pieces.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 import { join } from "path";
 
 async function syncPieces(apiUrl: string, apiKey: string, pieces: string[] | null) {
-  const piecesDirectory = join(process.cwd(), 'packages', 'pieces', 'community')
+  const piecesDirectory = join(process.cwd(), 'packages', 'pieces', 'custom')
   const pieceFolders = await findPieces(piecesDirectory, pieces);
     for (const pieceFolder of pieceFolders) {
       await publishPieceFromFolder(pieceFolder, apiUrl, apiKey);

--- a/packages/cli/src/lib/commands/sync-pieces.ts
+++ b/packages/cli/src/lib/commands/sync-pieces.ts
@@ -1,25 +1,28 @@
 import { Command } from "commander";
-import { findAllPieces, publishPieceFromFolder } from "../utils/piece-utils";
+import { findPieces, publishPieceFromFolder } from '../utils/piece-utils';
 import chalk from "chalk";
 import { join } from "path";
 
-
-async function syncPieces(apiUrl: string, apiKey: string) {
-    const piecesFolder = await findAllPieces(join(process.cwd(), 'packages', 'pieces', 'custom'));
-    for (const pieceFolder of piecesFolder) {
-        await publishPieceFromFolder(pieceFolder, apiUrl, apiKey);
+async function syncPieces(apiUrl: string, apiKey: string, pieces: string[] | null) {
+  const piecesDirectory = join(process.cwd(), 'packages', 'pieces', 'community')
+  const pieceFolders = await findPieces(piecesDirectory, pieces);
+    for (const pieceFolder of pieceFolders) {
+      await publishPieceFromFolder(pieceFolder, apiUrl, apiKey);
     }
 }
 
 export const syncPieceCommand = new Command('sync')
     .description('Find new pieces versions and sync them with the database')
     .requiredOption('-h, --apiUrl <url>', 'API URL ex: https://cloud.activepieces.com/api')
+    .option('-p, --pieces <pieces...>', 'Specify one or more piece names to sync. ' +
+      'If not provided, all custom pieces in the directory will be synced.')
     .action(async (options) => {
         const apiKey = process.env.AP_API_KEY;
         const apiUrlWithoutTrailSlash = options.apiUrl.replace(/\/$/, '');
+        const pieces = options.pieces ? [...new Set<string>(options.pieces)] : null;
         if (!apiKey) {
             console.error(chalk.red('AP_API_KEY environment variable is required'));
             process.exit(1);
         }
-        await syncPieces(apiUrlWithoutTrailSlash, apiKey);
+        await syncPieces(apiUrlWithoutTrailSlash, apiKey, pieces);
     });

--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -8,18 +8,29 @@ import chalk from 'chalk'
 import FormData from 'form-data';
 import fs from 'fs';
 
-export async function findAllPieces(inputPath?: string): Promise<string[]> {
-    const piecesPath = inputPath ?? path.join(cwd(), 'packages', 'pieces')
-    const paths = await traverseFolder(piecesPath)
-    return paths
+const customPiecePath = () => path.join(cwd(), 'packages', 'pieces', 'custom')
+
+export async function findPieces(inputPath?: string, pieces?: string[]): Promise<string[]> {
+    const piecesPath = inputPath ?? customPiecePath()
+    const piecesFolders = await traverseFolder(piecesPath)
+    if (pieces) {
+        return pieces.flatMap((piece) => {
+          const folder = piecesFolders.find((p) => {
+              const normalizedPath = path.normalize(p);
+              return normalizedPath.endsWith(path.sep + piece);
+          });
+          if (!folder) {
+              console.error(chalk.red(`Piece ${piece} not found`));
+              return [];
+          }
+          return [folder];
+      });
+    } else {
+        return piecesFolders
+    }
 }
 export async function findPieceSourceDirectory(pieceName: string): Promise<string | null> {
-    const piecesPath =  await findAllPieces()
-    const piecePath = piecesPath.find((p) => {
-        const normalizedPath = path.normalize(p);
-        return normalizedPath.endsWith(path.sep + pieceName);
-    });
-    return piecePath ?? null
+    return (await findPieces(customPiecePath(), [pieceName]))[0] ?? null;
 }
 
 

--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -8,7 +8,7 @@ import chalk from 'chalk'
 import FormData from 'form-data';
 import fs from 'fs';
 
-const customPiecePath = () => path.join(cwd(), 'packages', 'pieces', 'custom')
+export const customPiecePath = () => path.join(cwd(), 'packages', 'pieces', 'custom')
 
 export async function findPieces(inputPath?: string, pieces?: string[]): Promise<string[]> {
     const piecesPath = inputPath ?? customPiecePath()
@@ -20,7 +20,7 @@ export async function findPieces(inputPath?: string, pieces?: string[]): Promise
               return normalizedPath.endsWith(path.sep + piece);
           });
           if (!folder) {
-              console.error(chalk.red(`Piece ${piece} not found`));
+              console.error(chalk.red(`🚨 Piece ${piece} not found`));
               return [];
           }
           return [folder];
@@ -29,10 +29,9 @@ export async function findPieces(inputPath?: string, pieces?: string[]): Promise
         return piecesFolders
     }
 }
-export async function findPieceSourceDirectory(pieceName: string): Promise<string | null> {
-    return (await findPieces(customPiecePath(), [pieceName]))[0] ?? null;
+export async function findPiece(pieceName: string): Promise<string> {
+    return (await findPieces(customPiecePath(), [pieceName]))[0] ?? process.exit(1);
 }
-
 
 export async function buildPiece(pieceFolder: string): Promise<{ outputFolder: string, outputFile: string }> {
     const projectJson = await readProjectJson(pieceFolder);

--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -10,6 +10,13 @@ import fs from 'fs';
 
 export const customPiecePath = () => path.join(cwd(), 'packages', 'pieces', 'custom')
 
+/**
+ * Finds and returns the paths of specific pieces or all available pieces in a given directory.
+ *
+ * @param inputPath - The root directory to search for pieces. If not provided, a default path to custom pieces is used.
+ * @param pieces - An optional array of piece names to search for. If not provided, all pieces in the directory are returned.
+ * @returns A promise resolving to an array of strings representing the paths of the found pieces.
+ */
 export async function findPieces(inputPath?: string, pieces?: string[]): Promise<string[]> {
     const piecesPath = inputPath ?? customPiecePath()
     const piecesFolders = await traverseFolder(piecesPath)
@@ -29,6 +36,13 @@ export async function findPieces(inputPath?: string, pieces?: string[]): Promise
         return piecesFolders
     }
 }
+
+/**
+ * Finds and returns the path of a single piece. Exits the process if the piece is not found.
+ *
+ * @param pieceName - The name of the piece to search for.
+ * @returns A promise resolving to a string representing the path of the found piece. If not found, the process exits.
+ */
 export async function findPiece(pieceName: string): Promise<string> {
     return (await findPieces(customPiecePath(), [pieceName]))[0] ?? process.exit(1);
 }


### PR DESCRIPTION
## What does this PR do?

I am adding an optional flag for the `sync-pieces` CLI command called `--pieces` that lets a user specify which pieces they actually want to sync. I am adding this flag because our team has quite a few custom pieces in our AP project, and syncing them requires all of them to build, even though we only care about the one we are developing at the moment. The existing sync setup makes development unnecessarily slow, so I am adding a flag that we can use to sync only the piece we are working on. I was thinking that this feature could be useful more broadly for other teams facing the same issue.

