### PR TITLE
fix(trigger): handle JSON parsing for webhook payload

### DIFF
--- a/packages/pieces/community/respaid/package.json
+++ b/packages/pieces/community/respaid/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-respaid",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/pieces/community/respaid/src/lib/common/index.ts
+++ b/packages/pieces/community/respaid/src/lib/common/index.ts
@@ -67,4 +67,9 @@ export const respaidTriggersCommon = {
       throw new Error('Failed to unsubscribe to webhook');
     }
   },
+  getPayload: (context: TriggerHookContext<SecretTextProperty<true>, Record<string, never>, TriggerStrategy.WEBHOOK>) => {
+    return typeof context.payload.body === 'string' 
+    ? JSON.parse(context.payload.body) 
+    : context.payload;
+  }
 }

--- a/packages/pieces/community/respaid/src/lib/triggers/new_campaign_creation.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_campaign_creation.ts
@@ -44,7 +44,7 @@ export const newCampaignCreation = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_campaign_creation'),
     onDisable: respaidTriggersCommon.onDisable('new_campaign_creation'),
     async run(context) {
-        const payload = context.payload as NewCampaignTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as NewCampaignTriggerPayload];
     },
 })

--- a/packages/pieces/community/respaid/src/lib/triggers/new_cancelled_case.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_cancelled_case.ts
@@ -37,7 +37,7 @@ export const newCancelledCase = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_cancelled_case'),
     onDisable: respaidTriggersCommon.onDisable('new_cancelled_case'),
     async run(context) {
-        const payload = context.payload as NewCancelledCaseTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as NewCancelledCaseTriggerPayload];
     },
 })

--- a/packages/pieces/community/respaid/src/lib/triggers/new_disputed_case.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_disputed_case.ts
@@ -42,7 +42,7 @@ export const newDisputedCase = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_disputed_case'),
     onDisable: respaidTriggersCommon.onDisable('new_disputed_case'),
     async run(context) {
-        const payload = context.payload as NewDisputedCaseTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as NewDisputedCaseTriggerPayload];
     },
 })

--- a/packages/pieces/community/respaid/src/lib/triggers/new_payout.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_payout.ts
@@ -50,7 +50,7 @@ export const newPayout = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_payout'),
     onDisable: respaidTriggersCommon.onDisable('new_payout'),
     async run(context) {
-        const payload = context.payload as PayoutTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as PayoutTriggerPayload];
     },
 })

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_paid_to_creditor.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_paid_to_creditor.ts
@@ -36,7 +36,7 @@ export const newSuccessfulCollectionPaidToCreditor = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_successful_collection_paid_to_creditor'),
     onDisable: respaidTriggersCommon.onDisable('new_successful_collection_paid_to_creditor'),
     async run(context) {
-        const payload = context.payload as NewPaidTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as NewPaidTriggerPayload];
     },
 })

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_via_legal_officer.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_via_legal_officer.ts
@@ -36,7 +36,7 @@ export const newSuccessfulCollectionViaLegalOfficer = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_successful_collection_via_legal_officer'),
     onDisable: respaidTriggersCommon.onDisable('new_successful_collection_via_legal_officer'),
     async run(context) {
-        const payload = context.payload as NewPaidTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as NewPaidTriggerPayload];
     },
 })

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_via_respaid.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_collection_via_respaid.ts
@@ -39,7 +39,7 @@ export const newSuccessfulCollectionViaRespaid = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_successful_collection_via_respaid'),
     onDisable: respaidTriggersCommon.onDisable('new_successful_collection_via_respaid'),
     async run(context) {
-        const payload = context.payload as NewPaidTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as NewPaidTriggerPayload];
     },
 })

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_installment_payment_via_respaid.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_installment_payment_via_respaid.ts
@@ -44,7 +44,7 @@ export const newSuccessfulInstallmentPaymentViaRespaid = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_successful_installment_payment_via_respaid'),
     onDisable: respaidTriggersCommon.onDisable('new_successful_installment_payment_via_respaid'),
     async run(context) {
-        const payload = context.payload as NewPaidTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as NewPaidTriggerPayload];
     },
 })

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_partial_payment_to_creditor.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_partial_payment_to_creditor.ts
@@ -40,7 +40,7 @@ export const newSuccessfulPartialPaymentToCreditor = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_successful_partial_payment_to_creditor'),
     onDisable: respaidTriggersCommon.onDisable('new_successful_partial_payment_to_creditor'),
     async run(context) {
-        const payload = context.payload as NewPaidTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as NewPaidTriggerPayload];
     },
 })

--- a/packages/pieces/community/respaid/src/lib/triggers/new_successful_partial_payment_via_respaid.ts
+++ b/packages/pieces/community/respaid/src/lib/triggers/new_successful_partial_payment_via_respaid.ts
@@ -40,7 +40,7 @@ export const newSuccessfulPartialPaymentViaRespaid = createTrigger({
     onEnable: respaidTriggersCommon.onEnable('new_successful_partial_payment_via_respaid'),
     onDisable: respaidTriggersCommon.onDisable('new_successful_partial_payment_via_respaid'),
     async run(context) {
-        const payload = context.payload as NewPaidTriggerPayload; 
-        return [payload];
+        const payload = respaidTriggersCommon.getPayload(context);
+        return [payload as NewPaidTriggerPayload];
     },
 })


### PR DESCRIPTION
Ensure `context.payload.body` is parsed correctly, handling both stringified and object formats. 
Added a fallback to return the original payload if parsing fails.