### PR TITLE
feat(respaid): add actions and triggers v0

### DIFF
--- a/docs/handbook/customer-support/handle-requests.mdx
+++ b/docs/handbook/customer-support/handle-requests.mdx
@@ -6,7 +6,7 @@ icon: "ticket"
 As a support engineer, you should:
 
 * Fix the urgent issues (please see the definition below)
-* Open tickets for all non-urgent issues.
+* Open tickets for all non-urgent issues. **(DO NOT INCLUDE ANY SENSITIVE INFO IN ISSUE)**
 * Keep customers updated
 * Write clear ticket descriptions
 * Help the team prioritize work

--- a/packages/pieces/community/respaid/.eslintrc.json
+++ b/packages/pieces/community/respaid/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/respaid/README.md
+++ b/packages/pieces/community/respaid/README.md
@@ -1,0 +1,7 @@
+# pieces-respaid
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-respaid` to build the library.

--- a/packages/pieces/community/respaid/package.json
+++ b/packages/pieces/community/respaid/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-respaid",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/respaid/project.json
+++ b/packages/pieces/community/respaid/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-respaid",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/respaid/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/respaid",
+        "tsConfig": "packages/pieces/community/respaid/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/respaid/package.json",
+        "main": "packages/pieces/community/respaid/src/index.ts",
+        "assets": [
+          "packages/pieces/community/respaid/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/respaid/src/index.ts
+++ b/packages/pieces/community/respaid/src/index.ts
@@ -1,0 +1,20 @@
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { respaidActions } from "./lib/actions";
+import { respaidTriggers } from "./lib/triggers";
+
+export const respaidAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: 'You can find API Key in your Respaid account',
+});
+    
+export const respaid = createPiece({
+  displayName: "Respaid",
+  auth: respaidAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: "https://cdn.prod.website-files.com/6633d7e9bd4516c8fbe711be/6642b52b31103ce1aca6428d_Respaid.svg",
+  authors: [],
+  actions: respaidActions,
+  triggers: respaidTriggers,
+});
+    

--- a/packages/pieces/community/respaid/src/index.ts
+++ b/packages/pieces/community/respaid/src/index.ts
@@ -12,7 +12,7 @@ export const respaid = createPiece({
   displayName: "Respaid",
   auth: respaidAuth,
   minimumSupportedRelease: '0.36.1',
-  logoUrl: "https://cdn.prod.website-files.com/6633d7e9bd4516c8fbe711be/6642b52b31103ce1aca6428d_Respaid.svg",
+  logoUrl: "https://cdn.activepieces.com/pieces/respaid.jpg",
   authors: [],
   actions: respaidActions,
   triggers: respaidTriggers,

--- a/packages/pieces/community/respaid/src/lib/actions/create_new_campaign.ts
+++ b/packages/pieces/community/respaid/src/lib/actions/create_new_campaign.ts
@@ -1,0 +1,69 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { respaidAuth } from '../..';
+import { respaidCommon } from '../common';
+
+
+export const createNewCampaign = createAction({
+  name: 'create_new_campaign',
+  displayName: 'Create New Campaign',
+  description: 'Action for creating a new campaign.',
+  auth: respaidAuth,
+  props: {
+    campaign_name: Property.ShortText({
+      displayName: 'Campaign Name',
+      required: true,
+    }),
+    importData: Property.Json({
+      displayName: 'Import Data (Array of Invoices)',
+      required: true,
+      description: `Provide an array of invoice objects with the following example structure:
+      [{
+          "unique_identifier": "123",
+          "debtor_full_name": "John Doe",
+          "debtor_company_name": "Company XYZ",
+          "debtor_email": "john@example.com",
+          "debtor_mobile": "1234567890",
+          "debtor_address": "123 Street, City",
+          "amount_due": 1000,
+          "creditor_name": "Creditor ABC",
+          "creditor_address": "456 Avenue, City",
+          "invoice_number": "INV123",
+          "invoice_date": "2025-01-01",
+          "description": "Invoice for service"
+        }]`,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    if (!Array.isArray(propsValue.importData)) {
+      throw new Error('Import Data must be an array of objects.');
+    }
+
+    const requestBody = {
+      campaign_name: propsValue.campaign_name,
+      is_agency_collection: true,
+      import: propsValue.importData.map(invoice => ({
+        unique_identifier: invoice.unique_identifier,
+        debtor_full_name: invoice.debtor_full_name,
+        debtor_company_name: invoice.debtor_company_name,
+        debtor_email: invoice.debtor_email,
+        debtor_mobile: invoice.debtor_mobile,
+        debtor_address: invoice.debtor_address,
+        amount_due: invoice.amount_due,
+        creditor_name: invoice.creditor_name,
+        creditor_address: invoice.creditor_address,
+        invoice_number: invoice.invoice_number,
+        invoice_date: invoice.invoice_date,
+        description: invoice.description,
+      })),
+    };
+
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.POST,
+      url: `${respaidCommon.baseUrl}/actions/import_campaign`,
+      headers: respaidCommon.getHeadersStructure(auth),
+      body: ({ type: 'active_pieces', import: JSON.stringify(requestBody) }),
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/respaid/src/lib/actions/index.ts
+++ b/packages/pieces/community/respaid/src/lib/actions/index.ts
@@ -1,0 +1,11 @@
+import { createNewCampaign } from "./create_new_campaign";
+import { stopCollectionClientPaidDirectly } from "./stop_collection_client_paid_directly";
+import { stopCollectionForDirectInstalmentPayment } from "./stop_collection_for_direct_instalment_payment";
+import { stopCollectionForDirectPartialPayment } from "./stop_collection_for_direct_partial_payment";
+
+export const respaidActions = [
+    createNewCampaign,
+    stopCollectionClientPaidDirectly,
+    stopCollectionForDirectPartialPayment,
+    stopCollectionForDirectInstalmentPayment
+]

--- a/packages/pieces/community/respaid/src/lib/actions/stop_collection_client_paid_directly.ts
+++ b/packages/pieces/community/respaid/src/lib/actions/stop_collection_client_paid_directly.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { respaidAuth } from '../..';
+import { respaidCommon, respaidActionsCommon } from '../common';
+
+
+export const stopCollectionClientPaidDirectly = createAction({
+  name: 'stop_collection_client_paid_directly',
+  displayName: 'Stop Collection for Direct Full Payment Action',
+  description: 'Stops the collection process for a case and mark it as paid directly to the creditor.',
+  auth: respaidAuth,
+  props: {
+    unique_identifier: Property.ShortText({
+      displayName: 'Unique Identifier',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    if (!propsValue.unique_identifier && !propsValue.email) {
+      throw new Error('At least one of unique_identifier and email must be provided.');
+    }
+
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.POST,
+      url: `${respaidCommon.baseUrl}/actions/stop_collection_client_paid_directly`,
+      headers: respaidCommon.getHeadersStructure(auth),
+      body: respaidActionsCommon.getPayloadBodyStructure(propsValue),
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/respaid/src/lib/actions/stop_collection_for_direct_instalment_payment.ts
+++ b/packages/pieces/community/respaid/src/lib/actions/stop_collection_for_direct_instalment_payment.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { respaidAuth } from '../..';
+import { respaidCommon, respaidActionsCommon } from '../common';
+
+
+export const stopCollectionForDirectInstalmentPayment = createAction({
+  name: 'stop_collection_for_direct_instalment_payment',
+  displayName: 'Stop Collection for Direct Instalment Payment',
+  description: 'Stops the collection process for a case when an instalment plan is set up with the creditor.',
+  auth: respaidAuth,
+  props: {
+    unique_identifier: Property.ShortText({
+      displayName: 'Unique Identifier',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    if (!propsValue.unique_identifier && !propsValue.email) {
+      throw new Error('At least one of unique_identifier and email must be provided.');
+    }
+
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.POST,
+      url: `${respaidCommon.baseUrl}/actions/stop_collection_for_direct_instalment_payment`,
+      headers: respaidCommon.getHeadersStructure(auth),
+      body: respaidActionsCommon.getPayloadBodyStructure(propsValue),
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/respaid/src/lib/actions/stop_collection_for_direct_partial_payment.ts
+++ b/packages/pieces/community/respaid/src/lib/actions/stop_collection_for_direct_partial_payment.ts
@@ -1,0 +1,40 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { respaidAuth } from '../..';
+import { respaidCommon, respaidActionsCommon } from '../common';
+
+
+export const stopCollectionForDirectPartialPayment = createAction({
+  name: 'stop_collection_for_direct_partial_payment',
+  displayName: 'Stop Collection for Direct Partial Payment',
+  description: 'Stops the collection process for a case and mark it as partially paid directly to the creditor.',
+  auth: respaidAuth,
+  props: {
+      unique_identifier: Property.ShortText({
+        displayName: 'Unique Identifier',
+        required: true,
+      }),
+      amount: Property.ShortText({
+        displayName: 'Amount',
+        required: true,
+      }),
+      email: Property.ShortText({
+        displayName: 'Email',
+        required: true,
+      }),
+  },
+  async run({ auth, propsValue }) {
+    if (!propsValue.unique_identifier && !propsValue.amount && !propsValue.email) {
+      throw new Error('At least one of unique_identifier, amount and email must be provided.');
+    }
+
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.POST,
+      url: `${respaidCommon.baseUrl}/actions/stop_collection_for_direct_partial_payment`,
+      headers: respaidCommon.getHeadersStructure(auth),
+      body: respaidActionsCommon.getPayloadBodyStructure(propsValue),
+    });
+
+    return res.body;
+  },
+});

--- a/packages/pieces/community/respaid/src/lib/common/index.ts
+++ b/packages/pieces/community/respaid/src/lib/common/index.ts
@@ -1,0 +1,70 @@
+import { TriggerHookContext, TriggerStrategy, SecretTextProperty } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+interface ActionPayloadProps {
+  unique_identifier?: string;
+  invoice_number?: string;
+  email?: string;
+  amount?: string;
+}
+
+export const respaidCommon = {
+  baseUrl: 'https://backend.dev.widr.app/api/workflow',
+  getHeadersStructure: (auth: string) => ({
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'X-API-KEY': auth
+  }),
+};
+
+export const respaidActionsCommon = {
+  getPayloadBodyStructure: (propsValue: ActionPayloadProps) => ({
+    type: 'active_pieces',
+    payload: JSON.stringify({
+      ...(propsValue.unique_identifier && { unique_identifier: propsValue.unique_identifier }),
+      ...(propsValue.invoice_number && { invoice_number: propsValue.invoice_number }),
+      ...(propsValue.amount && { amount: propsValue.amount }),
+      ...(propsValue.email && { email: propsValue.email }),
+    })
+  }),
+}
+
+
+export const respaidTriggersCommon = {
+  onEnable: (eventType: string) => async(context: TriggerHookContext<SecretTextProperty<true>, Record<string, never>, TriggerStrategy.WEBHOOK>) => {
+    try {
+      console.log('Trigger enabled, subscribing to webhook');
+      await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${respaidCommon.baseUrl}/webhook/subscribe`,
+        headers: respaidCommon.getHeadersStructure(context.auth),
+        body: {
+          type: 'active_pieces',
+          event_type: eventType,
+          target_url: context.webhookUrl,
+        },
+      });
+    } catch (error) {
+      console.error('Error subscribing to webhook:', error);
+      throw new Error('Failed to subscribe to webhook');
+    }
+  },
+  onDisable: (eventType: string) => async(context: TriggerHookContext<SecretTextProperty<true>, Record<string, never>, TriggerStrategy.WEBHOOK>) => {
+    try {
+      console.log('Trigger disabled, unsubscribing from webhook');
+      await httpClient.sendRequest({
+        method: HttpMethod.DELETE,
+        url: `${respaidCommon.baseUrl}/webhook/unsubscribe`,
+        headers: respaidCommon.getHeadersStructure(context.auth),
+        body: {
+          type: 'active_pieces',
+          event_type: eventType,
+          target_url: context.webhookUrl,
+        },
+      });
+    } catch (error) {
+      console.error('Error unsubscribing from webhook:', error);
+      throw new Error('Failed to unsubscribe to webhook');
+    }
+  },
+}

