### PR TITLE
feat(piece): Hunter

### DIFF
--- a/packages/pieces/community/hunter/package.json
+++ b/packages/pieces/community/hunter/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-hunter",
+  "version": "0.4.20"
+}

--- a/packages/pieces/community/hunter/project.json
+++ b/packages/pieces/community/hunter/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "pieces-hunter",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/hunter/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    },
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/hunter",
+        "tsConfig": "packages/pieces/community/hunter/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/hunter/package.json",
+        "main": "packages/pieces/community/hunter/src/index.ts",
+        "assets": [
+          "packages/pieces/community/hunter/*.md",
+          {
+            "input": "packages/pieces/community/hunter/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/hunter/src/index.ts
+++ b/packages/pieces/community/hunter/src/index.ts
@@ -1,0 +1,47 @@
+import {
+  createPiece,
+  PieceAuth,
+} from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { hunterVerifyEmailAction } from './lib/actions/verify-email-action';
+import { hunterNewLeadTrigger } from './lib/triggers/new-lead.trigger';
+
+// Authentication for the Hunter piece. Users must supply their Hunter API key.
+export const hunterAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: `
+    To obtain your API key:
+    1. Log in to your Hunter account.
+    2. Navigate to the **API** section of your dashboard.
+    3. Copy your API key and paste it here.
+  `,
+});
+
+export const hunter = createPiece({
+  displayName: 'Hunter',
+  description:
+    'Connect to Hunter to verify email addresses and monitor new leads.',
+  minimumSupportedRelease: '0.30.0',
+  // Placeholder logo; Activepieces hosts piece logos at this CDN. If a custom
+  // logo is needed, upload it separately and update this URL accordingly.
+  logoUrl: 'https://cdn.activepieces.com/pieces/hunter.png',
+  authors: ['kishanprmr'],
+  categories: [PieceCategory.SALES_AND_CRM],
+  auth: hunterAuth,
+  actions: [
+    hunterVerifyEmailAction,
+    // Allow users to call any Hunter API endpoint through a custom API call.
+    createCustomApiCallAction({
+      baseUrl: () => {
+        return 'https://api.hunter.io/v2';
+      },
+      auth: hunterAuth,
+      authMapping: async (auth) => ({
+        'X-API-KEY': auth,
+      }),
+    }),
+  ],
+  triggers: [hunterNewLeadTrigger],
+});

--- a/packages/pieces/community/hunter/src/lib/actions/verify-email-action.ts
+++ b/packages/pieces/community/hunter/src/lib/actions/verify-email-action.ts
@@ -1,0 +1,38 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { hunterAuth } from '../..';
+
+/**
+ * Verify an email address using Hunter's Email Verifier endpoint.
+ *
+ * This action sends a GET request to the `/email-verifier` endpoint with the
+ * provided email address and API key. The response includes detailed
+ * verification information such as status, result, and score.
+ */
+export const hunterVerifyEmailAction = createAction({
+  auth: hunterAuth,
+  name: 'verify_email',
+  displayName: 'Verify Email',
+  description:
+    'Checks the deliverability of an email address and returns verification details.',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue } = context;
+    const { email } = propsValue;
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.hunter.io/v2/email-verifier',
+      queryParams: {
+        email,
+        api_key: auth,
+      },
+    });
+    // The verification data is nested under the `data` property in the response.
+    return response.body?.data ?? response.body;
+  },
+});

--- a/packages/pieces/community/hunter/src/lib/triggers/new-lead.trigger.ts
+++ b/packages/pieces/community/hunter/src/lib/triggers/new-lead.trigger.ts
@@ -1,0 +1,85 @@
+import {
+  DedupeStrategy,
+  Polling,
+  httpClient,
+  HttpMethod,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import {
+  StaticPropsValue,
+  TriggerStrategy,
+  Property,
+  createTrigger,
+} from '@activepieces/pieces-framework';
+import { hunterAuth } from '../..';
+
+/**
+ * Polls the Hunter Leads endpoint and emits any new leads based on their
+ * creation timestamp. The API returns leads sorted with the most recent
+ * entries first; we deduplicate on the `created_at` field.
+ */
+const props = {
+  /**
+   * Maximum number of leads to retrieve on each poll. Hunter accepts values
+   * between 1 and 1000 (default is 20). Keeping the limit small reduces
+   * bandwidth and ensures quick polling. If omitted, 20 is used.
+   */
+  limit: Property.Number({
+    displayName: 'Limit',
+    description:
+      'Number of leads to fetch per poll (between 1 and 1000). Defaults to 20.',
+    required: false,
+    defaultValue: 20,
+    minimum: 1,
+    maximum: 1000,
+  }),
+};
+
+// Define the polling logic. It returns an array of items with epoch timestamps
+// used by Activepieces to deduplicate events.
+const polling: Polling<string, StaticPropsValue<typeof props>> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue }) => {
+    const limit = propsValue.limit ?? 20;
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.hunter.io/v2/leads',
+      queryParams: {
+        api_key: auth,
+        limit: limit.toString(),
+      },
+    });
+    const leads = response.body?.data?.leads ?? [];
+    return leads.map((lead: any) => {
+      const createdAt = lead.created_at || lead.createdAt || lead.createdAtUTC;
+      return {
+        epochMilliSeconds: createdAt
+          ? Date.parse(createdAt)
+          : Date.now(),
+        data: lead,
+      };
+    });
+  },
+};
+
+export const hunterNewLeadTrigger = createTrigger({
+  auth: hunterAuth,
+  name: 'new_lead',
+  displayName: 'New Lead',
+  description: 'Triggers when a new lead is created in your Hunter account.',
+  props,
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async test(context) {
+    return pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return pollingHelper.poll(polling, context);
+  },
+});

--- a/packages/pieces/community/hunter/tsconfig.json
+++ b/packages/pieces/community/hunter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/hunter/tsconfig.lib.json
+++ b/packages/pieces/community/hunter/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

This pull request adds a new **Hunter** connector piece to Activepieces. The piece provides a trigger to poll for newly created leads in a Hunter account and an action to verify the deliverability of an email address using Hunter's Email Verifier API.

## How the feature works

- **Authentication**: The piece uses Secret Text authentication (`APP_HUNTER_API_KEY`) so users can securely enter their Hunter API key.
- **Trigger – New Lead**: Polls the `/v2/leads` endpoint and emits new lead items based on their `created_at` timestamp. Users can adjust the limit (1‑1000) of leads fetched per poll.
- **Action – Verify Email**: Sends a GET request to the `/v2/email-verifier` endpoint with an email address and returns detailed verification results (status, result, score, etc.).
- **Custom API Call**: A generic action is included to call other Hunter API endpoints if needed.

### Relevant user scenarios

- Sync Hunter leads into your CRM or marketing platform whenever a new lead is added.
- Verify the deliverability of email addresses before sending outreach campaigns.

Fixes #8506

```
ENV VARS REQUIRED:
APP_HUNTER_API_KEY
```


