### PR TITLE
feat(metabase): new action get graph

### DIFF
--- a/packages/pieces/community/metabase/package.json
+++ b/packages/pieces/community/metabase/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-metabase",
-  "version": "0.1.5"
+  "version": "0.1.6"
 }

--- a/packages/pieces/community/metabase/src/index.ts
+++ b/packages/pieces/community/metabase/src/index.ts
@@ -8,9 +8,10 @@ import { getQuestionPngPreview } from './lib/actions/get-png-rendering';
 import { getDashboardQuestions } from './lib/actions/get-dashboard';
 import { queryMetabaseApi } from './lib/common';
 import { HttpMethod } from '@activepieces/pieces-common';
+import { getGraphQuestion } from './lib/actions/get-graph-question';
 
 export const metabaseAuth = PieceAuth.CustomAuth({
-  description: 'Metabase authentication requires a username and password.',
+  description: 'Metabase authentication requires a baseUrl and a password.',
   required: true,
   props: {
     baseUrl: Property.ShortText({
@@ -22,6 +23,12 @@ export const metabaseAuth = PieceAuth.CustomAuth({
       description:
         'Generate one on your Metabase instance (settings -> authentication -> API keys)',
       required: true,
+    }),
+    embeddingKey: Property.ShortText({
+      displayName: 'Embedding key',
+      description:
+        'Needed if you want to generate a graph of a question (settings -> embedding -> static embedding).',
+      required: false,
     }),
   },
 
@@ -52,7 +59,12 @@ export const metabase = createPiece({
   auth: metabaseAuth,
   minimumSupportedRelease: '0.30.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/metabase.png',
-  authors: ['AdamSelene', 'abuaboud', 'valentin-mourtialon'],
-  actions: [getQuestion, getQuestionPngPreview, getDashboardQuestions],
+  authors: ['AdamSelene', 'abuaboud', 'valentin-mourtialon', 'Kevinyu-alan'],
+  actions: [
+    getQuestion,
+    getQuestionPngPreview,
+    getDashboardQuestions,
+    getGraphQuestion,
+  ],
   triggers: [],
 });

--- a/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
+++ b/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
@@ -1,0 +1,105 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { metabaseAuth } from '../..';
+import jwt from 'jsonwebtoken';
+import puppeteer from 'puppeteer';
+
+export const getGraphQuestion = createAction({
+  name: 'getGraphQuestion',
+  auth: metabaseAuth,
+  requireAuth: true,
+  displayName: 'Get the graph of the question',
+  description: 'Get the graph of a Metabase question and save it as a png',
+  props: {
+    questionId: Property.ShortText({
+      displayName: 'Metabase question ID',
+      required: true,
+    }),
+    parameters: Property.Object({
+      displayName: 'Parameters (slug name -> value)',
+      required: false,
+    }),
+    graphName: Property.ShortText({
+      displayName: 'The name of the graph (without the extension)',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue, files }) {
+    if (!auth.embeddingKey) return 'An embedding key is needed.';
+
+    const questionId = propsValue.questionId.split('-')[0];
+    const numericQuestionId = parseInt(questionId);
+
+    const payload = {
+      resource: { question: numericQuestionId },
+      params: propsValue.parameters,
+      exp: Math.round(Date.now() / 1000) + 10 * 60,
+    };
+
+    const token = jwt.sign(payload, auth.embeddingKey);
+    const graphName = propsValue.graphName
+      ? propsValue.graphName + '.png'
+      : `metabase_question_${questionId}.png`;
+
+    const iframeUrl =
+      auth.baseUrl + '/embed/question/' + token + '#bordered=true&titled=true';
+
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+
+    try {
+      const page = await browser.newPage();
+
+      await page.setViewport({
+        width: 1600,
+        height: 1200,
+        deviceScaleFactor: 2,
+      });
+
+      const response = await page.goto(iframeUrl, {
+        waitUntil: 'networkidle0',
+        timeout: 30000,
+      });
+
+      if (!response || !response.ok()) {
+        throw new Error(
+          `Page load failed with status: ${response ? response.status() : 400}`
+        );
+      }
+
+      const screenshotBuffer = await page.screenshot({
+        path: graphName,
+        type: 'png',
+        clip: {
+          x: 0,
+          y: 0,
+          width: 1600,
+          height: 1120, // so it screenshots only the graph
+        },
+      });
+
+      const fileUrl = await files.write({
+        fileName: graphName,
+        data: screenshotBuffer,
+      });
+
+      return {
+        file: {
+          filename: graphName,
+          base64Content: screenshotBuffer.toString('base64'),
+          download: fileUrl,
+        },
+        iframeUrl,
+      };
+    } catch (error) {
+      console.error(
+        'Please verify that either your embedding key, question id are valid or if the question is embed and published.'
+      );
+      console.error('Error capturing Metabase chart:', error);
+      throw error;
+    } finally {
+      await browser.close();
+    }
+  },
+});

--- a/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
+++ b/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
@@ -94,7 +94,7 @@ export const getGraphQuestion = createAction({
       };
     } catch (error) {
       console.error(
-        'Please verify that either your embedding key, question id are valid or if the question is embed and published.'
+        'Please verify that either your embedding key and question id are valid or that the question is embedded and published.'
       );
       console.error('Error capturing Metabase chart:', error);
       throw error;


### PR DESCRIPTION
## What does this PR do?

Add a new action for metabase that allows to get the graph of a question and download it.
This is only a V1 and we might change the way we do that by parsing the HTML later. I'm waiting confirmations to know if this is enough.
There's already an action for that, but the result and method are different. Let's keep both actions until this one works perfectly.

For that we need an embedding key and that the question is embed (only possible with an admin).
I put the embedding key as a ShortText instead of a SecretText because SecretText are all mandatory (even if the required is false). But by doing this, the field isn't hidden with dots, can be an issue.

Fixes Q-1275
