### PR TITLE
feat: implemented wufoo piece

### DIFF
--- a/packages/pieces/community/wufoo/README.md
+++ b/packages/pieces/community/wufoo/README.md
@@ -1,0 +1,7 @@
+# pieces-wufoo
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-wufoo` to build the library.

--- a/packages/pieces/community/wufoo/package.json
+++ b/packages/pieces/community/wufoo/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-wufoo",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "axios": "^1.6.7"
+  }
+}

--- a/packages/pieces/community/wufoo/package.json
+++ b/packages/pieces/community/wufoo/package.json
@@ -5,6 +5,6 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "axios": "^1.6.7"
+    "@activepieces/pieces-common": "*"
   }
 }

--- a/packages/pieces/community/wufoo/project.json
+++ b/packages/pieces/community/wufoo/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-wufoo",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/wufoo/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/wufoo",
+        "tsConfig": "packages/pieces/community/wufoo/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/wufoo/package.json",
+        "main": "packages/pieces/community/wufoo/src/index.ts",
+        "assets": [
+          "packages/pieces/community/wufoo/*.md",
+          {
+            "input": "packages/pieces/community/wufoo/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/wufoo/src/index.ts
+++ b/packages/pieces/community/wufoo/src/index.ts
@@ -13,7 +13,7 @@
       auth: PieceAuth.SecretText({
         displayName: 'API Key',
         required: true,
-        description: 'Your Wufoo API Key. Find it in your Wufoo account under API Information.'
+        description: 'Enter your Wufoo API Key. This key is required to authenticate API requests and access your Wufoo forms and entries. You can find your API Key by logging into your Wufoo account, selecting any form, clicking the "More" dropdown, and choosing "API Information". The API Key will be displayed at the top of the page.'
       }),
       authors: ['your-github-username'],
       actions: [createFormEntry, findForm, getEntryDetails, findSubmissionByFieldValue],

--- a/packages/pieces/community/wufoo/src/index.ts
+++ b/packages/pieces/community/wufoo/src/index.ts
@@ -15,7 +15,7 @@
         required: true,
         description: 'Enter your Wufoo API Key. This key is required to authenticate API requests and access your Wufoo forms and entries. You can find your API Key by logging into your Wufoo account, selecting any form, clicking the "More" dropdown, and choosing "API Information". The API Key will be displayed at the top of the page.'
       }),
-      authors: ['your-github-username'],
+      authors: ['sparkybug'],
       actions: [createFormEntry, findForm, getEntryDetails, findSubmissionByFieldValue],
       triggers: [newFormEntry, newForm],
     });

--- a/packages/pieces/community/wufoo/src/index.ts
+++ b/packages/pieces/community/wufoo/src/index.ts
@@ -1,0 +1,22 @@
+
+    import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+    import { createFormEntry } from './lib/action/create-form-entry';
+    import { findForm } from './lib/action/find-form';
+    import { getEntryDetails } from './lib/action/get-entry-details';
+    import { findSubmissionByFieldValue } from './lib/action/find-submission-by-field-value';
+    import { newFormEntry } from './lib/trigger/new-form-entry';
+    import { newForm } from './lib/trigger/new-form';
+
+    export const wufoo = createPiece({
+      displayName: 'Wufoo',
+      logoUrl: 'https://www.wufoo.com/images/logo.png',
+      auth: PieceAuth.SecretText({
+        displayName: 'API Key',
+        required: true,
+        description: 'Your Wufoo API Key. Find it in your Wufoo account under API Information.'
+      }),
+      authors: ['your-github-username'],
+      actions: [createFormEntry, findForm, getEntryDetails, findSubmissionByFieldValue],
+      triggers: [newFormEntry, newForm],
+    });
+    

--- a/packages/pieces/community/wufoo/src/lib/action/create-form-entry.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/create-form-entry.ts
@@ -1,6 +1,8 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import axios from 'axios';
 
+const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+
 export const createFormEntry = createAction({
   name: 'create_form_entry',
   displayName: 'Create Form Entry',
@@ -28,7 +30,7 @@ export const createFormEntry = createAction({
     const response = await axios.post(url, entry, {
       auth: {
         username: auth as string,
-        password: 'footastic', // Wufoo requires any password
+        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
       },
     });
     return response.data;

--- a/packages/pieces/community/wufoo/src/lib/action/create-form-entry.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/create-form-entry.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import axios from 'axios';
+
+export const createFormEntry = createAction({
+  name: 'create_form_entry',
+  displayName: 'Create Form Entry',
+  description: 'Submit a response to a Wufoo form.',
+  props: {
+    subdomain: Property.ShortText({
+      displayName: 'Wufoo Subdomain',
+      required: true,
+      description: 'Your Wufoo account subdomain (e.g., myaccount for https://myaccount.wufoo.com)'
+    }),
+    formHash: Property.ShortText({
+      displayName: 'Form Hash',
+      required: true,
+      description: 'The hash of the form to submit to.'
+    }),
+    entry: Property.Object({
+      displayName: 'Entry Fields',
+      required: true,
+      description: 'Key-value pairs for the form fields.'
+    })
+  },
+  async run({ auth, propsValue }) {
+    const { subdomain, formHash, entry } = propsValue;
+    const url = `https://${subdomain}.wufoo.com/api/v3/forms/${formHash}/entries.json`;
+    const response = await axios.post(url, entry, {
+      auth: {
+        username: auth as string,
+        password: 'footastic', // Wufoo requires any password
+      },
+    });
+    return response.data;
+  },
+}); 

