### PR TITLE
fix(docusign): fix filename which was always archive.zip even for PDFs

### DIFF
--- a/packages/pieces/community/docusign/package.json
+++ b/packages/pieces/community/docusign/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-docusign",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/pieces/community/docusign/src/lib/actions/get-document.ts
+++ b/packages/pieces/community/docusign/src/lib/actions/get-document.ts
@@ -34,8 +34,10 @@ export const getDocument = createAction({
   async run({ auth, propsValue, files }) {
     const apiClient = await createApiClient(auth as DocusignAuthType);
     const envelopeApiClient = new EnvelopesApi(apiClient);
+    const filename =
+      propsValue.documentId === 'archive' ? 'archive.zip' : 'document.pdf';
     return await files.write({
-      fileName: 'archive.zip',
+      fileName: filename,
       data: Buffer.from(
         await envelopeApiClient.getDocument(
           propsValue.accountId,


### PR DESCRIPTION
## What does this PR do?

Even when the document is a PDF, the retrieved file would be named `archive.zip`

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
