### PR TITLE
feat: add platform operator role

### DIFF
--- a/packages/react-ui/src/app/routes/platform/users/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/users/index.tsx
@@ -135,6 +135,8 @@ export default function UsersPage() {
                   <div className="text-left">
                     {row.original.platformRole === PlatformRole.ADMIN
                       ? t('Admin')
+                      : row.original.platformRole === PlatformRole.OPERATOR
+                      ? t('Operator')
                       : t('Member')}
                   </div>
                 );

--- a/packages/react-ui/src/app/routes/platform/users/update-user-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/users/update-user-dialog.tsx
@@ -105,6 +105,8 @@ export const UpdateUserDialog = ({
                           <SelectItem value={role} key={role}>
                             {role === PlatformRole.ADMIN
                               ? t('Admin')
+                              : role === PlatformRole.OPERATOR
+                              ? t('Operator')
                               : t('Member')}
                           </SelectItem>
                         ))}

--- a/packages/react-ui/src/features/team/component/platform-role-select.tsx
+++ b/packages/react-ui/src/features/team/component/platform-role-select.tsx
@@ -33,6 +33,9 @@ export const PlatformRoleSelect = ({ form }: PlatformRoleSelectProps) => {
               <SelectGroup>
                 <SelectLabel>{t('Platform Role')}</SelectLabel>
                 <SelectItem value={PlatformRole.ADMIN}>{t('Admin')}</SelectItem>
+                <SelectItem value={PlatformRole.OPERATOR}>
+                  {t('Operator')}
+                </SelectItem>
               </SelectGroup>
             </SelectContent>
           </Select>

--- a/packages/server/api/src/app/ee/projects/project-members/project-member.service.ts
+++ b/packages/server/api/src/app/ee/projects/project-members/project-member.service.ts
@@ -135,6 +135,9 @@ export const projectMemberService = (log: FastifyBaseLogger) => ({
         if (project.platformId === user.platformId && user.platformRole === PlatformRole.ADMIN) {
             return projectRoleService.getOneOrThrow({ name: DefaultProjectRole.ADMIN, platformId: project.platformId })
         }
+        if (project.platformId === user.platformId && user.platformRole === PlatformRole.OPERATOR) {
+            return projectRoleService.getOneOrThrow({ name: DefaultProjectRole.OPERATOR, platformId: project.platformId })
+        }
         const member = await repo().findOneBy({
             projectId,
             userId,

--- a/packages/server/api/test/integration/cloud/project/project.test.ts
+++ b/packages/server/api/test/integration/cloud/project/project.test.ts
@@ -612,6 +612,134 @@ describe('Project API', () => {
         })
     })
 
+    describe('Platform Operator Access', () => {
+        it('Platform operator can access all projects in their platform', async () => {
+            // arrange
+            const { mockOwner, mockPlatform } = await mockAndSaveBasicSetup()
+            
+            // Create a platform operator user
+            const { mockUser: operatorUser } = await mockBasicUser({
+                user: {
+                    platformId: mockPlatform.id,
+                    platformRole: PlatformRole.OPERATOR,
+                },
+            })
+            
+            // Create multiple projects owned by different users
+            const project1 = createMockProject({
+                ownerId: mockOwner.id,
+                platformId: mockPlatform.id,
+                displayName: 'Project 1',
+            })
+            const project2 = createMockProject({
+                ownerId: mockOwner.id,
+                platformId: mockPlatform.id,
+                displayName: 'Project 2',
+            })
+            
+            await databaseConnection().getRepository('project').save([project1, project2])
+            
+            const operatorToken = await generateMockToken({
+                type: PrincipalType.USER,
+                id: operatorUser.id,
+                platform: { id: mockPlatform.id },
+            })
+            
+            // act - list projects
+            const response = await app?.inject({
+                method: 'GET',
+                url: '/v1/users/projects',
+                headers: {
+                    authorization: `Bearer ${operatorToken}`,
+                },
+            })
+            
+            // assert
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const responseBody = response?.json()
+            // Platform operator should see all projects including the default one
+            expect(responseBody.data.length).toBeGreaterThanOrEqual(2)
+            const projectNames = responseBody.data.map((p: Project) => p.displayName)
+            expect(projectNames).toContain('Project 1')
+            expect(projectNames).toContain('Project 2')
+        })
+
+        it('Platform operator cannot update platform settings', async () => {
+            // arrange
+            const { mockPlatform } = await mockAndSaveBasicSetup()
+            
+            const { mockUser: operatorUser } = await mockBasicUser({
+                user: {
+                    platformId: mockPlatform.id,
+                    platformRole: PlatformRole.OPERATOR,
+                },
+            })
+            
+            const operatorToken = await generateMockToken({
+                type: PrincipalType.USER,
+                id: operatorUser.id,
+                platform: { id: mockPlatform.id },
+            })
+            
+            // act - try to update platform
+            const response = await app?.inject({
+                method: 'POST',
+                url: `/v1/platforms/${mockPlatform.id}`,
+                headers: {
+                    authorization: `Bearer ${operatorToken}`,
+                },
+                body: {
+                    name: 'Should not be allowed',
+                },
+            })
+            
+            // assert
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+
+        it('Platform member cannot access projects they are not member of', async () => {
+            // arrange
+            const { mockOwner, mockPlatform } = await mockAndSaveBasicSetup()
+            
+            // Create a regular platform member
+            const { mockUser: memberUser } = await mockBasicUser({
+                user: {
+                    platformId: mockPlatform.id,
+                    platformRole: PlatformRole.MEMBER,
+                },
+            })
+            
+            // Create a project the member is NOT part of
+            const project = createMockProject({
+                ownerId: mockOwner.id,
+                platformId: mockPlatform.id,
+                displayName: 'Restricted Project',
+            })
+            
+            await databaseConnection().getRepository('project').save(project)
+            
+            const memberToken = await generateMockToken({
+                type: PrincipalType.USER,
+                id: memberUser.id,
+                platform: { id: mockPlatform.id },
+            })
+            
+            // act - list projects
+            const response = await app?.inject({
+                method: 'GET',
+                url: '/v1/users/projects',
+                headers: {
+                    authorization: `Bearer ${memberToken}`,
+                },
+            })
+            
+            // assert
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const responseBody = response?.json()
+            expect(responseBody.data).toHaveLength(0) // Should not see any projects
+        })
+    })
+
 
 })
 

--- a/packages/shared/src/lib/user/user.ts
+++ b/packages/shared/src/lib/user/user.ts
@@ -5,8 +5,21 @@ import { ApId } from '../common/id-generator'
 export type UserId = ApId
 
 export enum PlatformRole {
+    /**
+     * Platform administrator with full control over platform settings,
+     * users, and all projects
+     */
     ADMIN = 'ADMIN',
+    /**
+     * Regular platform member with access only to projects they are
+     * explicitly invited to
+     */
     MEMBER = 'MEMBER',
+    /**
+     * Platform operator with automatic access to all projects in the
+     * platform but no platform administration capabilities
+     */
+    OPERATOR = 'OPERATOR',
 }
 
 export enum UserStatus {


### PR DESCRIPTION
## What does this PR do?

Fixes #7284 

This PR introduces a new platform role called **Platform Operator** - a middle-tier role between Platform Admin and Platform Member. The Platform Operator role provides automatic access to all projects within a platform without granting platform administration capabilities.

### Explain How the Feature Works

The Platform Operator role works as follows:
- **Project Access**: Operators automatically have access to all projects in their platform (similar to admins) but cannot modify platform settings
- **Role Assignment**: Platform admins can assign the Operator role to users through the user management interface
- **Permissions**: Operators get the `DefaultProjectRole.OPERATOR` role within projects they access
- **UI Integration**: The role appears in user listings, role selectors, and update dialogs with proper internationalization

### Relevant User Scenarios

- **Customer Support Teams**: Support staff need to access all customer projects to provide assistance without having full platform administration rights
- **Operations Teams**: DevOps/SRE teams need visibility into all projects for monitoring and troubleshooting without platform management capabilities  
- **Audit/Compliance**: Auditors need read access to all projects for compliance reviews without administrative privileges
- **Multi-tenant Environments**: Platform providers can assign operators to manage specific customer workloads without exposing platform configuration

The implementation includes:
- Frontend UI updates to display and select the new role
- Backend logic to grant automatic project access to operators
- Comprehensive test coverage validating operator permissions
- Type definitions and documentation for the new role