### PR TITLE
Delay After Queue Piece

### DIFF
--- a/packages/pieces/community/delay-after-queue/.eslintrc.json
+++ b/packages/pieces/community/delay-after-queue/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/delay-after-queue/README.md
+++ b/packages/pieces/community/delay-after-queue/README.md
@@ -1,0 +1,34 @@
+# Delay After Queue Piece
+
+A custom Activepieces piece that provides rate control for flow execution. This piece allows you to create queues that process flows one at a time with configurable delays between executions.
+
+## Features
+
+- **Queue-based rate limiting**: Multiple flows using the same queue name are processed sequentially
+- **Configurable delays**: Set delays in seconds, minutes, or hours
+- **Project-scoped queues**: Queues are shared across all flows in a project
+- **Automatic cleanup**: Queue entries are automatically removed after processing
+
+## Usage
+
+1. Add the "Delay After Queue" action to your flow
+2. Configure a unique queue name
+3. Set the delay amount and unit
+4. The flow will wait in the queue and apply the specified delay before continuing
+
+## Configuration
+
+- **Queue Name**: A unique identifier for the queue (required)
+- **Delay Unit**: Choose between seconds, minutes, or hours
+- **Delay Amount**: The number of time units to delay
+
+## Example Use Cases
+
+- Rate limiting API calls
+- Preventing database overload
+- Managing resource-intensive operations
+- Coordinating multiple flows that use the same external service
+
+## Building
+
+Run `nx build pieces-delay-after-queue` to build the library.

--- a/packages/pieces/community/delay-after-queue/README.md
+++ b/packages/pieces/community/delay-after-queue/README.md
@@ -1,34 +1,51 @@
-# Delay After Queue Piece
+**Delay After Queue Piece**
 
-A custom Activepieces piece that provides rate control for flow execution. This piece allows you to create queues that process flows one at a time with configurable delays between executions.
+- A custom Activepieces piece that provides rate control for flow execution. This piece allows you to create queues that process flows one at a time with configurable delays between executions.
 
-## Features
+**Features**
 
-- **Queue-based rate limiting**: Multiple flows using the same queue name are processed sequentially
-- **Configurable delays**: Set delays in seconds, minutes, or hours
-- **Project-scoped queues**: Queues are shared across all flows in a project
-- **Automatic cleanup**: Queue entries are automatically removed after processing
+- Queue-based rate limiting: Multiple flows using the same queue name are processed sequentially
 
-## Usage
+- Configurable delays: Set delays in seconds or minutes (max total delay of 10 minutes)
 
-1. Add the "Delay After Queue" action to your flow
-2. Configure a unique queue name
-3. Set the delay amount and unit
-4. The flow will wait in the queue and apply the specified delay before continuing
+- Project-scoped queues: Queues are shared across all flows in a project
 
-## Configuration
+- Automatic cleanup: Queue entries are automatically removed after processing
 
-- **Queue Name**: A unique identifier for the queue (required)
-- **Delay Unit**: Choose between seconds, minutes, or hours
-- **Delay Amount**: The number of time units to delay
+**Usage**
 
-## Example Use Cases
+- Add the "Delay After Queue" action to your flow
+
+- Configure a unique queue name
+
+- Set the delay amount and unit (seconds or minutes) — maximum total delay allowed is 10 minutes
+
+- The flow will wait in the queue and apply the specified delay before continuing
+
+**Configuration**
+
+- Queue Name: A unique identifier for the queue (required)
+
+- Delay Unit: Choose between seconds or minutes (hours not supported)
+
+- Delay Amount: The number of time units to delay (max total delay 10 minutes)
+
+**Limitations**
+
+- Delay durations longer than 10 minutes are not supported to avoid flow timeout errors.
+
+- If you need longer delays, consider splitting your flow or using external scheduling mechanisms.
+
+**Example Use Cases**
 
 - Rate limiting API calls
+
 - Preventing database overload
+
 - Managing resource-intensive operations
+
 - Coordinating multiple flows that use the same external service
 
