### PR TITLE
feat: add png rendering action to the Metabase piece

### DIFF
--- a/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
+++ b/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
@@ -28,6 +28,7 @@ export class AxiosHttpClient extends BaseHttpClient {
       const axiosRequestMethod = this.getAxiosRequestMethod(request.method);
       const timeout = request.timeout ? request.timeout : 0;
       const queryParams = request.queryParams || {}
+      const responseType = request.responseType || 'json';
 
       for (const [key, value] of urlQueryParams) {
         queryParams[key] = value
@@ -40,6 +41,7 @@ export class AxiosHttpClient extends BaseHttpClient {
         headers,
         data: request.body,
         timeout,
+        responseType,
       };
 
       if (request.retries && request.retries > 0) {

--- a/packages/pieces/community/common/src/lib/http/core/http-request.ts
+++ b/packages/pieces/community/common/src/lib/http/core/http-request.ts
@@ -13,4 +13,5 @@ export type HttpRequest<RequestBody extends HttpRequestBody = any> = {
   queryParams?: QueryParams | undefined;
   timeout?: number;
   retries?: number;
+  responseType?: 'arraybuffer' | 'json' | 'blob' | 'text';
 };

--- a/packages/pieces/community/metabase/package.json
+++ b/packages/pieces/community/metabase/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-metabase",
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/packages/pieces/community/metabase/src/index.ts
+++ b/packages/pieces/community/metabase/src/index.ts
@@ -4,6 +4,7 @@ import {
   Property,
 } from '@activepieces/pieces-framework';
 import { getQuestion } from './lib/actions/get-question';
+import { getQuestionPngPreview } from './lib/actions/get-png-rendering';
 import { queryMetabaseApi } from './lib/common';
 import { HttpMethod } from '@activepieces/pieces-common';
 
@@ -50,7 +51,7 @@ export const metabase = createPiece({
   auth: metabaseAuth,
   minimumSupportedRelease: '0.30.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/metabase.png',
-  authors: ['AdamSelene', 'abuaboud'],
-  actions: [getQuestion],
+  authors: ['AdamSelene', 'abuaboud', 'valentin-mourtialon'],
+  actions: [getQuestion, getQuestionPngPreview],
   triggers: [],
 });

--- a/packages/pieces/community/metabase/src/lib/actions/get-png-rendering.ts
+++ b/packages/pieces/community/metabase/src/lib/actions/get-png-rendering.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { metabaseAuth } from '../..';
+import { queryMetabaseApi } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const getQuestionPngPreview = createAction({
+  name: 'getQuestionPngPreview',
+  auth: metabaseAuth,
+  requireAuth: true,
+  displayName: 'Get Question PNG Preview',
+  description:
+    'Get PNG preview rendering (low resolution) of a Metabase card/question.',
+  props: {
+    questionId: Property.ShortText({
+      displayName: 'Metabase question ID',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue, files }) {
+    const questionId = propsValue.questionId.split('-')[0];
+
+    const response = await queryMetabaseApi(
+      {
+        endpoint: `pulse/preview_card_png/${questionId}`,
+        method: HttpMethod.GET,
+        headers: {
+          Accept: 'image/png',
+        },
+        responseType: 'arraybuffer',
+      },
+      auth
+    );
+
+    if (response.error) {
+      throw new Error(response.error);
+    }
+
+    const fileUrl = await files.write({
+      fileName: `metabase_question_${questionId}.png`,
+      data: Buffer.from(response, 'base64'),
+    });
+
+    return {
+      fileName: `metabase_question_${questionId}.png`,
+      file: fileUrl,
+    };
+  },
+});

--- a/packages/pieces/community/metabase/src/lib/common.ts
+++ b/packages/pieces/community/metabase/src/lib/common.ts
@@ -17,6 +17,7 @@ export async function queryMetabaseApi(
     queryParams?: QueryParams;
     headers?: HttpHeaders;
     body?: object;
+    responseType?: 'arraybuffer' | 'json' | 'blob' | 'text';
   },
   auth: StaticPropsValue<CustomAuthProps>
 ) {
@@ -30,6 +31,7 @@ export async function queryMetabaseApi(
       'X-API-KEY': auth.apiKey as string,
     },
     body: JSON.stringify(params.body),
+    responseType: params.responseType,
   };
   const response = await httpClient.sendRequest(request);
   return response.body;


### PR DESCRIPTION
## What does this PR do?

- Add a new action "**Get Question PNG Preview**" to fetch PNG renderings of Metabase questions.
- Update the `HttpRequest` type to support all Axios [RequestConfig](https://github.com/axios/axios#request-config) response types.
- Modify `axios-http-client` accordingly.

