### PR TITLE
chore: improve global error handling

### DIFF
--- a/packages/react-ui/src/app/builder/test-step/test-step-hooks.ts
+++ b/packages/react-ui/src/app/builder/test-step/test-step-hooks.ts
@@ -311,6 +311,7 @@ export const testStepHooks = {
         if (error.message === CANCEL_TEST_STEP_ERROR_MESSAGE) {
           return;
         }
+        toast(INTERNAL_ERROR_TOAST);
       },
     });
   },

--- a/packages/react-ui/src/app/routes/platform/projects/edit-project-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/projects/edit-project-dialog.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { useToast } from '@/components/ui/use-toast';
+import { INTERNAL_ERROR_TOAST, useToast } from '@/components/ui/use-toast';
 import { useAuthorization } from '@/hooks/authorization-hooks';
 import { platformHooks } from '@/hooks/platform-hooks';
 import { projectHooks } from '@/hooks/project-hooks';
@@ -118,6 +118,10 @@ export function EditProjectDialog({
             form.setError('root.serverError', {
               message: t('The external ID is already taken.'),
             });
+            break;
+          }
+          default: {
+            toast(INTERNAL_ERROR_TOAST);
             break;
           }
         }

--- a/packages/react-ui/src/app/routes/platform/projects/new-project-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/projects/new-project-dialog.tsx
@@ -48,9 +48,6 @@ export const NewProjectDialog = ({
       onCreate();
       setOpen(false);
     },
-    onError: () => {
-      setOpen(false);
-    },
   });
 
   return (

--- a/packages/react-ui/src/app/routes/platform/security/api-keys/new-api-key-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/security/api-keys/new-api-key-dialog.tsx
@@ -57,9 +57,6 @@ export const NewApiKeyDialog = ({
       setApiKey(apiKey);
       onCreate();
     },
-    onError: () => {
-      setOpen(false);
-    },
   });
 
   return (

--- a/packages/react-ui/src/app/routes/platform/setup/templates/upsert-template-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/templates/upsert-template-dialog.tsx
@@ -82,9 +82,6 @@ export const UpsertTemplateDialog = ({
       onDone();
       setOpen(false);
     },
-    onError: () => {
-      setOpen(false);
-    },
   });
 
   const onSubmit = () => {

--- a/packages/react-ui/src/app/routes/platform/users/update-user-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/users/update-user-dialog.tsx
@@ -61,9 +61,6 @@ export const UpdateUserDialog = ({
         onUpdate(user.platformRole);
         setOpen(false);
       },
-      onError: () => {
-        setOpen(false);
-      },
     },
   );
 

--- a/packages/react-ui/src/app/routes/project-release/apply-plan.tsx
+++ b/packages/react-ui/src/app/routes/project-release/apply-plan.tsx
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useState, ReactNode } from 'react';
 
 import { Button, ButtonProps } from '@/components/ui/button';
+import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
 import { ConnectGitDialog } from '@/features/git-sync/components/connect-git-dialog';
 import { gitSyncHooks } from '@/features/git-sync/lib/git-sync-hooks';
 import { projectReleaseApi } from '@/features/project-version/lib/project-release-api';
@@ -53,6 +54,7 @@ export const ApplyButton = ({
     },
     onError: () => {
       setLoadingRequestId(null);
+      toast(INTERNAL_ERROR_TOAST);
     },
   });
 

--- a/packages/react-ui/src/app/routes/settings/pieces/manage-pieces-dialog.tsx
+++ b/packages/react-ui/src/app/routes/settings/pieces/manage-pieces-dialog.tsx
@@ -74,9 +74,6 @@ export const ManagePiecesDialog = React.memo(
         });
         setOpen(false);
       },
-      onError: () => {
-        setOpen(false);
-      },
     });
 
     return (

--- a/packages/react-ui/src/components/ui/toast.tsx
+++ b/packages/react-ui/src/components/ui/toast.tsx
@@ -31,7 +31,7 @@ const toastVariants = cva(
       variant: {
         default: 'border bg-background text-foreground',
         destructive:
-          'border-destructive-100 bg-destructive-100 text-foreground',
+          'bg-destructive border-destructive text-primary-foreground',
       },
     },
     defaultVariants: {

--- a/packages/react-ui/src/features/alerts/lib/alert-hooks.ts
+++ b/packages/react-ui/src/features/alerts/lib/alert-hooks.ts
@@ -3,7 +3,7 @@ import { HttpStatusCode } from 'axios';
 import { t } from 'i18next';
 import { UseFormReturn } from 'react-hook-form';
 
-import { toast } from '@/components/ui/use-toast';
+import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
 import { api } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
 import { Alert, AlertChannel } from '@activepieces/ee-shared';
@@ -51,9 +51,12 @@ export const alertMutations = {
                 message: t('The email is already added.'),
               });
               break;
+            default: {
+              toast(INTERNAL_ERROR_TOAST);
+              break;
+            }
           }
         }
