### PR TITLE
feat(straico): add new agent actions

### DIFF
--- a/packages/pieces/community/straico/package.json
+++ b/packages/pieces/community/straico/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-straico",
-  "version": "0.1.1"
+  "version": "0.2.1"
 }

--- a/packages/pieces/community/straico/package.json
+++ b/packages/pieces/community/straico/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-straico",
-  "version": "0.2.1"
+  "version": "0.1.2"
 }

--- a/packages/pieces/community/straico/src/index.ts
+++ b/packages/pieces/community/straico/src/index.ts
@@ -15,6 +15,13 @@ import { getRagById } from './lib/actions/rag-get-by-id';
 import { updateRag } from './lib/actions/rag-update';
 import { deleteRag } from './lib/actions/rag-delete';
 import { ragPromptCompletion } from './lib/actions/rag-prompt-completion';
+import { agentCreate } from './lib/actions/agent-create';
+import { agentAddRag } from './lib/actions/agent-add-rag';
+import { agentList } from './lib/actions/agent-list';
+import { agentDelete } from './lib/actions/agent-delete';
+import { agentUpdate } from './lib/actions/agent-update';
+import { agentGet } from './lib/actions/agent-get';
+import { agentPromptCompletion } from './lib/actions/agent-prompt-completion';
 import { PieceCategory } from '@activepieces/shared';
 
 const markdownDescription = `
@@ -70,6 +77,13 @@ export const straico = createPiece({
     updateRag,
     deleteRag,
     ragPromptCompletion,
+    agentCreate,
+    agentAddRag,
+    agentList,
+    agentDelete,
+    agentUpdate,
+    agentGet,
+    agentPromptCompletion,
     createCustomApiCallAction({
       auth: straicoAuth,
       baseUrl: () => baseUrlv1,

--- a/packages/pieces/community/straico/src/lib/actions/agent-add-rag.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-add-rag.ts
@@ -1,0 +1,148 @@
+import { straicoAuth } from '../../index';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+
+import { baseUrlv0 } from '../common/common';
+
+interface AgentAddRagResponse {
+  success: boolean;
+  data: {
+    uuid4: string;
+    user_id: string;
+    default_llm: string;
+    custom_prompt: string;
+    name: string;
+    description: string;
+    status: string;
+    tags: string[];
+    last_interaction: null | string;
+    interaction_count: number;
+    visibility: string;
+    _id: string;
+  };
+}
+
+export const agentAddRag = createAction({
+  auth: straicoAuth,
+  name: 'agent-add-rag',
+  displayName: 'Add RAG to Agent',
+  description: 'Adds a new RAG to an agent in the database for the user.',
+  props: {
+    agent_id: Property.Dropdown({
+      displayName: 'Agent',
+      required: true,
+      description: 'The agent to add the RAG to',
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Enter your API key first',
+            options: [],
+          };
+        }
+        try {
+          const agents = await httpClient.sendRequest<{
+            success: boolean;
+            data: Array<{
+              _id: string;
+              name: string;
+              description: string;
+            }>;
+          }>({
+            url: `${baseUrlv0}/agent`,
+            method: HttpMethod.GET,
+            authentication: {
+              type: AuthenticationType.BEARER_TOKEN,
+              token: auth as string,
+            },
+          });
+          return {
+            disabled: false,
+            options:
+              agents.body?.data?.map((agent) => {
+                return {
+                  label: agent.name,
+                  value: agent._id,
+                };
+              }) || [],
+          };
+        } catch (error) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: "Couldn't load agents, API key is invalid",
+          };
+        }
+      },
+    }),
+    rag_id: Property.Dropdown({
+      displayName: 'RAG ID',
+      required: true,
+      description: 'The ID of the RAG to add to the agent',
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Enter your API key first',
+            options: [],
+          };
+        }
+        try {
+          const rags = await httpClient.sendRequest<{
+            success: boolean;
+            data: Array<{
+              _id: string;
+              name: string;
+            }>;
+          }>({
+            url: `${baseUrlv0}/rag/user`,
+            method: HttpMethod.GET,
+            authentication: {
+              type: AuthenticationType.BEARER_TOKEN,
+              token: auth as string,
+            },
+          });
+          return {
+            disabled: false,
+            options:
+              rags.body?.data?.map((rag) => {
+                return {
+                  label: rag.name,
+                  value: rag._id,
+                };
+              }) || [],
+          };
+        } catch (error) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: "Couldn't load RAGs, API key is invalid",
+          };
+        }
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { agent_id, rag_id } = propsValue;
+  
+    const response = await httpClient.sendRequest<AgentAddRagResponse>({
+      url: `${baseUrlv0}/agent/${agent_id}/rag`,
+      method: HttpMethod.POST,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth as string,
+      },
+      body: {
+        rag: rag_id,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/straico/src/lib/actions/agent-add-rag.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-add-rag.ts
@@ -7,6 +7,7 @@ import {
 } from '@activepieces/pieces-common';
 
 import { baseUrlv0 } from '../common/common';
+import { agentIdDropdown } from '../common/props';
 
 interface AgentAddRagResponse {
   success: boolean;
@@ -32,54 +33,7 @@ export const agentAddRag = createAction({
   displayName: 'Add RAG to Agent',
   description: 'Adds a new RAG to an agent in the database for the user.',
   props: {
-    agent_id: Property.Dropdown({
-      displayName: 'Agent',
-      required: true,
-      description: 'The agent to add the RAG to',
-      refreshers: [],
-      options: async ({ auth }) => {
-        if (!auth) {
-          return {
-            disabled: true,
-            placeholder: 'Enter your API key first',
-            options: [],
-          };
-        }
-        try {
-          const agents = await httpClient.sendRequest<{
-            success: boolean;
-            data: Array<{
-              _id: string;
-              name: string;
-              description: string;
-            }>;
-          }>({
-            url: `${baseUrlv0}/agent`,
-            method: HttpMethod.GET,
-            authentication: {
-              type: AuthenticationType.BEARER_TOKEN,
-              token: auth as string,
-            },
-          });
-          return {
-            disabled: false,
-            options:
-              agents.body?.data?.map((agent) => {
-                return {
-                  label: agent.name,
-                  value: agent._id,
-                };
-              }) || [],
-          };
-        } catch (error) {
-          return {
-            disabled: true,
-            options: [],
-            placeholder: "Couldn't load agents, API key is invalid",
-          };
-        }
-      },
-    }),
+    agent_id: agentIdDropdown('Agent','The agent to add the RAG to.'),
     rag_id: Property.Dropdown({
       displayName: 'RAG ID',
       required: true,

--- a/packages/pieces/community/straico/src/lib/actions/agent-create.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-create.ts
@@ -1,0 +1,137 @@
+import { straicoAuth } from '../../index';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+
+import { baseUrlv0, baseUrlv1 } from '../common/common';
+
+interface AgentCreateRequest {
+  name: string;
+  description: string;
+  custom_prompt: string;
+  default_llm: string;
+  tags?: string[];
+}
+
+interface AgentCreateResponse {
+  success: boolean;
+  data: {
+    uuid4: string;
+    user_id: string;
+    default_llm: string;
+    custom_prompt: string;
+    name: string;
+    description: string;
+    status: string;
+    tags: string[];
+    last_interaction: null | string;
+    interaction_count: number;
+    visibility: string;
+    _id: string;
+    __v: number;
+  };
+}
+
+export const agentCreate = createAction({
+  auth: straicoAuth,
+  name: 'agent-create',
+  displayName: 'Create Agent',
+  description: 'Creates a new agent in the database for the user.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Name',
+      required: true,
+      description: 'A name for the agent',
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      required: true,
+      description: 'A brief description of what the model does',
+    }),
+    custom_prompt: Property.LongText({
+      displayName: 'Custom Prompt',
+      required: true,
+      description: 'A model that the agent will use for processing prompts',
+    }),
+    default_llm: Property.Dropdown({
+      displayName: 'Default LLM',
+      required: true,
+      description: 'The language model which the agent will use for processing prompts',
+      refreshers: [],
+      defaultValue: 'openai/gpt-4o-mini',
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Enter your API key first',
+            options: [],
+          };
+        }
+        try {
+          const models = await httpClient.sendRequest<{
+            data: {
+              chat: Array<{
+                name: string;
+                model: string;
+              }>;
+            };
+          }>({
+            url: `${baseUrlv1}/models`,
+            method: HttpMethod.GET,
+            authentication: {
+              type: AuthenticationType.BEARER_TOKEN,
+              token: auth as string,
+            },
+          });
+          return {
+            disabled: false,
+            options:
+              models.body?.data?.chat?.map((model) => {
+                return {
+                  label: model.name,
+                  value: model.model,
+                };
+              }) || [],
+          };
+        } catch (error) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: "Couldn't load models, API key is invalid",
+          };
+        }
+      },
+    }),
+    tags: Property.Array({
+      displayName: 'Tags',
+      required: false,
+      description: 'An array of tags for the agent. Example: ["assistant","tag"]',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { name, description, custom_prompt, default_llm, tags } = propsValue;
+    
+    const requestBody: AgentCreateRequest = {
+      name,
+      description,
+      custom_prompt,
+      default_llm,
+      tags: tags as string[],
+    };
+  
+    const response = await httpClient.sendRequest<AgentCreateResponse>({
+      url: `${baseUrlv0}/agent`,
+      method: HttpMethod.POST,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth as string,
+      },
+      body: requestBody,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/straico/src/lib/actions/agent-delete.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-delete.ts
@@ -6,6 +6,7 @@ import {
   httpClient,
 } from '@activepieces/pieces-common';
 import { baseUrlv0 } from '../common/common';
+import { agentIdDropdown } from '../common/props';
 
 export const agentDelete = createAction({
   auth: straicoAuth,
@@ -13,53 +14,7 @@ export const agentDelete = createAction({
   displayName: 'Delete Agent',
   description: 'Delete a specific agent by its ID',
   props: {
-    agentId: Property.Dropdown({
-      displayName: 'Agent',
-      required: true,
-      description: 'Select the agent to delete',
-      refreshers: [],
-      options: async ({ auth }) => {
-        if (!auth) {
-          return {
-            disabled: true,
-            placeholder: 'Please authenticate first',
-            options: [],
-          };
-        }
-
-        const response = await httpClient.sendRequest<{
-          success: boolean;
-          data: Array<{
-            _id: string;
-            name: string;
-          }>;
-        }>({
-          url: `${baseUrlv0}/agent`,
-          method: HttpMethod.GET,
-          authentication: {
-            type: AuthenticationType.BEARER_TOKEN,
-            token: auth as string,
-          },
-        });
-
-        if (response.body.success && response.body.data) {
-          return {
-            options: response.body.data.map((agent) => {
-              return {
-                label: agent.name,
-                value: agent._id,
-              };
-            }),
-          };
-        }
-
-        return {
-          disabled: true,
-          placeholder: 'No agents found',
-          options: [],
-        };
-      },
-    }),
+    agentId: agentIdDropdown('Agent','Select the agent to delete')
   },
   async run({ auth, propsValue }) {
     const { agentId } = propsValue;

--- a/packages/pieces/community/straico/src/lib/actions/agent-delete.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-delete.ts
@@ -1,0 +1,85 @@
+import { straicoAuth } from '../../index';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { baseUrlv0 } from '../common/common';
+
+export const agentDelete = createAction({
+  auth: straicoAuth,
+  name: 'agent_delete',
+  displayName: 'Delete Agent',
+  description: 'Delete a specific agent by its ID',
+  props: {
+    agentId: Property.Dropdown({
+      displayName: 'Agent',
+      required: true,
+      description: 'Select the agent to delete',
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate first',
+            options: [],
+          };
+        }
+
+        const response = await httpClient.sendRequest<{
+          success: boolean;
+          data: Array<{
+            _id: string;
+            name: string;
+          }>;
+        }>({
+          url: `${baseUrlv0}/agent`,
+          method: HttpMethod.GET,
+          authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: auth as string,
+          },
+        });
+
+        if (response.body.success && response.body.data) {
+          return {
+            options: response.body.data.map((agent) => {
+              return {
+                label: agent.name,
+                value: agent._id,
+              };
+            }),
+          };
+        }
+
+        return {
+          disabled: true,
+          placeholder: 'No agents found',
+          options: [],
+        };
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { agentId } = propsValue;
+
+    if (!agentId) {
+      throw new Error('Agent ID is required');
+    }
+
+    const response = await httpClient.sendRequest<{
+      success: boolean;
+      message: string;
+    }>({
+      url: `${baseUrlv0}/agent/${agentId}`,
+      method: HttpMethod.DELETE,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth as string,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/straico/src/lib/actions/agent-get.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-get.ts
@@ -6,6 +6,7 @@ import {
   httpClient,
 } from '@activepieces/pieces-common';
 import { baseUrlv0 } from '../common/common';
+import { agentIdDropdown } from '../common/props';
 
 interface AgentGetResponse {
   _id: string;
@@ -29,53 +30,7 @@ export const agentGet = createAction({
   displayName: 'Get Agent Details',
   description: 'Retrieve details of a specific agent',
   props: {
-    agentId: Property.Dropdown({
-      displayName: 'Agent',
-      required: true,
-      description: 'Select the agent to get details for',
-      refreshers: [],
-      options: async ({ auth }) => {
-        if (!auth) {
-          return {
-            disabled: true,
-            placeholder: 'Please authenticate first',
-            options: [],
-          };
-        }
-
-        const response = await httpClient.sendRequest<{
-          success: boolean;
-          data: Array<{
-            _id: string;
-            name: string;
-          }>;
-        }>({
-          url: `${baseUrlv0}/agent`,
-          method: HttpMethod.GET,
-          authentication: {
-            type: AuthenticationType.BEARER_TOKEN,
-            token: auth as string,
-          },
-        });
-
-        if (response.body.success && response.body.data) {
-          return {
-            options: response.body.data.map((agent) => {
-              return {
-                label: agent.name,
-                value: agent._id,
-              };
-            }),
-          };
-        }
-
-        return {
-          disabled: true,
-          placeholder: 'No agents found',
-          options: [],
-        };
-      },
-    }),
+    agentId:agentIdDropdown('Agent','Select the agent to get details for.')
   },
   async run({ auth, propsValue }) {
     const { agentId } = propsValue;

--- a/packages/pieces/community/straico/src/lib/actions/agent-get.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-get.ts
@@ -1,0 +1,101 @@
+import { straicoAuth } from '../../index';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { baseUrlv0 } from '../common/common';
+
+interface AgentGetResponse {
+  _id: string;
+  uuid4: string;
+  user_id: string;
+  default_llm: string;
+  custom_prompt: string;
+  name: string;
+  description: string;
+  status: string;
+  tags: string[];
+  last_interaction: null | string;
+  interaction_count: number;
+  visibility: string;
+  rag_association?: string;
+}
+
+export const agentGet = createAction({
+  auth: straicoAuth,
+  name: 'agent_get',
+  displayName: 'Get Agent Details',
+  description: 'Retrieve details of a specific agent',
+  props: {
+    agentId: Property.Dropdown({
+      displayName: 'Agent',
+      required: true,
+      description: 'Select the agent to get details for',
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate first',
+            options: [],
+          };
+        }
+
+        const response = await httpClient.sendRequest<{
+          success: boolean;
+          data: Array<{
+            _id: string;
+            name: string;
+          }>;
+        }>({
+          url: `${baseUrlv0}/agent`,
+          method: HttpMethod.GET,
+          authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: auth as string,
+          },
+        });
+
+        if (response.body.success && response.body.data) {
+          return {
+            options: response.body.data.map((agent) => {
+              return {
+                label: agent.name,
+                value: agent._id,
+              };
+            }),
+          };
+        }
+
+        return {
+          disabled: true,
+          placeholder: 'No agents found',
+          options: [],
+        };
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { agentId } = propsValue;
+
+    if (!agentId) {
+      throw new Error('Agent ID is required');
+    }
+
+    const response = await httpClient.sendRequest<{
+      success: boolean;
+      data: AgentGetResponse;
+    }>({
+      url: `${baseUrlv0}/agent/${agentId}`,
+      method: HttpMethod.GET,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth as string,
+      },
+    });
+
+    return response.body.data;
+  },
+});

--- a/packages/pieces/community/straico/src/lib/actions/agent-list.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-list.ts
@@ -1,0 +1,47 @@
+import { straicoAuth } from '../../index';
+import { createAction } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { baseUrlv0 } from '../common/common';
+
+interface Agent {
+  _id: string;
+  uuid4: string;
+  user_id: string;
+  default_llm: string;
+  custom_prompt: string;
+  name: string;
+  description: string;
+  status: string;
+  tags: string[];
+  __v: number;
+  rag_association?: string;
+}
+
+interface AgentListResponse {
+  success: boolean;
+  data: Agent[];
+}
+
+export const agentList = createAction({
+  auth: straicoAuth,
+  name: 'agent-list',
+  displayName: 'List Agents',
+  description: 'Retrieves the list of agents created by and available to the user.',
+  props: {},
+  async run({ auth }) {
+    const response = await httpClient.sendRequest<AgentListResponse>({
+      url: `${baseUrlv0}/agent`,
+      method: HttpMethod.GET,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth as string,
+      },
+    });
+
+    return response.body.data;
+  },
+});

--- a/packages/pieces/community/straico/src/lib/actions/agent-prompt-completion.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-prompt-completion.ts
@@ -1,0 +1,165 @@
+import { straicoAuth } from '../../index';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { baseUrlv0 } from '../common/common';
+
+export const agentPromptCompletion = createAction({
+  auth: straicoAuth,
+  name: 'agent_prompt_completion',
+  displayName: 'Agent Prompt Completion',
+  description: 'Prompt an agent with a message and get a response',
+  props: {
+    agentId: Property.Dropdown({
+      displayName: 'Agent',
+      required: true,
+      description: 'Select the agent to prompt',
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate first',
+            options: [],
+          };
+        }
+
+        const response = await httpClient.sendRequest<{
+          success: boolean;
+          data: Array<{
+            _id: string;
+            name: string;
+          }>;
+        }>({
+          url: `${baseUrlv0}/agent`,
+          method: HttpMethod.GET,
+          authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: auth as string,
+          },
+        });
+
+        if (response.body.success && response.body.data) {
+          return {
+            options: response.body.data.map((agent) => {
+              return {
+                label: agent.name,
+                value: agent._id,
+              };
+            }),
+          };
+        }
+
+        return {
+          disabled: true,
+          placeholder: 'No agents found',
+          options: [],
+        };
+      },
+    }),
+    prompt: Property.LongText({
+      displayName: 'Prompt',
+      required: true,
+      description: 'The text prompt for the agent',
+    }),
+    searchType: Property.Dropdown({
+      displayName: 'Search Type',
+      required: false,
+      description: 'The search type to use for RAG model',
+      refreshers: [],
+      options: async () => {
+        return {
+          options: [
+            { label: 'Similarity', value: 'similarity' },
+            { label: 'MMR', value: 'mmr' },
+            { label: 'Similarity Score Threshold', value: 'similarity_score_threshold' },
+          ],
+        };
+      },
+    }),
+    k: Property.Number({
+      displayName: 'Number of Documents',
+      required: false,
+      description: 'Number of documents to return',
+    }),
+    fetchK: Property.Number({
+      displayName: 'Fetch K',
+      required: false,
+      description: 'Amount of documents to pass to MMR algorithm',
+    }),
+    lambdaMult: Property.Number({
+      displayName: 'Lambda Mult',
+      required: false,
+      description: 'Diversity of results returned by MMR (0 for minimum, 1 for maximum)',
+    }),
+    scoreThreshold: Property.Number({
+      displayName: 'Score Threshold',
+      required: false,
+      description: 'Minimum relevance threshold for similarity_score_threshold',
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { 
+      agentId, 
+      prompt, 
+      searchType, 
+      k, 
+      fetchK, 
+      lambdaMult, 
+      scoreThreshold 
+    } = propsValue;
+
+    if (!agentId) {
+      throw new Error('Agent ID is required');
+    }
+
+    if (!prompt) {
+      throw new Error('Prompt is required');
+    }
+
+    const requestBody: Record<string, unknown> = {
+      prompt,
+    };
+
+    const optionalParams = {
+      search_type: searchType,
+      k,
+      fetch_k: fetchK,
+      lambda_mult: lambdaMult,
+      score_threshold: scoreThreshold
+    };
+
+    Object.entries(optionalParams).forEach(([key, value]) => {
+      if (value !== undefined) {
+        requestBody[key] = value;
+      }
+    });
+
+    const response = await httpClient.sendRequest<{
+      success: boolean;
+      data: {
+        answer: string;
+        references: Array<{
+          page_content: string;
+          page: number;
+        }>;
+        file_name: string;
+        coins_used: number;
+        response: unknown;
+      };
+    }>({
+      url: `${baseUrlv0}/agent/${agentId}/prompt`,
+      method: HttpMethod.POST,
+      body: requestBody,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth as string,
+      },
+    });
+
+    return response.body.data;
+  },
+});

--- a/packages/pieces/community/straico/src/lib/actions/agent-prompt-completion.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-prompt-completion.ts
@@ -6,6 +6,7 @@ import {
   httpClient,
 } from '@activepieces/pieces-common';
 import { baseUrlv0 } from '../common/common';
+import { agentIdDropdown } from '../common/props';
 
 export const agentPromptCompletion = createAction({
   auth: straicoAuth,
@@ -13,71 +14,24 @@ export const agentPromptCompletion = createAction({
   displayName: 'Agent Prompt Completion',
   description: 'Prompt an agent with a message and get a response',
   props: {
-    agentId: Property.Dropdown({
-      displayName: 'Agent',
-      required: true,
-      description: 'Select the agent to prompt',
-      refreshers: [],
-      options: async ({ auth }) => {
-        if (!auth) {
-          return {
-            disabled: true,
-            placeholder: 'Please authenticate first',
-            options: [],
-          };
-        }
-
-        const response = await httpClient.sendRequest<{
-          success: boolean;
-          data: Array<{
-            _id: string;
-            name: string;
-          }>;
-        }>({
-          url: `${baseUrlv0}/agent`,
-          method: HttpMethod.GET,
-          authentication: {
-            type: AuthenticationType.BEARER_TOKEN,
-            token: auth as string,
-          },
-        });
-
-        if (response.body.success && response.body.data) {
-          return {
-            options: response.body.data.map((agent) => {
-              return {
-                label: agent.name,
-                value: agent._id,
-              };
-            }),
-          };
-        }
-
-        return {
-          disabled: true,
-          placeholder: 'No agents found',
-          options: [],
-        };
-      },
-    }),
+    agentId: agentIdDropdown('Agent','Select the agent to prompt.'),
     prompt: Property.LongText({
       displayName: 'Prompt',
       required: true,
       description: 'The text prompt for the agent',
     }),
-    searchType: Property.Dropdown({
+    searchType: Property.StaticDropdown({
       displayName: 'Search Type',
       required: false,
       description: 'The search type to use for RAG model',
-      refreshers: [],
-      options: async () => {
-        return {
+      options:  {
+        disabled:false,
           options: [
             { label: 'Similarity', value: 'similarity' },
             { label: 'MMR', value: 'mmr' },
             { label: 'Similarity Score Threshold', value: 'similarity_score_threshold' },
           ],
-        };
+      
       },
     }),
     k: Property.Number({

--- a/packages/pieces/community/straico/src/lib/actions/agent-update.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-update.ts
@@ -1,0 +1,231 @@
+import { straicoAuth } from '../../index';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { baseUrlv0, baseUrlv1 } from '../common/common';
+
+// Interface for agent update request body
+interface AgentUpdateRequestBody {
+  name?: string;
+  description?: string;
+  custom_prompt?: string;
+  default_llm?: string;
+  status?: 'active' | 'inactive';
+  visibility?: 'private' | 'public';
+}
+
+// Interface for agent update response data
+interface AgentUpdateResponse {
+  _id: string;
+  uuid4: string;
+  user_id: string;
+  default_llm: string;
+  custom_prompt: string;
+  name: string;
+  description: string;
+  status: string;
+  tags: string[];
+  last_interaction: null | string;
+  interaction_count: number;
+  visibility: string;
+  createdAt: string;
+  updatedAt: string;
+  __v: number;
+  rag_association?: string;
+}
+
+export const agentUpdate = createAction({
+  auth: straicoAuth,
+  name: 'agent_update',
+  displayName: 'Update Agent',
+  description: 'Update the details of a specific agent',
+  props: {
+    agentId: Property.Dropdown({
+      displayName: 'Agent',
+      required: true,
+      description: 'Select the agent to update',
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate first',
+            options: [],
+          };
+        }
+
+        const response = await httpClient.sendRequest<{
+          success: boolean;
+          data: Array<{
+            _id: string;
+            name: string;
+          }>;
+        }>({
+          url: `${baseUrlv0}/agent`,
+          method: HttpMethod.GET,
+          authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: auth as string,
+          },
+        });
+
+        if (response.body.success && response.body.data) {
+          return {
+            options: response.body.data.map((agent) => {
+              return {
+                label: agent.name,
+                value: agent._id,
+              };
+            }),
+          };
+        }
+
+        return {
+          disabled: true,
+          placeholder: 'No agents found',
+          options: [],
+        };
+      },
+    }),
+    name: Property.ShortText({
+      displayName: 'Name',
+      required: false,
+      description: 'New name for the agent',
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      required: false,
+      description: 'New description for the agent',
+    }),
+    customPrompt: Property.LongText({
+      displayName: 'Custom Prompt',
+      required: false,
+      description: 'New custom prompt for the agent',
+    }),
+    defaultLlm: Property.Dropdown({
+      displayName: 'Default LLM',
+      required: false,
+      description: 'New default LLM for the agent',
+      refreshers: ['auth'],
+      defaultValue: 'openai/gpt-4o-mini',
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Enter your API key first',
+            options: [],
+          };
+        }
+        try {
+          const models = await httpClient.sendRequest<{
+            data: {
+              chat: Array<{
+                name: string;
+                model: string;
+              }>;
+            };
+          }>({
+            url: `${baseUrlv1}/models`,
+            method: HttpMethod.GET,
+            authentication: {
+              type: AuthenticationType.BEARER_TOKEN,
+              token: auth as string,
+            },
+          });
+          return {
+            disabled: false,
+            options:
+              models.body?.data?.chat?.map((model) => {
+                return {
+                  label: model.name,
+                  value: model.model,
+                };
+              }) || [],
+          };
+        } catch (error) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: "Couldn't load models, API key is invalid",
+          };
+        }
+      },
+    }),
+    status: Property.Dropdown({
+      displayName: 'Status',
+      required: false,
+      description: 'New status for the agent',
+      refreshers: [],
+      options: async () => {
+        return {
+          options: [
+            { label: 'Active', value: 'active' },
+            { label: 'Inactive', value: 'inactive' },
+          ],
+        };
+      },
+    }),
+    visibility: Property.Dropdown({
+      displayName: 'Visibility',
+      required: false,
+      description: 'New visibility setting for the agent',
+      refreshers: [],
+      options: async () => {
+        return {
+          options: [
+            { label: 'Private', value: 'private' },
+            { label: 'Public', value: 'public' },
+          ],
+        };
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { 
+      agentId, 
+      name, 
+      description, 
+      customPrompt, 
+      defaultLlm, 
+      status, 
+      visibility 
+    } = propsValue;
+
+    if (!agentId) {
+      throw new Error('Agent ID is required');
+    }
+
+    const requestBody: AgentUpdateRequestBody = {};
+    
+    // Add properties to request body only if they are defined
+    if (name !== undefined) requestBody.name = name;
+    if (description !== undefined) requestBody.description = description;
+    if (customPrompt !== undefined) requestBody.custom_prompt = customPrompt;
+    if (defaultLlm !== undefined) requestBody.default_llm = defaultLlm;
+    if (status !== undefined) requestBody.status = status as 'active' | 'inactive';
+    if (visibility !== undefined) requestBody.visibility = visibility as 'private' | 'public';
+
+    // Only proceed if at least one property to update was provided
+    if (Object.keys(requestBody).length === 0) {
+      throw new Error('At least one property to update must be provided');
+    }
+
+    const response = await httpClient.sendRequest<{
+      success: boolean;
+      data: AgentUpdateResponse;
+    }>({
+      url: `${baseUrlv0}/agent/${agentId}`,
+      method: HttpMethod.PUT,
+      body: requestBody,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth as string,
+      },
+    });
+
+    return response.body.data;
+  },
+});

--- a/packages/pieces/community/straico/src/lib/actions/agent-update.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-update.ts
@@ -154,32 +154,30 @@ export const agentUpdate = createAction({
         }
       },
     }),
-    status: Property.Dropdown({
+    status: Property.StaticDropdown({
       displayName: 'Status',
       required: false,
       description: 'New status for the agent',
-      refreshers: [],
-      options: async () => {
-        return {
+      options:  {
+        disabled:false,
           options: [
             { label: 'Active', value: 'active' },
             { label: 'Inactive', value: 'inactive' },
           ],
-        };
+        
       },
     }),
-    visibility: Property.Dropdown({
+    visibility: Property.StaticDropdown({
       displayName: 'Visibility',
       required: false,
       description: 'New visibility setting for the agent',
-      refreshers: [],
-      options: async () => {
-        return {
+      options:  {
+        disabled:false,
           options: [
             { label: 'Private', value: 'private' },
             { label: 'Public', value: 'public' },
           ],
-        };
+        
       },
     }),
   },

--- a/packages/pieces/community/straico/src/lib/common/props.ts
+++ b/packages/pieces/community/straico/src/lib/common/props.ts
@@ -1,0 +1,51 @@
+import { AuthenticationType, httpClient, HttpMethod } from "@activepieces/pieces-common";
+import { Property } from "@activepieces/pieces-framework";
+import { baseUrlv0 } from "./common";
+
+export const agentIdDropdown =(displayName:string, desc:string)=> Property.Dropdown({
+      displayName,
+      required: true,
+      description: desc,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate first',
+            options: [],
+          };
+        }
+
+        const response = await httpClient.sendRequest<{
+          success: boolean;
+          data: Array<{
+            _id: string;
+            name: string;
+          }>;
+        }>({
+          url: `${baseUrlv0}/agent`,
+          method: HttpMethod.GET,
+          authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: auth as string,
+          },
+        });
+
+        if (response.body.success && response.body.data) {
+          return {
+            options: response.body.data.map((agent) => {
+              return {
+                label: agent.name,
+                value: agent._id,
+              };
+            }),
+          };
+        }
+
+        return {
+          disabled: true,
+          placeholder: 'No agents found',
+          options: [],
+        };
+      },
+    })


### PR DESCRIPTION
## What does this PR do?

This PR adds a new Agent system to the Straico piece in ActivePieces, allowing users to create and manage AI agents with RAG (Retrieval-Augmented Generation) capabilities.

### Explain How the Feature Works
The feature consists of several actions:

1. Create Agents
- Set up new agents with custom prompts and models
- Add tags for organization
2. Add RAG
- Connect agents to RAG models
- Enable document-aware responses
3. Use Agents
- Send prompts to agents
- Configure search settings
- Get responses with document references
4. Manage Agents
- List, view, update, and delete agents
- Control visibility and status

### Relevant User Scenarios
- Knowledge Assistant
- Team Setup
- Document Q&A
