### PR TITLE
Added scopes on slack for lumo workflow

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -73,10 +73,10 @@ export const slackAuth = PieceAuth.OAuth2({
     'chat:write.customize',
     'links:read',
     'links:write',
-		'emoji:read',
-		'users.profile:read'
-        'channels:write.invites'
-        'groups:write.invites'
+    'emoji:read',
+    'users.profile:read',
+    'channels:write.invites',
+    'groups:write.invites'
   ],
 });
 

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -46,7 +46,7 @@ import { inviteUserToChannelAction } from './lib/actions/invite-user-to-channel'
 export const slackAuth = PieceAuth.OAuth2({
   description: '',
   authUrl:
-    'https://slack.com/oauth/v2/authorize?user_scope=search:read,users.profile:write,reactions:read,im:history,stars:read',
+    'https://slack.com/oauth/v2/authorize?user_scope=search:read,users.profile:write,reactions:read,im:history,stars:read,channels:write,groups:write,im:write,mpim:write,channels:write.invites,groups:write.invites'
   tokenUrl: 'https://slack.com/api/oauth.v2.access',
   required: true,
   scope: [
@@ -75,6 +75,8 @@ export const slackAuth = PieceAuth.OAuth2({
     'links:write',
 		'emoji:read',
 		'users.profile:read'
+        'channels:write.invites'
+        'groups:write.invites'
   ],
 });
 


### PR DESCRIPTION
# Description

We updated the scoped of the slack piece to be able to use the following methods:
- https://api.slack.com/methods/conversations.create
- https://api.slack.com/methods/conversations.invite
- https://api.slack.com/methods/conversations.leave