### PR TITLE
Fix: Move Platform Plan Migration to enterprise only for 0.64.0

### DIFF
--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -384,7 +384,6 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
         AIUsagePostgres1750090291551,
         AddAgents1749405724276,
         AddAgentOutput1749859119064,
-        AddAgentsLimitToPlatformPlan1749917984363,
         RemoveDefaultLocaleFromPlatform1749733527371,
         AddStepToIssuesTable1750017637712,
         MakeStepNameOptional1750025401754,
@@ -477,7 +476,8 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
                 AddManualTaskCommentTable1742305104390,
                 AddMetadataFieldToFlowTemplates1744780800000,
                 AddLimitsOnPlatformPlan1747921788059,
-       
+
+                AddAgentsLimitToPlatformPlan1749917984363,
             )
             break
         case ApEdition.COMMUNITY:


### PR DESCRIPTION

## What does this PR do?

This is a fix for the issue #8161.
This moves `platform_plan` table migration to Enterprise flow, which will cause the migration fail on community version and couldn't start on 0.64.0

