### PR TITLE
feat: add teamleader integration piece with full trigger, action, and search support

### DIFF
--- a/packages/pieces/community/teamleader/.eslintrc.json
+++ b/packages/pieces/community/teamleader/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/teamleader/README.md
+++ b/packages/pieces/community/teamleader/README.md
@@ -1,0 +1,7 @@
+# pieces-teamleader
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-teamleader` to build the library.

--- a/packages/pieces/community/teamleader/package.json
+++ b/packages/pieces/community/teamleader/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-teamleader",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/teamleader/project.json
+++ b/packages/pieces/community/teamleader/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-teamleader",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/teamleader/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/teamleader",
+        "tsConfig": "packages/pieces/community/teamleader/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/teamleader/package.json",
+        "main": "packages/pieces/community/teamleader/src/index.ts",
+        "assets": [
+          "packages/pieces/community/teamleader/*.md",
+          {
+            "input": "packages/pieces/community/teamleader/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/teamleader/src/index.ts
+++ b/packages/pieces/community/teamleader/src/index.ts
@@ -1,0 +1,37 @@
+
+    import { createPiece } from '@activepieces/pieces-framework';
+    import { TeamleaderAuth } from './lib/common';
+    import { newContact } from './lib/triggers/new-contact';
+    import { newCompany } from './lib/triggers/new-company';
+    import { newDeal } from './lib/triggers/new-deal';
+    import { dealAccepted } from './lib/triggers/deal-accepted';
+    import { invoicePaid } from './lib/triggers/invoice-paid';
+    import { createContact } from './lib/actions/create-contact';
+    import { updateContact } from './lib/actions/update-contact';
+    import { createCompany } from './lib/actions/create-company';
+    import { updateCompany } from './lib/actions/update-company';
+    import { linkContactToCompany } from './lib/actions/link-contact-to-company';
+    import { unlinkContactFromCompany } from './lib/actions/unlink-contact-from-company';
+    import { createDeal } from './lib/actions/create-deal';
+    import { updateDeal } from './lib/actions/update-deal';
+    import { searchCompanies } from './lib/actions/search-companies';
+    import { searchContacts } from './lib/actions/search-contacts';
+    import { searchDeals } from './lib/actions/search-deals';
+    import { searchInvoices } from './lib/actions/search-invoices';
+
+    export const teamleader = createPiece({
+      displayName: 'Teamleader',
+      logoUrl: 'https://cdn.activepieces.com/pieces/teamleader.png',
+      auth: TeamleaderAuth,
+      authors: ['Your Name <you@example.com>'],
+      triggers: [
+        newContact, newCompany, newDeal, dealAccepted, invoicePaid
+      ],
+      actions: [
+        createContact, updateContact, createCompany, updateCompany,
+        linkContactToCompany, unlinkContactFromCompany,
+        createDeal, updateDeal,
+        searchCompanies, searchContacts, searchDeals, searchInvoices
+      ],
+    });
+    

--- a/packages/pieces/community/teamleader/src/index.ts
+++ b/packages/pieces/community/teamleader/src/index.ts
@@ -1,4 +1,3 @@
-
     import { createPiece } from '@activepieces/pieces-framework';
     import { TeamleaderAuth } from './lib/common';
     import { newContact } from './lib/triggers/new-contact';
@@ -23,7 +22,7 @@
       displayName: 'Teamleader',
       logoUrl: 'https://cdn.activepieces.com/pieces/teamleader.png',
       auth: TeamleaderAuth,
-      authors: ['Your Name <you@example.com>'],
+      authors: ['pranjal'],
       triggers: [
         newContact, newCompany, newDeal, dealAccepted, invoicePaid
       ],

--- a/packages/pieces/community/teamleader/src/lib/actions/create-company.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/create-company.ts
@@ -1,0 +1,31 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createCompany = createAction({
+  name: 'createCompany',
+  displayName: 'Create Company',
+  description: 'Add a new Company record in Teamleader.',
+  props: {
+    name: Property.ShortText({ displayName: 'Company Name', required: true }),
+    vatNumber: Property.ShortText({ displayName: 'VAT Number', required: false }),
+    // Add more fields as needed
+  },
+  async run(context) {
+    const { name, vatNumber } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/companies.add',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        name,
+        ...(vatNumber ? { vat_number: vatNumber } : {}),
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/create-company.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/create-company.ts
@@ -1,6 +1,8 @@
 import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+// Action: Add a new Company record in Teamleader
 export const createCompany = createAction({
   name: 'createCompany',
   displayName: 'Create Company',
@@ -8,24 +10,53 @@ export const createCompany = createAction({
   props: {
     name: Property.ShortText({ displayName: 'Company Name', required: true }),
     vatNumber: Property.ShortText({ displayName: 'VAT Number', required: false }),
+    website: Property.ShortText({ displayName: 'Website', required: false }),
+    email: Property.ShortText({ displayName: 'Email', required: false }),
+    phone: Property.ShortText({ displayName: 'Phone', required: false }),
+    address: Property.ShortText({ displayName: 'Address', required: false }),
     // Add more fields as needed
   },
   async run(context) {
-    const { name, vatNumber } = context.propsValue;
+    const { name, vatNumber, website, email, phone, address } = context.propsValue;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/companies.add',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        name,
-        ...(vatNumber ? { vat_number: vatNumber } : {}),
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/companies.add`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          name,
+          ...(vatNumber ? { vat_number: vatNumber } : {}),
+          ...(website ? { website } : {}),
+          ...(email ? { email } : {}),
+          ...(phone ? { telephone: phone } : {}),
+          ...(address ? { address } : {}),
+        },
+      });
+      if (!response.body?.data) {
+        throw new Error('Unexpected API response: missing data');
+      }
+      // Output schema: return the created company object
+      return {
+        id: response.body.data.id,
+        name: response.body.data.name,
+        vat_number: response.body.data.vat_number,
+        website: response.body.data.website,
+        email: response.body.data.email,
+        phone: response.body.data.telephone,
+        address: response.body.data.address,
+        created_at: response.body.data.created_at,
+      };
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        throw new Error(`Failed to create company: ${e.message}`);
+      }
+      throw new Error('Failed to create company: Unknown error');
+    }
   },
 }); 

