### PR TITLE
fix: remove justyf-center 

### DIFF
--- a/packages/react-ui/src/app/builder/test-step/test-sample-data-viewer.tsx
+++ b/packages/react-ui/src/app/builder/test-step/test-sample-data-viewer.tsx
@@ -40,7 +40,7 @@ const TestSampleDataViewer = React.memo(
         <div className="flex-grow flex flex-col w-full text-start gap-4">
           <div className="flex justify-center items-center">
             <div className="flex flex-col flex-grow gap-1">
-              <div className="text-md flex gap-1 justyf-center items-center">
+              <div className="text-md flex gap-1 items-center">
                 {errorMessage ? (
                   <>
                     <StepStatusIcon


### PR DESCRIPTION
Remove justyf-center as it contains a typo. However, fixing the typo to justify-center causes unwanted styling changes by centering the title, which does not match the rest of the design.