-## Building
+**Building**
 
-Run `nx build pieces-delay-after-queue` to build the library.
+- Run nx build pieces-delay-after-queue to build the library.

--- a/packages/pieces/community/delay-after-queue/package-lock.json
+++ b/packages/pieces/community/delay-after-queue/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drhomes/piece-delay-after-queue",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@drhomes/piece-delay-after-queue",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/packages/pieces/community/delay-after-queue/package-lock.json
+++ b/packages/pieces/community/delay-after-queue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@drhomes/piece-delay-after-queue",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@drhomes/piece-delay-after-queue",
-      "version": "0.1.0"
+      "version": "0.3.0"
     }
   }
 }

--- a/packages/pieces/community/delay-after-queue/package.json
+++ b/packages/pieces/community/delay-after-queue/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@drhomes/piece-delay-after-queue",
+  "version": "0.1.0"
+}

--- a/packages/pieces/community/delay-after-queue/package.json
+++ b/packages/pieces/community/delay-after-queue/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@drhomes/piece-delay-after-queue",
-  "version": "0.1.0"
+  "version": "0.3.0"
 }

--- a/packages/pieces/community/delay-after-queue/project.json
+++ b/packages/pieces/community/delay-after-queue/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-delay-after-queue",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/delay-after-queue/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/delay-after-queue",
+        "tsConfig": "packages/pieces/community/delay-after-queue/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/delay-after-queue/package.json",
+        "main": "packages/pieces/community/delay-after-queue/src/index.ts",
+        "assets": [
+          "packages/pieces/community/delay-after-queue/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/delay-after-queue/src/index.ts
+++ b/packages/pieces/community/delay-after-queue/src/index.ts
@@ -1,0 +1,15 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { delayAfterQueue } from './lib/actions/delay-after-queue';
+
+export const delayAfterQueuePiece = createPiece({
+  displayName: 'Delay After Queue',
+  description: 'Rate control piece that processes flows sequentially with configurable delays',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://dallasreynoldstn.com/wp-content/uploads/2025/07/ChatGPT-Image-Jul-10-2025-11_04_37-PM.svg',
+  authors: ['Dallas Reynolds Homes Inc'],
+  categories: [PieceCategory.CORE],
+  actions: [delayAfterQueue],
+  triggers: [],
+});

--- a/packages/pieces/community/delay-after-queue/src/lib/actions/delay-after-queue.ts
+++ b/packages/pieces/community/delay-after-queue/src/lib/actions/delay-after-queue.ts
@@ -1,0 +1,119 @@
+import {
+  createAction,
+  Property,
+  StoreScope,
+} from '@activepieces/pieces-framework';
+
+export const delayAfterQueue = createAction({
+  name: 'delay_after_queue',
+  displayName: 'Delay After Queue',
+  description:
+    'Delay After Queue enables rate control when multiple flows reach this step at the same time. ' +
+    'Flows using the same queue name are processed one at a time, in the order they arrive, ' +
+    'with the interval you set applied between each execution.',
+  props: {
+    queueName: Property.ShortText({
+      displayName: 'Queue Name',
+      description: 'Unique queue identifier for rate control',
+      required: true,
+    }),
+    delayUnit: Property.StaticDropdown({
+      displayName: 'Delay Unit',
+      description: 'Choose the unit for delay',
+      required: true,
+      options: {
+        options: [
+          { label: 'Seconds', value: 'seconds' },
+          { label: 'Minutes', value: 'minutes' },
+          { label: 'Hours', value: 'hours' },
+        ],
+      },
+      defaultValue: 'seconds',
+    }),
+    delayAmount: Property.Number({
+      displayName: 'Delay Amount',
+      description: 'Enter the amount of time to delay',
+      required: true,
+      defaultValue: 5,
+    }),
+  },
+  async run(context) {
+    const queueName = context.propsValue.queueName;
+    const delayAmount = context.propsValue.delayAmount;
+    const delayUnit = context.propsValue.delayUnit;
+
+    // Convert to milliseconds
+    let delayMs = delayAmount * 1000;
+    if (delayUnit === 'minutes') delayMs = delayAmount * 60 * 1000;
+    if (delayUnit === 'hours') delayMs = delayAmount * 60 * 60 * 1000;
+
+    const key = `delay_queue::${queueName}`;
+    const store = context.store;
+    const currentFlowId = context.run.id;
+
+    try {
+      // Add this run to the queue
+      const existingQueue = (await store.get<string[]>(key, StoreScope.PROJECT)) || [];
+      const updatedQueue = [...existingQueue, currentFlowId];
+      await store.put(key, updatedQueue, StoreScope.PROJECT);
+
+      // Wait until it's this flow's turn
+      while (true) {
+        const latestQueue = (await store.get<string[]>(key, StoreScope.PROJECT)) || [];
+        if (latestQueue[0] === currentFlowId) break;
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+
+      // Apply the delay
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+      // Remove from queue
+      const afterQueue = (await store.get<string[]>(key, StoreScope.PROJECT)) || [];
+      const newQueue = afterQueue.filter((id: string) => id !== currentFlowId);
+
+      if (newQueue.length === 0) {
+        await store.delete(key, StoreScope.PROJECT);
+      } else {
+        await store.put(key, newQueue, StoreScope.PROJECT);
+      }
+
+      return {
+        status: 'done',
+        queueName,
+        delayAmount,
+        delayUnit,
+        message: `Delayed execution for queue '${queueName}' by ${delayAmount} ${delayUnit}.`,
+      };
+    } catch (error) {
+      // Clean up on error
+      try {
+        const afterQueue = (await store.get<string[]>(key, StoreScope.PROJECT)) || [];
+        const newQueue = afterQueue.filter((id: string) => id !== currentFlowId);
+        
+        if (newQueue.length === 0) {
+          await store.delete(key, StoreScope.PROJECT);
+        } else {
+          await store.put(key, newQueue, StoreScope.PROJECT);
+        }
+      } catch (cleanupError) {
+        // Ignore cleanup errors
+      }
+      
+      throw error;
+    }
+  },
+  async test(context) {
+    // For testing, we'll simulate the delay without actually waiting
+    const queueName = context.propsValue.queueName;
+    const delayAmount = context.propsValue.delayAmount;
+    const delayUnit = context.propsValue.delayUnit;
+
+    return {
+      status: 'test_simulation',
+      queueName,
+      delayAmount,
+      delayUnit,
+      message: `Test simulation: Would delay execution for queue '${queueName}' by ${delayAmount} ${delayUnit}.`,
+    };
+  },
+});

--- a/packages/pieces/community/delay-after-queue/tsconfig.json
+++ b/packages/pieces/community/delay-after-queue/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/delay-after-queue/tsconfig.lib.json
+++ b/packages/pieces/community/delay-after-queue/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
**What does this PR do?**

- This PR introduces a new piece called Delay After Queue, designed to control the execution rate of flows in Activepieces. It ensures that flows are processed sequentially with a configurable delay between each execution. This is especially useful for systems that require throttling or rate-limited operations such as API calls, CRMs, or email platforms.

**Explain How the Feature Works**

- This piece queues each flow execution in a Redis-based system and introduces a delay (in seconds or minutes) before allowing the next execution to proceed.
- If multiple flows are triggered in rapid succession, each will:
- Be placed into the queue.
- Execute only after the previous flow has completed and the specified delay time has passed.
- Automatically fail if the delay exceeds 10 minutes (600 seconds), adhering to Activepieces system limits.
- An optional configuration for queue name allows separate delays per logical group or flow use case.

**No video link provided at this time**

**Relevant User Scenarios**

- Sending sequential API requests to an external service with strict rate limits.
- Throttling outbound SMS or email messages one at a time.
- Managing webhook bursts or large batches from CRMs, payment systems, etc.
- Avoiding collisions when automating workflows in multi-tenant setups.
- Reducing strain on databases by pacing data operations.

Fixes ##6844