### PR TITLE
fix: changed base url to prod. Made 'amount' field optional

### DIFF
--- a/packages/pieces/community/respaid/package.json
+++ b/packages/pieces/community/respaid/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-respaid",
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/packages/pieces/community/respaid/src/lib/actions/stop_collection_for_direct_partial_payment.ts
+++ b/packages/pieces/community/respaid/src/lib/actions/stop_collection_for_direct_partial_payment.ts
@@ -16,7 +16,7 @@ export const stopCollectionForDirectPartialPayment = createAction({
       }),
       amount: Property.ShortText({
         displayName: 'Amount',
-        required: true,
+        required: false,
       }),
       email: Property.ShortText({
         displayName: 'Email',

--- a/packages/pieces/community/respaid/src/lib/common/index.ts
+++ b/packages/pieces/community/respaid/src/lib/common/index.ts
@@ -9,7 +9,7 @@ interface ActionPayloadProps {
 }
 
 export const respaidCommon = {
-  baseUrl: 'https://backend.dev.widr.app/api/workflow',
+  baseUrl: 'https://backend.widr.app/api/workflow',
   getHeadersStructure: (auth: string) => ({
     'Content-Type': 'application/json',
     Accept: 'application/json',


### PR DESCRIPTION
Final fix. 
- Changed base url to production
- 'amount' in stop_collection_for_direct_partial_payment not required