### PR TITLE
feat(docusign): remove extra 'api/' from consent URL

### DIFF
--- a/packages/pieces/community/docusign/package.json
+++ b/packages/pieces/community/docusign/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-docusign",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/pieces/community/docusign/src/index.ts
+++ b/packages/pieces/community/docusign/src/index.ts
@@ -83,7 +83,9 @@ export const docusignAuth = PieceAuth.CustomAuth({
           '&client_id=' +
           auth.clientId +
           '&redirect_uri=' +
-          encodeURIComponent(`${server.publicUrl}/redirect`);
+          encodeURIComponent(
+            `${server.publicUrl.replace('/api', '')}/redirect`
+          );
         return {
           valid: false,
           error:


### PR DESCRIPTION
## What does this PR do?

`publicUrl` is actually the public **API** URL (and should be named `publicApiUrl` for consistency 😇 )
<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