--- a/packages/pieces/community/respaid/src/lib/triggers/index.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/index.ts
@@ -1,0 +1,23 @@
+import { newCampaignCreation } from "./new_campaign_creation";
+import { newCancelledCase } from "./new_cancelled_case";
+import { newDisputedCase } from "./new_disputed_case";
+import { newPayout } from "./new_payout";
+import { newSuccessfulCollectionPaidToCreditor } from "./new_successful_collection_paid_to_creditor";
+import { newSuccessfulInstallmentPaymentViaRespaid } from "./new_successful_installment_payment_via_respaid";
+import { newSuccessfulCollectionViaLegalOfficer } from "./new_successful_collection_via_legal_officer";
+import { newSuccessfulPartialPaymentToCreditor } from "./new_successful_partial_payment_to_creditor";
+import { newSuccessfulPartialPaymentViaRespaid } from "./new_successful_partial_payment_via_respaid";
+import { newSuccessfulCollectionViaRespaid } from "./new_successful_collection_via_respaid";
+
+export const respaidTriggers = [
+    newCampaignCreation,
+    newCancelledCase,
+    newDisputedCase,
+    newPayout,
+    newSuccessfulCollectionPaidToCreditor,
+    newSuccessfulInstallmentPaymentViaRespaid,
+    newSuccessfulCollectionViaLegalOfficer,
+    newSuccessfulPartialPaymentToCreditor,
+    newSuccessfulPartialPaymentViaRespaid,
+    newSuccessfulCollectionViaRespaid
+]

