### PR TITLE
feat(hubspot): add scheduler.meetings.meeting-link.read scope

### DIFF
--- a/packages/pieces/community/hubspot/package.json
+++ b/packages/pieces/community/hubspot/package.json
@@ -2,6 +2,6 @@
   "name": "@activepieces/piece-hubspot",
   "version": "0.7.1",
   "dependencies": {
-    "@hubspot/api-client": "12.0.1"
+    "@hubspot/api-client": "12.0.2"
   }
 }

--- a/packages/pieces/community/hubspot/src/index.ts
+++ b/packages/pieces/community/hubspot/src/index.ts
@@ -100,7 +100,8 @@ export const hubspotAuth = PieceAuth.OAuth2({
 		'settings.users.read',
 		'settings.users.teams.read',
 		'files',
-		'forms'
+		'forms',
+    'scheduler.meetings.meeting-link.read'
 		// 'business_units_view.read'
 	],
 });


### PR DESCRIPTION
## What does this PR do?

Add new scope `scheduler.meetings.meeting-link.read` in order to use the meeting links api