### PR TITLE
feat: add dappier piece

### DIFF
--- a/packages/pieces/community/dappier/.eslintrc.json
+++ b/packages/pieces/community/dappier/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/dappier/README.md
+++ b/packages/pieces/community/dappier/README.md
@@ -1,0 +1,7 @@
+# pieces-dappier
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-dappier` to build the library.

--- a/packages/pieces/community/dappier/package.json
+++ b/packages/pieces/community/dappier/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-dappier",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/dappier/project.json
+++ b/packages/pieces/community/dappier/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-dappier",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/dappier/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/dappier",
+        "tsConfig": "packages/pieces/community/dappier/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/dappier/package.json",
+        "main": "packages/pieces/community/dappier/src/index.ts",
+        "assets": [
+          "packages/pieces/community/dappier/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/dappier/src/index.ts
+++ b/packages/pieces/community/dappier/src/index.ts
@@ -26,7 +26,6 @@ export const dappier = createPiece({
   triggers: [],
   categories: [
     PieceCategory.ARTIFICIAL_INTELLIGENCE,
-    PieceCategory.BUSINESS_INTELLIGENCE,
-    PieceCategory.UNIVERSAL_AI
+    PieceCategory.BUSINESS_INTELLIGENCE
   ]
 });

--- a/packages/pieces/community/dappier/src/index.ts
+++ b/packages/pieces/community/dappier/src/index.ts
@@ -13,7 +13,7 @@ export const dappierAuth = PieceAuth.SecretText({
 
 export const dappier = createPiece({
   displayName: 'Dappier',
-  logoUrl: 'https://dappier-assets.b-cdn.net/logos/DappierLogo_Black.png',
+  logoUrl: 'https://cdn.activepieces.com/pieces/dappier.png',
   description: 'Enable fast, free real-time web search and access premium data from trusted media brands—news, financial markets, sports, entertainment, weather, and more. Build powerful AI agents with Dappier',
   auth: dappierAuth,
   authors: [],

--- a/packages/pieces/community/dappier/src/index.ts
+++ b/packages/pieces/community/dappier/src/index.ts
@@ -1,0 +1,32 @@
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { realTimeWebSearch } from './lib/actions/real-time-data';
+import { sportsNewsSearch } from './lib/actions/sports-news';
+import { stockMarketDataSearch } from './lib/actions/stock-market-data';
+import { lifestyleNewsSearch } from './lib/actions/lifestyle-news';
+
+export const dappierAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: 'Enter your Dappier API Key. You can generate one at https://platform.dappier.com/profile/api-keys.',
+});
+
+export const dappier = createPiece({
+  displayName: 'Dappier',
+  logoUrl: 'https://dappier-assets.b-cdn.net/logos/DappierLogo_Black.png',
+  description: 'Enable fast, free real-time web search and access premium data from trusted media brands—news, financial markets, sports, entertainment, weather, and more. Build powerful AI agents with Dappier',
+  auth: dappierAuth,
+  authors: [],
+  actions: [
+    realTimeWebSearch,
+    stockMarketDataSearch,
+    sportsNewsSearch,
+    lifestyleNewsSearch
+  ],
+  triggers: [],
+  categories: [
+    PieceCategory.ARTIFICIAL_INTELLIGENCE,
+    PieceCategory.BUSINESS_INTELLIGENCE,
+    PieceCategory.UNIVERSAL_AI
+  ]
+});

--- a/packages/pieces/community/dappier/src/lib/actions/lifestyle-news.ts
+++ b/packages/pieces/community/dappier/src/lib/actions/lifestyle-news.ts
@@ -1,0 +1,66 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { dappierAuth } from '../..';
+import { dappierCommon } from '../common';
+
+export const lifestyleNewsSearch = createAction({
+  name: 'lifestyle_news_search',
+  auth: dappierAuth,
+  displayName: 'Lifestyle News',
+  description:
+    'Real-time updates, analysis, and personalized content from top sources like The Mix, Snipdaily, Nerdable, and Familyproof.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'Enter a natural language query or URL',
+      required: true,
+    }),
+    similarity_top_k: Property.Number({
+      displayName: 'Number of Results',
+      description: 'Number of articles to return (default is 9)',
+      required: false,
+    }),
+    ref: Property.ShortText({
+      displayName: 'Preferred Domain',
+      description: 'Restrict results to a domain (e.g., familyproof.com)',
+      required: false,
+    }),
+    num_articles_ref: Property.Number({
+      displayName: 'Guaranteed Articles from Domain',
+      description: 'Minimum number of articles to match the preferred domain',
+      required: false,
+    }),
+    search_algorithm: Property.StaticDropdown({
+      displayName: 'Search Algorithm',
+      description: 'Choose how to match articles',
+      required: false,
+      options: {
+        options: [
+          { label: 'Semantic (Contextual)', value: 'semantic' },
+          { label: 'Most Recent', value: 'most_recent' },
+          { label: 'Most Recent + Semantic', value: 'most_recent_semantic' },
+          { label: 'Trending', value: 'trending' },
+        ],
+      },
+    }),
+  },
+  async run({ propsValue, auth }) {
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${dappierCommon.baseUrl}/app/v2/search?data_model_id=dm_01j0q82s4bfjmsqkhs3ywm3x6y`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        query: propsValue.query,
+        similarity_top_k: propsValue.similarity_top_k,
+        ref: propsValue.ref,
+        num_articles_ref: propsValue.num_articles_ref,
+        search_algorithm: propsValue.search_algorithm,
+      },
+    });
+
+    return res.body;
+  },
+});

