### PR TITLE
feat(dust): bump dust SDK version to re-allow creating conversation with empty messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@dnd-kit/core": "6.1.0",
         "@dnd-kit/modifiers": "7.0.0",
         "@dnd-kit/sortable": "8.0.0",
-        "@dust-tt/client": "1.0.41",
+        "@dust-tt/client": "1.0.49",
         "@fastify/basic-auth": "5.0.0",
         "@fastify/cors": "8.3.0",
         "@fastify/formbody": "7.4.0",
@@ -5417,10 +5417,12 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.41.tgz",
-      "integrity": "sha512-tEXQhgY0E96sUpPmZ/iBr+VGKgUH9o3KXV4uIfXL58rlLGKyCq/gXYt1Y1jnb/vPv869cJrzg6gYSxVMtRalWQ==",
+      "version": "1.0.49",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.49.tgz",
+      "integrity": "sha512-cabKRfiEJS1J+T8OBi+EwxkmtHW9sDhiMgbTL+iJjdtT3VFCWdE5DJfpYdJwqLmUf3J17YAZZKf74F+hhnCSfg==",
+      "license": "ISC",
       "dependencies": {
+        "@types/json-schema": "^7.0.15",
         "axios": "^1.7.9",
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
@@ -23089,7 +23091,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json2xml": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@dnd-kit/core": "6.1.0",
     "@dnd-kit/modifiers": "7.0.0",
     "@dnd-kit/sortable": "8.0.0",
-    "@dust-tt/client": "1.0.41",
+    "@dust-tt/client": "1.0.49",
     "@fastify/basic-auth": "5.0.0",
     "@fastify/cors": "8.3.0",
     "@fastify/formbody": "7.4.0",

--- a/packages/pieces/community/dust/package.json
+++ b/packages/pieces/community/dust/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-dust",
-  "version": "0.1.12"
+  "version": "0.1.13"
 }


### PR DESCRIPTION


## What does this PR do?

When we started to use the SDK, we broke the possibility to create empty conversations (i.e. placeholders) because the then-current version enforced a mandatory `message` - whereas the API has no such requirement
Dust just released version 1.0.49 which fixes this discrepancy