### PR TITLE
feat(pieces): implement Bluesky piece integration

### DIFF
--- a/packages/pieces/community/bluesky/.eslintrc.json
+++ b/packages/pieces/community/bluesky/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../../.eslintrc.json"]
+}

--- a/packages/pieces/community/bluesky/README.md
+++ b/packages/pieces/community/bluesky/README.md
@@ -1,0 +1,17 @@
+# Bluesky Piece for Activepieces
+
+This piece integrates the Bluesky decentralized social network with Activepieces, enabling automation of posts, likes, reposts, and content monitoring via the AT Protocol.
+
+## Features
+- Triggers: New Posts by Author, New Follower, New Timeline Posts, New Post (with Search)
+- Actions: Create Post, Like Post, Repost Post
+- Search: Find Post, Find Thread
+
+## Setup
+- Implemented in TypeScript
+- Follows Activepieces community piece guidelines
+
+## Development
+- See `src/` for implementation.
+- See [Activepieces Piece Development Guide](https://www.activepieces.com/docs/developers/building-pieces/overview)
+- See [Bluesky API Docs](https://docs.bsky.app/docs/category/tutorials)

--- a/packages/pieces/community/bluesky/package.json
+++ b/packages/pieces/community/bluesky/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@activepieces/piece-bluesky",
+  "version": "0.0.1",
+  "main": "dist/index.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@activepieces/pieces-framework": "^<latest-version>"
+  }
+}

--- a/packages/pieces/community/bluesky/project.json
+++ b/packages/pieces/community/bluesky/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "@activepieces/piece-bluesky",
+  "root": "packages/pieces/community/bluesky",
+  "sourceRoot": "packages/pieces/community/bluesky/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/bluesky",
+        "tsConfig": "packages/pieces/community/bluesky/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/bluesky/package.json",
+        "main": "packages/pieces/community/bluesky/src/index.ts",
+        "assets": []
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/bluesky/src/index.ts
+++ b/packages/pieces/community/bluesky/src/index.ts
@@ -1,0 +1,43 @@
+import { createPiece, PieceAuth, Property } from '@activepieces/pieces-framework';
+import { createPost } from './lib/actions/create-post';
+import { likePost } from './lib/actions/like-post';
+import { repostPost } from './lib/actions/repost-post';
+import { findPost } from './lib/actions/find-post';
+import { findThread } from './lib/actions/find-thread';
+import { newPostsByAuthor } from './lib/triggers/new-posts-by-author';
+import { newFollower } from './lib/triggers/new-follower';
+import { newTimelinePosts } from './lib/triggers/new-timeline-posts';
+import { newPostWithSearch } from './lib/triggers/new-post-with-search';
+
+export const blueskyAuth = PieceAuth.CustomAuth({
+  required: true,
+  description: 'Authenticate with your Bluesky account (handle/email and app password).',
+  props: {
+    serviceUrl: Property.ShortText({
+      displayName: 'Service URL',
+      description: 'Bluesky service URL (e.g., https://bsky.social)',
+      required: true,
+      defaultValue: 'https://bsky.social',
+    }),
+    identifier: Property.ShortText({
+      displayName: 'Handle or Email',
+      description: 'Your Bluesky handle or email',
+      required: true,
+    }),
+    password: PieceAuth.SecretText({
+      displayName: 'App Password',
+      description: 'Your Bluesky app password',
+      required: true,
+    }),
+  },
+});
+
+export default createPiece({
+  displayName: 'Bluesky',
+  description: 'Bluesky integration for Activepieces',
+  logoUrl: 'https://cdn.activepieces.com/pieces/bluesky.png',
+  authors: ['pranjal'],
+  auth: blueskyAuth,
+  actions: [createPost, likePost, repostPost, findPost, findThread],
+  triggers: [newPostsByAuthor, newFollower, newTimelinePosts, newPostWithSearch],
+});

