### PR TITLE
feat(sftp): add option to allow connecting to ftps server with a self-signed certificate

### DIFF
--- a/packages/pieces/community/sftp/package.json
+++ b/packages/pieces/community/sftp/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-sftp",
-  "version": "0.2.6"
+  "version": "0.2.7"
 }


### PR DESCRIPTION
This MR adds a checkbox to the SFTP auth that allows to connect to ftps server with a self-signed certificate. It now also returns the actual error when the connection fails, instead of a fixed message without a real cause.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