--- a/packages/pieces/community/teamleader/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/create-contact.ts
@@ -1,0 +1,33 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createContact = createAction({
+  name: 'createContact',
+  displayName: 'Create Contact',
+  description: 'Create a new Contact record in Teamleader.',
+  props: {
+    firstName: Property.ShortText({ displayName: 'First Name', required: true }),
+    lastName: Property.ShortText({ displayName: 'Last Name', required: true }),
+    email: Property.ShortText({ displayName: 'Email', required: false }),
+    // Add more fields as needed
+  },
+  async run(context) {
+    const { firstName, lastName, email } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/contacts.add',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        first_name: firstName,
+        last_name: lastName,
+        email,
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/create-contact.ts
@@ -1,33 +1,58 @@
 import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Contact {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email?: string;
+  telephone?: string;
+  address?: string;
+  created_at?: string;
+}
+
+// Action: Create a new contact in Teamleader
 export const createContact = createAction({
   name: 'createContact',
   displayName: 'Create Contact',
-  description: 'Create a new Contact record in Teamleader.',
+  description: 'Create a new contact in Teamleader.',
   props: {
     firstName: Property.ShortText({ displayName: 'First Name', required: true }),
     lastName: Property.ShortText({ displayName: 'Last Name', required: true }),
     email: Property.ShortText({ displayName: 'Email', required: false }),
-    // Add more fields as needed
+    phone: Property.ShortText({ displayName: 'Phone', required: false }),
+    address: Property.ShortText({ displayName: 'Address', required: false }),
   },
   async run(context) {
-    const { firstName, lastName, email } = context.propsValue;
+    const { firstName, lastName, email, phone, address } = context.propsValue;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/contacts.add',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        first_name: firstName,
-        last_name: lastName,
-        email,
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/contacts.add`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          first_name: firstName,
+          last_name: lastName,
+          ...(email ? { email } : {}),
+          ...(phone ? { telephone: phone } : {}),
+          ...(address ? { address } : {}),
+        },
+      });
+      if (!response.body?.data) {
+        throw new Error('Unexpected API response: missing data');
+      }
+      // Output schema: return the created contact object
+      const contact: Contact = response.body.data;
+      return contact;
+    } catch (e: unknown) {
+      throw new Error(`Failed to create contact: ${(e as Error).message}`);
+    }
   },
 }); 

--- a/packages/pieces/community/teamleader/src/lib/actions/create-deal.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/create-deal.ts
@@ -1,0 +1,35 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const createDeal = createAction({
+  name: 'createDeal',
+  displayName: 'Create Deal',
+  description: 'Create a new Deal/opportunity in Teamleader.',
+  props: {
+    title: Property.ShortText({ displayName: 'Title', required: true }),
+    companyId: Property.ShortText({ displayName: 'Company ID', required: false }),
+    contactId: Property.ShortText({ displayName: 'Contact ID', required: false }),
+    value: Property.Number({ displayName: 'Value', required: false }),
+    // Add more fields as needed
+  },
+  async run(context) {
+    const { title, companyId, contactId, value } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/deals.add',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        title,
+        ...(companyId ? { company_id: companyId } : {}),
+        ...(contactId ? { contact_id: contactId } : {}),
+        ...(value ? { value } : {}),
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/create-deal.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/create-deal.ts
@@ -1,35 +1,55 @@
 import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Deal {
+  id: string;
+  title: string;
+  status?: string;
+  value: number;
+  company_id?: string;
+  created_at?: string;
+}
+
+// Action: Create a new deal in Teamleader
 export const createDeal = createAction({
   name: 'createDeal',
   displayName: 'Create Deal',
-  description: 'Create a new Deal/opportunity in Teamleader.',
+  description: 'Create a new deal in Teamleader.',
   props: {
     title: Property.ShortText({ displayName: 'Title', required: true }),
-    companyId: Property.ShortText({ displayName: 'Company ID', required: false }),
-    contactId: Property.ShortText({ displayName: 'Contact ID', required: false }),
-    value: Property.Number({ displayName: 'Value', required: false }),
-    // Add more fields as needed
+    value: Property.Number({ displayName: 'Value', required: true }),
+    status: Property.ShortText({ displayName: 'Status', required: false, description: 'Deal status (e.g., open, won, lost).' }),
+    companyId: Property.ShortText({ displayName: 'Company ID', required: false, description: 'ID of the related company.' }),
   },
   async run(context) {
-    const { title, companyId, contactId, value } = context.propsValue;
+    const { title, value, status, companyId } = context.propsValue;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/deals.add',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        title,
-        ...(companyId ? { company_id: companyId } : {}),
-        ...(contactId ? { contact_id: contactId } : {}),
-        ...(value ? { value } : {}),
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/deals.add`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          title,
+          value,
+          ...(status ? { status } : {}),
+          ...(companyId ? { company_id: companyId } : {}),
+        },
+      });
+      if (!response.body?.data) {
+        throw new Error('Unexpected API response: missing data');
+      }
+      // Output schema: return the created deal object
+      const deal: Deal = response.body.data;
+      return deal;
+    } catch (e: unknown) {
+      throw new Error(`Failed to create deal: ${(e as Error).message}`);
+    }
   },
 }); 

