### PR TITLE
fix: show (Edit Flow) button when user is testing a flow that hasn't been published

### DIFF
--- a/packages/react-ui/src/app/builder/builder-flow-status-section/view-draft-or-edit-flow-button.tsx
+++ b/packages/react-ui/src/app/builder/builder-flow-status-section/view-draft-or-edit-flow-button.tsx
@@ -13,14 +13,15 @@ const EditFlowOrViewDraftButton = () => {
   const navigate = useNavigate();
   const { checkAccess } = useAuthorization();
   const { switchToDraft, isSwitchingToDraftPending } = useSwitchToDraft();
-  const [flowVersion, flowId, readonly] = useBuilderStateContext((state) => [
+  const [flowVersion, flowId, readonly, run] = useBuilderStateContext((state) => [
     state.flowVersion,
     state.flow.id,
     state.readonly,
+    state.run
   ]);
   const isViewingDraft = flowVersion.state === FlowVersionState.DRAFT;
   const permissionToEditFlow = checkAccess(Permission.WRITE_FLOW);
-  if (!readonly || isViewingDraft) {
+  if (!readonly || (isViewingDraft && !run)) {
     return null;
   }
 

--- a/packages/react-ui/src/app/builder/builder-flow-status-section/view-draft-or-edit-flow-button.tsx
+++ b/packages/react-ui/src/app/builder/builder-flow-status-section/view-draft-or-edit-flow-button.tsx
@@ -13,12 +13,9 @@ const EditFlowOrViewDraftButton = () => {
   const navigate = useNavigate();
   const { checkAccess } = useAuthorization();
   const { switchToDraft, isSwitchingToDraftPending } = useSwitchToDraft();
-  const [flowVersion, flowId, readonly, run] = useBuilderStateContext((state) => [
-    state.flowVersion,
-    state.flow.id,
-    state.readonly,
-    state.run
-  ]);
+  const [flowVersion, flowId, readonly, run] = useBuilderStateContext(
+    (state) => [state.flowVersion, state.flow.id, state.readonly, state.run],
+  );
   const isViewingDraft = flowVersion.state === FlowVersionState.DRAFT;
   const permissionToEditFlow = checkAccess(Permission.WRITE_FLOW);
   if (!readonly || (isViewingDraft && !run)) {


### PR DESCRIPTION
## What does this PR do?


closes #6714