--- a/packages/pieces/community/bluesky/src/lib/actions/create-post.ts
+++ b/packages/pieces/community/bluesky/src/lib/actions/create-post.ts
@@ -1,0 +1,191 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { postToBluesky, type BlueskyAuth, type BlueskyPostOptions } from '../common/bluesky-client';
+import { blueskyAuth } from '../..';
+
+function getMimeTypeFromExtension(extension?: string): string {
+  if (!extension) return 'image/png';
+  switch (extension.toLowerCase()) {
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'png':
+      return 'image/png';
+    case 'gif':
+      return 'image/gif';
+    case 'webp':
+      return 'image/webp';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function isNonEmptyString(str: string | undefined): boolean {
+  return typeof str === 'string' && str.trim().length > 0;
+}
+
+export const createPost = createAction({
+  auth: blueskyAuth,
+  name: 'create-post',
+  displayName: 'Create Post',
+  description: 'Publish a new post with text, images, and options to Bluesky.',
+  props: {
+    text: Property.LongText({
+      displayName: 'Text',
+      description: 'The content of the post.',
+      required: true,
+    }),
+    image_1: Property.File({
+      displayName: 'Image 1',
+      required: false,
+    }),
+    image_2: Property.File({
+      displayName: 'Image 2',
+      required: false,
+    }),
+    image_3: Property.File({
+      displayName: 'Image 3',
+      required: false,
+    }),
+    image_4: Property.File({
+      displayName: 'Image 4',
+      required: false,
+    }),
+    hashtags: Property.ShortText({
+      displayName: 'Hashtags',
+      description: 'Comma-separated hashtags (optional)',
+      required: false,
+    }),
+    language: Property.ShortText({
+      displayName: 'Language',
+      description: 'Language code(s), comma-separated (optional)',
+      required: false,
+    }),
+    replyRootUri: Property.ShortText({
+      displayName: 'Reply Root URI',
+      description: 'Root post URI if replying (optional)',
+      required: false,
+    }),
+    replyRootCid: Property.ShortText({
+      displayName: 'Reply Root CID',
+      description: 'Root post CID if replying (optional)',
+      required: false,
+    }),
+    replyParentUri: Property.ShortText({
+      displayName: 'Reply Parent URI',
+      description: 'Parent post URI if replying (optional)',
+      required: false,
+    }),
+    replyParentCid: Property.ShortText({
+      displayName: 'Reply Parent CID',
+      description: 'Parent post CID if replying (optional)',
+      required: false,
+    }),
+    quoteUri: Property.ShortText({
+      displayName: 'Quote Post URI',
+      description: 'URI of the post to quote (optional)',
+      required: false,
+    }),
+    quoteCid: Property.ShortText({
+      displayName: 'Quote Post CID',
+      description: 'CID of the post to quote (optional)',
+      required: false,
+    }),
+    websiteUrl: Property.ShortText({
+      displayName: 'Website Card URL',
+      description: 'URL to embed as a website card (optional)',
+      required: false,
+    }),
+    websiteTitle: Property.ShortText({
+      displayName: 'Website Card Title',
+      description: 'Title for the website card (optional)',
+      required: false,
+    }),
+    websiteDescription: Property.ShortText({
+      displayName: 'Website Card Description',
+      description: 'Description for the website card (optional)',
+      required: false,
+    }),
+    websiteThumb: Property.File({
+      displayName: 'Website Card Thumbnail',
+      description: 'Thumbnail image for the website card (optional)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    try {
+      const {
+        text, image_1, image_2, image_3, image_4, hashtags, language,
+        replyRootUri, replyRootCid, replyParentUri, replyParentCid,
+        quoteUri, quoteCid,
+        websiteUrl, websiteTitle, websiteDescription, websiteThumb
+      } = context.propsValue;
+
+      if (!isNonEmptyString(text)) {
+        return { error: 'Text is required and cannot be empty or whitespace.' };
+      }
+
+      let postText = text;
+      if (isNonEmptyString(hashtags)) {
+        const tags = hashtags.split(',').map((t: string) => t.trim()).filter(Boolean);
+        if (tags.length > 0) {
+          postText += '\n' + tags.map(t => (t.startsWith('#') ? t : `#${t}`)).join(' ');
+        }
+      }
+
+      const images = [image_1, image_2, image_3, image_4].filter(Boolean).map((img: any) => ({
+        base64: img.base64,
+        alt: img.name || '',
+        mimeType: getMimeTypeFromExtension(img.extension),
+      }));
+
+      const langs = language ? language.split(',').map((l: string) => l.trim()) : undefined;
+
+      let replyTo = undefined;
+      if ([replyRootUri, replyRootCid, replyParentUri, replyParentCid].every(isNonEmptyString)) {
+        replyTo = {
+          root: { uri: replyRootUri, cid: replyRootCid },
+          parent: { uri: replyParentUri, cid: replyParentCid },
+        };
+      } else if ([replyRootUri, replyRootCid, replyParentUri, replyParentCid].some(isNonEmptyString)) {
+        return { error: 'All reply fields (root URI, root CID, parent URI, parent CID) must be provided for a reply.' };
+      }
+
+      let quote = undefined;
+      if (isNonEmptyString(quoteUri) && isNonEmptyString(quoteCid)) {
+        quote = { uri: quoteUri, cid: quoteCid };
+      } else if (isNonEmptyString(quoteUri) || isNonEmptyString(quoteCid)) {
+        return { error: 'Both quote URI and quote CID must be provided for a quote post.' };
+      }
+
+      let websiteCard = undefined;
+      if (isNonEmptyString(websiteUrl) && isNonEmptyString(websiteTitle)) {
+        websiteCard = {
+          url: websiteUrl,
+          title: websiteTitle,
+          description: websiteDescription,
+          thumbnailBase64: websiteThumb?.base64,
+          thumbnailMimeType: getMimeTypeFromExtension(websiteThumb?.extension),
+        };
+      }
+
+      const auth: BlueskyAuth = {
+        serviceUrl: context.auth.serviceUrl,
+        identifier: context.auth.identifier,
+        password: context.auth.password,
+      };
+      const options: BlueskyPostOptions = {
+        text: postText,
+        images: images.length > 0 ? images : undefined,
+        hashtags,
+        language: langs,
+        replyTo,
+        quote,
+        websiteCard,
+      };
+      const response = await postToBluesky(auth, options);
+      return response;
+    } catch (error: any) {
+      return { error: error.message || 'Failed to create post.' };
+    }
+  },
+}); 

--- a/packages/pieces/community/bluesky/src/lib/actions/create-post.ts
+++ b/packages/pieces/community/bluesky/src/lib/actions/create-post.ts
@@ -126,7 +126,7 @@ export const createPost = createAction({
 
       let postText = text;
       if (isNonEmptyString(hashtags)) {
-        const tags = hashtags.split(',').map((t: string) => t.trim()).filter(Boolean);
+        const tags = hashtags!.split(',').map((t: string) => t.trim()).filter(Boolean);
         if (tags.length > 0) {
           postText += '\n' + tags.map(t => (t.startsWith('#') ? t : `#${t}`)).join(' ');
         }
@@ -138,13 +138,13 @@ export const createPost = createAction({
         mimeType: getMimeTypeFromExtension(img.extension),
       }));
 
-      const langs = language ? language.split(',').map((l: string) => l.trim()) : undefined;
+      const langs = isNonEmptyString(language) ? language!.split(',').map((l: string) => l.trim()) : undefined;
 
       let replyTo = undefined;
       if ([replyRootUri, replyRootCid, replyParentUri, replyParentCid].every(isNonEmptyString)) {
         replyTo = {
-          root: { uri: replyRootUri, cid: replyRootCid },
-          parent: { uri: replyParentUri, cid: replyParentCid },
+          root: { uri: replyRootUri!, cid: replyRootCid! },
+          parent: { uri: replyParentUri!, cid: replyParentCid! },
         };
       } else if ([replyRootUri, replyRootCid, replyParentUri, replyParentCid].some(isNonEmptyString)) {
         return { error: 'All reply fields (root URI, root CID, parent URI, parent CID) must be provided for a reply.' };
@@ -152,7 +152,7 @@ export const createPost = createAction({
 
       let quote = undefined;
       if (isNonEmptyString(quoteUri) && isNonEmptyString(quoteCid)) {
-        quote = { uri: quoteUri, cid: quoteCid };
+        quote = { uri: quoteUri!, cid: quoteCid! };
       } else if (isNonEmptyString(quoteUri) || isNonEmptyString(quoteCid)) {
         return { error: 'Both quote URI and quote CID must be provided for a quote post.' };
       }
@@ -160,8 +160,8 @@ export const createPost = createAction({
       let websiteCard = undefined;
       if (isNonEmptyString(websiteUrl) && isNonEmptyString(websiteTitle)) {
         websiteCard = {
-          url: websiteUrl,
-          title: websiteTitle,
+          url: websiteUrl!,
+          title: websiteTitle!,
           description: websiteDescription,
           thumbnailBase64: websiteThumb?.base64,
           thumbnailMimeType: getMimeTypeFromExtension(websiteThumb?.extension),

--- a/packages/pieces/community/bluesky/src/lib/actions/find-post.ts
+++ b/packages/pieces/community/bluesky/src/lib/actions/find-post.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { blueskyAuth } from '../..';
+import { BskyAgent } from '@atproto/api';
+
+function isNonEmptyString(str: string | undefined): boolean {
+  return typeof str === 'string' && str.trim().length > 0;
+}
+
+export const findPost = createAction({
+  auth: blueskyAuth,
+  name: 'find-post',
+  displayName: 'Find Post',
+  description: 'Retrieve a single post\'s details using its URL/URI.',
+  props: {
+    uri: Property.ShortText({
+      displayName: 'Post URI',
+      description: 'The URI of the post to retrieve.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    try {
+      const { serviceUrl, identifier, password } = context.auth;
+      const { uri } = context.propsValue;
+      if (!isNonEmptyString(uri)) {
+        return { error: 'Post URI is required and must be non-empty.' };
+      }
+      const agent = new BskyAgent({ service: serviceUrl });
+      await agent.login({ identifier, password });
+      const response = await agent.getPosts({ uris: [uri] });
+      return response.data.posts[0] || { error: 'Post not found' };
+    } catch (error: any) {
+      return { error: error.message || 'Failed to find post.' };
+    }
+  },
+}); 

--- a/packages/pieces/community/bluesky/src/lib/actions/find-thread.ts
+++ b/packages/pieces/community/bluesky/src/lib/actions/find-thread.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { blueskyAuth } from '../..';
+import { BskyAgent } from '@atproto/api';
+
+function isNonEmptyString(str: string | undefined): boolean {
+  return typeof str === 'string' && str.trim().length > 0;
+}
+
+export const findThread = createAction({
+  auth: blueskyAuth,
+  name: 'find-thread',
+  displayName: 'Find Thread',
+  description: 'Retrieve a full thread, including parent posts and replies, up to 100 deep.',
+  props: {
+    uri: Property.ShortText({
+      displayName: 'Thread Root Post URI',
+      description: 'The URI of the root post of the thread.',
+      required: true,
+    }),
+    depth: Property.Number({
+      displayName: 'Depth',
+      description: 'How deep to fetch replies (max 100).',
+      required: false,
+      defaultValue: 100,
+    }),
+  },
+  async run(context) {
+    try {
+      const { serviceUrl, identifier, password } = context.auth;
+      const { uri, depth } = context.propsValue;
+      if (!isNonEmptyString(uri)) {
+        return { error: 'Thread root post URI is required and must be non-empty.' };
+      }
+      const safeDepth = Math.min(depth || 100, 100);
+      const agent = new BskyAgent({ service: serviceUrl });
+      await agent.login({ identifier, password });
+      const response = await agent.getPostThread({ uri, depth: safeDepth });
+      return response;
+    } catch (error: any) {
+      return { error: error.message || 'Failed to find thread.' };
+    }
+  },
+}); 

--- a/packages/pieces/community/bluesky/src/lib/actions/like-post.ts
+++ b/packages/pieces/community/bluesky/src/lib/actions/like-post.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { blueskyAuth } from '../..';
+import { BskyAgent } from '@atproto/api';
+
+function isNonEmptyString(str: string | undefined): boolean {
+  return typeof str === 'string' && str.trim().length > 0;
+}
+
+export const likePost = createAction({
+  auth: blueskyAuth,
+  name: 'like-post',
+  displayName: 'Like Post',
+  description: 'Like a specific post by its URI and CID.',
+  props: {
+    uri: Property.ShortText({
+      displayName: 'Post URI',
+      description: 'The URI of the post to like.',
+      required: true,
+    }),
+    cid: Property.ShortText({
+      displayName: 'Post CID',
+      description: 'The CID (content hash) of the post to like.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    try {
+      const { serviceUrl, identifier, password } = context.auth;
+      const { uri, cid } = context.propsValue;
+      if (!isNonEmptyString(uri) || !isNonEmptyString(cid)) {
+        return { error: 'Both URI and CID are required and must be non-empty.' };
+      }
+      const agent = new BskyAgent({ service: serviceUrl });
+      await agent.login({ identifier, password });
+      const response = await agent.like(uri, cid);
+      return response;
+    } catch (error: any) {
+      return { error: error.message || 'Failed to like post.' };
+    }
+  },
+}); 

--- a/packages/pieces/community/bluesky/src/lib/actions/repost-post.ts
+++ b/packages/pieces/community/bluesky/src/lib/actions/repost-post.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { blueskyAuth } from '../..';
+import { BskyAgent } from '@atproto/api';
+
+function isNonEmptyString(str: string | undefined): boolean {
+  return typeof str === 'string' && str.trim().length > 0;
+}
+
+export const repostPost = createAction({
+  auth: blueskyAuth,
+  name: 'repost-post',
+  displayName: 'Repost Post',
+  description: 'Repost (boost) a specific post by its URI and CID.',
+  props: {
+    uri: Property.ShortText({
+      displayName: 'Post URI',
+      description: 'The URI of the post to repost.',
+      required: true,
+    }),
+    cid: Property.ShortText({
+      displayName: 'Post CID',
+      description: 'The CID (content hash) of the post to repost.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    try {
+      const { serviceUrl, identifier, password } = context.auth;
+      const { uri, cid } = context.propsValue;
+      if (!isNonEmptyString(uri) || !isNonEmptyString(cid)) {
+        return { error: 'Both URI and CID are required and must be non-empty.' };
+      }
+      const agent = new BskyAgent({ service: serviceUrl });
+      await agent.login({ identifier, password });
+      const response = await agent.repost(uri, cid);
+      return response;
+    } catch (error: any) {
+      return { error: error.message || 'Failed to repost post.' };
+    }
+  },
+}); 

--- a/packages/pieces/community/bluesky/src/lib/common/bluesky-client.ts
+++ b/packages/pieces/community/bluesky/src/lib/common/bluesky-client.ts
@@ -1,0 +1,96 @@
+import { BskyAgent, RichText } from '@atproto/api';
+
+export interface BlueskyAuth {
+  serviceUrl: string;
+  identifier: string;
+  password: string;
+}
+
+export interface BlueskyPostOptions {
+  text: string;
+  images?: Array<{ base64: string; alt?: string; mimeType?: string; }>;
+  hashtags?: string;
+  language?: string[];
+  replyTo?: { root: { uri: string; cid: string }; parent: { uri: string; cid: string } };
+  quote?: { uri: string; cid: string };
+  websiteCard?: { url: string; title: string; description?: string; thumbnailBase64?: string; thumbnailMimeType?: string };
+}
+
+export async function postToBluesky(auth: BlueskyAuth, options: BlueskyPostOptions) {
+  const agent = new BskyAgent({ service: auth.serviceUrl });
+  await agent.login({ identifier: auth.identifier, password: auth.password });
+
+  // RichText for mentions/links
+  const rt = new RichText({ text: options.text });
+  await rt.detectFacets(agent);
+
+  // Prepare post record
+  const postRecord: any = {
+    $type: 'app.bsky.feed.post',
+    text: rt.text,
+    facets: rt.facets,
+    createdAt: new Date().toISOString(),
+  };
+
+  if (options.language) {
+    postRecord.langs = options.language;
+  }
+
+  // Handle reply
+  if (options.replyTo) {
+    postRecord.reply = {
+      root: options.replyTo.root,
+      parent: options.replyTo.parent,
+    };
+  }
+
+  // Handle quote
+  if (options.quote) {
+    postRecord.embed = {
+      $type: 'app.bsky.embed.record',
+      record: options.quote,
+    };
+  }
+
+  // Handle website card
+  if (options.websiteCard) {
+    let thumbBlob;
+    if (options.websiteCard.thumbnailBase64 && options.websiteCard.thumbnailMimeType) {
+      const thumbRes = await agent.uploadBlob(Buffer.from(options.websiteCard.thumbnailBase64, 'base64'), {
+        encoding: options.websiteCard.thumbnailMimeType,
+      });
+      thumbBlob = thumbRes.data.blob;
+    }
+    postRecord.embed = {
+      $type: 'app.bsky.embed.external',
+      external: {
+        uri: options.websiteCard.url,
+        title: options.websiteCard.title,
+        description: options.websiteCard.description,
+        thumb: thumbBlob,
+      },
+    };
+  }
+
+  // Handle images
+  if (options.images && options.images.length > 0) {
+    const images = [];
+    for (const img of options.images) {
+      const res = await agent.uploadBlob(Buffer.from(img.base64, 'base64'), {
+        encoding: img.mimeType || 'image/png',
+      });
+      images.push({
+        image: res.data.blob,
+        alt: img.alt || '',
+      });
+    }
+    postRecord.embed = {
+      $type: 'app.bsky.embed.images',
+      images,
+    };
+  }
+
+  // Post
+  const response = await agent.post(postRecord);
+  return response;
+} 

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-follower.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-follower.ts
@@ -1,0 +1,43 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { blueskyAuth } from '../..';
+import { BskyAgent } from '@atproto/api';
+
+export const newFollower = createTrigger({
+  auth: blueskyAuth,
+  name: 'new-follower',
+  displayName: 'New Follower on Account',
+  description: 'Fires when someone new follows your account.',
+  props: {},
+  sampleData: {
+    did: 'did:example:123',
+    handle: 'follower.handle',
+    displayName: 'Follower Name',
+    followedAt: '2023-01-01T00:00:00Z',
+  },
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await context.store.put('lastSeenFollowers', []);
+  },
+  async onDisable(context) {
+    await context.store.delete('lastSeenFollowers');
+  },
+  async run(context) {
+    const { serviceUrl, identifier, password } = context.auth;
+    const agent = new BskyAgent({ service: serviceUrl });
+    await agent.login({ identifier, password });
+    const profile = await agent.getProfile({ actor: identifier });
+    const myDid = profile.data.did;
+    const followersRes = await agent.getFollowers({ actor: myDid, limit: 50 });
+    const followers = followersRes.data.followers || [];
+    const lastSeen = (await context.store.get<string[]>('lastSeenFollowers')) || [];
+    const newFollowers = followers.filter(f => !lastSeen.includes(f.did)).map(f => ({
+      did: f.did,
+      handle: f.handle,
+      displayName: f.displayName,
+      followedAt: f.createdAt,
+    }));
+    const currentDids = followers.map(f => f.did);
+    await context.store.put('lastSeenFollowers', currentDids);
+    return newFollowers.reverse(); // oldest first
+  },
+}); 

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-post-with-search.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-post-with-search.ts
@@ -47,13 +47,13 @@ export const newPostWithSearch = createTrigger({
     await agent.login({ identifier, password });
     let query = '';
     if (isNonEmptyString(keywords)) {
-      query += keywords.split(',').map((k: string) => k.trim()).filter(Boolean).join(' ');
+      query += keywords!.split(',').map((k: string) => k.trim()).filter(Boolean).join(' ');
     }
     if (isNonEmptyString(tags)) {
-      query += ' ' + tags.split(',').map((t: string) => t.trim().replace(/^#/, '')).filter(Boolean).map(t => `#${t}`).join(' ');
+      query += ' ' + tags!.split(',').map((t: string) => t.trim().replace(/^#/, '')).filter(Boolean).map(t => `#${t}`).join(' ');
     }
     if (isNonEmptyString(mentions)) {
-      query += ' ' + mentions.split(',').map((m: string) => m.trim()).filter(Boolean).map(m => m.startsWith('@') ? m : `@${m}`).join(' ');
+      query += ' ' + mentions!.split(',').map((m: string) => m.trim()).filter(Boolean).map(m => m.startsWith('@') ? m : `@${m}`).join(' ');
     }
     query = query.trim();
     if (!query) return [];
@@ -65,8 +65,8 @@ export const newPostWithSearch = createTrigger({
       if (post.uri === lastSeenUri) break;
       newPosts.push({
         uri: post.uri,
-        text: post.record?.text,
-        createdAt: post.record?.createdAt,
+        text: post.record?.['text'],
+        createdAt: post.record?.['createdAt'],
       });
     }
     if (posts[0]?.uri) {

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-post-with-search.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-post-with-search.ts
@@ -1,0 +1,77 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { blueskyAuth } from '../..';
+import { BskyAgent } from '@atproto/api';
+
+function isNonEmptyString(str: string | undefined): boolean {
+  return typeof str === 'string' && str.trim().length > 0;
+}
+
+export const newPostWithSearch = createTrigger({
+  auth: blueskyAuth,
+  name: 'new-post-with-search',
+  displayName: 'New Post (with Search Options)',
+  description: 'Fires when a new post matches given search criteria (mentions, tags, keywords).',
+  props: {
+    keywords: Property.ShortText({
+      displayName: 'Keywords',
+      description: 'Comma-separated keywords to search for.',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma-separated hashtags to search for.',
+      required: false,
+    }),
+    mentions: Property.ShortText({
+      displayName: 'Mentions',
+      description: 'Comma-separated handles or DIDs to search for mentions.',
+      required: false,
+    }),
+  },
+  sampleData: {
+    uri: 'at://did:example/app.bsky.feed.post/789',
+    text: 'Post with #tag and @mention',
+    createdAt: '2023-01-01T00:00:00Z',
+  },
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await context.store.put('lastSeenSearchPostUri', '');
+  },
+  async onDisable(context) {
+    await context.store.delete('lastSeenSearchPostUri');
+  },
+  async run(context) {
+    const { serviceUrl, identifier, password } = context.auth;
+    const { keywords, tags, mentions } = context.propsValue;
+    const agent = new BskyAgent({ service: serviceUrl });
+    await agent.login({ identifier, password });
+    let query = '';
+    if (isNonEmptyString(keywords)) {
+      query += keywords.split(',').map((k: string) => k.trim()).filter(Boolean).join(' ');
+    }
+    if (isNonEmptyString(tags)) {
+      query += ' ' + tags.split(',').map((t: string) => t.trim().replace(/^#/, '')).filter(Boolean).map(t => `#${t}`).join(' ');
+    }
+    if (isNonEmptyString(mentions)) {
+      query += ' ' + mentions.split(',').map((m: string) => m.trim()).filter(Boolean).map(m => m.startsWith('@') ? m : `@${m}`).join(' ');
+    }
+    query = query.trim();
+    if (!query) return [];
+    const searchRes = await agent.app.bsky.feed.searchPosts({ q: query, limit: 20 });
+    const posts = searchRes.data.posts || [];
+    const lastSeenUri = await context.store.get<string>('lastSeenSearchPostUri');
+    let newPosts = [];
+    for (const post of posts) {
+      if (post.uri === lastSeenUri) break;
+      newPosts.push({
+        uri: post.uri,
+        text: post.record?.text,
+        createdAt: post.record?.createdAt,
+      });
+    }
+    if (posts[0]?.uri) {
+      await context.store.put('lastSeenSearchPostUri', posts[0].uri);
+    }
+    return newPosts.reverse(); // oldest first
+  },
+}); 

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-posts-by-author.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-posts-by-author.ts
@@ -39,8 +39,8 @@ export const newPostsByAuthor = createTrigger({
       if (post.post && post.post.uri === lastSeenUri) break;
       if (post.post) newPosts.push({
         uri: post.post.uri,
-        text: post.post.record?.text,
-        createdAt: post.post.record?.createdAt,
+        text: post.post.record?.['text'],
+        createdAt: post.post.record?.['createdAt'],
       });
     }
     if (posts[0]?.post?.uri) {

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-posts-by-author.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-posts-by-author.ts
@@ -1,0 +1,51 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { blueskyAuth } from '../..';
+import { BskyAgent } from '@atproto/api';
+
+export const newPostsByAuthor = createTrigger({
+  auth: blueskyAuth,
+  name: 'new-posts-by-author',
+  displayName: 'New Posts by Author',
+  description: 'Fires when a selected author creates a new post.',
+  props: {
+    author: Property.ShortText({
+      displayName: 'Author DID or Handle',
+      description: 'The DID or handle of the author to monitor.',
+      required: true,
+    }),
+  },
+  sampleData: {
+    uri: 'at://did:example/app.bsky.feed.post/123',
+    text: 'Example post',
+    createdAt: '2023-01-01T00:00:00Z',
+  },
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await context.store.put('lastSeenPostUri', '');
+  },
+  async onDisable(context) {
+    await context.store.delete('lastSeenPostUri');
+  },
+  async run(context) {
+    const { serviceUrl, identifier, password } = context.auth;
+    const { author } = context.propsValue;
+    const agent = new BskyAgent({ service: serviceUrl });
+    await agent.login({ identifier, password });
+    const feed = await agent.getAuthorFeed({ actor: author, limit: 20 });
+    const posts = feed.data.feed || [];
+    const lastSeenUri = await context.store.get<string>('lastSeenPostUri');
+    let newPosts = [];
+    for (const post of posts) {
+      if (post.post && post.post.uri === lastSeenUri) break;
+      if (post.post) newPosts.push({
+        uri: post.post.uri,
+        text: post.post.record?.text,
+        createdAt: post.post.record?.createdAt,
+      });
+    }
+    if (posts[0]?.post?.uri) {
+      await context.store.put('lastSeenPostUri', posts[0].post.uri);
+    }
+    return newPosts.reverse(); // oldest first
+  },
+}); 

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-timeline-posts.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-timeline-posts.ts
@@ -32,8 +32,8 @@ export const newTimelinePosts = createTrigger({
       if (post.post && post.post.uri === lastSeenUri) break;
       if (post.post) newPosts.push({
         uri: post.post.uri,
-        text: post.post.record?.text,
-        createdAt: post.post.record?.createdAt,
+        text: post.post.record?.['text'],
+        createdAt: post.post.record?.['createdAt'],
       });
     }
     if (posts[0]?.post?.uri) {

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-timeline-posts.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-timeline-posts.ts
@@ -1,0 +1,44 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { blueskyAuth } from '../..';
+import { BskyAgent } from '@atproto/api';
+
+export const newTimelinePosts = createTrigger({
+  auth: blueskyAuth,
+  name: 'new-timeline-posts',
+  displayName: 'New Timeline Posts',
+  description: 'Fires when new posts appear in your "Following" feed (chronological).',
+  props: {},
+  sampleData: {
+    uri: 'at://did:example/app.bsky.feed.post/456',
+    text: 'Timeline post example',
+    createdAt: '2023-01-01T00:00:00Z',
+  },
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await context.store.put('lastSeenTimelinePostUri', '');
+  },
+  async onDisable(context) {
+    await context.store.delete('lastSeenTimelinePostUri');
+  },
+  async run(context) {
+    const { serviceUrl, identifier, password } = context.auth;
+    const agent = new BskyAgent({ service: serviceUrl });
+    await agent.login({ identifier, password });
+    const timeline = await agent.getTimeline({ limit: 20 });
+    const posts = timeline.data.feed || [];
+    const lastSeenUri = await context.store.get<string>('lastSeenTimelinePostUri');
+    let newPosts = [];
+    for (const post of posts) {
+      if (post.post && post.post.uri === lastSeenUri) break;
+      if (post.post) newPosts.push({
+        uri: post.post.uri,
+        text: post.post.record?.text,
+        createdAt: post.post.record?.createdAt,
+      });
+    }
+    if (posts[0]?.post?.uri) {
+      await context.store.put('lastSeenTimelinePostUri', posts[0].post.uri);
+    }
+    return newPosts.reverse(); // oldest first
+  },
+}); 

--- a/packages/pieces/community/bluesky/tsconfig.json
+++ b/packages/pieces/community/bluesky/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/bluesky/tsconfig.lib.json
+++ b/packages/pieces/community/bluesky/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -148,6 +148,9 @@
       "@activepieces/piece-calendly": [
         "packages/pieces/community/calendly/src/index.ts"
       ],
+      "@activepieces/piece-bluesky": [
+        "packages/pieces/community/bluesky/src/index.ts"
+      ],
       "@activepieces/piece-call-rounded": [
         "packages/pieces/community/call-rounded/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->

This PR adds new triggers and actions to the Bluesky piece integration. Users can now automate workflows based on Bluesky events and perform actions directly on the Bluesky platform within Activepieces.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

The Bluesky piece now supports:
- Triggers: Automatically start workflows when specific events occur on Bluesky (e.g., new post, mention, or other supported events).
- Actions: Perform operations on Bluesky, such as posting updates, replying to posts, or interacting with user content.

These features are implemented using the Bluesky API and follow Nx workspace best practices for piece development.

Fixes #8505
/claim #8505 
