### PR TITLE
feat(HTTP): add binary body  handling

### DIFF
--- a/packages/pieces/community/http/src/lib/actions/send-http-request-action.ts
+++ b/packages/pieces/community/http/src/lib/actions/send-http-request-action.ts
@@ -159,6 +159,12 @@ export const httpSendRequestAction = createAction({
         return fields;
       },
     }),
+    response_is_binary: Property.Checkbox({
+      displayName: 'Response is Binary',
+      description: 'Enable for files like PDFs, images, etc. A base64 body will be returned.',
+      required: false,
+      defaultValue: false,
+    }),
     use_proxy: Property.Checkbox({
       displayName: 'Use Proxy',
       defaultValue: false,
@@ -218,6 +224,7 @@ export const httpSendRequestAction = createAction({
       queryParams,
       body,
       body_type,
+      response_is_binary,
       timeout,
       failsafe,
       use_proxy,
@@ -256,6 +263,11 @@ export const httpSendRequestAction = createAction({
         break;
     }
 
+    // Set response type to arraybuffer if binary response is expected
+    if (response_is_binary) {
+      request.responseType = 'arraybuffer';
+    }
+
     if (body) {
       const bodyInput = body['data'];
       if (body_type === 'form_data') {
@@ -290,9 +302,20 @@ export const httpSendRequestAction = createAction({
         });
 
         const proxied_response = await axiosClient.request(request);
-        return proxied_response.data;
+        return handleBinaryResponse(
+          proxied_response.data,
+          proxied_response.status,
+          proxied_response.headers as HttpHeaders,
+          response_is_binary
+        );
       }
-      return await httpClient.sendRequest(request);
+      const response = await httpClient.sendRequest(request);
+      return handleBinaryResponse(
+        response.body,
+        response.status,
+        response.headers,
+        response_is_binary,
+      );
     } catch (error) {
       if (failsafe) {
         return (error as HttpError).errorMessage();
@@ -302,3 +325,24 @@ export const httpSendRequestAction = createAction({
     }
   },
 });
+
+const handleBinaryResponse = (
+  bodyContent: string | ArrayBuffer | Buffer,
+  status: number,
+  headers?: HttpHeaders,
+  isBinary?: boolean
+) => {
+  let body;
+
+  if (isBinary && isBinaryBody(bodyContent)) {
+    body = Buffer.from(bodyContent).toString('base64');
+  } else {
+    body = bodyContent;
+  }
+
+  return { status, headers, body };
+};
+
+const isBinaryBody = (body: string | ArrayBuffer | Buffer) => {
+  return body instanceof ArrayBuffer || Buffer.isBuffer(body);
+};


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to handle a binary body in the HTTP piece and return a Base64 body.

### Explain How the Feature Works

It adds a new field to the `HTTP > Send HTTP Request` action. This field, `Response is Binary` will handle the response body as binary and will expose it as Base64 instead of a (potentially broken) string.

<img src="https://github.com/user-attachments/assets/4a6ac865-f361-4317-9965-14b5acacafba" width="400" />
<img src="https://github.com/user-attachments/assets/e8136e42-c090-4747-8e28-60775e902bee" width="400" />

### Relevant User Scenarios

This is useful if you plan on using the content of a binary file (think PDF, or images, for instance) later in a scenario, like with the `Create File` action that does support Base64.

A basic scenario can be to use HTTP to get the content of a PDF file from somewhere, then use Create File with its content and finally store it in Dropbox, Drive or S3.

Also Fixes #7179.
