### PR TITLE
feat(slack): add customizable connection scopes

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.9.1"
+  "version": "0.10.0"
 }

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -45,37 +45,49 @@ import { inviteUserToChannelAction } from './lib/actions/invite-user-to-channel'
 
 export const slackAuth = PieceAuth.OAuth2({
   description: '',
-  authUrl:
-    'https://slack.com/oauth/v2/authorize?user_scope=search:read,users.profile:write,reactions:read,im:history,stars:read',
+  authUrl: 'https://slack.com/oauth/v2/authorize?scope={botScopes}&user_scope={userScopes}',
   tokenUrl: 'https://slack.com/api/oauth.v2.access',
   required: true,
-  scope: [
-    'channels:read',
-    'channels:manage',
-    'channels:history',
-    'chat:write',
-    'groups:read',
-    'groups:write',
-    'groups:history',
-    'reactions:read',
-    'mpim:read',
-    'mpim:write',
-    'mpim:history',
-    'im:write',
-    'im:read',
-    'im:history',
-    'users:read',
-    'files:write',
-    'files:read',
-    'users:read.email',
-    'reactions:write',
-    'usergroups:read',
-    'chat:write.customize',
-    'links:read',
-    'links:write',
-		'emoji:read',
-		'users.profile:read'
-  ],
+  props: {
+    botScopes: Property.ShortText({
+      displayName: 'Bot scopes',
+      description: 'Comma-separated list of scopes for the bot token',
+      required: true,
+      defaultValue:
+        'channels:read,channels:manage,' +
+        'channels:history,' +
+        'chat:write,' +
+        'groups:read,' +
+        'groups:write,' +
+        'groups:history,' +
+        'reactions:read,' +
+        'mpim:read,' +
+        'mpim:write,' +
+        'mpim:history,' +
+        'im:write,' +
+        'im:read,' +
+        'im:history,' +
+        'users:read,' +
+        'files:write,' +
+        'files:read,' +
+        'users:read.email,' +
+        'reactions:write,' +
+        'usergroups:read,' +
+        'chat:write.customize,' +
+        'links:read,' +
+        'links:write,' +
+        'emoji:read,' +
+        'users.profile:read',
+    }),
+    userScopes: Property.ShortText({
+      displayName: 'User scopes',
+      description: 'Comma-separated list of scopes for the user token',
+      required: true,
+      defaultValue:
+        'search:read,users.profile:write,reactions:read,im:history,stars:read',
+    }),
+  },
+  scope: ["{botScopes}"],
 });
 
 export const slack = createPiece({


### PR DESCRIPTION
## What does this PR do?

Scopes can now be customized to avoid `missing_scope` errors when doing a Custom API call

<img width="639" alt="Capture d’écran 2025-06-11 à 11 18 18" src="https://github.com/user-attachments/assets/101fd43f-5aee-4a51-9406-b8cba40b7341" />


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
