### PR TITLE
fix: make rename flow dialog default to the current flow name

### DIFF
--- a/packages/react-ui/src/features/flows/components/rename-flow-dialog.tsx
+++ b/packages/react-ui/src/features/flows/components/rename-flow-dialog.tsx
@@ -101,6 +101,7 @@ const RenameFlowDialog: React.FC<RenameFlowDialogProps> = ({
                     id="displayName"
                     placeholder={t('New Flow Name')}
                     className="rounded-sm"
+                    defaultValue={flowName}
                   />
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

