### PR TITLE
feat(microsoft-outlook): Add Reply to Email action

### DIFF
--- a/packages/pieces/community/microsoft-outlook/src/index.ts
+++ b/packages/pieces/community/microsoft-outlook/src/index.ts
@@ -5,7 +5,7 @@ import { downloadAttachmentAction } from './lib/actions/download-email-attachmen
 import { sendEmailAction } from './lib/actions/send-email';
 import { microsoftOutlookAuth } from './lib/common/auth';
 import { newEmailTrigger } from './lib/triggers/new-email';
-
+import { replyEmail } from './lib/actions/reply-email';
 export const microsoftOutlook = createPiece({
 	displayName: 'Microsoft Outlook',
 	auth: microsoftOutlookAuth,
@@ -16,6 +16,7 @@ export const microsoftOutlook = createPiece({
 	actions: [
 		sendEmailAction,
 		downloadAttachmentAction,
+		replyEmail,
 		createCustomApiCallAction({
 			auth: microsoftOutlookAuth,
 			baseUrl: () => 'https://graph.microsoft.com/v1.0/',

--- a/packages/pieces/community/microsoft-outlook/src/lib/actions/reply-email.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/actions/reply-email.ts
@@ -1,0 +1,169 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { microsoftOutlookAuth } from '../common/auth';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { BodyType, Message } from '@microsoft/microsoft-graph-types';
+export const replyEmail = createAction({
+  auth: microsoftOutlookAuth,
+  name: 'reply-email',
+  displayName: 'Reply to Email',
+  description: 'Reply to an outlook email',
+  props: {
+    messageId: Property.ShortText({
+      displayName: 'Message ID',
+      required: true,
+    }),
+    bodyFormat: Property.StaticDropdown({
+			displayName: 'Body Format',
+			required: true,
+			defaultValue: 'text',
+			options: {
+				disabled: false,
+				options: [
+					{ label: 'HTML', value: 'html' },
+					{ label: 'Text', value: 'text' },
+				],
+			},
+		}),
+    replyBody: Property.LongText({
+      displayName: 'Reply Body',
+      required: true,
+    }),
+    ccRecipients: Property.Array({
+      displayName: 'CC Recipients',
+      required: false,
+    }),
+    bccRecipients: Property.Array({
+      displayName: 'BCC Recipients',
+      required: false,
+    }),
+    attachments: Property.File({
+      displayName: 'Attachments',
+      description: 'Files to attach to the email',
+      required: false,
+    }),
+    draft: Property.Checkbox({
+      displayName: 'Create Draft',
+      description: 'If enabled, creates draft without sending',
+      required: true,
+      defaultValue: false,
+    }),
+  },
+
+  async run(context) {
+    const { auth, propsValue } = context;
+    const {
+      messageId,
+      bodyFormat,
+      replyBody,
+      ccRecipients,
+      bccRecipients,
+      attachments,
+      draft,
+    } = propsValue;
+
+    try {
+      // Step 1: Create draft reply
+      const draftResponse = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `https://graph.microsoft.com/v1.0/me/messages/${messageId}/createReply`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (draftResponse.status !== 201) {
+        throw new Error(
+          `Failed to create draft: ${JSON.stringify(draftResponse.body)}`
+        );
+      }
+
+      const draftId = draftResponse.body.id;
+
+      // Step 2: Update draft with content and recipients
+      const updatePayload: Message = {
+        body: {
+          content: replyBody,
+          contentType: bodyFormat as BodyType,
+        },
+      };
+
+      if (ccRecipients?.length) {
+        updatePayload.ccRecipients = ccRecipients
+          .filter((email) => typeof email === 'string')
+          .map((email: string) => ({
+            emailAddress: { address: email.trim() },
+          }));
+      }
+
+      if (bccRecipients?.length) {
+        updatePayload.bccRecipients = bccRecipients
+          .filter((email) => typeof email === 'string')
+          .map((email: string) => ({
+            emailAddress: { address: email.trim() },
+          }));
+      }
+
+      await httpClient.sendRequest({
+        method: HttpMethod.PATCH,
+        url: `https://graph.microsoft.com/v1.0/me/messages/${draftId}`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: updatePayload,
+      });
+
+      // Step 3: Add attachments if they exist
+      if (attachments) {
+        const attachmentResponse = await httpClient.sendRequest({
+          method: HttpMethod.POST,
+          url: `https://graph.microsoft.com/v1.0/me/messages/${draftId}/attachments`,
+          headers: {
+            Authorization: `Bearer ${auth.access_token}`,
+            'Content-Type': 'application/json',
+          },
+          body: {
+            '@odata.type': '#microsoft.graph.fileAttachment',
+            name: attachments.filename,
+            contentBytes: attachments.base64,
+          },
+        });
+
+        if (attachmentResponse.status !== 201) {
+          throw new Error(
+            `Failed to add attachment: ${JSON.stringify(
+              attachmentResponse.body
+            )}`
+          );
+        }
+      }
+      // Step 4: Send or keep as draft based on user selection
+      if (!draft) {
+        await httpClient.sendRequest({
+          method: HttpMethod.POST,
+          url: `https://graph.microsoft.com/v1.0/me/messages/${draftId}/send`,
+          headers: {
+            Authorization: `Bearer ${auth.access_token}`,
+          },
+        });
+        return {
+          success: true,
+          message: 'Reply sent successfully',
+          draftId: draftId,
+        };
+      } else {
+        return {
+          success: true,
+          message: 'Draft created successfully',
+          draftId: draftId,
+          draftLink: `https://outlook.office.com/mail/drafts/id/${draftId}`,
+        };
+      }
+    } catch (error) {
+      console.error('Reply Email Error:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(errorMessage);
+    }
+  },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/common/auth.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/common/auth.ts
@@ -6,9 +6,9 @@ export const microsoftOutlookAuth = PieceAuth.OAuth2({
 	tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
 	required: true,
 	scope: [
-		'https://graph.microsoft.com/Mail.ReadWrite', // Needed for modifying emails (createReply)
-		'https://graph.microsoft.com/Mail.Send', // Needed for sending emails
-		'offline_access', // Needed for refresh tokens
+		'https://graph.microsoft.com/Mail.ReadWrite',
+		'https://graph.microsoft.com/Mail.Send', 
+		'offline_access',
 	  ],
 	validate: async ({ auth }) => {
 		try {

--- a/packages/pieces/community/microsoft-outlook/src/lib/common/auth.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/common/auth.ts
@@ -5,7 +5,11 @@ export const microsoftOutlookAuth = PieceAuth.OAuth2({
 	authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
 	tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
 	required: true,
-	scope: ['Mail.Read', 'Mail.Send', 'Calendars.Read', 'offline_access', 'User.Read'],
+	scope: [
+		'https://graph.microsoft.com/Mail.ReadWrite', // Needed for modifying emails (createReply)
+		'https://graph.microsoft.com/Mail.Send', // Needed for sending emails
+		'offline_access', // Needed for refresh tokens
+	  ],
 	validate: async ({ auth }) => {
 		try {
 			const authValue = auth as OAuth2PropertyValue;


### PR DESCRIPTION
## Description
This PR adds a new "Reply to Email" action to the Microsoft Outlook connector, allowing users to programmatically reply to emails within their automations.

## Features
- Added new `reply-email` action that enables replying to existing emails
- Supports both HTML and plain text reply formats
- Allows adding CC and BCC recipients to the reply
- Supports file attachments
- Option to create a draft reply without sending immediately
- Returns success status and draft information in the response

## Implementation Details
- Created a new action that uses Microsoft Graph API's createReply endpoint
- Updated the OAuth2 scopes to include Mail.ReadWrite permission required for modifying emails
- Implemented proper error handling and response formatting
- Returns draft link for draft replies to easily access them in Outlook

## Testing
Tested the following scenarios:
- Replying to emails with both HTML and plain text formats
- Adding CC and BCC recipients
- Attaching files to replies
- Creating draft replies vs sending immediately