--- a/packages/pieces/community/teamleader/src/lib/actions/link-contact-to-company.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/link-contact-to-company.ts
@@ -1,0 +1,30 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const linkContactToCompany = createAction({
+  name: 'linkContactToCompany',
+  displayName: 'Link Contact to Company',
+  description: 'Associate Contact & Company in Teamleader.',
+  props: {
+    contactId: Property.ShortText({ displayName: 'Contact ID', required: true }),
+    companyId: Property.ShortText({ displayName: 'Company ID', required: true }),
+  },
+  async run(context) {
+    const { contactId, companyId } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/contacts.linkToCompany',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        contact_id: contactId,
+        company_id: companyId,
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/search-companies.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/search-companies.ts
@@ -1,34 +1,56 @@
 import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Company {
+  id: string;
+  name: string;
+  vat_number?: string;
+  website?: string;
+  created_at?: string;
+}
+
+// Action: Search for companies in Teamleader
 export const searchCompanies = createAction({
   name: 'searchCompanies',
   displayName: 'Search Companies',
-  description: 'List or filter Companies via Teamleader API.',
+  description: 'Search for companies in Teamleader.',
   props: {
-    name: Property.ShortText({ displayName: 'Company Name (filter)', required: false }),
-    vatNumber: Property.ShortText({ displayName: 'VAT Number (filter)', required: false }),
-    pageSize: Property.Number({ displayName: 'Page Size', required: false, defaultValue: 50 }),
+    query: Property.ShortText({ displayName: 'Query', required: false, description: 'Search term for company name or VAT number.' }),
+    vatNumber: Property.ShortText({ displayName: 'VAT Number', required: false, description: 'Filter by VAT number.' }),
   },
   async run(context) {
-    const { name, vatNumber, pageSize } = context.propsValue;
+    const { query, vatNumber } = context.propsValue;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/companies.list',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        filter: {
-          ...(name ? { name } : {}),
-          ...(vatNumber ? { vat_number: vatNumber } : {}),
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/companies.list`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
         },
-        page: { size: pageSize || 50 },
-      },
-    });
-    return response.body.data;
+        body: {
+          ...(query ? { filter: { name: { contains: query } } } : {}),
+          ...(vatNumber ? { filter: { ...(query ? { name: { contains: query } } : {}), vat_number: vatNumber } } : {}),
+          page: { size: 50 },
+        },
+      });
+      if (!response.body?.data || !Array.isArray(response.body.data)) {
+        throw new Error('Unexpected API response: missing data array');
+      }
+      // Map output to a clear schema
+      return response.body.data.map((company: Company) => ({
+        id: company.id,
+        name: company.name,
+        vat_number: company.vat_number,
+        website: company.website,
+        created_at: company.created_at,
+      }));
+    } catch (e: unknown) {
+      throw new Error(`Failed to search companies: ${(e as Error).message}`);
+    }
   },
 }); 

--- a/packages/pieces/community/teamleader/src/lib/actions/search-companies.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/search-companies.ts
@@ -1,0 +1,34 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const searchCompanies = createAction({
+  name: 'searchCompanies',
+  displayName: 'Search Companies',
+  description: 'List or filter Companies via Teamleader API.',
+  props: {
+    name: Property.ShortText({ displayName: 'Company Name (filter)', required: false }),
+    vatNumber: Property.ShortText({ displayName: 'VAT Number (filter)', required: false }),
+    pageSize: Property.Number({ displayName: 'Page Size', required: false, defaultValue: 50 }),
+  },
+  async run(context) {
+    const { name, vatNumber, pageSize } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/companies.list',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        filter: {
+          ...(name ? { name } : {}),
+          ...(vatNumber ? { vat_number: vatNumber } : {}),
+        },
+        page: { size: pageSize || 50 },
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/search-contacts.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/search-contacts.ts
@@ -1,0 +1,36 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const searchContacts = createAction({
+  name: 'searchContacts',
+  displayName: 'Search Contacts',
+  description: 'List or filter Contacts via Teamleader API.',
+  props: {
+    firstName: Property.ShortText({ displayName: 'First Name (filter)', required: false }),
+    lastName: Property.ShortText({ displayName: 'Last Name (filter)', required: false }),
+    email: Property.ShortText({ displayName: 'Email (filter)', required: false }),
+    pageSize: Property.Number({ displayName: 'Page Size', required: false, defaultValue: 50 }),
+  },
+  async run(context) {
+    const { firstName, lastName, email, pageSize } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/contacts.list',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        filter: {
+          ...(firstName ? { first_name: firstName } : {}),
+          ...(lastName ? { last_name: lastName } : {}),
+          ...(email ? { email } : {}),
+        },
+        page: { size: pageSize || 50 },
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/search-deals.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/search-deals.ts
@@ -1,0 +1,34 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const searchDeals = createAction({
+  name: 'searchDeals',
+  displayName: 'Search Deals',
+  description: 'List or filter Deals via Teamleader API.',
+  props: {
+    title: Property.ShortText({ displayName: 'Title (filter)', required: false }),
+    status: Property.ShortText({ displayName: 'Status (filter)', required: false }),
+    pageSize: Property.Number({ displayName: 'Page Size', required: false, defaultValue: 50 }),
+  },
+  async run(context) {
+    const { title, status, pageSize } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/deals.list',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        filter: {
+          ...(title ? { title } : {}),
+          ...(status ? { status } : {}),
+        },
+        page: { size: pageSize || 50 },
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/search-invoices.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/search-invoices.ts
@@ -1,34 +1,58 @@
 import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Invoice {
+  id: string;
+  invoice_number: string;
+  status: string;
+  amount: number;
+  due_on?: string;
+  paid_at?: string;
+}
+
+// Action: Search for invoices in Teamleader
 export const searchInvoices = createAction({
   name: 'searchInvoices',
   displayName: 'Search Invoices',
-  description: 'List or filter Invoices via Teamleader API.',
+  description: 'Search for invoices in Teamleader.',
   props: {
-    invoiceNumber: Property.ShortText({ displayName: 'Invoice Number (filter)', required: false }),
-    status: Property.ShortText({ displayName: 'Status (filter)', required: false }),
-    pageSize: Property.Number({ displayName: 'Page Size', required: false, defaultValue: 50 }),
+    query: Property.ShortText({ displayName: 'Query', required: false, description: 'Search term for invoice number or customer.' }),
+    status: Property.ShortText({ displayName: 'Status', required: false, description: 'Filter by invoice status (e.g., paid, open, draft).' }),
   },
   async run(context) {
-    const { invoiceNumber, status, pageSize } = context.propsValue;
+    const { query, status } = context.propsValue;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/invoices.list',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        filter: {
-          ...(invoiceNumber ? { invoice_number: invoiceNumber } : {}),
-          ...(status ? { status } : {}),
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/invoices.list`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
         },
-        page: { size: pageSize || 50 },
-      },
-    });
-    return response.body.data;
+        body: {
+          ...(query ? { filter: { invoice_number: { contains: query } } } : {}),
+          ...(status ? { filter: { ...(query ? { invoice_number: { contains: query } } : {}), status } } : {}),
+          page: { size: 50 },
+        },
+      });
+      if (!response.body?.data || !Array.isArray(response.body.data)) {
+        throw new Error('Unexpected API response: missing data array');
+      }
+      // Map output to a clear schema
+      return response.body.data.map((invoice: Invoice) => ({
+        id: invoice.id,
+        invoice_number: invoice.invoice_number,
+        status: invoice.status,
+        amount: invoice.amount,
+        due_on: invoice.due_on,
+        paid_at: invoice.paid_at,
+      }));
+    } catch (e: unknown) {
+      throw new Error(`Failed to search invoices: ${(e as Error).message}`);
+    }
   },
 }); 

