### PR TITLE
feat: Adding `fail-on-error` flag for `sync-pieces` and `publish-piece` tasks

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@activepieces/cli",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "bin": {
         "pieces-cli":"../../dist/cli/src/index.js"
     },

--- a/packages/cli/src/lib/commands/publish-piece.ts
+++ b/packages/cli/src/lib/commands/publish-piece.ts
@@ -6,15 +6,21 @@ import * as dotenv from 'dotenv';
 
 dotenv.config({path: 'packages/server/api/.env'});
 
-async function publishPieces(
-  apiUrl: string,
-  apiKey: string,
-  pieceName: string,
-  failOnError: boolean,
+async function publishPiece(
+    {apiUrl, apiKey, pieceName, failOnError}:
+    {apiUrl: string,
+    apiKey: string,
+    pieceName: string,
+    failOnError: boolean,}
 ) {
-    const piecesFolder = await findPiece(pieceName);
-    assertPieceExists(piecesFolder)
-    await publishPieceFromFolder(piecesFolder, apiUrl, apiKey, failOnError);
+    const pieceFolder = await findPiece(pieceName);
+    assertPieceExists(pieceFolder)
+    await publishPieceFromFolder({
+        pieceFolder,
+        apiUrl,
+        apiKey,
+        failOnError
+    });
 }
 
 function assertNullOrUndefinedOrEmpty(value: any, message: string) {
@@ -67,5 +73,10 @@ export const publishPieceCommand = new Command('publish')
         const apiUrlWithoutTrailSlash = answers.apiUrl.replace(/\/$/, '');
         const { failOnError } = command.opts();
 
-        await publishPieces(apiUrlWithoutTrailSlash, apiKey, answers.name, failOnError);
+        await publishPiece({
+            apiUrl: apiUrlWithoutTrailSlash,
+            apiKey,
+            pieceName: answers.name,
+            failOnError
+        });
     });

--- a/packages/cli/src/lib/commands/publish-piece.ts
+++ b/packages/cli/src/lib/commands/publish-piece.ts
@@ -6,10 +6,15 @@ import * as dotenv from 'dotenv';
 
 dotenv.config({path: 'packages/server/api/.env'});
 
