### PR TITLE
fix: update textProcessor to handle empty values of required strings

### DIFF
--- a/packages/engine/src/lib/variables/processors/text.ts
+++ b/packages/engine/src/lib/variables/processors/text.ts
@@ -1,16 +1,16 @@
 import { isNil } from '@activepieces/shared'
 import { ProcessorFn } from './types'
 
-export const textProcessor: ProcessorFn = (_property, value) => {
+export const textProcessor: ProcessorFn = (property, value) => {
     if (isNil(value)) {
         return value
     }
     if (typeof value === 'object') {
         return JSON.stringify(value)
     }
-    
+
     const result = value.toString()
-    if (result.length === 0) {
+    if (result.length === 0 && !property.required) {
         return undefined
     }
     return result

--- a/packages/pieces/community/store/package.json
+++ b/packages/pieces/community/store/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/piece-store",
-  "version": "0.6.0"
+  "version": "0.6.1"
 }
 

--- a/packages/pieces/community/store/src/lib/actions/store-append-action.ts
+++ b/packages/pieces/community/store/src/lib/actions/store-append-action.ts
@@ -5,6 +5,7 @@ import {
 import { common, getScopeAndKey } from './common';
 import { z } from 'zod';
 import { propsValidation } from '@activepieces/pieces-common';
+import { isNil } from '@activepieces/shared';
 
 export const storageAppendAction = createAction({
   name: 'append',
@@ -49,6 +50,9 @@ export const storageAppendAction = createAction({
       throw new Error(`Key ${context.propsValue.key} is not a string`);
     }
     const appendValue = context.propsValue.value;
+    if (appendValue === '' || isNil(appendValue)) {
+      return oldValue;
+    }
     let separator = context.propsValue.separator || '';
     separator = separator.replace(/\\n/g, '\n'); // Allow newline escape sequence
     const newValue =


### PR DESCRIPTION
This was added recently for optional strings as they should be undefined and not empty for actions like update deal on husbpot, but this broke the storage (append action), the empty string used to work and it no longer does.