### PR TITLE
fix: prevent dialog overflow on small screens in MCP Add Tool modal ( Issue #8002)

### DIFF
--- a/packages/react-ui/src/app/mcp/mcp-piece-tool-dialog/index.tsx
+++ b/packages/react-ui/src/app/mcp/mcp-piece-tool-dialog/index.tsx
@@ -1,9 +1,14 @@
+import { McpToolType } from '@activepieces/shared';
+import type { McpWithTools } from '@activepieces/shared';
 import { DialogTrigger } from '@radix-ui/react-dialog';
 import { useMutation } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { ChevronLeft, Search } from 'lucide-react';
 import React, { useState, useMemo } from 'react';
 import { useDebounce } from 'use-debounce';
+
+import { McpPieceActionsDialog } from './mcp-piece-actions';
+import { McpPiecesContent } from './mcp-pieces-content';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -25,11 +30,6 @@ import { useToast } from '@/components/ui/use-toast';
 import { mcpApi } from '@/features/mcp/lib/mcp-api';
 import { piecesHooks } from '@/features/pieces/lib/pieces-hook';
 import { PieceStepMetadataWithSuggestions } from '@/features/pieces/lib/types';
-import { McpToolType } from '@activepieces/shared';
-import type { McpWithTools } from '@activepieces/shared';
-
-import { McpPieceActionsDialog } from './mcp-piece-actions';
-import { McpPiecesContent } from './mcp-pieces-content';
 
 type McpPieceDialogProps = {
   children: React.ReactNode;
@@ -195,7 +195,7 @@ export function McpPieceDialog({
       }}
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="min-w-[700px] max-w-[700px] h-[800px] max-h-[800px] flex flex-col overflow-hidden">
+      <DialogContent className="w-[90vw] max-w-[750px] h-[80vh] max-h-[800px] flex flex-col overflow-hidden">
         <DialogHeader className={`${selectedPiece ? 'gap-2' : 'gap-0'}`}>
           <DialogTitle>
             {selectedPiece ? (


### PR DESCRIPTION
## What does this PR do?

This PR addresses a UI bug where the "Add Tool" dialog in the MCP section would overflow the screen on smaller viewports, making parts of the modal inaccessible. The fix ensures the modal respects screen boundaries across devices, enhancing the overall user experience.

### Explain How the Feature Works

The modal's styling was updated to include proper maximum width and height constraints, ensuring it fits within smaller screens and supports internal scrolling. This improves layout consistency and usability.

### Relevant User Scenarios

* Users working on smaller screens (e.g., laptops or small monitors) who open the "Add Tool" dialog will now see the entire content without it overflowing off-screen.
* Improves accessibility and usability across devices.

**Before:**
![image](https://github.com/user-attachments/assets/1d87a2f2-19ea-46b1-b9c0-211f12862e33)


**After:**
![image](https://github.com/user-attachments/assets/aa2ef076-e9bd-43dd-8fd2-7c83f713c2af)


Fixes #8002
