### PR TITLE
fix: missing encoding in Content-Disposition header when downloading step files

### DIFF
--- a/packages/server/api/src/app/file/step-file/step-file.controller.ts
+++ b/packages/server/api/src/app/file/step-file/step-file.controller.ts
@@ -40,7 +40,7 @@ export const stepFileController: FastifyPluginAsyncTypebox = async (app) => {
         return reply
             .header(
                 'Content-Disposition',
-                `attachment; filename="${file.fileName}"`,
+                `attachment; filename="${encodeURI(file.fileName ?? '')}"`,
             )
             .type('application/octet-stream')
             .status(StatusCodes.OK)


### PR DESCRIPTION
See https://fastify.dev/docs/latest/Reference/Reply/#headerkey-value

The error in our logs:
```json
{
	"level": 40,
	"time": 1741003493410,
	"pid": 10,
	"hostname": "secret",
	"reqId": "secret",
	"req": {
		"method": "GET",
		"url": "/v1/step-files/signed?token=verysecret",
		"hostname": "flowbuilder.secret",
		"remoteAddress": "127.0.0.1",
		"remotePort": 44938
	},
	"res": {
		"statusCode": 500
	},
	"err": {
		"type": "TypeError",
		"message": "Invalid character in header content [\"content-disposition\"]",
		"stack": "TypeError [ERR_INVALID_CHAR]: Invalid character in header content [\"content-disposition\"]\n    at __node_internal_captureLargerStackTrace (node:internal/errors:496:5)\n    at new NodeError (node:internal/errors:405:5)\n    at __node_internal_ (node:_http_outgoing:635:11)\n    at storeHeader (node:_http_outgoing:583:5)\n    at processHeader (node:_http_outgoing:578:3)\n    at ServerResponse._storeHeader (node:_http_outgoing:452:11)\n    at ServerResponse.writeHead (node:_http_server:420:8)\n    at /usr/src/app/dist/packages/server/api/node_modules/fastify/lib/error-handler.js:37:19\n    at fallbackErrorHandler (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/error-handler.js:140:3)\n    at handleError (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/error-handler.js:35:5)\n    at onErrorHook (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/reply.js:845:5)\n    at Reply.send (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/reply.js:157:5)\n    at handleError (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/error-handler.js:78:11)\n    at onErrorHook (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/reply.js:845:5)\n    at Reply.send (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/reply.js:157:5)\n    at <anonymous> (webpack:///src/app/helper/error-handler.ts:61:14)\n    at Generator.next (<anonymous>)\n    at /usr/src/app/dist/packages/server/api/node_modules/tslib/tslib.js:169:75\n    at new Promise (<anonymous>)\n    at Object.__awaiter (/usr/src/app/dist/packages/server/api/node_modules/tslib/tslib.js:165:16)\n    at Object.t.errorHandler (webpack:///src/app/helper/error-handler.ts:11:20)\n    at handleError (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/error-handler.js:69:20)\n    at onErrorHook (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/reply.js:845:5)\n    at Reply.send (/usr/src/app/dist/packages/server/api/node_modules/fastify/lib/reply.js:157:5)\n    at /usr/src/app/dist/packages/server/api/node_modules/fastify/lib/wrapThenable.js:41:13\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
		"code": "ERR_INVALID_CHAR"
	},
	"msg": "Invalid character in header content [\"content-disposition\"]"
}
```

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes downloading files with weird characters in the filename.

