### PR TITLE
feat: clickup piece enhancements

### DIFF
--- a/packages/pieces/community/clickup/src/index.ts
+++ b/packages/pieces/community/clickup/src/index.ts
@@ -22,6 +22,19 @@ import { filterClickupWorkspaceTimeEntries } from './lib/actions/tasks/filter-wo
 import { getClickupTask } from './lib/actions/tasks/get-task';
 import { updateClickupTask } from './lib/actions/tasks/update-task';
 import { clickupTriggers as triggers } from './lib/triggers';
+import { getClickupChannels } from './lib/actions/chat/get-channels';
+import { getClickupChannelMessages } from './lib/actions/chat/get-channel-messages';
+import { createClickupChannel } from './lib/actions/chat/create-channel';
+import { createClickupChannelInSpaceFolderOrList } from './lib/actions/chat/create-channel-in-space-folder-list';
+import { getClickupChannel } from './lib/actions/chat/get-channel';
+import { createClickupMessage } from './lib/actions/chat/create-message';
+import { createClickupMessageReply } from './lib/actions/chat/create-message-reply';
+import { createClickupMessageReaction } from './lib/actions/chat/create-message-reaction';
+import { getClickupMessageReactions } from './lib/actions/chat/get-message-reactions';
+import { getClickupMessageReplies } from './lib/actions/chat/get-message-replies';
+import { updateClickupMessage } from './lib/actions/chat/update-message';
+import { deleteClickupMessage } from './lib/actions/chat/delete-message';
+import { deleteClickupMessageReaction } from './lib/actions/chat/delete-message-reaction';
 
 export const clickupAuth = PieceAuth.OAuth2({
   description: '',
@@ -44,14 +57,26 @@ export const clickup = createPiece({
     createClickupFolderlessList,
     createClickupTaskComment,
     createClickupSubtask,
+    createClickupChannel,
+    createClickupChannelInSpaceFolderOrList,
+    createClickupMessage,
+    createClickupMessageReaction,
+    createClickupMessageReply,
     getClickupList,
     getClickupTask,
     getClickupSpace,
     getClickupSpaces,
     getClickupTaskComments,
+    getClickupChannel,
+    getClickupChannels,
+    getClickupChannelMessages,
+    getClickupMessageReactions,
+    getClickupMessageReplies,
     filterClickupWorkspaceTasks,
     filterClickupWorkspaceTimeEntries,
     updateClickupTask,
+    updateClickupMessage,
+    deleteClickupMessage,
     deleteClickupTask,
     getClickupAccessibleCustomFields,
     setClickupCustomFieldValue,

--- a/packages/pieces/community/clickup/src/index.ts
+++ b/packages/pieces/community/clickup/src/index.ts
@@ -35,6 +35,7 @@ import { getClickupMessageReplies } from './lib/actions/chat/get-message-replies
 import { updateClickupMessage } from './lib/actions/chat/update-message';
 import { deleteClickupMessage } from './lib/actions/chat/delete-message';
 import { deleteClickupMessageReaction } from './lib/actions/chat/delete-message-reaction';
+import { getClickupTaskByName } from './lib/actions/tasks/get-task-by-name';
 
 export const clickupAuth = PieceAuth.OAuth2({
   description: '',
@@ -64,6 +65,7 @@ export const clickup = createPiece({
     createClickupMessageReply,
     getClickupList,
     getClickupTask,
+    getClickupTaskByName,
     getClickupSpace,
     getClickupSpaces,
     getClickupTaskComments,

--- a/packages/pieces/community/clickup/src/index.ts
+++ b/packages/pieces/community/clickup/src/index.ts
@@ -77,6 +77,7 @@ export const clickup = createPiece({
     updateClickupTask,
     updateClickupMessage,
     deleteClickupMessage,
+    deleteClickupMessageReaction,
     deleteClickupTask,
     getClickupAccessibleCustomFields,
     setClickupCustomFieldValue,

--- a/packages/pieces/community/clickup/src/lib/actions/chat/create-channel-in-space-folder-list.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/create-channel-in-space-folder-list.ts
@@ -1,0 +1,81 @@
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../..';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const createClickupChannelInSpaceFolderOrList = createAction({
+  auth: clickupAuth,
+  name: 'create_channel_in_space_folder_list',
+  description: 'Creates a channel in a ClickUp workspace in a space, folder or list',
+  displayName: 'Create Channel in Space/Folder/List',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    description: Property.ShortText({
+      description: 'Description of the channel',
+      displayName: 'Channel Description',
+      required: false,
+      defaultValue: '',
+    }),
+    topic: Property.ShortText({
+      description: 'Topic of the channel',
+      displayName: 'Channel Topic',
+      required: false,
+      defaultValue: '',
+    }),
+    location: Property.Array({
+      description: 'Location of the channel',
+      displayName: 'Channel Location',
+      required: true,
+      properties: {
+        type: Property.StaticDropdown({
+          description: 'Type of location',
+          displayName: 'Location Type',
+          required: true,
+          options: {
+            options: [
+              { label: 'Folder', value: 'folder' },
+              { label: 'Space', value: 'space' },
+              { label: 'List', value: 'list' },
+            ],
+          },
+          defaultValue: 'folder',
+        }),
+        id: Property.ShortText({
+          description: 'ID of the location',
+          displayName: 'Location ID',
+          required: true,
+        }),
+      },
+    }),
+    // TODO: add user ids
+    visibility: Property.StaticDropdown({
+      description: 'Visibility of the channel',
+      displayName: 'Channel Visibility',
+      required: true,
+      options: {
+        options: [
+          { label: 'Public', value: 'PUBLIC' },
+          { label: 'Private', value: 'PRIVATE' },
+        ],
+      },
+      defaultValue: 'public',
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id,  description, visibility } =
+      configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.POST,
+      `workspaces/${workspace_id}/chat/channels/location`,
+      getAccessTokenOrThrow(configValue.auth),
+      {
+        description,
+        visibility,
+      },
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/create-channel.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/create-channel.ts
@@ -1,0 +1,63 @@
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const createClickupChannel = createAction({
+  auth: clickupAuth,
+  name: 'create_channel',
+  description: 'Creates a channel in a ClickUp workspace',
+  displayName: 'Create Channel',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    name: Property.ShortText({
+      description: 'Name of the channel',
+      displayName: 'Channel Name',
+      required: true,
+      defaultValue: '',
+    }),
+    description: Property.ShortText({
+      description: 'Description of the channel',
+      displayName: 'Channel Description',
+      required: false,
+      defaultValue: '',
+    }),
+    topic: Property.ShortText({
+      description: 'Topic of the channel',
+      displayName: 'Channel Topic',
+      required: false,
+      defaultValue: '',
+    }),
+    // TODO: add user ids
+    visibility: Property.StaticDropdown({
+      description: 'Visibility of the channel',
+      displayName: 'Channel Visibility',
+      required: true,
+      options: {
+        options: [
+          { label: 'Public', value: 'PUBLIC' },
+          { label: 'Private', value: 'PRIVATE' },
+        ],
+      },
+      defaultValue: 'public',
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id, name, description, visibility } =
+      configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.POST,
+      `workspaces/${workspace_id}/chat/channels`,
+      getAccessTokenOrThrow(configValue.auth),
+      {
+        name,
+        description,
+        visibility,
+      },
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/create-message-reaction.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/create-message-reaction.ts
@@ -1,0 +1,37 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const createClickupMessageReaction = createAction({
+  auth: clickupAuth,
+  name: 'create_message_reaction',
+  description: 'Creates a reaction to a message in a ClickUp channel',
+  displayName: 'Create Message Reaction',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    message_id: Property.ShortText({
+      description: 'ID of the message to create reaction for',
+      displayName: 'Message ID',
+      required: true,
+    }),
+    emoji: Property.ShortText({
+      description: 'Emoji to react with',
+      displayName: 'Emoji',
+      required: true,
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id, message_id, emoji } = configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.POST,
+      `workspaces/${workspace_id}/chat/messages/${message_id}/reactions`,
+      getAccessTokenOrThrow(configValue.auth),
+      { emoji },
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/create-message-reply.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/create-message-reply.ts
@@ -1,0 +1,52 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const createClickupMessageReply = createAction({
+  auth: clickupAuth,
+  name: 'create_message_reply',
+  description: 'Creates a reply to a message in a ClickUp channel',
+  displayName: 'Create Message Reply',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    message_id: Property.ShortText({
+      description: 'ID of the message to reply to',
+      displayName: 'Message ID',
+      required: true,
+    }),
+    content: Property.LongText({
+      description: 'Content of the message',
+      displayName: 'Message Content',
+      required: true,
+    }),
+    type: Property.StaticDropdown({
+      description: 'Type of the message',
+      displayName: 'Message Type',
+      required: true,
+      options: {
+        options: [
+          { label: 'Message', value: 'message' },
+          { label: 'Post', value: 'post' },
+        ],
+      },
+      defaultValue: 'message',
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id, message_id, content, type } = configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.POST,
+      `workspaces/${workspace_id}/chat/messages/${message_id}/replies`,
+      getAccessTokenOrThrow(configValue.auth),
+      {
+        content,
+        type,
+      },
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/create-message.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/create-message.ts
@@ -1,0 +1,48 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const createClickupMessage = createAction({
+  auth: clickupAuth,
+  name: 'create_message',
+  description: 'Creates a message in a ClickUp channel',
+  displayName: 'Create Message',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    channel_id: clickupCommon.channel_id(),
+    content: Property.LongText({
+      description: 'Content of the message',
+      displayName: 'Message Content',
+      required: true,
+    }),
+    type: Property.StaticDropdown({
+      description: 'Type of the message',
+      displayName: 'Message Type',
+      required: true,
+      options: {
+        options: [
+          { label: 'Message', value: 'message' },
+          { label: 'Post', value: 'post' },
+        ],
+      },
+      defaultValue: 'message',
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id, channel_id, content, type } = configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.POST,
+      `workspaces/${workspace_id}/chat/channels/${channel_id}/messages`,
+      getAccessTokenOrThrow(configValue.auth),
+      {
+        content,
+        type,
+      },
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/delete-message-reaction.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/delete-message-reaction.ts
@@ -1,0 +1,37 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const deleteClickupMessageReaction = createAction({
+  auth: clickupAuth,
+  name: 'delete_message_reaction',
+  description: 'Deletes a reaction from a message in a ClickUp channel',
+  displayName: 'Delete Message Reaction',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    message_id: Property.ShortText({
+      description: 'ID of the message to delete reaction from',
+      displayName: 'Message ID',
+      required: true,
+    }),
+    reaction_id: Property.ShortText({
+      description: 'ID of the reaction to delete',
+      displayName: 'Reaction ID',
+      required: true,
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id, message_id, reaction_id } = configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.DELETE,
+      `workspaces/${workspace_id}/chat/messages/${message_id}/reactions/${reaction_id}`,
+      getAccessTokenOrThrow(configValue.auth),
+      {},
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/delete-message.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/delete-message.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const deleteClickupMessage = createAction({
+  auth: clickupAuth,
+  name: 'delete_message',
+  description: 'Deletes a message in a ClickUp channel',
+  displayName: 'Delete Message',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    message_id: Property.ShortText({
+      description: 'ID of the message to delete',
+      displayName: 'Message ID',
+      required: true,
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id, message_id } = configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.DELETE,
+      `workspaces/${workspace_id}/chat/messages/${message_id}`,
+      getAccessTokenOrThrow(configValue.auth),
+      {},
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/get-channel-messages.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/get-channel-messages.ts
@@ -1,0 +1,64 @@
+import { Property } from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  getAccessTokenOrThrow,
+  propsValidation,
+} from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+import { z } from 'zod';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getClickupChannelMessages = createAction({
+  auth: clickupAuth,
+  name: 'get_channel_messages',
+  description: 'Gets all messages in a ClickUp channel',
+  displayName: 'Get Channel Messages',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    channel_id: clickupCommon.channel_id(),
+    limit: Property.Number({
+      description: 'Limit the number of messages returned',
+      displayName: 'Limit',
+      required: false,
+      defaultValue: 50,
+    }),
+    content_format: Property.StaticDropdown({
+      description: 'Format the content of the messages',
+      displayName: 'Format Content',
+      required: false,
+      options: {
+        options: [
+          { label: 'Markdown', value: 'text/md' },
+          { label: 'Plain Text', value: 'text/plain' },
+        ],
+      },
+      defaultValue: 'text/md',
+    }),
+  },
+
+  async run(configValue) {
+    await propsValidation.validateZod(configValue.propsValue, {
+      limit: z
+        .number()
+        .min(0)
+        .max(100, 'You can fetch between 1 and 100 messages'),
+    });
+
+    const { workspace_id, channel_id, limit, content_format } =
+      configValue.propsValue;
+
+    const response = await callClickUpApi3(
+      HttpMethod.GET,
+      `workspaces/${workspace_id}/chat/channels/${channel_id}/messages`,
+      getAccessTokenOrThrow(configValue.auth),
+      undefined,
+      {
+        limit,
+        content_format,
+      }
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/get-channel.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/get-channel.ts
@@ -1,0 +1,27 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const getClickupChannel = createAction({
+  auth: clickupAuth,
+  name: 'get_channel',
+  description: 'Gets a channel in a ClickUp workspace',
+  displayName: 'Get Channel',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    channel_id: clickupCommon.channel_id(),
+  },
+  
+  async run(configValue) {
+    const { workspace_id, channel_id } = configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.GET,
+      `workspaces/${workspace_id}/chat/channels/${channel_id}`,
+      getAccessTokenOrThrow(configValue.auth),
+      undefined,
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/get-channels.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/get-channels.ts
@@ -1,0 +1,56 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  getAccessTokenOrThrow,
+  propsValidation,
+} from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+import { z } from 'zod';
+
+export const getClickupChannels = createAction({
+  auth: clickupAuth,
+  name: 'get_channels',
+  description: 'Gets all channels in a ClickUp workspace',
+  displayName: 'Get Channels',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    include_hidden: Property.Checkbox({
+      description: 'Include hidden channels',
+      displayName: 'Include Hidden',
+      required: false,
+      defaultValue: false,
+    }),
+    limit: Property.Number({
+      description: 'Limit the number of channels returned',
+      displayName: 'Limit',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+
+  async run(configValue) {
+    await propsValidation.validateZod(configValue.propsValue, {
+      limit: z
+        .number()
+        .min(0)
+        .max(100, 'You can fetch between 1 and 100 messages'),
+    });
+
+    const { workspace_id, include_hidden, limit } = configValue.propsValue;
+
+    const response = await callClickUpApi3(
+      HttpMethod.GET,
+      `workspaces/${workspace_id}/chat/channels`,
+      getAccessTokenOrThrow(configValue.auth),
+      undefined,
+      {
+        limit,
+        is_follower: false,
+        include_hidden,
+      }
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/get-message-reactions.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/get-message-reactions.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const getClickupMessageReactions = createAction({
+  auth: clickupAuth,
+  name: 'get_message_reactions',
+  description: 'Gets the reactions of a message in a ClickUp channel',
+  displayName: 'Get Message Reactions',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    message_id: Property.ShortText({
+      description: 'ID of the message to get reactions for',
+      displayName: 'Message ID',
+      required: true,
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id, message_id } = configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.GET,
+      `workspaces/${workspace_id}/chat/messages/${message_id}/reactions`,
+      getAccessTokenOrThrow(configValue.auth),
+      {},
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/get-message-replies.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/get-message-replies.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const getClickupMessageReplies = createAction({
+  auth: clickupAuth,
+  name: 'get_message_replies',
+  description: 'Gets the replies of a message in a ClickUp channel',
+  displayName: 'Get Message Replies',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    message_id: Property.ShortText({
+      description: 'ID of the message to get replies for',
+      displayName: 'Message ID',
+      required: true,
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id, message_id } = configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.GET,
+      `workspaces/${workspace_id}/chat/messages/${message_id}/replies`,
+      getAccessTokenOrThrow(configValue.auth),
+      {},
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/chat/update-message.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/chat/update-message.ts
@@ -1,0 +1,51 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi3, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const updateClickupMessage = createAction({
+  auth: clickupAuth,
+  name: 'update_message',
+  description: 'Updates a message in a ClickUp channel',
+  displayName: 'Update Message',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    message_id: Property.ShortText({
+      description: 'ID of the message to update',
+      displayName: 'Message ID',
+      required: true,
+    }),
+    content: Property.LongText({
+      description: 'Content of the message',
+      displayName: 'Message Content',
+      required: true,
+    }),
+    content_format: Property.StaticDropdown({
+      description: 'Format of the message content',
+      displayName: 'Message Content Format',
+      required: true,
+      options: {
+        options: [
+          { label: 'Markdown', value: 'text/md' },
+          { label: 'Plain Text', value: 'text/plain' },
+        ],
+      },
+    }),
+  },
+
+  async run(configValue) {
+    const { workspace_id,  message_id, content, content_format } = configValue.propsValue;
+    const response = await callClickUpApi3(
+      HttpMethod.PATCH,
+      `workspaces/${workspace_id}/chat/messages/${message_id}`,
+      getAccessTokenOrThrow(configValue.auth),
+      {
+        content,
+        content_format,
+      },
+      {}
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/spaces/get-space.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/spaces/get-space.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
 
-import { callClickUpApi } from '../../common';
+import { callClickUpApi, clickupCommon } from '../../common';
 import { clickupAuth } from '../../../';
 
 export const getClickupSpace = createAction({
@@ -10,11 +10,7 @@ export const getClickupSpace = createAction({
   description: 'Gets a space in a ClickUp',
   displayName: 'Get Space',
   props: {
-    space_id: Property.ShortText({
-      description: 'The id of the space to get',
-      displayName: 'Space ID',
-      required: true,
-    }),
+    space_id: clickupCommon.space_id(),
   },
   async run(configValue) {
     const { space_id } = configValue.propsValue;

--- a/packages/pieces/community/clickup/src/lib/actions/tasks/get-task-by-name.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/tasks/get-task-by-name.ts
@@ -1,0 +1,57 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi, clickupCommon } from '../../common';
+import { clickupAuth } from '../../../';
+
+export const getClickupTaskByName = createAction({
+  auth: clickupAuth,
+  name: 'get_task_by_name',
+  description: 'Fetches a task by name in a ClickUp list',
+  displayName: 'Get Task by Name',
+  props: {
+    workspace_id: clickupCommon.workspace_id(),
+    space_id: clickupCommon.space_id(),
+    list_id: clickupCommon.list_id(),
+    task_name: Property.ShortText({
+      description: 'The name of the task to find',
+      displayName: 'Task Name',
+      required: true,
+    }),
+  },
+  async run(configValue) {
+    const { list_id, task_name } = configValue.propsValue;
+    const accessToken = getAccessTokenOrThrow(configValue.auth);
+
+    let page = 0;
+    const pageSize = 100;
+    let hasMorePages = true;
+
+    while (hasMorePages) {
+      const response = await callClickUpApi(
+        HttpMethod.GET,
+        `list/${list_id}/task`,
+        accessToken,
+        undefined,
+        { page, limit: pageSize }
+      );
+
+
+      const tasks = response.body.tasks;
+
+      if (!tasks || tasks.length === 0) {
+        hasMorePages = false;
+        break;
+      }
+
+      const matchingTask = tasks.find((task: any) => task.name === task_name);
+
+      if (matchingTask) {
+        return matchingTask;
+      }
+
+      page++;
+    }
+
+    throw new Error(`Task with name "${task_name}" not found in list "${list_id}".`);
+  },
+});

--- a/packages/pieces/community/clickup/src/lib/actions/tasks/get-task.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/tasks/get-task.ts
@@ -1,8 +1,7 @@
-import { Property, createAction } from "@activepieces/pieces-framework";
-import { HttpMethod, getAccessTokenOrThrow } from "@activepieces/pieces-common";
-import { callClickUpApi } from "../../common";
-import { clickupAuth } from "../../../";
-
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { callClickUpApi } from '../../common';
+import { clickupAuth } from '../../../';
 
 export const getClickupTask = createAction({
   auth: clickupAuth,
@@ -11,16 +10,26 @@ export const getClickupTask = createAction({
   displayName: 'Get Task',
   props: {
     task_id: Property.ShortText({
-      description: 'The id of the tas to get',
+      description: 'The ID of the task to get',
       displayName: 'Task ID',
       required: true,
-  }),
+    }),
+    include_subtasks: Property.Checkbox({
+      description: 'Include subtasks in the response',
+      displayName: 'Include Subtasks',
+      required: false,
+      defaultValue: false,
+    }),
   },
   async run(configValue) {
     const { task_id } = configValue.propsValue;
-    const response = await callClickUpApi(HttpMethod.GET,
-      `task/${task_id}`, getAccessTokenOrThrow(configValue.auth), {
-    });
+
+    const response = await callClickUpApi(
+      HttpMethod.GET,
+      `task/${task_id}`,
+      getAccessTokenOrThrow(configValue.auth),
+      undefined
+    );
 
     return response.body;
   },

--- a/packages/pieces/community/clickup/src/lib/common/index.ts
+++ b/packages/pieces/community/clickup/src/lib/common/index.ts
@@ -611,6 +611,11 @@ export async function callClickUpApi<T extends HttpMessageBody = any>(
   queryParams: any | undefined = undefined,
   headers: any | undefined = undefined
 ): Promise<HttpResponse<T>> {
+  headers = {
+    accept: 'application/json',
+    ...headers,
+  };
+
   return await httpClient.sendRequest<T>({
     method: method,
     url: `https://api.clickup.com/api/v2/${apiUrl}`,
@@ -619,7 +624,7 @@ export async function callClickUpApi<T extends HttpMessageBody = any>(
       token: accessToken,
     },
     headers,
-    body,
+    body: method === 'GET' ? undefined : body,
     queryParams,
   });
 }
@@ -632,8 +637,6 @@ export async function callClickUpApi3<T extends HttpMessageBody = any>(
   queryParams: any | undefined = undefined,
   headers: any | undefined = {}
 ): Promise<HttpResponse<T>> {
-  console.log(accessToken);
-
   headers = {
     accept: 'application/json',
     ...headers,
@@ -647,7 +650,7 @@ export async function callClickUpApi3<T extends HttpMessageBody = any>(
       token: accessToken,
     },
     headers,
-    body,
+    body: method === 'GET' ? undefined : body,
     queryParams,
   });
 }

--- a/packages/pieces/community/clickup/src/lib/common/models.ts
+++ b/packages/pieces/community/clickup/src/lib/common/models.ts
@@ -27,6 +27,7 @@ export const enum ClickupEventType {
   KEY_RESULT_CREATED = 'keyResultCreated',
   KEY_RESULT_UPDATED = 'keyResultUpdated',
   KEY_RESULT_DELETED = 'keyResultDeleted',
+  AUTOMATION_CREATED = 'automationCreated',
 }
 
 export interface ClickupTask {

--- a/packages/pieces/community/clickup/src/lib/triggers/index.ts
+++ b/packages/pieces/community/clickup/src/lib/triggers/index.ts
@@ -66,6 +66,7 @@ export const sampleTask = {
 };
 
 export const triggers = [
+  // task created
   {
     name: 'task_created',
     eventType: ClickupEventType.TASK_CREATED,
@@ -99,6 +100,7 @@ export const triggers = [
       webhook_id: '9b2708b6-87e8-4fff-851a-2ebf0e35130f',
     },
   },
+  // task updated
   {
     name: 'task_updated',
     eventType: ClickupEventType.TASK_UPDATED,
@@ -132,6 +134,7 @@ export const triggers = [
       webhook_id: 'c065bdfd-eb7a-48dc-b25e-0cf5babf5ec8',
     },
   },
+  // task deleted
   {
     name: 'task_deleted',
     eventType: ClickupEventType.TASK_DELETED,
@@ -143,6 +146,264 @@ export const triggers = [
       webhook_id: '78674f1e-ec8e-4302-908f-4190bdcfdf6a',
     },
   },
+  // task priority updated
+  {
+    name: 'task_priority_updated',
+    eventType: ClickupEventType.TASK_PRIORITY_UPDATED,
+    displayName: "Task Priority Updated",
+    description: 'Triggered when a task priority is updated.',
+    sampleData: {
+      "event": "taskPriorityUpdated",
+      "history_items": [
+        {
+          "id": "2800773800802162647",
+          "type": 1,
+          "date": "1642735267148",
+          "field": "priority",
+          "parent_id": "162641062",
+          "data": {},
+          "source": null,
+          "user": {
+            "id": 183,
+            "username": "John",
+            "email": "john@company.com",
+            "color": "#7b68ee",
+            "initials": "J",
+            "profilePicture": null
+          },
+          "before": null,
+          "after": {
+            "id": "2",
+            "priority": "high",
+            "color": "#ffcc00",
+            "orderindex": "2"
+          }
+        }
+      ],
+      "task_id": "1vj38vv",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // task status updated
+  {
+    name: 'task_status_updated',
+    eventType: ClickupEventType.TASK_STATUS_UPDATED,
+    displayName: 'Task Status Updated',
+    description: 'Triggered when a task status is updated.',
+    sampleData: {
+      "event": "taskStatusUpdated",
+      "history_items": [
+        {
+          "id": "2800787326392370170",
+          "type": 1,
+          "date": "1642736073330",
+          "field": "status",
+          "parent_id": "162641062",
+          "data": {
+            "status_type": "custom"
+          },
+          "source": null,
+          "user": {
+                "id": 183,
+                "username": "John",
+                "email": "john@company.com",
+                "color": "#7b68ee",
+                "initials": "J",
+                "profilePicture": null
+          },
+          "before": {
+            "status": "to do",
+            "color": "#f9d900",
+            "orderindex": 0,
+            "type": "open"
+          },
+          "after": {
+            "status": "in progress",
+            "color": "#7C4DFF",
+            "orderindex": 1,
+            "type": "custom"
+          }
+        }
+      ],
+      "task_id": "1vj38vv",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // task assignee updated
+  {
+    name: 'task_assignee_updated',
+    eventType: ClickupEventType.TASK_ASSIGNEE_UPDATED,
+    displayName: 'Task Assignee Updated',
+    description: 'Triggered when a task assignee is updated.',
+    sampleData: {
+      "event": "taskAssigneeUpdated",
+      "history_items": [
+        {
+          "id": "2800789353868594308",
+          "type": 1,
+          "date": "1642736194135",
+          "field": "assignee_add",
+          "parent_id": "162641062",
+          "data": {},
+          "source": null,
+          "user": {
+            "id": 183,
+            "username": "John",
+            "email": "john@company.com",
+            "color": "#7b68ee",
+            "initials": "J",
+            "profilePicture": null
+          },
+          "after": {
+            "id": 184,
+            "username": "Sam",
+            "email": "sam@company.com",
+            "color": "#7b68ee",
+            "initials": "S",
+            "profilePicture": null
+          }
+        }
+      ],
+      "task_id": "1vj38vv",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // task due date updated
+  {
+    name: 'task_due_date_updated',
+    eventType: ClickupEventType.TASK_DUEDATE_UPDATED,
+    displayName: 'Task Due Date Updated',
+    description: 'Triggered when a task due date is updated.',
+    sampleData: {
+      "event": "taskDueDateUpdated",
+      "history_items": [
+        {
+          "id": "2800792714143635886",
+          "type": 1,
+          "date": "1642736394447",
+          "field": "due_date",
+          "parent_id": "162641062",
+          "data": {
+            "due_date_time": true,
+            "old_due_date_time": false
+          },
+          "source": null,
+          "user": {
+            "id": 183,
+            "username": "John",
+            "email": "john@company.com",
+            "color": "#7b68ee",
+            "initials": "J",
+            "profilePicture": null
+          },
+          "before": "1642701600000",
+          "after": "1643608800000"
+        }
+      ],
+      "task_id": "1vj38vv",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // task tag updated
+  {
+    name: 'task_tag_updated',
+    eventType: ClickupEventType.TASK_TAG_UPDATED,
+    displayName: 'Task Tag Updated',
+    description: 'Triggered when a task tag is updated.',
+    sampleData: {
+      "event": "taskTagUpdated",
+      "history_items": [
+        {
+          "id": "2800797048554170804",
+          "type": 1,
+          "date": "1642736652800",
+          "field": "tag",
+          "parent_id": "162641062",
+          "data": {},
+          "source": null,
+          "user": {
+            "id": 183,
+            "username": "John",
+            "email": "john@company.com",
+            "color": "#7b68ee",
+            "initials": "J",
+            "profilePicture": null
+          },
+          "before": null,
+          "after": [
+            {
+              "name": "def",
+              "tag_fg": "#FF4081",
+              "tag_bg": "#FF4081",
+              "creator": 2770032
+            }
+          ]
+        }
+      ],
+      "task_id": "1vj38vv",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // task moved
+  {
+    name: 'task_moved',
+    eventType: ClickupEventType.TASK_MOVED,
+    displayName: 'Task Moved',
+    description: 'Triggered when a task is moved.',
+    sampleData: {
+      "event": "taskMoved",
+      "history_items": [
+        {
+          "id": "2800800851630274181",
+          "type": 1,
+          "date": "1642736879339",
+          "field": "section_moved",
+          "parent_id": "162641285",
+          "data": {
+            "mute_notifications": true
+          },
+          "source": null,
+          "user": {
+            "id": 183,
+            "username": "John",
+            "email": "john@company.com",
+            "color": "#7b68ee",
+            "initials": "J",
+            "profilePicture": null
+          },
+          "before": {
+            "id": "162641062",
+            "name": "Webhook payloads",
+            "category": {
+              "id": "96771950",
+              "name": "hidden",
+              "hidden": true
+            },
+            "project": {
+              "id": "7002367",
+              "name": "This is my API Space"
+            }
+          },
+          "after": {
+            "id": "162641285",
+            "name": "webhook payloads 2",
+            "category": {
+              "id": "96772049",
+              "name": "hidden",
+              "hidden": true
+            },
+            "project": {
+              "id": "7002367",
+              "name": "This is my API Space"
+            }
+          }
+        }
+      ],
+      "task_id": "1vj38vv",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // task comment posted
   {
     name: 'task_comment_posted',
     eventType: ClickupEventType.TASK_COMMENT_POSTED,
@@ -182,6 +443,7 @@ export const triggers = [
       webhook_id: '6a86ce24-6276-4315-87f7-b580a9264284',
     },
   },
+  // task comment updated
   {
     name: 'task_comment_updated',
     eventType: ClickupEventType.TASK_COMMENT_UPDATED,
@@ -221,6 +483,99 @@ export const triggers = [
       webhook_id: '1c14c8af-5509-4d81-ae7f-c0790c0f9683',
     },
   },
+  // task time estimate updated
+  {
+    name: 'task_time_estimate_updated',
+    eventType: ClickupEventType.TASK_TIME_ESTIMATE_UPDATED,
+    displayName: 'Task Time Estimate Updated',
+    description: 'Triggered when a task time estimate is updated.',
+    sampleData: {
+      "event": "taskTimeEstimateUpdated",
+      "history_items": [
+        {
+          "id": "2800808904123520175",
+          "type": 1,
+          "date": "1642737359443",
+          "field": "time_estimate",
+          "parent_id": "162641285",
+          "data": {
+            "time_estimate_string": "1 hour 30 minutes",
+            "old_time_estimate_string": null,
+            "rolled_up_time_estimate": 5400000,
+            "time_estimate": 5400000,
+            "time_estimates_by_user": [
+              {
+                "userid": 2770032,
+                "user_time_estimate": "5400000",
+                "user_rollup_time_estimate": "5400000"
+              }
+            ]
+          },
+          "source": null,
+          "user": {
+                "id": 183,
+                "username": "John",
+                "email": "john@company.com",
+                "color": "#7b68ee",
+                "initials": "J",
+                "profilePicture": null
+          },
+          "before": null,
+          "after": "5400000"
+        }
+      ],
+      "task_id": "1vj38vv",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // task time tracked updated
+  {
+    name: 'task_time_tracked_updated',
+    eventType: ClickupEventType.TASK_TIME_TRACKED_UPDATED,
+    displayName: 'Task Time Tracked Updated',
+    description: 'Triggered when a task time tracked is updated.',
+    sampleData: {
+      "event": "taskTimeTrackedUpdated",
+      "history_items": [
+        {
+          "id": "2800809188061123931",
+          "type": 1,
+          "date": "1642737376354",
+          "field": "time_spent",
+          "parent_id": "162641285",
+          "data": {
+            "total_time": "900000",
+            "rollup_time": "900000"
+          },
+          "source": null,
+          "user": {
+                "id": 183,
+                "username": "John",
+                "email": "john@company.com",
+                "color": "#7b68ee",
+                "initials": "J",
+                "profilePicture": null
+          },
+          "before": null,
+          "after": {
+            "id": "2800809188061119507",
+            "start": "1642736476215",
+            "end": "1642737376215",
+            "time": "900000",
+            "source": "clickup",
+            "date_added": "1642737376354"
+          }
+        }
+      ],
+      "task_id": "1vj38vv",
+      "data": {
+        "description": "Time Tracking Created",
+        "interval_id": "2800809188061119507"
+      },
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // list created
   {
     name: 'list_created',
     eventType: ClickupEventType.LIST_CREATED,
@@ -231,6 +586,379 @@ export const triggers = [
       list_id: '900201745120',
       webhook_id: 'eda9be69-dbb9-4c59-a3e2-3f871d5d3b9e',
     },
+  },
+  // list updated
+  {
+    name: 'list_updated',
+    eventType: ClickupEventType.LIST_UPDATED,
+    displayName: 'List Updated',
+    description: 'Triggered when a list is updated.',
+    sampleData: {
+      "event": "listUpdated",
+      "history_items": [
+        {
+          "id": "8a2f82db-7718-4fdb-9493-4849e67f009d",
+          "type": 6,
+          "date": "1642740510345",
+          "field": "name",
+          "parent_id": "162641285",
+          "data": {},
+          "source": null,
+          "user": {
+                "id": 183,
+                "username": "John",
+                "email": "john@company.com",
+                "color": "#7b68ee",
+                "initials": "J",
+                "profilePicture": null
+          },
+          "before": "webhook payloads 2",
+          "after": "Webhook payloads round 2"
+        }
+      ],
+      "list_id": "162641285",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // list deleted
+  {
+    name: 'list_deleted',
+    eventType: ClickupEventType.LIST_DELETED,
+    displayName: 'List Deleted',
+    description: 'Triggered when a list is deleted.',
+    sampleData: {
+      "event": "listDeleted",
+      "list_id": "162641062",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // folder created
+  {
+    name: 'folder_created',
+    eventType: ClickupEventType.FOLDER_CREATED,
+    displayName: 'Folder Created',
+    description: 'Triggered when a new folder is created.',
+    sampleData: {
+      "event": "folderCreated",
+      "folder_id": "96772212",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // folder updated
+  {
+    name: 'folder_updated',
+    eventType: ClickupEventType.FOLDER_UPDATED,
+    displayName: 'Folder Updated',
+    description: 'Triggered when a folder is updated.',
+    sampleData: { "event": "folderUpdated",
+      "folder_id": "96772212",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // folder deleted
+  {
+    name: 'folder_deleted',
+    eventType: ClickupEventType.FOLDER_DELETED,
+    displayName: 'Folder Deleted',
+    description: 'Triggered when a folder is deleted.',
+    sampleData: {
+      "event": "listDeleted",
+      "list_id": "162641543",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // space created
+  {
+    name: 'space_created',
+    eventType: ClickupEventType.SPACE_CREATED,
+    displayName: 'Space Created',
+    description: 'Triggered when a new space is created.',
+    sampleData: {
+      "event": "spaceCreated",
+      "space_id": "54650507",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // space updated
+  {
+    name: 'space_updated',
+    eventType: ClickupEventType.SPACE_UPDATED,
+    displayName: 'Space Updated',
+    description: 'Triggered when a space is updated.',
+    sampleData: {
+      "event": "spaceUpdated",
+      "space_id": "54650507",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // space deleted
+  {
+    name: 'space_deleted',
+    eventType: ClickupEventType.SPACE_DELETED,
+    displayName: 'Space Deleted',
+    description: 'Triggered when a space is deleted.',
+    sampleData: {
+      "event": "spaceDeleted",
+      "space_id": "54650507",
+      "webhook_id": "7fa3ec74-69a8-4530-a251-8a13730bd204"
+    }
+  },
+  // automation created
+  {
+    name: 'automation_created',
+    eventType: ClickupEventType.AUTOMATION_CREATED,
+    displayName: 'Automation Created',
+    description: 'Triggered when a new automation is created.',
+    sampleData: {
+      "id": "b4ced072-ae72-4c70-b898-fea5dd142408:main",
+      "trigger_id": "6f612d16-9ff7-4db2-a2f6-19528ee3b90c",
+      "date": "2024-01-11T19:40:17.927Z",
+      "payload": {
+        "id": "8687096vn",
+        "custom_id": "DEF-43",
+        "custom_item_id": 0,
+        "name": "task name",
+        "text_content": "",
+        "description": "",
+        "status": {
+          "id": "p90090203753_p54073272_p54073128_p54071092_p54067915_r9V2QX7O",
+          "status": "complete",
+          "color": "#008844",
+          "orderindex": 1,
+          "type": "closed"
+        },
+        "orderindex": "39906954.00000000000000000000000000000000",
+        "date_created": "1705002014968",
+        "date_updated": "1705002016108",
+        "date_closed": "1705002016108",
+        "date_done": "1705002016108",
+        "archived": false,
+        "creator": {
+          "id": 26191384,
+          "username": "John",
+          "color": "#5f7c8a",
+          "email": "john@company.com",
+          "profilePicture": "https://attachments.clickup.com/profilePictures/26191384_HoB.jpg"
+        },
+        "assignees": [],
+        "watchers": [
+          {
+            "id": 26191384,
+            "username": "John",
+            "color": "#5f7c8a",
+            "initials": "J",
+            "email": "john@company.com",
+            "profilePicture": "https://attachments.clickup.com/profilePictures/26191384_HoB.jpg"
+          }
+        ],
+        "checklists": [],
+        "tags": [],
+        "parent": null,
+        "priority": null,
+        "due_date": null,
+        "start_date": null,
+        "points": null,
+        "time_estimate": null,
+        "time_spent": 0,
+        "custom_fields": [
+          {
+            "id": "ede917d5-4dbb-46eb-9f7c-5d4f0a652b1f",
+            "name": "ijjb",
+            "type": "formula",
+            "type_config": {
+              "version": "1.6",
+              "is_dynamic": false,
+              "return_types": [
+                "null"
+              ],
+              "calculation_state": "ready"
+            },
+            "date_created": "1698260411360",
+            "hide_from_guests": false,
+            "required": false
+          },
+          {
+            "id": "7d979288-84e1-48b0-abaf-238ecb27e0fa",
+            "name": "formula 1",
+            "type": "currency",
+            "type_config": {
+              "default": null,
+              "precision": 2,
+              "currency_type": "USD"
+            },
+            "date_created": "1694298925344",
+            "hide_from_guests": false,
+            "required": false
+          },
+          {
+            "id": "89bbdeeb-6724-4ec0-a8a7-c21d944199a7",
+            "name": "Marketing Task Type",
+            "type": "drop_down",
+            "type_config": {
+              "default": 0,
+              "placeholder": null,
+              "options": [
+                {
+                  "id": "d73a55af-88f5-4161-a948-7341d2bbb045",
+                  "name": "Campaign",
+                  "color": null,
+                  "orderindex": 0
+                },
+                {
+                  "id": "0010111d-91da-4cb7-8cc1-d642f90ef194",
+                  "name": "asd",
+                  "color": null,
+                  "orderindex": 1
+                }
+              ]
+            },
+            "date_created": "1698177406311",
+            "hide_from_guests": false,
+            "required": false
+          },
+          {
+            "id": "07119fd9-e1eb-4457-bc69-3e5913707ca2",
+            "name": "files",
+            "type": "attachment",
+            "type_config": {},
+            "date_created": "1700237528128",
+            "hide_from_guests": false,
+            "required": false
+          },
+          {
+            "id": "60392065-eb67-40c3-afe2-10f288d0695d",
+            "name": "new field",
+            "type": "currency",
+            "type_config": {
+              "precision": 2,
+              "currency_type": "EUR"
+            },
+            "date_created": "1696603471462",
+            "hide_from_guests": true,
+            "required": false
+          }
+        ],
+        "dependencies": [],
+        "linked_tasks": [],
+        "locations": [],
+        "team_id": "36003581",
+        "url": "https://app.clickup.com/t/8687096vn",
+        "sharing": {
+          "public": false,
+          "public_share_expires_on": null,
+          "public_fields": [
+            "assignees",
+            "priority",
+            "due_date",
+            "content",
+            "comments",
+            "attachments",
+            "customFields",
+            "subtasks",
+            "tags",
+            "checklists",
+            "coverimage"
+          ],
+          "token": null,
+          "seo_optimized": false
+        },
+        "list": {
+          "id": "901102008938",
+          "name": "List",
+          "access": true
+        },
+        "project": {
+          "id": "90110993233",
+          "name": "test folder",
+          "hidden": false,
+          "access": true
+        },
+        "folder": {
+          "id": "90110993233",
+          "name": "test folder",
+          "hidden": false,
+          "access": true
+        },
+        "space": {
+          "id": "90090203753"
+        }
+      }
+    }
+  },
+  // goal created
+  {
+    name: 'goal_created',
+    eventType: ClickupEventType.GOAL_CREATED,
+    displayName: 'Goal Created',
+    description: 'Triggered when a new goal is created.',
+    sampleData: {
+      "event": "goalCreated",
+      "goal_id": "a23e5a3d-74b5-44c2-ab53-917ebe85045a",
+      "webhook_id": "d5eddb2d-db2b-49e9-87d4-bc6cfbe2313b"
+    }
+  },
+  // goal updated
+  {
+    name: 'goal_updated',
+    eventType: ClickupEventType.GOAL_UPDATED,
+    displayName: 'Goal Updated',
+    description: 'Triggered when a goal is updated.',
+    sampleData: {
+      "event": "goalUpdated",
+      "goal_id": "a23e5a3d-74b5-44c2-ab53-917ebe85045a",
+      "webhook_id": "d5eddb2d-db2b-49e9-87d4-bc6cfbe2313b"
+    }
+  },
+  // goal deleted
+  {
+    name: 'goal_deleted',
+    eventType: ClickupEventType.GOAL_DELETED,
+    displayName: 'Goal Deleted',
+    description: 'Triggered when a goal is deleted.',
+    sampleData: {
+      "event": "goalDeleted",
+      "goal_id": "a23e5a3d-74b5-44c2-ab53-917ebe85045a",
+      "webhook_id": "d5eddb2d-db2b-49e9-87d4-bc6cfbe2313b"
+    }
+  },
+  // key result created
+  {
+    name: 'key_result_created',
+    eventType: ClickupEventType.KEY_RESULT_CREATED,
+    displayName: 'Key Result Created',
+    description: 'Triggered when a new key result is created.',
+    sampleData: {
+      "event": "keyResultCreated",
+      "goal_id": "a23e5a3d-74b5-44c2-ab53-917ebe85045a",
+      "key_result_id": "47608e42-ad0e-4934-a39e-950539c77e79",
+      "webhook_id": "d5eddb2d-db2b-49e9-87d4-bc6cfbe2313b"
+    }
+  },
+  // key result updated
+  {
+    name: 'key_result_updated',
+    eventType: ClickupEventType.KEY_RESULT_UPDATED,
+    displayName: 'Key Result Updated',
+    description: 'Triggered when a key result is updated.',
+    sampleData: {
+      "event": "keyResultUpdated",
+      "goal_id": "a23e5a3d-74b5-44c2-ab53-917ebe85045a",
+      "key_result_id": "47608e42-ad0e-4934-a39e-950539c77e79",
+      "webhook_id": "d5eddb2d-db2b-49e9-87d4-bc6cfbe2313b"
+    }
+  },
+  // key result deleted
+  {
+    name: 'key_result_deleted',
+    eventType: ClickupEventType.KEY_RESULT_DELETED,
+    displayName: 'Key Result Deleted',
+    description: 'Triggered when a key result is deleted.',
+    sampleData: {
+      "event": "keyResultDeleted",
+      "goal_id": "a23e5a3d-74b5-44c2-ab53-917ebe85045a",
+      "key_result_id": "47608e42-ad0e-4934-a39e-950539c77e79",
+      "webhook_id": "d5eddb2d-db2b-49e9-87d4-bc6cfbe2313b"
+    }
   },
 ].map((props) => clickupRegisterTrigger(props));
 

--- a/packages/pieces/community/clickup/src/lib/triggers/register-trigger.ts
+++ b/packages/pieces/community/clickup/src/lib/triggers/register-trigger.ts
@@ -29,19 +29,32 @@ export const clickupRegisterTrigger = ({
     description,
     props: {
       workspace_id: clickupCommon.workspace_id(true),
+      space_id: clickupCommon.space_id(false), // Optional, depends on workspace
+      folder_id: clickupCommon.folder_id(false), // Optional, depends on space
+      list_id: clickupCommon.list_id(false), // Optional, depends on folder or space
+      task_id: clickupCommon.task_id(false), // Optional, depends on list
     },
     sampleData,
     type: TriggerStrategy.WEBHOOK,
     async onEnable(context) {
-      const { workspace_id } = context.propsValue;
+      const { workspace_id, space_id, folder_id, list_id, task_id } =
+        context.propsValue;
+
+      const requestBody: Record<string, unknown> = {
+        endpoint: context.webhookUrl,
+        events: [eventType],
+      };
+
+      // Add scope narrowing properties to the webhook request body
+      if (space_id) requestBody.space_id = space_id;
+      if (folder_id) requestBody.folder_id = folder_id;
+      if (list_id) requestBody.list_id = list_id;
+      if (task_id) requestBody.task_id = task_id;
 
       const request: HttpRequest = {
         method: HttpMethod.POST,
         url: `https://api.clickup.com/api/v2/team/${workspace_id}/webhook`,
-        body: {
-          endpoint: context.webhookUrl,
-          events: [eventType],
-        },
+        body: requestBody,
         authentication: {
           type: AuthenticationType.BEARER_TOKEN,
           token: context.auth.access_token,
@@ -114,10 +127,10 @@ interface WebhookInformation {
     endpoint: string;
     client_id: string;
     events: ClickupEventType[];
-    task_id: string;
-    list_id: string;
-    folder_id: string;
-    space_id: string;
+    task_id?: string;
+    list_id?: string;
+    folder_id?: string;
+    space_id?: string;
     health: {
       status: string;
       fail_count: number;


### PR DESCRIPTION
## What does this PR do?

- adds a trigger for every relevant section of the webhooks api
- allows triggers to be filtered down to task level
- add a piece for finding tasks based on their name
- add what I would consider to be the most frequently used functions based on the new ClickUp Chat API

Still going through testing but I believe the code to be mostly complete at this point