### PR TITLE
fix(dialog): fix overflow issue in New Flow dialog on MCP page ( Fixes #8094 )

### DIFF
--- a/packages/react-ui/src/app/routes/mcp-servers/id/mcp-flow-tool-dialog/index.tsx
+++ b/packages/react-ui/src/app/routes/mcp-servers/id/mcp-flow-tool-dialog/index.tsx
@@ -1,8 +1,12 @@
+import { McpToolType, TriggerType, McpWithTools } from '@activepieces/shared';
+import type { PopulatedFlow } from '@activepieces/shared';
 import { DialogTrigger } from '@radix-ui/react-dialog';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { Search } from 'lucide-react';
 import React, { useState } from 'react';
+
+import { McpFlowDialogContent } from './mcp-flow-dialog-content';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -20,10 +24,6 @@ import { useToast } from '@/components/ui/use-toast';
 import { flowsApi } from '@/features/flows/lib/flows-api';
 import { mcpApi } from '@/features/mcp/lib/mcp-api';
 import { authenticationSession } from '@/lib/authentication-session';
-import { McpToolType, TriggerType, McpWithTools } from '@activepieces/shared';
-import type { PopulatedFlow } from '@activepieces/shared';
-
-import { McpFlowDialogContent } from './mcp-flow-dialog-content';
 
 type McpFlowDialogProps = {
   children: React.ReactNode;
@@ -119,7 +119,7 @@ export function McpFlowDialog({
       }}
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="min-w-[750px] max-w-[750px] h-[800px] max-h-[800px] flex flex-col overflow-hidden">
+      <DialogContent className="w-[90vw] max-w-[750px] h-[80vh] max-h-[800px] flex flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle>{t('Add Flow Tools')}</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## What does this PR do?

Fixes a UI bug where the "New Flow" dialog overflows outside the viewport when accessed via the MCP page. This improves the layout and user experience, especially on smaller screens or zoomed views.

### Explain How the Feature Works

The issue was due to incorrect or missing overflow styling on the dialog container. The fix ensures the dialog respects the viewport boundaries by adjusting CSS overflow rules. This prevents layout breaking or hidden content issues.

Before Screenshot :

![image](https://github.com/user-attachments/assets/2356ebf8-d323-4bb1-9677-473bf7dfd615)

After Screenshot :

![image](https://github.com/user-attachments/assets/f8ebbb6e-e8fe-47f4-958e-4cd518469699)


### Relevant User Scenarios

- A user creating a new MCP server and adding a new tool will now see the “New Flow” dialog properly within the screen.
- On smaller screen sizes, the dialog no longer overflows or causes awkward scrolling behavior.

Fixes #8094  
