### PR TITLE
feat: add gpt 4.1 models

### DIFF
--- a/packages/pieces/community/common/package.json
+++ b/packages/pieces/community/common/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "commonjs"
 }

--- a/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
+++ b/packages/pieces/community/common/src/lib/ai/providers/openai/index.ts
@@ -225,4 +225,7 @@ export const openaiModels = [
 		value: 'omni-moderation-latest',
 		supported: ['moderation'],
 	}),
+	model({label:'gpt-4.1',value:'gpt-4.1',supported:['text','function']}),
+	model({label:'gpt-4.1-mini',value:'gpt-4.1-mini',supported:['text','function']}),
+	model({label:'gpt-4.1-nano',value:'gpt-4.1-nano',supported:['text','function']})
 ];

--- a/packages/pieces/community/text-ai/package.json
+++ b/packages/pieces/community/text-ai/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-text-ai",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/packages/pieces/community/utility-ai/package.json
+++ b/packages/pieces/community/utility-ai/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-utility-ai",
-  "version": "0.2.1"
+  "version": "0.2.2"
 }


### PR DESCRIPTION
## What does this PR do?

Adds support for new OpenAI GPT-4.1 models — including GPT-4.1, GPT-4.1 Mini, and GPT-4.1 Nano — in AI Pieces (Text AI and Utility AI).

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes #7379 
