### PR TITLE
feat(pieces): Add Text to CAD integration piece

### DIFF
--- a/packages/pieces/community/text-to-cad/.eslintrc.json
+++ b/packages/pieces/community/text-to-cad/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/text-to-cad/README.md
+++ b/packages/pieces/community/text-to-cad/README.md
@@ -1,0 +1,7 @@
+# pieces-text-to-cad
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-text-to-cad` to build the library.

--- a/packages/pieces/community/text-to-cad/package.json
+++ b/packages/pieces/community/text-to-cad/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-text-to-cad",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/text-to-cad/project.json
+++ b/packages/pieces/community/text-to-cad/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-text-to-cad",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/text-to-cad/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/text-to-cad",
+        "tsConfig": "packages/pieces/community/text-to-cad/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/text-to-cad/package.json",
+        "main": "packages/pieces/community/text-to-cad/src/index.ts",
+        "assets": [
+          "packages/pieces/community/text-to-cad/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/text-to-cad/src/index.ts
+++ b/packages/pieces/community/text-to-cad/src/index.ts
@@ -1,0 +1,34 @@
+
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { ML_ACTIONS } from './lib/actions';
+import { API_CALLS_ACTIONS } from './lib/actions/api-calls';
+import { API_TOKENS_ACTIONS } from './lib/actions/api-tokens';
+import { FILE_ACTIONS } from './lib/actions/file';
+import { META_ACTIONS } from './lib/actions/meta';
+import { MODELING_ACTIONS } from './lib/actions/modeling';
+import { ORGS_ACTIONS } from './lib/actions/orgs';
+import { PAYMENTS_ACTIONS } from './lib/actions/payments';
+import { SERVICE_ACCOUNTS_ACTIONS } from './lib/actions/service-accounts';
+import { SHORTLINKS_ACTIONS } from './lib/actions/shortlinks';
+import { UNIT_ACTIONS } from './lib/actions/unit';
+import { USER_ACTIONS } from './lib/actions/users';
+
+export const textToCadAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: 'Your Zoo API Key (Bearer Token).',
+});
+
+export const textToCad = createPiece({
+  displayName: 'Text to CAD',
+  description: 'Generate and iterate on 3D models from text descriptions using ML endpoints.',
+  logoUrl: 'https://imagedelivery.net/bHREz764QO9n_1kIQUR2sw/0133eedc-79ed-443b-9074-c4bed3563200/public',
+  auth: textToCadAuth,
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  minimumSupportedRelease: '0.20.0',
+  authors: ['SwanBlocks/Ahmad Shawar'],
+  actions: [...ML_ACTIONS, ...API_CALLS_ACTIONS, ...API_TOKENS_ACTIONS, ...FILE_ACTIONS, ...META_ACTIONS, ...MODELING_ACTIONS, ...ORGS_ACTIONS, ...PAYMENTS_ACTIONS, ...SERVICE_ACCOUNTS_ACTIONS, ...SHORTLINKS_ACTIONS, ...UNIT_ACTIONS, ...USER_ACTIONS],
+  triggers: [],
+});    
+    

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/get-async-operation.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/get-async-operation.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getAsyncOperationAction = createAction({
+  name: 'get_async_operation',
+  displayName: 'Get Async Operation',
+  description: 'Retrieve details of an asynchronous operation',
+  auth: textToCadAuth,
+  category: 'API Calls',
+  props: {
+    operationId: Property.ShortText({
+      displayName: 'Operation ID',
+      required: true,
+      description: 'The ID of the async operation to retrieve',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/async/operations/${propsValue.operationId}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/get-org-api-call.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/get-org-api-call.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getOrgApiCallAction = createAction({
+  name: 'get_org_api_call',
+  displayName: 'Get Organization API Call',
+  description: 'Retrieve details of a specific API call made by your organization',
+  auth: textToCadAuth,
+  category: 'API Calls',
+  props: {
+    callId: Property.ShortText({
+      displayName: 'Call ID',
+      required: true,
+      description: 'The ID of the API call to retrieve',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/org/api-calls/${propsValue.callId}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/get-user-api-call.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/get-user-api-call.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getUserApiCallAction = createAction({
+  name: 'get_user_api_call',
+  displayName: 'Get User API Call',
+  description: 'Retrieve details of a specific API call made by your user account',
+  auth: textToCadAuth,
+  category: 'API Calls',
+  props: {
+    callId: Property.ShortText({
+      displayName: 'Call ID',
+      required: true,
+      description: 'The ID of the API call to retrieve',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/user/api-calls/${propsValue.callId}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/index.ts
@@ -1,0 +1,13 @@
+import { getAsyncOperationAction } from './get-async-operation.action';
+import { listOrgApiCallsAction } from './list-org-api-calls.action';
+import { getOrgApiCallAction } from './get-org-api-call.action';
+import { listUserApiCallsAction } from './list-user-api-calls.action';
+import { getUserApiCallAction } from './get-user-api-call.action';
+
+export const API_CALLS_ACTIONS = [
+  getAsyncOperationAction,
+  listOrgApiCallsAction,
+  getOrgApiCallAction,
+  listUserApiCallsAction,
+  getUserApiCallAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/list-org-api-calls.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/list-org-api-calls.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listOrgApiCallsAction = createAction({
+  name: 'list_org_api_calls',
+  displayName: 'List Organization API Calls',
+  description: 'List API calls made by your organization',
+  auth: textToCadAuth,
+  category: 'API Calls',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of API calls to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of API calls to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org/api-calls',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/list-user-api-calls.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-calls/list-user-api-calls.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listUserApiCallsAction = createAction({
+  name: 'list_user_api_calls',
+  displayName: 'List User API Calls',
+  description: 'List API calls made by your user account',
+  auth: textToCadAuth,
+  category: 'API Calls',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of API calls to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of API calls to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/api-calls',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/create-api-token.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/create-api-token.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createApiTokenAction = createAction({
+  name: 'create_api_token',
+  displayName: 'Create API Token',
+  description: 'Create a new API token for your user account',
+  auth: textToCadAuth,
+  category: 'API Tokens',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Token Name',
+      required: true,
+      description: 'A name to identify this token',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/user/api-tokens',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        name: propsValue.name,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/delete-api-token.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/delete-api-token.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const deleteApiTokenAction = createAction({
+  name: 'delete_api_token',
+  displayName: 'Delete API Token',
+  description: 'Delete an API token from your user account',
+  auth: textToCadAuth,
+  category: 'API Tokens',
+  props: {
+    token: Property.ShortText({
+      displayName: 'Token',
+      required: true,
+      description: 'The token to delete',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.DELETE,
+      url: `https://api.zoo.dev/user/api-tokens/${propsValue.token}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/get-api-token.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/get-api-token.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getApiTokenAction = createAction({
+  name: 'get_api_token',
+  displayName: 'Get API Token',
+  description: 'Retrieve details of a specific API token',
+  auth: textToCadAuth,
+  category: 'API Tokens',
+  props: {
+    token: Property.ShortText({
+      displayName: 'Token',
+      required: true,
+      description: 'The token to retrieve details for',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/user/api-tokens/${propsValue.token}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/index.ts
@@ -1,0 +1,11 @@
+import { listApiTokensAction } from './list-api-tokens.action';
+import { createApiTokenAction } from './create-api-token.action';
+import { getApiTokenAction } from './get-api-token.action';
+import { deleteApiTokenAction } from './delete-api-token.action';
+
+export const API_TOKENS_ACTIONS = [
+  listApiTokensAction,
+  createApiTokenAction,
+  getApiTokenAction,
+  deleteApiTokenAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/list-api-tokens.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/api-tokens/list-api-tokens.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listApiTokensAction = createAction({
+  name: 'list_api_tokens',
+  displayName: 'List API Tokens',
+  description: 'List all API tokens for your user account',
+  auth: textToCadAuth,
+  category: 'API Tokens',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of tokens to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of tokens to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/api-tokens',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/file/convert-cad-file.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/file/convert-cad-file.action.ts
@@ -1,0 +1,62 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertCadFileAction = createAction({
+  name: 'convert_cad_file',
+  displayName: 'Convert CAD File',
+  description: 'Convert a CAD file from one format to another',
+  auth: textToCadAuth,
+  category: 'File Operations',
+  props: {
+    file: Property.File({
+      displayName: 'CAD File',
+      required: true,
+      description: 'The CAD file to convert',
+    }),
+    sourceFormat: Property.StaticDropdown({
+      displayName: 'Source Format',
+      required: true,
+      options: {
+        options: [
+          { label: 'FBX', value: 'fbx' },
+          { label: 'GLB', value: 'glb' },
+          { label: 'GLTF', value: 'gltf' },
+          { label: 'OBJ', value: 'obj' },
+          { label: 'PLY', value: 'ply' },
+          { label: 'STEP', value: 'step' },
+          { label: 'STL', value: 'stl' },
+        ],
+      },
+    }),
+    outputFormat: Property.StaticDropdown({
+      displayName: 'Output Format',
+      required: true,
+      options: {
+        options: [
+          { label: 'FBX', value: 'fbx' },
+          { label: 'GLB', value: 'glb' },
+          { label: 'GLTF', value: 'gltf' },
+          { label: 'OBJ', value: 'obj' },
+          { label: 'PLY', value: 'ply' },
+          { label: 'STEP', value: 'step' },
+          { label: 'STL', value: 'stl' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const formData = new FormData();
+    formData.append('file', new Blob([propsValue.file.data]), propsValue.file.filename);
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `https://api.zoo.dev/file/conversion/${propsValue.sourceFormat}/${propsValue.outputFormat}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: formData,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/file/get-center-of-mass.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/file/get-center-of-mass.action.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getCenterOfMassAction = createAction({
+  name: 'get_center_of_mass',
+  displayName: 'Get Center of Mass',
+  description: 'Calculate the center of mass of a CAD file',
+  auth: textToCadAuth,
+  category: 'File Operations',
+  props: {
+    file: Property.File({
+      displayName: 'CAD File',
+      required: true,
+      description: 'The CAD file to analyze',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const formData = new FormData();
+    formData.append('file', new Blob([propsValue.file.data]), propsValue.file.filename);
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/file/center-of-mass',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: formData,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/file/get-density.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/file/get-density.action.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getDensityAction = createAction({
+  name: 'get_density',
+  displayName: 'Get Density',
+  description: 'Calculate the density of a CAD file',
+  auth: textToCadAuth,
+  category: 'File Operations',
+  props: {
+    file: Property.File({
+      displayName: 'CAD File',
+      required: true,
+      description: 'The CAD file to analyze',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const formData = new FormData();
+    formData.append('file', new Blob([propsValue.file.data]), propsValue.file.filename);
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/file/density',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: formData,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/file/get-mass.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/file/get-mass.action.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getMassAction = createAction({
+  name: 'get_mass',
+  displayName: 'Get Mass',
+  description: 'Calculate the mass of a CAD file',
+  auth: textToCadAuth,
+  category: 'File Operations',
+  props: {
+    file: Property.File({
+      displayName: 'CAD File',
+      required: true,
+      description: 'The CAD file to analyze',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const formData = new FormData();
+    formData.append('file', new Blob([propsValue.file.data]), propsValue.file.filename);
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/file/mass',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: formData,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/file/get-surface-area.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/file/get-surface-area.action.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getSurfaceAreaAction = createAction({
+  name: 'get_surface_area',
+  displayName: 'Get Surface Area',
+  description: 'Calculate the surface area of a CAD file',
+  auth: textToCadAuth,
+  category: 'File Operations',
+  props: {
+    file: Property.File({
+      displayName: 'CAD File',
+      required: true,
+      description: 'The CAD file to analyze',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const formData = new FormData();
+    formData.append('file', new Blob([propsValue.file.data]), propsValue.file.filename);
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/file/surface-area',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: formData,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/file/get-volume.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/file/get-volume.action.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getVolumeAction = createAction({
+  name: 'get_volume',
+  displayName: 'Get Volume',
+  description: 'Calculate the volume of a CAD file',
+  auth: textToCadAuth,
+  category: 'File Operations',
+  props: {
+    file: Property.File({
+      displayName: 'CAD File',
+      required: true,
+      description: 'The CAD file to analyze',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const formData = new FormData();
+    formData.append('file', new Blob([propsValue.file.data]), propsValue.file.filename);
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/file/volume',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: formData,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/file/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/file/index.ts
@@ -1,0 +1,15 @@
+import { getCenterOfMassAction } from './get-center-of-mass.action';
+import { convertCadFileAction } from './convert-cad-file.action';
+import { getDensityAction } from './get-density.action';
+import { getMassAction } from './get-mass.action';
+import { getSurfaceAreaAction } from './get-surface-area.action';
+import { getVolumeAction } from './get-volume.action';
+
+export const FILE_ACTIONS = [
+  getCenterOfMassAction,
+  convertCadFileAction,
+  getDensityAction,
+  getMassAction,
+  getSurfaceAreaAction,
+  getVolumeAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/index.ts
@@ -1,0 +1,15 @@
+import { generateCadModelAction } from './ml/generate-cad-model.action';
+import { kclCompletionsAction } from './ml/kcl-completions.action';
+import { textToCadIterationAction } from './ml/text-to-cad-iteration.action';
+import { listCadModelsAction } from './ml/list-cad-models.action';
+import { getCadModelAction } from './ml/get-cad-model.action';
+import { giveModelFeedbackAction } from './ml/give-model-feedback.action';
+
+export const ML_ACTIONS = [
+  generateCadModelAction,
+  kclCompletionsAction,
+  textToCadIterationAction,
+  listCadModelsAction,
+  getCadModelAction,
+  giveModelFeedbackAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/meta/get-openapi-schema.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/meta/get-openapi-schema.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getOpenApiSchemaAction = createAction({
+  name: 'get_openapi_schema',
+  displayName: 'Get OpenAPI Schema',
+  description: 'Retrieve the OpenAPI schema for the Zoo API',
+  auth: textToCadAuth,
+  category: 'Meta',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/meta/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/meta/index.ts
@@ -1,0 +1,7 @@
+import { getOpenApiSchemaAction } from './get-openapi-schema.action';
+import { returnPongAction } from './return-pong.action';
+
+export const META_ACTIONS = [
+  getOpenApiSchemaAction,
+  returnPongAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/meta/return-pong.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/meta/return-pong.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const returnPongAction = createAction({
+  name: 'return_pong',
+  displayName: 'Return Pong',
+  description: 'Health check endpoint that returns "pong"',
+  auth: textToCadAuth,
+  category: 'Meta',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/ping',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/ml/generate-cad-model.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/ml/generate-cad-model.action.ts
@@ -1,0 +1,50 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const generateCadModelAction = createAction({
+  name: 'generate_cad_model',
+  displayName: 'Generate CAD Model',
+  description: 'Generate a 3D model from text prompt',
+  auth: textToCadAuth,
+  category: 'Machine Learning (ML)',
+  props: {
+    outputFormat: Property.StaticDropdown({
+      displayName: 'Output Format',
+      required: true,
+      options: {
+        options: [
+          { label: 'FBX', value: 'fbx' },
+          { label: 'GLB', value: 'glb' },
+          { label: 'GLTF', value: 'gltf' },
+          { label: 'OBJ', value: 'obj' },
+          { label: 'PLY', value: 'ply' },
+          { label: 'STEP', value: 'step' },
+          { label: 'STL', value: 'stl' },
+        ],
+      },
+    }),
+    outputKcl: Property.Checkbox({
+      displayName: 'Include KCL Output',
+      required: false,
+    }),
+    prompt: Property.ShortText({
+      displayName: 'Prompt',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `https://api.zoo.dev/ai/text-to-cad/${propsValue.outputFormat}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        output_kcl: propsValue.outputKcl,
+        prompt: propsValue.prompt,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/ml/get-cad-model.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/ml/get-cad-model.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getCadModelAction = createAction({
+  name: 'get_cad_model',
+  displayName: 'Get CAD Model',
+  description: 'Retrieve details of a specific 3D model',
+  auth: textToCadAuth,
+  category: 'Machine Learning (ML)',
+  props: {
+    modelId: Property.ShortText({
+      displayName: 'Model ID',
+      required: true,
+      description: 'The ID of the model to retrieve',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/user/text-to-cad/${propsValue.modelId}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/ml/give-model-feedback.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/ml/give-model-feedback.action.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const giveModelFeedbackAction = createAction({
+  name: 'give_model_feedback',
+  displayName: 'Give Model Feedback',
+  description: 'Provide feedback on a generated 3D model',
+  auth: textToCadAuth,
+  category: 'Machine Learning (ML)',
+  props: {
+    modelId: Property.ShortText({
+      displayName: 'Model ID',
+      required: true,
+      description: 'The ID of the model to give feedback on',
+    }),
+    feedback: Property.StaticDropdown({
+      displayName: 'Feedback Type',
+      required: true,
+      options: {
+        options: [
+          { label: 'Thumbs Up', value: 'thumbs_up' },
+          { label: 'Thumbs Down', value: 'thumbs_down' },
+          { label: 'Accepted', value: 'accepted' },
+          { label: 'Rejected', value: 'rejected' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `https://api.zoo.dev/user/text-to-cad/${propsValue.modelId}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        feedback: propsValue.feedback,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/ml/kcl-completions.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/ml/kcl-completions.action.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const kclCompletionsAction = createAction({
+  name: 'kcl_completions',
+  displayName: 'KCL Code Completions',
+  description: 'Get code completions for KCL (Kernel Configuration Language)',
+  auth: textToCadAuth,
+  category: 'Machine Learning (ML)',
+  props: {
+    prompt: Property.LongText({
+      displayName: 'Prompt',
+      required: true,
+      description: 'The KCL code prompt to get completions for',
+    }),
+    temperature: Property.Number({
+      displayName: 'Temperature',
+      required: false,
+      description: 'Controls randomness in completion generation (0.0 to 1.0)',
+    }),
+    maxTokens: Property.Number({
+      displayName: 'Max Tokens',
+      required: false,
+      description: 'Maximum number of tokens to generate',
+    }),
+    stop: Property.Array({
+      displayName: 'Stop Sequences',
+      required: false,
+      description: 'Sequences where the API will stop generating further tokens',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/ml/kcl/completions',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        prompt: propsValue.prompt,
+        temperature: propsValue.temperature,
+        max_tokens: propsValue.maxTokens,
+        stop: propsValue.stop,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/ml/list-cad-models.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/ml/list-cad-models.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listCadModelsAction = createAction({
+  name: 'list_cad_models',
+  displayName: 'List CAD Models',
+  description: 'Retrieve a list of your generated 3D models',
+  auth: textToCadAuth,
+  category: 'Machine Learning (ML)',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of models to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of models to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/text-to-cad',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/ml/text-to-cad-iteration.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/ml/text-to-cad-iteration.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const textToCadIterationAction = createAction({
+  name: 'text_to_cad_iteration',
+  displayName: 'Iterate CAD Model',
+  description: 'Create a new iteration of an existing 3D model',
+  auth: textToCadAuth,
+  category: 'Machine Learning (ML)',
+  props: {
+    prompt: Property.ShortText({
+      displayName: 'Prompt',
+      required: true,
+      description: 'The prompt describing desired changes',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/ml/text-to-cad/iteration',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        prompt: propsValue.prompt,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/modeling/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/modeling/index.ts
@@ -1,0 +1,5 @@
+import { sendModelingCommandAction } from './send-modeling-command.action';
+
+export const MODELING_ACTIONS = [
+  sendModelingCommandAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/modeling/send-modeling-command.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/modeling/send-modeling-command.action.ts
@@ -1,0 +1,34 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const sendModelingCommandAction = createAction({
+  name: 'send_modeling_command',
+  displayName: 'Send Modeling Command',
+  description: 'Send a command to the modeling WebSocket endpoint',
+  auth: textToCadAuth,
+  category: 'Modeling',
+  props: {
+    command: Property.Object({
+      displayName: 'Command',
+      required: true,
+      description: 'The modeling command to send',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    // First get the WebSocket URL
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/ws/modeling/commands',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+
+    // Return the WebSocket URL and command for the client to handle the connection
+    return {
+      websocketUrl: response.body.url,
+      command: propsValue.command,
+    };
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/orgs/add-org-member.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/orgs/add-org-member.action.ts
@@ -1,0 +1,42 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const addOrgMemberAction = createAction({
+  name: 'add_org_member',
+  displayName: 'Add Organization Member',
+  description: 'Add a new member to your organization',
+  auth: textToCadAuth,
+  category: 'Organizations',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: true,
+      description: 'Email address of the user to add',
+    }),
+    role: Property.StaticDropdown({
+      displayName: 'Role',
+      required: true,
+      options: {
+        options: [
+          { label: 'Admin', value: 'admin' },
+          { label: 'Member', value: 'member' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/org/members',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        email: propsValue.email,
+        role: propsValue.role,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/orgs/create-org.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/orgs/create-org.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createOrgAction = createAction({
+  name: 'create_org',
+  displayName: 'Create Organization',
+  description: 'Create a new organization',
+  auth: textToCadAuth,
+  category: 'Organizations',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Organization Name',
+      required: true,
+      description: 'The name for the new organization',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/org',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        name: propsValue.name,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/orgs/get-org-member.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/orgs/get-org-member.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getOrgMemberAction = createAction({
+  name: 'get_org_member',
+  displayName: 'Get Organization Member',
+  description: 'Get details of a specific organization member',
+  auth: textToCadAuth,
+  category: 'Organizations',
+  props: {
+    userId: Property.ShortText({
+      displayName: 'User ID',
+      required: true,
+      description: 'ID of the member to retrieve',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/org/members/${propsValue.userId}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/orgs/get-org.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/orgs/get-org.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getOrgAction = createAction({
+  name: 'get_org',
+  displayName: 'Get Organization',
+  description: 'Retrieve details of your organization',
+  auth: textToCadAuth,
+  category: 'Organizations',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/orgs/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/orgs/index.ts
@@ -1,0 +1,15 @@
+import { getOrgAction } from './get-org.action';
+import { updateOrgAction } from './update-org.action';
+import { createOrgAction } from './create-org.action';
+import { listOrgMembersAction } from './list-org-members.action';
+import { addOrgMemberAction } from './add-org-member.action';
+import { getOrgMemberAction } from './get-org-member.action';
+
+export const ORGS_ACTIONS = [
+  getOrgAction,
+  updateOrgAction,
+  createOrgAction,
+  listOrgMembersAction,
+  addOrgMemberAction,
+  getOrgMemberAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/orgs/list-org-members.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/orgs/list-org-members.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listOrgMembersAction = createAction({
+  name: 'list_org_members',
+  displayName: 'List Organization Members',
+  description: 'List all members of your organization',
+  auth: textToCadAuth,
+  category: 'Organizations',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of members to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of members to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org/members',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/orgs/update-org.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/orgs/update-org.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateOrgAction = createAction({
+  name: 'update_org',
+  displayName: 'Update Organization',
+  description: 'Update your organization details',
+  auth: textToCadAuth,
+  category: 'Organizations',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Organization Name',
+      required: true,
+      description: 'The new name for your organization',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: 'https://api.zoo.dev/org',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        name: propsValue.name,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/create-org-payment.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/create-org-payment.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createOrgPaymentAction = createAction({
+  name: 'create_org_payment',
+  displayName: 'Create Organization Payment Info',
+  description: 'Create payment information for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    paymentMethodId: Property.ShortText({
+      displayName: 'Payment Method ID',
+      required: true,
+      description: 'ID of the payment method to use',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/org/payment',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        payment_method_id: propsValue.paymentMethodId,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/create-org-subscription.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/create-org-subscription.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createOrgSubscriptionAction = createAction({
+  name: 'create_org_subscription',
+  displayName: 'Create Organization Subscription',
+  description: 'Create a new subscription for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    planId: Property.ShortText({
+      displayName: 'Plan ID',
+      required: true,
+      description: 'ID of the subscription plan',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/org/payment/subscriptions',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        plan_id: propsValue.planId,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/create-user-payment.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/create-user-payment.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createUserPaymentAction = createAction({
+  name: 'create_user_payment',
+  displayName: 'Create User Payment Info',
+  description: 'Create payment information for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    paymentMethodId: Property.ShortText({
+      displayName: 'Payment Method ID',
+      required: true,
+      description: 'ID of the payment method to use',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/user/payment',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        payment_method_id: propsValue.paymentMethodId,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/create-user-subscription.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/create-user-subscription.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createUserSubscriptionAction = createAction({
+  name: 'create_user_subscription',
+  displayName: 'Create User Subscription',
+  description: 'Create a new subscription for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    planId: Property.ShortText({
+      displayName: 'Plan ID',
+      required: true,
+      description: 'ID of the subscription plan',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/user/payment/subscriptions',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        plan_id: propsValue.planId,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/delete-org-payment.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/delete-org-payment.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const deleteOrgPaymentAction = createAction({
+  name: 'delete_org_payment',
+  displayName: 'Delete Organization Payment Info',
+  description: 'Delete payment information for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.DELETE,
+      url: 'https://api.zoo.dev/org/payment',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/delete-user-payment.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/delete-user-payment.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const deleteUserPaymentAction = createAction({
+  name: 'delete_user_payment',
+  displayName: 'Delete User Payment Info',
+  description: 'Delete payment information for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.DELETE,
+      url: 'https://api.zoo.dev/user/payment',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-org-balance.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-org-balance.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getOrgBalanceAction = createAction({
+  name: 'get_org_balance',
+  displayName: 'Get Organization Balance',
+  description: 'Retrieve the current balance for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org/payment/balance',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-org-payment.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-org-payment.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getOrgPaymentAction = createAction({
+  name: 'get_org_payment',
+  displayName: 'Get Organization Payment Info',
+  description: 'Retrieve payment information for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org/payment',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-org-subscription.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-org-subscription.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getOrgSubscriptionAction = createAction({
+  name: 'get_org_subscription',
+  displayName: 'Get Organization Subscription',
+  description: 'Retrieve the current subscription for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org/payment/subscriptions',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-user-balance.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-user-balance.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getUserBalanceAction = createAction({
+  name: 'get_user_balance',
+  displayName: 'Get User Balance',
+  description: 'Retrieve the current balance for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/payment/balance',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-user-payment.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-user-payment.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getUserPaymentAction = createAction({
+  name: 'get_user_payment',
+  displayName: 'Get User Payment Info',
+  description: 'Retrieve payment information for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/payment',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-user-subscription.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/get-user-subscription.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getUserSubscriptionAction = createAction({
+  name: 'get_user_subscription',
+  displayName: 'Get User Subscription',
+  description: 'Retrieve the current subscription for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/payment/subscriptions',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/index.ts
@@ -1,0 +1,43 @@
+import { getOrgPaymentAction } from './get-org-payment.action';
+import { updateOrgPaymentAction } from './update-org-payment.action';
+import { createOrgPaymentAction } from './create-org-payment.action';
+import { deleteOrgPaymentAction } from './delete-org-payment.action';
+import { getOrgBalanceAction } from './get-org-balance.action';
+import { listOrgInvoicesAction } from './list-org-invoices.action';
+import { listOrgPaymentMethodsAction } from './list-org-payment-methods.action';
+import { getOrgSubscriptionAction } from './get-org-subscription.action';
+import { updateOrgSubscriptionAction } from './update-org-subscription.action';
+import { createOrgSubscriptionAction } from './create-org-subscription.action';
+import { getUserPaymentAction } from './get-user-payment.action';
+import { updateUserPaymentAction } from './update-user-payment.action';
+import { createUserPaymentAction } from './create-user-payment.action';
+import { deleteUserPaymentAction } from './delete-user-payment.action';
+import { getUserBalanceAction } from './get-user-balance.action';
+import { listUserInvoicesAction } from './list-user-invoices.action';
+import { listUserPaymentMethodsAction } from './list-user-payment-methods.action';
+import { getUserSubscriptionAction } from './get-user-subscription.action';
+import { updateUserSubscriptionAction } from './update-user-subscription.action';
+import { createUserSubscriptionAction } from './create-user-subscription.action';
+
+export const PAYMENTS_ACTIONS = [
+  getOrgPaymentAction,
+  updateOrgPaymentAction,
+  createOrgPaymentAction,
+  deleteOrgPaymentAction,
+  getOrgBalanceAction,
+  listOrgInvoicesAction,
+  listOrgPaymentMethodsAction,
+  getOrgSubscriptionAction,
+  updateOrgSubscriptionAction,
+  createOrgSubscriptionAction,
+  getUserPaymentAction,
+  updateUserPaymentAction,
+  createUserPaymentAction,
+  deleteUserPaymentAction,
+  getUserBalanceAction,
+  listUserInvoicesAction,
+  listUserPaymentMethodsAction,
+  getUserSubscriptionAction,
+  updateUserSubscriptionAction,
+  createUserSubscriptionAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/list-org-invoices.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/list-org-invoices.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listOrgInvoicesAction = createAction({
+  name: 'list_org_invoices',
+  displayName: 'List Organization Invoices',
+  description: 'List all invoices for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of invoices to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of invoices to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org/payment/invoices',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/list-org-payment-methods.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/list-org-payment-methods.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listOrgPaymentMethodsAction = createAction({
+  name: 'list_org_payment_methods',
+  displayName: 'List Organization Payment Methods',
+  description: 'List all payment methods for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of payment methods to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of payment methods to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org/payment/methods',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/list-user-invoices.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/list-user-invoices.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listUserInvoicesAction = createAction({
+  name: 'list_user_invoices',
+  displayName: 'List User Invoices',
+  description: 'List all invoices for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of invoices to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of invoices to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/payment/invoices',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/list-user-payment-methods.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/list-user-payment-methods.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listUserPaymentMethodsAction = createAction({
+  name: 'list_user_payment_methods',
+  displayName: 'List User Payment Methods',
+  description: 'List all payment methods for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of payment methods to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of payment methods to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/payment/methods',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/update-org-payment.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/update-org-payment.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateOrgPaymentAction = createAction({
+  name: 'update_org_payment',
+  displayName: 'Update Organization Payment Info',
+  description: 'Update payment information for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    paymentMethodId: Property.ShortText({
+      displayName: 'Payment Method ID',
+      required: true,
+      description: 'ID of the payment method to use',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: 'https://api.zoo.dev/org/payment',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        payment_method_id: propsValue.paymentMethodId,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/update-org-subscription.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/update-org-subscription.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateOrgSubscriptionAction = createAction({
+  name: 'update_org_subscription',
+  displayName: 'Update Organization Subscription',
+  description: 'Update the subscription for your organization',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    planId: Property.ShortText({
+      displayName: 'Plan ID',
+      required: true,
+      description: 'ID of the subscription plan',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: 'https://api.zoo.dev/org/payment/subscriptions',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        plan_id: propsValue.planId,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/update-user-payment.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/update-user-payment.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateUserPaymentAction = createAction({
+  name: 'update_user_payment',
+  displayName: 'Update User Payment Info',
+  description: 'Update payment information for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    paymentMethodId: Property.ShortText({
+      displayName: 'Payment Method ID',
+      required: true,
+      description: 'ID of the payment method to use',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: 'https://api.zoo.dev/user/payment',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        payment_method_id: propsValue.paymentMethodId,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/payments/update-user-subscription.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/payments/update-user-subscription.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateUserSubscriptionAction = createAction({
+  name: 'update_user_subscription',
+  displayName: 'Update User Subscription',
+  description: 'Update the subscription for your user account',
+  auth: textToCadAuth,
+  category: 'Payments',
+  props: {
+    planId: Property.ShortText({
+      displayName: 'Plan ID',
+      required: true,
+      description: 'ID of the subscription plan',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: 'https://api.zoo.dev/user/payment/subscriptions',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        plan_id: propsValue.planId,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/create-service-account.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/create-service-account.action.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createServiceAccountAction = createAction({
+  name: 'create_service_account',
+  displayName: 'Create Service Account',
+  description: 'Create a new service account for your organization',
+  auth: textToCadAuth,
+  category: 'Service Accounts',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Name',
+      required: true,
+      description: 'Name for the service account',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/org/service-accounts',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        name: propsValue.name,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/delete-service-account.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/delete-service-account.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const deleteServiceAccountAction = createAction({
+  name: 'delete_service_account',
+  displayName: 'Delete Service Account',
+  description: 'Delete a service account from your organization',
+  auth: textToCadAuth,
+  category: 'Service Accounts',
+  props: {
+    token: Property.ShortText({
+      displayName: 'Token',
+      required: true,
+      description: 'Token of the service account to delete',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.DELETE,
+      url: `https://api.zoo.dev/org/service-accounts/${propsValue.token}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/get-service-account.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/get-service-account.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getServiceAccountAction = createAction({
+  name: 'get_service_account',
+  displayName: 'Get Service Account',
+  description: 'Retrieve details of a specific service account',
+  auth: textToCadAuth,
+  category: 'Service Accounts',
+  props: {
+    token: Property.ShortText({
+      displayName: 'Token',
+      required: true,
+      description: 'Token of the service account to retrieve',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/org/service-accounts/${propsValue.token}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/index.ts
@@ -1,0 +1,11 @@
+import { listServiceAccountsAction } from './list-service-accounts.action';
+import { createServiceAccountAction } from './create-service-account.action';
+import { getServiceAccountAction } from './get-service-account.action';
+import { deleteServiceAccountAction } from './delete-service-account.action';
+
+export const SERVICE_ACCOUNTS_ACTIONS = [
+  listServiceAccountsAction,
+  createServiceAccountAction,
+  getServiceAccountAction,
+  deleteServiceAccountAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/list-service-accounts.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/service-accounts/list-service-accounts.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listServiceAccountsAction = createAction({
+  name: 'list_service_accounts',
+  displayName: 'List Service Accounts',
+  description: 'List all service accounts for your organization',
+  auth: textToCadAuth,
+  category: 'Service Accounts',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of service accounts to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of service accounts to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org/service-accounts',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/create-shortlink.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/create-shortlink.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createShortlinkAction = createAction({
+  name: 'create_shortlink',
+  displayName: 'Create Shortlink',
+  description: 'Create a new shortlink for your user account',
+  auth: textToCadAuth,
+  category: 'Shortlinks',
+  props: {
+    url: Property.ShortText({
+      displayName: 'URL',
+      required: true,
+      description: 'The URL to shorten',
+    }),
+    key: Property.ShortText({
+      displayName: 'Key',
+      required: false,
+      description: 'Custom key for the shortlink (optional)',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.zoo.dev/user/shortlinks',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        url: propsValue.url,
+        ...(propsValue.key && { key: propsValue.key }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/delete-shortlink.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/delete-shortlink.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const deleteShortlinkAction = createAction({
+  name: 'delete_shortlink',
+  displayName: 'Delete Shortlink',
+  description: 'Delete an existing shortlink',
+  auth: textToCadAuth,
+  category: 'Shortlinks',
+  props: {
+    key: Property.ShortText({
+      displayName: 'Key',
+      required: true,
+      description: 'The key of the shortlink to delete',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.DELETE,
+      url: `https://api.zoo.dev/user/shortlinks/${propsValue.key}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/index.ts
@@ -1,0 +1,13 @@
+import { listOrgShortlinksAction } from './list-org-shortlinks.action';
+import { listUserShortlinksAction } from './list-user-shortlinks.action';
+import { createShortlinkAction } from './create-shortlink.action';
+import { updateShortlinkAction } from './update-shortlink.action';
+import { deleteShortlinkAction } from './delete-shortlink.action';
+
+export const SHORTLINKS_ACTIONS = [
+  listOrgShortlinksAction,
+  listUserShortlinksAction,
+  createShortlinkAction,
+  updateShortlinkAction,
+  deleteShortlinkAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/list-org-shortlinks.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/list-org-shortlinks.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listOrgShortlinksAction = createAction({
+  name: 'list_org_shortlinks',
+  displayName: 'List Organization Shortlinks',
+  description: 'List all shortlinks for your organization',
+  auth: textToCadAuth,
+  category: 'Shortlinks',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of shortlinks to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of shortlinks to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/org/shortlinks',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/list-user-shortlinks.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/list-user-shortlinks.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const listUserShortlinksAction = createAction({
+  name: 'list_user_shortlinks',
+  displayName: 'List User Shortlinks',
+  description: 'List all shortlinks for your user account',
+  auth: textToCadAuth,
+  category: 'Shortlinks',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      required: false,
+      description: 'Maximum number of shortlinks to return',
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      required: false,
+      description: 'Number of shortlinks to skip',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/shortlinks',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        ...(propsValue.limit && { limit: propsValue.limit.toString() }),
+        ...(propsValue.offset && { offset: propsValue.offset.toString() }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/update-shortlink.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/shortlinks/update-shortlink.action.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateShortlinkAction = createAction({
+  name: 'update_shortlink',
+  displayName: 'Update Shortlink',
+  description: 'Update an existing shortlink',
+  auth: textToCadAuth,
+  category: 'Shortlinks',
+  props: {
+    key: Property.ShortText({
+      displayName: 'Key',
+      required: true,
+      description: 'The key of the shortlink to update',
+    }),
+    url: Property.ShortText({
+      displayName: 'URL',
+      required: true,
+      description: 'The new URL for the shortlink',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: `https://api.zoo.dev/user/shortlinks/${propsValue.key}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        url: propsValue.url,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-angle.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-angle.action.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertAngleAction = createAction({
+  name: 'convert_angle',
+  displayName: 'Convert Angle',
+  description: 'Convert angle measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The angle value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Degrees', value: 'deg' },
+          { label: 'Radians', value: 'rad' },
+          { label: 'Gradians', value: 'grad' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Degrees', value: 'deg' },
+          { label: 'Radians', value: 'rad' },
+          { label: 'Gradians', value: 'grad' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/angle/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-area.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-area.action.ts
@@ -1,0 +1,63 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertAreaAction = createAction({
+  name: 'convert_area',
+  displayName: 'Convert Area',
+  description: 'Convert area measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The area value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Square Meters', value: 'm2' },
+          { label: 'Square Feet', value: 'ft2' },
+          { label: 'Square Inches', value: 'in2' },
+          { label: 'Square Yards', value: 'yd2' },
+          { label: 'Square Kilometers', value: 'km2' },
+          { label: 'Square Miles', value: 'mi2' },
+          { label: 'Hectares', value: 'ha' },
+          { label: 'Acres', value: 'ac' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Square Meters', value: 'm2' },
+          { label: 'Square Feet', value: 'ft2' },
+          { label: 'Square Inches', value: 'in2' },
+          { label: 'Square Yards', value: 'yd2' },
+          { label: 'Square Kilometers', value: 'km2' },
+          { label: 'Square Miles', value: 'mi2' },
+          { label: 'Hectares', value: 'ha' },
+          { label: 'Acres', value: 'ac' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/area/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-current.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-current.action.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertCurrentAction = createAction({
+  name: 'convert_current',
+  displayName: 'Convert Current',
+  description: 'Convert electrical current measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The current value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Amperes', value: 'A' },
+          { label: 'Milliamperes', value: 'mA' },
+          { label: 'Kiloamperes', value: 'kA' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Amperes', value: 'A' },
+          { label: 'Milliamperes', value: 'mA' },
+          { label: 'Kiloamperes', value: 'kA' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/current/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-energy.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-energy.action.ts
@@ -1,0 +1,61 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertEnergyAction = createAction({
+  name: 'convert_energy',
+  displayName: 'Convert Energy',
+  description: 'Convert energy measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The energy value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Joules', value: 'J' },
+          { label: 'Kilojoules', value: 'kJ' },
+          { label: 'Calories', value: 'cal' },
+          { label: 'Kilocalories', value: 'kcal' },
+          { label: 'Watt Hours', value: 'Wh' },
+          { label: 'Kilowatt Hours', value: 'kWh' },
+          { label: 'British Thermal Units', value: 'BTU' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Joules', value: 'J' },
+          { label: 'Kilojoules', value: 'kJ' },
+          { label: 'Calories', value: 'cal' },
+          { label: 'Kilocalories', value: 'kcal' },
+          { label: 'Watt Hours', value: 'Wh' },
+          { label: 'Kilowatt Hours', value: 'kWh' },
+          { label: 'British Thermal Units', value: 'BTU' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/energy/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-force.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-force.action.ts
@@ -1,0 +1,55 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertForceAction = createAction({
+  name: 'convert_force',
+  displayName: 'Convert Force',
+  description: 'Convert force measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The force value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Newtons', value: 'N' },
+          { label: 'Kilonewtons', value: 'kN' },
+          { label: 'Pound-force', value: 'lbf' },
+          { label: 'Dynes', value: 'dyn' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Newtons', value: 'N' },
+          { label: 'Kilonewtons', value: 'kN' },
+          { label: 'Pound-force', value: 'lbf' },
+          { label: 'Dynes', value: 'dyn' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/force/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-frequency.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-frequency.action.ts
@@ -1,0 +1,55 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertFrequencyAction = createAction({
+  name: 'convert_frequency',
+  displayName: 'Convert Frequency',
+  description: 'Convert frequency measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The frequency value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Hertz', value: 'Hz' },
+          { label: 'Kilohertz', value: 'kHz' },
+          { label: 'Megahertz', value: 'MHz' },
+          { label: 'Gigahertz', value: 'GHz' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Hertz', value: 'Hz' },
+          { label: 'Kilohertz', value: 'kHz' },
+          { label: 'Megahertz', value: 'MHz' },
+          { label: 'Gigahertz', value: 'GHz' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/frequency/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-length.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-length.action.ts
@@ -1,0 +1,63 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertLengthAction = createAction({
+  name: 'convert_length',
+  displayName: 'Convert Length',
+  description: 'Convert length measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The length value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Meters', value: 'm' },
+          { label: 'Kilometers', value: 'km' },
+          { label: 'Centimeters', value: 'cm' },
+          { label: 'Millimeters', value: 'mm' },
+          { label: 'Inches', value: 'in' },
+          { label: 'Feet', value: 'ft' },
+          { label: 'Yards', value: 'yd' },
+          { label: 'Miles', value: 'mi' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Meters', value: 'm' },
+          { label: 'Kilometers', value: 'km' },
+          { label: 'Centimeters', value: 'cm' },
+          { label: 'Millimeters', value: 'mm' },
+          { label: 'Inches', value: 'in' },
+          { label: 'Feet', value: 'ft' },
+          { label: 'Yards', value: 'yd' },
+          { label: 'Miles', value: 'mi' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/length/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-mass.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-mass.action.ts
@@ -1,0 +1,59 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertMassAction = createAction({
+  name: 'convert_mass',
+  displayName: 'Convert Mass',
+  description: 'Convert mass measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The mass value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Kilograms', value: 'kg' },
+          { label: 'Grams', value: 'g' },
+          { label: 'Milligrams', value: 'mg' },
+          { label: 'Pounds', value: 'lb' },
+          { label: 'Ounces', value: 'oz' },
+          { label: 'Metric Tons', value: 't' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Kilograms', value: 'kg' },
+          { label: 'Grams', value: 'g' },
+          { label: 'Milligrams', value: 'mg' },
+          { label: 'Pounds', value: 'lb' },
+          { label: 'Ounces', value: 'oz' },
+          { label: 'Metric Tons', value: 't' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/mass/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-power.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-power.action.ts
@@ -1,0 +1,55 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertPowerAction = createAction({
+  name: 'convert_power',
+  displayName: 'Convert Power',
+  description: 'Convert power measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The power value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Watts', value: 'W' },
+          { label: 'Kilowatts', value: 'kW' },
+          { label: 'Megawatts', value: 'MW' },
+          { label: 'Horsepower', value: 'hp' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Watts', value: 'W' },
+          { label: 'Kilowatts', value: 'kW' },
+          { label: 'Megawatts', value: 'MW' },
+          { label: 'Horsepower', value: 'hp' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/power/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-pressure.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-pressure.action.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertPressureAction = createAction({
+  name: 'convert_pressure',
+  displayName: 'Convert Pressure',
+  description: 'Convert pressure measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The pressure value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Pascal', value: 'Pa' },
+          { label: 'Kilopascal', value: 'kPa' },
+          { label: 'Bar', value: 'bar' },
+          { label: 'Atmosphere', value: 'atm' },
+          { label: 'Pounds per Square Inch', value: 'psi' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Pascal', value: 'Pa' },
+          { label: 'Kilopascal', value: 'kPa' },
+          { label: 'Bar', value: 'bar' },
+          { label: 'Atmosphere', value: 'atm' },
+          { label: 'Pounds per Square Inch', value: 'psi' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/pressure/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-temperature.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-temperature.action.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertTemperatureAction = createAction({
+  name: 'convert_temperature',
+  displayName: 'Convert Temperature',
+  description: 'Convert temperature measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The temperature value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Celsius', value: 'C' },
+          { label: 'Fahrenheit', value: 'F' },
+          { label: 'Kelvin', value: 'K' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Celsius', value: 'C' },
+          { label: 'Fahrenheit', value: 'F' },
+          { label: 'Kelvin', value: 'K' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/temperature/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-torque.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-torque.action.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertTorqueAction = createAction({
+  name: 'convert_torque',
+  displayName: 'Convert Torque',
+  description: 'Convert torque measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The torque value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Newton Meter', value: 'Nm' },
+          { label: 'Pound Foot', value: 'lbft' },
+          { label: 'Kilogram Force Meter', value: 'kgfm' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Newton Meter', value: 'Nm' },
+          { label: 'Pound Foot', value: 'lbft' },
+          { label: 'Kilogram Force Meter', value: 'kgfm' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/torque/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-volume.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/convert-volume.action.ts
@@ -1,0 +1,61 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const convertVolumeAction = createAction({
+  name: 'convert_volume',
+  displayName: 'Convert Volume',
+  description: 'Convert volume measurements between different units',
+  auth: textToCadAuth,
+  category: 'Unit Conversion',
+  props: {
+    value: Property.Number({
+      displayName: 'Value',
+      required: true,
+      description: 'The volume value to convert',
+    }),
+    inputUnit: Property.StaticDropdown({
+      displayName: 'Input Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Cubic Meters', value: 'm3' },
+          { label: 'Cubic Feet', value: 'ft3' },
+          { label: 'Cubic Inches', value: 'in3' },
+          { label: 'Liters', value: 'L' },
+          { label: 'Gallons', value: 'gal' },
+          { label: 'Milliliters', value: 'mL' },
+          { label: 'Fluid Ounces', value: 'fl_oz' },
+        ],
+      },
+    }),
+    outputUnit: Property.StaticDropdown({
+      displayName: 'Output Unit',
+      required: true,
+      options: {
+        options: [
+          { label: 'Cubic Meters', value: 'm3' },
+          { label: 'Cubic Feet', value: 'ft3' },
+          { label: 'Cubic Inches', value: 'in3' },
+          { label: 'Liters', value: 'L' },
+          { label: 'Gallons', value: 'gal' },
+          { label: 'Milliliters', value: 'mL' },
+          { label: 'Fluid Ounces', value: 'fl_oz' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/unit/conversion/volume/${propsValue.inputUnit}/${propsValue.outputUnit}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        value: propsValue.value.toString(),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/unit/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/unit/index.ts
@@ -1,0 +1,29 @@
+import { convertAngleAction } from './convert-angle.action';
+import { convertAreaAction } from './convert-area.action';
+import { convertCurrentAction } from './convert-current.action';
+import { convertEnergyAction } from './convert-energy.action';
+import { convertForceAction } from './convert-force.action';
+import { convertFrequencyAction } from './convert-frequency.action';
+import { convertLengthAction } from './convert-length.action';
+import { convertMassAction } from './convert-mass.action';
+import { convertPowerAction } from './convert-power.action';
+import { convertPressureAction } from './convert-pressure.action';
+import { convertTemperatureAction } from './convert-temperature.action';
+import { convertTorqueAction } from './convert-torque.action';
+import { convertVolumeAction } from './convert-volume.action';
+
+export const UNIT_ACTIONS = [
+  convertAngleAction,
+  convertAreaAction,
+  convertCurrentAction,
+  convertEnergyAction,
+  convertForceAction,
+  convertFrequencyAction,
+  convertLengthAction,
+  convertMassAction,
+  convertPowerAction,
+  convertPressureAction,
+  convertTemperatureAction,
+  convertTorqueAction,
+  convertVolumeAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/delete-user.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/delete-user.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const deleteUserAction = createAction({
+  name: 'delete_user',
+  displayName: 'Delete User',
+  description: 'Delete your user account',
+  auth: textToCadAuth,
+  category: 'Users',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.DELETE,
+      url: 'https://api.zoo.dev/user',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/get-extended-user.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/get-extended-user.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getExtendedUserAction = createAction({
+  name: 'get_extended_user',
+  displayName: 'Get Extended User Info',
+  description: 'Retrieve extended information about your user account',
+  auth: textToCadAuth,
+  category: 'Users',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/extended',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/get-oauth2-providers.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/get-oauth2-providers.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getOAuth2ProvidersAction = createAction({
+  name: 'get_oauth2_providers',
+  displayName: 'Get OAuth2 Providers',
+  description: 'Get the OAuth2 providers available for your user account',
+  auth: textToCadAuth,
+  category: 'Users',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/oauth2/providers',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/get-privacy-settings.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/get-privacy-settings.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getPrivacySettingsAction = createAction({
+  name: 'get_privacy_settings',
+  displayName: 'Get Privacy Settings',
+  description: 'Get your user privacy settings',
+  auth: textToCadAuth,
+  category: 'Users',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/privacy',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/get-user-org.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/get-user-org.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getUserOrgAction = createAction({
+  name: 'get_user_org',
+  displayName: 'Get User Organization',
+  description: 'Get the organization associated with your user account',
+  auth: textToCadAuth,
+  category: 'Users',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user/org',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/get-user-session.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/get-user-session.action.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getUserSessionAction = createAction({
+  name: 'get_user_session',
+  displayName: 'Get User Session',
+  description: 'Get details about a specific user session',
+  auth: textToCadAuth,
+  category: 'Users',
+  props: {
+    token: Property.ShortText({
+      displayName: 'Session Token',
+      required: true,
+      description: 'The token of the session to retrieve',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.zoo.dev/user/session/${propsValue.token}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/get-user.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/get-user.action.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getUserAction = createAction({
+  name: 'get_user',
+  displayName: 'Get User',
+  description: 'Retrieve your user information',
+  auth: textToCadAuth,
+  category: 'Users',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.zoo.dev/user',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/index.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/index.ts
@@ -1,0 +1,21 @@
+import { getUserAction } from './get-user.action';
+import { updateUserAction } from './update-user.action';
+import { deleteUserAction } from './delete-user.action';
+import { getExtendedUserAction } from './get-extended-user.action';
+import { getOAuth2ProvidersAction } from './get-oauth2-providers.action';
+import { getUserOrgAction } from './get-user-org.action';
+import { getPrivacySettingsAction } from './get-privacy-settings.action';
+import { updatePrivacySettingsAction } from './update-privacy-settings.action';
+import { getUserSessionAction } from './get-user-session.action';
+
+export const USER_ACTIONS = [
+  getUserAction,
+  updateUserAction,
+  deleteUserAction,
+  getExtendedUserAction,
+  getOAuth2ProvidersAction,
+  getUserOrgAction,
+  getPrivacySettingsAction,
+  updatePrivacySettingsAction,
+  getUserSessionAction,
+];

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/update-privacy-settings.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/update-privacy-settings.action.ts
@@ -1,0 +1,29 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updatePrivacySettingsAction = createAction({
+  name: 'update_privacy_settings',
+  displayName: 'Update Privacy Settings',
+  description: 'Update your user privacy settings',
+  auth: textToCadAuth,
+  category: 'Users',
+  props: {
+    settings: Property.Object({
+      displayName: 'Privacy Settings',
+      required: true,
+      description: 'The new privacy settings to apply',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: 'https://api.zoo.dev/user/privacy',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: propsValue.settings,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/src/lib/actions/users/update-user.action.ts
+++ b/packages/pieces/community/text-to-cad/src/lib/actions/users/update-user.action.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { textToCadAuth } from '../../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateUserAction = createAction({
+  name: 'update_user',
+  displayName: 'Update User',
+  description: 'Update your user information',
+  auth: textToCadAuth,
+  category: 'Users',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Name',
+      required: false,
+      description: 'Your new display name',
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: false,
+      description: 'Your new email address',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: 'https://api.zoo.dev/user',
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: {
+        ...(propsValue.name && { name: propsValue.name }),
+        ...(propsValue.email && { email: propsValue.email }),
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/text-to-cad/tsconfig.json
+++ b/packages/pieces/community/text-to-cad/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/text-to-cad/tsconfig.lib.json
+++ b/packages/pieces/community/text-to-cad/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -661,6 +661,9 @@
       "@activepieces/piece-text-helper": [
         "packages/pieces/community/text-helper/src/index.ts"
       ],
+      "@activepieces/piece-text-to-cad": [
+        "packages/pieces/community/text-to-cad/src/index.ts"
+      ],
       "@activepieces/piece-thankster": [
         "packages/pieces/community/thankster/src/index.ts"
       ],


### PR DESCRIPTION
This PR introduces a new integration for Text to CAD, a service that enables generating and iterating on 3D models from text descriptions using machine learning.

⚠️ **Dependencies**: This PR depends on #[6946](https://github.com/activepieces/activepieces/pull/6946) which handles actions grouping. Please review and merge that PR first.

## Features

- **Authentication**: API Key (Bearer Token) authentication
- **Categories**: Artificial Intelligence
- **Action Groups**:
  - Machine Learning Operations
  - API Management
  - File Operations
  - 3D Modeling
  - Organization Management
  - Payment Processing
  - Service Accounts
  - Shortlinks
  - Unit Operations
  - User Management

## Integration Capabilities

This integration allows Activepieces users to:
- Generate 3D models from text descriptions
- Manage and iterate on 3D models
- Handle file operations for 3D assets
- Manage organization and user access
- Process payments and handle API usage

## Screenshots
![image](https://github.com/user-attachments/assets/ebdfa290-4fbe-4a1c-ba20-0c0731acd8f8)

![image](https://github.com/user-attachments/assets/3caec51e-bf7e-416d-8e6f-a3d5e5a7d239)


## Additional Notes
This integration brings powerful 3D modeling capabilities to Activepieces workflows, enabling users to automate CAD model generation and management through text descriptions.

