### PR TITLE
feat: add trello card deadline trigger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activepieces",
-  "version": "0.66.3",
+  "version": "0.66.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activepieces",
-      "version": "0.66.3",
+      "version": "0.66.4",
       "dependencies": {
         "@activepieces/import-fresh-webpack": "3.3.0",
         "@ai-sdk/anthropic": "1.2.12",

--- a/packages/pieces/community/trello/src/index.ts
+++ b/packages/pieces/community/trello/src/index.ts
@@ -9,6 +9,7 @@ import { createCard } from './lib/actions/create-card';
 import { getCard } from './lib/actions/get-card';
 import { cardMovedTrigger } from './lib/triggers/cardMoved';
 import { newCardTrigger } from './lib/triggers/newCard';
+import { deadlineTrigger } from './lib/triggers/deadline';
 
 const markdownProperty = `
 To obtain your API key and token, follow these steps:
@@ -73,5 +74,5 @@ export const trello = createPiece({
   categories: [PieceCategory.PRODUCTIVITY],
   auth: trelloAuth,
   actions: [createCard, getCard],
-  triggers: [cardMovedTrigger, newCardTrigger],
+  triggers: [cardMovedTrigger, newCardTrigger, deadlineTrigger],
 });

--- a/packages/pieces/community/trello/src/lib/triggers/deadline.ts
+++ b/packages/pieces/community/trello/src/lib/triggers/deadline.ts
@@ -1,0 +1,78 @@
+import { trelloAuth } from '../..';
+import { TriggerStrategy, createTrigger, PiecePropValueSchema, Property } from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import dayjs from 'dayjs';
+import { trelloCommon, getCardsInBoard, getCardsInList } from '../common';
+
+interface Props {
+    board_id: string;
+    list_id_opt?: string;
+    time_before_due: number;
+    time_unit: string;
+}
+
+const polling: Polling<PiecePropValueSchema<typeof trelloAuth>, Props> = {
+    strategy: DedupeStrategy.TIMEBASED,
+    async items({ auth, propsValue, lastFetchEpochMS }) {
+        const { board_id, list_id_opt, time_before_due, time_unit } = propsValue;
+        const getCards = list_id_opt ? getCardsInList : getCardsInBoard;
+        const cards: any[] = await getCards(auth.username, auth.password, list_id_opt || board_id);
+        const now = dayjs();
+        const upcoming = now.add(time_before_due, time_unit as dayjs.ManipulateType);
+
+        return cards
+            .filter(card => card.due && !card.dueComplete && dayjs(card.due).isAfter(now) && dayjs(card.due).isBefore(upcoming) && dayjs(card.due).valueOf() > lastFetchEpochMS)
+            .map(card => ({
+                epochMilliSeconds: dayjs(card.due).valueOf(),
+                data: card,
+            }));
+    },
+};
+
+export const deadlineTrigger = createTrigger({
+    auth: trelloAuth,
+    name: 'deadline',
+    displayName: 'Card Deadline',
+    description: 'Triggers at a specified time before a card deadline.',
+    type: TriggerStrategy.POLLING,
+    props: {
+        board_id: trelloCommon.board_id,
+        list_id_opt: trelloCommon.list_id_opt,
+        time_unit: Property.StaticDropdown({
+            displayName: 'Time unit',
+            description: 'Select unit for time before due',
+            required: true,
+            options: {
+            options: [
+                { label: 'Minutes', value: 'minutes' },
+                { label: 'Hours', value: 'hours' },
+            ],
+            },
+            defaultValue: 'hours',
+        }),
+        time_before_due: Property.Number({
+            displayName: 'Time before due',
+            description: 'How long before the due date the trigger should run (use with time unit)',
+            required: true,
+            defaultValue: 24,
+        }),
+    },
+    async onEnable(context) {
+        await pollingHelper.onEnable(polling, context);
+    },
+    async onDisable(context) {
+        await pollingHelper.onDisable(polling, context);
+    },
+    async run(context) {
+        return await pollingHelper.poll(polling, context);
+    },
+    async test(context) {
+        return await pollingHelper.test(polling, context);
+    },
+    sampleData: {
+        id: 'card-id',
+        name: 'Card close to deadline',
+        due: dayjs().add(12, 'hour').toISOString(),
+        dueComplete: false,
+    },
+});


### PR DESCRIPTION
## What does this PR do?

Adds support for customizable time-based triggers in Trello integration.  
Users can now specify how long before a card’s due date the trigger should fire (in minutes or hours).

### Explain How the Feature Works

These are passed to the polling function, which calculates a time window and filters Trello cards accordingly.