### PR TITLE
feat(close-crm): implement close crm piece with actions and triggers

### DIFF
--- a/packages/pieces/community/close-crm/.eslintrc.json
+++ b/packages/pieces/community/close-crm/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/close-crm/README.md
+++ b/packages/pieces/community/close-crm/README.md
@@ -1,0 +1,7 @@
+# pieces-close-crm
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-close-crm` to build the library.

--- a/packages/pieces/community/close-crm/package.json
+++ b/packages/pieces/community/close-crm/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-close-crm",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/close-crm/project.json
+++ b/packages/pieces/community/close-crm/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-close-crm",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/close-crm/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/close-crm",
+        "tsConfig": "packages/pieces/community/close-crm/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/close-crm/package.json",
+        "main": "packages/pieces/community/close-crm/src/index.ts",
+        "assets": [
+          "packages/pieces/community/close-crm/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/close-crm/src/index.ts
+++ b/packages/pieces/community/close-crm/src/index.ts
@@ -1,4 +1,6 @@
 import { createPiece, PieceAuth, Piece } from "@activepieces/pieces-framework";
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { CLOSE_API_URL } from './lib/common/constants';
 import { findLead } from "./lib/actions/find-lead";
 import { findContact } from "./lib/actions/find-contact";
 import { findOpportunity } from "./lib/actions/find-opportunity";
@@ -10,16 +12,37 @@ import { newLeadCreated } from './lib/triggers/new-lead-trigger';
 import { newContactAdded } from './lib/triggers/new-contact-trigger';
 import { opportunityStatusChanged } from './lib/triggers/opportunity-status-changed-trigger';
 
-export const closeCrmAuth = PieceAuth.BasicAuth({
-  description: "API Key from Close CRM (found in Settings -> API Keys). Use the API key as the username and leave the password field empty.",
+export const closeCrmAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Close CRM API Key (found in Settings -> API Keys).',
   required: true,
-  username: {
-    displayName: "API Key",
-    description: "Your Close CRM API Key.",
-  },
-  password: {
-    displayName: "Password (leave empty)",
-    description: "Leave this field empty.",
+  validate: async ({ auth }) => {
+    if (!auth) {
+      return {
+        valid: false,
+        error: 'API Key cannot be empty.',
+      };
+    }
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${CLOSE_API_URL}/me/`,
+        headers: {
+          'Authorization': 'Basic ' + Buffer.from(`${auth}:`).toString('base64'),
+          'Accept': 'application/json',
+        },
+      });
+      return { valid: true };
+    } catch (e: any) {
+        let error = 'Invalid API Key.';
+        if (e.response?.status === 401) {
+            error = 'API Key is invalid or does not have sufficient permissions.';
+        }
+      return {
+        valid: false,
+        error: error,
+      };
+    }
   },
 });
 

--- a/packages/pieces/community/close-crm/src/index.ts
+++ b/packages/pieces/community/close-crm/src/index.ts
@@ -1,0 +1,34 @@
+import { createPiece, PieceAuth, Piece } from "@activepieces/pieces-framework";
+import { findLead } from "./lib/actions/find-lead";
+import { findContact } from "./lib/actions/find-contact";
+import { findOpportunity } from "./lib/actions/find-opportunity";
+import { createLead } from "./lib/actions/create-lead";
+import { createContact } from "./lib/actions/create-contact";
+import { createOpportunity } from "./lib/actions/create-opportunity";
+import { sendEmail } from "./lib/actions/send-email";
+import { newLeadCreated } from './lib/triggers/new-lead-trigger';
+import { newContactAdded } from './lib/triggers/new-contact-trigger';
+import { opportunityStatusChanged } from './lib/triggers/opportunity-status-changed-trigger';
+
+export const closeCrmAuth = PieceAuth.BasicAuth({
+  description: "API Key from Close CRM (found in Settings -> API Keys). Use the API key as the username and leave the password field empty.",
+  required: true,
+  username: {
+    displayName: "API Key",
+    description: "Your Close CRM API Key.",
+  },
+  password: {
+    displayName: "Password (leave empty)",
+    description: "Leave this field empty.",
+  },
+});
+
+export const closeCrm: Piece = createPiece({
+  displayName: "Close CRM",
+  auth: closeCrmAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: "https://cdn.activepieces.com/pieces/close-crm.png",
+  authors: [],
+  actions: [findLead, findContact, findOpportunity, createLead, createContact, createOpportunity, sendEmail],
+  triggers: [newLeadCreated, newContactAdded, opportunityStatusChanged],
+});

