### PR TITLE
feat(dust): bump SDK version to fix API error

### DIFF
--- a/packages/pieces/community/dust/package.json
+++ b/packages/pieces/community/dust/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@activepieces/piece-dust",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "dependencies": {
-    "@dust-tt/client": "1.0.49"
+    "@dust-tt/client": "1.0.57"
   }
 }


### PR DESCRIPTION
## What does this PR do?

Should fix errors like this when uploading a file to a conversation:
> API Error: Unexpected response format from DustAPI calling https://dust.tt/api/v1/w/*****/assistant/conversation
