### PR TITLE
fix: support duplicate query params for arrays

### DIFF
--- a/packages/pieces/community/common/package.json
+++ b/packages/pieces/community/common/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "commonjs"
 }

--- a/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
+++ b/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
@@ -30,14 +30,14 @@ export class AxiosHttpClient extends BaseHttpClient {
       const queryParams = request.queryParams || {}
       const responseType = request.responseType || 'json';
 
-      for (const [key, value] of urlQueryParams) {
-        queryParams[key] = value
+      for (const [key, value] of Object.entries(queryParams)) {
+        urlQueryParams.append(key, value);
       }
 
       const config: AxiosRequestConfig = {
         method: axiosRequestMethod,
         url: urlWithoutQueryParams,
-        params: queryParams,
+        params: urlQueryParams,
         headers,
         data: request.body,
         timeout,

--- a/packages/pieces/community/http/package.json
+++ b/packages/pieces/community/http/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/piece-http",
-  "version": "0.6.1"
+  "version": "0.6.2"
 }
 


### PR DESCRIPTION
## What does this PR do?

The `HTTP (Send HTTP request)` action does not support sending query params in an array style eg. `https://httpbin.org/get?ids[]=1&ids[]=2`. It ends up only sending the last element `ids[]=2` even when providing the query params explicitly on the URL.

![Screenshot 2025-03-12 at 10 41 45 PM](https://github.com/user-attachments/assets/e569822d-4143-4cc7-86ed-911306b9010e)


## Approach

Currently the httpClient extracts url params from the url (type `URLSearchParams`), then merges that into the provided query parameters (type `Record`/object). `URLSearchParams` supports duplicate keys but `Record` doesn't. This is passed into [`AxiosRequestConfig.params`](https://axios-http.com/docs/req_config) which supports either a plain object or a URLSearchParams object.

This PR merges the provided query params into the `URLSearchParams` object instead, supporting duplicate keys like `ids[]`.

![Screenshot 2025-03-12 at 10 41 06 PM](https://github.com/user-attachments/assets/bf78bde9-d6fb-419b-ae83-2e11f5167b05)

## Caveats

- This should be backwards compatible for most cases, unless there are cases where people are expecting implicit query param deduplication.
- This doesn't fix the UI form for inputting query params. It still automatically picks the last value. Workaround is to provide it explicitly on the URL itself like my example.



