### PR TITLE
fix: image to pdf extension check

### DIFF
--- a/packages/pieces/community/pdf/package.json
+++ b/packages/pieces/community/pdf/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-pdf",
-  "version": "0.2.2"
+  "version": "0.2.3"
 }

--- a/packages/pieces/community/pdf/src/lib/actions/image-to-pdf.ts
+++ b/packages/pieces/community/pdf/src/lib/actions/image-to-pdf.ts
@@ -24,6 +24,7 @@ export const imageToPdf = createAction({
 	async run(context) {
 		try {
 			const image = context.propsValue.image;
+			const imageExtension = image.extension?.toLowerCase();
 
 			const pdfDoc = await PDFDocument.create();
 			const page = pdfDoc.addPage();
@@ -36,12 +37,12 @@ export const imageToPdf = createAction({
 
 			let result: PDFImage | null = null;
 
-			if (image.extension === 'png') {
+			if (imageExtension === 'png') {
 				result = await pdfDoc.embedPng(image.data);
-			} else if (image.extension === 'jpg' || image.extension === 'jpeg') {
+			} else if (imageExtension === 'jpg' || imageExtension === 'jpeg') {
 				result = await pdfDoc.embedJpg(image.data);
 			} else {
-				throw new Error(`Unsupported image format: ${image.extension}`);
+				throw new Error(`Unsupported image format: ${imageExtension}`);
 			}
 
 			if (result === null) {


### PR DESCRIPTION
## What does this PR do?

There is a minor bug where the image-to-pdf action wrongly rejects valid files because the extension check is case sensitive.

eg. trying to convert `test.PNG` fails with this error but lowercasing the extension (`test.png`) passes
```
Failed to convert text to PDF: Unsupported image format: PNG
```

This PR normalizes the extension to lowercase when doing the check
