### PR TITLE
fix: make the inital title and icon for the app load from env variables

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,18 @@
 #!/bin/sh
 
+# Set default values if not provided
+export AP_APP_TITLE="${AP_APP_TITLE:-Activepieces}"
+export AP_FAVICON_URL="${AP_FAVICON_URL:-https://cdn.activepieces.com/brand/favicon.ico}"
+
+# Debug: Print environment variables
+echo "AP_APP_TITLE: $AP_APP_TITLE"
+echo "AP_FAVICON_URL: $AP_FAVICON_URL"
+
+# Process environment variables in index.html BEFORE starting services
+envsubst '${AP_APP_TITLE} ${AP_FAVICON_URL}' < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html.tmp && \
+mv /usr/share/nginx/html/index.html.tmp /usr/share/nginx/html/index.html
+
+
 # Start Nginx server
 nginx -g "daemon off;" &
 

--- a/docs/install/configuration/environment-variables.mdx
+++ b/docs/install/configuration/environment-variables.mdx
@@ -78,7 +78,9 @@ it will produce these values. </Tip>
 | `AP_MAX_TABLES_PER_PROJECT` | The maximum allowed number of tables per project | `20` | `20`
 | `AP_MAX_MCPS_PER_PROJECT` | The maximum allowed number of mcp per project | `20` | `20`
 | `AP_ENABLE_FLOW_ON_PUBLISH` | Whether publishing a new flow version should automatically enable the flow | `true` | `false`  
-| `AP_ISSUE_ARCHIVE_DAYS`            | Controls the automatic archival of issues in the system. Issues that have not been updated for this many days will be automatically moved to an archived state.| `14` | `1` 
+| `AP_ISSUE_ARCHIVE_DAYS`            | Controls the automatic archival of issues in the system. Issues that have not been updated for this many days will be automatically moved to an archived state.| `14`  | `1`
+| `AP_APP_TITLE` | Initial title shown in the browser tab while loading the app | `Activepieces`  | `Activepieces`
+| `AP_FAVICON_URL` | Initial favicon shown in the browser tab while loading the app | `https://cdn.activepieces.com/brand/favicon.ico` | `https://cdn.activepieces.com/brand/favicon.ico`
 
 <Warning>
   The frontend URL is essential for webhooks and app triggers to work. It must

--- a/packages/react-ui/index.html
+++ b/packages/react-ui/index.html
@@ -1,16 +1,15 @@
+<!-- Keep title and favicon in one line, so the github actions remove them correctly -->
 <!DOCTYPE html>
 <html lang="en">
 
 <head>
   <meta charset="utf-8" />
-  <title>Activepieces</title>
+  <title>${AP_APP_TITLE}</title>
   <base href="/" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="icon" type="image/x-icon" href="https://cdn.activepieces.com/brand/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="${AP_FAVICON_URL}">
   <link rel="stylesheet" href="/src/styles.css" />
-
-
 </head>
 
 <body>


### PR DESCRIPTION
fixes #8254

Done by editing the index.html file before serving via Nginx instead of removing it totally from index.html and letting the app set it, so when search engines index our cloud, it still shows our favicon and our title.