### PR TITLE
feat(cloutly): send review invite action

### DIFF
--- a/packages/pieces/community/cloutly/.eslintrc.json
+++ b/packages/pieces/community/cloutly/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/cloutly/README.md
+++ b/packages/pieces/community/cloutly/README.md
@@ -1,0 +1,7 @@
+# pieces-cloutly
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-cloutly` to build the library.

--- a/packages/pieces/community/cloutly/package.json
+++ b/packages/pieces/community/cloutly/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-cloutly",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/cloutly/project.json
+++ b/packages/pieces/community/cloutly/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-cloutly",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/cloutly/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/cloutly",
+        "tsConfig": "packages/pieces/community/cloutly/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/cloutly/package.json",
+        "main": "packages/pieces/community/cloutly/src/index.ts",
+        "assets": [
+          "packages/pieces/community/cloutly/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/cloutly/src/index.ts
+++ b/packages/pieces/community/cloutly/src/index.ts
@@ -1,0 +1,19 @@
+
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { sendReviewInvite } from "./lib/actions/send-review-invite";
+
+export const cloutlyAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: 'Please enter the API Key obtain from Cloutly.',
+});
+
+export const cloutly = createPiece({
+  displayName: "Cloutly Reviews",
+  auth: cloutlyAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: "https://app.cloutly.com/assets/images/icon-cloutly.svg",
+  authors: ['joshuaheslin'],
+  actions: [sendReviewInvite],
+  triggers: [],
+});

--- a/packages/pieces/community/cloutly/src/index.ts
+++ b/packages/pieces/community/cloutly/src/index.ts
@@ -5,7 +5,7 @@ import { sendReviewInvite } from "./lib/actions/send-review-invite";
 export const cloutlyAuth = PieceAuth.SecretText({
   displayName: 'API Key',
   required: true,
-  description: 'Please enter the API Key obtain from Cloutly.',
+  description: 'Please enter the API Key obtained from Cloutly.',
 });
 
 export const cloutly = createPiece({

--- a/packages/pieces/community/cloutly/src/lib/actions/send-review-invite.ts
+++ b/packages/pieces/community/cloutly/src/lib/actions/send-review-invite.ts
@@ -27,7 +27,7 @@ export const sendReviewInvite = createAction({
     }),
     sourceCustomerId: Property.ShortText({
       displayName: 'Source Customer ID',
-      required: true
+      required: false
     }),
     businessId: Property.ShortText({
       displayName: 'Business ID',
@@ -40,6 +40,11 @@ export const sendReviewInvite = createAction({
     inviteDelayDays: Property.Number({
       displayName: 'Invite Delay Days',
       description: 'The number of days to delay the invite (i.e send after X days)',
+      required: false
+    }),
+    salesRepEmail: Property.ShortText({
+      displayName: 'Sales Rep Email',
+      description: 'The email of the sales rep to associate the review and customer',
       required: false
     }),
   },
@@ -56,6 +61,7 @@ export const sendReviewInvite = createAction({
       businessId: context.propsValue.businessId,
       campaignId: context.propsValue.campaignId,
       inviteDelayDays: context.propsValue.inviteDelayDays,
+      salesRepEmail: context.propsValue.salesRepEmail,
     };
 
     const apiKey = context.auth as string

--- a/packages/pieces/community/cloutly/src/lib/actions/send-review-invite.ts
+++ b/packages/pieces/community/cloutly/src/lib/actions/send-review-invite.ts
@@ -1,0 +1,76 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import axios from 'axios';
+
+export const sendReviewInvite = createAction({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'sendReviewInvite',
+  displayName: 'Send Review Invite',
+  description: 'Ask a customer to review your business',
+  props: {
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      required: true
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'The email of the customer to send the invite to (required if Phone Number is empty)',
+      required: false
+    }),
+    phoneNumber: Property.ShortText({
+      displayName: 'Phone Number',
+      description: 'The phone number of the customer to send the invite to (required if Email is empty)',
+      required: false
+    }),
+    sourceCustomerId: Property.ShortText({
+      displayName: 'Source Customer ID',
+      required: true
+    }),
+    businessId: Property.ShortText({
+      displayName: 'Business ID',
+      required: true
+    }),
+    campaignId: Property.ShortText({
+      displayName: 'Campaign ID',
+      required: true
+    }),
+    inviteDelayDays: Property.Number({
+      displayName: 'Invite Delay Days',
+      description: 'The number of days to delay the invite (i.e send after X days)',
+      required: false
+    }),
+  },
+  async run(context) {
+    const data = {
+      firstName: context.propsValue.firstName,
+      lastName: context.propsValue.lastName,
+      channel: {
+        email: context.propsValue.email,
+        phoneNumber: context.propsValue.phoneNumber,
+      },
+      source: 'api',
+      sourceCustomerId: context.propsValue.sourceCustomerId,
+      businessId: context.propsValue.businessId,
+      campaignId: context.propsValue.campaignId,
+      inviteDelayDays: context.propsValue.inviteDelayDays,
+    };
+
+    const apiKey = context.auth as string
+
+    const response = await axios.post(
+      'https://app.cloutly.com/api/v1/send-review-invite', 
+      data, 
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-app': 'activepieces',
+          'x-api-key': apiKey
+        }
+      },
+    );
+    return response.data;
+  },
+});

--- a/packages/pieces/community/cloutly/tsconfig.json
+++ b/packages/pieces/community/cloutly/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/cloutly/tsconfig.lib.json
+++ b/packages/pieces/community/cloutly/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -142,6 +142,9 @@
       "@activepieces/piece-clockodo": [
         "packages/pieces/community/clockodo/src/index.ts"
       ],
+      "@activepieces/piece-cloutly": [
+        "packages/pieces/community/cloutly/src/index.ts"
+      ],
       "@activepieces/piece-confluence": [
         "packages/pieces/community/confluence/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

- PR introduces new community piece: `cloutly`
- Piece action: `SendReviewInvite` will send an email/SMS to review the business on Google/Facebook via the Cloutly Platform.
- Cloutly platform: https://cloutly.com/
- API docs: https://support.cloutly.com/en/article/getting-started-with-rest-api-k79sfu/#1-post-send-review-invite
- Cloutly has numerous integrations so it would be great to add this to the growing list in activepieces.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # N/A

