### PR TITLE
chore(stripe): do not schedule usage report without stripe

### DIFF
--- a/packages/server/api/src/app/ee/platform/platform-plan/platform-plan.module.ts
+++ b/packages/server/api/src/app/ee/platform/platform-plan/platform-plan.module.ts
@@ -20,13 +20,6 @@ export const platformPlanModule: FastifyPluginAsyncTypebox = async (app) => {
         const log = app.log
         log.info('Running platform-daily-report')
 
-        const stripe = stripeHelper(log).getStripe()
-
-        if (isNil(stripe)) {
-            log.info('Skipping platform-daily-report as Stripe is not configured')
-            return
-        }
-
         const startOfDay = dayjs().startOf('day').toISOString()
         const endOfDay = dayjs().endOf('day').toISOString()
         const currentTimestamp = dayjs().unix()
@@ -40,6 +33,8 @@ export const platformPlanModule: FastifyPluginAsyncTypebox = async (app) => {
         )`, { startDate: startOfDay, endDate: endOfDay })
             .getRawMany()
         log.info({ platformCount: platforms.length }, 'Found platforms with usage in the current day')
+        const stripe = stripeHelper(log).getStripe()
+        assertNotNullOrUndefined(stripe, 'Stripe is not configured')
 
         for (const { platformId } of platforms) {
             const platformBilling = await platformPlanService(log).getOrCreateForPlatform(platformId)

--- a/packages/server/api/src/app/ee/platform/platform-plan/platform-plan.module.ts
+++ b/packages/server/api/src/app/ee/platform/platform-plan/platform-plan.module.ts
@@ -1,8 +1,9 @@
 import { ApSubscriptionStatus } from '@activepieces/ee-shared'
-import { assertNotNullOrUndefined, isNil } from '@activepieces/shared'
+import { ApEdition, assertNotNullOrUndefined, isNil } from '@activepieces/shared'
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
 import dayjs from 'dayjs'
 import Stripe from 'stripe'
+import { system } from '../../../helper/system/system'
 import { systemJobsSchedule } from '../../../helper/system-jobs'
 import { SystemJobName } from '../../../helper/system-jobs/common'
 import { systemJobHandlers } from '../../../helper/system-jobs/job-handlers'
@@ -59,8 +60,7 @@ export const platformPlanModule: FastifyPluginAsyncTypebox = async (app) => {
         log.info('Finished platform-daily-report')
     })
 
-    const stripe = stripeHelper(app.log).getStripe()
-    if (!isNil(stripe)) {
+    if (system.getEdition() === ApEdition.CLOUD) {
         await systemJobsSchedule(app.log).upsertJob({
             job: {
                 name: SystemJobName.PLATFORM_USAGE_REPORT,
@@ -73,7 +73,7 @@ export const platformPlanModule: FastifyPluginAsyncTypebox = async (app) => {
         })
     }
     else {
-        app.log.info('Skipping platform usage report job registration as Stripe is not configured')
+        app.log.info('Skipping platform usage report job registration as it is not CLOUD edition')
     }
 
     await app.register(platformPlanController, { prefix: '/v1/platform-billing' })


### PR DESCRIPTION
## What does this PR do?

Do not schedule usage report if Stripe is not configured.

Stripe is used only on Activepieces Cloud Edition. Self-hosted version might not need it.


### Explain How the Feature Works

Just an `if` validation.

### Relevant User Scenarios

Do not schedule usage report if Stripe is not configured.

Currently, it is resulting in false-positive failing jobs on `system-job-queue`:

![ipaas-internal pipefy com_api_ui_queue_system-job-queue_status=failed](https://github.com/user-attachments/assets/70dc03cd-67e8-4877-990b-1a758efbb827)