--- a/packages/pieces/community/dappier/src/lib/actions/real-time-data.ts
+++ b/packages/pieces/community/dappier/src/lib/actions/real-time-data.ts
@@ -1,0 +1,34 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { dappierAuth } from '../..';
+import { dappierCommon } from '../common';
+
+export const realTimeWebSearch = createAction({
+  name: 'real_time_web_search',
+  auth: dappierAuth,
+  displayName: 'Real Time Data',
+  description:
+    'Access real-time Google web search results including the latest news, weather, travel, deals and more.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'Enter your search query',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${dappierCommon.baseUrl}/app/aimodel/am_01j0rzq4tvfscrgzwac7jv1p4c`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        query: propsValue.query,
+      },
+    });
+
+    return res.body;
+  },
+});

--- a/packages/pieces/community/dappier/src/lib/actions/sports-news.ts
+++ b/packages/pieces/community/dappier/src/lib/actions/sports-news.ts
@@ -1,0 +1,66 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { dappierAuth } from '../..';
+import { dappierCommon } from '../common';
+
+export const sportsNewsSearch = createAction({
+  name: 'sports_news_search', 
+  auth: dappierAuth,
+  displayName: 'Sports News',
+  description:
+    'Real-time news, updates, and personalized content from top sports sources like Sportsnaut, Forever Blueshirts, Minnesota Sports Fan, LAFB Network, Bounding Into Sports, and Ringside Intel.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'Enter a natural language query or URL',
+      required: true,
+    }),
+    similarity_top_k: Property.Number({
+      displayName: 'Number of Results',
+      description: 'Number of articles to return (default is 9)',
+      required: false,
+    }),
+    ref: Property.ShortText({
+      displayName: 'Preferred Domain',
+      description: 'Restrict results to a domain (e.g., sportsnaut.com)',
+      required: false,
+    }),
+    num_articles_ref: Property.Number({
+      displayName: 'Guaranteed Articles from Domain',
+      description: 'Minimum number of articles to match the preferred domain',
+      required: false,
+    }),
+    search_algorithm: Property.StaticDropdown({
+      displayName: 'Search Algorithm',
+      description: 'Choose how to match articles',
+      required: false,
+      options: {
+        options: [
+          { label: 'Semantic (Contextual)', value: 'semantic' },
+          { label: 'Most Recent', value: 'most_recent' },
+          { label: 'Most Recent + Semantic', value: 'most_recent_semantic' },
+          { label: 'Trending', value: 'trending' },
+        ],
+      },
+    }),
+  },
+  async run({ propsValue, auth }) {
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${dappierCommon.baseUrl}/app/v2/search?data_model_id=dm_01j0pb465keqmatq9k83dthx34`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        query: propsValue.query,
+        similarity_top_k: propsValue.similarity_top_k,
+        ref: propsValue.ref,
+        num_articles_ref: propsValue.num_articles_ref,
+        search_algorithm: propsValue.search_algorithm,
+      },
+    });
+
+    return res.body;
+  },
+});

--- a/packages/pieces/community/dappier/src/lib/actions/stock-market-data.ts
+++ b/packages/pieces/community/dappier/src/lib/actions/stock-market-data.ts
@@ -1,0 +1,34 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { dappierAuth } from '../..';
+import { dappierCommon } from '../common';
+
+export const stockMarketDataSearch = createAction({
+  name: 'stock_market_data_search',
+  auth: dappierAuth,
+  displayName: 'Stock Market Data',
+  description:
+    'Access real-time financial news, stock prices, and trades from polygon.io, with AI-powered insights and up-to-the-minute updates to keep you informed on all your financial interests.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'Enter your stock market query',
+      required: true,
+    }),
+  },
+  async run({ propsValue, auth }) {
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${dappierCommon.baseUrl}/app/aimodel/am_01j749h8pbf7ns8r1bq9s2evrh`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        query: propsValue.query,
+      },
+    });
+
+    return res.body;
+  },
+});

