### PR TITLE
fix(bird): fix messagebird for new APIs

### DIFF
--- a/packages/pieces/community/messagebird/package.json
+++ b/packages/pieces/community/messagebird/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-messagebird",
-  "version": "0.0.1"
+  "version": "0.1.0"
 }

--- a/packages/pieces/community/messagebird/src/index.ts
+++ b/packages/pieces/community/messagebird/src/index.ts
@@ -1,21 +1,16 @@
 import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
 import { sendSMSAction } from './lib/actions/send-sms.action';
 import { PieceCategory } from '@activepieces/shared';
-
-export const messageBirdAuth = PieceAuth.SecretText({
-  displayName: 'API Key',
-  description: '',
-  required: true,
-});
+import { birdAuth } from './lib/auth';
 
 export const messagebird = createPiece({
-  displayName: 'MessageBird',
-  description: 'Next generation CRM for Marketing, Services and Payments',
-  auth: messageBirdAuth,
+  displayName: 'Bird',
+  description: 'Unified CRM for Marketing, Service & Payments',
+  auth: birdAuth,
   minimumSupportedRelease: '0.30.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/messagebird.png',
-  categories: [PieceCategory.MARKETING],
-  authors: ['kishanprmr'],
+  categories: [PieceCategory.MARKETING, PieceCategory.COMMUNICATION],
+  authors: ['kishanprmr', 'geekyme'],
   actions: [sendSMSAction],
   triggers: [],
 });

--- a/packages/pieces/community/messagebird/src/lib/auth.ts
+++ b/packages/pieces/community/messagebird/src/lib/auth.ts
@@ -1,0 +1,28 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export interface BirdAuthValue {
+  apiKey: string;
+  workspaceId: string;
+  channelId: string;
+}
+
+export const birdAuth = PieceAuth.CustomAuth({
+  props: {
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API Key',
+      description: 'Bird API Access Key from Settings > Security > Access Keys',
+      required: true,
+    }),
+    workspaceId: PieceAuth.SecretText({
+      displayName: 'Workspace ID',
+      description: 'Bird Workspace ID found in your workspace URL',
+      required: true,
+    }),
+    channelId: PieceAuth.SecretText({
+      displayName: 'Channel ID',
+      description: 'Your SMS channel ID from Bird dashboard',
+      required: true,
+    }),
+  },
+  required: true,
+}); 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Before

Messagebird has [rebranded](https://techcrunch.com/2024/02/01/messagebird-rebrands-as-bird-and-slashes-prices-by-90-on-sms-to-take-on-twilio/?guccounter=1&guce_referrer=aHR0cHM6Ly93d3cuZ29vZ2xlLmNvbS8&guce_referrer_sig=AQAAACaAaN8j5mlMDWpYoL0aJbER5NB48Qq_0ctCOaAucrUCqigukAOaFFzz3aCF-1e_GxCJBojXGjJlgr1MCnznFlb6_HPfY7rzYPxAR5HuPWni80qaJONozb_iyoWltSsi_-O8wudshhB5YRTnsmEWsbYcBq4KVydYsvbU-r6TKj6h) to Bird and the original piece is broken if you were trying to use it against the new APIs.
 
<img width="1437" alt="messagebird activepieces old" src="https://github.com/user-attachments/assets/0c5a65eb-b9dd-4725-a8ce-eda1e349d2b1" />

### After

I have fixed it so that the `send-sms` will successfully work with the new APIs. 
![bird activepieces](https://github.com/user-attachments/assets/6a3e8108-b38f-4ac9-8204-1c74ef00a6b1)

<img width="452" alt="Screenshot 2025-03-28 at 4 01 17 PM" src="https://github.com/user-attachments/assets/2e60184b-93cb-41eb-861d-865869bbcc72" />

<img width="821" alt="Screenshot 2025-03-28 at 4 04 53 PM" src="https://github.com/user-attachments/assets/336b22a8-e9fd-4bb2-8ad4-7ff97fa98608" />

