### PR TITLE
feat(piece): add BlackBlaze Bucket Piece

### DIFF
--- a/packages/pieces/community/blackblaze/.eslintrc.json
+++ b/packages/pieces/community/blackblaze/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/blackblaze/README.md
+++ b/packages/pieces/community/blackblaze/README.md
@@ -1,0 +1,7 @@
+# piece-blackblaze
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running lint
+
+Run `nx lint piece-blackblaze` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/pieces/community/blackblaze/package.json
+++ b/packages/pieces/community/blackblaze/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@nhnansari/piece-blackblaze",
+  "version": "0.3.9"
+}

--- a/packages/pieces/community/blackblaze/project.json
+++ b/packages/pieces/community/blackblaze/project.json
@@ -1,0 +1,26 @@
+{
+  "name": "piece-blackblaze",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/blackblaze/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/blackblaze",
+        "tsConfig": "packages/pieces/community/blackblaze/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/blackblaze/package.json",
+        "main": "packages/pieces/community/blackblaze/src/index.ts",
+        "assets": ["packages/pieces/community/blackblaze/*.md"],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/blackblaze/src/index.ts
+++ b/packages/pieces/community/blackblaze/src/index.ts
@@ -1,0 +1,199 @@
+import {
+  PieceAuth,
+  Property,
+  createPiece,
+} from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { readBlackBlazeFile } from './lib/actions/read-file';
+import { blackBlazes3UploadFile } from './lib/actions/upload-file';
+import { createBlackBlazeS3 } from './lib/common';
+import { newBlackBlazeFile } from './lib/triggers/new-file';
+
+const description = `
+This piece allows you to upload files to BlackBlaze Bucket compatible services.
+
+BlackBlaze Settings:
+Regions: https://www.backblaze.com/apidocs/introduction-to-the-s3-compatible-api
+Endpoint: leave blank
+`;
+
+export const blackBlazeS3Auth = PieceAuth.CustomAuth({
+  description: description,
+  props: {
+    accessKeyId: Property.ShortText({
+      displayName: 'Access Key ID',
+      required: true,
+    }),
+    secretAccessKey: PieceAuth.SecretText({
+      displayName: 'Secret Access Key',
+      required: true,
+    }),
+    bucket: Property.ShortText({
+      displayName: 'Bucket',
+      required: true,
+    }),
+    endpoint: Property.ShortText({
+      displayName: 'Endpoint',
+      required: false,
+    }),
+    region: Property.StaticDropdown({
+      displayName: 'Region',
+      options: {
+        options: [
+          {
+            label: 'Default',
+            value: 'us-east-1',
+          },
+          {
+            label: 'US East (N. Virginia) [us-east-1]',
+            value: 'us-east-1',
+          },
+          {
+            label: 'US East (Ohio) [us-east-2]',
+            value: 'us-east-2',
+          },
+          {
+            label: 'US West (N. California) [us-west-1]',
+            value: 'us-west-1',
+          },
+          {
+            label: 'US West (Oregon) [us-west-2]',
+            value: 'us-west-2',
+          },
+          {
+            label: 'Africa (Cape Town) [af-south-1]',
+            value: 'af-south-1',
+          },
+          {
+            label: 'Asia Pacific (Hong Kong) [ap-east-1]',
+            value: 'ap-east-1',
+          },
+          {
+            label: 'Asia Pacific (Mumbai) [ap-south-1]',
+            value: 'ap-south-1',
+          },
+          {
+            label: 'Asia Pacific (Osaka-Local) [ap-northeast-3]',
+            value: 'ap-northeast-3',
+          },
+          {
+            label: 'Asia Pacific (Seoul) [ap-northeast-2]',
+            value: 'ap-northeast-2',
+          },
+          {
+            label: 'Asia Pacific (Singapore) [ap-southeast-1]',
+            value: 'ap-southeast-1',
+          },
+          {
+            label: 'Asia Pacific (Sydney) [ap-southeast-2]',
+            value: 'ap-southeast-2',
+          },
+          {
+            label: 'Asia Pacific (Tokyo) [ap-northeast-1]',
+            value: 'ap-northeast-1',
+          },
+          {
+            label: 'Canada (Central) [ca-central-1]',
+            value: 'ca-central-1',
+          },
+          {
+            label: 'Europe (Frankfurt) [eu-central-1]',
+            value: 'eu-central-1',
+          },
+          {
+            label: 'Europe (Ireland) [eu-west-1]',
+            value: 'eu-west-1',
+          },
+          {
+            label: 'Europe (London) [eu-west-2]',
+            value: 'eu-west-2',
+          },
+          {
+            label: 'Europe (Milan) [eu-south-1]',
+            value: 'eu-south-1',
+          },
+          {
+            label: 'Europe (Paris) [eu-west-3]',
+            value: 'eu-west-3',
+          },
+          {
+            label: 'Europe (Stockholm) [eu-north-1]',
+            value: 'eu-north-1',
+          },
+          {
+            label: 'Middle East (Bahrain) [me-south-1]',
+            value: 'me-south-1',
+          },
+          {
+            label: 'South America (São Paulo) [sa-east-1]',
+            value: 'sa-east-1',
+          },
+          {
+            label: 'Europe (Spain) [eu-south-2]',
+            value: 'eu-south-2',
+          },
+          {
+            label: 'Asia Pacific (Hyderabad) [ap-south-2]',
+            value: 'ap-south-2',
+          },
+          {
+            label: 'Asia Pacific (Jakarta) [ap-southeast-3]',
+            value: 'ap-southeast-3',
+          },
+          {
+            label: 'Asia Pacific (Melbourne) [ap-southeast-4]',
+            value: 'ap-southeast-4',
+          },
+          {
+            label: 'China (Beijing) [cn-north-1]',
+            value: 'cn-north-1',
+          },
+          {
+            label: 'China (Ningxia) [cn-northwest-1]',
+            value: 'cn-northwest-1',
+          },
+          {
+            label: 'Europe (Zurich) [eu-central-2]',
+            value: 'eu-central-2',
+          },
+          {
+            label: 'Middle East (UAE) [me-central-1]',
+            value: 'me-central-1',
+          },
+        ],
+      },
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    const s3 = createBlackBlazeS3(auth);
+    try {
+      await s3.listObjectsV2({
+        Bucket: auth.bucket,
+        MaxKeys: 1,
+      });
+      return {
+        valid: true,
+      };
+    } catch (e) {
+      return {
+        valid: false,
+        error: (e as Error)?.message,
+      };
+    }
+  },
+  required: true,
+});
+
+export const blackblaze = createPiece({
+  displayName: 'Black Blaze',
+  description: 'Scalable storage in the cloud',
+
+  logoUrl: 'https://companieslogo.com/img/orig/BLZE-59480c3d.png?t=1720244491',
+  minimumSupportedRelease: '0.30.0',
+  authors: ["nhnansari","Willianwg","kishanprmr","MoShizzle","AbdulTheActivePiecer","khaledmashaly","abuaboud"],
+  categories: [PieceCategory.DEVELOPER_TOOLS],
+  auth: blackBlazeS3Auth,
+  actions: [blackBlazes3UploadFile, readBlackBlazeFile],
+  triggers: [newBlackBlazeFile],
+});

--- a/packages/pieces/community/blackblaze/src/lib/actions/read-file.ts
+++ b/packages/pieces/community/blackblaze/src/lib/actions/read-file.ts
@@ -1,0 +1,36 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { S3 } from '@aws-sdk/client-s3';
+import { blackBlazeS3Auth } from '../..';
+import { createBlackBlazeS3 } from '../common';
+
+export const readBlackBlazeFile = createAction({
+  auth: blackBlazeS3Auth,
+  name: 'read-blackblaze-file',
+  displayName: 'Read File',
+  description: 'Read a file from black blaze bucket to use it in other steps',
+  props: {
+    key: Property.ShortText({
+      displayName: 'Key',
+      description: 'The key of the file to read. include extension if file has any extension.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { bucket } = context.auth;
+    const { key } = context.propsValue;
+    const s3 = createBlackBlazeS3(context.auth);
+
+    const file = await s3.getObject({
+      Bucket: bucket,
+      Key: key,
+    });
+    const base64 = await file.Body?.transformToString('base64');
+    if (!base64) {
+      throw new Error(`Could not read file ${key} from bucket`);
+    }
+    return await context.files.write({
+      fileName: key,
+      data: Buffer.from(base64, 'base64'),
+    });
+  },
+});

--- a/packages/pieces/community/blackblaze/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/blackblaze/src/lib/actions/upload-file.ts
@@ -1,0 +1,137 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { blackBlazeS3Auth } from '../..';
+import { createBlackBlazeS3 } from '../common';
+import { ObjectCannedACL } from '@aws-sdk/client-s3';
+
+export const blackBlazes3UploadFile = createAction({
+  auth: blackBlazeS3Auth,
+  name: 'upload-blackblaze-file',
+  displayName: 'Upload File',
+  description: 'Upload an File to bucket',
+  props: {
+    file: Property.File({
+      displayName: 'File',
+      required: true,
+    }),
+    fileName: Property.ShortText({
+      displayName: 'File Name',
+      required: false,
+      description: 'my-file-name (no extension). write full path if you want to store in the directories or sub-directories.',
+    }),
+    acl: Property.StaticDropdown({
+      displayName: 'ACL',
+      required: false,
+      options: {
+        options: [
+          {
+            label: 'private',
+            value: 'private',
+          },
+          {
+            label: 'public-read',
+            value: 'public-read',
+          },
+          {
+            label: 'public-read-write',
+            value: 'public-read-write',
+          },
+          {
+            label: 'authenticated-read',
+            value: 'authenticated-read',
+          },
+          {
+            label: 'aws-exec-read',
+            value: 'aws-exec-read',
+          },
+          {
+            label: 'bucket-owner-read',
+            value: 'bucket-owner-read',
+          },
+          {
+            label: 'bucket-owner-full-control',
+            value: 'bucket-owner-full-control',
+          },
+        ],
+      },
+    }),
+    type: Property.StaticDropdown({
+      displayName: 'Type',
+      required: true,
+      options: {
+        options: [
+          {
+            label: 'image/png',
+            value: 'image/png',
+          },
+          {
+            label: 'image/jpeg',
+            value: 'image/jpeg',
+          },
+          {
+            label: 'image/gif',
+            value: 'image/gif',
+          },
+          {
+            label: 'audio/mpeg',
+            value: 'audio/mpeg',
+          },
+          {
+            label: 'audio/wav',
+            value: 'audio/wav',
+          },
+          {
+            label: 'video/mp4',
+            value: 'video/mp4',
+          },
+          {
+            label: 'application/pdf',
+            value: 'application/pdf',
+          },
+          {
+            label: 'application/msword',
+            value: 'application/msword',
+          },
+          {
+            label: 'text/plain',
+            value: 'text/plain',
+          },
+          {
+            label: 'application/json',
+            value: 'application/json',
+          },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { bucket } = context.auth;
+    const { file, fileName, acl, type } = context.propsValue;
+
+    const s3 = createBlackBlazeS3(context.auth);
+
+    const contentType = type;
+    const [_, ext] = contentType.split('/');
+    const extension = '.' + ext;
+
+    const generatedName = new Date().toISOString() + Date.now() + extension;
+
+    const finalFileName = fileName ? fileName + extension : generatedName;
+
+    const uploadResponse = await s3.putObject({
+      Bucket: bucket,
+      Key: finalFileName,
+      ACL: acl as ObjectCannedACL | undefined,
+      ContentType: contentType,
+      Body: file.data,
+    });
+
+    const endpoint = context.auth.endpoint ? context.auth.endpoint :"";
+    const cleanEndpoint = endpoint.replace("https://","")
+    const url = `https://${bucket}.${cleanEndpoint}/${finalFileName}`
+    return {
+      fileName: finalFileName,
+      etag: uploadResponse.ETag,
+      url: url,
+    };
+  },
+});

--- a/packages/pieces/community/blackblaze/src/lib/common.ts
+++ b/packages/pieces/community/blackblaze/src/lib/common.ts
@@ -1,0 +1,21 @@
+import { isNil } from '@activepieces/shared';
+import { S3 } from '@aws-sdk/client-s3';
+
+export function createBlackBlazeS3(auth: {
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string | undefined;
+  endpoint: string | undefined;
+}) {
+  const s3 = new S3({
+    credentials: {
+      accessKeyId: auth.accessKeyId,
+      secretAccessKey: auth.secretAccessKey,
+    },
+    forcePathStyle: auth.endpoint ? true : undefined,
+    region: auth.region,
+    endpoint:
+      auth.endpoint === '' || isNil(auth.endpoint) ? undefined : auth.endpoint,
+  });
+  return s3;
+}

--- a/packages/pieces/community/blackblaze/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/blackblaze/src/lib/triggers/new-file.ts
@@ -1,0 +1,94 @@
+import {
+  PiecePropValueSchema,
+  Property,
+  createTrigger,
+} from '@activepieces/pieces-framework';
+import { TriggerStrategy } from '@activepieces/pieces-framework';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+
+import { blackBlazeS3Auth } from '../..';
+import { createBlackBlazeS3 } from '../common';
+
+const polling: Polling<
+  PiecePropValueSchema<typeof blackBlazeS3Auth>,
+  { folderPath?: string }
+> = {
+  strategy: DedupeStrategy.LAST_ITEM,
+  items: async ({ auth, lastItemId, propsValue }) => {
+    const s3 = createBlackBlazeS3(auth);
+    const params: any = {
+      Bucket: auth.bucket,
+      MaxKeys: 100,
+      StartAfter: lastItemId,
+    };
+    if (propsValue.folderPath)
+      params.Prefix = `${
+        propsValue.folderPath.endsWith('/')
+          ? propsValue.folderPath.slice(0, -1)
+          : propsValue.folderPath
+      }`;
+
+    const currentValues = (await s3.listObjectsV2(params)).Contents ?? [];
+    const items = (currentValues as any[]).map((item: { Key: string }) => ({
+      id: item.Key,
+      data: item,
+    }));
+    return items;
+  },
+};
+
+export const newBlackBlazeFile = createTrigger({
+  auth: blackBlazeS3Auth,
+  name: 'new_blackblaze_file',
+  displayName: 'New File',
+  description: 'Trigger when a new file is uploaded.',
+  props: {
+    folderPath: Property.ShortText({
+      displayName: 'Folder Path',
+      required: false,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  onEnable: async (context) => {
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  onDisable: async (context) => {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  run: async (context) => {
+    return await pollingHelper.poll(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+  test: async (context) => {
+    return await pollingHelper.test(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue, 
+      files: context.files,
+    });
+  },
+
+  sampleData: {
+    Key: 'myfolder/100-3.png',
+    LastModified: '2023-08-04T13:51:26.000Z',
+    ETag: '"e9f16cce12352322272525f5af65a2e"',
+    Size: 40239,
+    StorageClass: 'STANDARD',
+  },
+});

--- a/packages/pieces/community/blackblaze/tsconfig.json
+++ b/packages/pieces/community/blackblaze/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/blackblaze/tsconfig.lib.json
+++ b/packages/pieces/community/blackblaze/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

Added BlackBlaze.com S3 File upload, read actions, and trigger via dedicated Piece


### Explain How the Feature Works
This piece implements AWS S3-compatible APIs provided by BlackBlaze to upload, read files from the specified S3 Bucket. Authentication is same as AWS S3.
 
### Relevant User Scenarios

1. Listen for New file events in blackblaze and perform operations on the content.
2. Upload Files to Blackblaze cloud storage bucket.
3. Read file from blackblaze Cloud storage bucket.



Fixes # (issue)
