### PR TITLE
Fix pipedrive api usage

### DIFF
--- a/packages/pieces/community/pipedrive/package.json
+++ b/packages/pieces/community/pipedrive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-pipedrive",
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/packages/pieces/community/pipedrive/src/lib/actions/add-follower.ts
+++ b/packages/pieces/community/pipedrive/src/lib/actions/add-follower.ts
@@ -1,12 +1,6 @@
 import { pipedriveAuth } from '../../index';
-import { createAction, PiecePropValueSchema, Property } from '@activepieces/pieces-framework';
-import {
-	fetchDealsOptions,
-	fetchOrganizationsOptions,
-	fetchPersonsOptions,
-	fetchProductsOptions,
-	ownerIdProp,
-} from '../common/props';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { ownerIdProp } from '../common/props';
 import { pipedriveApiCall } from '../common';
 import { HttpMethod } from '@activepieces/pieces-common';
 

--- a/packages/pieces/community/pipedrive/src/lib/common/index.ts
+++ b/packages/pieces/community/pipedrive/src/lib/common/index.ts
@@ -61,6 +61,18 @@ export type PipedriveApiCallParams = {
 	body?: any;
 };
 
+export type PipedriveApiCustomFilter<T> = (element: T) => boolean
+
+export type PipedrivePaginatedApiCallParams = {
+	accessToken: string;
+	apiDomain: string;
+	method: HttpMethod;
+	resourceUri: string;
+	query?: RequestParams;
+	body?: any;
+	customFilter?: PipedriveApiCustomFilter<any>;
+};
+
 export async function pipedriveApiCall<T extends HttpMessageBody>({
 	accessToken,
 	apiDomain,
@@ -119,7 +131,8 @@ export async function pipedrivePaginatedApiCall<T extends HttpMessageBody>({
 	resourceUri,
 	query,
 	body,
-}: PipedriveApiCallParams): Promise<T[]> {
+	customFilter,
+}: PipedrivePaginatedApiCallParams): Promise<T[]> {
 	const qs = query ? query : {};
 
 	qs.start = 0;
@@ -140,7 +153,20 @@ export async function pipedrivePaginatedApiCall<T extends HttpMessageBody>({
 		if (isNil(response.data)) {
 			break;
 		}
-		resultData.push(...response.data);
+
+		// performs custom filtering on response data, assumes sorting is applied through the query for consistency
+		if (isNil(customFilter)) {
+			resultData.push(...response.data);
+		} else {
+			const filteredData = response.data.filter(customFilter);
+			resultData.push(...filteredData);
+
+			// if the filter returns false on any element in the response, return elements that pass the filter and stop pagination
+			if (filteredData.length != response.data.length) {
+				break;
+			}
+		}
+
 		qs.start = response.additional_data.pagination.next_start;
 		hasMoreItems = response.additional_data.pagination.more_items_in_collection;
 	} while (hasMoreItems);

--- a/packages/pieces/community/pipedrive/src/lib/common/props.ts
+++ b/packages/pieces/community/pipedrive/src/lib/common/props.ts
@@ -35,78 +35,6 @@ export async function fetchFiltersOptions(
 	return options;
 }
 
-export async function fetchProductsOptions(
-	auth: PiecePropValueSchema<typeof pipedriveAuth>,
-): Promise<DropdownOption<number>[]> {
-	const products = await pipedrivePaginatedApiCall<{ id: number; name: string }>({
-		accessToken: auth.access_token,
-		apiDomain: auth.data['api_domain'],
-		method: HttpMethod.GET,
-		resourceUri: '/products',
-		query: {
-			sort: 'update_time DESC',
-		},
-	});
-
-	const options: DropdownOption<number>[] = [];
-	for (const product of products) {
-		options.push({
-			label: product.name,
-			value: product.id,
-		});
-	}
-
-	return options;
-}
-
-export async function fetchDealsOptions(
-	auth: PiecePropValueSchema<typeof pipedriveAuth>,
-): Promise<DropdownOption<number>[]> {
-	const deals = await pipedrivePaginatedApiCall<{ id: number; title: string }>({
-		accessToken: auth.access_token,
-		apiDomain: auth.data['api_domain'],
-		method: HttpMethod.GET,
-		resourceUri: '/deals',
-		query: {
-			sort: 'update_time DESC',
-		},
-	});
-
-	const options: DropdownOption<number>[] = [];
-	for (const deal of deals) {
-		options.push({
-			label: deal.title,
-			value: deal.id,
-		});
-	}
-
-	return options;
-}
-
-export async function fetchLeadsOptions(
-	auth: PiecePropValueSchema<typeof pipedriveAuth>,
-): Promise<DropdownOption<number>[]> {
-	const leads = await pipedrivePaginatedApiCall<{ id: number; title: string }>({
-		accessToken: auth.access_token,
-		apiDomain: auth.data['api_domain'],
-		method: HttpMethod.GET,
-		resourceUri: '/leads',
-		query: {
-			sort: 'update_time DESC',
-		},
-	});
-
-	const options: DropdownOption<number>[] = [];
-	for (const lead of leads) {
-		options.push({
-			label: lead.title,
-			value: lead.id,
-		});
-	}
-
-	return options;
-}
-
 export async function fetchActivityTypesOptions(
 	auth: PiecePropValueSchema<typeof pipedriveAuth>,
 ): Promise<DropdownOption<string>[]> {
@@ -193,30 +121,6 @@ export async function fetchOwnersOptions(
 		options.push({
 			label: user.email,
 			value: user.id,
-		});
-	}
-
-	return options;
-}
-
-export async function fetchOrganizationsOptions(
-	auth: PiecePropValueSchema<typeof pipedriveAuth>,
-): Promise<DropdownOption<number>[]> {
-	const organizations = await pipedrivePaginatedApiCall<{ id: number; name: string }>({
-		accessToken: auth.access_token,
-		apiDomain: auth.data['api_domain'],
-		method: HttpMethod.GET,
-		resourceUri: '/organizations:(id,name)',
-		query: {
-			sort: 'update_time DESC',
-		},
-	});
-
-	const options: DropdownOption<number>[] = [];
-	for (const org of organizations) {
-		options.push({
-			label: org.name,
-			value: org.id,
 		});
 	}
 
@@ -729,26 +633,9 @@ export const visibleToProp = Property.StaticDropdown({
 });
 
 export const leadIdProp = (required = false) =>
-	Property.Dropdown({
-		displayName: 'Lead',
-		refreshers: [],
+	Property.Number({
+		displayName: 'Lead ID',
 		required,
-		options: async ({ auth }) => {
-			if (!auth) {
-				return {
-					disabled: true,
-					options: [],
-					placeholder: 'Please connect your account.',
-				};
-			}
-			const authValue = auth as PiecePropValueSchema<typeof pipedriveAuth>;
-			const options = await fetchLeadsOptions(authValue);
-
-			return {
-				disabled: false,
-				options,
-			};
-		},
 	});
 
 export const activityTypeIdProp = (required = false) =>

--- a/packages/pieces/community/pipedrive/src/lib/trigger/new-lead.ts
+++ b/packages/pieces/community/pipedrive/src/lib/trigger/new-lead.ts
@@ -36,12 +36,18 @@ const polling: Polling<PiecePropValueSchema<typeof pipedriveAuth>, Record<string
 				leads.push(lead);
 			}
 		} else {
+			// API does not support filtering by add_time, provide custom filter that can short circuit pagination
+			const customFilter = (elem: Record<string, any>) => {
+				return dayjs(elem.add_time).valueOf() > lastFetchEpochMS;
+			}
+
 			const response = await pipedrivePaginatedApiCall<Record<string, any>>({
 				accessToken: auth.access_token,
 				apiDomain: auth.data['api_domain'],
 				method: HttpMethod.GET,
 				resourceUri: '/leads',
 				query: { sort: 'add_time DESC' },
+				customFilter: customFilter,
 			});
 			if (isNil(response)) {
 				return [];

--- a/packages/pieces/community/pipedrive/src/lib/trigger/new-note.ts
+++ b/packages/pieces/community/pipedrive/src/lib/trigger/new-note.ts
@@ -32,12 +32,18 @@ const polling: Polling<PiecePropValueSchema<typeof pipedriveAuth>, Record<string
 				notes.push(note);
 			}
 		} else {
+			// API does not support filtering by add_time, provide custom filter that can short circuit pagination
+			const customFilter = (elem: Record<string, any>) => {
+				return dayjs(elem.add_time).valueOf() > lastFetchEpochMS;
+			}
+			
 			const response = await pipedrivePaginatedApiCall<Record<string, any>>({
 				accessToken: auth.access_token,
 				apiDomain: auth.data['api_domain'],
 				method: HttpMethod.GET,
 				resourceUri: '/notes',
 				query: { sort: 'add_time DESC' },
+				customFilter: customFilter,
 			});
 			if (isNil(response)) {
 				return [];

--- a/packages/pieces/community/pipedrive/src/lib/trigger/new-organization.ts
+++ b/packages/pieces/community/pipedrive/src/lib/trigger/new-organization.ts
@@ -36,12 +36,18 @@ const polling: Polling<PiecePropValueSchema<typeof pipedriveAuth>, Record<string
 				organizations.push(org);
 			}
 		} else {
+			// API does not support filtering by add_time, provide custom filter that can short circuit pagination
+			const customFilter = (elem: Record<string, any>) => {
+				return dayjs(elem.add_time).valueOf() > lastFetchEpochMS;
+			}
+			
 			const response = await pipedrivePaginatedApiCall<Record<string, any>>({
 				accessToken: auth.access_token,
 				apiDomain: auth.data['api_domain'],
 				method: HttpMethod.GET,
 				resourceUri: '/organizations',
 				query: { sort: 'add_time DESC' },
+				customFilter: customFilter,
 			});
 			if (isNil(response)) {
 				return [];

--- a/packages/pieces/community/pipedrive/src/lib/trigger/updated-organization.ts
+++ b/packages/pieces/community/pipedrive/src/lib/trigger/updated-organization.ts
@@ -36,12 +36,18 @@ const polling: Polling<PiecePropValueSchema<typeof pipedriveAuth>, Record<string
                 organizations.push(org);
             }
         } else {
+            // API does not support filtering by update_time, provide custom filter that can short circuit pagination
+			const customFilter = (elem: Record<string, any>) => {
+				return dayjs(elem.update_time).valueOf() > lastFetchEpochMS;
+			}
+
             const response = await pipedrivePaginatedApiCall<Record<string, any>>({
                 accessToken: auth.access_token,
                 apiDomain: auth.data['api_domain'],
                 method: HttpMethod.GET,
                 resourceUri: '/organizations',
                 query: { sort: 'update_time DESC' },
+                customFilter: customFilter,
             });
             if (isNil(response)) {
                 return [];


### PR DESCRIPTION
## What does this PR do?

Automatic pagination of certain endpoints are dangerous if they can return a lot of data. This can exhaust the API quota and/or cause the AP instance to run out of memory.

### UI Props

In general only `/*Fields` endpoints like `/dealFields` or `leadFields` are safe as they usually contain that much data and are needed for the UI based filtering. Other UI inputs should be changed to basic inputs instead of dropdowns with options, as paginating through all the eg. Leads or Organizations can potentially return thousands of records.

This is an extension of https://github.com/activepieces/activepieces/pull/7708, with more props converted.

### Triggers

Some of the triggers are broken. On polling they return **all** the paginated data, instead of those added/updated since the last run. Since the APIs don't support filtering by these fields, we have to do it with custom filters. This has to be done on each paginated response instead of after all the data is retrieved. If a page of responses have any elements that do not pass the filter, the pagination terminates and only data that pass the filter are returned.

Note that this is expected to work together with sorting. Eg. if we want to filter by `add_time`, the pagination query should include `sort: add_time DESC` so that the latest page with any `add_time` that doesn't meet the criteria would trigger the stop condition.