-async function publishPieces(apiUrl: string, apiKey: string, pieceName: string) {
+async function publishPieces(
+  apiUrl: string,
+  apiKey: string,
+  pieceName: string,
+  failOnError: boolean,
+) {
     const piecesFolder = await findPiece(pieceName);
     assertPieceExists(piecesFolder)
-    await publishPieceFromFolder(piecesFolder, apiUrl, apiKey);
+    await publishPieceFromFolder(piecesFolder, apiUrl, apiKey, failOnError);
 }
 
 function assertNullOrUndefinedOrEmpty(value: any, message: string) {
@@ -21,7 +26,8 @@ function assertNullOrUndefinedOrEmpty(value: any, message: string) {
 
 export const publishPieceCommand = new Command('publish')
     .description('Publish pieces to the platform')
-    .action(async () => {
+    .option('-f, --fail-on-error', 'Exit the process if an error occurs while syncing a piece', false)
+    .action(async (command) => {
         const questions = [
             {
                 type: 'input',
@@ -59,6 +65,7 @@ export const publishPieceCommand = new Command('publish')
         assertNullOrUndefinedOrEmpty(apiKey, 'API Key is required');
 
         const apiUrlWithoutTrailSlash = answers.apiUrl.replace(/\/$/, '');
+        const { failOnError } = command.opts();
 
-        await publishPieces(apiUrlWithoutTrailSlash, apiKey, answers.name);
+        await publishPieces(apiUrlWithoutTrailSlash, apiKey, answers.name, failOnError);
     });

--- a/packages/cli/src/lib/commands/sync-pieces.ts
+++ b/packages/cli/src/lib/commands/sync-pieces.ts
@@ -3,11 +3,16 @@ import { findPieces, publishPieceFromFolder } from '../utils/piece-utils';
 import chalk from "chalk";
 import { join } from "path";
 
-async function syncPieces(apiUrl: string, apiKey: string, pieces: string[] | null) {
-  const piecesDirectory = join(process.cwd(), 'packages', 'pieces', 'custom')
+async function syncPieces(
+  apiUrl: string,
+  apiKey: string,
+  pieces: string[] | null,
+  failOnError: boolean,
+) {
+  const piecesDirectory = join(process.cwd(), 'packages', 'pieces', 'community')
   const pieceFolders = await findPieces(piecesDirectory, pieces);
     for (const pieceFolder of pieceFolders) {
-      await publishPieceFromFolder(pieceFolder, apiUrl, apiKey);
+      await publishPieceFromFolder(pieceFolder, apiUrl, apiKey, failOnError);
     }
 }
 
@@ -16,13 +21,15 @@ export const syncPieceCommand = new Command('sync')
     .requiredOption('-h, --apiUrl <url>', 'API URL ex: https://cloud.activepieces.com/api')
     .option('-p, --pieces <pieces...>', 'Specify one or more piece names to sync. ' +
       'If not provided, all custom pieces in the directory will be synced.')
+    .option('-f, --fail-on-error', 'Exit the process if an error occurs while syncing a piece', false)
     .action(async (options) => {
         const apiKey = process.env.AP_API_KEY;
         const apiUrlWithoutTrailSlash = options.apiUrl.replace(/\/$/, '');
         const pieces = options.pieces ? [...new Set<string>(options.pieces)] : null;
+        const failOnError = options.failOnError;
         if (!apiKey) {
             console.error(chalk.red('AP_API_KEY environment variable is required'));
             process.exit(1);
         }
-        await syncPieces(apiUrlWithoutTrailSlash, apiKey, pieces);
+        await syncPieces(apiUrlWithoutTrailSlash, apiKey, pieces, failOnError);
     });

--- a/packages/cli/src/lib/commands/sync-pieces.ts
+++ b/packages/cli/src/lib/commands/sync-pieces.ts
@@ -9,7 +9,7 @@ async function syncPieces(
   pieces: string[] | null,
   failOnError: boolean,
 ) {
-  const piecesDirectory = join(process.cwd(), 'packages', 'pieces', 'community')
+  const piecesDirectory = join(process.cwd(), 'packages', 'pieces', 'custom')
   const pieceFolders = await findPieces(piecesDirectory, pieces);
     for (const pieceFolder of pieceFolders) {
       await publishPieceFromFolder(pieceFolder, apiUrl, apiKey, failOnError);

--- a/packages/cli/src/lib/commands/sync-pieces.ts
+++ b/packages/cli/src/lib/commands/sync-pieces.ts
@@ -4,20 +4,18 @@ import chalk from "chalk";
 import { join } from "path";
 
 async function syncPieces(
-  {apiUrl, apiKey, pieces, failOnError}:
+  params:
   {apiUrl: string,
   apiKey: string,
   pieces: string[] | null,
   failOnError: boolean,}
 ) {
   const piecesDirectory = join(process.cwd(), 'packages', 'pieces', 'custom')
-  const pieceFolders = await findPieces(piecesDirectory, pieces);
+  const pieceFolders = await findPieces(piecesDirectory, params.pieces);
     for (const pieceFolder of pieceFolders) {
       await publishPieceFromFolder({
-        pieceFolder: pieceFolder,
-        apiUrl: apiUrl,
-        apiKey: apiKey,
-        failOnError: failOnError
+        pieceFolder,
+       ...params
       });
     }
 }
@@ -30,7 +28,6 @@ export const syncPieceCommand = new Command('sync')
     .option('-f, --fail-on-error', 'Exit the process if an error occurs while syncing a piece', false)
     .action(async (options) => {
         const apiKey = process.env.AP_API_KEY;
-        const apiUrlWithoutTrailSlash = options.apiUrl.replace(/\/$/, '');
         const pieces = options.pieces ? [...new Set<string>(options.pieces)] : null;
         const failOnError = options.failOnError;
         if (!apiKey) {
@@ -38,9 +35,9 @@ export const syncPieceCommand = new Command('sync')
             process.exit(1);
         }
         await syncPieces({
-          apiUrl: apiUrlWithoutTrailSlash,
-          apiKey: apiKey,
-          pieces: pieces,
-          failOnError: failOnError
+          apiUrl: options.apiUrl.replace(/\/$/, ''),
+          apiKey,
+          pieces,
+          failOnError
         });
     });

--- a/packages/cli/src/lib/commands/sync-pieces.ts
+++ b/packages/cli/src/lib/commands/sync-pieces.ts
@@ -4,15 +4,21 @@ import chalk from "chalk";
 import { join } from "path";
 
 async function syncPieces(
-  apiUrl: string,
+  {apiUrl, apiKey, pieces, failOnError}:
+  {apiUrl: string,
   apiKey: string,
   pieces: string[] | null,
-  failOnError: boolean,
+  failOnError: boolean,}
 ) {
   const piecesDirectory = join(process.cwd(), 'packages', 'pieces', 'custom')
   const pieceFolders = await findPieces(piecesDirectory, pieces);
     for (const pieceFolder of pieceFolders) {
-      await publishPieceFromFolder(pieceFolder, apiUrl, apiKey, failOnError);
+      await publishPieceFromFolder({
+        pieceFolder: pieceFolder,
+        apiUrl: apiUrl,
+        apiKey: apiKey,
+        failOnError: failOnError
+      });
     }
 }
 
@@ -31,5 +37,10 @@ export const syncPieceCommand = new Command('sync')
             console.error(chalk.red('AP_API_KEY environment variable is required'));
             process.exit(1);
         }
-        await syncPieces(apiUrlWithoutTrailSlash, apiKey, pieces, failOnError);
+        await syncPieces({
+          apiUrl: apiUrlWithoutTrailSlash,
+          apiKey: apiKey,
+          pieces: pieces,
+          failOnError: failOnError
+        });
     });

--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -98,20 +98,20 @@ export async function publishPieceFromFolder(
             } else if (Math.floor(axiosError.response.status / 100) !== 2) {
                 console.info(chalk.red(`Error publishing piece '${packageJson.name}', ` + JSON.stringify(axiosError.response.data)));
                 if (failOnError) {
-                    process.exitCode = 1
+                    console.info(chalk.yellow(`Terminating process due to publish failure for piece '${packageJson.name}' (fail-on-error is enabled)`));
                     process.exit(1);
                 }
             } else {
                 console.error(chalk.red(`Unexpected error: ${error.message}`));
                 if (failOnError) {
-                    process.exitCode = 1
+                    console.info(chalk.yellow(`Terminating process due to unexpected error for piece '${packageJson.name}' (fail-on-error is enabled)`));
                     process.exit(1);
                 }
             }
         } else {
             console.error(chalk.red(`Unexpected error: ${error.message}`));
             if (failOnError) {
-              process.exitCode = 1
+              console.info(chalk.yellow(`Terminating process due to unexpected error for piece '${packageJson.name}' (fail-on-error is enabled)`));
               process.exit(1);
             }
         }

--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -62,10 +62,11 @@ export async function buildPiece(pieceFolder: string): Promise<{ outputFolder: s
 }
 
 export async function publishPieceFromFolder(
-  pieceFolder: string,
+    {pieceFolder, apiUrl, apiKey, failOnError}:
+  {pieceFolder: string,
   apiUrl: string,
   apiKey: string,
-  failOnError: boolean,
+  failOnError: boolean,}
 ) {
     const projectJson = await readProjectJson(pieceFolder);
     const packageJson = await readPackageJson(pieceFolder);

--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -61,7 +61,12 @@ export async function buildPiece(pieceFolder: string): Promise<{ outputFolder: s
     };
 }
 
-export async function publishPieceFromFolder(pieceFolder: string, apiUrl: string, apiKey: string) {
+export async function publishPieceFromFolder(
+  pieceFolder: string,
+  apiUrl: string,
+  apiKey: string,
+  failOnError = true,
+) {
     const projectJson = await readProjectJson(pieceFolder);
     const packageJson = await readPackageJson(pieceFolder);
 
@@ -92,11 +97,23 @@ export async function publishPieceFromFolder(pieceFolder: string, apiUrl: string
                 console.info(chalk.yellow(`Piece '${packageJson.name}' and '${packageJson.version}' already published.`));
             } else if (Math.floor(axiosError.response.status / 100) !== 2) {
                 console.info(chalk.red(`Error publishing piece '${packageJson.name}', ` + JSON.stringify(axiosError.response.data)));
+                if (failOnError) {
+                    process.exitCode = 1
+                    process.exit(1);
+                }
             } else {
                 console.error(chalk.red(`Unexpected error: ${error.message}`));
+                if (failOnError) {
+                    process.exitCode = 1
+                    process.exit(1);
+                }
             }
         } else {
             console.error(chalk.red(`Unexpected error: ${error.message}`));
+            if (failOnError) {
+              process.exitCode = 1
+              process.exit(1);
+            }
         }
     }
 }

--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -65,7 +65,7 @@ export async function publishPieceFromFolder(
   pieceFolder: string,
   apiUrl: string,
   apiKey: string,
-  failOnError = true,
+  failOnError: boolean,
 ) {
     const projectJson = await readProjectJson(pieceFolder);
     const packageJson = await readPackageJson(pieceFolder);


### PR DESCRIPTION
## What does this PR do?

This PR adds an optional `fail-on-error` flag to both the `sync-pieces` and `publish-piece` commands that changes how publishing failures are handled.

### Current Behavior
Currently, when running these commands, the process continues and exits with a status code of 0 (success) even if piece publishing fails. This means:
- CI pipelines continue to subsequent steps despite publishing failures 
- Package registry updates can proceed even when AP updates have failed
- There's potential for version mismatches between AP and package registries

### Proposed Change
Added a new `fail-on-error` flag that:
- Causes the process to exit with a non-zero status code if any piece fails to publish
- Enables CI pipelines to halt on publishing failures
- Prevents package registry updates when AP synchronization fails

### Why is this needed?
This change helps maintain consistency between AP and package registries by ensuring that package updates only proceed when all pieces have been successfully published to AP. This is particularly valuable for teams using both AP and package registries in their deployment workflow.

### Example Usage
```bash
npm run sync-pieces -- --apiUrl <url> --fail-on-error true
npm run publish-piece -- <piece-name> --apiUrl <url> --fail-on-error true