-        setOpen(true);
       },
     });
   },

--- a/packages/react-ui/src/features/billing/lib/billing-hooks.ts
+++ b/packages/react-ui/src/features/billing/lib/billing-hooks.ts
@@ -2,7 +2,7 @@ import { QueryClient, useMutation, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { useNavigate } from 'react-router-dom';
 
-import { toast } from '@/components/ui/use-toast';
+import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
 import { api } from '@/lib/api';
 import {
   CreateSubscriptionParams,
@@ -125,8 +125,10 @@ export const billingMutations = {
               variant: 'default',
               duration: 5000,
             });
+            return;
           }
         }
+        toast(INTERNAL_ERROR_TOAST);
       },
     });
   },

--- a/packages/react-ui/src/features/connections/lib/app-connections-hooks.ts
+++ b/packages/react-ui/src/features/connections/lib/app-connections-hooks.ts
@@ -205,6 +205,8 @@ export const appConnectionsMutations = {
           renameConnectionForm.setError('displayName', {
             message: error.message,
           });
+        } else {
+          toast(INTERNAL_ERROR_TOAST);
         }
       },
     });

--- a/packages/react-ui/src/features/connections/lib/global-connections-hooks.ts
+++ b/packages/react-ui/src/features/connections/lib/global-connections-hooks.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { UseFormReturn } from 'react-hook-form';
 
-import { toast } from '@/components/ui/use-toast';
+import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
 import {
   AppConnectionWithoutSensitiveData,
   ListGlobalConnectionsRequestQuery,
@@ -111,6 +111,8 @@ export const globalConnectionsMutations = {
           editConnectionForm.setError('projectIds', {
             message: error.message,
           });
+        } else {
+          toast(INTERNAL_ERROR_TOAST);
         }
       },
     }),

--- a/packages/react-ui/src/features/flows/components/import-flow-dialog.tsx
+++ b/packages/react-ui/src/features/flows/components/import-flow-dialog.tsx
@@ -27,7 +27,7 @@ import {
   SelectItem,
 } from '@/components/ui/select';
 import { LoadingSpinner } from '@/components/ui/spinner';
-import { toast } from '@/components/ui/use-toast';
+import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
 import { foldersHooks } from '@/features/folders/lib/folders-hooks';
 import { api } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
@@ -161,6 +161,8 @@ const ImportFlowDialog = (
       ) {
         setErrorMessage(t('Template file is invalid'));
         console.log(err);
+      } else {
+        toast(INTERNAL_ERROR_TOAST);
       }
     },
   });

--- a/packages/react-ui/src/features/folders/component/create-folder-dialog.tsx
+++ b/packages/react-ui/src/features/folders/component/create-folder-dialog.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/dialog';
 import { FormField, FormItem, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { toast } from '@/components/ui/use-toast';
+import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
 import { api } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
 import { FolderDto } from '@activepieces/shared';
@@ -81,6 +81,10 @@ export const CreateFolderDialog = ({
             form.setError('root.serverError', {
               message: t('The folder name already exists.'),
             });
+            break;
+          }
+          default: {
+            toast(INTERNAL_ERROR_TOAST);
             break;
           }
         }

--- a/packages/react-ui/src/features/folders/component/rename-folder-dialog.tsx
+++ b/packages/react-ui/src/features/folders/component/rename-folder-dialog.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/ui/dialog';
 import { FormField, FormItem, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { toast } from '@/components/ui/use-toast';
+import { INTERNAL_ERROR_TOAST, toast } from '@/components/ui/use-toast';
 import { validationUtils } from '@/lib/utils';
 import { Folder } from '@activepieces/shared';
 
@@ -64,6 +64,8 @@ const RenameFolderDialog = ({
         form.setError('displayName', {
           message: t('Folder name already used'),
         });
+      } else {
+        toast(INTERNAL_ERROR_TOAST);
       }
     },
   });

--- a/packages/react-ui/src/features/platform-admin/components/new-signing-key-dialog.tsx
+++ b/packages/react-ui/src/features/platform-admin/components/new-signing-key-dialog.tsx
@@ -46,9 +46,6 @@ export const NewSigningKeyDialog = ({
       setSigningKey(key);
       onCreate();
     },
-    onError: () => {
-      setOpen(false);
-    },
   });
 
   return (


### PR DESCRIPTION
Global error handling was always showing internal error toast even if the mutation handles the error state. 