### PR TITLE
feat(returning-ai): add react message action

### DIFF
--- a/packages/pieces/community/returning-ai/package.json
+++ b/packages/pieces/community/returning-ai/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-returning-ai",
-  "version": "0.0.3"
+  "version": "0.0.4"
 }

--- a/packages/pieces/community/returning-ai/package.json
+++ b/packages/pieces/community/returning-ai/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-returning-ai",
-  "version": "0.0.4"
+  "version": "0.0.5"
 }

--- a/packages/pieces/community/returning-ai/src/index.ts
+++ b/packages/pieces/community/returning-ai/src/index.ts
@@ -1,6 +1,7 @@
 import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
 import { replyMessage } from './lib/actions/reply-message';
 import { sendMessage } from './lib/actions/send-message';
+import { reactMessage } from './lib/actions/react-message';
 
 export const returningAiAuth = PieceAuth.SecretText({
   displayName: 'API Key',
@@ -14,6 +15,6 @@ export const returningAi = createPiece({
   minimumSupportedRelease: '0.36.1',
   logoUrl: `https://cdn.activepieces.com/pieces/returning-ai.png`,
   authors: ['mg-wunna'],
-  actions: [sendMessage, replyMessage],
+  actions: [sendMessage, replyMessage, reactMessage],
   triggers: [],
 });

--- a/packages/pieces/community/returning-ai/src/lib/actions/react-message.ts
+++ b/packages/pieces/community/returning-ai/src/lib/actions/react-message.ts
@@ -1,0 +1,70 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getApiEndpoint } from '../common';
+import { returningAiAuth } from '../../index';
+
+/**
+ * This action allows you to react to a specific message as a chosen user in a channel.
+ * The reaction will appear as if the selected user added it directly to the message.
+ * 
+ * When using this action, you need to provide:
+ * 1. The username or email of the sender (who will appear to have reacted)
+ * 2. The ID of the message being reacted to
+ * 3. The emoji reaction to add (e.g. :sparkling_heart:)
+ * 
+ * The API will handle adding the reaction appropriately to the message.
+ * 
+ * @example
+ * ```
+ * // Example response
+ * {
+ *   "status": "success",
+ *   "message": "Reaction added successfully"
+ * }
+ * ```
+ * 
+ * @link https://dev.returning.ai/api-16179164
+ */
+export const reactMessage = createAction({
+  auth: returningAiAuth,
+  name: 'reactMessage', 
+  displayName: 'React to Message',
+  description: 'Add an emoji reaction to a specific message as a chosen user.',
+  props: {
+    description: Property.MarkDown({
+      value:
+        'This action allows you to add an emoji reaction to a message in any accessible channel on behalf of a specific user. The reaction will appear as if the selected user added it directly to the message.',
+    }),
+    user: Property.ShortText({
+      displayName: 'Sender (Username or email)',
+      description: 'The user account that will add the reaction',
+      required: true,
+    }),
+    messageId: Property.ShortText({
+      displayName: 'React to (Message ID)', 
+      description: 'The ID of the message to react to',
+      required: true,
+    }),
+    emoji: Property.ShortText({
+      displayName: 'Reaction emoji',
+      description: 'The emoji to react with (e.g. :sparkling_heart:)',
+      required: true,
+    }),
+  },
+  async run({ propsValue, auth }) {
+    const authToken = auth as string;
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${getApiEndpoint(authToken)}/apis/v1/messages/react`,
+      headers: {
+        Authorization: `Bearer ${authToken.split(':')[1]}`,
+      },
+      body: {
+        messageId: propsValue.messageId,
+        emoji: propsValue.emoji,
+        sender: propsValue.user,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/returning-ai/src/lib/actions/react-message.ts
+++ b/packages/pieces/community/returning-ai/src/lib/actions/react-message.ts
@@ -57,7 +57,7 @@ export const reactMessage = createAction({
       method: HttpMethod.POST,
       url: `${getApiEndpoint(authToken)}/apis/v1/messages/react`,
       headers: {
-        Authorization: `Bearer ${authToken.split(':')[1]}`,
+        Authorization: `Bearer ${authToken.includes(':') ? authToken.split(':')[1] : authToken}`,
       },
       body: {
         messageId: propsValue.messageId,

--- a/packages/pieces/community/returning-ai/src/lib/actions/reply-message.ts
+++ b/packages/pieces/community/returning-ai/src/lib/actions/reply-message.ts
@@ -57,7 +57,7 @@ export const replyMessage = createAction({
       method: HttpMethod.POST,
       url: `${getApiEndpoint(authToken)}/apis/v1/messages/reply`,
       headers: {
-        Authorization: `Bearer ${authToken.split(':')[1]}`,
+        Authorization: `Bearer ${authToken.includes(':') ? authToken.split(':')[1] : authToken}`,
       },
       body: {
         messageId: propsValue.messageId,

--- a/packages/pieces/community/returning-ai/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/returning-ai/src/lib/actions/send-message.ts
@@ -64,7 +64,7 @@ export const sendMessage = createAction({
           method: HttpMethod.GET,
           url: `${getApiEndpoint(authToken)}/apis/v1/channels`,
           headers: {
-            Authorization: `Bearer ${authToken.split(':')[1]}`,
+            Authorization: `Bearer ${authToken.includes(':') ? authToken.split(':')[1] : authToken}`,
           },
         });
 
@@ -131,7 +131,7 @@ export const sendMessage = createAction({
       method: HttpMethod.POST,
       url: `${getApiEndpoint(authToken)}/apis/v1/messages/send`,
       headers: {
-        Authorization: `Bearer ${authToken.split(':')[1]}`,
+        Authorization: `Bearer ${authToken.includes(':') ? authToken.split(':')[1] : authToken}`,
       },
       body: {
         channelId: channelData.id,


### PR DESCRIPTION
## What does this PR do?

This PR adds a new React Message action to the Returning AI piece that allows users to add emoji reactions to messages.

### Explain How the Feature Works

The React Message action enables users to:
1. Specify a message ID to react to
2. Choose an emoji reaction (e.g. ":smile:", ":heart:", ":thumbsup:")
3. Add the reaction on behalf of a specific user

The action makes a POST request to the Returning AI API endpoint to add the reaction.

API Documentation: https://dev.returning.ai/api-17792861

### Relevant User Scenarios

- Community managers wanting to engage with user messages through emoji reactions
- Automated reaction workflows based on message content or triggers
- Adding standardized reactions to specific types of messages
- Building engagement metrics through reaction tracking
