### PR TITLE
fix: fix bug related to handling null/undefined formValues

### DIFF
--- a/packages/react-ui/src/app/builder/piece-properties/array-property.tsx
+++ b/packages/react-ui/src/app/builder/piece-properties/array-property.tsx
@@ -100,10 +100,10 @@ const ArrayPieceProperty = React.memo(
         : '';
       const formValues = form.getValues(inputName);
       const newFields = [
-        ...formValues.map((value: string | Record<string, unknown>) => ({
+        ...(formValues ? formValues.map((value: string | Record<string, unknown>) => ({
           id: nanoid(),
-          value,
-        })),
+          value
+        })) : []),
         { id: nanoid(), value },
       ];
 


### PR DESCRIPTION
When disabling and re-enabling the form via dynamic values, the "add item"  button was not functioning due to null formValues. Added null check to prevent  "properties of undefined" error.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

