### PR TITLE
feat(metabase): add timeout so graph can load

### DIFF
--- a/packages/pieces/community/metabase/package.json
+++ b/packages/pieces/community/metabase/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-metabase",
-  "version": "0.1.9"
+  "version": "0.1.10"
 }

--- a/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
+++ b/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
@@ -73,6 +73,9 @@ export const getGraphQuestion = createAction({
         );
       }
 
+      // we wait 15 seconds so the graph can load
+      await page.waitForTimeout(15000);
+
       const screenshotBuffer = await page.screenshot({
         path: graphName,
         type: 'png',

--- a/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
+++ b/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
@@ -22,10 +22,20 @@ export const getGraphQuestion = createAction({
       displayName: 'The name of the graph (without the extension)',
       required: false,
     }),
+    waitTime: Property.Number({
+      displayName: 'Wait Time (seconds)',
+      description:
+        'How long to wait for the graph to render completely in seconds',
+      required: true,
+      defaultValue: 5,
+    }),
   },
   async run({ auth, propsValue, files }) {
     if ('embeddingKey' in auth && !auth.embeddingKey)
       return 'An embedding key is needed.';
+
+    if (propsValue.waitTime <= 0)
+      return 'The wait time needs to be superior to 0';
 
     const questionId = propsValue.questionId.split('-')[0];
     const numericQuestionId = parseInt(questionId);
@@ -73,8 +83,8 @@ export const getGraphQuestion = createAction({
         );
       }
 
-      // we wait 15 seconds so the graph can load
-      await page.waitForTimeout(15000);
+      // we wait so the graph can load
+      await page.waitForTimeout(propsValue.waitTime * 1000);
 
       const screenshotBuffer = await page.screenshot({
         path: graphName,


### PR DESCRIPTION
## What does this PR do?

When using playwright to go to the iframe of a metabase graph, it doesn't let enough time for the graph to load so it only screens a loading page. Added a property wait time for the timeout.


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