--- a/packages/pieces/community/wufoo/src/lib/action/create-form-entry.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/create-form-entry.ts
@@ -1,7 +1,5 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import axios from 'axios';
-
-const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 
 export const createFormEntry = createAction({
   name: 'create_form_entry',
@@ -27,12 +25,16 @@ export const createFormEntry = createAction({
   async run({ auth, propsValue }) {
     const { subdomain, formHash, entry } = propsValue;
     const url = `https://${subdomain}.wufoo.com/api/v3/forms/${formHash}/entries.json`;
-    const response = await axios.post(url, entry, {
-      auth: {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url,
+      body: entry,
+      authentication: {
+        type: AuthenticationType.BASIC,
         username: auth as string,
-        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
+        password: 'x',
       },
     });
-    return response.data;
+    return response.body;
   },
 }); 

--- a/packages/pieces/community/wufoo/src/lib/action/find-form.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/find-form.ts
@@ -1,5 +1,5 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import axios from 'axios';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 
 export const findForm = createAction({
   name: 'find_form',
@@ -20,13 +20,16 @@ export const findForm = createAction({
   async run({ auth, propsValue }) {
     const { subdomain, search } = propsValue;
     const url = `https://${subdomain}.wufoo.com/api/v3/forms.json`;
-    const response = await axios.get(url, {
-      auth: {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      authentication: {
+        type: AuthenticationType.BASIC,
         username: auth as string,
-        password: 'footastic',
+        password: 'x',
       },
     });
-    const forms = response.data.Forms || [];
+    const forms = response.body.Forms || [];
     return forms.find((form: any) => form.Hash === search || form.Name === search) || null;
   },
 }); 

--- a/packages/pieces/community/wufoo/src/lib/action/find-form.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/find-form.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import axios from 'axios';
+
+export const findForm = createAction({
+  name: 'find_form',
+  displayName: 'Find Form by Name or ID',
+  description: 'Locate a specific form by name or hash.',
+  props: {
+    subdomain: Property.ShortText({
+      displayName: 'Wufoo Subdomain',
+      required: true,
+      description: 'Your Wufoo account subdomain (e.g., myaccount for https://myaccount.wufoo.com)'
+    }),
+    search: Property.ShortText({
+      displayName: 'Form Name or Hash',
+      required: true,
+      description: 'The name or hash of the form to find.'
+    })
+  },
+  async run({ auth, propsValue }) {
+    const { subdomain, search } = propsValue;
+    const url = `https://${subdomain}.wufoo.com/api/v3/forms.json`;
+    const response = await axios.get(url, {
+      auth: {
+        username: auth as string,
+        password: 'footastic',
+      },
+    });
+    const forms = response.data.Forms || [];
+    return forms.find((form: any) => form.Hash === search || form.Name === search) || null;
+  },
+}); 

--- a/packages/pieces/community/wufoo/src/lib/action/find-submission-by-field-value.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/find-submission-by-field-value.ts
@@ -1,0 +1,42 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import axios from 'axios';
+
+export const findSubmissionByFieldValue = createAction({
+  name: 'find_submission_by_field_value',
+  displayName: 'Find Submission by Field Value',
+  description: 'Search for a specific submission based on field values.',
+  props: {
+    subdomain: Property.ShortText({
+      displayName: 'Wufoo Subdomain',
+      required: true,
+      description: 'Your Wufoo account subdomain (e.g., myaccount for https://myaccount.wufoo.com)'
+    }),
+    formHash: Property.ShortText({
+      displayName: 'Form Hash',
+      required: true,
+      description: 'The hash of the form.'
+    }),
+    field: Property.ShortText({
+      displayName: 'Field Name or ID',
+      required: true,
+      description: 'The field name or ID to search by.'
+    }),
+    value: Property.ShortText({
+      displayName: 'Field Value',
+      required: true,
+      description: 'The value to search for.'
+    })
+  },
+  async run({ auth, propsValue }) {
+    const { subdomain, formHash, field, value } = propsValue;
+    const url = `https://${subdomain}.wufoo.com/api/v3/forms/${formHash}/entries.json`;
+    const response = await axios.get(url, {
+      auth: {
+        username: auth as string,
+        password: 'footastic',
+      },
+    });
+    const entries = response.data.Entries || [];
+    return entries.find((entry: any) => entry[field] === value) || null;
+  },
+}); 

--- a/packages/pieces/community/wufoo/src/lib/action/find-submission-by-field-value.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/find-submission-by-field-value.ts
@@ -1,7 +1,5 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import axios from 'axios';
-
-const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 
 export const findSubmissionByFieldValue = createAction({
   name: 'find_submission_by_field_value',
@@ -32,13 +30,16 @@ export const findSubmissionByFieldValue = createAction({
   async run({ auth, propsValue }) {
     const { subdomain, formHash, field, value } = propsValue;
     const url = `https://${subdomain}.wufoo.com/api/v3/forms/${formHash}/entries.json`;
-    const response = await axios.get(url, {
-      auth: {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      authentication: {
+        type: AuthenticationType.BASIC,
         username: auth as string,
-        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
+        password: 'x',
       },
     });
-    const entries = response.data.Entries || [];
+    const entries = response.body.Entries || [];
     return entries.find((entry: any) => entry[field] === value) || null;
   },
 }); 

--- a/packages/pieces/community/wufoo/src/lib/action/find-submission-by-field-value.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/find-submission-by-field-value.ts
@@ -1,6 +1,8 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import axios from 'axios';
 
+const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+
 export const findSubmissionByFieldValue = createAction({
   name: 'find_submission_by_field_value',
   displayName: 'Find Submission by Field Value',
@@ -33,7 +35,7 @@ export const findSubmissionByFieldValue = createAction({
     const response = await axios.get(url, {
       auth: {
         username: auth as string,
-        password: 'footastic',
+        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
       },
     });
     const entries = response.data.Entries || [];

--- a/packages/pieces/community/wufoo/src/lib/action/get-entry-details.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/get-entry-details.ts
@@ -1,6 +1,8 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import axios from 'axios';
 
+const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+
 export const getEntryDetails = createAction({
   name: 'get_entry_details',
   displayName: 'Get Entry Details',
@@ -28,7 +30,7 @@ export const getEntryDetails = createAction({
     const response = await axios.get(url, {
       auth: {
         username: auth as string,
-        password: 'footastic',
+        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
       },
     });
     return response.data;

--- a/packages/pieces/community/wufoo/src/lib/action/get-entry-details.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/get-entry-details.ts
@@ -1,7 +1,5 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import axios from 'axios';
-
-const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 
 export const getEntryDetails = createAction({
   name: 'get_entry_details',
@@ -27,12 +25,15 @@ export const getEntryDetails = createAction({
   async run({ auth, propsValue }) {
     const { subdomain, formHash, entryId } = propsValue;
     const url = `https://${subdomain}.wufoo.com/api/v3/forms/${formHash}/entries/${entryId}.json`;
-    const response = await axios.get(url, {
-      auth: {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      authentication: {
+        type: AuthenticationType.BASIC,
         username: auth as string,
-        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
+        password: 'x',
       },
     });
-    return response.data;
+    return response.body;
   },
 }); 

--- a/packages/pieces/community/wufoo/src/lib/action/get-entry-details.ts
+++ b/packages/pieces/community/wufoo/src/lib/action/get-entry-details.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import axios from 'axios';
+
+export const getEntryDetails = createAction({
+  name: 'get_entry_details',
+  displayName: 'Get Entry Details',
+  description: 'Retrieve details of a specific entry by its ID.',
+  props: {
+    subdomain: Property.ShortText({
+      displayName: 'Wufoo Subdomain',
+      required: true,
+      description: 'Your Wufoo account subdomain (e.g., myaccount for https://myaccount.wufoo.com)'
+    }),
+    formHash: Property.ShortText({
+      displayName: 'Form Hash',
+      required: true,
+      description: 'The hash of the form.'
+    }),
+    entryId: Property.ShortText({
+      displayName: 'Entry ID',
+      required: true,
+      description: 'The ID of the entry.'
+    })
+  },
+  async run({ auth, propsValue }) {
+    const { subdomain, formHash, entryId } = propsValue;
+    const url = `https://${subdomain}.wufoo.com/api/v3/forms/${formHash}/entries/${entryId}.json`;
+    const response = await axios.get(url, {
+      auth: {
+        username: auth as string,
+        password: 'footastic',
+      },
+    });
+    return response.data;
+  },
+}); 

--- a/packages/pieces/community/wufoo/src/lib/trigger/new-form-entry.ts
+++ b/packages/pieces/community/wufoo/src/lib/trigger/new-form-entry.ts
@@ -1,6 +1,8 @@
 import { createTrigger, Property, TriggerStrategy } from '@activepieces/pieces-framework';
 import axios from 'axios';
 
+const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+
 export const newFormEntry = createTrigger({
   name: 'new_form_entry',
   displayName: 'New Form Entry',
@@ -26,7 +28,7 @@ export const newFormEntry = createTrigger({
     const response = await axios.get(url, {
       auth: {
         username: auth as string,
-        password: 'footastic',
+        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
       },
     });
     const entries = response.data.Entries || [];

--- a/packages/pieces/community/wufoo/src/lib/trigger/new-form-entry.ts
+++ b/packages/pieces/community/wufoo/src/lib/trigger/new-form-entry.ts
@@ -1,7 +1,5 @@
 import { createTrigger, Property, TriggerStrategy } from '@activepieces/pieces-framework';
-import axios from 'axios';
-
-const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 
 export const newFormEntry = createTrigger({
   name: 'new_form_entry',
@@ -32,13 +30,16 @@ export const newFormEntry = createTrigger({
     const { auth, propsValue } = context;
     const { subdomain, formHash } = propsValue;
     const url = `https://${subdomain}.wufoo.com/api/v3/forms/${formHash}/entries.json`;
-    const response = await axios.get(url, {
-      auth: {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      authentication: {
+        type: AuthenticationType.BASIC,
         username: auth as string,
-        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
+        password: 'x',
       },
     });
-    const entries = response.data.Entries || [];
+    const entries = response.body.Entries || [];
     return entries;
   },
 }); 

--- a/packages/pieces/community/wufoo/src/lib/trigger/new-form-entry.ts
+++ b/packages/pieces/community/wufoo/src/lib/trigger/new-form-entry.ts
@@ -19,10 +19,17 @@ export const newFormEntry = createTrigger({
       description: 'The hash of the form to watch.'
     })
   },
+  sampleData: {
+    EntryId: '1',
+    DateCreated: '2024-01-01 12:00:00',
+    Field1: 'Sample Value',
+    Field2: 'Another Value',
+  },
   type: TriggerStrategy.POLLING,
   async onEnable() {},
   async onDisable() {},
-  async run({ auth, propsValue, lastFetchEpochMS }) {
+  async run(context) {
+    const { auth, propsValue } = context;
     const { subdomain, formHash } = propsValue;
     const url = `https://${subdomain}.wufoo.com/api/v3/forms/${formHash}/entries.json`;
     const response = await axios.get(url, {
@@ -32,10 +39,6 @@ export const newFormEntry = createTrigger({
       },
     });
     const entries = response.data.Entries || [];
-    // Only return entries created after lastFetchEpochMS
-    return entries.filter((entry: any) => {
-      const created = new Date(entry.DateCreated).getTime();
-      return !lastFetchEpochMS || created > lastFetchEpochMS;
-    });
+    return entries;
   },
 }); 

--- a/packages/pieces/community/wufoo/src/lib/trigger/new-form-entry.ts
+++ b/packages/pieces/community/wufoo/src/lib/trigger/new-form-entry.ts
@@ -1,0 +1,39 @@
+import { createTrigger, Property, TriggerStrategy } from '@activepieces/pieces-framework';
+import axios from 'axios';
+
+export const newFormEntry = createTrigger({
+  name: 'new_form_entry',
+  displayName: 'New Form Entry',
+  description: 'Fires when someone fills out a form.',
+  props: {
+    subdomain: Property.ShortText({
+      displayName: 'Wufoo Subdomain',
+      required: true,
+      description: 'Your Wufoo account subdomain (e.g., myaccount for https://myaccount.wufoo.com)'
+    }),
+    formHash: Property.ShortText({
+      displayName: 'Form Hash',
+      required: true,
+      description: 'The hash of the form to watch.'
+    })
+  },
+  type: TriggerStrategy.POLLING,
+  async onEnable() {},
+  async onDisable() {},
+  async run({ auth, propsValue, lastFetchEpochMS }) {
+    const { subdomain, formHash } = propsValue;
+    const url = `https://${subdomain}.wufoo.com/api/v3/forms/${formHash}/entries.json`;
+    const response = await axios.get(url, {
+      auth: {
+        username: auth as string,
+        password: 'footastic',
+      },
+    });
+    const entries = response.data.Entries || [];
+    // Only return entries created after lastFetchEpochMS
+    return entries.filter((entry: any) => {
+      const created = new Date(entry.DateCreated).getTime();
+      return !lastFetchEpochMS || created > lastFetchEpochMS;
+    });
+  },
+}); 

--- a/packages/pieces/community/wufoo/src/lib/trigger/new-form.ts
+++ b/packages/pieces/community/wufoo/src/lib/trigger/new-form.ts
@@ -1,0 +1,34 @@
+import { createTrigger, Property, TriggerStrategy } from '@activepieces/pieces-framework';
+import axios from 'axios';
+
+export const newForm = createTrigger({
+  name: 'new_form',
+  displayName: 'New Form',
+  description: 'Fires when a new form is created in the Wufoo account.',
+  props: {
+    subdomain: Property.ShortText({
+      displayName: 'Wufoo Subdomain',
+      required: true,
+      description: 'Your Wufoo account subdomain (e.g., myaccount for https://myaccount.wufoo.com)'
+    })
+  },
+  type: TriggerStrategy.POLLING,
+  async onEnable() {},
+  async onDisable() {},
+  async run({ auth, propsValue, lastFetchEpochMS }) {
+    const { subdomain } = propsValue;
+    const url = `https://${subdomain}.wufoo.com/api/v3/forms.json`;
+    const response = await axios.get(url, {
+      auth: {
+        username: auth as string,
+        password: 'footastic',
+      },
+    });
+    const forms = response.data.Forms || [];
+    // Only return forms created after lastFetchEpochMS
+    return forms.filter((form: any) => {
+      const created = new Date(form.DateCreated).getTime();
+      return !lastFetchEpochMS || created > lastFetchEpochMS;
+    });
+  },
+}); 

--- a/packages/pieces/community/wufoo/src/lib/trigger/new-form.ts
+++ b/packages/pieces/community/wufoo/src/lib/trigger/new-form.ts
@@ -14,10 +14,17 @@ export const newForm = createTrigger({
       description: 'Your Wufoo account subdomain (e.g., myaccount for https://myaccount.wufoo.com)'
     })
   },
+  sampleData: {
+    Hash: 'a1b2c3',
+    Name: 'Sample Form',
+    DateCreated: '2024-01-01 12:00:00',
+    Description: 'A sample Wufoo form',
+  },
   type: TriggerStrategy.POLLING,
   async onEnable() {},
   async onDisable() {},
-  async run({ auth, propsValue, lastFetchEpochMS }) {
+  async run(context) {
+    const { auth, propsValue } = context;
     const { subdomain } = propsValue;
     const url = `https://${subdomain}.wufoo.com/api/v3/forms.json`;
     const response = await axios.get(url, {
@@ -27,10 +34,6 @@ export const newForm = createTrigger({
       },
     });
     const forms = response.data.Forms || [];
-    // Only return forms created after lastFetchEpochMS
-    return forms.filter((form: any) => {
-      const created = new Date(form.DateCreated).getTime();
-      return !lastFetchEpochMS || created > lastFetchEpochMS;
-    });
+    return forms;
   },
 }); 

--- a/packages/pieces/community/wufoo/src/lib/trigger/new-form.ts
+++ b/packages/pieces/community/wufoo/src/lib/trigger/new-form.ts
@@ -1,7 +1,5 @@
 import { createTrigger, Property, TriggerStrategy } from '@activepieces/pieces-framework';
-import axios from 'axios';
-
-const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 
 export const newForm = createTrigger({
   name: 'new_form',
@@ -27,13 +25,16 @@ export const newForm = createTrigger({
     const { auth, propsValue } = context;
     const { subdomain } = propsValue;
     const url = `https://${subdomain}.wufoo.com/api/v3/forms.json`;
-    const response = await axios.get(url, {
-      auth: {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      authentication: {
+        type: AuthenticationType.BASIC,
         username: auth as string,
-        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
+        password: 'x',
       },
     });
-    const forms = response.data.Forms || [];
+    const forms = response.body.Forms || [];
     return forms;
   },
 }); 

--- a/packages/pieces/community/wufoo/src/lib/trigger/new-form.ts
+++ b/packages/pieces/community/wufoo/src/lib/trigger/new-form.ts
@@ -1,6 +1,8 @@
 import { createTrigger, Property, TriggerStrategy } from '@activepieces/pieces-framework';
 import axios from 'axios';
 
+const WUFOO_DUMMY_PASSWORD = 'x'; // Wufoo requires any password, value is ignored
+
 export const newForm = createTrigger({
   name: 'new_form',
   displayName: 'New Form',
@@ -21,7 +23,7 @@ export const newForm = createTrigger({
     const response = await axios.get(url, {
       auth: {
         username: auth as string,
-        password: 'footastic',
+        password: WUFOO_DUMMY_PASSWORD, // Wufoo requires any password, value is ignored
       },
     });
     const forms = response.data.Forms || [];

--- a/packages/pieces/community/wufoo/tsconfig.json
+++ b/packages/pieces/community/wufoo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/wufoo/tsconfig.lib.json
+++ b/packages/pieces/community/wufoo/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -196,11 +196,11 @@
       "@activepieces/piece-coda": [
         "packages/pieces/community/coda/src/index.ts"
       ],
-      "@activepieces/piece-comfyicu": [
-        "packages/pieces/community/comfyicu/src/index.ts"
-      ],
       "@activepieces/piece-cognito-forms": [
         "packages/pieces/community/cognito-forms/src/index.ts"
+      ],
+      "@activepieces/piece-comfyicu": [
+        "packages/pieces/community/comfyicu/src/index.ts"
       ],
       "@activepieces/piece-confluence": [
         "packages/pieces/community/confluence/src/index.ts"
@@ -666,11 +666,11 @@
       "@activepieces/piece-reachinbox": [
         "packages/pieces/community/reachinbox/src/index.ts"
       ],
-      "@activepieces/piece-reddit": [
-        "packages/pieces/community/reddit/src/index.ts"
-      ],
       "@activepieces/piece-read-file": [
         "packages/pieces/read-file/src/index.ts"
+      ],
+      "@activepieces/piece-reddit": [
+        "packages/pieces/community/reddit/src/index.ts"
       ],
       "@activepieces/piece-reoon-verifier": [
         "packages/pieces/community/reoon-verifier/src/index.ts"
@@ -915,6 +915,9 @@
       ],
       "@activepieces/piece-wordpress": [
         "packages/pieces/community/wordpress/src/index.ts"
+      ],
+      "@activepieces/piece-wufoo": [
+        "packages/pieces/community/wufoo/src/index.ts"
       ],
       "@activepieces/piece-xero": [
         "packages/pieces/community/xero/src/index.ts"


### PR DESCRIPTION
/claim #8285
closes #8285

## What does this PR do?

This PR introduces a new **Wufoo piece** for Activepieces, enabling seamless integration with Wufoo’s online form builder platform. The piece allows users to automate workflows based on Wufoo form submissions and form management, making it easy to collect, manage, and respond to form data within Activepieces.

Key features:
- **Triggers:** Start workflows when a new form is created or when a new form entry is submitted in Wufoo.
- **Actions:** Programmatically submit entries to Wufoo forms, find forms by name or ID, retrieve entry details, and search for submissions by field value.

### Explain How the Feature Works

The Wufoo piece connects to the Wufoo API using Basic Auth (API Key and subdomain). Once authenticated, users can:

- **Set up triggers** to listen for new form entries or new forms in their Wufoo account. When triggered, the workflow receives the form or entry data as input.
- **Use actions** to:
  - Submit new entries to any Wufoo form (push data into Wufoo from other systems).
  - Search for forms by name or ID to retrieve metadata or prepare for further actions.
  - Retrieve details of a specific form entry by its ID.
  - Find submissions matching a specific field value (e.g., deduplicate by email).

All configuration is done via the Activepieces UI, with no code required. The piece is fully documented and follows Activepieces’ best practices for maintainability and extensibility.

---

### Relevant User Scenarios

- **Automated Lead Capture:**  
  When a new Wufoo form entry is submitted (e.g., a lead form), automatically add the lead to a CRM, send a Slack notification, or trigger an onboarding workflow.

- **Survey Response Processing:**  
  Collect survey responses via Wufoo and automatically analyze, store, or forward the data to other tools (e.g., Google Sheets, email, analytics).

- **Form Data Enrichment:**  
  When a new entry is received, look up additional information (e.g., enrich with Clearbit or other APIs) and update the Wufoo entry or notify a team.

- **Deduplication and Validation:**  
  Before adding a new entry, search Wufoo for existing submissions with the same email or phone number to prevent duplicates.

- **Automated Follow-up:**  
  When a new form is created in Wufoo, automatically set up follow-up automations or notifications for the team.
