### PR TITLE
fix(apitable): fix API baseurl

### DIFF
--- a/packages/pieces/community/apitable/package.json
+++ b/packages/pieces/community/apitable/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-apitable",
-  "version": "0.0.19"
+  "version": "0.0.20"
 }

--- a/packages/pieces/community/apitable/src/index.ts
+++ b/packages/pieces/community/apitable/src/index.ts
@@ -35,7 +35,7 @@ export const APITableAuth = PieceAuth.CustomAuth({
       displayName: 'Instance Url',
       description: 'The url of the AITable instance.',
       required: true,
-      defaultValue: 'https://api.aitable.ai',
+      defaultValue: 'https://aitable.ai',
     }),
   },
   validate: async ({ auth }) => {


### PR DESCRIPTION
## What does this PR do?

AITable has changed its base API URL from `https://api.aitable.ai` to `https://aitable.ai`.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
