### PR TITLE
feat: add base64-encode and base64-decode actions to crypto piece

### DIFF
--- a/packages/pieces/community/crypto/package.json
+++ b/packages/pieces/community/crypto/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-crypto",
-  "version": "0.0.6"
+  "version": "0.0.7"
 }

--- a/packages/pieces/community/crypto/src/index.ts
+++ b/packages/pieces/community/crypto/src/index.ts
@@ -3,6 +3,8 @@ import { PieceCategory } from '@activepieces/shared';
 import { generatePassword } from './lib/actions/generate-password';
 import { hashText } from './lib/actions/hash-text';
 import { hmacSignature } from './lib/actions/hmac-signature';
+import { base64Decode } from './lib/actions/base64-decode';
+import { base64Encode } from './lib/actions/base64-encode';
 
 export const Crypto = createPiece({
   displayName: 'Crypto',
@@ -11,7 +13,7 @@ export const Crypto = createPiece({
   minimumSupportedRelease: '0.30.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/crypto.png',
   categories: [PieceCategory.CORE],
-  authors: ['AbdullahBitar', 'kishanprmr', 'abuaboud', 'matthieu-lombard', 'antonyvigouret'],
-  actions: [hashText, hmacSignature, generatePassword],
+  authors: ['AbdullahBitar', 'kishanprmr', 'abuaboud', 'matthieu-lombard', 'antonyvigouret', 'danielpoonwj'],
+  actions: [hashText, hmacSignature, generatePassword, base64Decode, base64Encode],
   triggers: [],
 });

--- a/packages/pieces/community/crypto/src/lib/actions/base64-decode.ts
+++ b/packages/pieces/community/crypto/src/lib/actions/base64-decode.ts
@@ -1,0 +1,17 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const base64Decode = createAction({
+  name: 'base64-decode',
+  description: 'Decode Base64 text',
+  displayName: 'Base64 Decode',
+  props: {
+    text: Property.ShortText({
+      displayName: 'Text',
+      description: 'The text to be decoded',
+      required: true,
+    }),
+  },
+  async run(context) {
+    return Buffer.from(context.propsValue.text, 'base64').toString();
+  },
+});

--- a/packages/pieces/community/crypto/src/lib/actions/base64-encode.ts
+++ b/packages/pieces/community/crypto/src/lib/actions/base64-encode.ts
@@ -1,0 +1,17 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const base64Encode = createAction({
+  name: 'base64-encode',
+  description: 'Base64 encode text',
+  displayName: 'Base64 Encode',
+  props: {
+    text: Property.ShortText({
+      displayName: 'Text',
+      description: 'The text to be encoded',
+      required: true,
+    }),
+  },
+  async run(context) {
+    return Buffer.from(context.propsValue.text).toString('base64');
+  },
+});


### PR DESCRIPTION
## What does this PR do?

We currently don't have a way to Base64 encode/decode text. On stricter sandbox modes we can't use the custom code piece either.

![Screenshot 2025-06-27 at 3 03 12 PM](https://github.com/user-attachments/assets/303b57bd-ba93-4cbf-ba90-9cde07ab8cf8)

### Explain How the Feature Works

#### Base64 Encode

![Screenshot 2025-06-27 at 3 24 03 PM](https://github.com/user-attachments/assets/5eec5180-d68d-49ba-a8f8-45c5cafc85e8)

#### Base64 Decode

![Screenshot 2025-06-27 at 3 24 11 PM](https://github.com/user-attachments/assets/f271fef7-8015-413b-8aba-7423fb5ffd64)

