### PR TITLE
feat(notion): improve error management when generating dynamic input properties

### DIFF
--- a/packages/pieces/community/notion/package.json
+++ b/packages/pieces/community/notion/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-notion",
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/packages/pieces/community/notion/src/lib/common/index.ts
+++ b/packages/pieces/community/notion/src/lib/common/index.ts
@@ -158,46 +158,55 @@ export const notionCommon = {
           database_id: database_id as unknown as string,
         });
         for (const key in properties) {
-          const property = properties[key];
-          if (
-            [
-              'rollup',
-              'button',
-              'files',
-              'verification',
-              'formula',
-              'unique_id',
-              'relation',
-              'created_by',
-              'created_time',
-              'last_edited_by',
-              'last_edited_time',
-            ].includes(property.type)
-          ) {
-            continue;
-          }
-          if (property.type === 'people') {
-            const { results } = await notion.users.list({ page_size: 100 });
-            fields[property.name] = Property.StaticMultiSelectDropdown({
-              displayName: property.name,
-              required: false,
-              options: {
-                disabled: false,
-                options: results
-                  .filter(
-                    (user) => user.type === 'person' && user.name !== null
-                  )
-                  .map((option: { id: string; name: any }) => {
-                    return {
-                      label: option.name,
-                      value: option.id,
-                    };
-                  }),
-              },
-            });
-          } else {
-            fields[property.name] =
-              NotionFieldMapping[property.type].buildActivepieceType(property);
+          try {
+            const property = properties[key];
+            if (
+              [
+                'rollup',
+                'button',
+                'files',
+                'verification',
+                'formula',
+                'unique_id',
+                'relation',
+                'created_by',
+                'created_time',
+                'last_edited_by',
+                'last_edited_time',
+              ].includes(property.type)
+            ) {
+              continue;
+            }
+            if (property.type === 'people') {
+              const { results } = await notion.users.list({ page_size: 100 });
+              fields[property.name] = Property.StaticMultiSelectDropdown({
+                displayName: property.name,
+                required: false,
+                options: {
+                  disabled: false,
+                  options: results
+                    .filter(
+                      (user) => user.type === 'person' && user.name !== null
+                    )
+                    .map((option: { id: string; name: any }) => {
+                      return {
+                        label: option.name,
+                        value: option.id,
+                      };
+                    }),
+                },
+              });
+            } else {
+              fields[property.name] =
+                NotionFieldMapping[property.type].buildActivepieceType(
+                  property
+                );
+            }
+          } catch (e) {
+            console.error(
+              'Notion: could not generate dynamic input property',
+              e
+            );
           }
         }
       } catch (e) {


### PR DESCRIPTION
## What does this PR do?

In some cases we fail to generate the dynamic properties to e.g. insert a database item, returning an incomplete array.
This PR adds try/catch block so that only problematic properties are missing + we try to log a proper error message

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
