### PR TITLE
fix(dust): uploadFile piece compatibility with node v18

### DIFF
--- a/packages/pieces/community/dust/package.json
+++ b/packages/pieces/community/dust/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-dust",
-  "version": "0.1.11"
+  "version": "0.1.12"
 }

--- a/packages/pieces/community/dust/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/dust/src/lib/actions/upload-file.ts
@@ -22,15 +22,19 @@ export const uploadFile = createAction({
     const contentType = (mimeTypes.lookup(file.filename) ||
       'text/plain') as FileUploadUrlRequestType['contentType'];
 
-    const fileObject = new File([file.data], file.filename, {
-      type: contentType,
-    });
+    const blob = new Blob([file.data], { type: contentType });
+    const formData = new FormData();
+    formData.append('file', blob, file.filename);
+    const fileObject = formData.get('file');
+    if (!fileObject || typeof fileObject === 'string') {
+      throw new Error('File object is missing');
+    }
 
     const response = await client.uploadFile({
       contentType,
       fileObject,
       fileName: file.filename,
-      fileSize: fileObject.size,
+      fileSize: blob.size,
       useCase: 'conversation',
     });
 


### PR DESCRIPTION
## What does this PR do?

In https://github.com/activepieces/activepieces/pull/7518, I introduced a new piece to be able to upload a file to Dust. I wrongly tested on Node 20, while ActivePieces is still on Node 18.

the `new File` API doesn't exist in Node v18, so the piece is broken

This PR handles compatibility with Node v18 by switching to the `FormData` API in order to create the `File`.

Tested locally with the right version of Node this time
