### PR TITLE
feat(firecrawl): add extract with prompt and schema

### DIFF
--- a/packages/pieces/community/firecrawl/.eslintrc.json
+++ b/packages/pieces/community/firecrawl/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/firecrawl/README.md
+++ b/packages/pieces/community/firecrawl/README.md
@@ -1,0 +1,7 @@
+# pieces-firecrawl
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-firecrawl` to build the library.

--- a/packages/pieces/community/firecrawl/package.json
+++ b/packages/pieces/community/firecrawl/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-firecrawl",
+  "version": "0.1.0"
+}

--- a/packages/pieces/community/firecrawl/package.json
+++ b/packages/pieces/community/firecrawl/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-firecrawl",
-  "version": "0.1.0"
+  "version": "0.0.1"
 }

--- a/packages/pieces/community/firecrawl/project.json
+++ b/packages/pieces/community/firecrawl/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-firecrawl",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/firecrawl/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/firecrawl",
+        "tsConfig": "packages/pieces/community/firecrawl/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/firecrawl/package.json",
+        "main": "packages/pieces/community/firecrawl/src/index.ts",
+        "assets": [
+          "packages/pieces/community/firecrawl/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/firecrawl/src/index.ts
+++ b/packages/pieces/community/firecrawl/src/index.ts
@@ -1,0 +1,67 @@
+import { createCustomApiCallAction, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { extractWithPrompt } from './lib/actions/extract-with-prompt';
+import { extractWithSchema } from './lib/actions/extract-with-schema';
+const markdownDescription = `
+Follow these steps to obtain your Firecrawl API Key:
+
+1. Visit [Firecrawl](https://firecrawl.dev) and create an account.
+2. Log in and navigate to your dashboard.
+3. Locate and copy your API key from the API settings section.
+`;
+
+export const firecrawlAuth = PieceAuth.SecretText({
+  description: markdownDescription,
+  displayName: 'API Key',
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: 'https://api.firecrawl.dev/v1/scrape',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${auth}`,
+        },
+        body: {
+          url: 'https://www.example.com',
+          formats: ['json'],
+          jsonOptions: {
+            prompt: 'test'
+          }
+        },
+      });
+      return {
+        valid: true,
+      };
+    } catch (e) {
+      return {
+        valid: false,
+        error: 'Invalid API Key',
+      };
+    }
+  },
+});
+
+export const firecrawl = createPiece({
+  displayName: 'Firecrawl',
+  description: 'Extract structured data from websites using AI with natural language prompts',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/firecrawl.png', // This URL needs to be updated when logo is available
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  authors: ["YourUsername"], // Replace with your username
+  auth: firecrawlAuth,
+  actions: [
+    extractWithPrompt,
+    extractWithSchema,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.firecrawl.dev/v1',
+      auth: firecrawlAuth,
+      authMapping: async (auth) => ({
+        'Authorization': `Bearer ${auth}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/firecrawl/src/index.ts
+++ b/packages/pieces/community/firecrawl/src/index.ts
@@ -48,9 +48,9 @@ export const firecrawl = createPiece({
   displayName: 'Firecrawl',
   description: 'Extract structured data from websites using AI with natural language prompts',
   minimumSupportedRelease: '0.30.0',
-  logoUrl: 'https://cdn.activepieces.com/pieces/firecrawl.png', // This URL needs to be updated when logo is available
+  logoUrl: 'https://cdn.activepieces.com/pieces/firecrawl.png',
   categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
-  authors: ["YourUsername"], // Replace with your username
+  authors: ["geekyme-fsmk"],
   auth: firecrawlAuth,
   actions: [
     extractWithPrompt,

--- a/packages/pieces/community/firecrawl/src/lib/actions/extract-with-prompt.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/extract-with-prompt.ts
@@ -6,16 +6,16 @@ export const extractWithPrompt = createAction({
   auth: firecrawlAuth,
   name: 'extractWithPrompt',
   displayName: 'Extract with Prompt',
-  description: 'Extract structured data from any URL using a natural language prompt',
+  description: 'Extract structured data from any URL using a natural language prompt.',
   props: {
     url: Property.ShortText({
       displayName: 'Website URL',
-      description: 'The webpage URL to extract data from',
+      description: 'The webpage URL to extract data from.',
       required: true,
     }),
     prompt: Property.LongText({
       displayName: 'Extraction Prompt',
-      description: 'Describe what information you want to extract in natural language',
+      description: 'Describe what information you want to extract in natural language.',
       required: true,
     }),
   },

--- a/packages/pieces/community/firecrawl/src/lib/actions/extract-with-prompt.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/extract-with-prompt.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { firecrawlAuth } from '../../index';
+
+export const extractWithPrompt = createAction({
+  auth: firecrawlAuth,
+  name: 'extractWithPrompt',
+  displayName: 'Extract with Prompt',
+  description: 'Extract structured data from any URL using a natural language prompt',
+  props: {
+    url: Property.ShortText({
+      displayName: 'Website URL',
+      description: 'The webpage URL to extract data from',
+      required: true,
+    }),
+    prompt: Property.LongText({
+      displayName: 'Extraction Prompt',
+      description: 'Describe what information you want to extract in natural language',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const body = {
+      url: propsValue.url,
+      formats: ['json'],
+      jsonOptions: {
+        prompt: propsValue.prompt
+      }
+    };
+    
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.firecrawl.dev/v1/scrape',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${auth}`,
+      },
+      body: body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/firecrawl/src/lib/actions/extract-with-schema.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/extract-with-schema.ts
@@ -1,0 +1,51 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { firecrawlAuth } from '../../index';
+
+export const extractWithSchema = createAction({
+  auth: firecrawlAuth,
+  name: 'extractWithSchema',
+  displayName: 'Extract with Schema',
+  description: 'Extract structured data from any URL using a predefined JSON schema',
+  props: {
+    url: Property.ShortText({
+      displayName: 'Website URL',
+      description: 'The webpage URL to extract data from',
+      required: true,
+    }),
+    schema: Property.Json({
+      displayName: 'Extraction Schema',
+      description: 'JSON schema defining the structure of data to extract',
+      required: true,
+      defaultValue: {
+        "type": "object",
+        "properties": {
+          "company_name": {"type": "string"},
+          "pricing_tiers": {"type": "array", "items": {"type": "string"}},
+          "has_free_tier": {"type": "boolean"}
+        }
+      }
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const body = {
+      url: propsValue.url,
+      formats: ['json'],
+      jsonOptions: {
+        schema: propsValue.schema
+      }
+    };
+    
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.firecrawl.dev/v1/scrape',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${auth}`,
+      },
+      body: body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/firecrawl/src/lib/actions/extract-with-schema.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/extract-with-schema.ts
@@ -6,16 +6,16 @@ export const extractWithSchema = createAction({
   auth: firecrawlAuth,
   name: 'extractWithSchema',
   displayName: 'Extract with Schema',
-  description: 'Extract structured data from any URL using a predefined JSON schema',
+  description: 'Extract structured data from any URL using a predefined JSON schema.',
   props: {
     url: Property.ShortText({
       displayName: 'Website URL',
-      description: 'The webpage URL to extract data from',
+      description: 'The webpage URL to extract data from.',
       required: true,
     }),
     schema: Property.Json({
       displayName: 'Extraction Schema',
-      description: 'JSON schema defining the structure of data to extract',
+      description: 'JSON schema defining the structure of data to extract.',
       required: true,
       defaultValue: {
         "type": "object",

--- a/packages/pieces/community/firecrawl/tsconfig.json
+++ b/packages/pieces/community/firecrawl/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/firecrawl/tsconfig.lib.json
+++ b/packages/pieces/community/firecrawl/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -212,6 +212,9 @@
       "@activepieces/piece-figma": [
         "packages/pieces/community/figma/src/index.ts"
       ],
+      "@activepieces/piece-firecrawl":[
+        "packages/pieces/community/firecrawl/src/index.ts"
+      ],
       "@activepieces/piece-file-helper": [
         "packages/pieces/community/file-helper/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Adds firecrawl extraction actions - https://docs.firecrawl.dev/introduction#extraction

## Screenshots

### Initialising connection
<img width="1029" alt="Screenshot 2025-02-26 at 5 39 36 PM" src="https://github.com/user-attachments/assets/81022bc3-12db-4ddd-8cc8-b8e601dbc170" />

### Extract with prompt
<img width="1261" alt="Screenshot 2025-02-26 at 5 33 28 PM" src="https://github.com/user-attachments/assets/7a972640-3c41-4fb6-8348-37aa8ed14bf7" />


### Extract with schema
<img width="1379" alt="Screenshot 2025-02-26 at 5 37 20 PM" src="https://github.com/user-attachments/assets/c5da99ce-8529-4640-991e-8f07ef4f701f" />