### PR TITLE
fix(oauth2): change code challenge to 43 char

### DIFF
--- a/packages/react-ui/src/lib/oauth2-utils.ts
+++ b/packages/react-ui/src/lib/oauth2-utils.ts
@@ -19,7 +19,7 @@ async function openOAuth2Popup(
   params: OAuth2PopupParams,
 ): Promise<OAuth2PopupResponse> {
   closeOAuth2Popup();
-  const pckeChallenge = nanoid();
+  const pckeChallenge = nanoid(43);
   const url = constructUrl(params, pckeChallenge);
   currentPopup = openWindow(url);
   return {


### PR DESCRIPTION
The Oauth2 challenge code (pkce) does not comply with RFC 7636 (https://datatracker.ietf.org/doc/html/rfc7636#section-4.1).

It must be between 43 and 128 characters long, which is not the case with the default use of `nanoid` (21 characters). I therefore changed the length of `nanoid` to 43. 
This should not have any impact on existing integrations unless the connector does not fully comply with the Oauth2 specifications.