### PR TITLE
fix: return entity not found instead of missing project id

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "nx-mcp": {
+      "url": "http://localhost:9536/sse"
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ scratch.md
 
 # environment variables
 .env
+
+.cursor/rules/nx-rules.mdc
+.github/instructions/nx.instructions.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,5 @@
     "editor.formatOnSave": false,
     "typescript.tsdk": "node_modules/typescript/lib",
     "javascript.preferences.importModuleSpecifier": "relative",
+    "nxConsole.generateAiAgentRules": true,
 }

--- a/packages/server/api/src/app/core/security/authn/platform-api-key-authn-handler.ts
+++ b/packages/server/api/src/app/core/security/authn/platform-api-key-authn-handler.ts
@@ -99,7 +99,6 @@ export class PlatformApiKeyAuthnHandler extends BaseSecurityHandler {
     private async extractProjectIdOrThrow(
         request: FastifyRequest,
     ): Promise<ProjectId> {
-        const projectIdFromRequest = requestUtils.extractProjectId(request)
         
         // Check if route has :id parameter
         const hasIdParam = request.routerPath.includes(':id') &&
@@ -122,6 +121,8 @@ export class PlatformApiKeyAuthnHandler extends BaseSecurityHandler {
                 },
             })
         }
+        const projectIdFromRequest = requestUtils.extractProjectId(request)
+
         
         // Route doesn't have :id parameter, must get project ID from request
         if (isNil(projectIdFromRequest)) {

--- a/packages/server/api/src/app/core/security/authn/platform-api-key-authn-handler.ts
+++ b/packages/server/api/src/app/core/security/authn/platform-api-key-authn-handler.ts
@@ -101,33 +101,29 @@ export class PlatformApiKeyAuthnHandler extends BaseSecurityHandler {
     ): Promise<ProjectId> {
         const projectIdFromRequest = requestUtils.extractProjectId(request)
         
-        // Check if route has :id parameter
         const hasIdParam = request.routerPath.includes(':id') &&
             isObject(request.params) &&
             'id' in request.params &&
             typeof request.params.id === 'string'
         
         if (hasIdParam) {
-            // Route has :id parameter, try to fetch from resource
             const projectIdFromResource = await this.extractProjectIdFromResource(request)
             if (!isNil(projectIdFromResource)) {
                 return projectIdFromResource
             }
             
-            // Resource with :id not found
             const resourceName = extractResourceName(request.routerPath)
             const resourceId = (request.params as { id: string }).id
             throw new ActivepiecesError({
                 code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    message: `${resourceName || 'resource'} with id ${resourceId} not found`,
+                    message: `${resourceId} not found`,
                     entityType: resourceName,
                     entityId: resourceId,
                 },
             })
         }
         
-        // Route doesn't have :id parameter, must get project ID from request
         if (isNil(projectIdFromRequest)) {
             throw new ActivepiecesError({
                 code: ErrorCode.VALIDATION,

--- a/packages/server/api/src/app/core/security/authn/platform-api-key-authn-handler.ts
+++ b/packages/server/api/src/app/core/security/authn/platform-api-key-authn-handler.ts
@@ -99,6 +99,7 @@ export class PlatformApiKeyAuthnHandler extends BaseSecurityHandler {
     private async extractProjectIdOrThrow(
         request: FastifyRequest,
     ): Promise<ProjectId> {
+        const projectIdFromRequest = requestUtils.extractProjectId(request)
         
         // Check if route has :id parameter
         const hasIdParam = request.routerPath.includes(':id') &&
@@ -114,15 +115,17 @@ export class PlatformApiKeyAuthnHandler extends BaseSecurityHandler {
             }
             
             // Resource with :id not found
+            const resourceName = extractResourceName(request.routerPath)
+            const resourceId = (request.params as { id: string }).id
             throw new ActivepiecesError({
                 code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    message: `resource with id ${(request.params as { id: string }).id} not found`,
+                    message: `${resourceName || 'resource'} with id ${resourceId} not found`,
+                    entityType: resourceName,
+                    entityId: resourceId,
                 },
             })
         }
-        const projectIdFromRequest = requestUtils.extractProjectId(request)
-
         
         // Route doesn't have :id parameter, must get project ID from request
         if (isNil(projectIdFromRequest)) {

--- a/packages/server/api/test/integration/cloud/core/security.test.ts
+++ b/packages/server/api/test/integration/cloud/core/security.test.ts
@@ -331,7 +331,7 @@ describe('API Security', () => {
             // assert
             await expect(result).rejects.toEqual(
                 new ActivepiecesError({
-                    code: ErrorCode.AUTHORIZATION,
+                    code: ErrorCode.VALIDATION,
                     params: {
                         message: 'invalid project id',
                     },


### PR DESCRIPTION
The `extractProjectIdOrThrow` method in `packages/server/api/src/app/core/security/authn/platform-api-key-authn-handler.ts` was updated to refine project ID extraction and error handling based on route parameters.

*   **For routes containing an `:id` parameter**:
    *   The method now attempts to extract the project ID from the resource.
    *   If the resource is not found, `ErrorCode.ENTITY_NOT_FOUND` is thrown.
    *   The `ENTITY_NOT_FOUND` error `params` now include `entityType` (the resource name) and `entityId` (the ID from the route), along with a descriptive message.
*   **For routes without an `:id` parameter**:
    *   The method attempts to extract the project ID directly from the request (body/query).
    *   If the project ID is missing, `ErrorCode.VALIDATION` is thrown with a "missing project id in request" message.

This change differentiates between resource not found errors and missing request parameter errors, providing more precise API responses.