### PR TITLE
feat(piece): add stop-flow piece

### DIFF
--- a/packages/pieces/community/stopflow/README.md
+++ b/packages/pieces/community/stopflow/README.md
@@ -1,0 +1,25 @@
+# pieces-stopflow
+An Activepieces piece to immediately stop the current flow's execution. This library was generated with Nx.
+
+# Action: Stop Flow Execution
+Description: When this action is reached in a flow, it terminates all subsequent execution.
+
+**Inputs:** None.
+
+**Outputs:** None.
+
+# Use Case
+This piece is primarily used to exit a loop, such as a "For Each" step, once a specific condition has been met. This prevents further items in a list from being processed, saving time and tasks.
+
+**Example Flow:**
+
+- A `Trigger` provides a list of items.
+
+- A `For Each` step iterates over the list.
+
+- A `Branch` step checks if the current item meets a condition.
+
+- The `Stop Flow` action is placed in the "True" path of the Branch to halt the entire execution.
+
+# Building
+Run `nx build pieces-stopflow` to build the library.a

--- a/packages/pieces/community/stopflow/package.json
+++ b/packages/pieces/community/stopflow/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-stopflow",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/stopflow/project.json
+++ b/packages/pieces/community/stopflow/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-stopflow",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/stopflow/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/stopflow",
+        "tsConfig": "packages/pieces/community/stopflow/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/stopflow/package.json",
+        "main": "packages/pieces/community/stopflow/src/index.ts",
+        "assets": [
+          "packages/pieces/community/stopflow/*.md",
+          {
+            "input": "packages/pieces/community/stopflow/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/stopflow/src/index.ts
+++ b/packages/pieces/community/stopflow/src/index.ts
@@ -1,0 +1,17 @@
+
+    import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+    import { stopFlow } from "./lib/actions/stop-flow";
+
+    export const stopflow = createPiece({
+      displayName: "Stop Flow",
+      auth: PieceAuth.None(),
+      minimumSupportedRelease: '0.36.1',
+      logoUrl: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSIjZmY3MjcyIiBkPSJNNSAzaDE0YTIgMiAwIDAgMSAyIDJ2MTRhMiAyIDAgMCAxLTIgMkg1YTIgMiAwIDAgMS0yLTJWNWEyIDIgMCAwIDEgMi0ybTggMTBWN2gtMnY2em0wIDR2LTJoLTJ2MnoiLz48L3N2Zz4=",
+      description: 'A piece to immediately stop the flow execution.',
+      authors: [],
+      actions: [
+        stopFlow
+      ],
+      triggers: [],
+    });
+    

--- a/packages/pieces/community/stopflow/src/lib/actions/stop-flow.ts
+++ b/packages/pieces/community/stopflow/src/lib/actions/stop-flow.ts
@@ -1,0 +1,11 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+
+export const stopFlow = createAction({
+  name: 'stopFlow',
+  displayName: 'Stop flow',
+  description: 'Stops the flow immediately this step is reached',
+  props: {},
+  async run(context) {
+    context.run.stop();
+  },
+});

--- a/packages/pieces/community/stopflow/tsconfig.json
+++ b/packages/pieces/community/stopflow/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/stopflow/tsconfig.lib.json
+++ b/packages/pieces/community/stopflow/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -693,11 +693,11 @@
       "@activepieces/piece-queue": [
         "packages/pieces/community/queue/src/index.ts"
       ],
+      "@activepieces/piece-quickbooks": [
+        "packages/pieces/community/quickbooks/src/index.ts"
+      ],
       "@activepieces/piece-quickzu": [
         "packages/pieces/community/quickzu/src/index.ts"
-      ],
-       "@activepieces/piece-quickbooks": [
-        "packages/pieces/community/quickbooks/src/index.ts"
       ],
       "@activepieces/piece-rabbitmq": [
         "packages/pieces/community/rabbitmq/src/index.ts"
@@ -834,6 +834,9 @@
       ],
       "@activepieces/piece-stable-diffusion-webui": [
         "packages/pieces/community/stable-diffusion-webui/src/index.ts"
+      ],
+      "@activepieces/piece-stopflow": [
+        "packages/pieces/community/stopflow/src/index.ts"
       ],
       "@activepieces/piece-store": [
         "packages/pieces/community/store/src/index.ts"


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new community piece named `Stop Flow`.

This piece is designed to provide developers and users with precise control over their flow's execution. It adds a single, straightforward action that allows a flow to be terminated immediately and intentionally when a specific step is reached. This is particularly useful for optimizing flows that involve loops or complex conditional branches, preventing unnecessary task consumption and improving overall efficiency.

### Explain How the Feature Works

The `Stop Flow` piece is straightforward and contains a single action: `Stop Flow Execution`.

When this action is triggered within a flow, it internally calls the `context.run.stop()` function from the Activepieces framework. This call instructs the Activepieces engine to halt the current run immediately. No subsequent steps in the flow will be processed, and the run will conclude with a "Succeeded" status, as the termination was intentional.

The action requires no configuration (inputs) and produces no data (outputs), as its sole purpose is to terminate the execution path.

### Relevant User Scenarios
This feature is valuable in several common automation scenarios:

**Exiting Loops Early:** A user is iterating through a large list of records (e.g., 10,000 users from a Google Sheet) to find the first record that matches a specific criterion (e.g., a specific email address). Once found, the `Stop Flow` piece can be used to immediately exit the loop, saving thousands of unnecessary task operations.

**Conditional Flow Termination based on Input:** A flow is triggered by a webhook. A `Branch` step validates the incoming payload. If the payload is invalid or doesn't meet required conditions (e.g., a missing key), the `Stop Flow` action can terminate the run immediately, preventing errors in subsequent steps that depend on valid data.

**Search-and-Find Operations:** When searching for a file in a series of cloud storage folders or looking for a specific piece of data across multiple API calls, the flow can be stopped as soon as the target is found, making the process much more efficient.

Fixes #8495