### PR TITLE
feat(Gslide): generate from template new props placeholder

### DIFF
--- a/packages/pieces/community/google-slides/package.json
+++ b/packages/pieces/community/google-slides/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-slides",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/pieces/community/google-slides/src/lib/commons/common.ts
+++ b/packages/pieces/community/google-slides/src/lib/commons/common.ts
@@ -2,18 +2,49 @@ import { AuthenticationType, httpClient, HttpMethod } from "@activepieces/pieces
 
 export interface PageElement {
     objectId: string;
-    table?: {
-        tableRows: any[];
-    };
+    table?: Table
     sheetsChart?: {
         spreadsheetId: string;
         chartId: number;
     };
-    shape?: {
-        text: {
-            textElements: {textRun: {content: string}}[]
-        };
-    };
+    shape?: Shape
+}
+
+interface Presentation {
+    slides?: Slide[];
+}
+
+interface Slide {
+    pageElements?: PageElement[];
+}
+
+
+interface Shape {
+    text?: Text;
+}
+
+interface Text {
+    textElements?: TextElement[];
+}
+
+export interface TextElement {
+    textRun?: TextRun;
+}
+
+interface TextRun {
+    content?: string;
+}
+
+interface Table {
+    tableRows?: TableRow[];
+}
+
+interface TableRow {
+    tableCells?: TableCell[];
+}
+
+export interface TableCell {
+    text?: Text;
 }
 
 export const googleSheetsCommon = {


### PR DESCRIPTION
## What does this PR do?

Add a new props placeholder that will allow the user to choose between {{}} and [[]] for the variables of the template.
Also manage to also detect and change the variables in tables.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<img width="809" alt="Capture d’écran 2025-04-28 à 17 09 54" src="https://github.com/user-attachments/assets/9b1e70dd-c251-4f4d-bb75-3676187afa07" />
<img width="793" alt="Capture d’écran 2025-04-28 à 17 10 45" src="https://github.com/user-attachments/assets/79158c73-59e7-42d7-b167-55d3dbd465c0" />


Fixes Q-1319
