### PR TITLE
feat: add google vertex AI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@fastify/rate-limit": "9.1.0",
         "@fastify/swagger": "8.9.0",
         "@fastify/type-provider-typebox": "3.5.0",
+        "@google/genai": "0.12.0",
         "@google/generative-ai": "0.21.0",
         "@hookform/resolvers": "3.9.0",
         "@langchain/anthropic": "0.3.20",
@@ -6485,6 +6486,101 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-0.12.0.tgz",
+      "integrity": "sha512-SJtCHac+HPgmwELpJpPKbaV4rk397bS2D42XgFR2NBEARDKd/79RcaRUFFd55pYUJ+gfaz9Bv6KYoiz/P6eZKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "ws": "^8.18.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google/genai/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@google/generative-ai": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@fastify/rate-limit": "9.1.0",
     "@fastify/swagger": "8.9.0",
     "@fastify/type-provider-typebox": "3.5.0",
+    "@google/genai": "0.12.0",
     "@google/generative-ai": "0.21.0",
     "@hookform/resolvers": "3.9.0",
     "@langchain/anthropic": "0.3.20",

--- a/packages/pieces/community/google-vertex-ai/.eslintrc.json
+++ b/packages/pieces/community/google-vertex-ai/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/google-vertex-ai/README.md
+++ b/packages/pieces/community/google-vertex-ai/README.md
@@ -1,0 +1,7 @@
+# pieces-google-vertex-ai
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-google-vertex-ai` to build the library.

--- a/packages/pieces/community/google-vertex-ai/package.json
+++ b/packages/pieces/community/google-vertex-ai/package.json
@@ -2,7 +2,9 @@
   "name": "@activepieces/piece-google-vertex-ai",
   "version": "0.0.1",
   "dependencies": {
+    "@activepieces/pieces-framework": "0.3.0",
     "@google/genai": "^0.3.0",
-    "google-auth-library": "^9.0.0"
+    "google-auth-library": "^9.0.0",
+    "mime-types": "^2.1.35"
   }
 }

--- a/packages/pieces/community/google-vertex-ai/package.json
+++ b/packages/pieces/community/google-vertex-ai/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@activepieces/piece-google-vertex-ai",
+  "version": "0.0.1",
+  "dependencies": {
+    "@google/genai": "^0.3.0",
+    "google-auth-library": "^9.0.0"
+  }
+}

--- a/packages/pieces/community/google-vertex-ai/project.json
+++ b/packages/pieces/community/google-vertex-ai/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-google-vertex-ai",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/google-vertex-ai/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/google-vertex-ai",
+        "tsConfig": "packages/pieces/community/google-vertex-ai/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/google-vertex-ai/package.json",
+        "main": "packages/pieces/community/google-vertex-ai/src/index.ts",
+        "assets": [
+          "packages/pieces/community/google-vertex-ai/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/google-vertex-ai/src/index.ts
+++ b/packages/pieces/community/google-vertex-ai/src/index.ts
@@ -1,0 +1,40 @@
+import { PieceAuth, createPiece, Property } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { generateContentWithGemini } from './lib/actions/generate-content-with-gemini';
+
+const markdownDescription = `
+Follow these instructions to get your Service Account JSON:
+1. Go to the Google Cloud Console (https://console.cloud.google.com)
+2. Navigate to "IAM & Admin" > "Service Accounts"
+3. Create a new service account or select an existing one
+4. Create a new key (JSON format) for the service account
+5. Download the JSON key file
+6. Copy the contents of the JSON file and paste it here
+
+Make sure the service account has the following roles:
+- Vertex AI User (roles/aiplatform.user)
+`;
+
+export const googleVertexAuth = PieceAuth.CustomAuth({
+  required: true,
+  props: {
+    serviceAccountJson: Property.LongText({
+      displayName: 'Service Account JSON',
+      required: true,
+      description: markdownDescription,
+    }),
+  },
+});
+
+export const googleVertex = createPiece({
+  displayName: 'Google Vertex AI',
+  auth: googleVertexAuth,
+  description: 'Interact with Google Vertex AI services',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/google-vertex-ai.png',
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  authors: ["geekyme"],
+  actions: [generateContentWithGemini],
+  triggers: [],
+});
+    

--- a/packages/pieces/community/google-vertex-ai/src/lib/actions/generate-content-with-gemini.ts
+++ b/packages/pieces/community/google-vertex-ai/src/lib/actions/generate-content-with-gemini.ts
@@ -1,6 +1,5 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { GoogleGenAI, HarmCategory, HarmBlockThreshold, ContentListUnion } from '@google/genai';
-import { GoogleAuth } from 'google-auth-library';
+import { GoogleGenAI, ContentListUnion, createPartFromBase64, createPartFromUri } from '@google/genai';
 import mime from 'mime-types';
 import { ApFile } from '@activepieces/pieces-framework';
 
@@ -87,22 +86,12 @@ export const generateContentWithGemini = createAction({
       for (const file of files as FileItem[]) {
         const base64Data = file.file.data.toString('base64');
         const mimeType = mime.lookup(file.file.extension || '') || 'application/octet-stream';
-        contentParts.push({
-          inlineData: {
-            data: base64Data,
-            mimeType
-          }
-        });
+        contentParts.push(createPartFromBase64(base64Data, mimeType));
       }
     }
 
     if (youtubeUrl) {
-      contentParts.push({
-        fileData: {
-          fileUri: youtubeUrl,
-          mimeType: 'video/mp4'
-        }
-      });
+      contentParts.push(createPartFromUri(youtubeUrl, 'video/mp4'));
     }
 
     const result = await ai.models.generateContent({

--- a/packages/pieces/community/google-vertex-ai/src/lib/actions/generate-content-with-gemini.ts
+++ b/packages/pieces/community/google-vertex-ai/src/lib/actions/generate-content-with-gemini.ts
@@ -1,0 +1,80 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { GoogleGenAI, HarmCategory, HarmBlockThreshold } from '@google/genai';
+import { GoogleAuth } from 'google-auth-library';
+
+interface ServiceAccountAuth {
+  serviceAccountJson: string;
+}
+
+export const generateContentWithGemini = createAction({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'generateContentWithGemini',
+  displayName: 'Generate Content with Gemini',
+  description: 'Generate content using Google Vertex AI Gemini model',
+  props: {
+    model: Property.Dropdown({
+      displayName: 'Model',
+      required: true,
+      refreshers: [],
+      options: async () => {
+        return {
+          disabled: false,
+          options: [
+            { label: 'Gemini Pro', value: 'gemini-pro' },
+            { label: 'Gemini Pro Vision', value: 'gemini-pro-vision' },
+            { label: 'Gemini 2.5 Pro Preview', value: 'gemini-2.5-pro-preview-05-06' },
+          ],
+        };
+      },
+    }),
+    prompt: Property.LongText({
+      displayName: 'Prompt',
+      required: true,
+      description: 'The prompt to generate content from',
+    }),
+    maxOutputTokens: Property.Number({
+      displayName: 'Max Output Tokens',
+      required: false,
+      description: 'Maximum number of tokens to generate',
+      defaultValue: 2048,
+    }),
+    temperature: Property.Number({
+      displayName: 'Temperature',
+      required: false,
+      description: 'Controls randomness: 0 is deterministic, 1 is creative',
+      defaultValue: 0,
+    })
+  },
+  async run(context) {
+    const auth = context.auth as ServiceAccountAuth;
+    const serviceAccountJson = JSON.parse(auth.serviceAccountJson);
+    const { model, prompt, maxOutputTokens, temperature } = context.propsValue;
+
+    // Initialize Gemini client with service account
+    const ai = new GoogleGenAI({
+      vertexai: true,
+      googleAuthOptions: {
+        credentials: serviceAccountJson,
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      },
+      project: serviceAccountJson.project_id,
+      location: 'us-central1' // Default location, can be made configurable if needed
+    });
+
+    // Set up generation config
+    const generationConfig = {
+      maxOutputTokens,
+      temperature
+    };
+
+    const result = await ai.models.generateContent({
+      model,
+      config: generationConfig,
+      contents: prompt
+    });
+    
+    return {
+      response: result
+    };
+  },
+});

--- a/packages/pieces/community/google-vertex-ai/tsconfig.json
+++ b/packages/pieces/community/google-vertex-ai/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/google-vertex-ai/tsconfig.lib.json
+++ b/packages/pieces/community/google-vertex-ai/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -338,6 +338,9 @@
       "@activepieces/piece-google-tasks": [
         "packages/pieces/community/google-tasks/src/index.ts"
       ],
+      "@activepieces/piece-google-vertex-ai": [
+        "packages/pieces/community/google-vertex-ai/src/index.ts"
+      ],
       "@activepieces/piece-gotify": [
         "packages/pieces/community/gotify/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Adds Google Vertex AI, which is the enterprise version of gemini. It has different authentication and different mechanisms so I did not use the existing `google-gemini`. 

### Explain How the Feature Works
- authentication is from [service account](https://cloud.google.com/iam/docs/service-account-overview) 
- generate text from multimodal input
- supports multiple files (image, pdf, etc.), youtube url
- supports the latest models from https://cloud.google.com/vertex-ai/generative-ai/docs/models


### Relevant User Scenarios

<img width="1228" alt="Screenshot 2025-05-09 at 1 38 02 PM" src="https://github.com/user-attachments/assets/e230aa5c-80a6-45ae-9c9c-b0d634c61d9c" />

<img width="1437" alt="Screenshot 2025-05-09 at 1 33 56 PM" src="https://github.com/user-attachments/assets/f3a8f73a-d70b-454f-938a-6a42faec07cf" />


Fixes # (issue)
(NA)