### PR TITLE
feat: add personal ai piece

### DIFF
--- a/packages/pieces/community/personal-ai/.eslintrc.json
+++ b/packages/pieces/community/personal-ai/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/personal-ai/.gitignore
+++ b/packages/pieces/community/personal-ai/.gitignore
@@ -1,0 +1,1 @@
+node_modules/\n.env\nsrc/lib/common/constants.ts

--- a/packages/pieces/community/personal-ai/README.md
+++ b/packages/pieces/community/personal-ai/README.md
@@ -1,0 +1,7 @@
+# pieces-personal-ai
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-personal-ai` to build the library.

--- a/packages/pieces/community/personal-ai/package.json
+++ b/packages/pieces/community/personal-ai/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-personal-ai",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/personal-ai/project.json
+++ b/packages/pieces/community/personal-ai/project.json
@@ -1,0 +1,39 @@
+{
+  "name": "pieces-personal-ai",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/personal-ai/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/personal-ai",
+        "tsConfig": "packages/pieces/community/personal-ai/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/personal-ai/package.json",
+        "main": "packages/pieces/community/personal-ai/src/index.ts",
+        "assets": ["packages/pieces/community/personal-ai/*.md"],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  }
+}

--- a/packages/pieces/community/personal-ai/src/index.ts
+++ b/packages/pieces/community/personal-ai/src/index.ts
@@ -1,0 +1,43 @@
+
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+
+import { createMemory } from './lib/actions/memory/create-memory';
+import { createMessage } from './lib/actions/messaging/create-message';
+import { createChatGPTInstruction } from './lib/actions/ai_interaction/create-chatgpt-instruction';
+import { createCustomTraining } from './lib/actions/ai_interaction/create-custom-training';
+import { getConversation } from './lib/actions/messaging/get-conversation';
+import { uploadDocument } from './lib/actions/documents/upload-document';
+import { uploadFile } from './lib/actions/documents/upload-file';
+import { uploadUrl } from './lib/actions/documents/upload-url';
+import { updateDocument } from './lib/actions/documents/update-document';
+import { getDocument } from './lib/actions/documents/get-document';
+
+export const BASE_URL = 'https://api.personal.ai';
+
+export const aiAssistant = createPiece({
+  displayName: 'Personal AI',
+  description: 'Manage memory storage, messaging, and documents through AI integration',
+  logoUrl: 'https://imagedelivery.net/bHREz764QO9n_1kIQUR2sw/d5a94216-33f4-4f38-7116-c9afaef95700/public',
+  auth: PieceAuth.SecretText({
+    displayName: 'API Key',
+    description: 'API Key for authentication',
+    required: true,
+  }),
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  minimumSupportedRelease: '0.20.0',
+  authors: ['Swanblocks/Reem Ayoush'],
+  actions: [
+    createMemory,
+    createMessage,
+    createChatGPTInstruction,
+    createCustomTraining,
+    getConversation,
+    uploadDocument,
+    uploadFile,
+    uploadUrl,
+    updateDocument,
+    getDocument,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/ai_interaction/create-chatgpt-instruction.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/ai_interaction/create-chatgpt-instruction.ts
@@ -1,0 +1,78 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const createChatGPTInstruction = createAction({
+  name: 'create_chatgpt_instruction',
+  displayName: 'Send ChatGPT Instruction',
+  description: 'Send an instruction to AI assistant using ChatGPT integration',
+  category: 'AI Interaction',
+  props: {
+    text: Property.LongText({
+      displayName: 'Instruction Text',
+      description: 'The instruction or prompt to send to ChatGPT',
+      required: true,
+    }),
+    context: Property.LongText({
+      displayName: 'Context',
+      description: 'Additional context for the AI response',
+      required: false,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI profile',
+      required: false,
+    }),
+    userName: Property.ShortText({
+      displayName: 'User Name',
+      description: 'Name of the user sending the request',
+      required: false,
+    }),
+    sessionId: Property.ShortText({
+      displayName: 'Session ID',
+      description: 'Use the same sessionId to continue conversation on that session',
+      required: false,
+    }),
+    sourceName: Property.ShortText({
+      displayName: 'Source Name',
+      description: 'Name of the source app of the inbound instruction',
+      required: false,
+    }),
+    isStack: Property.Checkbox({
+      displayName: 'Add to Memory',
+      description: 'Flag to also add the user instruction to memory',
+      required: false,
+      defaultValue: false,
+    }),
+    isDraft: Property.Checkbox({
+      displayName: 'Create Draft',
+      description: 'Flag to create a copilot message for the AI',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { text, context: messageContext, domainName, userName, sessionId, sourceName, isStack, isDraft } } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/v1/instruction?cmd=chatgpt`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': auth as string,
+      },
+      body: {
+        Text: text,
+        ...(messageContext && { Context: messageContext }),
+        ...(domainName && { DomainName: domainName }),
+        ...(userName && { UserName: userName }),
+        ...(sessionId && { SessionId: sessionId }),
+        ...(sourceName && { SourceName: sourceName }),
+        ...(isStack !== undefined && { is_stack: isStack }),
+        ...(isDraft !== undefined && { is_draft: isDraft }),
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/ai_interaction/create-custom-training.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/ai_interaction/create-custom-training.ts
@@ -1,0 +1,78 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const createCustomTraining = createAction({
+  name: 'create_custom_training',
+  displayName: 'Send Custom Training',
+  description: 'Send a custom training instruction to AI assistant',
+  category: 'AI Interaction',
+  props: {
+    text: Property.LongText({
+      displayName: 'Training Text',
+      description: 'The training instruction or prompt to send',
+      required: true,
+    }),
+    context: Property.LongText({
+      displayName: 'Context',
+      description: 'Additional context for the AI response',
+      required: false,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI profile',
+      required: false,
+    }),
+    userName: Property.ShortText({
+      displayName: 'User Name',
+      description: 'Name of the user sending the request',
+      required: false,
+    }),
+    sessionId: Property.ShortText({
+      displayName: 'Session ID',
+      description: 'Use the same sessionId to continue conversation on that session',
+      required: false,
+    }),
+    sourceName: Property.ShortText({
+      displayName: 'Source Name',
+      description: 'Name of the source app of the inbound training',
+      required: false,
+    }),
+    isStack: Property.Checkbox({
+      displayName: 'Add to Memory',
+      description: 'Flag to also add the training instruction to memory',
+      required: false,
+      defaultValue: false,
+    }),
+    isDraft: Property.Checkbox({
+      displayName: 'Create Draft',
+      description: 'Flag to create a copilot message for the AI',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { text, context: messageContext, domainName, userName, sessionId, sourceName, isStack, isDraft } } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/v1/training?cmd=custom`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': auth as string,
+      },
+      body: {
+        Text: text,
+        ...(messageContext && { Context: messageContext }),
+        ...(domainName && { DomainName: domainName }),
+        ...(userName && { UserName: userName }),
+        ...(sessionId && { SessionId: sessionId }),
+        ...(sourceName && { SourceName: sourceName }),
+        ...(isStack !== undefined && { is_stack: isStack }),
+        ...(isDraft !== undefined && { is_draft: isDraft }),
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/documents/get-document.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/documents/get-document.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const getDocument = createAction({
+  name: 'get_document',
+  displayName: 'Get Document',
+  description: 'Retrieve a document from AI assistant',
+  category: 'Documents',
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The unique identifier of the document to retrieve',
+      required: true,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI profile',
+      required: false,
+    }),
+    includeContent: Property.Checkbox({
+      displayName: 'Include Content',
+      description: 'Flag to include the document content in the response',
+      required: false,
+      defaultValue: true,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { documentId, domainName, includeContent } } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${BASE_URL}/get-document`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': auth as string,
+      },
+      queryParams: {
+        DocumentId: documentId,
+        ...(domainName && { DomainName: domainName }),
+        ...(includeContent !== undefined && { IncludeContent: includeContent.toString() }),
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/documents/update-document.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/documents/update-document.ts
@@ -1,0 +1,77 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const updateDocument = createAction({
+  name: 'update_document',
+  displayName: 'Update Document',
+  description: 'Update an existing document in AI assistant',
+  category: 'Documents',
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The unique identifier of the document to update',
+      required: true,
+    }),
+    text: Property.LongText({
+      displayName: 'Document Text',
+      description: 'The updated text content of the document',
+      required: true,
+    }),
+    title: Property.ShortText({
+      displayName: 'Document Title',
+      description: 'Updated title of the document',
+      required: false,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI profile',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma delimited list of tags for the document',
+      required: false,
+    }),
+    sourceName: Property.ShortText({
+      displayName: 'Source Name',
+      description: 'Name of the source or application',
+      required: false,
+    }),
+    createdTime: Property.ShortText({
+      displayName: 'Created Time',
+      description: 'Time (including timezone) of the document creation (e.g., Wed, 19 Sep 2023 13:31:00 PDT)',
+      required: false,
+    }),
+    isStack: Property.Checkbox({
+      displayName: 'Add to Memory',
+      description: 'Flag to also add the document to memory',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { documentId, text, title, domainName, tags, sourceName, createdTime, isStack } } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: `${BASE_URL}/update-document`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': auth as string,
+      },
+      body: {
+        DocumentId: documentId,
+        Text: text,
+        ...(title && { Title: title }),
+        ...(domainName && { DomainName: domainName }),
+        ...(tags && { Tags: tags }),
+        ...(sourceName && { SourceName: sourceName }),
+        ...(createdTime && { CreatedTime: createdTime }),
+        ...(isStack !== undefined && { is_stack: isStack }),
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/documents/upload-document.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/documents/upload-document.ts
@@ -1,0 +1,71 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const uploadDocument = createAction({
+  name: 'upload_document',
+  displayName: 'Upload Document',
+  description: 'Upload a text document to AI assistant',
+  category: 'Documents',
+  props: {
+    text: Property.LongText({
+      displayName: 'Document Text',
+      description: 'The text content of the document to upload',
+      required: true,
+    }),
+    title: Property.ShortText({
+      displayName: 'Document Title',
+      description: 'Title of the document',
+      required: true,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI profile',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma delimited list of tags for the document',
+      required: false,
+    }),
+    sourceName: Property.ShortText({
+      displayName: 'Source Name',
+      description: 'Name of the source or application',
+      required: false,
+    }),
+    createdTime: Property.ShortText({
+      displayName: 'Created Time',
+      description: 'Time (including timezone) of the document creation (e.g., Wed, 19 Sep 2023 13:31:00 PDT)',
+      required: false,
+    }),
+    isStack: Property.Checkbox({
+      displayName: 'Add to Memory',
+      description: 'Flag to also add the document to memory',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { text, title, domainName, tags, sourceName, createdTime, isStack } } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/v1/upload-text`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': auth as string,
+      },
+      body: {
+        Text: text,
+        Title: title,
+        ...(domainName && { DomainName: domainName }),
+        ...(tags && { Tags: tags }),
+        ...(sourceName && { SourceName: sourceName }),
+        ...(createdTime && { CreatedTime: createdTime }),
+        ...(isStack !== undefined && { is_stack: isStack }),
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/documents/upload-file.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/documents/upload-file.ts
@@ -1,0 +1,72 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const uploadFile = createAction({
+  name: 'upload_file',
+  displayName: 'Upload File',
+  description: 'Upload a file to AI assistant',
+  category: 'Documents',
+  props: {
+    file: Property.File({
+      displayName: 'File',
+      description: 'The file to upload',
+      required: true,
+    }),
+    fileName: Property.ShortText({
+      displayName: 'File Name',
+      description: 'Name of the file to be uploaded',
+      required: true,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI profile',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma delimited list of tags for the file',
+      required: false,
+    }),
+    sourceName: Property.ShortText({
+      displayName: 'Source Name',
+      description: 'Name of the source or application',
+      required: false,
+    }),
+    createdTime: Property.ShortText({
+      displayName: 'Created Time',
+      description: 'Time (including timezone) of the file creation (e.g., Wed, 19 Sep 2023 13:31:00 PDT)',
+      required: false,
+    }),
+    isStack: Property.Checkbox({
+      displayName: 'Add to Memory',
+      description: 'Flag to also add the file content to memory',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { file, fileName, domainName, tags, sourceName, createdTime, isStack } } = context;
+
+    // Create form data for file upload
+    const formData = new FormData();
+    const blob = new Blob([file.data], { type: 'application/octet-stream' });
+    formData.append('file', blob, fileName);
+    if (domainName) formData.append('DomainName', domainName);
+    if (tags) formData.append('Tags', tags);
+    if (sourceName) formData.append('SourceName', sourceName);
+    if (createdTime) formData.append('CreatedTime', createdTime);
+    if (isStack !== undefined) formData.append('is_stack', isStack.toString());
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/upload-file`,
+      headers: {
+        'x-api-key': auth as string,
+      },
+      body: formData,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/documents/upload-url.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/documents/upload-url.ts
@@ -1,0 +1,71 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const uploadUrl = createAction({
+  name: 'upload_url',
+  displayName: 'Upload URL Content',
+  description: 'Upload content from a URL to AI assistant',
+  category: 'Documents',
+  props: {
+    url: Property.ShortText({
+      displayName: 'URL',
+      description: 'The URL of the content to upload',
+      required: true,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'Title for the uploaded content',
+      required: true,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI profile',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma delimited list of tags for the content',
+      required: false,
+    }),
+    sourceName: Property.ShortText({
+      displayName: 'Source Name',
+      description: 'Name of the source or application',
+      required: false,
+    }),
+    createdTime: Property.ShortText({
+      displayName: 'Created Time',
+      description: 'Time (including timezone) of the content creation (e.g., Wed, 19 Sep 2023 13:31:00 PDT)',
+      required: false,
+    }),
+    isStack: Property.Checkbox({
+      displayName: 'Add to Memory',
+      description: 'Flag to also add the content to memory',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { url, title, domainName, tags, sourceName, createdTime, isStack } } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/upload-url`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': auth as string,
+      },
+      body: {
+        Url: url,
+        Title: title,
+        ...(domainName && { DomainName: domainName }),
+        ...(tags && { Tags: tags }),
+        ...(sourceName && { SourceName: sourceName }),
+        ...(createdTime && { CreatedTime: createdTime }),
+        ...(isStack !== undefined && { is_stack: isStack }),
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/memory/create-memory.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/memory/create-memory.ts
@@ -1,0 +1,64 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const createMemory = createAction({
+  name: 'create_memory',
+  displayName: 'Create Memory',
+  description: 'Upload memories to your AI assistant stack',
+  category: 'Memory',
+  props: {
+    text: Property.LongText({
+      displayName: 'Memory Text',
+      description: 'Plain text memories to upload to your stack',
+      required: true,
+    }),
+    sourceName: Property.ShortText({
+      displayName: 'Source Name',
+      description: 'The source or application of memory to help you recall where it is from',
+      required: true,
+    }),
+    createdTime: Property.ShortText({
+      displayName: 'Created Time',
+      description: 'Time (including timezone) of the memory (e.g., Wed, 19 Sep 2023 13:31:00 PDT)',
+      required: false,
+    }),
+    rawFeedText: Property.LongText({
+      displayName: 'Raw Feed Text',
+      description: 'The formatted text that can be stored as it is',
+      required: false,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI persona',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma delimited list of tags for the memory',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { text, sourceName, createdTime, rawFeedText, domainName, tags } } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/v1/memory`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': auth as string,
+      },
+      body: {
+        Text: text,
+        SourceName: sourceName,
+        ...(createdTime && { CreatedTime: createdTime }),
+        ...(rawFeedText && { RawFeedText: rawFeedText }),
+        ...(domainName && { DomainName: domainName }),
+        ...(tags && { Tags: tags }),
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/messaging/create-message.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/messaging/create-message.ts
@@ -1,0 +1,78 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const createMessage = createAction({
+  name: 'create_message',
+  displayName: 'Send Message',
+  description: 'Send a message to the AI assistant for a response',
+  category: 'Messaging',
+  props: {
+    text: Property.LongText({
+      displayName: 'Message Text',
+      description: 'Message to send to your AI for a response',
+      required: true,
+    }),
+    context: Property.LongText({
+      displayName: 'Context',
+      description: 'Additional context for the AI response (Similar to Reply function)',
+      required: false,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI profile',
+      required: false,
+    }),
+    userName: Property.ShortText({
+      displayName: 'User Name',
+      description: 'Name of the user sending the request',
+      required: false,
+    }),
+    sessionId: Property.ShortText({
+      displayName: 'Session ID',
+      description: 'Use the same sessionId to continue conversation on that session',
+      required: false,
+    }),
+    sourceName: Property.ShortText({
+      displayName: 'Source Name',
+      description: 'Name of the source app of the inbound message',
+      required: false,
+    }),
+    isStack: Property.Checkbox({
+      displayName: 'Add to Memory',
+      description: 'Flag to also add the user message to memory',
+      required: false,
+      defaultValue: false,
+    }),
+    isDraft: Property.Checkbox({
+      displayName: 'Create Draft',
+      description: 'Flag to create a copilot message for the AI',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { text, context: messageContext, domainName, userName, sessionId, sourceName, isStack, isDraft } } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/v1/message`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': auth as string,
+      },
+      body: {
+        Text: text,
+        ...(messageContext && { Context: messageContext }),
+        ...(domainName && { DomainName: domainName }),
+        ...(userName && { UserName: userName }),
+        ...(sessionId && { SessionId: sessionId }),
+        ...(sourceName && { SourceName: sourceName }),
+        ...(isStack !== undefined && { is_stack: isStack }),
+        ...(isDraft !== undefined && { is_draft: isDraft }),
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/src/lib/actions/messaging/get-conversation.ts
+++ b/packages/pieces/community/personal-ai/src/lib/actions/messaging/get-conversation.ts
@@ -1,0 +1,70 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { BASE_URL } from '../../../index';
+
+export const getConversation = createAction({
+  name: 'get_conversation',
+  displayName: 'Get Conversation History',
+  description: 'Retrieve conversation history from AI assistant',
+  category: 'Messaging',
+  props: {
+    channelId: Property.ShortText({
+      displayName: 'Channel ID',
+      description: 'The unique identifier for the conversation channel',
+      required: true,
+    }),
+    domainName: Property.ShortText({
+      displayName: 'Domain Name',
+      description: 'The domain identifier for the AI profile',
+      required: false,
+    }),
+    userName: Property.ShortText({
+      displayName: 'User Name',
+      description: 'Name of the user requesting the conversation',
+      required: false,
+    }),
+    sessionId: Property.ShortText({
+      displayName: 'Session ID',
+      description: 'Filter conversation by specific session ID',
+      required: false,
+    }),
+    sourceName: Property.ShortText({
+      displayName: 'Source Name',
+      description: 'Filter conversation by source application',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of messages to return',
+      required: false,
+    }),
+    skip: Property.Number({
+      displayName: 'Skip',
+      description: 'Number of messages to skip (for pagination)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue: { channelId, domainName, userName, sessionId, sourceName, limit, skip } } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/v1/conversation`,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': auth as string,
+      },
+      body: {
+        ChannelId: channelId,
+        ...(domainName && { DomainName: domainName }),
+        ...(userName && { UserName: userName }),
+        ...(sessionId && { SessionId: sessionId }),
+        ...(sourceName && { SourceName: sourceName }),
+        ...(limit !== undefined && { Limit: limit }),
+        ...(skip !== undefined && { Skip: skip }),
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/personal-ai/tsconfig.json
+++ b/packages/pieces/community/personal-ai/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/personal-ai/tsconfig.lib.json
+++ b/packages/pieces/community/personal-ai/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -783,6 +783,9 @@
       "activepieces/piece-zuora": [
         "packages/pieces/community/zuora/src/index.ts"
       ],
+      "@activepieces/piece-personal-ai": [
+        "packages/pieces/community/personal-ai/src/index.ts"
+      ],
       "ee-embed-sdk": ["packages/ee/ui/embed-sdk/src/index.ts"],
       "server-worker": ["packages/server/worker/src/index.ts"],
       "ui-feature-forms": ["packages/ui/features-forms/src/index.ts"]


### PR DESCRIPTION
Personal AI offers a piece for creating customized AI personas trained on proprietary data, enhancing team efficiency and collaboration. 

### Actions included:

Ingestion API: Facilitates the import of data from diverse sources to train Personal AI models.

Inference API: Enables interaction with trained AI models by posing questions and receiving responses.

AI-native Messaging API: Allows seamless incorporation of Personal AI into websites or applications for enhanced communication.

AI Message Endpoint: Supports sending messages to AI personas and receiving contextually relevant replies.

Upload URL Endpoint: Permits uploading content from URLs to enrich the AI's memory.

Depends on: https://github.com/activepieces/activepieces/pull/6946 PR