### PR TITLE
fix: correct token expiration time unit in managed authentication

### DIFF
--- a/packages/server/api/src/app/ee/managed-authn/managed-authn-service.ts
+++ b/packages/server/api/src/app/ee/managed-authn/managed-authn-service.ts
@@ -64,7 +64,7 @@ export const managedAuthnService = (log: FastifyBaseLogger) => ({
                 id: externalPrincipal.platformId,
             },
             tokenVersion: identity.tokenVersion,
-        }, 7 * 24 * 60 * 60 * 1000)
+        }, 7 * 24 * 60 * 60)
         return {
             id: user.id,
             platformRole: user.platformRole,


### PR DESCRIPTION
## What does this PR do?

The accessTokenManager.generateToken method expects expiration time in seconds, but was receiving milliseconds (7 * 24 * 60 * 60 * 1000). This caused tokens to expire after ~19.7 years instead of the intended 7 days.

This PR corrects the expiration time unit to seconds.