### PR TITLE
feat: add due date property to new task action

### DIFF
--- a/packages/pieces/community/google-tasks/src/lib/actions/new-task.ts
+++ b/packages/pieces/community/google-tasks/src/lib/actions/new-task.ts
@@ -11,6 +11,7 @@ export const googleTasksAddNewTaskAction = createAction({
     tasks_list: googleTasksCommon.tasksList,
     title: googleTasksCommon.title,
     notes: googleTasksCommon.notes,
+    due: googleTasksCommon.due,
     completed: googleTasksCommon.completed,
   },
   async run({ auth, propsValue }) {
@@ -22,6 +23,9 @@ export const googleTasksAddNewTaskAction = createAction({
       title: propsValue.title,
       completed: propsValue.completed ? new Date().toISOString() : '',
       notes: propsValue.notes,
+      due: propsValue.due
+        ? `${new Date(propsValue.due).toISOString().split('T')[0]}T00:00:00Z`
+        : undefined,
     };
 
     return createTask(auth, propsValue.tasks_list!, task);

--- a/packages/pieces/community/google-tasks/src/lib/common/index.ts
+++ b/packages/pieces/community/google-tasks/src/lib/common/index.ts
@@ -95,6 +95,12 @@ export const googleTasksCommon = {
     displayName: 'Notes',
     required: false,
   }),
+  due: Property.DateTime({
+    displayName: 'Due Date',
+    description: 'Due date of the task (YYYY-MM-DD)',
+    required: false,
+    defaultValue: new Date().toISOString(),
+  }),
   completed: Property.Checkbox({
     displayName: 'Completed',
     description: 'Mark task as completed',


### PR DESCRIPTION
## What does this PR do?
This PR adds support for setting the Due Date when creating a Google Task in Activepieces, based on the feature request #7398.
	•	New field: Due On
	•	Now users can optionally specify a due date when creating a Google Task through Activepieces.
	•	Matching functionality similar to Zapier’s Google Tasks integration.


### Explain How the Feature Works
•	In the Create Google Task action:
	•	A new optional input field “Due On” has been added.
	•	Users can either:
	•	Leave it blank (task will have no due date), or
	•	Provide a valid date (e.g., 2025-04-30) to set a due date for the task.

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes #7398
