### PR TITLE
fix: adjust sidebar background for dark mode (#8005)

### DIFF
--- a/packages/react-ui/src/styles.css
+++ b/packages/react-ui/src/styles.css
@@ -113,7 +113,7 @@
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
 
-    --sidebar-background: 240 5.9% 10%;
+    --sidebar-background: 20 14.3% 4.1%;
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 224.3 76.3% 48%;
     --sidebar-primary-foreground: 0 0% 100%;


### PR DESCRIPTION
## What does this PR do?

This PR resolves a UI inconsistency in dark mode where the sidebar background remained different colored, matching the light theme instead of adapting to the dark mode styling. The fix ensures the sidebar now correctly reflects the active theme, improving overall visual coherence.

### Explain How the Feature Works

The theme setup was already in place — the sidebar was using the wrong variable for its background. This PR updates it to use the correct theme-aware value so it displays appropriately in dark mode.

### Relevant User Scenarios

- Users browsing the app in **dark mode** will now see a sidebar background that matches the rest of the UI theme.
- This improves readability and visual consistency in dark mode.

### Before / After Screenshots (Optional)

**Before (Dark Mode):**  
![image](https://github.com/user-attachments/assets/8fd41598-6ccf-40f2-98cf-54e09981f0c1)->

**After (Dark Mode):**  
![image](https://github.com/user-attachments/assets/06d30c8e-cbd1-44ad-8dad-ecb0bf73bae8)


Fixes #8005
