### PR TITLE
feat(slack): simulate triggers instead of using sample data

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.8.1"
+  "version": "0.8.2"
 }

--- a/packages/pieces/community/slack/src/lib/triggers/new-command.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-command.ts
@@ -10,42 +10,6 @@ import { WebClient } from '@slack/web-api';
 import { isNil } from '@activepieces/shared';
 import { getFirstFiveOrAll } from '../common/utils';
 
-const sampleData = {
-  client_msg_id: '2767cf34-0651-44e0-b9c8-1b167ce9b7a9',
-  type: 'message',
-  text: '<@U07BN652T52> help argument1 argument2',
-  user: 'U037UG6FKPU',
-  ts: '1678231735.586539',
-  blocks: [
-    {
-      type: 'rich_text',
-      block_id: 'jCFSh',
-      elements: [
-        {
-          type: 'rich_text_section',
-          elements: [
-            {
-              type: 'user',
-              user_id: 'U07BN652T52',
-            },
-            {
-              type: 'text',
-              text: ' help argument1 argument2',
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  team: 'T037MS4FGDC',
-  channel: 'C037RTX2ZDM',
-  event_ts: '1678231735.586539',
-  channel_type: 'channel',
-  parsed_command: {
-    command: 'help',
-    args: ['argument1', 'argument2'],
-  },
-};
 
 export const newCommand = createTrigger({
   auth: slackAuth,
@@ -94,7 +58,7 @@ export const newCommand = createTrigger({
     }),
   },
   type: TriggerStrategy.APP_WEBHOOK,
-  sampleData: sampleData,
+  sampleData: undefined,
   onEnable: async (context) => {
     // Older OAuth2 has team_id, newer has team.id
     const teamId =
@@ -106,66 +70,6 @@ export const newCommand = createTrigger({
   },
   onDisable: async (context) => {
     // Ignored
-  },
-
-  test: async (context) => {
-    const channels = context.propsValue.channels as string[];
-    const commands = context.propsValue.commands as string[];
-    const user = context.propsValue.user as string;
-
-    if (!channels || (Array.isArray(channels) && channels.length === 0)) {
-      return [
-        {
-          ...sampleData,
-          parsed_command: {
-            command: commands.length > 0 ? commands[0] : 'help',
-            args: ['argument1', 'argument2'],
-          },
-        },
-      ];
-    }
-
-    const client = new WebClient(context.auth.access_token);
-    const response = await client.conversations.history({
-      channel: channels[0],
-      limit: 100,
-    });
-
-    if (!response.messages) {
-      return [];
-    }
-
-    // Filter and process messages with bot mention + command
-    const processedMessages = response.messages
-      .filter((message) => !isNil(message.ts))
-      .filter((message) => {
-        // Ignore bot messages if configured to do so
-        if (context.propsValue.ignoreBots && message.bot_id) {
-          return false;
-        }
-        // Look for mentions of the bot user
-        return message.text && message.text.includes(`<@${user}>`);
-      })
-      .map((message) => {
-        // Parse the command
-        const parsedCommand = parseCommand(message.text || '', user, commands);
-
-        // Only include messages with valid commands
-        if (parsedCommand && commands.includes(parsedCommand.command)) {
-          return {
-            ...message,
-            channel: channels[0],
-            event_ts: '1678231735.586539',
-            channel_type: 'channel',
-            parsed_command: parsedCommand,
-          };
-        }
-        return null;
-      })
-      .filter((message) => message !== null)
-      .sort((a, b) => parseFloat(b!.ts!) - parseFloat(a!.ts!));
-
-    return getFirstFiveOrAll(processedMessages);
   },
 
   run: async (context) => {

--- a/packages/pieces/community/slack/src/lib/triggers/new-direct-message.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-direct-message.ts
@@ -1,34 +1,7 @@
 import { Property, TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 import { slackAuth } from '../../';
 
-const sampleData = {
-	user: 'U06C9507WGH',
-	type: 'message',
-	ts: '1741787044.231539',
-	client_msg_id: '6f6e5257-6c39-40d8-bf22-f2bc2b7d8de9',
-	text: 'Test Message',
-	team: 'T06BTHUEFFF',
-	blocks: [
-		{
-			type: 'rich_text',
-			block_id: 'oUF4b',
-			elements: [
-				{
-					type: 'rich_text_section',
-					elements: [
-						{
-							type: 'text',
-							text: 'Test Message',
-						},
-					],
-				},
-			],
-		},
-	],
-	channel: 'D06BFVAL8CF',
-	event_ts: '1741787044.231539',
-	channel_type: 'im',
-};
+
 
 export const newDirectMessageTrigger = createTrigger({
 	auth: slackAuth,
@@ -48,7 +21,7 @@ export const newDirectMessageTrigger = createTrigger({
 		}),
 	},
 	type: TriggerStrategy.APP_WEBHOOK,
-	sampleData: sampleData,
+	sampleData: undefined,
 	onEnable: async (context) => {
 		// Older OAuth2 has team_id, newer has team.id
 		const teamId = context.auth.data['team_id'] ?? context.auth.data['team']['id'];
@@ -59,10 +32,6 @@ export const newDirectMessageTrigger = createTrigger({
 	},
 	onDisable: async (context) => {
 		// Ignored
-	},
-
-	async test(context) {
-		return [sampleData];
 	},
 
 	async run(context) {

--- a/packages/pieces/community/slack/src/lib/triggers/new-mention.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-mention.ts
@@ -10,38 +10,6 @@ import { WebClient } from '@slack/web-api';
 import { isNil } from '@activepieces/shared';
 import { getFirstFiveOrAll } from '../common/utils';
 
-const sampleData = {
-  client_msg_id: '2767cf34-0651-44e0-b9c8-1b167ce9b7a9',
-  type: 'message',
-  text: 'heeeelllo\n<@U07BN652T52>',
-  user: 'U037UG6FKPU',
-  ts: '1678231735.586539',
-  blocks: [
-    {
-      type: 'rich_text',
-      block_id: 'jCFSh',
-      elements: [
-        {
-          type: 'rich_text_section',
-          elements: [
-            {
-              type: 'text',
-              text: 'heeeelllo\n',
-            },
-            {
-              type: 'user',
-              user_id: 'U07BN652T52',
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  team: 'T037MS4FGDC',
-  channel: 'C037RTX2ZDM',
-  event_ts: '1678231735.586539',
-  channel_type: 'channel',
-};
 
 export const newMention = createTrigger({
   auth: slackAuth,
@@ -82,7 +50,7 @@ export const newMention = createTrigger({
     }),
   },
   type: TriggerStrategy.APP_WEBHOOK,
-  sampleData: sampleData,
+  sampleData: undefined,
   onEnable: async (context) => {
     // Older OAuth2 has team_id, newer has team.id
     const teamId =
@@ -94,39 +62,6 @@ export const newMention = createTrigger({
   },
   onDisable: async (context) => {
     // Ignored
-  },
-
-  test: async (context) => {
-    const channels = context.propsValue.channels as string[];
-
-    if (!channels || (Array.isArray(channels) && channels.length === 0)) {
-      return [sampleData];
-    }
-    const client = new WebClient(context.auth.access_token);
-    const response = await client.conversations.history({
-      channel: channels[0],
-      limit: 100,
-    });
-    if (!response.messages) {
-      return [];
-    }
-    const messages =  response.messages
-    .filter((message) => !isNil(message.ts))
-      .filter(
-        (message) =>
-          message.text && message.text.includes(`<@${context.propsValue.user}>`)
-      )
-      .filter((message) => !(context.propsValue.ignoreBots && message.bot_id))
-      .map((message) => {
-        return {
-          ...message,
-          channel: channels[0],
-          event_ts: '1678231735.586539',
-          channel_type: 'channel',
-        };
-      }).sort((a, b) => parseFloat(b.ts!) - parseFloat(a.ts!));
-
-      return getFirstFiveOrAll(messages);
   },
 
   run: async (context) => {

--- a/packages/pieces/community/slack/src/lib/triggers/new-message-in-channel.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-message-in-channel.ts
@@ -5,34 +5,7 @@ import { WebClient } from '@slack/web-api';
 import { isNil } from '@activepieces/shared';
 import { getFirstFiveOrAll } from '../common/utils';
 
-const sampleData = {
-	client_msg_id: '2767cf34-0651-44e0-b9c8-1b167ce9b7a9',
-	type: 'message',
-	text: 'f',
-	user: 'U037UG6FKPU',
-	ts: '1678231735.586539',
-	blocks: [
-		{
-			type: 'rich_text',
-			block_id: '4CM',
-			elements: [
-				{
-					type: 'rich_text_section',
-					elements: [
-						{
-							type: 'text',
-							text: 'f',
-						},
-					],
-				},
-			],
-		},
-	],
-	team: 'T037MS4FGDC',
-	channel: 'C037RTX2ZDM',
-	event_ts: '1678231735.586539',
-	channel_type: 'channel',
-};
+
 
 export const newMessageInChannelTrigger = createTrigger({
 	auth: slackAuth,
@@ -49,7 +22,7 @@ export const newMessageInChannelTrigger = createTrigger({
 		}),
 	},
 	type: TriggerStrategy.APP_WEBHOOK,
-	sampleData: sampleData,
+	sampleData: undefined,
 	async onEnable(context) {
 		// Older OAuth2 has team_id, newer has team.id
 		const teamId = context.auth.data['team_id'] ?? context.auth.data['team']['id'];
@@ -60,33 +33,6 @@ export const newMessageInChannelTrigger = createTrigger({
 	},
 	async onDisable(context) {
 		// Ignored
-	},
-
-	async test(context) {
-		if (!context.propsValue.channel) {
-			return [sampleData];
-		}
-		const client = new WebClient(context.auth.access_token);
-		const response = await client.conversations.history({
-			channel: context.propsValue.channel,
-			limit: 100,
-		});
-		if (!response.messages) {
-			return [];
-		}
-		const messages = response.messages
-			.filter((message) => !isNil(message.ts))
-			.filter((message) => !(context.propsValue.ignoreBots && message.bot_id))
-			.map((message) => {
-				return {
-					...message,
-					channel: context.propsValue.channel,
-					event_ts: '1678231735.586539',
-					channel_type: 'channel',
-				};
-			})
-			.sort((a, b) => parseFloat(b.ts!) - parseFloat(a.ts!));
-		return getFirstFiveOrAll(messages);
 	},
 
 	async run(context) {

--- a/packages/pieces/community/slack/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-message.ts
@@ -4,34 +4,6 @@ import { WebClient } from '@slack/web-api';
 import { isNil } from '@activepieces/shared';
 import { getFirstFiveOrAll } from '../common/utils';
 
-const sampleData = {
-	client_msg_id: '2767cf34-0651-44e0-b9c8-1b167ce9b7a9',
-	type: 'message',
-	text: 'f',
-	user: 'U037UG6FKPU',
-	ts: '1678231735.586539',
-	blocks: [
-		{
-			type: 'rich_text',
-			block_id: '4CM',
-			elements: [
-				{
-					type: 'rich_text_section',
-					elements: [
-						{
-							type: 'text',
-							text: 'f',
-						},
-					],
-				},
-			],
-		},
-	],
-	team: 'T037MS4FGDC',
-	channel: 'C037RTX2ZDM',
-	event_ts: '1678231735.586539',
-	channel_type: 'channel',
-};
 
 export const newMessageTrigger = createTrigger({
 	auth: slackAuth,
@@ -46,7 +18,7 @@ export const newMessageTrigger = createTrigger({
 		}),
 	},
 	type: TriggerStrategy.APP_WEBHOOK,
-	sampleData: sampleData,
+	sampleData: undefined,
 	onEnable: async (context) => {
 		// Older OAuth2 has team_id, newer has team.id
 		const teamId = context.auth.data['team_id'] ?? context.auth.data['team']['id'];
@@ -57,43 +29,6 @@ export const newMessageTrigger = createTrigger({
 	},
 	onDisable: async (context) => {
 		// Ignored
-	},
-
-	test: async (context) => {
-		const client = new WebClient(context.auth.access_token);
-
-		const channelList = await client.conversations.list({
-			types: 'public_channel,private_channel',
-			exclude_archived: true,
-			limit: 1,
-		});
-
-		if (!channelList.channels || channelList.channels.length === 0) {
-			return [sampleData];
-		}
-
-		const channel = channelList.channels[0].id ?? '';
-		const response = await client.conversations.history({
-			channel: channel,
-			limit: 100,
-		});
-
-		if (!response.messages) {
-			return [sampleData];
-		}
-
-		const messages = response.messages
-			.filter((message) => !isNil(message.ts))
-			.filter((message) => !(context.propsValue.ignoreBots && message.bot_id))
-			.map((message) => {
-				return {
-					...message,
-					event_ts: '1678231735.586539',
-					channel_type: 'channel',
-				};
-			})
-			.sort((a, b) => parseFloat(b.ts!) - parseFloat(a.ts!));
-		return getFirstFiveOrAll(messages);
 	},
 
 	run: async (context) => {

--- a/packages/pieces/community/slack/src/lib/triggers/new-reaction-added.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-reaction-added.ts
@@ -7,34 +7,6 @@ import { slackAuth } from '../../';
 import { slackChannel } from '../common/props';
 import { WebClient } from '@slack/web-api';
 
-const sampleData = {
-  client_msg_id: '2767cf34-0651-44e0-b9c8-1b167ce9b7a9',
-  type: 'message',
-  text: 'f',
-  user: 'U037UG6FKPU',
-  ts: '1678231735.586539',
-  blocks: [
-    {
-      type: 'rich_text',
-      block_id: '4CM',
-      elements: [
-        {
-          type: 'rich_text_section',
-          elements: [
-            {
-              type: 'text',
-              text: 'f',
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  team: 'T037MS4FGDC',
-  channel: 'C037RTX2ZDM',
-  event_ts: '1678231735.586539',
-  channel_type: 'channel',
-};
 
 export const newReactionAdded = createTrigger({
   auth: slackAuth,
@@ -50,7 +22,7 @@ export const newReactionAdded = createTrigger({
     channel: slackChannel(false),
   },
   type: TriggerStrategy.APP_WEBHOOK,
-  sampleData: sampleData,
+  sampleData: undefined,
   onEnable: async (context) => {
     // Older OAuth2 has team_id, newer has team.id
     const teamId =
@@ -64,31 +36,7 @@ export const newReactionAdded = createTrigger({
     // Ignored
   },
 
-  test: async (context) => {
-    const client = new WebClient(
-      context.auth.data['authed_user']?.access_token
-    );
-    const response = await client.reactions.list({ limit: 10, full: true });
-    if (!response.items) {
-      return [];
-    }
-    return response.items
-      .filter((item) => item.type === 'message')
-      .map((item) => {
-        return {
-          type: 'reaction_added',
-          user: item.message?.reactions?.[0].users?.[0],
-          reaction: item.message?.reactions?.[0].name,
-          item_user: item.message?.user,
-          item: {
-            type: 'message',
-            channel: item.channel,
-            ts: item.message?.ts,
-          },
-          event_ts: '1360782804.083113',
-        };
-      });
-  },
+
 
   run: async (context) => {
     const payloadBody = context.payload.body as PayloadBody;


### PR DESCRIPTION
## What does this PR do?

Since https://github.com/activepieces/activepieces/pull/6187 it's possible to properly simulate triggers (loading real data) which is often much more useful than static sample data
