### PR TITLE
feat(gslide): create from template, get presentation and refresh sheets charts actions

### DIFF
--- a/packages/pieces/community/google-slides/package.json
+++ b/packages/pieces/community/google-slides/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-slides",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/pieces/community/google-slides/src/index.ts
+++ b/packages/pieces/community/google-slides/src/index.ts
@@ -1,5 +1,8 @@
 import { createPiece, PieceAuth, OAuth2PropertyValue } from "@activepieces/pieces-framework";
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { refreshSheetsCharts } from "./lib/actions/refresh-charts";
+import { generateFromTemplate } from "./lib/actions/generate-from-template";
+import { getPresentation } from "./lib/actions/get-presentation";
 
 export const googleSlidesAuth = PieceAuth.OAuth2({
   description: '',
@@ -9,8 +12,8 @@ export const googleSlidesAuth = PieceAuth.OAuth2({
   required: true,
   scope: [
     'https://www.googleapis.com/auth/presentations',
-    'https://www.googleapis.com/auth/presentations.readonly',
-    'https://www.googleapis.com/auth/drive.file',
+    'https://www.googleapis.com/auth/drive',
+    'https://www.googleapis.com/auth/spreadsheets',
   ],
 });
 
@@ -21,6 +24,9 @@ export const googleSlide = createPiece({
   logoUrl: "https://cdn.activepieces.com/pieces/google-slides.png",
   authors: ["Kevinyu-alan"],
   actions: [
+    getPresentation,
+    refreshSheetsCharts,
+    generateFromTemplate,
     createCustomApiCallAction({
       baseUrl: () => 'https://slides.googleapis.com/v1/presentations/',
       auth: googleSlidesAuth,

--- a/packages/pieces/community/google-slides/src/lib/actions/generate-from-template.ts
+++ b/packages/pieces/community/google-slides/src/lib/actions/generate-from-template.ts
@@ -1,0 +1,117 @@
+import { googleSlidesAuth } from '../../index';
+import { createAction, DynamicPropsValue, Property } from "@activepieces/pieces-framework";
+import { getSlide, PageElement, batchUpdate } from '../commons/common';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const generateFromTemplate = createAction({
+    name: 'generate_from_template',
+    displayName: 'Generate from template',
+    description: 'Generate a new slide from a template',
+    auth: googleSlidesAuth,
+    props: {
+        template_presentation_id: Property.ShortText({
+            displayName: 'Template presentation ID',
+            description: 'The ID of the templated presentation',
+            required: true,
+        }),
+        table_data: Property.DynamicProperties({
+            displayName: 'Table Data',
+            required: true,
+            refreshers: ['template_presentation_id'],
+            props: async ({auth, template_presentation_id}) => {
+                if (!template_presentation_id || !auth)
+                    return {};
+        
+                const presentation = await getSlide(auth["access_token"] as unknown as string, template_presentation_id as unknown as string);
+                if (!presentation)
+                    return {}
+
+                const fields = {
+                    title: Property.ShortText({
+                        displayName: 'Presentation Title',
+                        description: 'Title of the new presentation',
+                        defaultValue: `Copy of: ${presentation.title}`,
+                        required: true,
+                    })
+                } as DynamicPropsValue;
+        
+                presentation.slides?.forEach(slide => {
+                    slide.pageElements?.forEach((element: PageElement) => {
+                        if (element.shape?.text?.textElements) {
+                            element.shape.text.textElements.forEach(textElement => {
+                                if (textElement.textRun?.content) {
+                                    const matches = textElement.textRun.content.match(/\{\{([^}]+)\}\}/g);
+                                    if (matches) {
+                                        matches.forEach((match: string) => {
+                                            const varName = match.replace(/[{}]/g, '').trim();
+                                            fields[varName] = Property.ShortText({
+                                                displayName: varName.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
+                                                description: `Value for ${varName}`,
+                                                required: false,
+                                            });
+                                        });
+                                    }
+                                }
+                            });
+                        }
+                    });
+                });
+        
+                return fields;
+            }
+        })
+    },
+    async run(context) {
+        const { access_token } = context.auth;
+        const { template_presentation_id, table_data } = context.propsValue;
+
+        try {
+            const authClient = new OAuth2Client();
+            authClient.setCredentials(context.auth);
+            
+            const drive = google.drive({ version: 'v3', auth: authClient });
+                
+            const copyResponse = await drive.files.copy({
+                fileId: template_presentation_id as string,
+                requestBody: {
+                    name: table_data["title"] || "New Presentation"
+                }
+            });
+            
+            const newPresentationId = copyResponse.data.id;
+            if (!newPresentationId)
+                return
+
+            const requests = Object.entries(table_data)
+                .map(([key, value]): { replaceAllText: unknown } => {
+                    return {
+                        replaceAllText: {
+                            containsText: {
+                                text: `{{${key}}}`,
+                                matchCase: true
+                            },
+                            replaceText: value as string
+                        }
+                    };
+                });
+    
+            
+            if (requests.length > 0) {
+                await batchUpdate(
+                    access_token,
+                    newPresentationId,
+                    requests
+                );
+            }
+    
+            return {
+                presentationId: newPresentationId,
+                presentationUrl: `https://docs.google.com/presentation/d/${newPresentationId}/edit`
+            };
+        } catch (error) {
+            console.error('Error creating presentation:', error);
+            throw error;
+        }
+    }
+});

--- a/packages/pieces/community/google-slides/src/lib/actions/generate-from-template.ts
+++ b/packages/pieces/community/google-slides/src/lib/actions/generate-from-template.ts
@@ -40,14 +40,16 @@ export const generateFromTemplate = createAction({
                     slide.pageElements?.forEach((element: PageElement) => {
                         if (element.shape?.text?.textElements) {
                             element.shape.text.textElements.forEach(textElement => {
-                                if (textElement.textRun?.content) {
-                                    const matches = textElement.textRun.content.match(/\{\{([^}]+)\}\}/g);
+                                const content = textElement?.textRun?.content
+                                if (content) {
+                                    const matches = content.match(/\{\{([^}]+)\}\}/g);
                                     if (matches) {
                                         matches.forEach((match: string) => {
-                                            const varName = match.replace(/[{}]/g, '').trim();
-                                            fields[varName] = Property.ShortText({
+                                            const matchValue = match.replace(/[{}]/g, '');
+                                            const varName = matchValue.trim();
+                                            fields[matchValue] = Property.ShortText({
                                                 displayName: varName.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
-                                                description: `Value for ${varName}`,
+                                                description: `Value for "${matchValue}"`,
                                                 required: false,
                                             });
                                         });
@@ -76,7 +78,8 @@ export const generateFromTemplate = createAction({
                 fileId: template_presentation_id as string,
                 requestBody: {
                     name: table_data["title"] || "New Presentation"
-                }
+                },
+                supportsAllDrives: true
             });
             
             const newPresentationId = copyResponse.data.id;

--- a/packages/pieces/community/google-slides/src/lib/actions/get-presentation.ts
+++ b/packages/pieces/community/google-slides/src/lib/actions/get-presentation.ts
@@ -1,0 +1,22 @@
+import { googleSlidesAuth } from '../../index';
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { getSlide } from "../commons/common";
+
+export const getPresentation = createAction({
+    name: 'get_presentation',
+    displayName: 'Get Presentation',
+    description: 'Get all slides from a presentation',
+    auth: googleSlidesAuth,
+    props: {
+        presentation_id: Property.ShortText({
+            displayName: 'Presentation ID',
+            description: 'The ID of the presentation',
+            required: true,
+        })
+    },
+    async run(context) {
+        const { presentation_id } = context.propsValue;
+        const { access_token } = context.auth;
+        return await getSlide(access_token, presentation_id);
+    },
+});

--- a/packages/pieces/community/google-slides/src/lib/actions/refresh-charts.ts
+++ b/packages/pieces/community/google-slides/src/lib/actions/refresh-charts.ts
@@ -1,0 +1,51 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { batchUpdate, getSlide, PageElement } from '../commons/common';
+import { googleSlidesAuth } from '../..';
+
+export const refreshSheetsCharts = createAction({
+  name: 'refresh_sheets_charts',
+  displayName: 'Refresh Sheets Charts',
+  description: 'Refresh all Google Sheets charts in the presentation',
+  auth: googleSlidesAuth,
+  props: {
+      presentation_id: Property.ShortText({
+          displayName: 'Presentation ID',
+          description: 'The ID of the presentation, between /d and /edit',
+          required: true,
+      }),
+  },
+  async run(context) {
+      const { presentation_id } = context.propsValue;
+      const { access_token } = context.auth;
+      const presentation = await getSlide(access_token, presentation_id);
+      
+      const requests: { refreshSheetsChart: { objectId: string; }; }[] = [];
+      
+      presentation.slides?.forEach((slide) => {
+        slide.pageElements?.forEach((element: PageElement) => {
+          if (element.sheetsChart) {
+            const refreshRequest = {
+              refreshSheetsChart: {
+                  objectId: element.objectId
+              }
+            };
+            requests.push(refreshRequest);
+          }
+        });
+      });
+      
+      if (requests.length > 0) {
+          const result = await batchUpdate(access_token, presentation_id, requests);
+          return {
+              success: true,
+              message: `Successfully refreshed ${requests.length} Google Sheets charts`,
+              result: result
+          };
+      } else {
+          return {
+              success: false,
+              message: 'No Google Sheets charts found in the presentation'
+          };
+      }
+  }
+});

--- a/packages/pieces/community/google-slides/src/lib/commons/common.ts
+++ b/packages/pieces/community/google-slides/src/lib/commons/common.ts
@@ -1,0 +1,82 @@
+import { AuthenticationType, httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export interface PageElement {
+    objectId: string;
+    table?: {
+        tableRows: any[];
+    };
+    sheetsChart?: {
+        spreadsheetId: string;
+        chartId: number;
+    };
+    shape?: {
+        text: {
+            textElements: {textRun: {content: string}}[]
+        };
+    };
+}
+
+export const googleSheetsCommon = {
+	baseUrl: 'https://slides.googleapis.com/v1/presentations/',
+    batchUpdate,
+    getSlide,
+    createSlide
+};
+
+export async function batchUpdate(access_token: string, slide_id: string, requests: any) {
+    return (
+        await httpClient.sendRequest<{
+            spreadsheetId: string;
+        }>({
+            method: HttpMethod.POST,
+            url: `https://slides.googleapis.com/v1/presentations/${slide_id}:batchUpdate`,
+            body: {
+                requests: requests
+            },
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: access_token,
+            },
+        })
+    ).body;
+}
+
+export async function getSlide(access_token: string, slide_id: string) {
+    return (
+        await httpClient.sendRequest<{
+            presentationId: string;
+            title: string;
+            slides: {
+                pageElements: any; objectId: object; 
+}[];
+        }>({
+            method: HttpMethod.GET,
+            url: `https://slides.googleapis.com/v1/presentations/${slide_id}`,
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: access_token,
+            },
+        })
+    ).body;
+}
+
+export async function createSlide(access_token: string, requests: any) {
+    return (
+        await httpClient.sendRequest<{
+            presentationId: string;
+            title: string;
+            spreadsheetId: string;
+            replies: any[];
+        }>({
+            method: HttpMethod.POST,
+            url: `https://slides.googleapis.com/v1/presentations`,
+            body: {
+                requests: requests
+            },
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: access_token,
+            },
+        })
+    ).body;
+}


### PR DESCRIPTION
## What does this PR do?

Create new actions for GSlide: get, generated from template and refresh charts.
<img width="389" alt="Capture d’écran 2025-04-07 à 17 49 26" src="https://github.com/user-attachments/assets/01873b84-b872-48e2-9778-a15f3e196c5e" />


Fixes Q-1118


### What Problem Does This Feature Solve?
They can refresh all charts in a presentation easily.
They can generate a new presentation from a template and directly fill the value.

### Relevant User Scenarios
