### PR TITLE
feat(google-drive): duplicate file as a specific mime type (gdocs or gsheet)

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.39"
+  "version": "0.5.40"
 }

--- a/packages/pieces/community/google-drive/src/index.ts
+++ b/packages/pieces/community/google-drive/src/index.ts
@@ -50,6 +50,7 @@ export const googleDrive = createPiece({
     'AbdulTheActivePiecer',
     'khaledmashaly',
     'abuaboud',
+    'geekyme'
   ],
   triggers: [newFile, newFolder],
   actions: [

--- a/packages/pieces/community/google-drive/src/lib/action/duplicate-file.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/duplicate-file.action.ts
@@ -25,6 +25,19 @@ export const duplicateFileAction = createAction({
       description: 'The ID of the folder where the file will be duplicated',
       required: true,
     }),
+    mimeType: Property.StaticDropdown({
+      displayName: 'Convert to Google Workspace Format',
+      description: 'Optionally convert the file to a Google Workspace format',
+      required: false,
+      options: {
+        options: [
+          {
+            label: 'CSV to Google Spreadsheet',
+            value: 'application/vnd.google-apps.spreadsheet',
+          }
+        ],
+      },
+    }),
     include_team_drives: common.properties.include_team_drives,
   },
   async run(context) {
@@ -34,13 +47,23 @@ export const duplicateFileAction = createAction({
     const fileId = context.propsValue.fileId;
     const nameForNewFile = context.propsValue.name;
     const parentFolderId = context.propsValue.folderId;
+    const mimeType = context.propsValue.mimeType;
 
     const drive = google.drive({ version: 'v3', auth: authClient });
+
+    const requestBody: any = {
+      name: nameForNewFile,
+      parents: [parentFolderId],
+    };
+
+    if (mimeType) {
+      requestBody.mimeType = mimeType;
+    }
 
     const response = await drive.files.copy({
       fileId,
       auth: authClient,
-      requestBody: { name: nameForNewFile, parents: [parentFolderId] },
+      requestBody,
       supportsAllDrives: context.propsValue.include_team_drives,
     });
 

--- a/packages/pieces/community/google-drive/src/lib/action/duplicate-file.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/duplicate-file.action.ts
@@ -26,14 +26,18 @@ export const duplicateFileAction = createAction({
       required: true,
     }),
     mimeType: Property.StaticDropdown({
-      displayName: 'Convert to Google Workspace Format',
-      description: 'Optionally convert the file to a Google Workspace format',
+      displayName: 'Duplicate as',
+      description: 'If left unselected the file will be duplicated as it is',
       required: false,
       options: {
         options: [
           {
-            label: 'CSV to Google Spreadsheet',
+            label: 'Google Sheets',
             value: 'application/vnd.google-apps.spreadsheet',
+          },
+          {
+            label: 'Google Docs',
+            value: 'application/vnd.google-apps.document',
           }
         ],
       },


### PR DESCRIPTION
## What does this PR do?

Allows opening a csv file in google drive in google spreadsheet format by supplying an optional param when using `Duplicate File`.


### Explain How the Feature Works

In activepieces:
<img width="1136" alt="Screenshot 2025-06-04 at 4 18 08 PM" src="https://github.com/user-attachments/assets/b25ef4ac-90e5-424d-9d33-39c8aaf7ca23" />

Result in gdrive.
<img width="352" alt="Screenshot 2025-06-04 at 4 25 24 PM" src="https://github.com/user-attachments/assets/dbc8944a-9642-4e6e-a44a-47518c3b6878" />


### Relevant User Scenarios

- if user need to use google sheets actions on a .csv, its not possible until they open that .csv in google sheets.
