### PR TITLE
fix: add username to redis sentinel setup

### DIFF
--- a/packages/server/api/src/app/database/redis-connection.ts
+++ b/packages/server/api/src/app/database/redis-connection.ts
@@ -63,6 +63,7 @@ const createSentinelClient = (config: Partial<RedisOptions>): Redis => {
     const sentinelList = system.getOrThrow(AppSystemProp.REDIS_SENTINEL_HOSTS)
     const sentinelName = system.getOrThrow(AppSystemProp.REDIS_SENTINEL_NAME)
     const sentinelrole = system.get<'master' | 'slave'>(AppSystemProp.REDIS_SENTINEL_ROLE)
+    const username = system.get(AppSystemProp.REDIS_USER)
 
     const sentinels = sentinelList.split(',').map((sentinel) => {
         const [host, port] = sentinel.split(':')
@@ -73,6 +74,7 @@ const createSentinelClient = (config: Partial<RedisOptions>): Redis => {
         ...config,
         ...({ sentinels }),
         name: sentinelName,
+        username,
         password,
         role: sentinelrole,
         ...getTlsOptionsForSentinel(useSsl, tlsCa),


### PR DESCRIPTION
## What does this PR do?
When using a Sentinel setup for Redis database connections, the database might require a username (depending on Redis configuration)

### Explain How the Feature Works
The (already existing) `REDIS_USER` environment variable is read and passed to the `RedisOptions` object. The variable is optional.
reference: https://github.com/redis/ioredis/blob/main/lib/redis/RedisOptions.ts 

### Relevant User Scenarios
A Redis sentinel setup where the database configuration requires password AND username.



Fixes #7722 