### PR TITLE
feat: add run.id to trigger context

### DIFF
--- a/packages/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/engine/src/lib/helper/trigger-helper.ts
@@ -176,6 +176,9 @@ export const triggerHelper = {
                                 stepName: triggerName,
                                 flowId: params.flowVersion.flowId,
                             }),
+                            run: {
+                                id: constants.flowRunId,
+                            },
                         }),
                     }
                 }
@@ -230,6 +233,9 @@ export const triggerHelper = {
                         flowId: params.flowVersion.flowId,
                         stepName: triggerName,
                     }),
+                    run: {
+                        id: constants.flowRunId,
+                    },
                 })
                 if (!Array.isArray(items)) {
                     throw new Error(`Trigger run should return an array of items, but returned ${typeof items}`)

--- a/packages/pieces/community/framework/src/lib/context.ts
+++ b/packages/pieces/community/framework/src/lib/context.ts
@@ -84,6 +84,7 @@ export type TestOrRunHookContext<
   S extends TriggerStrategy
 > = TriggerHookContext<PieceAuth, TriggerProps, S> & {
   files: FilesService;
+  run: Pick<RunContext, 'id'>;
 };
 
 export type StopHookParams = {


### PR DESCRIPTION
## What does this PR do?

Currently, only actions have access to run within the run() context. For triggers, run is accessible in the onStart callback, but not within run itself. This capability is useful for enabling logging inside triggers for log correlation purposes.


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