--- a/packages/pieces/community/respaid/src/lib/triggers/new_campaign_creation.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_campaign_creation.ts
@@ -1,0 +1,50 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+interface NewCampaignTriggerPayload {
+    request_id?: string;
+    is_campaign_created?: boolean;
+    valid_files?: {
+        unique_identifier: string;
+        sequence_code: string;
+    }[];
+    invalid_files?: {
+        invalid_email: Record<string, string>;
+    }[];
+    file_processing_report?: string;
+}
+
+export const newCampaignCreation = createTrigger({
+    name: 'new_campaign_creation',
+    displayName: 'New Campaign Creation Result',
+    description: "Triggers when the campaign is created.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "request_id": "1234",
+        "is_campaign_created": true,
+        "valid_files": [{
+            "unique_identifier": "1",
+            "sequence_code": 'SQ###1'
+        }, {
+            "unique_identifier": "2",
+            "sequence_code": 'SQ###2'
+        }],
+        "invalid_files": [{
+            "invalid_email": {
+                "unique_identifier_3": "3",
+                "unique_identifier_4": "4"
+            }
+        }],
+        "file_processing_report": 'https://link_excel.com'
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_campaign_creation'),
+    onDisable: respaidTriggersCommon.onDisable('new_campaign_creation'),
+    async run(context) {
+        const payload = context.payload as NewCampaignTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/src/lib/triggers/new_cancelled_case.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_cancelled_case.ts
@@ -1,0 +1,43 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+interface NewCancelledCaseTriggerPayload {
+    unique_identifier?: string;
+    name?: string;
+    company_name?: string;
+    email?: string;
+    phone_number?: string;
+    invoice_number?: string;
+    amount?: number;
+    currency?: string;
+    reason?: string;
+}
+  
+
+export const newCancelledCase = createTrigger({
+    name: 'new_cancelled_case',
+    displayName: 'New Cancelled Case',
+    description: "Triggers when a collection process for a given sequence (case) was cancelled.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "unique_identifier": "123",
+        "name": "John Doe",
+        "company_name": "Company XYZ",
+        "email": "john@example.com",
+        "phone_number": "1234567890",
+        "invoice_number": "INV123",
+        "amount": 1000,
+        "currency": "usd",
+        "reason": "Issue with invoice"
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_cancelled_case'),
+    onDisable: respaidTriggersCommon.onDisable('new_cancelled_case'),
+    async run(context) {
+        const payload = context.payload as NewCancelledCaseTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/src/lib/triggers/new_disputed_case.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_disputed_case.ts
@@ -1,0 +1,48 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+
+interface NewDisputedCaseTriggerPayload {
+    unique_identifier?: string;
+    name?: string;
+    company_name?: string;
+    email?: string;
+    phone_number?: string;
+    invoice_number?: string;
+    amount?: number;
+    currency?: string;
+    context?: string;
+    attachment?: string;
+}
+
+export const newDisputedCase = createTrigger({
+    name: 'new_disputed_case',
+    displayName: 'New Disputed Case',
+    description: "Triggers when a collection process was disputed by the debtor.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "unique_identifier": "123",
+        "name": "John Doe",
+        "company_name": "Company XYZ",
+        "email": "john@example.com",
+        "phone_number": "1234567890",
+        "invoice_number": "INV123",
+        "amount": 1000,
+        "currency": "usd",
+        "context": "Q: In order to stop the proceedings against you and not increase the amount of the debt, we can offer you\n" +
+            "A: Payment in instalments of up to 5 months (activation of instalments within 1 working day).\n" +
+            "Q: Do you agree to sign the following mandate?\n" +
+            "A: I agree",
+        "attachment": "https://link_excel.com/"
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_disputed_case'),
+    onDisable: respaidTriggersCommon.onDisable('new_disputed_case'),
+    async run(context) {
+        const payload = context.payload as NewDisputedCaseTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/src/lib/triggers/new_payout.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_payout.ts
@@ -1,0 +1,56 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+type Payment = Partial<{
+    reference: string;
+    unique_identifier: string;
+    name: string;
+    company_name: string;
+    email: string;
+    phone_number: string;
+    invoice_number: string;
+    amount: number;
+    fees: number;
+    currency: string;
+    paid_at: string;
+}>
+
+type PayoutTriggerPayload = Partial<{
+    date: string;
+    payout_id: string;
+    payments: Payment[];
+}>
+
+export const newPayout = createTrigger({
+    name: 'new_payout',
+    displayName: 'New Payout',
+    description: "Triggers when a payout is successfully sent to your bank account.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "payout_id": "1234",
+        "date": "2025-03-02T00:00:00+0000",
+        "payments": [{
+            "reference": "XXX123",
+            "unique_identifier": "123",
+            "name": "John Doe",
+            "company_name": "Company XYZ",
+            "email": "john@example.com",
+            "phone_number": "1234567890",
+            "invoice_number": "INV123",
+            "amount": 1000,
+            "fees": 2.5,
+            "currency": "usd",
+            "paid_at": "2025-03-02T00:00:00+0000"
+        }]
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_payout'),
+    onDisable: respaidTriggersCommon.onDisable('new_payout'),
+    async run(context) {
+        const payload = context.payload as PayoutTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_paid_to_creditor.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_paid_to_creditor.ts
@@ -1,0 +1,42 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+interface NewPaidTriggerPayload {
+    unique_identifier?: string;
+    name?: string;
+    company_name?: string;
+    email?: string;
+    phone_number?: string;
+    invoice_number?: string;
+    amount?: number;
+    currency?: string;
+    paid_at?: string;
+}
+
+export const newSuccessfulCollectionPaidToCreditor = createTrigger({
+    name: 'new_successful_collection_paid_to_creditor',
+    displayName: 'New Successful Collection Paid to Creditor',
+    description: "Triggers when a debt is paid directly to the creditor.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "unique_identifier": "123",
+        "name": "John Doe",
+        "company_name": "Company XYZ",
+        "email": "john@example.com",
+        "phone_number": "1234567890",
+        "invoice_number": "INV123",
+        "amount": 1000,
+        "currency": "usd",
+        "paid_at": "Issue with invoice"
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_successful_collection_paid_to_creditor'),
+    onDisable: respaidTriggersCommon.onDisable('new_successful_collection_paid_to_creditor'),
+    async run(context) {
+        const payload = context.payload as NewPaidTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_via_legal_officer.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_via_legal_officer.ts
@@ -1,0 +1,42 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+interface NewPaidTriggerPayload {
+    unique_identifier?: string;
+    name?: string;
+    company_name?: string;
+    email?: string;
+    phone_number?: string;
+    invoice_number?: string;
+    amount?: number;
+    currency?: string;
+    paid_at?: string;
+}
+
+export const newSuccessfulCollectionViaLegalOfficer = createTrigger({
+    name: 'new_successful_collection_via_legal_officer',
+    displayName: 'New Successful Collection via Legal Officer',
+    description: "Triggers when a debt is paid to the Legal Officer responsible for the collection campaign.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "unique_identifier": "123",
+        "name": "John Doe",
+        "company_name": "Company XYZ",
+        "email": "john@example.com",
+        "phone_number": "1234567890",
+        "invoice_number": "INV123",
+        "amount": 1000,
+        "currency": "usd",
+        "paid_at": "2025-03-02T00:00:00+0000"
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_successful_collection_via_legal_officer'),
+    onDisable: respaidTriggersCommon.onDisable('new_successful_collection_via_legal_officer'),
+    async run(context) {
+        const payload = context.payload as NewPaidTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_via_respaid.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_via_respaid.ts
@@ -1,0 +1,45 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+
+interface NewPaidTriggerPayload {
+    unique_identifier?: string;
+    name?: string;
+    company_name?: string;
+    email?: string;
+    phone_number?: string;
+    invoice_number?: string;
+    amount?: number;
+    currency?: string;
+    payment_mode?: string | null;
+    paid_at?: string;
+}
+
+export const newSuccessfulCollectionViaRespaid = createTrigger({
+    name: 'new_successful_collection_via_respaid',
+    displayName: 'New Successful Collection via Respaid',
+    description: "Triggers when a debt is paid online via Respaid's payment link.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "unique_identifier": "123",
+        "name": "John Doe",
+        "company_name": "Company XYZ",
+        "email": "john@example.com",
+        "phone_number": "1234567890",
+        "invoice_number": "INV123",
+        "amount": 1000,
+        "currency": "usd",
+        "payment_mode": "one-shot",
+        "paid_at": "2025-03-02T00:00:00+0000"
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_successful_collection_via_respaid'),
+    onDisable: respaidTriggersCommon.onDisable('new_successful_collection_via_respaid'),
+    async run(context) {
+        const payload = context.payload as NewPaidTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_installment_payment_via_respaid.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_installment_payment_via_respaid.ts
@@ -1,0 +1,50 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+interface NewPaidTriggerPayload {
+    unique_identifier?: string;
+    name?: string;
+    company_name?: string;
+    email?: string;
+    phone_number?: string;
+    invoice_number?: string;
+    amount?: number;
+    paid_amount?: number;
+    installments_number?: number;
+    current_installment_step?: number;
+    balance?: number;
+    currency?: string;
+    paid_at?: string;
+}
+
+export const newSuccessfulInstallmentPaymentViaRespaid = createTrigger({
+    name: 'new_successful_installment_payment_via_respaid',
+    displayName: 'New Successful Installment Payment via Respaid',
+    description: "Triggers when one of the installment payments is made for a given case within a collection's payment plan.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "unique_identifier": "123",
+        "name": "John Doe",
+        "company_name": "Company XYZ",
+        "email": "john@example.com",
+        "phone_number": "1234567890",
+        "invoice_number": "INV123",
+        "amount": 1000,
+        "paid_amount": 250,
+        "installments_number": 4,
+        "current_installment_step": 1,
+        "balance": 750,
+        "currency": "usd",
+        "paid_at": "2025-03-02T00:00:00+0000"
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_successful_installment_payment_via_respaid'),
+    onDisable: respaidTriggersCommon.onDisable('new_successful_installment_payment_via_respaid'),
+    async run(context) {
+        const payload = context.payload as NewPaidTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_partial_payment_to_creditor.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_partial_payment_to_creditor.ts
@@ -1,0 +1,46 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+interface NewPaidTriggerPayload {
+    unique_identifier?: string;
+    name?: string;
+    company_name?: string;
+    email?: string;
+    phone_number?: string;
+    invoice_number?: string;
+    amount?: number;
+    paid_amount?: number;
+    balance?: number;
+    currency?: string;
+    paid_at?: string;
+}
+
+export const newSuccessfulPartialPaymentToCreditor = createTrigger({
+    name: 'new_successful_partial_payment_to_creditor',
+    displayName: 'New Successful Partial Payment to Creditor',
+    description: "Triggers when the debt is partially paid directly to the creditor.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "unique_identifier": "123",
+        "name": "John Doe",
+        "company_name": "Company XYZ",
+        "email": "john@example.com",
+        "phone_number": "1234567890",
+        "invoice_number": "INV123",
+        "amount": 1000,
+        "paid_amount": 250,
+        "balance": 750,
+        "currency": "usd",
+        "paid_at": "2025-03-02T00:00:00+0000"
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_successful_partial_payment_to_creditor'),
+    onDisable: respaidTriggersCommon.onDisable('new_successful_partial_payment_to_creditor'),
+    async run(context) {
+        const payload = context.payload as NewPaidTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_partial_payment_via_respaid.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_partial_payment_via_respaid.ts
@@ -1,0 +1,46 @@
+
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { respaidAuth } from '../../index';
+import { respaidTriggersCommon } from '../common';
+
+interface NewPaidTriggerPayload {
+    unique_identifier?: string;
+    name?: string;
+    company_name?: string;
+    email?: string;
+    phone_number?: string;
+    invoice_number?: string;
+    amount?: number;
+    paid_amount?: number;
+    balance?: number;
+    currency?: string;
+    paid_at?: string;
+}
+
+export const newSuccessfulPartialPaymentViaRespaid = createTrigger({
+    name: 'new_successful_partial_payment_via_respaid',
+    displayName: 'New Successful Partial Payment via Respaid',
+    description: "Triggers when the debt is partially paid via Respaid's payment link.",
+    auth: respaidAuth,
+    props: {},
+    sampleData: {
+        "unique_identifier": "123",
+        "name": "John Doe",
+        "company_name": "Company XYZ",
+        "email": "john@example.com",
+        "phone_number": "1234567890",
+        "invoice_number": "INV123",
+        "amount": 1000,
+        "paid_amount": 250,
+        "balance": 750,
+        "currency": "usd",
+        "paid_at": "2025-03-02T00:00:00+0000"
+    },
+    type: TriggerStrategy.WEBHOOK,
+    onEnable: respaidTriggersCommon.onEnable('new_successful_partial_payment_via_respaid'),
+    onDisable: respaidTriggersCommon.onDisable('new_successful_partial_payment_via_respaid'),
+    async run(context) {
+        const payload = context.payload as NewPaidTriggerPayload; 
+        return [payload];
+    },
+})

--- a/packages/pieces/community/respaid/tsconfig.json
+++ b/packages/pieces/community/respaid/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/respaid/tsconfig.lib.json
+++ b/packages/pieces/community/respaid/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -519,6 +519,9 @@
       "@activepieces/piece-resend": [
         "packages/pieces/community/resend/src/index.ts"
       ],
+      "@activepieces/piece-respaid": [
+        "packages/pieces/community/respaid/src/index.ts"
+      ],
       "@activepieces/piece-retable": [
         "packages/pieces/community/retable/src/index.ts"
       ],


### PR DESCRIPTION
This PR adds new actions and triggers for Respaid integration, including:
- Webhook triggers (`new_payout`, `new_campaign_creation`, etc.)
- API actions for managing workflows

