### PR TITLE
fix(dust): update Dust error format after API change

### DIFF
--- a/packages/pieces/community/dust/package.json
+++ b/packages/pieces/community/dust/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-dust",
-  "version": "0.1.6"
+  "version": "0.1.7"
 }

--- a/packages/pieces/community/dust/src/lib/common.ts
+++ b/packages/pieces/community/dust/src/lib/common.ts
@@ -107,10 +107,9 @@ export async function getConversationContent(
         `Could not load conversation ${conversationId} after ${timeout}s - ${conversationStatus} - consider increasing timeout value`
       );
     } else {
+      const error = getConversationError(conversation.body);
       throw new Error(
-        `Could not load conversation ${conversationId} - ${conversationStatus}: ${
-          conversation.body['conversation']['content']?.at(-1)?.at(0)?.error
-        }`
+        `Could not load conversation ${conversationId} - ${conversationStatus}: ${error.message} (${error.code})`
       );
     }
   }
@@ -120,4 +119,11 @@ export async function getConversationContent(
 
 function getConversationStatus(conversation: HttpMessageBody): string {
   return conversation['conversation']['content']?.at(-1)?.at(0)?.status;
+}
+
+function getConversationError(conversation: HttpMessageBody): {
+  code: string;
+  message: string;
+} {
+  return conversation['conversation']['content']?.at(-1)?.at(0)?.error;
 }


### PR DESCRIPTION
## What does this PR do?

Dust changed their API to return an error **object** instead of a simple message