### PR TITLE
feat(gmail): change impl of new labeled email to use messages API

### DIFF
--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,4 +1,4 @@
 {
 	"name": "@activepieces/piece-gmail",
-	"version": "0.8.1"
+	"version": "0.9.0"
 }

--- a/packages/pieces/community/gmail/src/lib/triggers/new-labeled-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-labeled-email.ts
@@ -72,71 +72,61 @@ export const gmailNewLabeledEmailTrigger = createTrigger({
     authClient.setCredentials(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
-    const profile = await gmail.users.getProfile({
+    const messagesResponse = await gmail.users.messages.list({
       userId: 'me',
+      labelIds: [context.propsValue.label.id],
+      maxResults: 1,
     });
 
-    await context.store.put('lastHistoryId', profile.data.historyId);
+    await context.store.put('lastMessageId', messagesResponse.data.messages?.[0]?.id || '');
   },
   onDisable: async (context) => {
-    await context.store.delete('lastHistoryId');
+    await context.store.delete('lastMessageId');
   },
   run: async (context) => {
     const authClient = new OAuth2Client();
     authClient.setCredentials(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
-    const lastHistoryId = await context.store.get('lastHistoryId');
-
-    const historyResponse = await gmail.users.history.list({
-      userId: 'me',
-      startHistoryId: lastHistoryId as string,
-      labelId: context.propsValue.label.id,
-      historyTypes: ['labelAdded'],
-    });
-
-    const labeledMessages = new Map<string, string>();
+    const lastMessageId = await context.store.get('lastMessageId');
     const results = [];
 
-    if (historyResponse.data.history) {
-      for (const history of historyResponse.data.history) {
-        if (history.labelsAdded) {
-          for (const labelAdded of history.labelsAdded) {
-            if (
-              labelAdded.labelIds?.includes(context.propsValue.label.id) &&
-              labelAdded.message?.id
-            ) {
-              labeledMessages.set(
-                labelAdded.message.id,
-                history.id?.toString() || ''
-              );
-            }
-          }
+    const messagesResponse = await gmail.users.messages.list({
+      userId: 'me',
+      labelIds: [context.propsValue.label.id],
+      maxResults: 10,
+    });
+
+    if (messagesResponse.data.messages) {
+      let foundLastMessage = false;
+      
+      for (const message of messagesResponse.data.messages) {
+        if (!message.id) continue;
+        
+        if (message.id === lastMessageId) {
+          foundLastMessage = true;
+          break;
         }
-      }
-    }
 
-    for (const [messageId, historyId] of labeledMessages) {
-      const enrichedMessage = await enrichGmailMessage({
-        gmail,
-        messageId,
-        files: context.files,
-        labelInfo: {
-          labelId: context.propsValue.label.id,
-          labelName: context.propsValue.label.name,
-        },
-      });
+        const enrichedMessage = await enrichGmailMessage({
+          gmail,
+          messageId: message.id,
+          files: context.files,
+          labelInfo: {
+            labelId: context.propsValue.label.id,
+            labelName: context.propsValue.label.name,
+          },
+        });
 
-      if (lastHistoryId !== historyId) {
         results.push({
-          id: historyId,
+          id: message.id,
           data: enrichedMessage,
         });
       }
-    }
 
-    if (historyResponse.data.historyId) {
-      await context.store.put('lastHistoryId', historyResponse.data.historyId);
+      if (messagesResponse.data.messages.length > 0) {
+        await context.store.put('lastMessageId', messagesResponse.data.messages[0].id);
+      }
     }
 
     return results;


### PR DESCRIPTION
## What does this PR do?

Changes the implementation of the "New Labelled Email" trigger to use the `messages` API instead of the `history` API. 
https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/list

The previous implementation works well when we are labelling emails manually, but does not get triggered when the labels are auto applied via [gmail filters](https://support.google.com/mail/answer/6579?hl=en). 

### Explain How the Feature Works
Same as before, internal change.

### Relevant User Scenarios
Same as before, internal change.

<img width="1435" alt="Screenshot 2025-05-16 at 6 14 15 PM" src="https://github.com/user-attachments/assets/8713226a-befa-4898-bd3b-5f9cf2211ccd" />

Fixes #7737 

Manually tested:
- triggers on filter auto applying label
- triggers on manually applying label in the gmail app
- triggers once per email, even when multiple emails are labelled within the polling intervals
