### PR TITLE
feat: add autocalls piece

### DIFF
--- a/packages/pieces/community/autocalls/.eslintrc.json
+++ b/packages/pieces/community/autocalls/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/autocalls/README.md
+++ b/packages/pieces/community/autocalls/README.md
@@ -1,0 +1,7 @@
+# pieces-autocalls
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-autocalls` to build the library.

--- a/packages/pieces/community/autocalls/package.json
+++ b/packages/pieces/community/autocalls/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-autocalls",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/autocalls/project.json
+++ b/packages/pieces/community/autocalls/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-autocalls",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/autocalls/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/autocalls",
+        "tsConfig": "packages/pieces/community/autocalls/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/autocalls/package.json",
+        "main": "packages/pieces/community/autocalls/src/index.ts",
+        "assets": [
+          "packages/pieces/community/autocalls/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/autocalls/src/index.ts
+++ b/packages/pieces/community/autocalls/src/index.ts
@@ -1,0 +1,57 @@
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { makePhoneCall } from "./lib/actions/make-phone-call";
+import { phoneCallEnded } from "./lib/triggers/phone-call-ended";
+import { addLead } from "./lib/actions/add-lead";
+import { sendSms } from "./lib/actions/send-sms";
+import { inboundCall } from "./lib/triggers/inbound-call";
+import { getAssistants } from "./lib/triggers/get-assistants";
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { campaignControl } from "./lib/actions/campaign-control";
+import { deleteLead } from "./lib/actions/delete-lead";
+
+export const baseApiUrl = 'https://app.autocalls.ai/';
+
+export const autocalls = createPiece({
+  displayName: "Autocalls",
+  auth: PieceAuth.SecretText({
+    displayName: 'API Key',
+    description: 'Create an API key in your Autocalls account and paste the value here. Get API key here -> https://app.autocalls.ai',
+    required: true,
+    validate: async ({ auth }) => {
+      try {
+        const response = await httpClient.sendRequest({
+          method: HttpMethod.GET,
+          url: baseApiUrl + 'api/user/me',
+          headers: {
+            'Authorization': `Bearer ${auth}`,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+        });
+
+        if (response.status === 200) {
+          return {
+            valid: true,
+          };
+        } else {
+          return {
+            valid: false,
+            error: 'Invalid API key or authentication failed'
+          };
+        }
+      } catch (error) {
+        return {
+          valid: false,
+          error: 'Failed to validate API key. Please check your API key and try again.'
+        };
+      }
+    }
+  }),
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: "https://autocalls.ai/doar-logo.png",
+  description: "Automate phone calls using our AI calling platform.",
+  authors: ['Stefan Petrea'],
+  actions: [addLead,sendSms,campaignControl,makePhoneCall,deleteLead],
+  triggers: [phoneCallEnded,getAssistants,inboundCall],
+});
+    

--- a/packages/pieces/community/autocalls/src/lib/actions/add-lead.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/add-lead.ts
@@ -1,0 +1,181 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { baseApiUrl } from '../..';
+
+export const addLead = createAction({
+  name: 'addLead',
+  displayName: 'Add lead to a campaign',
+  description: "Add lead to an outbound campaign, to be called by an assistant from our platform.",
+  props: {
+    campaign: Property.Dropdown({
+      displayName: 'Campaign',
+      description: 'Select a campaign',
+      required: true,
+      refreshers: ['auth'],
+      refreshOnSearch: false,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate first',
+            options: []
+          };
+        }
+
+        try {
+          const res = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: baseApiUrl + 'api/user/campaigns',
+            headers: {
+              Authorization: "Bearer " + auth,
+              'Content-Type': 'application/json',
+              'Accept': 'application/json'
+            },
+          });
+
+          if (res.status !== 200) {
+            return {
+              disabled: true,
+              placeholder: 'Error fetching campaigns',
+              options: [],
+            };
+          } else if (!res.body || res.body.length === 0) {
+            return {
+              disabled: true,
+              placeholder: 'No campaigns found. Create one first.',
+              options: [],
+            };
+          }
+
+          return {
+            options: res.body.map((campaign: any) => ({
+              value: campaign.id,
+              label: campaign.name,
+            })),
+          };
+        } catch (error) {
+          return {
+            disabled: true,
+            placeholder: 'Failed to fetch campaigns',
+            options: [],
+          };
+        }
+      }
+    }),
+    phone_number: Property.ShortText({
+      displayName: 'Customer phone number',
+      description: 'Enter the phone number of the customer',
+      required: true,
+    }),
+    variables: Property.Object({
+      displayName: 'Variables',
+      description: 'Variables to pass to the assistant',
+      required: true,
+      defaultValue: {
+        customer_name: 'John',
+      }
+    }),
+    allow_dupplicate: Property.Checkbox({
+      displayName: 'Allow duplicates',
+      description: 'Allow the same phone number to be added to the campaign more than once',
+      required: true,
+      defaultValue: false
+    }),
+    num_secondary_contacts: Property.Number({
+      displayName: 'Number of Secondary Contacts',
+      description: 'How many secondary contacts do you want to add?',
+      required: false,
+      defaultValue: 0,
+    }),
+    secondary_contacts: Property.DynamicProperties({
+      displayName: 'Secondary Contacts',
+      description: 'Add secondary contacts for this lead. Each contact can have its own phone number and variables.',
+      required: false,
+      refreshers: ['num_secondary_contacts'],
+      props: async ({ num_secondary_contacts }) => {
+        const contacts: any = {};
+        const numContacts = Number(num_secondary_contacts) || 0;
+        
+        // Generate fields based on the number specified
+        for (let i = 1; i <= numContacts && i <= 10; i++) {
+          contacts[`contact_${i}_phone`] = Property.ShortText({
+            displayName: `Contact ${i} - Phone Number`,
+            description: `Phone number for secondary contact ${i}`,
+            required: true,
+          });
+          
+          contacts[`contact_${i}_variables`] = Property.Object({
+            displayName: `Contact ${i} - Variables`,
+            description: `Variables for secondary contact ${i} as key-value pairs`,
+            required: false,
+            defaultValue: {
+              customer_name: 'John',
+            }
+          });
+        }
+        
+        return contacts;
+      },
+    })
+  },
+  async run(context) {
+    if (!context.auth) {
+      throw new Error('Authentication is required');
+    }
+
+    try {
+      const body: any = {
+        campaign_id: context.propsValue['campaign'],
+        phone_number: context.propsValue['phone_number'],
+        variables: context.propsValue['variables'],
+        allow_dupplicate: context.propsValue['allow_dupplicate'],
+      };
+
+      // Add secondary contacts if provided
+      if (context.propsValue['secondary_contacts']) {
+        const secondaryContactsData = context.propsValue['secondary_contacts'] as Record<string, any>;
+        const numContacts = Number(context.propsValue['num_secondary_contacts']) || 0;
+        const secondaryContacts: any[] = [];
+        
+        // Process the specified number of contacts
+        for (let i = 1; i <= numContacts && i <= 10; i++) {
+          const phoneNumber = secondaryContactsData[`contact_${i}_phone`];
+          const variables = secondaryContactsData[`contact_${i}_variables`];
+          
+          // Only add contact if phone number is provided
+          if (phoneNumber && phoneNumber.trim() !== '') {
+            secondaryContacts.push({
+              phone_number: phoneNumber,
+              variables: variables || {
+                customer_name: '',
+              }
+            });
+          }
+        }
+        
+        if (secondaryContacts.length > 0) {
+          body.secondary_contacts = secondaryContacts;
+        }
+      }
+
+      const res = await httpClient.sendRequest<string[]>({
+        method: HttpMethod.POST,
+        url: baseApiUrl + 'api/user/lead',
+        body: body,
+        headers: {
+          Authorization: "Bearer " + context.auth,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+      });
+
+      if (res.status !== 200) {
+        throw new Error(`Failed to add lead: ${res.status}`);
+      }
+
+      return res.body;
+    } catch (error) {
+      throw new Error(`Failed to add lead: ${error}`);
+    }
+  },
+});

--- a/packages/pieces/community/autocalls/src/lib/actions/campaign-control.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/campaign-control.ts
@@ -1,0 +1,77 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { baseApiUrl } from '../..';
+
+export const campaignControl = createAction({
+  name: 'campaignControl',
+  displayName: 'Start/Stop Campaign',
+  description: "Start or stop an outbound campaign from our platform.",
+  props: {
+    campaign: Property.Dropdown({
+      displayName: 'Campaign',
+      description: 'Select a campaign',
+      required: true,
+      refreshers: ['auth'],
+      refreshOnSearch: false,
+      options: async ({ auth }) => {
+        const res = await httpClient.sendRequest({
+          method: HttpMethod.GET,
+          url: baseApiUrl + 'api/user/campaigns',
+          headers: {
+            Authorization: "Bearer " + auth,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+        });
+
+        if (res.status !== 200) {
+          return {
+            disabled: true,
+            placeholder: 'Error fetching campaigns',
+            options: [],
+          };
+        } else if (res.body.length === 0) {
+          return {
+            disabled: true,
+            placeholder: 'No campaigns found. Create one first.',
+            options: [],
+          };
+        }
+
+        return {
+          options: res.body.map((campaign: any) => ({
+            value: campaign.id,
+            label: campaign.name,
+          })),
+        };
+      }
+    }),
+    action: Property.StaticDropdown({
+      displayName: 'Action',
+      description: 'Select action to perform on the campaign',
+      required: true,
+      options: {
+        options: [
+          { label: 'Start Campaign', value: 'start' },
+          { label: 'Stop Campaign', value: 'stop' }
+        ]
+      }
+    })
+  },
+  async run(context) {
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.POST,
+      url: baseApiUrl + 'api/user/campaigns/update-status',
+      body: {
+        campaign_id: context.propsValue['campaign'],
+        action: context.propsValue['action'],
+      },
+      headers: {
+        Authorization: "Bearer " + context.auth,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/autocalls/src/lib/actions/delete-lead.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/delete-lead.ts
@@ -1,0 +1,64 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { baseApiUrl } from '../..';
+
+export const deleteLead = createAction({
+  name: 'deleteLead',
+  displayName: 'Delete Lead',
+  description: "Delete a lead from a campaign.",
+  props: {
+    lead: Property.Dropdown({
+      displayName: 'Lead',
+      description: 'Select a lead to delete',
+      required: true,
+      refreshers: ['auth'],
+      refreshOnSearch: false,
+      options: async ({ auth }) => {
+        const res = await httpClient.sendRequest({
+          method: HttpMethod.GET,
+          url: baseApiUrl + 'api/user/leads',
+          headers: {
+            Authorization: "Bearer " + auth,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+        });
+
+        if (res.status !== 200) {
+          return {
+            disabled: true,
+            placeholder: 'Error fetching leads',
+            options: [],
+          };
+        } else if (res.body.length === 0) {
+          return {
+            disabled: true,
+            placeholder: 'No leads found.',
+            options: [],
+          };
+        }
+
+        return {
+          options: res.body.map((lead: any) => ({
+            value: lead.id,
+            label: `${lead.phone_number} - ${lead.campaign.name}`,
+          })),
+        };
+      }
+    })
+  },
+  async run(context) {
+    const leadId = context.propsValue['lead'];
+    
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.DELETE,
+      url: baseApiUrl + 'api/user/leads/' + leadId,
+      headers: {
+        Authorization: "Bearer " + context.auth,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/autocalls/src/lib/actions/make-phone-call.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/make-phone-call.ts
@@ -1,0 +1,77 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { baseApiUrl } from '../..';
+
+export const makePhoneCall = createAction({
+  name: 'makePhoneCall',
+  displayName: 'Make phone call',
+  description: "Call a customer by it's phone number using an assistant from our platform.",
+  props: {
+    assistant: Property.Dropdown({
+      displayName: 'Assistant',
+      description: 'Select an assistant',
+      required: true,
+      refreshers: ['auth'],
+      refreshOnSearch: false,
+      options: async ({ auth }) => {
+        const res = await httpClient.sendRequest({
+          method: HttpMethod.GET,
+          url: baseApiUrl + 'api/user/assistants/outbound',
+          headers: {
+            Authorization: "Bearer " + auth,
+          },
+        });
+
+        if (res.status !== 200) {
+          return {
+            disabled: true,
+            placeholder: 'Error fetching assistants',
+            options: [],
+          };
+        } else if (res.body.length === 0) {
+          return {
+            disabled: true,
+            placeholder: 'No outbound assistants found. Create one first.',
+            options: [],
+          };
+        }
+
+        return {
+          options: res.body.map((assistant: any) => ({
+            value: assistant.id,
+            label: assistant.name,
+          })),
+        };
+      }
+    }),
+    phone_number: Property.ShortText({
+      displayName: 'Customer phone number',
+      description: 'Enter the phone number of the customer',
+      required: true,
+    }),
+
+    variables: Property.Object({
+      displayName: 'Variables',
+      description: 'Variables to pass to the assistant',
+      required: true,
+      defaultValue: {
+        customer_name: 'John',
+      }
+    })
+  },
+  async run(context) {
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.POST,
+      url: baseApiUrl + 'api/user/make_call',
+      body: {
+        assistant_id: context.propsValue['assistant'],
+        phone_number: context.propsValue['phone_number'],
+        variables: context.propsValue['variables'],
+      },
+      headers: {
+        Authorization: "Bearer " + context.auth,
+      },
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/autocalls/src/lib/actions/send-sms.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/send-sms.ts
@@ -1,0 +1,78 @@
+import { createAction, Property} from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { baseApiUrl } from '../..';
+
+export const sendSms = createAction({
+  name: 'sendSms',
+  displayName: 'Send SMS to a customer',
+  description: "Send an SMS to a customer using a phone number from our platform.",
+  props: {
+    from: Property.Dropdown({
+      displayName: 'From phone number',
+      description: 'Select an SMS capable phone number to send the SMS from',
+      required: true,
+      refreshers: ['auth'],
+      refreshOnSearch: false,
+      options: async ({ auth }) => {
+        const res = await httpClient.sendRequest({
+          method: HttpMethod.GET,
+          url: baseApiUrl + 'api/user/phone-numbers',
+          headers: {
+            Authorization: "Bearer " + auth,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+        });
+
+        if (res.status !== 200) {
+          return {
+            disabled: true,
+            placeholder: 'Error fetching phone numbers',
+            options: [],
+          };
+        } else if (res.body.length === 0) {
+          return {
+            disabled: true,
+            placeholder: 'No phone numbers found. Purchase an SMS capable phone number first.',
+            options: [],
+          };
+        }
+
+        return {
+          options: res.body.map((phoneNumber: any) => ({
+            value: phoneNumber.id,
+            label: phoneNumber.phone_number,
+          })),
+        };
+      }
+    }),
+    to: Property.ShortText({
+      displayName: 'Customer phone number',
+      description: 'Enter the phone number of the customer',
+      required: true,
+    }),
+
+    body: Property.ShortText({
+      displayName: 'Text message',
+      description: 'Enter the text message to send to the customer (max 300 characters)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.POST,
+      url: baseApiUrl + 'api/user/sms',
+      body: {
+        from: context.propsValue['from'],
+        to: context.propsValue['to'],
+        body: context.propsValue['body'],
+      },
+      headers: {
+        Authorization: "Bearer " + context.auth,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/autocalls/src/lib/triggers/get-assistants.ts
+++ b/packages/pieces/community/autocalls/src/lib/triggers/get-assistants.ts
@@ -1,0 +1,63 @@
+import { createTrigger, TriggerStrategy, PiecePropValueSchema } from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { baseApiUrl } from '../..';
+import dayjs from 'dayjs';
+
+const polling: Polling<PiecePropValueSchema<any>, Record<string, never>> = {
+    strategy: DedupeStrategy.TIMEBASED,
+    items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+        const res = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: baseApiUrl + 'api/user/assistants',
+            headers: {
+                Authorization: "Bearer " + auth,
+            },
+        });
+
+        if (res.status !== 200) {
+            throw new Error(`Failed to fetch assistants. Status: ${res.status}`);
+        }
+
+        const assistants = res.body || [];
+        
+        return [{
+            epochMilliSeconds: dayjs().valueOf(),
+            data: assistants,
+        }];
+        }
+};
+
+export const getAssistants = createTrigger({
+name: 'getAssistants',
+    displayName: 'Get Assistants',
+    description: 'Triggers when assistants are fetched or updated in your Autocalls account.',
+props: {},
+    sampleData: {
+        id: "assistant_123",
+        name: "Customer Support Assistant",
+        description: "Handles customer inquiries and support requests",
+        status: "active",
+        created_at: "2024-01-15T10:30:00Z",
+        updated_at: "2024-01-15T14:20:00Z",
+        settings: {
+            voice: "en-US-female",
+            language: "en-US",
+            max_duration: 300
+        }
+    },
+type: TriggerStrategy.POLLING,
+async test(context) {
+    return await pollingHelper.test(polling, context);
+},
+async onEnable(context) {
+    const { store, auth, propsValue } = context;
+    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+},
+async onDisable(context) {
+    const { store, auth, propsValue } = context;
+    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+},
+async run(context) {
+    return await pollingHelper.poll(polling, context);
+},
+});

--- a/packages/pieces/community/autocalls/src/lib/triggers/inbound-call.ts
+++ b/packages/pieces/community/autocalls/src/lib/triggers/inbound-call.ts
@@ -1,0 +1,75 @@
+import { createTrigger, Property, TriggerStrategy } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { baseApiUrl } from '../..';
+
+export const inboundCall = createTrigger({
+    name: 'inboundCall',
+    displayName: 'Inbound call variables',
+    description: 'Inject variables before connecting an inbound call.',
+    props: {
+        assistant: Property.Dropdown({
+            displayName: 'Assistant',
+            description: 'Select an assistant',
+            required: true,
+            refreshers: ['auth'],
+            refreshOnSearch: false,
+            options: async ({ auth }) => {
+                const res = await httpClient.sendRequest({
+                    method: HttpMethod.GET,
+                    url: baseApiUrl + 'api/user/assistants',
+                    headers: {
+                        Authorization: "Bearer " + auth,
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json'
+                    },
+                });
+
+                if (res.status !== 200) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Error fetching assistants',
+                        options: [],
+                    };
+                } else if (res.body.length === 0) {
+                    return {
+                        disabled: true,
+                        placeholder: 'No assistants found. Create one first.',
+                        options: [],
+                    };
+                }
+
+                return {
+                    options: res.body.map((assistant: any) => ({
+                        value: assistant.id,
+                        label: assistant.name,
+                    })),
+                };
+            }
+        }),
+    },
+    sampleData: {
+        customer_phone: '+16380991171',
+        assistant_phone: '+16380991171',
+    },
+    type: TriggerStrategy.WEBHOOK,
+    async onEnable(context) {
+        await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: baseApiUrl + 'api/user/assistants/enable-inbound-webhook',
+            body: {
+                assistant_id: context.propsValue['assistant'],
+                webhook_url: context.webhookUrl + '/sync',
+            },
+            headers: {
+                Authorization: "Bearer " + context.auth,
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            },
+        });
+    },
+    async onDisable(context) {
+    },
+    async run(context) {
+        return [context.payload.body]
+    }
+})

--- a/packages/pieces/community/autocalls/src/lib/triggers/inbound-call.ts
+++ b/packages/pieces/community/autocalls/src/lib/triggers/inbound-call.ts
@@ -68,6 +68,18 @@ export const inboundCall = createTrigger({
         });
     },
     async onDisable(context) {
+        await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: baseApiUrl + 'api/user/assistants/disable-inbound-webhook',
+            body: {
+                assistant_id: context.propsValue['assistant'],
+            },
+            headers: {
+                Authorization: "Bearer " + context.auth,
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            },
+        });
     },
     async run(context) {
         return [context.payload.body]

--- a/packages/pieces/community/autocalls/src/lib/triggers/phone-call-ended.ts
+++ b/packages/pieces/community/autocalls/src/lib/triggers/phone-call-ended.ts
@@ -1,0 +1,112 @@
+import { createTrigger, Property, TriggerStrategy } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { baseApiUrl } from '../..';
+
+export const phoneCallEnded = createTrigger({
+    name: 'phoneCallEnded',
+    displayName: 'Phone call ended',
+    description: 'Triggers when a phone call ends, with extracted variables.',
+    props: {
+        assistant: Property.Dropdown({
+            displayName: 'Assistant',
+            description: 'Select an assistant',
+            required: true,
+            refreshers: ['auth'],
+            refreshOnSearch: false,
+            options: async ({ auth }) => {
+                const res = await httpClient.sendRequest({
+                    method: HttpMethod.GET,
+                    url: baseApiUrl + 'api/user/assistants',
+                    headers: {
+                        Authorization: "Bearer " + auth,
+                    },
+                });
+
+                if (res.status !== 200) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Error fetching assistants',
+                        options: [],
+                    };
+                } else if (res.body.length === 0) {
+                    return {
+                        disabled: true,
+                        placeholder: 'No assistants found. Create one first.',
+                        options: [],
+                    };
+                }
+
+                return {
+                    options: res.body.map((assistant: any) => ({
+                        value: assistant.id,
+                        label: assistant.name,
+                    })),
+                };
+            }
+        }),
+    },
+    sampleData: {
+        customer_phone: '+16380991171',
+        assistant_phone: '+16380991171',
+        duration: 120,
+        status: 'completed',
+        extracted_variables: {
+            status: false,
+            summary: 'Call ended without clear objective being met.'
+        },
+        input_variables: {
+            customer_name: 'John'
+        },
+        transcript: [
+            {
+                sender: 'bot',
+                timestamp: 1722347063.574402,
+                text: 'Hi! How are you, John?'
+            },
+            {
+                sender: 'human',
+                timestamp: 1722347068.886166,
+                text: 'Im fine. How about you?'
+            },
+            {
+                sender: 'bot',
+                timestamp: 1722347069.76683,
+                text: 'Im doing well, thank you for asking.'
+            },
+            {
+                sender: 'bot',
+                timestamp: 1722347071.577889,
+                text: 'How can I assist you today?'
+            },
+        ]
+    },
+    type: TriggerStrategy.WEBHOOK,
+    async onEnable(context) {
+        await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: baseApiUrl + 'api/user/assistants/enable-webhook',
+            body: {
+                assistant_id: context.propsValue['assistant'],
+                webhook_url: context.webhookUrl,
+            },
+            headers: {
+                Authorization: "Bearer " + context.auth,
+            },
+        });
+    },
+    async onDisable(context) {
+        await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: baseApiUrl + 'api/user/assistants/disable-webhook',
+            body: {
+                assistant_id: context.propsValue['assistant'],
+            },
+            headers: {
+                Authorization: "Bearer " + context.auth,
+            },
+        });
+    },
+    async run(context) {
+        return [context.payload.body]
+    }
+})

--- a/packages/pieces/community/autocalls/tsconfig.json
+++ b/packages/pieces/community/autocalls/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/autocalls/tsconfig.lib.json
+++ b/packages/pieces/community/autocalls/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds a new **Autocalls AI Phone Calling** integration to Activepieces, enabling users to automate voice and SMS outreach using the Autocalls.ai platform. It introduces five new actions and three triggers, allowing seamless campaign management, lead operations, and AI-driven call workflows directly from Activepieces. (https://autocalls.ai/)

### Explain How the Feature Works

* **Authentication & Setup**
  Users connect their Autocalls.ai account via an API key. 

* **Actions (5 total)**

  1. **Add Lead**

     * Select a campaign from the user’s existing campaigns
     * Provide a primary contact (with phone number) and optional custom variables
     * Optionally include up to 10 secondary contacts per lead
  2. **Send SMS**

     * Choose from the user’s SMS-enabled phone numbers
     * Send personalized text messages using custom variables
  3. **Campaign Control**

     * Start or stop any existing Autocalls.ai campaign with a single action
  4. **Make Phone Call**

     * Select an outbound-capable AI assistant
     * Inject custom variables into the call script for personalization
     * Dial any phone number for immediate AI-powered calling
  5. **Delete Lead**

     * Remove a lead from a campaign by selecting the campaign context and lead phone number

* **Triggers (3 total)**

  1. **Phone Call Ended**

     * Fires via webhook when an AI call completes
     * Outputs the full call transcript with timestamps, extracted variables, call duration, status, and any input variables used
  2. **Get Assistants**

     * Polling trigger that retrieves an up-to-date list of AI assistants from the user’s workspace
     * Provides assistant metadata (name, ID, capabilities) for dynamic workflow branching
  3. **Inbound Call Variables**

     * Webhook trigger that fires before the AI assistant answers an incoming call
     * Injects caller-provided variables into the AI context for personalized inbound handling

https://www.loom.com/share/9a5742676b85409b8e2316126c112aae?sid=ed69554f-4e2b-4400-84e3-150bad1cccab

### Relevant User Scenarios

* **Cold Calling for Sales Teams**
  AI voice agents can cold call prospects, follow up on leads, qualify them, and book appointments—fully automated without expanding your sales headcount. Use **Add Lead** to enroll contacts, **Make Phone Call** for outreach, and **Send SMS** for follow-ups. 

* **Lead Import and Campaign Enrollment**
  Automatically fetch new leads from a Google Sheet or CRM and enroll them into an outbound campaign. In Activepieces, the **Add Lead** action maps custom variables from your source data to Autocalls.ai campaigns for seamless syncing. 

* **Post-Call Data Handling**
  After each AI call completes, the **Phone Call Ended** trigger delivers transcripts, call metadata, and extracted variables. You can then update a CRM, notify your team via SMS, or schedule the next touchpoint. 

* **Inbound Support Call Personalization**
  On incoming calls, the **Inbound Call Variables** webhook fires before connection, letting you look up caller data in your CRM and inject it into the AI context—ensuring every support call is tailored from the first ring. 

* **Automated Appointment Scheduling & Reminders**
  AI assistants integrate with live calendars (e.g., Cal.com, GoHighLevel) to offer and book appointment slots. After booking via **Make Phone Call**, use **Send SMS** to send confirmations and reminders. 




