### PR TITLE
fix: stop throwing errors when (fetching dropdown data or saving step testing result) if sample data file is not found.

### DIFF
--- a/packages/server/api/src/app/file/file.service.ts
+++ b/packages/server/api/src/app/file/file.service.ts
@@ -60,17 +60,21 @@ export const fileService = (log: FastifyBaseLogger) => ({
             }
         }
     },
-    async getFileOrThrow({ projectId, fileId, type }: GetOneParams): Promise<File> {
+    async getFile({ projectId, fileId, type }: GetOneParams): Promise<File | null> {
         const file = await fileRepo().findOneBy({
             projectId,
             id: fileId,
             type,
         })
+        return file
+    },
+    async getFileOrThrow(params: GetOneParams): Promise<File> {
+        const file = await this.getFile(params)
         if (isNil(file)) {
             throw new ActivepiecesError({
                 code: ErrorCode.FILE_NOT_FOUND,
                 params: {
-                    id: fileId,
+                    id: params.fileId,
                 },
             })
         }

--- a/packages/server/api/src/app/file/file.service.ts
+++ b/packages/server/api/src/app/file/file.service.ts
@@ -76,6 +76,18 @@ export const fileService = (log: FastifyBaseLogger) => ({
         }
         return file
     },
+    async getData({ projectId, fileId, type }: GetOneParams): Promise<GetDataResponse | undefined> {
+        try {
+            return await this.getDataOrThrow({ projectId, fileId, type })
+        }
+        catch (error) {
+            log.error({
+                error,
+            }, '[FileService#getData] error')
+            return undefined
+        }
+
+    },
     async getDataOrThrow({ projectId, fileId, type }: GetOneParams): Promise<GetDataResponse> {
         const file = await fileRepo().findOneBy({
             projectId,

--- a/packages/server/api/src/app/file/file.service.ts
+++ b/packages/server/api/src/app/file/file.service.ts
@@ -80,7 +80,7 @@ export const fileService = (log: FastifyBaseLogger) => ({
         }
         return file
     },
-    async getData({ projectId, fileId, type }: GetOneParams): Promise<GetDataResponse | undefined> {
+    async getDataOrUndefined({ projectId, fileId, type }: GetOneParams): Promise<GetDataResponse | undefined> {
         try {
             return await this.getDataOrThrow({ projectId, fileId, type })
         }

--- a/packages/server/api/src/app/flows/step-run/sample-data.service.ts
+++ b/packages/server/api/src/app/flows/step-run/sample-data.service.ts
@@ -80,7 +80,7 @@ export const sampleDataService = (log: FastifyBaseLogger) => ({
             return {}
         }
         if (!isNil(fileId)) {
-            const response = await fileService(log).getData({
+            const response = await fileService(log).getDataOrUndefined({
                 projectId: params.projectId,
                 fileId,
                 type: fileType,

--- a/packages/server/api/src/app/flows/step-run/sample-data.service.ts
+++ b/packages/server/api/src/app/flows/step-run/sample-data.service.ts
@@ -80,12 +80,15 @@ export const sampleDataService = (log: FastifyBaseLogger) => ({
             return {}
         }
         if (!isNil(fileId)) {
-            const { data } = await fileService(log).getDataOrThrow({
+            const response = await fileService(log).getData({
                 projectId: params.projectId,
                 fileId,
                 type: fileType,
             })
-            return JSON.parse(data.toString('utf-8'))
+            if (isNil(response)) {
+                return undefined
+            }
+            return JSON.parse(response.data.toString('utf-8'))
         }
         if (fileType === FileType.SAMPLE_DATA_INPUT) {
             return undefined

--- a/packages/server/api/src/app/flows/step-run/sample-data.service.ts
+++ b/packages/server/api/src/app/flows/step-run/sample-data.service.ts
@@ -130,13 +130,13 @@ async function useExistingOrCreateNewSampleId(projectId: ProjectId, flowVersion:
     if (isNil(sampleDataId)) {
         return apId()
     }
-    const file = await fileService(log).getFileOrThrow({
+    const file = await fileService(log).getFile({
         projectId,
         fileId: sampleDataId,
         type: fileType,
     })
-    const isNewVersion = file.metadata?.flowVersionId !== flowVersion.id
-    if (isNewVersion) {
+    const isNewVersion = file?.metadata?.flowVersionId !== flowVersion.id
+    if (isNewVersion || isNil(file)) {
         return apId()
     }
     return file.id


### PR DESCRIPTION
fixes #6870 