### PR TITLE
feat(pieces): AnyHook Integration for Activepieces (GraphQL & WebSocket)

### DIFF
--- a/packages/pieces/community/anyhook-graphql/.eslintrc.json
+++ b/packages/pieces/community/anyhook-graphql/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/anyhook-graphql/README.md
+++ b/packages/pieces/community/anyhook-graphql/README.md
@@ -1,0 +1,7 @@
+# pieces-anyhook-graphql
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-anyhook-graphql` to build the library.

--- a/packages/pieces/community/anyhook-graphql/package.json
+++ b/packages/pieces/community/anyhook-graphql/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-anyhook-graphql",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/anyhook-graphql/project.json
+++ b/packages/pieces/community/anyhook-graphql/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-anyhook-graphql",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/anyhook-graphql/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/anyhook-graphql",
+        "tsConfig": "packages/pieces/community/anyhook-graphql/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/anyhook-graphql/package.json",
+        "main": "packages/pieces/community/anyhook-graphql/src/index.ts",
+        "assets": [
+          "packages/pieces/community/anyhook-graphql/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/anyhook-graphql/src/index.ts
+++ b/packages/pieces/community/anyhook-graphql/src/index.ts
@@ -1,0 +1,18 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { graphqlCommon } from './lib/common/common';
+import { graphqlSubscriptionTrigger } from './lib/triggers/graphql-subscription-trigger';
+
+export const anyHookGraphql = createPiece({
+  displayName: 'AnyHook GraphQL',
+  description:
+    'AnyHook GraphQL enables real-time communication through AnyHook proxy server by allowing you to subscribe and listen to GraphQL subscription events',
+  auth: graphqlCommon.auth,
+  minimumSupportedRelease: '0.20.0',
+  logoUrl:
+    'https://imagedelivery.net/bHREz764QO9n_1kIQUR2sw/dcf09712-b3bf-46b2-88b2-afa00d42b600/public',
+  authors: ['Swanblocks/Ahmad Shawar'],
+  actions: [],
+  triggers: [
+    graphqlSubscriptionTrigger,
+  ],
+});

--- a/packages/pieces/community/anyhook-graphql/src/lib/common/common.ts
+++ b/packages/pieces/community/anyhook-graphql/src/lib/common/common.ts
@@ -1,0 +1,30 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+
+export const graphqlCommon = {
+  connectionType: "graphql",
+  auth: PieceAuth.CustomAuth({
+    required: true,
+    props: {
+      proxyBaseUrl: Property.ShortText({
+        displayName: 'AnyHook Server URL',
+        description: 'The URL of your AnyHook server',
+        required: true,
+        defaultValue: 'http://10.0.0.101:3001'
+      }),
+    },
+  }),
+  apiCall: async function (
+    url: string,
+    method: string,
+    data: object | undefined = undefined
+  ) {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+    return response.json();
+  },
+};

--- a/packages/pieces/community/anyhook-graphql/src/lib/triggers/graphql-subscription-trigger.ts
+++ b/packages/pieces/community/anyhook-graphql/src/lib/triggers/graphql-subscription-trigger.ts
@@ -1,0 +1,61 @@
+import { TriggerStrategy, createTrigger, PieceAuth, Property } from '@activepieces/pieces-framework';
+import { createGraphQLSubscription, deleteGraphQLSubscription } from './helpers';
+import { graphqlCommon } from '../common/common';
+
+export const graphqlSubscriptionTrigger = createTrigger({
+  auth: graphqlCommon.auth,
+  name: 'graphql_subscription_trigger',
+  displayName: 'New GraphQL Subscription Event',
+  description: 'Triggers on a new GraphQL subscription event',
+  type: TriggerStrategy.WEBHOOK,
+  props: {
+    websocketUrl: Property.ShortText({
+      displayName: 'Endpoint URL',
+      description: 'The GraphQL websocket to connect to.',
+      required: true,
+      defaultValue: 'wss://streaming.bitquery.io/graphql?token=xxxx',
+    }),
+    headers: Property.Object({
+      displayName: 'Headers',
+      description: 'Custom headers for the GraphQL connection, such as authentication tokens.',
+      required: false,
+    }),
+    query: Property.LongText({
+      displayName: 'GraphQL Query',
+      description: 'GraphQL subscription query to listen to events',
+      required: true,
+      defaultValue: 'subscription { EVM(network: eth, trigger_on: head) { Blocks { Block { BaseFee BaseFeeInUSD Bloom Coinbase } } } }',
+    }),
+  },
+  async onEnable(context) {
+    const subscriptionInfo = await createGraphQLSubscription(
+      context.propsValue.websocketUrl,
+      context.propsValue.headers,
+      context.propsValue.query,
+      context.webhookUrl,
+      context.auth.proxyBaseUrl
+    );
+
+    // Store subscription info
+    await context.store.put('graphql_subscription_trigger', subscriptionInfo.subscriptionId);
+  },
+  async onDisable(context) {
+    const subscriptionId: string = (await context.store.get('graphql_subscription_trigger')) as string;
+    if (subscriptionId) {
+      await deleteGraphQLSubscription(subscriptionId, context.auth.proxyBaseUrl);
+      await context.store.delete('graphql_subscription_trigger');
+    }
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+  async test(context) {
+    return [
+      {
+        event: 'GraphQL event data',
+        details: 'Details of the event',
+      },
+    ];
+  },
+  sampleData: {},
+});

--- a/packages/pieces/community/anyhook-graphql/src/lib/triggers/helpers.ts
+++ b/packages/pieces/community/anyhook-graphql/src/lib/triggers/helpers.ts
@@ -1,0 +1,32 @@
+import { PiecePropValueSchema } from '@activepieces/pieces-framework';
+import { graphqlCommon } from '../common/common';
+
+export async function createGraphQLSubscription(
+  websocketUrl: string,
+  headers: Record<string, unknown> | undefined,
+  query: string,
+  webhookUrl: string,
+  proxyBaseUrl: string
+) {
+  const subscriptionApiUrl = `${proxyBaseUrl}/subscribe`;
+  const data = {
+    connection_type: graphqlCommon.connectionType,
+    webhook_url: webhookUrl,
+    args: {
+      endpoint_url: websocketUrl,
+      headers: headers ? JSON.stringify(headers) : undefined,
+      query,
+    },
+  };
+  const response = await graphqlCommon.apiCall(subscriptionApiUrl, 'POST', data);
+  return response;
+}
+
+export async function deleteGraphQLSubscription(subscriptionId: string, proxyBaseUrl: string) {
+  const deleteApiUrl = `${proxyBaseUrl}/unsubscribe`;
+  const data = {
+    subscription_id: subscriptionId,
+  };
+  const response = await graphqlCommon.apiCall(deleteApiUrl, 'POST', data);
+  return response;
+}

--- a/packages/pieces/community/anyhook-graphql/tsconfig.json
+++ b/packages/pieces/community/anyhook-graphql/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/anyhook-graphql/tsconfig.lib.json
+++ b/packages/pieces/community/anyhook-graphql/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/anyhook-websocket/.eslintrc.json
+++ b/packages/pieces/community/anyhook-websocket/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/anyhook-websocket/README.md
+++ b/packages/pieces/community/anyhook-websocket/README.md
@@ -1,0 +1,7 @@
+# pieces-anyhook-websocket
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-anyhook-websocket` to build the library.

