### PR TITLE
fix(tables): passing records w/ non-matching field in records filter 

### DIFF
--- a/packages/server/api/src/app/tables/record/record.service.ts
+++ b/packages/server/api/src/app/tables/record/record.service.ts
@@ -135,7 +135,18 @@ export const recordService = {
             record.cells = cells.filter((cell) => cell.recordId === record.id)
         })
         const filteredOutRecords = records.filter((record) => {
-            return record.cells.every((cell) => doesCellValueMatchFilters(cell, filters ?? []))
+            if (!filters || filters.length === 0) {
+                return true
+            }
+
+            const relevantCells = record.cells.filter(cell => 
+                filters.some(filter => filter.fieldId === cell.fieldId),
+            )
+
+            if (relevantCells.length === 0) {
+                return false
+            }
+            return relevantCells.every((cell) => doesCellValueMatchFilters(cell, filters))
         })
        
         const populatedRecords = await formatRecordsAndFetchField({ records: filteredOutRecords, tableId, projectId })
@@ -411,11 +422,10 @@ function doesCellValueMatchFilters(cell: Cell, filters: Filter[]): boolean {
     if (filters.length === 0) {
         return true
     }
-    const filtersForCellFields = filters.filter((filter) => filter.fieldId === cell.fieldId)
-    if (filtersForCellFields.length === 0) {
-        return true
-    }
-    return filtersForCellFields.every((filter) => {
+    return filters.every((filter) => {
+        if (filter.fieldId !== cell.fieldId) {
+            return true
+        }
         if (filter.operator === undefined) {
             return true
         }


### PR DESCRIPTION
## What does this PR do?

Fixed a bug in record filtering where records without matching filter fields were incorrectly included in results. Previously, cells with non-matching field IDs were automatically passing filter checks. Now records must have the fields being filtered on AND match the filter conditions to be included.

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
