### PR TITLE
fix: shell command built from environment values

### DIFF
--- a/tools/scripts/pieces/update-authors.ts
+++ b/tools/scripts/pieces/update-authors.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import semVer from 'semver';
 
 const contributors = [
@@ -421,8 +421,8 @@ function cleanAuthors(authors: string[]) {
 }
 
 function loadAuthors(directoryPath: string) {
-    const gitLogCommand = `git log --format="%aN" -- ${directoryPath}`;
-    const result = execSync(gitLogCommand, { cwd: '/workspace/', encoding: 'utf-8' });
+    const gitLogArgs = ['log', '--format=%aN', '--', directoryPath];
+    const result = execFileSync('git', gitLogArgs, { cwd: '/workspace/', encoding: 'utf-8' });
     if (result.length === 0) {
         return [];
     }


### PR DESCRIPTION
https://github.com/activepieces/activepieces/blob/41abf8b765ef09185ef0a3eeec77a09d28949856/tools/scripts/pieces/update-authors.ts#L3-L3

https://github.com/activepieces/activepieces/blob/41abf8b765ef09185ef0a3eeec77a09d28949856/tools/scripts/pieces/update-authors.ts#L423-L425


https://github.com/activepieces/activepieces/blob/41abf8b765ef09185ef0a3eeec77a09d28949856/tools/scripts/pieces/update-authors.ts#L439-L439


Fix the issue the dynamically constructed shell command should be replaced with a safer alternative that avoids shell interpretation. The `execSync` function should be replaced with `execFileSync`, which allows passing arguments separately from the command, ensuring that special characters in the arguments are not interpreted by the shell.

Specifically:
1. Replace the dynamic construction of `gitLogCommand` with a hardcoded command (`git log`) and pass the `directoryPath` as an argument.
2. Update the `execSync` call to `execFileSync` and pass the arguments as an array.

This change ensures that the `directoryPath` is treated as a literal argument and not interpreted by the shell, mitigating the risk of command injection.

[OWASP CodeQL Command Injection](https://codeql.github.com/codeql-query-help/javascript/js-shell-command-injection-from-environment/)

---

**Fixes Ticket 🎟️ :** #7902