### PR TITLE
fix: resolve OS-specific path bug in publish-piece

### DIFF
--- a/tools/scripts/pieces/publish-piece.ts
+++ b/tools/scripts/pieces/publish-piece.ts
@@ -5,17 +5,13 @@ import { readPackageJson, readProjectJson } from '../utils/files'
 import { findAllPiecesDirectoryInSource } from '../utils/piece-script-utils'
 import { isNil } from '@activepieces/shared'
 import chalk from 'chalk'
+import path from 'node:path'
 
 export const publishPiece = async (name: string): Promise<void> => {
   assert(name, '[publishPiece] parameter "name" is required')
 
   const distPaths = await findAllPiecesDirectoryInSource()
-  const directory = distPaths.find(path => {
-    if (path.endsWith(`/${name}`)) {
-      return true;
-    }
-    return false
-  })
+  const directory = distPaths.find(p => path.basename(p) === name)
   if (isNil(directory)) {
     console.error(chalk.red(`[publishPiece] can't find the directory with name ${name}`))
     return


### PR DESCRIPTION
## What does this PR do?

In `/tools/scripts/pieces/publish-piece.ts`, the following code threw up an error on Windows after running `npm run publish-piece <piece_name>`:

```typescript
  const distPaths = await findAllPiecesDirectoryInSource()
  const directory = distPaths.find(path => {
    if (path.endsWith(`/${name}`)) {
      return true;
    }
    return false
  })
```
The error thrown was the one triggered by this line:
```typescript
console.error(chalk.red(`[publishPiece] can't find the directory with name ${name}`))
```
The problem was that the `/${name}` part caused an error to be thrown on Windows, which uses `\` for its directory paths. 

The fix is to use Node's built-in `path`  module, specifically the `path.basename` method to accomplish this check, to make it platform-independent. 

**The updated code block:**

```typescript
  const directory = distPaths.find(p => path.basename(p) === name)
```

Fixes #8345 