### PR TITLE
Removed all references to the public schema in migrations

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1732324567513-AddIndiciesToRunAndTriggerData.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1732324567513-AddIndiciesToRunAndTriggerData.ts
@@ -18,13 +18,13 @@ export class AddIndiciesToRunAndTriggerData1732324567513 implements MigrationInt
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX IF EXISTS CONCURRENTLY "public"."idx_run_flow_id"
+            DROP INDEX IF EXISTS CONCURRENTLY "idx_run_flow_id"
         `)
         await queryRunner.query(`
-            DROP INDEX IF EXISTS CONCURRENTLY "public"."idx_trigger_event_file_id"
+            DROP INDEX IF EXISTS CONCURRENTLY "idx_trigger_event_file_id"
         `)
         await queryRunner.query(`
-            DROP INDEX IF EXISTS CONCURRENTLY "public"."idx_trigger_event_project_id_flow_id"
+            DROP INDEX IF EXISTS CONCURRENTLY "idx_trigger_event_project_id_flow_id"
         `)
     }
 

--- a/packages/server/api/src/app/database/migration/postgres/1734355488179-TablesProduct.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1734355488179-TablesProduct.ts
@@ -96,13 +96,13 @@ export class TablesProduct1734355488179 implements MigrationInterface {
             DROP TABLE "record"
         `)
         await queryRunner.query(`
-              DROP INDEX "public"."idx_field_table_id_name"
+              DROP INDEX "idx_field_table_id_name"
         `)
         await queryRunner.query(`
             DROP TABLE "field"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_table_project_id_name"
+            DROP INDEX "idx_table_project_id_name"
         `)
         await queryRunner.query(`
             DROP TABLE "table"

--- a/packages/server/api/src/app/database/migration/postgres/1734969829406-FieldAndRecordAndCell_ProjectId.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1734969829406-FieldAndRecordAndCell_ProjectId.ts
@@ -5,7 +5,7 @@ export class FieldAndRecordAndCellProjectId1734969829406 implements MigrationInt
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_field_table_id_name"
+            DROP INDEX "idx_field_table_id_name"
         `)
         await queryRunner.query(`
             ALTER TABLE "field"
@@ -47,7 +47,7 @@ export class FieldAndRecordAndCellProjectId1734969829406 implements MigrationInt
             ALTER TABLE "field" DROP CONSTRAINT "fk_field_project_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_field_project_id_table_id_name"
+            DROP INDEX "idx_field_project_id_table_id_name"
         `)
         await queryRunner.query(`
             ALTER TABLE "cell" DROP COLUMN "projectId"

--- a/packages/server/api/src/app/database/migration/postgres/1734971881345-AddPlatformBilling.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1734971881345-AddPlatformBilling.ts
@@ -34,7 +34,7 @@ export class AddPlatformBilling1734971881345 implements MigrationInterface {
             ALTER TABLE "platform_billing" DROP CONSTRAINT "fk_platform_billing_platform_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_platform_billing_platform_id"
+            DROP INDEX "idx_platform_billing_platform_id"
         `)
         await queryRunner.query(`
             DROP TABLE "platform_billing"

--- a/packages/server/api/src/app/database/migration/postgres/1735057498882-AddCellUniqueIndex.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1735057498882-AddCellUniqueIndex.ts
@@ -11,7 +11,7 @@ export class AddCellUniqueIndex1735057498882 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_cell_project_id_field_id_record_id_unique"
+            DROP INDEX "idx_cell_project_id_field_id_record_id_unique"
         `)
     }
 

--- a/packages/server/api/src/app/database/migration/postgres/1741669458075-CreateTableWebhooks.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1741669458075-CreateTableWebhooks.ts
@@ -5,7 +5,7 @@ export class CreateTableWebhooks1741669458075 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_table_project_id_name"
+            DROP INDEX "idx_table_project_id_name"
         `)
         await queryRunner.query(`
             CREATE TABLE "table_webhook" (
@@ -50,10 +50,10 @@ export class CreateTableWebhooks1741669458075 implements MigrationInterface {
             ALTER TABLE "table_webhook" DROP CONSTRAINT "fk_table_webhook_project_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_record_project_id_table_id"
+            DROP INDEX "idx_record_project_id_table_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_table_project_id_name"
+            DROP INDEX "idx_table_project_id_name"
         `)
         await queryRunner.query(`
             DROP TABLE "table_webhook"

--- a/packages/server/api/src/app/database/migration/postgres/1742304857701-AddManualTaskTable.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1742304857701-AddManualTaskTable.ts
@@ -70,13 +70,13 @@ export class AddManualTaskTable1742304857701 implements MigrationInterface {
             ALTER TABLE "manual_task" DROP CONSTRAINT "fk_manual_task_platform_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_manual_task_platform_id"
+            DROP INDEX "idx_manual_task_platform_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_manual_task_flow_id"
+            DROP INDEX "idx_manual_task_flow_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_manual_task_project_id"
+            DROP INDEX "idx_manual_task_project_id"
         `)
         await queryRunner.query(`
             DROP TABLE "manual_task"

--- a/packages/server/api/src/app/database/migration/postgres/1742305104390-AddManualTaskCommentTable.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1742305104390-AddManualTaskCommentTable.ts
@@ -39,10 +39,10 @@ export class AddManualTaskCommentTable1742305104390 implements MigrationInterfac
             ALTER TABLE "manual_task_comment" DROP CONSTRAINT "fk_manual_task_comment_task_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_manual_task_comment_user_id"
+            DROP INDEX "idx_manual_task_comment_user_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_manual_task_comment_task_id"
+            DROP INDEX "idx_manual_task_comment_task_id"
         `)
         await queryRunner.query(`
             DROP TABLE "manual_task_comment"

--- a/packages/server/api/src/app/database/migration/postgres/1742433144687-ChangeManualTasksCommentsToTodoComments.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1742433144687-ChangeManualTasksCommentsToTodoComments.ts
@@ -39,10 +39,10 @@ export class ChangeManualTasksCommentsToTodoComments1742433144687 implements Mig
             ALTER TABLE "todo_comment" DROP CONSTRAINT "fk_todo_comment_todo_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_todo_comment_user_id"
+            DROP INDEX "idx_todo_comment_user_id"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."idx_todo_comment_todo_id"
+            DROP INDEX "idx_todo_comment_todo_id"
         `)
         await queryRunner.query(`
             DROP TABLE "todo_comment"


### PR DESCRIPTION
## What does this PR do?

The migrations file had several references to the public schema. This causes issues when being run in a schema other than public. 

