### PR TITLE
chore: removed public schema references

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1743128816786-AddMCP.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1743128816786-AddMCP.ts
@@ -28,13 +28,13 @@ export class AddMCP1743128816786 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."idx_app_connection_mcp_id"
+            DROP INDEX "idx_app_connection_mcp_id"
         `)
         await queryRunner.query(`
             ALTER TABLE "app_connection" DROP COLUMN "mcpId"
         `)
         await queryRunner.query(`
-            DROP INDEX "public"."mcp_project_id"
+            DROP INDEX "mcp_project_id"
         `)
         await queryRunner.query(`
             DROP TABLE "mcp"


### PR DESCRIPTION
## What does this PR do?

Removes additional public schema references in a migration file.

