### PR TITLE
upd: add additional access scope to xero piece to include settings

### DIFF
--- a/packages/pieces/community/xero/src/index.ts
+++ b/packages/pieces/community/xero/src/index.ts
@@ -27,6 +27,7 @@ export const xeroAuth = PieceAuth.OAuth2({
     'offline_access',
     'accounting.contacts',
     'accounting.transactions',
+    'accounting.settings.read',
   ],
 });
 


### PR DESCRIPTION
## What does this PR do?
This PR adds support for the Xero Organisation endpoint, enabling the retrieval of organisation-level details such as name, legal name, base currency, country code, and other metadata. This enhancement allows our system to access and display up-to-date information about the authenticated organisation directly from Xero's API.


### Explain How the Feature Works
This feature introduces a new method that calls the Xero /Organisation endpoint, parses the response, and exposes key organisation properties for use within our application. The implementation closely follows the official Xero API documentation: https://developer.xero.com/documentation/api/accounting/organisation

### Relevant User Scenarios
- Admin users can view current organisation details pulled from Xero without manual data entry.
- Reporting tools can automatically populate company metadata such as legal name and currency.
- Integrations relying on country-specific configurations can now reference the organisation’s country code from Xero directly.

Fixes #7997 
