### PR TITLE
feat(linear): set team_id optional on linear issue update trigger

### DIFF
--- a/packages/pieces/community/linear/package.json
+++ b/packages/pieces/community/linear/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-linear",
-  "version": "0.1.6"
+  "version": "0.1.7"
 }


### PR DESCRIPTION
## What does this PR do?

Make the `team_id` optional for the trigger Linear Issue update to listen to any team for a given automation.

### Test

The issue update is triggered with no team selected

<img width="1512" alt="Screenshot 2025-02-28 at 23 14 50" src="https://github.com/user-attachments/assets/3b71886d-c07a-4ad7-898c-0fcdc6962a91" />
