### PR TITLE
feat: add support for component field type in Jira Cloud

### DIFF
--- a/packages/pieces/community/jira-cloud/package.json
+++ b/packages/pieces/community/jira-cloud/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-jira-cloud",
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/packages/pieces/community/jira-cloud/src/lib/common/props.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/common/props.ts
@@ -446,6 +446,26 @@ export async function createPropertyDefinition(
 				options: { disabled: false, options: priorityOptions },
 			});
 		}
+		case 'component': {
+			const componentOptions = field.allowedValues
+				? field.allowedValues.map((option) => ({
+						label: option.name,
+						value: option.id,
+				  }))
+				: [];
+
+			return isArray
+				? Property.StaticMultiSelectDropdown({
+						displayName: field.name,
+						required: isRequired,
+						options: { disabled: false, options: componentOptions },
+				  })
+				: Property.StaticDropdown({
+						displayName: field.name,
+						required: isRequired,
+						options: { disabled: false, options: componentOptions },
+				  });
+		}
 		case 'option': {
 			const options = field.allowedValues
 				? field.allowedValues.map((option) => ({
@@ -568,6 +588,7 @@ export function formatIssueFields(
 			case 'option':
 			case 'priority':
 			case 'issuetype':
+			case 'component':
 				fieldsOutput[key] = { id: fieldInputValue };
 				break;
 

--- a/packages/pieces/community/jira-cloud/src/lib/common/types.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/common/types.ts
@@ -9,7 +9,7 @@ export type IssueFieldMetaData ={
     key:string,
     fieldId:string,
     schema:{
-        type:"string"|"date"|"datetime"|"array"|"number"|"option"|"user"|"group"|"version"|"project"|"issuelink"|"priority"|"issuetype", // "option-with-child",
+        type:"string"|"date"|"datetime"|"array"|"number"|"option"|"user"|"group"|"version"|"project"|"issuelink"|"priority"|"issuetype"|"component", // "option-with-child",
         items:string,
         custom?:string,
         customId?:number,


### PR DESCRIPTION
Add handling for the 'component' field type in Jira Cloud integration, including property definitions and field formatting. Bump version to 0.1.5.

## What does this PR do?

Add handling for the 'component' field type in Jira Cloud integration, including property definitions and field formatting. Bump version to 0.1.5.

### Explain How the Feature Works

<img width="619" alt="image" src="https://github.com/user-attachments/assets/c9b0cc77-7b3a-436f-898d-49f1f90185c9" />