### PR TITLE
fix(tables): passing records w/ non-matching field in records filter

### DIFF
--- a/packages/pieces/community/tables/package.json
+++ b/packages/pieces/community/tables/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-tables",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/packages/pieces/community/tables/src/lib/common/index.ts
+++ b/packages/pieces/community/tables/src/lib/common/index.ts
@@ -64,12 +64,11 @@ export const tablesCommon = {
   }),
 
   async getTableFields({ tableId, context }: { tableId: string, context: { server: { apiUrl: string, token: string } } }) {
-    const convertedTableId = await this.convertTableExternalIdToId(tableId, context);
     const fieldsResponse = await httpClient.sendRequest({
       method: HttpMethod.GET,
       url: `${context.server.apiUrl}v1/fields`,
       queryParams: {
-        tableId: convertedTableId,
+        tableId,
       },
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,

--- a/packages/server/api/src/app/server.ts
+++ b/packages/server/api/src/app/server.ts
@@ -30,6 +30,7 @@ async function setupBaseApp(): Promise<FastifyInstance> {
     const MAX_FILE_SIZE_MB = system.getNumberOrThrow(AppSystemProp.MAX_FILE_SIZE_MB)
     const fileSizeLimit =  Math.max(25 * 1024 * 1024, (MAX_FILE_SIZE_MB + 4) * 1024 * 1024)
     const app = fastify({
+        querystringParser: qs.parse,
         logger: system.globalLogger() as FastifyBaseLogger,
         ignoreTrailingSlash: true,
         pluginTimeout: 30000,

--- a/packages/server/api/src/app/tables/record/record.service.ts
+++ b/packages/server/api/src/app/tables/record/record.service.ts
@@ -109,7 +109,6 @@ export const recordService = {
         filters,
         limit,
     }: ListParams): Promise<SeekPage<PopulatedRecord>> {
-       
         const fields = await fieldService.getAll({
             tableId,
             projectId,

--- a/packages/server/api/src/app/tables/record/record.service.ts
+++ b/packages/server/api/src/app/tables/record/record.service.ts
@@ -134,7 +134,18 @@ export const recordService = {
             record.cells = cells.filter((cell) => cell.recordId === record.id)
         })
         const filteredOutRecords = records.filter((record) => {
-            return record.cells.every((cell) => doesCellValueMatchFilters(cell, filters ?? []))
+            if (!filters || filters.length === 0) {
+                return true
+            }
+
+            const relevantCells = record.cells.filter(cell => 
+                filters.some(filter => filter.fieldId === cell.fieldId),
+            )
+
+            if (relevantCells.length === 0) {
+                return false
+            }
+            return relevantCells.every((cell) => doesCellValueMatchFilters(cell, filters))
         })
        
         const populatedRecords = await formatRecordsAndFetchField({ records: filteredOutRecords, tableId, projectId })
@@ -410,11 +421,10 @@ function doesCellValueMatchFilters(cell: Cell, filters: Filter[]): boolean {
     if (filters.length === 0) {
         return true
     }
-    const filtersForCellFields = filters.filter((filter) => filter.fieldId === cell.fieldId)
-    if (filtersForCellFields.length === 0) {
-        return true
-    }
-    return filtersForCellFields.every((filter) => {
+    return filters.every((filter) => {
+        if (filter.fieldId !== cell.fieldId) {
+            return true
+        }
         if (filter.operator === undefined) {
             return true
         }


### PR DESCRIPTION
## What does this PR do?

Fixed a bug in record filtering where records without matching filter fields were incorrectly included in results. Previously, cells with non-matching field IDs were automatically passing filter checks. Now records must have the fields being filtered on AND match the filter conditions to be included.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