--- a/packages/pieces/community/dappier/src/lib/common/index.ts
+++ b/packages/pieces/community/dappier/src/lib/common/index.ts
@@ -1,0 +1,3 @@
+export const dappierCommon = {
+  baseUrl: 'https://api.dappier.com',
+};

--- a/packages/pieces/community/dappier/tsconfig.json
+++ b/packages/pieces/community/dappier/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/dappier/tsconfig.lib.json
+++ b/packages/pieces/community/dappier/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -182,6 +182,9 @@
         "packages/pieces/community/crypto/src/index.ts"
       ],
       "@activepieces/piece-csv": ["packages/pieces/community/csv/src/index.ts"],
+      "@activepieces/piece-dappier": [
+        "packages/pieces/community/dappier/src/index.ts"
+      ],
       "@activepieces/piece-data-mapper": [
         "packages/pieces/community/data-mapper/src/index.ts"
       ],


### PR DESCRIPTION
[Dappier](https://dappier.com/) connects any LLM or your Agentic AI to real-time, rights-cleared, proprietary data from trusted sources, making your AI an expert in anything. Our specialized models include Real-Time Web Search, News, Sports, Financial Stock Market Data, Crypto Data, and exclusive content from premium publishers. Explore a wide range of data models in our marketplace at [marketplace.dappier.com](https://marketplace.dappier.com/)

## What does this PR do?

This PR adds support for the **Dappier** integration to Activepieces, including 4 new actions that allow users to access real-time and personalized content across various domains directly within their workflows.

The new actions include:

* **Real-Time Web Search** – Access real-time google web search results including the latest news, weather, travel, deals and more.
* **Stock Market Data Search** – Access real-time financial news, stock prices, and trades from polygon.io, with AI-powered insights and up-to-the-minute updates to keep you informed on all your financial interests.
* **Sports News Search** – Real-time news, updates, and personalized content from top sports sources like Sportsnaut, Forever Blueshirts, Minnesota Sports Fan, LAFB Network, Bounding Into Sports, and Ringside Intel.
* **Lifestyle News Search** – Real-time updates, analysis, and personalized content from top sources like The Mix, Snipdaily, Nerdable, and Familyproof

### Explain How the Feature Works

Please refer to the below video to understand it's working.


https://github.com/user-attachments/assets/c6e5c8c2-7ad0-46a4-961b-3e08a3526ae5



### Relevant User Scenarios

* **Travel Agents and Planners** can build **real-time, dynamic travel itineraries** based on destination, dates, and trending local activities.
* **Investors and Analysts** can use the **stock market data model** actions to extract up-to-date financial performance and insights for smarter decision-making.


* **Content Creators** can schedule personalized news digests in newsletters or Slack.
* **Marketing Teams** can monitor brand mentions or competitor updates in real-time.
* **Finance Teams** can pull fresh stock market snapshots or earnings news into dashboards.
* **Sports Enthusiasts** can receive live updates and match previews from curated sources.
* **Lifestyle Bloggers** can auto-fetch trending topics for scheduled publishing.

Fixes #7586 
Closes #7586 