### PR TITLE
feat(slack): add usergroups:read Slack permission

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.7.12"
+  "version": "0.7.13"
 }

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -55,6 +55,7 @@ export const slackAuth = PieceAuth.OAuth2({
     'files:read',
     'users:read.email',
     'reactions:write',
+    'usergroups:read'
   ],
 });
 


### PR DESCRIPTION
## What does this PR do?

Add missing scope to get the members of a Slack user group 
(courtesy of @kylieatalan)