--- a/packages/pieces/community/teamleader/src/lib/actions/search-invoices.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/search-invoices.ts
@@ -1,0 +1,34 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const searchInvoices = createAction({
+  name: 'searchInvoices',
+  displayName: 'Search Invoices',
+  description: 'List or filter Invoices via Teamleader API.',
+  props: {
+    invoiceNumber: Property.ShortText({ displayName: 'Invoice Number (filter)', required: false }),
+    status: Property.ShortText({ displayName: 'Status (filter)', required: false }),
+    pageSize: Property.Number({ displayName: 'Page Size', required: false, defaultValue: 50 }),
+  },
+  async run(context) {
+    const { invoiceNumber, status, pageSize } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/invoices.list',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        filter: {
+          ...(invoiceNumber ? { invoice_number: invoiceNumber } : {}),
+          ...(status ? { status } : {}),
+        },
+        page: { size: pageSize || 50 },
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/unlink-contact-from-company.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/unlink-contact-from-company.ts
@@ -1,0 +1,30 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const unlinkContactFromCompany = createAction({
+  name: 'unlinkContactFromCompany',
+  displayName: 'Unlink Contact from Company',
+  description: 'Remove association between Contact and Company in Teamleader.',
+  props: {
+    contactId: Property.ShortText({ displayName: 'Contact ID', required: true }),
+    companyId: Property.ShortText({ displayName: 'Company ID', required: true }),
+  },
+  async run(context) {
+    const { contactId, companyId } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/contacts.unlinkFromCompany',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        contact_id: contactId,
+        company_id: companyId,
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/unlink-contact-from-company.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/unlink-contact-from-company.ts
@@ -1,10 +1,18 @@
 import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface LinkResult {
+  success: boolean;
+  contact_id: string;
+  company_id: string;
+}
+
+// Action: Unlink a contact from a company in Teamleader
 export const unlinkContactFromCompany = createAction({
   name: 'unlinkContactFromCompany',
   displayName: 'Unlink Contact from Company',
-  description: 'Remove association between Contact and Company in Teamleader.',
+  description: 'Unlink a contact from a company in Teamleader.',
   props: {
     contactId: Property.ShortText({ displayName: 'Contact ID', required: true }),
     companyId: Property.ShortText({ displayName: 'Company ID', required: true }),
@@ -13,18 +21,28 @@ export const unlinkContactFromCompany = createAction({
     const { contactId, companyId } = context.propsValue;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/contacts.unlinkFromCompany',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        contact_id: contactId,
-        company_id: companyId,
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/contacts.unlinkFromCompany`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          contact_id: contactId,
+          company_id: companyId,
+        },
+      });
+      if (!response.body?.data) {
+        throw new Error('Unexpected API response: missing data');
+      }
+      // Output schema: return the result object
+      const result: LinkResult = response.body.data;
+      return result;
+    } catch (e: unknown) {
+      throw new Error(`Failed to unlink contact from company: ${(e as Error).message}`);
+    }
   },
 }); 

--- a/packages/pieces/community/teamleader/src/lib/actions/update-company.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/update-company.ts
@@ -1,33 +1,63 @@
 import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Company {
+  id: string;
+  name: string;
+  vat_number?: string;
+  website?: string;
+  email?: string;
+  telephone?: string;
+  address?: string;
+  created_at?: string;
+}
+
+// Action: Update a company in Teamleader
 export const updateCompany = createAction({
   name: 'updateCompany',
   displayName: 'Update Company',
-  description: 'Modify Company information in Teamleader.',
+  description: 'Update an existing company in Teamleader.',
   props: {
-    id: Property.ShortText({ displayName: 'Company ID', required: true }),
+    id: Property.ShortText({ displayName: 'Company ID', required: true, description: 'The ID of the company to update.' }),
     name: Property.ShortText({ displayName: 'Company Name', required: false }),
     vatNumber: Property.ShortText({ displayName: 'VAT Number', required: false }),
-    // Add more fields as needed
+    website: Property.ShortText({ displayName: 'Website', required: false }),
+    email: Property.ShortText({ displayName: 'Email', required: false }),
+    phone: Property.ShortText({ displayName: 'Phone', required: false }),
+    address: Property.ShortText({ displayName: 'Address', required: false }),
   },
   async run(context) {
-    const { id, name, vatNumber } = context.propsValue;
+    const { id, name, vatNumber, website, email, phone, address } = context.propsValue;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/companies.update',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        id,
-        ...(name ? { name } : {}),
-        ...(vatNumber ? { vat_number: vatNumber } : {}),
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/companies.update`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          id,
+          ...(name ? { name } : {}),
+          ...(vatNumber ? { vat_number: vatNumber } : {}),
+          ...(website ? { website } : {}),
+          ...(email ? { email } : {}),
+          ...(phone ? { telephone: phone } : {}),
+          ...(address ? { address } : {}),
+        },
+      });
+      if (!response.body?.data) {
+        throw new Error('Unexpected API response: missing data');
+      }
+      // Output schema: return the updated company object
+      const company: Company = response.body.data;
+      return company;
+    } catch (e: unknown) {
+      throw new Error(`Failed to update company: ${(e as Error).message}`);
+    }
   },
 }); 

--- a/packages/pieces/community/teamleader/src/lib/actions/update-company.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/update-company.ts
@@ -1,0 +1,33 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateCompany = createAction({
+  name: 'updateCompany',
+  displayName: 'Update Company',
+  description: 'Modify Company information in Teamleader.',
+  props: {
+    id: Property.ShortText({ displayName: 'Company ID', required: true }),
+    name: Property.ShortText({ displayName: 'Company Name', required: false }),
+    vatNumber: Property.ShortText({ displayName: 'VAT Number', required: false }),
+    // Add more fields as needed
+  },
+  async run(context) {
+    const { id, name, vatNumber } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/companies.update',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        id,
+        ...(name ? { name } : {}),
+        ...(vatNumber ? { vat_number: vatNumber } : {}),
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/update-contact.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/update-contact.ts
@@ -1,0 +1,35 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateContact = createAction({
+  name: 'updateContact',
+  displayName: 'Update Contact',
+  description: 'Modify existing Contact in Teamleader.',
+  props: {
+    id: Property.ShortText({ displayName: 'Contact ID', required: true }),
+    firstName: Property.ShortText({ displayName: 'First Name', required: false }),
+    lastName: Property.ShortText({ displayName: 'Last Name', required: false }),
+    email: Property.ShortText({ displayName: 'Email', required: false }),
+    // Add more fields as needed
+  },
+  async run(context) {
+    const { id, firstName, lastName, email } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/contacts.update',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        id,
+        ...(firstName ? { first_name: firstName } : {}),
+        ...(lastName ? { last_name: lastName } : {}),
+        ...(email ? { email } : {}),
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/actions/update-contact.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/update-contact.ts
@@ -1,35 +1,60 @@
 import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Contact {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email?: string;
+  telephone?: string;
+  address?: string;
+  created_at?: string;
+}
+
+// Action: Update a contact in Teamleader
 export const updateContact = createAction({
   name: 'updateContact',
   displayName: 'Update Contact',
-  description: 'Modify existing Contact in Teamleader.',
+  description: 'Update an existing contact in Teamleader.',
   props: {
-    id: Property.ShortText({ displayName: 'Contact ID', required: true }),
+    id: Property.ShortText({ displayName: 'Contact ID', required: true, description: 'The ID of the contact to update.' }),
     firstName: Property.ShortText({ displayName: 'First Name', required: false }),
     lastName: Property.ShortText({ displayName: 'Last Name', required: false }),
     email: Property.ShortText({ displayName: 'Email', required: false }),
-    // Add more fields as needed
+    phone: Property.ShortText({ displayName: 'Phone', required: false }),
+    address: Property.ShortText({ displayName: 'Address', required: false }),
   },
   async run(context) {
-    const { id, firstName, lastName, email } = context.propsValue;
+    const { id, firstName, lastName, email, phone, address } = context.propsValue;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/contacts.update',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        id,
-        ...(firstName ? { first_name: firstName } : {}),
-        ...(lastName ? { last_name: lastName } : {}),
-        ...(email ? { email } : {}),
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/contacts.update`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          id,
+          ...(firstName ? { first_name: firstName } : {}),
+          ...(lastName ? { last_name: lastName } : {}),
+          ...(email ? { email } : {}),
+          ...(phone ? { telephone: phone } : {}),
+          ...(address ? { address } : {}),
+        },
+      });
+      if (!response.body?.data) {
+        throw new Error('Unexpected API response: missing data');
+      }
+      // Output schema: return the updated contact object
+      const contact: Contact = response.body.data;
+      return contact;
+    } catch (e: unknown) {
+      throw new Error(`Failed to update contact: ${(e as Error).message}`);
+    }
   },
 }); 

--- a/packages/pieces/community/teamleader/src/lib/actions/update-deal.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/update-deal.ts
@@ -1,33 +1,55 @@
 import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Deal {
+  id: string;
+  title: string;
+  status?: string;
+  value?: number;
+  company_id?: string;
+  created_at?: string;
+}
+
+// Action: Update a deal in Teamleader
 export const updateDeal = createAction({
   name: 'updateDeal',
   displayName: 'Update Deal',
-  description: 'Modify Deal properties in Teamleader.',
+  description: 'Update an existing deal in Teamleader.',
   props: {
-    id: Property.ShortText({ displayName: 'Deal ID', required: true }),
+    id: Property.ShortText({ displayName: 'Deal ID', required: true, description: 'The ID of the deal to update.' }),
     title: Property.ShortText({ displayName: 'Title', required: false }),
+    status: Property.ShortText({ displayName: 'Status', required: false, description: 'Deal status (e.g., open, won, lost).' }),
     value: Property.Number({ displayName: 'Value', required: false }),
-    // Add more fields as needed
   },
   async run(context) {
-    const { id, title, value } = context.propsValue;
+    const { id, title, status, value } = context.propsValue;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/deals.update',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        id,
-        ...(title ? { title } : {}),
-        ...(value ? { value } : {}),
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/deals.update`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          id,
+          ...(title ? { title } : {}),
+          ...(status ? { status } : {}),
+          ...(value !== undefined ? { value } : {}),
+        },
+      });
+      if (!response.body?.data) {
+        throw new Error('Unexpected API response: missing data');
+      }
+      // Output schema: return the updated deal object
+      const deal: Deal = response.body.data;
+      return deal;
+    } catch (e: unknown) {
+      throw new Error(`Failed to update deal: ${(e as Error).message}`);
+    }
   },
 }); 

--- a/packages/pieces/community/teamleader/src/lib/actions/update-deal.ts
+++ b/packages/pieces/community/teamleader/src/lib/actions/update-deal.ts
@@ -1,0 +1,33 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const updateDeal = createAction({
+  name: 'updateDeal',
+  displayName: 'Update Deal',
+  description: 'Modify Deal properties in Teamleader.',
+  props: {
+    id: Property.ShortText({ displayName: 'Deal ID', required: true }),
+    title: Property.ShortText({ displayName: 'Title', required: false }),
+    value: Property.Number({ displayName: 'Value', required: false }),
+    // Add more fields as needed
+  },
+  async run(context) {
+    const { id, title, value } = context.propsValue;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/deals.update',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        id,
+        ...(title ? { title } : {}),
+        ...(value ? { value } : {}),
+      },
+    });
+    return response.body.data;
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/auth.ts
+++ b/packages/pieces/community/teamleader/src/lib/auth.ts
@@ -1,6 +1,8 @@
-import { PieceAuth } from '@activepieces/pieces-framework';
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
 
-// Custom Teamleader OAuth2 authentication using the correct endpoints and parameters
+// Enhanced Teamleader OAuth2 authentication with user guidance and custom domain field
+// NOTE: Dynamic domain support for authUrl/tokenUrl is not possible if the framework does not support function values for these fields.
+// The customDomain property is left for future support or for use in API calls.
 export const TeamleaderAuth = PieceAuth.OAuth2({
   required: true,
   authUrl: 'https://focus.teamleader.eu/oauth2/authorize',
@@ -19,8 +21,13 @@ export const TeamleaderAuth = PieceAuth.OAuth2({
     'timeTracking:read',
     'timeTracking:write',
   ],
-  // Optionally, you can add extra fields if Teamleader requires them
   props: {
-    // Example: Property.ShortText({ displayName: 'Custom Field', required: false })
+    // Optional: Allow user to specify a custom Teamleader domain (for multi-region or custom environments)
+    customDomain: Property.ShortText({
+      displayName: 'Custom Teamleader Domain',
+      required: false,
+      description: 'If your Teamleader account uses a custom region or environment, enter the full domain (e.g., https://myregion.teamleader.eu). Otherwise, leave blank.',
+    }),
   },
+  // No need for a custom validate function; validation is handled in the UI or in API calls.
 }); 

--- a/packages/pieces/community/teamleader/src/lib/auth.ts
+++ b/packages/pieces/community/teamleader/src/lib/auth.ts
@@ -1,0 +1,26 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+// Custom Teamleader OAuth2 authentication using the correct endpoints and parameters
+export const TeamleaderAuth = PieceAuth.OAuth2({
+  required: true,
+  authUrl: 'https://focus.teamleader.eu/oauth2/authorize',
+  tokenUrl: 'https://focus.teamleader.eu/oauth2/access_token',
+  scope: [
+    'contacts:read',
+    'contacts:write',
+    'companies:read',
+    'companies:write',
+    'deals:read',
+    'deals:write',
+    'invoices:read',
+    'invoices:write',
+    'tasks:read',
+    'tasks:write',
+    'timeTracking:read',
+    'timeTracking:write',
+  ],
+  // Optionally, you can add extra fields if Teamleader requires them
+  props: {
+    // Example: Property.ShortText({ displayName: 'Custom Field', required: false })
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/common.ts
+++ b/packages/pieces/community/teamleader/src/lib/common.ts
@@ -1,3 +1,14 @@
 import { TeamleaderAuth } from './auth'; 
+import { OAuth2PropertyValue } from '@activepieces/pieces-framework';
 
 export { TeamleaderAuth };
+
+// Utility to get the Teamleader API base URL from auth props
+export function getTeamleaderApiBaseUrl(auth: OAuth2PropertyValue): string {
+  // If customDomain is provided in auth, use it; otherwise, use the default
+  const customDomain = (auth as Record<string, unknown>)?.['customDomain'] as string | undefined;
+  if (customDomain && /^https:\/\/.+\.teamleader\.eu$/.test(customDomain)) {
+    return `${customDomain}/api.focus.teamleader.eu`;
+  }
+  return 'https://api.focus.teamleader.eu';
+}

--- a/packages/pieces/community/teamleader/src/lib/common.ts
+++ b/packages/pieces/community/teamleader/src/lib/common.ts
@@ -1,21 +1,3 @@
-import { PieceAuth } from '@activepieces/pieces-framework';
+import { TeamleaderAuth } from './auth'; 
 
-export const TeamleaderAuth = PieceAuth.OAuth2({
-  required: true,
-  authUrl: 'https://app.teamleader.eu/oauth2/authorize',
-  tokenUrl: 'https://app.teamleader.eu/oauth2/access_token',
-  scope: [
-    'contacts:read',
-    'contacts:write',
-    'companies:read',
-    'companies:write',
-    'deals:read',
-    'deals:write',
-    'invoices:read',
-    'invoices:write',
-    'tasks:read',
-    'tasks:write',
-    'timeTracking:read',
-    'timeTracking:write',
-  ],
-}); 
+export { TeamleaderAuth };

--- a/packages/pieces/community/teamleader/src/lib/common.ts
+++ b/packages/pieces/community/teamleader/src/lib/common.ts
@@ -1,0 +1,21 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const TeamleaderAuth = PieceAuth.OAuth2({
+  required: true,
+  authUrl: 'https://app.teamleader.eu/oauth2/authorize',
+  tokenUrl: 'https://app.teamleader.eu/oauth2/access_token',
+  scope: [
+    'contacts:read',
+    'contacts:write',
+    'companies:read',
+    'companies:write',
+    'deals:read',
+    'deals:write',
+    'invoices:read',
+    'invoices:write',
+    'tasks:read',
+    'tasks:write',
+    'timeTracking:read',
+    'timeTracking:write',
+  ],
+}); 

--- a/packages/pieces/community/teamleader/src/lib/triggers/deal-accepted.ts
+++ b/packages/pieces/community/teamleader/src/lib/triggers/deal-accepted.ts
@@ -1,0 +1,43 @@
+import { createTrigger, TriggerStrategy, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const dealAccepted = createTrigger({
+  name: 'dealAccepted',
+  displayName: 'Deal Accepted',
+  description: 'Fires when a Deal is marked “won” in Teamleader.',
+  type: TriggerStrategy.POLLING,
+  props: {
+    since: Property.DateTime({
+      displayName: 'Accepted Since',
+      required: false,
+      description: 'Only fetch deals accepted after this date/time',
+    }),
+  },
+  sampleData: {},
+  async onEnable() { /* Required by interface. No setup needed. */ },
+  async onDisable() { /* Required by interface. No teardown needed. */ },
+  async run(context) {
+    const since = context.propsValue.since;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/deals.list',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        filter: {
+          ...(since ? { won_on: { gte: since } } : {}),
+          status: 'won',
+        },
+        page: { size: 50 },
+      },
+    });
+    return response.body.data;
+  },
+  async test(context) {
+    return await this.run(context as never);
+  },
+});

--- a/packages/pieces/community/teamleader/src/lib/triggers/invoice-paid.ts
+++ b/packages/pieces/community/teamleader/src/lib/triggers/invoice-paid.ts
@@ -1,10 +1,20 @@
 import { createTrigger, TriggerStrategy, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Invoice {
+  id: string;
+  invoice_number: string;
+  paid_at: string;
+  amount: number;
+  status: string;
+}
+
+// Trigger: Fires when an invoice is paid in Teamleader
 export const invoicePaid = createTrigger({
   name: 'invoicePaid',
   displayName: 'Invoice Paid',
-  description: 'Fires when an Invoice is sent or paid in Teamleader.',
+  description: 'Fires when an invoice is paid in Teamleader.',
   type: TriggerStrategy.POLLING,
   props: {
     since: Property.DateTime({
@@ -13,29 +23,51 @@ export const invoicePaid = createTrigger({
       description: 'Only fetch invoices paid after this date/time',
     }),
   },
-  sampleData: {},
-  async onEnable() { /* Required by interface. No setup needed. */ },
-  async onDisable() { /* Required by interface. No teardown needed. */ },
+  sampleData: {
+    id: '55555',
+    invoice_number: 'INV-2024-001',
+    paid_at: '2024-01-01T12:00:00Z',
+    amount: 500,
+    status: 'paid',
+  },
+  // Required by interface, intentionally left empty for framework compliance
+  async onEnable(): Promise<void> { /* intentionally empty */ },
+  async onDisable(): Promise<void> { /* intentionally empty */ },
   async run(context) {
     const since = context.propsValue.since;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/invoices.list',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        filter: {
-          ...(since ? { paid_at: { gte: since } } : {}),
-          status: 'paid',
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/invoices.list`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
         },
-        page: { size: 50 },
-      },
-    });
-    return response.body.data;
+        body: {
+          filter: {
+            ...(since ? { paid_at: { gte: since } } : {}),
+            status: 'paid',
+          },
+          page: { size: 50 },
+        },
+      });
+      if (!response.body?.data || !Array.isArray(response.body.data)) {
+        throw new Error('Unexpected API response: missing data array');
+      }
+      // Map output to a clear schema
+      return response.body.data.map((invoice: Invoice) => ({
+        id: invoice.id,
+        invoice_number: invoice.invoice_number,
+        paid_at: invoice.paid_at,
+        amount: invoice.amount,
+        status: invoice.status,
+      }));
+    } catch (e: unknown) {
+      throw new Error(`Failed to fetch invoices: ${(e as Error).message}`);
+    }
   },
   async test(context) {
     return await this.run(context as never);

--- a/packages/pieces/community/teamleader/src/lib/triggers/invoice-paid.ts
+++ b/packages/pieces/community/teamleader/src/lib/triggers/invoice-paid.ts
@@ -1,0 +1,43 @@
+import { createTrigger, TriggerStrategy, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const invoicePaid = createTrigger({
+  name: 'invoicePaid',
+  displayName: 'Invoice Paid',
+  description: 'Fires when an Invoice is sent or paid in Teamleader.',
+  type: TriggerStrategy.POLLING,
+  props: {
+    since: Property.DateTime({
+      displayName: 'Paid Since',
+      required: false,
+      description: 'Only fetch invoices paid after this date/time',
+    }),
+  },
+  sampleData: {},
+  async onEnable() { /* Required by interface. No setup needed. */ },
+  async onDisable() { /* Required by interface. No teardown needed. */ },
+  async run(context) {
+    const since = context.propsValue.since;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/invoices.list',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        filter: {
+          ...(since ? { paid_at: { gte: since } } : {}),
+          status: 'paid',
+        },
+        page: { size: 50 },
+      },
+    });
+    return response.body.data;
+  },
+  async test(context) {
+    return await this.run(context as never);
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/triggers/new-company.ts
+++ b/packages/pieces/community/teamleader/src/lib/triggers/new-company.ts
@@ -1,0 +1,40 @@
+import { createTrigger, TriggerStrategy, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const newCompany = createTrigger({
+  name: 'newCompany',
+  displayName: 'New Company',
+  description: 'Fires when a new Company is added in Teamleader.',
+  type: TriggerStrategy.POLLING,
+  props: {
+    since: Property.DateTime({
+      displayName: 'Created Since',
+      required: false,
+      description: 'Only fetch companies created after this date/time',
+    }),
+  },
+  sampleData: {},
+  async onEnable() { /* Required by interface. No setup needed. */ },
+  async onDisable() { /* Required by interface. No teardown needed. */ },
+  async run(context) {
+    const since = context.propsValue.since;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/companies.list',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        ...(since ? { filter: { created_at: { gte: since } } } : {}),
+        page: { size: 50 },
+      },
+    });
+    return response.body.data;
+  },
+  async test(context) {
+    return await this.run(context as never);
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/triggers/new-company.ts
+++ b/packages/pieces/community/teamleader/src/lib/triggers/new-company.ts
@@ -1,6 +1,16 @@
 import { createTrigger, TriggerStrategy, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Company {
+  id: string;
+  name: string;
+  vat_number: string;
+  created_at: string;
+  website?: string;
+}
+
+// Trigger: Fires when a new Company is added in Teamleader
 export const newCompany = createTrigger({
   name: 'newCompany',
   displayName: 'New Company',
@@ -13,26 +23,48 @@ export const newCompany = createTrigger({
       description: 'Only fetch companies created after this date/time',
     }),
   },
-  sampleData: {},
-  async onEnable() { /* Required by interface. No setup needed. */ },
-  async onDisable() { /* Required by interface. No teardown needed. */ },
+  sampleData: {
+    id: '123456',
+    name: 'Acme Corp',
+    vat_number: 'BE0123456789',
+    created_at: '2024-01-01T12:00:00Z',
+    website: 'https://acme.com',
+  },
+  // Required by interface, intentionally left empty for framework compliance
+  async onEnable(): Promise<void> { /* intentionally empty */ },
+  async onDisable(): Promise<void> { /* intentionally empty */ },
   async run(context) {
     const since = context.propsValue.since;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/companies.list',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        ...(since ? { filter: { created_at: { gte: since } } } : {}),
-        page: { size: 50 },
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/companies.list`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          ...(since ? { filter: { created_at: { gte: since } } } : {}),
+          page: { size: 50 },
+        },
+      });
+      if (!response.body?.data || !Array.isArray(response.body.data)) {
+        throw new Error('Unexpected API response: missing data array');
+      }
+      // Map output to a clear schema
+      return response.body.data.map((company: Company) => ({
+        id: company.id,
+        name: company.name,
+        vat_number: company.vat_number,
+        created_at: company.created_at,
+        website: company.website,
+      }));
+    } catch (e: unknown) {
+      throw new Error(`Failed to fetch companies: ${(e as Error).message}`);
+    }
   },
   async test(context) {
     return await this.run(context as never);

--- a/packages/pieces/community/teamleader/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/teamleader/src/lib/triggers/new-contact.ts
@@ -1,10 +1,20 @@
 import { createTrigger, TriggerStrategy, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Contact {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email?: string;
+  created_at: string;
+}
+
+// Trigger: Fires when a new contact is added in Teamleader
 export const newContact = createTrigger({
   name: 'newContact',
   displayName: 'New Contact',
-  description: 'Fires when a new Contact is created in Teamleader.',
+  description: 'Fires when a new contact is added in Teamleader.',
   type: TriggerStrategy.POLLING,
   props: {
     since: Property.DateTime({
@@ -13,26 +23,48 @@ export const newContact = createTrigger({
       description: 'Only fetch contacts created after this date/time',
     }),
   },
-  sampleData: {},
-  async onEnable() { /* Required by interface. No setup needed. */ },
-  async onDisable() { /* Required by interface. No teardown needed. */ },
+  sampleData: {
+    id: '22222',
+    first_name: 'John',
+    last_name: 'Doe',
+    email: 'john.doe@example.com',
+    created_at: '2024-01-01T12:00:00Z',
+  },
+  // Required by interface, intentionally left empty for framework compliance
+  async onEnable(): Promise<void> { /* intentionally empty */ },
+  async onDisable(): Promise<void> { /* intentionally empty */ },
   async run(context) {
     const since = context.propsValue.since;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/contacts.list',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        ...(since ? { filter: { created_at: { gte: since } } } : {}),
-        page: { size: 50 },
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/contacts.list`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          ...(since ? { filter: { created_at: { gte: since } } } : {}),
+          page: { size: 50 },
+        },
+      });
+      if (!response.body?.data || !Array.isArray(response.body.data)) {
+        throw new Error('Unexpected API response: missing data array');
+      }
+      // Map output to a clear schema
+      return response.body.data.map((contact: Contact) => ({
+        id: contact.id,
+        first_name: contact.first_name,
+        last_name: contact.last_name,
+        email: contact.email,
+        created_at: contact.created_at,
+      }));
+    } catch (e: unknown) {
+      throw new Error(`Failed to fetch contacts: ${(e as Error).message}`);
+    }
   },
   async test(context) {
     return await this.run(context as never);

--- a/packages/pieces/community/teamleader/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/teamleader/src/lib/triggers/new-contact.ts
@@ -1,0 +1,40 @@
+import { createTrigger, TriggerStrategy, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const newContact = createTrigger({
+  name: 'newContact',
+  displayName: 'New Contact',
+  description: 'Fires when a new Contact is created in Teamleader.',
+  type: TriggerStrategy.POLLING,
+  props: {
+    since: Property.DateTime({
+      displayName: 'Created Since',
+      required: false,
+      description: 'Only fetch contacts created after this date/time',
+    }),
+  },
+  sampleData: {},
+  async onEnable() { /* Required by interface. No setup needed. */ },
+  async onDisable() { /* Required by interface. No teardown needed. */ },
+  async run(context) {
+    const since = context.propsValue.since;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/contacts.list',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        ...(since ? { filter: { created_at: { gte: since } } } : {}),
+        page: { size: 50 },
+      },
+    });
+    return response.body.data;
+  },
+  async test(context) {
+    return await this.run(context as never);
+  },
+}); 

--- a/packages/pieces/community/teamleader/src/lib/triggers/new-deal.ts
+++ b/packages/pieces/community/teamleader/src/lib/triggers/new-deal.ts
@@ -1,10 +1,20 @@
 import { createTrigger, TriggerStrategy, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { getTeamleaderApiBaseUrl } from '../common';
 
+interface Deal {
+  id: string;
+  title: string;
+  status: string;
+  created_at: string;
+  value?: number;
+}
+
+// Trigger: Fires when a new deal is added in Teamleader
 export const newDeal = createTrigger({
   name: 'newDeal',
   displayName: 'New Deal',
-  description: 'Fires when a new Deal/opportunity is created in Teamleader.',
+  description: 'Fires when a new deal is added in Teamleader.',
   type: TriggerStrategy.POLLING,
   props: {
     since: Property.DateTime({
@@ -13,26 +23,48 @@ export const newDeal = createTrigger({
       description: 'Only fetch deals created after this date/time',
     }),
   },
-  sampleData: {},
-  async onEnable() { /* Required by interface. No setup needed. */ },
-  async onDisable() { /* Required by interface. No teardown needed. */ },
+  sampleData: {
+    id: '33333',
+    title: 'New Opportunity',
+    status: 'open',
+    created_at: '2024-01-01T12:00:00Z',
+    value: 5000,
+  },
+  // Required by interface, intentionally left empty for framework compliance
+  async onEnable(): Promise<void> { /* intentionally empty */ },
+  async onDisable(): Promise<void> { /* intentionally empty */ },
   async run(context) {
     const since = context.propsValue.since;
     const auth = context.auth as OAuth2PropertyValue;
     if (!auth?.access_token) throw new Error('Missing access token');
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: 'https://api.focus.teamleader.eu/deals.list',
-      headers: {
-        Authorization: `Bearer ${auth.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: {
-        ...(since ? { filter: { created_at: { gte: since } } } : {}),
-        page: { size: 50 },
-      },
-    });
-    return response.body.data;
+    const apiBase = getTeamleaderApiBaseUrl(auth);
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${apiBase}/deals.list`,
+        headers: {
+          Authorization: `Bearer ${auth.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          ...(since ? { filter: { created_at: { gte: since } } } : {}),
+          page: { size: 50 },
+        },
+      });
+      if (!response.body?.data || !Array.isArray(response.body.data)) {
+        throw new Error('Unexpected API response: missing data array');
+      }
+      // Map output to a clear schema
+      return response.body.data.map((deal: Deal) => ({
+        id: deal.id,
+        title: deal.title,
+        status: deal.status,
+        created_at: deal.created_at,
+        value: deal.value,
+      }));
+    } catch (e: unknown) {
+      throw new Error(`Failed to fetch deals: ${(e as Error).message}`);
+    }
   },
   async test(context) {
     return await this.run(context as never);

--- a/packages/pieces/community/teamleader/src/lib/triggers/new-deal.ts
+++ b/packages/pieces/community/teamleader/src/lib/triggers/new-deal.ts
@@ -1,0 +1,40 @@
+import { createTrigger, TriggerStrategy, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const newDeal = createTrigger({
+  name: 'newDeal',
+  displayName: 'New Deal',
+  description: 'Fires when a new Deal/opportunity is created in Teamleader.',
+  type: TriggerStrategy.POLLING,
+  props: {
+    since: Property.DateTime({
+      displayName: 'Created Since',
+      required: false,
+      description: 'Only fetch deals created after this date/time',
+    }),
+  },
+  sampleData: {},
+  async onEnable() { /* Required by interface. No setup needed. */ },
+  async onDisable() { /* Required by interface. No teardown needed. */ },
+  async run(context) {
+    const since = context.propsValue.since;
+    const auth = context.auth as OAuth2PropertyValue;
+    if (!auth?.access_token) throw new Error('Missing access token');
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.focus.teamleader.eu/deals.list',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        ...(since ? { filter: { created_at: { gte: since } } } : {}),
+        page: { size: 50 },
+      },
+    });
+    return response.body.data;
+  },
+  async test(context) {
+    return await this.run(context as never);
+  },
+}); 

--- a/packages/pieces/community/teamleader/tsconfig.json
+++ b/packages/pieces/community/teamleader/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/teamleader/tsconfig.lib.json
+++ b/packages/pieces/community/teamleader/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -693,11 +693,11 @@
       "@activepieces/piece-queue": [
         "packages/pieces/community/queue/src/index.ts"
       ],
+      "@activepieces/piece-quickbooks": [
+        "packages/pieces/community/quickbooks/src/index.ts"
+      ],
       "@activepieces/piece-quickzu": [
         "packages/pieces/community/quickzu/src/index.ts"
-      ],
-       "@activepieces/piece-quickbooks": [
-        "packages/pieces/community/quickbooks/src/index.ts"
       ],
       "@activepieces/piece-rabbitmq": [
         "packages/pieces/community/rabbitmq/src/index.ts"
@@ -879,6 +879,9 @@
       ],
       "@activepieces/piece-tavily": [
         "packages/pieces/community/tavily/src/index.ts"
+      ],
+      "@activepieces/piece-teamleader": [
+        "packages/pieces/community/teamleader/src/index.ts"
       ],
       "@activepieces/piece-telegram-bot": [
         "packages/pieces/community/telegram-bot/src/index.ts"


### PR DESCRIPTION
**Description:**  
This PR introduces a robust Teamleader integration piece for Activepieces, enabling seamless automation with the Teamleader platform. The piece supports OAuth2 authentication and provides a comprehensive set of triggers, actions, and search operations, including:

- **Triggers:** new contact, new company, new deal, deal accepted, invoice paid  
- **Actions:** create/update contact, create/update company, link/unlink contact to company, create/update deal  
- **Searches:** search companies, contacts, deals, and invoices

/claim #8489 
Fixes #8489 
