### PR TITLE
feat(returning-ai): add forum channel send message action

### DIFF
--- a/packages/pieces/community/returning-ai/package.json
+++ b/packages/pieces/community/returning-ai/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-returning-ai",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/pieces/community/returning-ai/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/returning-ai/src/lib/actions/send-message.ts
@@ -1,5 +1,5 @@
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
-import { createAction, Property } from '@activepieces/pieces-framework';
+import { createAction, Property, DynamicPropsValue } from '@activepieces/pieces-framework';
 import { getApiEndpoint } from '../common';
 import { returningAiAuth } from '../../index';
 
@@ -71,9 +71,16 @@ export const sendMessage = createAction({
         if (response.body.status === 'success') {
           return {
             options: response.body.data.map(
-              (channel: { _id: string; topic: string }) => ({
+              (channel: {
+                _id: string;
+                topic: string;
+                channelType: string;
+              }) => ({
                 label: channel.topic,
-                value: channel._id,
+                value: JSON.stringify({
+                  id: channel._id,
+                  type: channel.channelType,
+                }),
               })
             ),
           };
@@ -86,6 +93,29 @@ export const sendMessage = createAction({
         }
       },
     }),
+    dynamicFields: Property.DynamicProperties({
+      displayName: 'Channel Fields',
+      description: 'Additional fields based on channel type',
+      required: true,
+      refreshers: ['channel'],
+      props: async ({ channel }) => {
+        const properties: Record<string, any> = {};
+
+        if (channel) {
+          const channelData = JSON.parse(channel as unknown as string);
+          if (channelData.type === 'forum') {
+            properties['topicId'] = Property.ShortText({
+              displayName: 'Topic ID',
+              description:
+                'The topic ID of the forum channel where the message will be posted',
+              required: true,
+            });
+          }
+        }
+
+        return properties;
+      },
+    }),
     message: Property.LongText({
       displayName: 'Message',
       description: 'The message to be posted',
@@ -94,6 +124,9 @@ export const sendMessage = createAction({
   },
   async run({ propsValue, auth }) {
     const authToken = auth as string;
+    const channelData = JSON.parse(propsValue.channel as string);
+    const dynamicFields = propsValue.dynamicFields as DynamicPropsValue;
+
     const response = await httpClient.sendRequest({
       method: HttpMethod.POST,
       url: `${getApiEndpoint(authToken)}/apis/v1/messages/send`,
@@ -101,9 +134,12 @@ export const sendMessage = createAction({
         Authorization: `Bearer ${authToken.split(':')[1]}`,
       },
       body: {
-        channelId: propsValue.channel,
+        channelId: channelData.id,
         message: propsValue.message,
         sender: propsValue.user,
+        ...(channelData.type === 'forum' && {
+          forumTopicId: dynamicFields['topicId'],
+        }),
       },
     });
 


### PR DESCRIPTION
## What does this PR do?

This PR enhances the Returning AI integration by adding support for sending messages to forum channels. It introduces dynamic fields based on channel type, specifically adding support for forum channels with topic ID selection.

### Explain How the Feature Works

The feature extends the existing "Send Message" action to handle different channel types:
1. When a user selects a channel, the system now checks the channel type
2. For forum channels, an additional "Topic ID" field appears dynamically
3. The message can then be sent to a specific topic within the forum channel

The implementation:
- Adds channel type information to the channel selection dropdown
- Introduces dynamic properties that show/hide fields based on channel type
- Modifies the API request to include forum-specific parameters when needed

### Relevant User Scenarios

1. **Forum Discussions**: Users can now send messages to specific topics within forum channels, enabling more organized discussions and targeted communication
2. **Automated Forum Responses**: Workflows can be created to automatically respond to forum topics with relevant information
3. **Cross-Channel Communication**: Users can maintain different message flows for regular channels and forum channels within the same workflow

### Technical Details

- Added support for channel type detection
- Implemented dynamic properties system for channel-specific fields
- Modified the API request structure to handle forum-specific parameters
- Enhanced type safety with proper TypeScript types

### Testing Notes

To test this feature:
1. Select a forum channel from the channel dropdown
2. Verify that the Topic ID field appears
3. Enter a valid topic ID and message
4. Confirm the message is posted to the correct forum topic

### Reference

https://dev.returning.ai/api-15023884
https://dev.returning.ai/api-15023851

Fixes # (issue number to be added)