### PR TITLE
fix: dont enable triggers when flows should not be activated on publish

### DIFF
--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -120,7 +120,7 @@ export const flowService = (log: FastifyBaseLogger) => ({
             },
         })
         const queryWhere: Record<string, unknown> = { projectId }
-        
+
         if (folderId !== undefined) {
             queryWhere.folderId = folderId === 'NULL' ? IsNull() : folderId
         }
@@ -579,7 +579,7 @@ export const flowService = (log: FastifyBaseLogger) => ({
             id: flowId,
             projectId,
         })
-        
+
         flow.updated = dayjs().toISOString()
         await flowRepo().save(flow)
     },


### PR DESCRIPTION
## What does this PR do?

#7835 / #7953 introduced a bug because triggers are still enabled even if the flow is not marked as published - leading to very confusing situations (flow is running while disabled)

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
