### PR TITLE
fix: saving SSO providers + show trial license key expiration date

### DIFF
--- a/packages/react-ui/src/app/builder/piece-properties/array-property.tsx
+++ b/packages/react-ui/src/app/builder/piece-properties/array-property.tsx
@@ -41,6 +41,7 @@ const getDefaultValuesForInputs = (arrayProperties: ArraySubProps<boolean>) => {
       case PropertyType.LONG_TEXT:
       case PropertyType.SHORT_TEXT:
       case PropertyType.NUMBER:
+      case PropertyType.JSON:
         return {
           ...acc,
           [key]: '',

--- a/packages/react-ui/src/app/builder/step-settings/branch-settings/branch-single-condition.tsx
+++ b/packages/react-ui/src/app/builder/step-settings/branch-settings/branch-single-condition.tsx
@@ -143,9 +143,11 @@ const BranchSingleCondition = ({
                       e !== null &&
                       !singleValueConditions.includes(e as BranchOperator)
                     ) {
+                      //TODO: fix this
+                      //@ts-expect-ignore
                       form.setValue(
                         `settings.branches.${branchIndex}.conditions.${groupIndex}.${conditionIndex}.secondValue`,
-                        '',
+                        '' as any,
                       );
                     }
                     field.onChange(e);

--- a/packages/react-ui/src/app/routes/platform/security/sso/allowed-domain.tsx
+++ b/packages/react-ui/src/app/routes/platform/security/sso/allowed-domain.tsx
@@ -19,10 +19,13 @@ import { Form, FormField, FormItem, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
 import { platformApi } from '@/lib/platforms-api';
-import { Platform, UpdatePlatformRequestBody } from '@activepieces/shared';
+import {
+  PlatformWithoutSensitiveData,
+  UpdatePlatformRequestBody,
+} from '@activepieces/shared';
 
 type AllowedDomainDialogProps = {
-  platform: Platform;
+  platform: PlatformWithoutSensitiveData;
   refetch: () => Promise<void>;
 };
 

--- a/packages/react-ui/src/app/routes/platform/security/sso/oauth2-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/security/sso/oauth2-dialog.tsx
@@ -94,7 +94,7 @@ export const NewOAuth2Dialog = ({
             onClick={(e) => {
               mutate({
                 federatedAuthProviders: {
-                  [providerName]: undefined,
+                  [providerName]: null,
                 },
               });
               e.preventDefault();

--- a/packages/react-ui/src/app/routes/platform/security/sso/oauth2-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/security/sso/oauth2-dialog.tsx
@@ -20,12 +20,15 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
 import { platformApi } from '@/lib/platforms-api';
-import { Platform, UpdatePlatformRequestBody } from '@activepieces/shared';
+import {
+  PlatformWithoutSensitiveData,
+  UpdatePlatformRequestBody,
+} from '@activepieces/shared';
 
 type NewOAuth2DialogProps = {
   providerName: 'google' | 'github';
   providerDisplayName: string;
-  platform: Platform;
+  platform: PlatformWithoutSensitiveData;
   connected: boolean;
   refetch: () => Promise<void>;
 };
@@ -91,7 +94,6 @@ export const NewOAuth2Dialog = ({
             onClick={(e) => {
               mutate({
                 federatedAuthProviders: {
-                  ...platform.federatedAuthProviders,
                   [providerName]: undefined,
                 },
               });
@@ -132,7 +134,6 @@ export const NewOAuth2Dialog = ({
             onSubmit={form.handleSubmit((data) => {
               mutate({
                 federatedAuthProviders: {
-                  ...platform.federatedAuthProviders,
                   [providerName]: data,
                 },
               });

--- a/packages/react-ui/src/app/routes/platform/security/sso/saml-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/security/sso/saml-dialog.tsx
@@ -96,7 +96,7 @@ export const ConfigureSamlDialog = ({
             onClick={(e) => {
               mutate({
                 federatedAuthProviders: {
-                  saml: undefined,
+                  saml: null,
                 },
               });
               e.preventDefault();

--- a/packages/react-ui/src/app/routes/platform/security/sso/saml-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/security/sso/saml-dialog.tsx
@@ -24,12 +24,12 @@ import { flagsHooks } from '@/hooks/flags-hooks';
 import { platformApi } from '@/lib/platforms-api';
 import {
   ApFlagId,
-  Platform,
+  PlatformWithoutSensitiveData,
   UpdatePlatformRequestBody,
 } from '@activepieces/shared';
 
 type ConfigureSamlDialogProps = {
-  platform: Platform;
+  platform: PlatformWithoutSensitiveData;
   connected: boolean;
   refetch: () => Promise<void>;
 };
@@ -96,7 +96,6 @@ export const ConfigureSamlDialog = ({
             onClick={(e) => {
               mutate({
                 federatedAuthProviders: {
-                  ...platform.federatedAuthProviders,
                   saml: undefined,
                 },
               });
@@ -149,7 +148,6 @@ Activepieces
             onSubmit={form.handleSubmit((data) => {
               mutate({
                 federatedAuthProviders: {
-                  ...platform.federatedAuthProviders,
                   saml: data,
                 },
               });

--- a/packages/react-ui/src/app/routes/platform/setup/ai/copilot/configure-provider-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/ai/copilot/configure-provider-dialog.tsx
@@ -79,10 +79,8 @@ export const ConfigureProviderDialog = ({
       const platformId = authenticationSession.getPlatformId();
       if (!platformId) return;
 
-      const currentSettings = platform?.copilotSettings || { providers: {} };
       const newSettings: CopilotSettings = {
         providers: {
-          ...currentSettings.providers,
           [selectedProvider]:
             selectedProvider === CopilotProviderType.OPENAI
               ? {

--- a/packages/react-ui/src/app/routes/platform/setup/ai/copilot/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/ai/copilot/index.tsx
@@ -37,7 +37,6 @@ const CopilotSetup = () => {
   const getConfiguredProvider = () => {
     if (!platform?.copilotSettings?.providers) return null;
     const { providers } = platform.copilotSettings;
-
     if (!isNil(providers[CopilotProviderType.OPENAI])) {
       return {
         type: CopilotProviderType.OPENAI,

--- a/packages/react-ui/src/app/routes/platform/setup/ai/copilot/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/ai/copilot/index.tsx
@@ -20,14 +20,14 @@ const CopilotSetup = () => {
     mutationFn: async () => {
       const platformId = authenticationSession.getPlatformId();
       if (!platformId) return null;
-      return( await platformApi.update(
+      return await platformApi.update(
         {
           copilotSettings: {
             providers: {},
           },
         },
         platformId,
-      ));
+      );
     },
     onSuccess: (response) => {
       if (response) {

--- a/packages/react-ui/src/app/routes/platform/setup/ai/copilot/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/ai/copilot/index.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { Bot, Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
@@ -14,23 +14,25 @@ import { ConfigureProviderDialog } from './configure-provider-dialog';
 
 const CopilotSetup = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const { platform, refetch } = platformHooks.useCurrentPlatform();
-
-  const deleteMutation = useMutation({
+  const { platform, setCurrentPlatform } = platformHooks.useCurrentPlatform();
+  const queryClient = useQueryClient();
+  const { mutate: deleteMutation, isPending: isDeleting } = useMutation({
     mutationFn: async () => {
       const platformId = authenticationSession.getPlatformId();
-      if (!platformId) return;
-      await platformApi.update(
+      if (!platformId) return null;
+      return( await platformApi.update(
         {
           copilotSettings: {
             providers: {},
           },
         },
         platformId,
-      );
+      ));
     },
-    onSuccess: () => {
-      refetch();
+    onSuccess: (response) => {
+      if (response) {
+        setCurrentPlatform(queryClient, response);
+      }
     },
   });
 
@@ -85,6 +87,7 @@ const CopilotSetup = () => {
             <Button
               variant={configuredProvider ? 'ghost' : 'basic'}
               size={'sm'}
+              disabled={isDeleting}
               onClick={handleConfigure}
             >
               {configuredProvider ? <Pencil className="size-4" /> : t('Enable')}
@@ -93,7 +96,10 @@ const CopilotSetup = () => {
               <Button
                 variant="ghost"
                 size={'sm'}
-                onClick={() => deleteMutation.mutate()}
+                onClick={() => {
+                  deleteMutation();
+                }}
+                loading={isDeleting}
                 className="text-destructive hover:text-destructive/90 hover:bg-destructive/10 flex items-center gap-2"
               >
                 <Trash2 className="size-4" />

--- a/packages/react-ui/src/app/routes/platform/setup/ai/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/ai/index.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
-
 import { Skeleton } from '@/components/ui/skeleton';
 import { TableTitle } from '@/components/ui/table-title';
 import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';

--- a/packages/react-ui/src/app/routes/platform/setup/ai/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/ai/index.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
+
 import { Skeleton } from '@/components/ui/skeleton';
 import { TableTitle } from '@/components/ui/table-title';
 import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';

--- a/packages/react-ui/src/app/routes/platform/setup/license-key/activate-license-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/license-key/activate-license-dialog.tsx
@@ -95,7 +95,7 @@ export const ActivateLicenseDialog = ({
         <DialogHeader>
           <DialogTitle className="text-center">
             {showCelebration
-              ? t('Woohoo! It worked')
+              ? t('License activated! Let the magic begin!')
               : t('Activate License Key')}
           </DialogTitle>
         </DialogHeader>

--- a/packages/react-ui/src/app/routes/platform/setup/license-key/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/license-key/index.tsx
@@ -1,17 +1,8 @@
 import { typeboxResolver } from '@hookform/resolvers/typebox';
 import { Static, Type } from '@sinclair/typebox';
-import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { t } from 'i18next';
-import {
-  CircleCheckBig,
-  Eye,
-  EyeOff,
-  CalendarDays,
-  Zap,
-  AlertTriangle,
-  Loader2,
-} from 'lucide-react';
+import { CircleCheckBig, CalendarDays, Zap, AlertTriangle } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
@@ -19,17 +10,10 @@ import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
 import { flagsHooks } from '@/hooks/flags-hooks';
 import { platformHooks } from '@/hooks/platform-hooks';
-import { platformApi } from '@/lib/platforms-api';
 import { formatUtils } from '@/lib/utils';
-import { ApEdition, ApFlagId, isNil } from '@activepieces/shared';
+import { ApEdition, ApFlagId } from '@activepieces/shared';
 
 import { ActivateLicenseDialog } from './activate-license-dialog';
 
@@ -67,26 +51,7 @@ const LicenseKeyPage = () => {
     mode: 'onChange',
   });
   const { platform, refetch } = platformHooks.useCurrentPlatform();
-  const [licenseKey, setLicenseKey] = useState(platform.licenseKey || '');
   const [isOpenDialog, setIsOpenDialog] = useState(false);
-  const [showLicenseKey, setShowLicenseKey] = useState(false);
-
-  const {
-    data: keyData,
-    isLoading,
-    refetch: refetchKeyData,
-  } = useQuery({
-    queryKey: ['license-key'],
-    queryFn: async () => {
-      if (isNil(platform.licenseKey) || platform.licenseKey === '') {
-        return null;
-      }
-      const response = await platformApi.getLicenseKey(platform.licenseKey);
-      return response;
-    },
-    enabled: !isNil(platform.licenseKey),
-    refetchOnWindowFocus: false,
-  });
   const { data: edition } = flagsHooks.useFlag<ApEdition>(ApFlagId.EDITION);
   const { data: showPlatformDemo } = flagsHooks.useFlag<boolean>(
     ApFlagId.SHOW_PLATFORM_DEMO,
@@ -128,15 +93,15 @@ const LicenseKeyPage = () => {
 
   const handleActivateLicenseKey = () => {
     refetch();
-    refetchKeyData();
   };
 
   const expired =
-    keyData?.expiresAt && dayjs(keyData.expiresAt).isBefore(dayjs());
+    platform?.licenseExpiresAt &&
+    dayjs(platform.licenseExpiresAt).isBefore(dayjs());
   const expiresSoon =
     !expired &&
-    keyData?.expiresAt &&
-    dayjs(keyData.expiresAt).isBefore(dayjs().add(7, 'day'));
+    platform?.licenseExpiresAt &&
+    dayjs(platform.licenseExpiresAt).isBefore(dayjs().add(7, 'day'));
 
   return (
     <div className="flex-col w-full max-w-2xl">
@@ -149,101 +114,70 @@ const LicenseKeyPage = () => {
         </div>
       </div>
 
-      {isLoading ? (
-        <div className="flex justify-center items-center h-64">
-          <Loader2 className="w-8 h-8 animate-spin" />
-        </div>
-      ) : (
-        <>
-          <div className="flex flex-col gap-3">
-            {licenseKey && (
-              <div className="relative">
-                <Input
-                  value={licenseKey}
-                  readOnly
-                  disabled={true}
-                  type={showLicenseKey ? 'text' : 'password'}
-                  onChange={(e) => setLicenseKey(e.target.value)}
-                  placeholder={t('License Key')}
-                  className="pr-20 text-base"
-                />
-                <div className="absolute inset-y-0 right-0 flex items-center">
-                  <TooltipProvider delayDuration={300}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setShowLicenseKey(!showLicenseKey)}
-                          className="mr-1"
-                        >
-                          {showLicenseKey ? (
-                            <EyeOff className="h-4 w-4" />
-                          ) : (
-                            <Eye className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="text-xs">
-                        {showLicenseKey ? t('Hide') : t('Show')}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </div>
-            )}
-            <Button size="sm" className="w-full" onClick={handleOpenDialog}>
-              <Zap className="w-4 h-4 mr-2" />
-              {t('Activate License')}
-            </Button>
-            <ActivateLicenseDialog
-              isOpen={isOpenDialog}
-              onOpenChange={setIsOpenDialog}
-              onActivate={handleActivateLicenseKey}
+      <div className="flex flex-col gap-3">
+        {platform.hasLicenseKey && (
+          <div className="relative">
+            <Input
+              value={'....................'}
+              readOnly
+              disabled={true}
+              type={'password'}
+              onChange={(e) => {}}
+              placeholder={t('License Key')}
+              className="pr-20 text-base"
             />
           </div>
+        )}
+        <Button size="sm" className="w-full" onClick={handleOpenDialog}>
+          <Zap className="w-4 h-4 mr-2" />
+          {t('Activate License')}
+        </Button>
+        <ActivateLicenseDialog
+          isOpen={isOpenDialog}
+          onOpenChange={setIsOpenDialog}
+          onActivate={handleActivateLicenseKey}
+        />
+      </div>
 
-          {keyData && !isNil(keyData?.expiresAt) && (
-            <div className="rounded-lg p-3 mt-5">
-              <div className="flex items-center space-x-2">
-                <CalendarDays className="w-5 h-5" />
-                <div>
-                  <p className="font-semibold text-sm">{t('Expiration')}</p>
-                  <p className="text-xs">
-                    {t('Valid until')}{' '}
-                    {formatUtils.formatDateOnly(
-                      dayjs(keyData.expiresAt).toDate(),
-                    )}
-                    {(expiresSoon || expired) && (
-                      <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-warning-100 text-warning-300">
-                        <AlertTriangle className="w-3 h-3 mr-1" />
-                        {expired ? t('Expired') : t('Expires soon')}
-                      </span>
-                    )}
-                  </p>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {!isNil(keyData?.expiresAt) && <Separator className="my-5" />}
-
-          <div className="rounded-lg p-4">
-            <h2 className="text-lg font-semibold mb-5">{t('Features')}</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-1">
-              {Object.entries(LICENSE_PROPS_MAP).map(
-                ([key, label]) =>
-                  platform?.[key as keyof typeof platform] && (
-                    <div className="flex items-center p-2 rounded-md" key={key}>
-                      <CircleCheckBig className="w-4 h-4 text-green-500 mr-2" />
-                      <span className={`text-sm`}>{t(label)}</span>
-                    </div>
-                  ),
-              )}
+      {platform.licenseExpiresAt && (
+        <div className="rounded-lg p-3 mt-5">
+          <div className="flex items-center space-x-2">
+            <CalendarDays className="w-5 h-5" />
+            <div>
+              <p className="font-semibold text-sm">{t('Expiration')}</p>
+              <p className="text-xs">
+                {t('Valid until')}{' '}
+                {formatUtils.formatDateOnly(
+                  dayjs(platform.licenseExpiresAt).toDate(),
+                )}
+                {(expiresSoon || expired) && (
+                  <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-warning-100 text-warning-300">
+                    <AlertTriangle className="w-3 h-3 mr-1" />
+                    {expired ? t('Expired') : t('Expires soon')}
+                  </span>
+                )}
+              </p>
             </div>
           </div>
-        </>
+        </div>
       )}
+
+      {platform.licenseExpiresAt && <Separator className="my-5" />}
+
+      <div className="rounded-lg p-4">
+        <h2 className="text-lg font-semibold mb-5">{t('Features')}</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-1">
+          {Object.entries(LICENSE_PROPS_MAP).map(
+            ([key, label]) =>
+              platform?.[key as keyof typeof platform] && (
+                <div className="flex items-center p-2 rounded-md" key={key}>
+                  <CircleCheckBig className="w-4 h-4 text-green-500 mr-2" />
+                  <span className={`text-sm`}>{t(label)}</span>
+                </div>
+              ),
+          )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/packages/react-ui/src/lib/platforms-api.ts
+++ b/packages/react-ui/src/lib/platforms-api.ts
@@ -1,5 +1,4 @@
 import {
-  LicenseKeyEntity,
   PlatformWithoutSensitiveData,
   UpdatePlatformRequestBody,
 } from '@activepieces/shared';
@@ -18,10 +17,6 @@ export const platformApi = {
 
   listPlatforms() {
     return api.get<PlatformWithoutSensitiveData[]>(`/v1/platforms`);
-  },
-
-  getLicenseKey(licenseKey: string) {
-    return api.get<LicenseKeyEntity>(`/v1/license-keys/${licenseKey}`);
   },
 
   verifyLicenseKey(licenseKey: string) {

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -58,8 +58,8 @@ export default defineConfig({
       typescript: {
         buildMode: true,
         tsconfigPath: './tsconfig.json',
-        root: __dirname
-      }
+        root: __dirname,
+      },
     }),
   ],
 
@@ -70,7 +70,7 @@ export default defineConfig({
     commonjsOptions: {
       transformMixedEsModules: true,
     },
-  
+
     rollupOptions: {
       onLog(level, log, handler) {
         if (

--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -28,10 +28,11 @@ export const platformController: FastifyPluginAsyncTypebox = async (app) => {
             await smtpEmailSender(req.log).validateOrThrow(smtp)
         }
 
-        return platformService.update({
+        const platform = await platformService.update({
             id: req.params.id,
             ...req.body,
         })
+        return platform
     })
 
     app.get('/', ListPlatformsForIdentityRequest, async (req) => {

--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -14,6 +14,7 @@ import {
 import { StatusCodes } from 'http-status-codes'
 import { platformMustBeOwnedByCurrentUser } from '../ee/authentication/ee-authorization'
 import { smtpEmailSender } from '../ee/helper/email/email-sender/smtp-email-sender'
+import { licenseKeysService } from '../ee/license-keys/license-keys-service'
 import { userService } from '../user/user-service'
 import { platformService } from './platform.service'
 import { platformUtils } from './platform.utils'
@@ -47,7 +48,12 @@ export const platformController: FastifyPluginAsyncTypebox = async (app) => {
             'paramId',
         )
         const platform = await platformService.getOneOrThrow(req.params.id)
-        return platform
+        const licenseKey = await licenseKeysService(req.log).getKey(platform.licenseKey)
+       
+        const platformWithoutSensitiveData = platform as PlatformWithoutSensitiveData
+        platformWithoutSensitiveData.licenseExpiresAt = licenseKey?.expiresAt
+        platformWithoutSensitiveData.hasLicenseKey = licenseKey !== null
+        return platformWithoutSensitiveData
     })
 }
 

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -117,8 +117,18 @@ export const platformService = {
     },
     async update(params: UpdateParams): Promise<Platform> {
         const platform = await this.getOneOrThrow(params.id)
+        const federatedAuthProviders = {
+            ...platform.federatedAuthProviders,
+            ...(params.federatedAuthProviders ?? {}),
+        }
+        const copilotSettings = params.copilotSettings? {
+            ...platform.copilotSettings,
+            ...params.copilotSettings
+        }: platform.copilotSettings;
         const updatedPlatform: Platform = {
             ...platform,
+            copilotSettings,
+            federatedAuthProviders,
             ...spreadIfDefined('name', params.name),
             ...spreadIfDefined('auditLogEnabled', params.auditLogEnabled),
             ...spreadIfDefined('primaryColor', params.primaryColor),
@@ -128,10 +138,6 @@ export const platformService = {
             ...spreadIfDefined('filteredPieceNames', params.filteredPieceNames),
             ...spreadIfDefined('filteredPieceBehavior', params.filteredPieceBehavior),
             ...spreadIfDefined('analyticsEnabled', params.analyticsEnabled),
-            ...spreadIfDefined(
-                'federatedAuthProviders',
-                params.federatedAuthProviders,
-            ),
             ...spreadIfDefined('cloudAuthEnabled', params.cloudAuthEnabled),
             ...spreadIfDefined('defaultLocale', params.defaultLocale),
             ...spreadIfDefined('showPoweredBy', params.showPoweredBy),
@@ -157,10 +163,8 @@ export const platformService = {
             ...spreadIfDefined('alertsEnabled', params.alertsEnabled),
             ...spreadIfDefined('licenseKey', params.licenseKey),
             ...spreadIfDefined('pinnedPieces', params.pinnedPieces),
-            ...spreadIfDefined('copilotSettings', params.copilotSettings),
             smtp: params.smtp,
         }
-
         return repo().save(updatedPlatform)
     },
 

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -121,10 +121,10 @@ export const platformService = {
             ...platform.federatedAuthProviders,
             ...(params.federatedAuthProviders ?? {}),
         }
-        const copilotSettings = params.copilotSettings? {
+        const copilotSettings = params.copilotSettings ? {
             ...platform.copilotSettings,
-            ...params.copilotSettings
-        }: platform.copilotSettings;
+            ...params.copilotSettings,
+        } : platform.copilotSettings
         const updatedPlatform: Platform = {
             ...platform,
             copilotSettings,

--- a/packages/server/worker/package.json
+++ b/packages/server/worker/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@activepieces/pieces-framework": "0.7.44",
     "@activepieces/server-shared": "0.0.1",
-    "@activepieces/shared": "0.10.151",
+    "@activepieces/shared": "0.10.152",
     "async-mutex": "0.4.0",
     "axios": "1.7.8",
     "axios-retry": "4.4.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.10.151",
+  "version": "0.10.152",
   "type": "commonjs"
 }

--- a/packages/shared/src/lib/federated-authn/index.ts
+++ b/packages/shared/src/lib/federated-authn/index.ts
@@ -1,6 +1,6 @@
 import { Static, Type } from '@sinclair/typebox'
-import { ThirdPartyAuthnProviderEnum } from './authn-provider-name'
 import { Nullable } from '../common'
+import { ThirdPartyAuthnProviderEnum } from './authn-provider-name'
 
 export * from './authn-provider-name'
 

--- a/packages/shared/src/lib/federated-authn/index.ts
+++ b/packages/shared/src/lib/federated-authn/index.ts
@@ -1,5 +1,6 @@
 import { Static, Type } from '@sinclair/typebox'
 import { ThirdPartyAuthnProviderEnum } from './authn-provider-name'
+import { Nullable } from '../common'
 
 export * from './authn-provider-name'
 
@@ -35,16 +36,16 @@ export const SAMLAuthnProviderConfig = Type.Object({
 export type SAMLAuthnProviderConfig = Static<typeof SAMLAuthnProviderConfig>
 
 export const FederatedAuthnProviderConfig = Type.Object({
-    google: Type.Optional(GoogleAuthnProviderConfig),
-    github: Type.Optional(GithubAuthnProviderConfig),
-    saml: Type.Optional(SAMLAuthnProviderConfig),
+    google: Nullable(GoogleAuthnProviderConfig),
+    github: Nullable(GithubAuthnProviderConfig),
+    saml: Nullable(SAMLAuthnProviderConfig),
 })
 export type FederatedAuthnProviderConfig = Static<typeof FederatedAuthnProviderConfig>
 
 export const FederatedAuthnProviderConfigWithoutSensitiveData = Type.Object({
-    google: Type.Optional(Type.Pick(GoogleAuthnProviderConfig, ['clientId'])),
-    github: Type.Optional(Type.Pick(GithubAuthnProviderConfig, ['clientId'])),
-    saml: Type.Optional(Type.Object({})),
+    google: Nullable(Type.Pick(GoogleAuthnProviderConfig, ['clientId'])),
+    github: Nullable(Type.Pick(GithubAuthnProviderConfig, ['clientId'])),
+    saml: Nullable(Type.Object({})),
 })
 
 export type FederatedAuthnProviderConfigWithoutSensitiveData = Static<typeof FederatedAuthnProviderConfigWithoutSensitiveData>

--- a/packages/shared/src/lib/platform/platform.model.ts
+++ b/packages/shared/src/lib/platform/platform.model.ts
@@ -116,9 +116,11 @@ export type Platform = Static<typeof Platform>
 
 export const PlatformWithoutSensitiveData = Type.Composite([Type.Object({
     federatedAuthProviders: FederatedAuthnProviderConfigWithoutSensitiveData,
-    defaultLocale: Nullable(Type.String()),
+    defaultLocale: Type.Optional(Type.Enum(LocalesEnum)),
     copilotSettings: Type.Optional(CopilotSettingsWithoutSensitiveData),
     smtp: Nullable(Type.Object({})),
+    hasLicenseKey: Type.Optional(Type.Boolean()),
+    licenseExpiresAt: Type.Optional(Type.String()),
 }), Type.Pick(Platform, [
     'id',
     'created',

--- a/packages/shared/src/lib/platform/platform.model.ts
+++ b/packages/shared/src/lib/platform/platform.model.ts
@@ -115,7 +115,7 @@ export type Platform = Static<typeof Platform>
 
 
 export const PlatformWithoutSensitiveData = Type.Composite([Type.Object({
-    federatedAuthProviders: FederatedAuthnProviderConfigWithoutSensitiveData,
+    federatedAuthProviders: Nullable(FederatedAuthnProviderConfigWithoutSensitiveData),
     defaultLocale: Type.Optional(Type.Enum(LocalesEnum)),
     copilotSettings: Type.Optional(CopilotSettingsWithoutSensitiveData),
     smtp: Nullable(Type.Object({})),


### PR DESCRIPTION
1) We now don't pass the client secret for SSO to the frontend, so if someone has SAML and Google activated and edits one of them the other one will be broken.

2) Vite will not build if there are typescript related issues in React from now on.