--- a/packages/pieces/community/close-crm/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/create-contact.ts
@@ -1,0 +1,73 @@
+import { Property, createAction } from "@activepieces/pieces-framework";
+import { HttpMethod, httpClient } from "@activepieces/pieces-common";
+import { CLOSE_API_URL } from "../common/constants";
+import { closeCrmAuth } from "../../index";
+
+export const createContact = createAction({
+  auth: closeCrmAuth,
+  name: 'create_contact',
+  displayName: 'Create Contact',
+  description: 'Add a new contact to a lead in Close CRM.',
+  props: {
+    lead_id: Property.ShortText({
+      displayName: 'Lead ID',
+      description: 'The ID of the lead to which this contact will be added.',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Contact Name',
+      description: 'The name of the new contact.',
+      required: true,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The title of the contact.',
+      required: false,
+    }),
+    emails: Property.Json({
+      displayName: 'Emails',
+      description: 'Array of email objects, e.g., `[{"email": "john.doe@example.com", "type": "office"}]`',
+      required: false,
+      defaultValue: [],
+    }),
+    phones: Property.Json({
+      displayName: 'Phones',
+      description: 'Array of phone objects, e.g., `[{"phone": "+15551234567", "type": "mobile"}]`',
+      required: false,
+      defaultValue: [],
+    }),
+    urls: Property.Json({
+      displayName: 'URLs',
+      description: 'Array of URL objects, e.g., `[{"url": "http://example.com", "type": "url"}]`',
+      required: false,
+      defaultValue: [],
+    }),
+  },
+  async run(context) {
+    const { lead_id, name, title, emails, phones, urls } = context.propsValue;
+    const api_key = context.auth.username;
+
+    const payload: any = {
+      lead_id: lead_id,
+      name: name,
+    };
+
+    if (title) payload.title = title;
+    if (emails && Array.isArray(emails) && emails.length > 0) payload.emails = emails;
+    if (phones && Array.isArray(phones) && phones.length > 0) payload.phones = phones;
+    if (urls && Array.isArray(urls) && urls.length > 0) payload.urls = urls;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${CLOSE_API_URL}/contact/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: payload,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/close-crm/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/create-contact.ts
@@ -45,7 +45,7 @@ export const createContact = createAction({
   },
   async run(context) {
     const { lead_id, name, title, emails, phones, urls } = context.propsValue;
-    const api_key = context.auth.username;
+    const apiKey = context.auth;
 
     const payload: any = {
       lead_id: lead_id,
@@ -61,7 +61,7 @@ export const createContact = createAction({
       method: HttpMethod.POST,
       url: `${CLOSE_API_URL}/contact/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },

--- a/packages/pieces/community/close-crm/src/lib/actions/create-lead.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/create-lead.ts
@@ -39,7 +39,7 @@ export const createLead = createAction({
   },
   async run(context) {
     const { name, url, description, status_id, contacts } = context.propsValue;
-    const api_key = context.auth.username;
+    const apiKey = context.auth;
 
     const payload: any = {
       name: name,
@@ -56,7 +56,7 @@ export const createLead = createAction({
       method: HttpMethod.POST,
       url: `${CLOSE_API_URL}/lead/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },

--- a/packages/pieces/community/close-crm/src/lib/actions/create-lead.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/create-lead.ts
@@ -1,0 +1,68 @@
+import { Property, createAction } from "@activepieces/pieces-framework";
+import { HttpMethod, httpClient } from "@activepieces/pieces-common";
+import { CLOSE_API_URL } from "../common/constants";
+import { closeCrmAuth } from "../../index";
+
+export const createLead = createAction({
+  auth: closeCrmAuth,
+  name: 'create_lead',
+  displayName: 'Create Lead',
+  description: 'Add a new lead to Close CRM.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Lead Name',
+      description: 'The name of the new lead.',
+      required: true,
+    }),
+    url: Property.ShortText({
+      displayName: 'URL',
+      description: 'Website URL for the lead.',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'A description for the lead.',
+      required: false,
+    }),
+    status_id: Property.ShortText({
+      displayName: 'Status ID',
+      description: 'Optional ID of the status to assign. If omitted, the default status will be used.',
+      required: false,
+    }),
+    contacts: Property.Json({
+        displayName: "Contacts",
+        description: "Optional array of contact objects. E.g., ```[{\"name\": \"Jane Doe\", \"title\": \"CEO\", \"emails\": [{\"email\": \"jane@example.com\", \"type\": \"office\"}]}]```. See Close CRM API docs for full structure.",
+        required: false,
+        defaultValue: []
+    })
+    // We could add custom fields later if needed, similar to contacts (JSON object)
+  },
+  async run(context) {
+    const { name, url, description, status_id, contacts } = context.propsValue;
+    const api_key = context.auth.username;
+
+    const payload: any = {
+      name: name,
+    };
+
+    if (url) payload.url = url;
+    if (description) payload.description = description;
+    if (status_id) payload.status_id = status_id;
+    if (contacts && Array.isArray(contacts) && contacts.length > 0) {
+        payload.contacts = contacts;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${CLOSE_API_URL}/lead/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: payload,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/close-crm/src/lib/actions/create-opportunity.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/create-opportunity.ts
@@ -1,0 +1,102 @@
+import { Property, createAction } from "@activepieces/pieces-framework";
+import { HttpMethod, httpClient } from "@activepieces/pieces-common";
+import { CLOSE_API_URL } from "../common/constants";
+import { closeCrmAuth } from "../../index";
+
+export const createOpportunity = createAction({
+  auth: closeCrmAuth,
+  name: 'create_opportunity',
+  displayName: 'Create Opportunity',
+  description: 'Log a new opportunity linked to a lead.',
+  props: {
+    lead_id: Property.ShortText({
+      displayName: 'Lead ID',
+      description: 'The ID of the lead this opportunity is associated with. If omitted, a new lead will be created (not recommended for typical use).',
+      required: true,
+    }),
+    note: Property.LongText({
+      displayName: 'Note',
+      description: 'A note for the opportunity.',
+      required: false,
+    }),
+    confidence: Property.Number({
+      displayName: 'Confidence',
+      description: 'Confidence level (0-100) for this opportunity.',
+      required: false,
+    }),
+    status_id: Property.ShortText({
+      displayName: 'Status ID',
+      description: 'ID of the opportunity status. If omitted, the default status will be used.',
+      required: false,
+    }),
+    value: Property.Number({
+        displayName: 'Value (in cents)',
+        description: 'Monetary value of the opportunity in cents (e.g., 50000 for $500.00).',
+        required: false,
+    }),
+    value_period: Property.StaticDropdown({
+        displayName: 'Value Period',
+        description: "Period for the value (one_time, monthly, annual). Required if 'Value' is set.",
+        required: false,
+        options: {
+            options: [
+                { label: 'One-Time', value: 'one_time' },
+                { label: 'Monthly', value: 'monthly' },
+                { label: 'Annual', value: 'annual' },
+            ]
+        }
+    }),
+    user_id: Property.ShortText({
+        displayName: 'User ID',
+        description: 'ID of the user to assign this opportunity to.',
+        required: false,
+    }),
+    contact_id: Property.ShortText({
+        displayName: 'Contact ID',
+        description: 'ID of the contact (on the lead) to associate with this opportunity.',
+        required: false,
+    }),
+    date_won: Property.ShortText({
+        displayName: 'Date Won (YYYY-MM-DD)',
+        description: "Date the opportunity was won. Automatically set if status is 'won' and this is not provided.",
+        required: false,
+    })
+  },
+  async run(context) {
+    const { lead_id, note, confidence, status_id, value, value_period, user_id, contact_id, date_won } = context.propsValue;
+    const api_key = context.auth.username;
+
+    const payload: any = {
+      lead_id: lead_id,
+    };
+
+    if (note) payload.note = note;
+    if (confidence !== undefined && confidence !== null) payload.confidence = confidence;
+    if (status_id) payload.status_id = status_id;
+    if (value !== undefined && value !== null) {
+        payload.value = value;
+        if (value_period) {
+            payload.value_period = value_period;
+        } else {
+            // Consider throwing an error or Close API might handle it.
+            // For now, rely on Close API validation if value is set but period is not.
+        }
+    }
+    if (user_id) payload.user_id = user_id;
+    if (contact_id) payload.contact_id = contact_id;
+    if (date_won) payload.date_won = date_won;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${CLOSE_API_URL}/opportunity/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: payload,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/close-crm/src/lib/actions/create-opportunity.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/create-opportunity.ts
@@ -64,7 +64,7 @@ export const createOpportunity = createAction({
   },
   async run(context) {
     const { lead_id, note, confidence, status_id, value, value_period, user_id, contact_id, date_won } = context.propsValue;
-    const api_key = context.auth.username;
+    const apiKey = context.auth;
 
     const payload: any = {
       lead_id: lead_id,
@@ -90,7 +90,7 @@ export const createOpportunity = createAction({
       method: HttpMethod.POST,
       url: `${CLOSE_API_URL}/opportunity/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },

--- a/packages/pieces/community/close-crm/src/lib/actions/find-contact.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/find-contact.ts
@@ -52,7 +52,7 @@ export const findContact = createAction({
   },
   async run(context) {
     const { search_field, search_term, contact_name_match_type, contact_email_match_type } = context.propsValue;
-    const api_key = context.auth.username;
+    const apiKey = context.auth;
 
     let query_payload: any;
     const baseQuery = {
@@ -121,7 +121,7 @@ export const findContact = createAction({
       method: HttpMethod.POST,
       url: `${CLOSE_API_URL}/data/search/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },

--- a/packages/pieces/community/close-crm/src/lib/actions/find-contact.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/find-contact.ts
@@ -1,0 +1,133 @@
+import { Property, createAction } from "@activepieces/pieces-framework";
+import { HttpMethod, httpClient } from "@activepieces/pieces-common";
+import { CLOSE_API_URL } from "../common/constants";
+import { closeCrmAuth } from "../../index";
+
+export const findContact = createAction({
+  auth: closeCrmAuth,
+  name: 'find_contact',
+  displayName: 'Find Contact',
+  description: 'Retrieve contact details by name or email.',
+  props: {
+    search_field: Property.StaticDropdown({
+      displayName: 'Search By',
+      description: 'Field to search on.',
+      required: true,
+      options: {
+        options: [
+          { label: 'Contact Name', value: 'contact_name' },
+          { label: 'Contact Email', value: 'contact_email' },
+        ],
+      },
+    }),
+    search_term: Property.ShortText({
+      displayName: 'Search Term',
+      description: 'The name or email to search for.',
+      required: true,
+    }),
+    contact_name_match_type: Property.StaticDropdown({
+      displayName: 'Contact Name Match Type',
+      description: 'How to match the contact name.',
+      required: false,
+      defaultValue: 'full_words',
+      options: {
+        options: [
+          { label: 'Full Words (Flexible)', value: 'full_words' },
+          { label: 'Exact Phrase', value: 'phrase' },
+        ],
+      },
+    }),
+    contact_email_match_type: Property.StaticDropdown({
+      displayName: 'Contact Email Match Type',
+      description: 'How to match the contact email.',
+      required: false,
+      defaultValue: 'phrase',
+      options: {
+        options: [
+          { label: 'Exact Match (Recommended)', value: 'phrase' },
+          { label: 'Contains', value: 'full_words' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { search_field, search_term, contact_name_match_type, contact_email_match_type } = context.propsValue;
+    const api_key = context.auth.username;
+
+    let query_payload: any;
+    const baseQuery = {
+      "type": "object_type",
+      "object_type": "contact"
+    };
+
+    let fieldCondition: any;
+
+    if (search_field === 'contact_name') {
+      fieldCondition = {
+        "type": "field_condition",
+        "field": {
+          "type": "regular_field",
+          "object_type": "contact",
+          "field_name": "name"
+        },
+        "condition": {
+          "type": "text",
+          "mode": contact_name_match_type || 'full_words',
+          "value": search_term
+        }
+      };
+      query_payload = {
+        "query": {
+          "type": "and",
+          "queries": [baseQuery, fieldCondition]
+        },
+        "_fields": {
+          "contact": ["id", "name", "title", "lead_id", "date_created", "date_updated", "emails", "phones", "urls"]
+        }
+      };
+    } else if (search_field === 'contact_email') {
+      fieldCondition = {
+        "type": "has_related",
+        "this_object_type": "contact",
+        "related_object_type": "contact_email",
+        "related_query": {
+          "type": "field_condition",
+          "field": {
+            "type": "regular_field",
+            "object_type": "contact_email",
+            "field_name": "email"
+          },
+          "condition": {
+            "type": "text",
+            "mode": contact_email_match_type || 'phrase',
+            "value": search_term
+          }
+        }
+      };
+      query_payload = {
+        "query": {
+          "type": "and",
+          "queries": [baseQuery, fieldCondition]
+        },
+        "_fields": {
+           "contact": ["id", "name", "title", "lead_id", "date_created", "date_updated", "emails", "phones", "urls"]
+        }
+      };
+    } else {
+      throw new Error('Invalid search_field selected.');
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${CLOSE_API_URL}/data/search/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: query_payload,
+    });
+
+    return response.body.data || [];
+  },
+});

--- a/packages/pieces/community/close-crm/src/lib/actions/find-lead.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/find-lead.ts
@@ -52,7 +52,7 @@ export const findLead = createAction({
   },
   async run(context) {
     const { search_field, search_term, lead_name_match_type, contact_email_match_type } = context.propsValue;
-    const api_key = context.auth.username; // BasicAuth username is the API key
+    const apiKey = context.auth; // Changed from context.auth.username
 
     let query_payload: any;
     const baseQuery = {
@@ -127,7 +127,7 @@ export const findLead = createAction({
       method: HttpMethod.POST,
       url: `${CLOSE_API_URL}/data/search/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'), // Changed api_key to apiKey
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },

--- a/packages/pieces/community/close-crm/src/lib/actions/find-lead.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/find-lead.ts
@@ -1,0 +1,139 @@
+import { Property, createAction } from "@activepieces/pieces-framework";
+import { HttpMethod, httpClient } from "@activepieces/pieces-common";
+import { CLOSE_API_URL } from "../common/constants";
+import { closeCrmAuth } from "../../index";
+
+export const findLead = createAction({
+  auth: closeCrmAuth,
+  name: 'find_lead',
+  displayName: 'Find Lead',
+  description: 'Search for leads by name or contact email.',
+  props: {
+    search_field: Property.StaticDropdown({
+      displayName: 'Search By',
+      description: 'Field to search on.',
+      required: true,
+      options: {
+        options: [
+          { label: 'Lead Name', value: 'lead_name' },
+          { label: 'Contact Email', value: 'contact_email' },
+        ],
+      },
+    }),
+    search_term: Property.ShortText({
+      displayName: 'Search Term',
+      description: 'The name or email to search for.',
+      required: true,
+    }),
+    lead_name_match_type: Property.StaticDropdown({
+      displayName: 'Lead Name Match Type',
+      description: 'How to match the lead name.',
+      required: false,
+      defaultValue: 'full_words',
+      options: {
+        options: [
+          { label: 'Full Words (Flexible)', value: 'full_words' },
+          { label: 'Exact Phrase', value: 'phrase' },
+        ],
+      },
+    }),
+    contact_email_match_type: Property.StaticDropdown({
+      displayName: 'Contact Email Match Type',
+      description: 'How to match the contact email.',
+      required: false,
+      defaultValue: 'phrase',
+      options: {
+        options: [
+          { label: 'Exact Match (Recommended)', value: 'phrase' },
+          { label: 'Contains', value: 'full_words' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { search_field, search_term, lead_name_match_type, contact_email_match_type } = context.propsValue;
+    const api_key = context.auth.username; // BasicAuth username is the API key
+
+    let query_payload: any;
+    const baseQuery = {
+      "type": "object_type",
+      "object_type": "lead"
+    };
+
+    let fieldCondition: any;
+
+    if (search_field === 'lead_name') {
+      fieldCondition = {
+        "type": "field_condition",
+        "field": {
+          "type": "regular_field",
+          "object_type": "lead",
+          "field_name": "name"
+        },
+        "condition": {
+          "type": "text",
+          "mode": lead_name_match_type || 'full_words',
+          "value": search_term
+        }
+      };
+      query_payload = {
+        "query": {
+          "type": "and",
+          "queries": [baseQuery, fieldCondition]
+        },
+        "_fields": {
+          "lead": ["id", "name", "display_name", "url", "status_label", "date_created", "date_updated", "contacts"]
+        }
+      };
+    } else if (search_field === 'contact_email') {
+      fieldCondition = {
+        "type": "has_related",
+        "this_object_type": "lead",
+        "related_object_type": "contact",
+        "related_query": {
+          "type": "has_related",
+          "this_object_type": "contact",
+          "related_object_type": "contact_email",
+          "related_query": {
+            "type": "field_condition",
+            "field": {
+              "type": "regular_field",
+              "object_type": "contact_email",
+              "field_name": "email"
+            },
+            "condition": {
+              "type": "text",
+              "mode": contact_email_match_type || 'phrase',
+              "value": search_term
+            }
+          }
+        }
+      };
+      query_payload = {
+        "query": {
+          "type": "and",
+          "queries": [baseQuery, fieldCondition]
+        },
+        "_fields": {
+           "lead": ["id", "name", "display_name", "url", "status_label", "date_created", "date_updated", "contacts"]
+        }
+      };
+    } else {
+      // Should not happen due to dropdown validation
+      throw new Error('Invalid search_field selected.');
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${CLOSE_API_URL}/data/search/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: query_payload,
+    });
+
+    return response.body.data || [];
+  },
+});

--- a/packages/pieces/community/close-crm/src/lib/actions/find-opportunity.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/find-opportunity.ts
@@ -1,0 +1,74 @@
+import { Property, createAction } from "@activepieces/pieces-framework";
+import { HttpMethod, QueryParams, httpClient } from "@activepieces/pieces-common";
+import { CLOSE_API_URL } from "../common/constants";
+import { closeCrmAuth } from "../../index";
+
+export const findOpportunity = createAction({
+  auth: closeCrmAuth,
+  name: 'find_opportunity',
+  displayName: 'Find Opportunity',
+  description: 'Locate opportunities by status or lead ID.',
+  props: {
+    search_by: Property.StaticDropdown({
+      displayName: 'Search By',
+      description: 'Field to search for an opportunity.',
+      required: true,
+      options: {
+        options: [
+          { label: 'Status ID', value: 'status_id' },
+          { label: 'Status Label', value: 'status_label' },
+          { label: 'Lead ID', value: 'lead_id' },
+        ],
+      },
+    }),
+    search_value: Property.ShortText({
+      displayName: 'Search Value',
+      description: 'The ID or label to search for.',
+      required: true,
+    }),
+    status_type: Property.StaticDropdown({
+        displayName: 'Status Type (if searching by Status Label)',
+        description: 'Filter by status type when searching by label (e.g., active, won, lost).',
+        required: false,
+        options: {
+            options: [
+                { label: 'Any', value: '' },
+                { label: 'Active', value: 'active' },
+                { label: 'Won', value: 'won' },
+                { label: 'Lost', value: 'lost' },
+            ]
+        }
+    })
+  },
+  async run(context) {
+    const { search_by, search_value, status_type } = context.propsValue;
+    const api_key = context.auth.username;
+
+    const queryParams: QueryParams = {
+        _fields: 'id,lead_id,lead_name,status_id,status_label,status_type,pipeline_id,pipeline_name,user_id,user_name,contact_id,value,value_period,value_formatted,expected_value,annualized_value,annualized_expected_value,confidence,note,date_created,date_updated,date_won'
+    };
+
+    if (search_by === 'status_id') {
+      queryParams['status_id'] = search_value;
+    } else if (search_by === 'status_label') {
+      queryParams['status_label'] = search_value;
+      if (status_type) {
+        queryParams['status_type'] = status_type;
+      }
+    } else if (search_by === 'lead_id') {
+      queryParams['lead_id'] = search_value;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${CLOSE_API_URL}/opportunity/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Accept': 'application/json',
+      },
+      queryParams: queryParams,
+    });
+
+    return response.body.data || [];
+  },
+});

--- a/packages/pieces/community/close-crm/src/lib/actions/find-opportunity.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/find-opportunity.ts
@@ -42,7 +42,7 @@ export const findOpportunity = createAction({
   },
   async run(context) {
     const { search_by, search_value, status_type } = context.propsValue;
-    const api_key = context.auth.username;
+    const apiKey = context.auth;
 
     const queryParams: QueryParams = {
         _fields: 'id,lead_id,lead_name,status_id,status_label,status_type,pipeline_id,pipeline_name,user_id,user_name,contact_id,value,value_period,value_formatted,expected_value,annualized_value,annualized_expected_value,confidence,note,date_created,date_updated,date_won'
@@ -63,7 +63,7 @@ export const findOpportunity = createAction({
       method: HttpMethod.GET,
       url: `${CLOSE_API_URL}/opportunity/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         'Accept': 'application/json',
       },
       queryParams: queryParams,

--- a/packages/pieces/community/close-crm/src/lib/actions/send-email.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/send-email.ts
@@ -1,0 +1,92 @@
+import { Property, createAction } from "@activepieces/pieces-framework";
+import { HttpMethod, httpClient } from "@activepieces/pieces-common";
+import { CLOSE_API_URL } from "../common/constants";
+import { closeCrmAuth } from "../../index";
+
+export const sendEmail = createAction({
+  auth: closeCrmAuth,
+  name: 'send_email',
+  displayName: 'Send Email',
+  description: 'Dispatch an email to a lead or contact directly from Close CRM.',
+  props: {
+    lead_id: Property.ShortText({
+      displayName: 'Lead ID',
+      description: 'ID of the lead to associate this email with.',
+      required: true,
+    }),
+    to_emails: Property.ShortText({
+      displayName: 'To Email(s)',
+      description: 'Comma-separated list of recipient email addresses.',
+      required: true,
+    }),
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'The subject line of the email.',
+      required: true,
+    }),
+    body_html: Property.LongText({
+      displayName: 'Body (HTML)',
+      description: 'The HTML content of the email.',
+      required: true,
+    }),
+    contact_id: Property.ShortText({
+      displayName: 'Contact ID (Optional)',
+      description: 'ID of a specific contact on the lead to associate this email with.',
+      required: false,
+    }),
+    sender: Property.ShortText({
+      displayName: 'Sender (Optional)',
+      description: 'Sender email address. Can be in format "Name <email@example.com>". Defaults to API key owner if not set.',
+      required: false,
+    }),
+    cc_emails: Property.ShortText({
+      displayName: 'CC Email(s) (Optional)',
+      description: 'Comma-separated list of CC recipient email addresses.',
+      required: false,
+    }),
+    bcc_emails: Property.ShortText({
+      displayName: 'BCC Email(s) (Optional)',
+      description: 'Comma-separated list of BCC recipient email addresses.',
+      required: false,
+    }),
+    user_id: Property.ShortText({
+        displayName: 'User ID (Optional)',
+        description: 'ID of the user to be marked as the sender. Defaults to the API key owner.',
+        required: false,
+    })
+    // Attachments can be complex, involving a separate file upload step first.
+    // We can consider adding Property.Json for 'attachments' later if needed.
+  },
+  async run(context) {
+    const { lead_id, to_emails, subject, body_html, contact_id, sender, cc_emails, bcc_emails, user_id } = context.propsValue;
+    const api_key = context.auth.username;
+
+    const payload: any = {
+      lead_id: lead_id,
+      to: to_emails.split(',').map(email => email.trim()).filter(email => email.length > 0),
+      subject: subject,
+      body_html: body_html,
+      status: 'outbox', // To send the email
+      direction: 'outgoing',
+    };
+
+    if (contact_id) payload.contact_id = contact_id;
+    if (sender) payload.sender = sender;
+    if (cc_emails) payload.cc = cc_emails.split(',').map(email => email.trim()).filter(email => email.length > 0);
+    if (bcc_emails) payload.bcc = bcc_emails.split(',').map(email => email.trim()).filter(email => email.length > 0);
+    if (user_id) payload.user_id = user_id;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${CLOSE_API_URL}/activity/email/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: payload,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/close-crm/src/lib/actions/send-email.ts
+++ b/packages/pieces/community/close-crm/src/lib/actions/send-email.ts
@@ -59,7 +59,7 @@ export const sendEmail = createAction({
   },
   async run(context) {
     const { lead_id, to_emails, subject, body_html, contact_id, sender, cc_emails, bcc_emails, user_id } = context.propsValue;
-    const api_key = context.auth.username;
+    const apiKey = context.auth;
 
     const payload: any = {
       lead_id: lead_id,
@@ -80,7 +80,7 @@ export const sendEmail = createAction({
       method: HttpMethod.POST,
       url: `${CLOSE_API_URL}/activity/email/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${api_key}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },

--- a/packages/pieces/community/close-crm/src/lib/common/constants.ts
+++ b/packages/pieces/community/close-crm/src/lib/common/constants.ts
@@ -1,0 +1,1 @@
+export const CLOSE_API_URL = 'https://api.close.com/api/v1';

--- a/packages/pieces/community/close-crm/src/lib/triggers/new-contact-trigger.ts
+++ b/packages/pieces/community/close-crm/src/lib/triggers/new-contact-trigger.ts
@@ -1,0 +1,114 @@
+import { TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, HttpRequest } from '@activepieces/pieces-common';
+import { closeCrmAuth } from '../../index';
+import { CLOSE_API_URL } from '../common/constants';
+import crypto from 'crypto';
+
+// Use a unique store key for this trigger to avoid collisions if user has multiple triggers
+const TRIGGER_DATA_STORE_KEY = 'close_crm_new_contact_trigger_data';
+
+const verifySignature = (signatureKey: string, timestamp: string, rawBody: string, signatureHash: string) => {
+  const dataToHmac = timestamp + rawBody;
+  const generatedHash = crypto.createHmac('sha256', Buffer.from(signatureKey, 'hex'))
+                              .update(dataToHmac)
+                              .digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(generatedHash), Buffer.from(signatureHash));
+};
+
+export const newContactAdded = createTrigger({
+  auth: closeCrmAuth,
+  name: 'new_contact_added',
+  displayName: 'New Contact Added',
+  description: 'Triggers when a new contact is linked to a lead.',
+  props: {},
+  type: TriggerStrategy.WEBHOOK,
+  async onEnable(context) {
+    const request: HttpRequest = {
+      method: HttpMethod.POST,
+      url: `${CLOSE_API_URL}/webhook/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: {
+        url: context.webhookUrl,
+        events: [{ object_type: 'contact', action: 'created' }],
+      },
+    };
+    const response = await httpClient.sendRequest<{ id: string, signature_key: string }>(request);
+    if (response.status === 200 || response.status === 201) {
+      await context.store.put(TRIGGER_DATA_STORE_KEY, {
+        webhookId: response.body.id,
+        signatureKey: response.body.signature_key
+      });
+    } else {
+      console.error('Failed to create webhook for new contact', response);
+      throw new Error(`Failed to create webhook: ${response.status} ${JSON.stringify(response.body)}`);
+    }
+  },
+  async onDisable(context) {
+    const triggerData = await context.store.get<{ webhookId: string, signatureKey: string }>(TRIGGER_DATA_STORE_KEY);
+    if (triggerData && triggerData.webhookId) {
+      const request: HttpRequest = {
+        method: HttpMethod.DELETE,
+        url: `${CLOSE_API_URL}/webhook/${triggerData.webhookId}`,
+        headers: {
+          'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+        },
+      };
+      await httpClient.sendRequest(request); // Error handling can be added as in newLeadCreated
+    }
+    await context.store.delete(TRIGGER_DATA_STORE_KEY);
+  },
+  async run(context) {
+    const triggerData = await context.store.get<{ webhookId: string, signatureKey: string }>(TRIGGER_DATA_STORE_KEY);
+    if (!triggerData || !triggerData.signatureKey) {
+      return [];
+    }
+    const signatureHash = context.payload.headers['close-sig-hash'] as string;
+    const timestamp = context.payload.headers['close-sig-timestamp'] as string;
+    const rawBody = context.payload.rawBody as string;
+
+    if (!signatureHash || !timestamp || rawBody === undefined) {
+      return [];
+    }
+    const isValid = verifySignature(triggerData.signatureKey, timestamp, rawBody, signatureHash);
+    if (!isValid) {
+      return [];
+    }
+    const webhookBody = context.payload.body as { event: any, subscription_id: string };
+    if (webhookBody && webhookBody.event) {
+        if (webhookBody.event.object_type === 'contact' && webhookBody.event.action === 'created') {
+            return [webhookBody.event];
+        }
+    }
+    return [];
+  },
+  async test(context) {
+    return [this.sampleData];
+  },
+  sampleData: {
+    date_created: "2023-10-27T10:00:00.000Z",
+    meta: {},
+    id: "ev_sample_contact_created",
+    action: "created",
+    date_updated: "2023-10-27T10:00:00.000Z",
+    changed_fields: [],
+    previous_data: {},
+    organization_id: "orga_sample_org_id",
+    data: {
+      id: "cont_sample_contact_id",
+      lead_id: "lead_sample_lead_id",
+      name: "Jane Doe (Sample Contact)",
+      title: "VP of Samples",
+      date_created: "2023-10-27T10:00:00.000Z",
+      date_updated: "2023-10-27T10:00:00.000Z",
+      emails: [{ type: 'office', email: 'jane.doe@example.com' }],
+      phones: [{ type: 'mobile', phone: '+15551237890' }]
+    },
+    object_id: "cont_sample_contact_id",
+    user_id: "user_sample_user_id",
+    object_type: "contact",
+    lead_id: "lead_sample_lead_id"
+  }
+});

--- a/packages/pieces/community/close-crm/src/lib/triggers/new-contact-trigger.ts
+++ b/packages/pieces/community/close-crm/src/lib/triggers/new-contact-trigger.ts
@@ -23,11 +23,12 @@ export const newContactAdded = createTrigger({
   props: {},
   type: TriggerStrategy.WEBHOOK,
   async onEnable(context) {
+    const apiKey = context.auth;
     const request: HttpRequest = {
       method: HttpMethod.POST,
       url: `${CLOSE_API_URL}/webhook/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         'Content-Type': 'application/json',
       },
       body: {
@@ -47,13 +48,14 @@ export const newContactAdded = createTrigger({
     }
   },
   async onDisable(context) {
+    const apiKey = context.auth;
     const triggerData = await context.store.get<{ webhookId: string, signatureKey: string }>(TRIGGER_DATA_STORE_KEY);
     if (triggerData && triggerData.webhookId) {
       const request: HttpRequest = {
         method: HttpMethod.DELETE,
         url: `${CLOSE_API_URL}/webhook/${triggerData.webhookId}`,
         headers: {
-          'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+          'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         },
       };
       await httpClient.sendRequest(request); // Error handling can be added as in newLeadCreated

--- a/packages/pieces/community/close-crm/src/lib/triggers/new-lead-trigger.ts
+++ b/packages/pieces/community/close-crm/src/lib/triggers/new-lead-trigger.ts
@@ -1,0 +1,132 @@
+import {TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, HttpRequest } from '@activepieces/pieces-common';
+import { closeCrmAuth } from '../../index';
+import { CLOSE_API_URL } from '../common/constants';
+import crypto from 'crypto';
+
+const TRIGGER_DATA_STORE_KEY = 'close_crm_trigger_data';
+
+const verifySignature = (signatureKey: string, timestamp: string, rawBody: string, signatureHash: string) => {
+  const dataToHmac = timestamp + rawBody;
+  const generatedHash = crypto.createHmac('sha256', Buffer.from(signatureKey, 'hex'))
+                              .update(dataToHmac)
+                              .digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(generatedHash), Buffer.from(signatureHash));
+};
+
+export const newLeadCreated = createTrigger({
+  auth: closeCrmAuth,
+  name: 'new_lead_created',
+  displayName: 'New Lead Created',
+  description: 'Triggers when a new lead is added to Close CRM.',
+  props: {},
+  type: TriggerStrategy.WEBHOOK,
+  async onEnable(context) {
+    const request: HttpRequest = {
+      method: HttpMethod.POST,
+      url: `${CLOSE_API_URL}/webhook/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: {
+        url: context.webhookUrl,
+        events: [{ object_type: 'lead', action: 'created' }],
+      },
+    };
+    const response = await httpClient.sendRequest<{ id: string, signature_key: string }>(request);
+    if (response.status === 200 || response.status === 201) {
+      await context.store.put(TRIGGER_DATA_STORE_KEY, {
+        webhookId: response.body.id,
+        signatureKey: response.body.signature_key
+      });
+    } else {
+      console.error('Failed to create webhook', response);
+      throw new Error(`Failed to create webhook: ${response.status} ${JSON.stringify(response.body)}`);
+    }
+  },
+  async onDisable(context) {
+    const triggerData = await context.store.get<{ webhookId: string, signatureKey: string }>(TRIGGER_DATA_STORE_KEY);
+    if (triggerData && triggerData.webhookId) {
+      const request: HttpRequest = {
+        method: HttpMethod.DELETE,
+        url: `${CLOSE_API_URL}/webhook/${triggerData.webhookId}`,
+        headers: {
+          'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+        },
+      };
+      const response = await httpClient.sendRequest(request);
+      if (response.status !== 200 && response.status !== 204) {
+        console.warn(`Failed to delete webhook ${triggerData.webhookId}:`, response);
+        // Not throwing an error here to allow disabling even if Close API fails to delete
+      }
+    }
+    await context.store.delete(TRIGGER_DATA_STORE_KEY);
+  },
+  async run(context) {
+    const triggerData = await context.store.get<{ webhookId: string, signatureKey: string }>(TRIGGER_DATA_STORE_KEY);
+    if (!triggerData || !triggerData.signatureKey) {
+      console.warn('Signature key not found in store. Cannot verify webhook.');
+      // Depending on policy, might return empty or throw error
+      return [];
+    }
+
+    const signatureHash = context.payload.headers['close-sig-hash'] as string;
+    const timestamp = context.payload.headers['close-sig-timestamp'] as string;
+    const rawBody = context.payload.rawBody as string;
+
+    if (!signatureHash || !timestamp || rawBody === undefined) {
+      console.warn('Missing signature headers or body for webhook verification.');
+      return [];
+    }
+
+    const isValid = verifySignature(triggerData.signatureKey, timestamp, rawBody, signatureHash);
+
+    if (!isValid) {
+      console.warn('Webhook signature mismatch. Potential tampering or misconfiguration.');
+      return [];
+    }
+    // The actual event data we want is nested under the 'event' key in the body
+    const webhookBody = context.payload.body as { event: any, subscription_id: string };
+    if (webhookBody && webhookBody.event) {
+        // Ensure the event matches what we subscribed to (optional, but good practice)
+        if (webhookBody.event.object_type === 'lead' && webhookBody.event.action === 'created') {
+            return [webhookBody.event];
+        }
+    }
+    return [];
+  },
+  async test(context) {
+    // For webhook triggers, test usually just returns sample data.
+    // It can optionally send a request to the API to confirm auth, but not strictly necessary for webhooks.
+    return [this.sampleData];
+  },
+  sampleData: {
+    // This is the 'event' object from the example webhook data
+    date_created: "2019-01-15T12:41:24.496000", // Assuming a new lead uses current time, adjusted for sample
+    meta: {},
+    id: "ev_sample_lead_created",
+    action: "created",
+    date_updated: "2019-01-15T12:41:24.496000",
+    changed_fields: [], // For 'created' event, changed_fields might be empty or list all fields
+    previous_data: {},
+    organization_id: "orga_XbVPx5fFbKlYTz9PW5Ih1XDhViV10YihIaEgMEb6fVW",
+    data: {
+      // Example fields for a newly created lead - adapt as needed from Lead object structure
+      // Using a simplified version here for brevity. Actual webhook will contain more fields.
+      id: "lead_newly_created_sample",
+      name: "New Sample Lead Inc.",
+      display_name: "New Sample Lead Inc.",
+      status_label: "Potential",
+      status_id: "stat_potential_default",
+      date_created: "2019-01-15T12:41:24.496000+00:00",
+      date_updated: "2019-01-15T12:41:24.496000+00:00",
+      contacts: [],
+      opportunities: [],
+    },
+    object_id: "lead_newly_created_sample",
+    user_id: "user_N6KhMpzHRCYQHdn4gRNIFNN5JExnsrprKA6ekxM63XA", // User who performed action
+    object_type: "lead",
+    lead_id: "lead_newly_created_sample"
+  }
+});

--- a/packages/pieces/community/close-crm/src/lib/triggers/new-lead-trigger.ts
+++ b/packages/pieces/community/close-crm/src/lib/triggers/new-lead-trigger.ts
@@ -22,11 +22,12 @@ export const newLeadCreated = createTrigger({
   props: {},
   type: TriggerStrategy.WEBHOOK,
   async onEnable(context) {
+    const apiKey = context.auth;
     const request: HttpRequest = {
       method: HttpMethod.POST,
       url: `${CLOSE_API_URL}/webhook/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         'Content-Type': 'application/json',
       },
       body: {
@@ -46,13 +47,14 @@ export const newLeadCreated = createTrigger({
     }
   },
   async onDisable(context) {
+    const apiKey = context.auth;
     const triggerData = await context.store.get<{ webhookId: string, signatureKey: string }>(TRIGGER_DATA_STORE_KEY);
     if (triggerData && triggerData.webhookId) {
       const request: HttpRequest = {
         method: HttpMethod.DELETE,
         url: `${CLOSE_API_URL}/webhook/${triggerData.webhookId}`,
         headers: {
-          'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+          'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         },
       };
       const response = await httpClient.sendRequest(request);

--- a/packages/pieces/community/close-crm/src/lib/triggers/opportunity-status-changed-trigger.ts
+++ b/packages/pieces/community/close-crm/src/lib/triggers/opportunity-status-changed-trigger.ts
@@ -22,11 +22,12 @@ export const opportunityStatusChanged = createTrigger({
   props: {},
   type: TriggerStrategy.WEBHOOK,
   async onEnable(context) {
+    const apiKey = context.auth;
     const request: HttpRequest = {
       method: HttpMethod.POST,
       url: `${CLOSE_API_URL}/webhook/`,
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         'Content-Type': 'application/json',
       },
       body: {
@@ -46,13 +47,14 @@ export const opportunityStatusChanged = createTrigger({
     }
   },
   async onDisable(context) {
+    const apiKey = context.auth;
     const triggerData = await context.store.get<{ webhookId: string, signatureKey: string }>(TRIGGER_DATA_STORE_KEY);
     if (triggerData && triggerData.webhookId) {
       const request: HttpRequest = {
         method: HttpMethod.DELETE,
         url: `${CLOSE_API_URL}/webhook/${triggerData.webhookId}`,
         headers: {
-          'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+          'Authorization': 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
         },
       };
       await httpClient.sendRequest(request);

--- a/packages/pieces/community/close-crm/src/lib/triggers/opportunity-status-changed-trigger.ts
+++ b/packages/pieces/community/close-crm/src/lib/triggers/opportunity-status-changed-trigger.ts
@@ -1,0 +1,156 @@
+import { TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, HttpRequest } from '@activepieces/pieces-common';
+import { closeCrmAuth } from '../../index';
+import { CLOSE_API_URL } from '../common/constants';
+import crypto from 'crypto';
+
+const TRIGGER_DATA_STORE_KEY = 'close_crm_opp_status_trigger_data';
+
+const verifySignature = (signatureKey: string, timestamp: string, rawBody: string, signatureHash: string) => {
+  const dataToHmac = timestamp + rawBody;
+  const generatedHash = crypto.createHmac('sha256', Buffer.from(signatureKey, 'hex'))
+                              .update(dataToHmac)
+                              .digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(generatedHash), Buffer.from(signatureHash));
+};
+
+export const opportunityStatusChanged = createTrigger({
+  auth: closeCrmAuth,
+  name: 'opportunity_status_changed',
+  displayName: 'Opportunity Status Changed',
+  description: 'Triggers when an opportunity status is updated.',
+  props: {},
+  type: TriggerStrategy.WEBHOOK,
+  async onEnable(context) {
+    const request: HttpRequest = {
+      method: HttpMethod.POST,
+      url: `${CLOSE_API_URL}/webhook/`,
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+        'Content-Type': 'application/json',
+      },
+      body: {
+        url: context.webhookUrl,
+        events: [{ object_type: 'opportunity', action: 'updated' }],
+      },
+    };
+    const response = await httpClient.sendRequest<{ id: string, signature_key: string }>(request);
+    if (response.status === 200 || response.status === 201) {
+      await context.store.put(TRIGGER_DATA_STORE_KEY, {
+        webhookId: response.body.id,
+        signatureKey: response.body.signature_key
+      });
+    } else {
+      console.error('Failed to create webhook for opportunity status change', response);
+      throw new Error(`Failed to create webhook: ${response.status} ${JSON.stringify(response.body)}`);
+    }
+  },
+  async onDisable(context) {
+    const triggerData = await context.store.get<{ webhookId: string, signatureKey: string }>(TRIGGER_DATA_STORE_KEY);
+    if (triggerData && triggerData.webhookId) {
+      const request: HttpRequest = {
+        method: HttpMethod.DELETE,
+        url: `${CLOSE_API_URL}/webhook/${triggerData.webhookId}`,
+        headers: {
+          'Authorization': 'Basic ' + Buffer.from(`${context.auth.username}:`).toString('base64'),
+        },
+      };
+      await httpClient.sendRequest(request);
+    }
+    await context.store.delete(TRIGGER_DATA_STORE_KEY);
+  },
+  async run(context) {
+    const triggerData = await context.store.get<{ webhookId: string, signatureKey: string }>(TRIGGER_DATA_STORE_KEY);
+    if (!triggerData || !triggerData.signatureKey) {
+      return [];
+    }
+    const signatureHash = context.payload.headers['close-sig-hash'] as string;
+    const timestamp = context.payload.headers['close-sig-timestamp'] as string;
+    const rawBody = context.payload.rawBody as string;
+
+    if (!signatureHash || !timestamp || rawBody === undefined) {
+      return [];
+    }
+    const isValid = verifySignature(triggerData.signatureKey, timestamp, rawBody, signatureHash);
+    if (!isValid) {
+      return [];
+    }
+
+    const webhookBody = context.payload.body as { event: any, subscription_id: string };
+    if (webhookBody && webhookBody.event) {
+      const event = webhookBody.event;
+      if (event.object_type === 'opportunity' && event.action === 'updated') {
+        // Check if status was actually changed
+        const changedFields = event.changed_fields || [];
+        const statusRelatedFieldsChanged = changedFields.some((field: string) =>
+          ['status_id', 'status_label', 'status_type'].includes(field)
+        );
+        if (statusRelatedFieldsChanged) {
+          return [event];
+        }
+      }
+    }
+    return [];
+  },
+  async test(context) {
+    return [this.sampleData];
+  },
+  sampleData: {
+    // This is the 'event' object from the webhook documentation for an opportunity status change
+    date_created: "2019-01-15T12:48:23.395000",
+    meta: {
+      request_method: "PUT",
+      request_path: "/api/v1/opportunity/oppo_7H4sjNso7FyBFaeR3RXi5PMJbilfo0c6UPCxsJtEhCO/"
+    },
+    id: "ev_2sYKRjcrA79yKxi3S4Crd7",
+    action: "updated",
+    date_updated: "2019-01-15T12:48:23.395000",
+    changed_fields: [
+      "confidence",
+      "date_updated",
+      "status_id",
+      "status_label",
+      "status_type"
+    ],
+    previous_data: {
+      status_type: "active",
+      confidence: 70,
+      date_updated: "2019-01-15T12:47:39.873000+00:00",
+      status_id: "stat_3FD9DnGUCJzccBKTh8LiiKoyVPpMJsOkJdcGoA5AYKH",
+      status_label: "Active"
+    },
+    organization_id: "orga_XbVPx5fFbKlYTz9PW5Ih1XDhViV10YihIaEgMEb6fVW",
+    data: {
+      contact_name: "Mr. Jones",
+      user_name: "Joe Kemp",
+      value_period: "one_time",
+      updated_by_name: "Joe Kemp",
+      date_created: "2019-01-15T12:41:24.496000+00:00",
+      user_id: "user_N6KhMpzHRCYQHdn4gRNIFNN5JExnsrprKA6ekxM63XA",
+      updated_by: "user_N6KhMpzHRCYQHdn4gRNIFNN5JExnsrprKA6ekxM63XA",
+      value_currency: "USD",
+      organization_id: "orga_XbVPx5fFbKlYTz9PW5Ih1XDhViV10YihIaEgMEb6fVW",
+      status_label: "Won",
+      contact_id: "cont_BwlwYQkIP6AooiXP1CMvc6Zbb5gGh2gPu4dqIDlDrII",
+      status_type: "won",
+      created_by_name: "Joe Kemp",
+      id: "oppo_8H4sjNso7FyBFaeR3RXi5PMJbilfo0c6UPCxsJtEhCO",
+      lead_name: "KLine",
+      date_lost: null,
+      note: "",
+      date_updated: "2019-01-15T12:48:23.392000+00:00",
+      status_id: "stat_wMS9M6HC2O3CSEOzF5g2vEGt6RM5R3RfhIQixdnmjf2",
+      value: 100000,
+      created_by: "user_N6KhMpzHRCYQHdn4gRNIFNN5JExnsrprKA6ekxM63XA",
+      value_formatted: "$1,000",
+      date_won: "2019-01-15",
+      lead_id: "lead_zwqYhEFwzPyfCErS8uQ77is2wFLvr9BgVi6cTfbFM68",
+      confidence: 100
+    },
+    request_id: "req_4S2L8JTBAA1OUS74SVmfbN",
+    object_id: "oppo_7H4sjNso7FyBFaeR3RXi5PMJbilfo0c6UPCxsJtEhCO",
+    user_id: "user_N6KhMpzHRCYQHdn4gRNIFNN5JExnsrprKA6ekxM63XA",
+    object_type: "opportunity",
+    lead_id: "lead_zwqYhEFwzPyfCErS8uQ77is2wFLvr9BgVi6cTfbFM68"
+  }
+});

--- a/packages/pieces/community/close-crm/tsconfig.json
+++ b/packages/pieces/community/close-crm/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/close-crm/tsconfig.lib.json
+++ b/packages/pieces/community/close-crm/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -160,6 +160,9 @@
       "@activepieces/piece-clockodo": [
         "packages/pieces/community/clockodo/src/index.ts"
       ],
+      "@activepieces/piece-close-crm": [
+        "packages/pieces/community/close-crm/src/index.ts"
+      ],
       "@activepieces/piece-cloutly": [
         "packages/pieces/community/cloutly/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new community piece for Close CRM, a sales automation platform. It allows users to connect their Close CRM accounts to Activepieces, enabling them to automate various sales workflows, synchronize data with other tools, and enhance sales productivity.

The piece includes a comprehensive set of actions and triggers:
*   **Search Actions**: Find Lead, Find Contact, Find Opportunity.
*   **Write Actions**: Create Lead, Create Contact, Create Opportunity, Send Email.
*   **Triggers**: New Lead Created, New Contact Added, Opportunity Status Changed.

### Explain How the Feature Works

The Close CRM piece integrates with the Close API using an API Key, which is configured via Basic Authentication (API key as username, empty password).

**Authentication:**
*   Uses the user's Close CRM API Key.

**Search Actions:**
*   **Find Lead**: Searches for leads by name or contact's email using the Close CRM Advanced Filtering API (`POST /api/v1/data/search/`). Allows specifying match type (full words, exact phrase).
*   **Find Contact**: Retrieves contact details by name or email, also utilizing the Advanced Filtering API (`POST /api/v1/data/search/`). Allows specifying match type.
*   **Find Opportunity**: Locates opportunities by status (ID or label) or by Lead ID using the standard List Opportunities endpoint (`GET /api/v1/opportunity/`) with query parameters.

**Write Actions:**
*   **Create Lead**: Adds a new lead (`POST /api/v1/lead/`) with details like name, URL, description, status, and optionally, nested contact objects.
*   **Create Contact**: Adds a new contact under a specific lead (`POST /api/v1/contact/`) including name, title, emails, phones, and URLs.
*   **Create Opportunity**: Logs a new opportunity linked to a lead (`POST /api/v1/opportunity/`) with details such as note, confidence, status, value, value period, and associated user/contact.
*   **Send Email**: Dispatches an email by creating an email activity (`POST /api/v1/activity/email/`) with status `outbox`. It allows specifying recipients (To, CC, BCC), subject, HTML body, sender, and associating with a lead/contact.

**Triggers (Webhook-based):**
All triggers utilize Close CRM's webhook functionality and include HMAC SHA256 signature verification for security.
*   **New Lead Created**:
    *   `onEnable`: Subscribes to `lead.created` events by creating a webhook in Close CRM targeting the Activepieces `webhookUrl`. Stores the returned `webhookId` and `signature_key`.
    *   `run`: Verifies the incoming webhook signature. If valid, processes the event payload for new leads.
    *   `onDisable`: Deletes the webhook subscription from Close CRM.
*   **New Contact Added**:
    *   Similar to "New Lead Created", but subscribes to `contact.created` events.
*   **Opportunity Status Changed**:
    *   Subscribes to `opportunity.updated` events.
    *   `run`: After signature verification, it specifically checks the `changed_fields` array in the event payload to ensure that `status_id`, `status_label`, or `status_type` was part of the update before triggering the flow. This prevents firing on every opportunity update (e.g., note change).

### Relevant User Scenarios

*   **Automated Lead Onboarding:** When a "New Lead Created" in Close, trigger a flow to send a personalized welcome email via the "Send Email" action, create a task in a project management tool, and add the lead to a specific email sequence.
*   **CRM Data Synchronization:** When a "New Contact Added" to a lead in Close, use the trigger to update or create a corresponding record in another CRM, a marketing automation platform, or a customer support system.
*   **Sales Pipeline Automation & Notifications:**
    *   When an "Opportunity Status Changed" to "Won", initiate an automated customer onboarding process, notify the finance team to generate an invoice, and update the sales dashboard.
    *   If an opportunity status changes to "Lost", trigger a flow to send a survey to the lead and log the feedback.
*   **Duplicate Prevention & Data Enrichment:** Before adding a new lead from a web form, use the "Find Lead" action (by email) to check for existing entries. If found, update the existing lead; otherwise, use "Create Lead".
*   **Targeted Communication:** Allow users to "Find Contact" by specific criteria (e.g., email) and then use the "Send Email" action to dispatch targeted messages as part of a larger Activepieces flow.
*   **Streamlined Opportunity Management:** Use "Create Opportunity" to automatically log new deals in Close CRM when a deal is qualified in an external system or form.

Fixes #7563
/claim #7563