--- a/packages/pieces/community/anyhook-websocket/package.json
+++ b/packages/pieces/community/anyhook-websocket/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-anyhook-websocket",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/anyhook-websocket/project.json
+++ b/packages/pieces/community/anyhook-websocket/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-anyhook-websocket",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/anyhook-websocket/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/anyhook-websocket",
+        "tsConfig": "packages/pieces/community/anyhook-websocket/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/anyhook-websocket/package.json",
+        "main": "packages/pieces/community/anyhook-websocket/src/index.ts",
+        "assets": [
+          "packages/pieces/community/anyhook-websocket/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/anyhook-websocket/src/index.ts
+++ b/packages/pieces/community/anyhook-websocket/src/index.ts
@@ -1,0 +1,18 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { websocketCommon } from './lib/common/common';
+import { websocketSubscriptionTrigger } from './lib/triggers/websocket-subscription-trigger';
+
+export const anyHookWebsocket = createPiece({
+  displayName: 'AnyHook Websocket',
+  description:
+    'AnyHook Websocket enables real-time communication through AnyHook proxy server by allowing you to subscribe and listen to websocket events',
+  auth: websocketCommon.auth,
+  minimumSupportedRelease: '0.20.0',
+  logoUrl:
+    'https://imagedelivery.net/bHREz764QO9n_1kIQUR2sw/c49d06c2-2602-43d5-3dff-de83b0c31300/public',
+  authors: ['Swanblocks/Ahmad Shawar'],
+  actions: [],
+  triggers: [
+    websocketSubscriptionTrigger,
+  ],
+});

--- a/packages/pieces/community/anyhook-websocket/src/lib/common/common.ts
+++ b/packages/pieces/community/anyhook-websocket/src/lib/common/common.ts
@@ -1,0 +1,30 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+
+export const websocketCommon = {
+  connectionType: "websocket",
+  auth: PieceAuth.CustomAuth({
+    required: true,
+    props: {
+      proxyBaseUrl: Property.ShortText({
+        displayName: 'AnyHook Server URL',
+        description: 'The URL of your AnyHook server',
+        required: true,
+        defaultValue: 'http://10.0.0.101:3001'
+      }),
+    },
+  }),
+  apiCall: async function (
+    url: string,
+    method: string,
+    data: object | undefined = undefined
+  ) {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+    return response.json();
+  },
+};

--- a/packages/pieces/community/anyhook-websocket/src/lib/triggers/helpers.ts
+++ b/packages/pieces/community/anyhook-websocket/src/lib/triggers/helpers.ts
@@ -1,0 +1,31 @@
+import { websocketCommon } from '../common/common';
+
+export async function createWebsocketSubscription(
+  websocketUrl: string,
+  headers: Record<string, unknown> | undefined,
+  message: Record<string, unknown>,
+  webhookUrl: string,
+  proxyBaseUrl: string
+) {
+  const subscriptionApiUrl = `${proxyBaseUrl}/subscribe`;
+  const data = {
+    connection_type: websocketCommon.connectionType,
+    webhook_url: webhookUrl,
+    args: {
+      endpoint_url: websocketUrl,
+      headers: headers ? JSON.stringify(headers) : undefined,
+      message,
+    },
+  };
+  const response = await websocketCommon.apiCall(subscriptionApiUrl, 'POST', data);
+  return response;
+}
+
+export async function deleteWebsocketSubscription(subscriptionId: string, proxyBaseUrl: string) {
+  const deleteApiUrl = `${proxyBaseUrl}/unsubscribe`;
+  const data = {
+    subscription_id: subscriptionId,
+  };
+  const response = await websocketCommon.apiCall(deleteApiUrl, 'POST', data);
+  return response;
+}

--- a/packages/pieces/community/anyhook-websocket/src/lib/triggers/websocket-subscription-trigger.ts
+++ b/packages/pieces/community/anyhook-websocket/src/lib/triggers/websocket-subscription-trigger.ts
@@ -1,0 +1,66 @@
+import { TriggerStrategy, createTrigger, PieceAuth, Property } from '@activepieces/pieces-framework';
+import { createWebsocketSubscription, deleteWebsocketSubscription } from './helpers';
+import { websocketCommon } from '../common/common';
+
+export const websocketSubscriptionTrigger = createTrigger({
+  auth: websocketCommon.auth,
+  name: 'websocket_subscription_trigger',
+  displayName: 'New Websocket Subscription Event',
+  description: 'Triggers on a new Websocket subscription event',
+  type: TriggerStrategy.WEBHOOK,
+  props: {
+    websocketUrl: Property.ShortText({
+      displayName: 'Endpoint URL',
+      description: 'Websocket endpoint URL to connect to.',
+      required: true,
+      defaultValue: 'wss://testnets-stream.openseabeta.com/socket/websocket?token=xxxx',
+    }),
+    headers: Property.Object({
+      displayName: 'Headers',
+      description: 'Custom headers for the Websocket connection, such as authentication tokens.',
+      required: false
+    }),
+    message: Property.Json({
+      displayName: 'Subscription Message',
+      description: 'The message to send to the Websocket server to subscribe to events.',
+      required: true,
+      defaultValue: {
+        "topic": "collection:boredapeyachtclub",
+        "event": "phx_join",
+        "payload": {},
+        "ref": 0
+      }
+    }),
+  },
+  async onEnable(context) {
+    const subscriptionInfo = await createWebsocketSubscription(
+      context.propsValue.websocketUrl,
+      context.propsValue.headers,
+      context.propsValue.message,
+      context.webhookUrl,
+      context.auth.proxyBaseUrl
+    );
+
+    // Store subscription info
+    await context.store.put('websocket_subscription_trigger', subscriptionInfo.subscriptionId);
+  },
+  async onDisable(context) {
+    const subscriptionId: string = (await context.store.get('websocket_subscription_trigger')) as string;
+    if (subscriptionId) {
+      await deleteWebsocketSubscription(subscriptionId, context.auth.proxyBaseUrl);
+      await context.store.delete('websocket_subscription_trigger');
+    }
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+  async test(context) {
+    return [
+      {
+        event: 'Websocket event data',
+        details: 'Details of the event',
+      },
+    ];
+  },
+  sampleData: {},
+});

--- a/packages/pieces/community/anyhook-websocket/tsconfig.json
+++ b/packages/pieces/community/anyhook-websocket/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/anyhook-websocket/tsconfig.lib.json
+++ b/packages/pieces/community/anyhook-websocket/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -54,6 +54,12 @@
       "@activepieces/piece-aminos": [
         "packages/pieces/community/aminos/src/index.ts"
       ],
+      "@activepieces/piece-anyhook-graphql": [
+        "packages/pieces/community/anyhook-graphql/src/index.ts"
+      ],
+      "@activepieces/piece-anyhook-websocket": [
+        "packages/pieces/community/anyhook-websocket/src/index.ts"
+      ],
       "@activepieces/piece-apify": [
         "packages/pieces/community/apify/src/index.ts"
       ],
@@ -215,11 +221,11 @@
       "@activepieces/piece-figma": [
         "packages/pieces/community/figma/src/index.ts"
       ],
-      "@activepieces/piece-firecrawl":[
-        "packages/pieces/community/firecrawl/src/index.ts"
-      ],
       "@activepieces/piece-file-helper": [
         "packages/pieces/community/file-helper/src/index.ts"
+      ],
+      "@activepieces/piece-firecrawl": [
+        "packages/pieces/community/firecrawl/src/index.ts"
       ],
       "@activepieces/piece-fliqr-ai": [
         "packages/pieces/community/fliqr-ai/src/index.ts"


### PR DESCRIPTION
This PR introduces two new integrations for AnyHook, an open-source real-time proxy server that connects data sources like GraphQL and WebSocket to webhook endpoints.

## Features

- **Categories**: Developer Tools, Real-Time Data, Integration Platforms
- **Pieces**:
  - **AnyHook GraphQL**: Subscribe to GraphQL subscription events
  - **AnyHook WebSocket**: Subscribe to WebSocket events

## Integration Capabilities

These integrations allow Activepieces users to:
- Connect to real-time data sources through the AnyHook proxy server
- Trigger workflows based on GraphQL subscription events
- Trigger workflows based on WebSocket messages
- Simplify real-time data integration into automation workflows

## Pre-requisites

These integrations require a running instance of the [AnyHook proxy server](https://github.com/SwanBlocks-inc/anyhook) which needs to be self-hosted. The server acts as the intermediary between data sources and Activepieces, handling:
- Connection management
- Automatic reconnection
- Subscription tracking
- Reliable data delivery

## Example Use Cases
- Real-time cryptocurrency price monitoring
- Live chat application integrations
- IoT device status updates
- Stock market data analysis
- Gaming platform event tracking
- Real-time notification systems
- Live sports or financial data processing

## Additional Notes
The AnyHook proxy server needs to be configured and running before these integrations can be used. Users will need to:
1. Set up the AnyHook server (via Docker or manual installation)
2. Configure the server URL in the piece configuration
3. Create subscriptions through the pieces to start receiving real-time data

These integrations bring advanced real-time capabilities to Activepieces by leveraging the robust AnyHook server for maintaining persistent connections and handling delivery reliability.
