### PR TITLE
fix: add missing resolve when internal error happens in the flow

### DIFF
--- a/packages/server/worker/src/lib/engine/threads/worker.ts
+++ b/packages/server/worker/src/lib/engine/threads/worker.ts
@@ -136,6 +136,8 @@ export class EngineWorker {
                             stdError,
                             stdOut,
                         })
+                    } else {
+                        reject({ status: EngineResponseStatus.ERROR, response: 'Worker exited with code ' + code + ' and signal ' + signal })
                     }
                 })
                 worker.send({ operation, operationType })
@@ -161,7 +163,7 @@ export class EngineWorker {
                         error: e,
                     }, 'Error terminating worker')
                 }
-                this.workers[workerIndex] = undefined  
+                this.workers[workerIndex] = undefined
             }
             this.log.debug({
                 workerIndex,


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


The missing resolve is causing one time jobs to hang and stuck for ever.

Fixes # (issue)
