### PR TITLE
fix: support vendor-prefixed content-type responses

### DIFF
--- a/packages/pieces/community/common/src/lib/helpers/index.ts
+++ b/packages/pieces/community/common/src/lib/helpers/index.ts
@@ -193,6 +193,8 @@ i.e ${getBaseUrlForDescription(baseUrl,auth)}/resource or /resource`,
         'application/x-www-form-urlencoded',  // Form submissions
       ];
 
+      const objectContentTypeSuffixes = ['+json', '+xml'];
+
       let response;
       try {
         response = await httpClient.sendRequest(request);
@@ -209,7 +211,10 @@ i.e ${getBaseUrlForDescription(baseUrl,auth)}/resource or /resource`,
         : response.headers?.['content-type']
 
       // Return unaltered response if content type is associated with objects or strings
-      if (objectContentTypes.some(type => (contentTypeValue ?? '').includes(type))) {
+      const isObjectContentType = objectContentTypes.some(type => (contentTypeValue ?? '').includes(type)) ||
+                                   objectContentTypeSuffixes.some(suffix => (contentTypeValue ?? '').endsWith(suffix));
+      
+      if (isObjectContentType) {
         try {
           // Parse JSON responses if valid
           response.body = JSON.parse(response.body || '{}');


### PR DESCRIPTION
## What does this PR do?

#7805 introduced a breaking change to custom API call response handling. In it's implementation, it relied on a fixed array of content-types to treat as objects. Anything that's not in the list gets treated as a file. The impact is if an API endpoint returns a non-supported content-type, you cannot chain the output because you get a "Download File" button instead in the body.

Our endpoints return content-type as `application/vnd.api+json`. This PR enhances the check to also consider vendor-prefixed content types.


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
