### PR TITLE
feat: adding the fail flow piece

### DIFF
--- a/packages/pieces/community/flow-helper/package.json
+++ b/packages/pieces/community/flow-helper/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-flow-helper",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/pieces/community/flow-helper/src/index.ts
+++ b/packages/pieces/community/flow-helper/src/index.ts
@@ -1,14 +1,13 @@
-
-    import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
 import { getRunId } from "./lib/actions/get-run-id";
+import { failFlow } from "./lib/actions/fail-flow";
 
-    export const flowHelper = createPiece({
-      displayName: "Flow Helper",
-      auth: PieceAuth.None(),
-      minimumSupportedRelease: '0.36.1',
-      logoUrl: "https://cdn.activepieces.com/pieces/flow-helper.svg",
-      authors: ["AbdulTheActivePiecer"],
-      actions: [getRunId],
-      triggers: [],
-    });
-    
+export const flowHelper = createPiece({
+  displayName: "Flow Helper",
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: "https://cdn.activepieces.com/pieces/flow-helper.svg",
+  authors: ["AbdulTheActivePiecer","AnkitSharmaOnGithub"],
+  actions: [getRunId, failFlow],
+  triggers: [],
+});

--- a/packages/pieces/community/flow-helper/src/lib/actions/fail-flow.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/fail-flow.ts
@@ -1,0 +1,17 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+
+export const failFlow = createAction({
+  name: 'failFlow',
+  displayName: 'Fail Flow',
+  description: 'Fails the flow execution with a custom message',
+  props: {
+    message: Property.LongText({
+      displayName: 'Error Message',
+      description: 'The error message to show when the flow fails',
+      required: true,
+    }),
+  },
+  async run(context) {
+    throw new Error(context.propsValue.message);
+  },
+});


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new piece that allows users to intentionally mark a flow as failed. The piece provides an action where the user can specify a custom failure message, and when executed, it throws an exception with that message—effectively terminating the flow with an error.

Fixes #7613