### PR TITLE
fix(oAuth): ability to alter prompt query parameter

### DIFF
--- a/packages/pieces/community/framework/src/lib/property/authentication/oauth2-prop.ts
+++ b/packages/pieces/community/framework/src/lib/property/authentication/oauth2-prop.ts
@@ -39,7 +39,7 @@ const OAuth2ExtraProps = Type.Object({
   authUrl: Type.String(),
   tokenUrl: Type.String(),
   scope: Type.Array(Type.String()),
-  consent: Type.Optional(Type.Union([Type.Literal('none'), Type.Literal('consent'), Type.Literal('login'), Type.Literal('omit')])),
+  prompt: Type.Optional(Type.Union([Type.Literal('none'), Type.Literal('consent'), Type.Literal('login'), Type.Literal('omit')])),
   pkce: Type.Optional(Type.Boolean()),
   pkceMethod: Type.Optional(Type.Union([Type.Literal('plain'), Type.Literal('S256')])),
   authorizationMethod: Type.Optional(Type.Enum(OAuth2AuthorizationMethod)),
@@ -52,7 +52,7 @@ type OAuth2ExtraProps = {
   authUrl: string
   tokenUrl: string
   scope: string[]
-  consent?: 'none' |  'consent' | 'login' | 'omit' 
+  prompt?: 'none' |  'consent' | 'login' | 'omit' 
   pkce?: boolean
   pkceMethod?: 'plain' | 'S256'
   authorizationMethod?: OAuth2AuthorizationMethod

--- a/packages/pieces/community/framework/src/lib/property/authentication/oauth2-prop.ts
+++ b/packages/pieces/community/framework/src/lib/property/authentication/oauth2-prop.ts
@@ -39,6 +39,7 @@ const OAuth2ExtraProps = Type.Object({
   authUrl: Type.String(),
   tokenUrl: Type.String(),
   scope: Type.Array(Type.String()),
+  consent: Type.Optional(Type.Union([Type.Literal('none'), Type.Literal('consent'), Type.Literal('login'), Type.Literal('omit')])),
   pkce: Type.Optional(Type.Boolean()),
   pkceMethod: Type.Optional(Type.Union([Type.Literal('plain'), Type.Literal('S256')])),
   authorizationMethod: Type.Optional(Type.Enum(OAuth2AuthorizationMethod)),
@@ -51,6 +52,7 @@ type OAuth2ExtraProps = {
   authUrl: string
   tokenUrl: string
   scope: string[]
+  consent?: 'none' |  'consent' | 'login' | 'omit' 
   pkce?: boolean
   pkceMethod?: 'plain' | 'S256'
   authorizationMethod?: OAuth2AuthorizationMethod

--- a/packages/pieces/community/microsoft-dynamics-365-business-central/src/index.ts
+++ b/packages/pieces/community/microsoft-dynamics-365-business-central/src/index.ts
@@ -27,6 +27,7 @@ export const businessCentralAuth = PieceAuth.OAuth2({
     'https://api.businesscentral.dynamics.com/user_impersonation',
     'https://api.businesscentral.dynamics.com/Financials.ReadWrite.All',
   ],
+  prompt: 'omit',
   authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
   tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
 });

--- a/packages/pieces/community/microsoft-dynamics-crm/src/index.ts
+++ b/packages/pieces/community/microsoft-dynamics-crm/src/index.ts
@@ -34,6 +34,7 @@ export const dynamicsCRMAuth = PieceAuth.OAuth2({
   },
   required: true,
   scope: ['{hostUrl}/.default', 'openid', 'email', 'profile', 'offline_access'],
+  prompt: 'omit',
   authUrl: 'https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/authorize',
   tokenUrl: 'https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token',
 });

--- a/packages/pieces/community/microsoft-excel-365/src/index.ts
+++ b/packages/pieces/community/microsoft-excel-365/src/index.ts
@@ -30,6 +30,7 @@ export const excelAuth = PieceAuth.OAuth2({
   tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
   required: true,
   scope: ['Files.ReadWrite', 'offline_access'],
+  prompt: 'omit'
 });
 
 export const microsoftExcel = createPiece({

--- a/packages/pieces/community/microsoft-onedrive/src/index.ts
+++ b/packages/pieces/community/microsoft-onedrive/src/index.ts
@@ -18,6 +18,7 @@ export const oneDriveAuth = PieceAuth.OAuth2({
   tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
   required: true,
   scope: ['Files.ReadWrite', 'offline_access'],
+  prompt: 'omit'
 });
 
 export const microsoftOneDrive = createPiece({

--- a/packages/pieces/community/microsoft-outlook-calendar/src/index.ts
+++ b/packages/pieces/community/microsoft-outlook-calendar/src/index.ts
@@ -16,6 +16,7 @@ export const outlookCalendarAuth = PieceAuth.OAuth2({
   tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
   required: true,
   scope: ['User.Read', 'Calendars.ReadWrite', 'offline_access'],
+  prompt: 'omit'
 });
 
 export const microsoftOutlookCalendar = createPiece({

--- a/packages/pieces/community/microsoft-outlook/src/lib/common/auth.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/common/auth.ts
@@ -6,6 +6,7 @@ export const microsoftOutlookAuth = PieceAuth.OAuth2({
 	tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
 	required: true,
 	scope: ['Mail.ReadWrite', 'Mail.Send', 'Calendars.Read', 'offline_access', 'User.Read'],
+	prompt: 'omit',
 	validate: async ({ auth }) => {
 		try {
 			const authValue = auth as OAuth2PropertyValue;

--- a/packages/pieces/community/microsoft-power-bi/src/index.ts
+++ b/packages/pieces/community/microsoft-power-bi/src/index.ts
@@ -17,6 +17,7 @@ export const microsoftPowerBiAuth = PieceAuth.OAuth2({
     'https://analysis.windows.net/powerbi/api/Dataset.ReadWrite.All',
     'offline_access',
   ],
+  prompt: 'omit'
 });
 
 export const microsoftPowerBi = createPiece({

--- a/packages/pieces/community/microsoft-sharepoint/src/index.ts
+++ b/packages/pieces/community/microsoft-sharepoint/src/index.ts
@@ -26,6 +26,7 @@ export const microsoftSharePointAuth = PieceAuth.OAuth2({
     'Sites.Manage.All',
     'Files.ReadWrite',
   ],
+  prompt: 'omit'
 });
 
 export const microsoftSharePoint = createPiece({

--- a/packages/pieces/community/microsoft-teams/src/index.ts
+++ b/packages/pieces/community/microsoft-teams/src/index.ts
@@ -29,6 +29,7 @@ export const microsoftTeamsAuth = PieceAuth.OAuth2({
     'User.ReadBasic.All',
     'Presence.Read.All',
 	],
+	prompt: 'omit',
 	authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
 	tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
 	validate: async ({ auth }) => {

--- a/packages/pieces/community/microsoft-todo/src/index.ts
+++ b/packages/pieces/community/microsoft-todo/src/index.ts
@@ -16,6 +16,7 @@ export const microsoftToDoAuth = PieceAuth.OAuth2({
 	tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
 	required: true,
 	scope: ['Tasks.ReadWrite', 'User.Read', 'offline_access'],
+	prompt: 'omit'
 });
 
 export const microsoftTodo = createPiece({

--- a/packages/react-ui/src/app/connections/oauth2-connection-settings.tsx
+++ b/packages/react-ui/src/app/connections/oauth2-connection-settings.tsx
@@ -285,6 +285,7 @@ const OAuth2ConnectionSettingsForm = ({
       clientId,
       redirectUrl,
       scope,
+      consent: authProperty.consent ?? 'consent',
       pkce: authProperty.pkce ?? false,
       pkceMethod: authProperty.pkceMethod ?? 'plain',
       extraParams: authProperty.extra ?? {},

--- a/packages/react-ui/src/app/connections/oauth2-connection-settings.tsx
+++ b/packages/react-ui/src/app/connections/oauth2-connection-settings.tsx
@@ -285,7 +285,7 @@ const OAuth2ConnectionSettingsForm = ({
       clientId,
       redirectUrl,
       scope,
-      consent: authProperty.consent ?? 'consent',
+      prompt: authProperty.consent ?? 'consent',
       pkce: authProperty.pkce ?? false,
       pkceMethod: authProperty.pkceMethod ?? 'plain',
       extraParams: authProperty.extra ?? {},

--- a/packages/react-ui/src/lib/oauth2-utils.ts
+++ b/packages/react-ui/src/lib/oauth2-utils.ts
@@ -90,10 +90,10 @@ async function constructUrl(params: OAuth2PopupParams, pckeChallenge: string) {
     scope: params.scope,
     ...(params.extraParams || {}),
   };
-  if (params.consent === 'omit') {
+  if (params.prompt === 'omit') {
     delete queryParams['prompt']
   } else {
-    queryParams['prompt'] = params.consent;
+    queryParams['prompt'] = params.prompt;
   }
   if (params.pkce) {
     const method = params.pkceMethod || 'plain';
@@ -137,7 +137,7 @@ type OAuth2PopupParams = {
   clientId: string;
   redirectUrl: string;
   scope: string;
-  consent: 'none' | 'consent' | 'login' | 'omit';
+  prompt: 'none' | 'consent' | 'login' | 'omit';
   pkce: boolean;
   pkceMethod?: 'plain' | 'S256';
   extraParams?: Record<string, string>;

--- a/packages/react-ui/src/lib/oauth2-utils.ts
+++ b/packages/react-ui/src/lib/oauth2-utils.ts
@@ -90,6 +90,11 @@ async function constructUrl(params: OAuth2PopupParams, pckeChallenge: string) {
     scope: params.scope,
     ...(params.extraParams || {}),
   };
+  if (params.consent === 'omit') {
+    delete queryParams['prompt']
+  } else {
+    queryParams['prompt'] = params.consent;
+  }
   if (params.pkce) {
     const method = params.pkceMethod || 'plain';
     queryParams['code_challenge_method'] = method;
@@ -132,6 +137,7 @@ type OAuth2PopupParams = {
   clientId: string;
   redirectUrl: string;
   scope: string;
+  consent: 'none' | 'consent' | 'login' | 'omit';
   pkce: boolean;
   pkceMethod?: 'plain' | 'S256';
   extraParams?: Record<string, string>;


### PR DESCRIPTION
## What does this PR do?

There was an issue where the prompt query paramater in the oAuth authentication request was always set to `consent`. Now the user can determine what to set the paramater to for each piece


### Explain How the Feature Works
There are now four available options for the prompt query parameter `consent`, `none`, `login` and `omit`. When the value is set to omit the query parameter will not be set at all. Otherwise the value will be set to whatever was chosen, defaulting to `consent` when the prompt value is not explicitly set.

### Relevant User Scenarios

- There is an issue within Microsoft where the user will end up in a consent loop if the parameter is set to `consent`
           This issue is due to the way that Microsoft handles the prompt=consent query parameter, it will cause the program to always ask for consent, even when admin consent is already given. Here is an [article](https://medium.com/@namsoochoi/solved-need-admin-approval-or-approval-required-aadsts90094-error-during-microsoft-sign-in-b3fde2ec4523) that explains the phenomenon in more detail (cause 1)

- Developers can now choose what to set the prompt value to per piece, allowing for more flexibility



Fixes # (issue)
