### PR TITLE
fix: router branches with same subflow now return correct outputs for different inputs

### DIFF
--- a/packages/engine/test/handler/flow-with-pause.test.ts
+++ b/packages/engine/test/handler/flow-with-pause.test.ts
@@ -194,4 +194,71 @@ describe('flow with pause', () => {
         })
     })
 
+    it('should pause at most one flow when router has multiple branches with pause actions', async () => {
+        const routerWithTwoPauseActions = buildRouterWithOneCondition({
+            conditions: [
+                {
+                    operator: BranchOperator.BOOLEAN_IS_TRUE,
+                    firstValue: 'true',
+                },
+                {
+                    operator: BranchOperator.BOOLEAN_IS_TRUE,
+                    firstValue: 'true',
+                },
+            ],
+            executionType: RouterExecutionType.EXECUTE_ALL_MATCH,
+            children: [
+                buildPieceAction({
+                    name: 'approval_1',
+                    pieceName: '@activepieces/piece-approval',
+                    actionName: 'wait_for_approval',
+                    input: {},
+                    nextAction: buildCodeAction({
+                        name: 'echo_step',
+                        input: {},
+                    }),
+                }),
+                buildPieceAction({
+                    name: 'approval_2',
+                    pieceName: '@activepieces/piece-approval',
+                    actionName: 'wait_for_approval',
+                    input: {},
+                    nextAction: buildCodeAction({
+                        name: 'echo_step_1',
+                        input: {},
+                    }),
+                }),
+            ],
+        })
+
+        const result = await flowExecutor.execute({
+            action: routerWithTwoPauseActions,
+            executionState: FlowExecutorContext.empty().setPauseRequestId('requestId'),
+            constants: generateMockEngineConstants(),
+        })
+
+        expect(result.verdict).toBe(ExecutionVerdict.PAUSED)
+        expect(result.verdictResponse).toEqual({
+            'pauseMetadata': {
+                response: {},
+                requestId: 'requestId',
+                'type': 'WEBHOOK',
+            },
+            'reason': 'PAUSED',
+        })
+
+        const routerOutput = result.steps.router
+        expect(routerOutput).toBeDefined()
+        expect(routerOutput.output).toBeDefined()
+        
+        const executedBranches = (routerOutput.output as any)?.branches?.filter((branch: any) => branch.evaluation === true)
+        expect(executedBranches).toHaveLength(2)
+        
+        expect(result.steps.approval_1).toBeDefined()
+        expect(result.steps.approval_1.status).toBe('PAUSED')
+        expect(result.steps.approval_2).toBeUndefined()
+        
+        expect(Object.keys(result.steps)).toEqual(['router', 'approval_1'])
+    })
+
 })

--- a/packages/engine/test/handler/flow-with-pause.test.ts
+++ b/packages/engine/test/handler/flow-with-pause.test.ts
@@ -194,7 +194,7 @@ describe('flow with pause', () => {
         })
     })
 
-    it('should pause at most one flow when router has multiple branches with pause actions', async () => {
+    it('should pause at most one action when router has multiple branches with pause actions', async () => {
         const routerWithTwoPauseActions = buildRouterWithOneCondition({
             conditions: [
                 {

--- a/packages/engine/test/handler/flow-with-pause.test.ts
+++ b/packages/engine/test/handler/flow-with-pause.test.ts
@@ -247,11 +247,11 @@ describe('flow with pause', () => {
             'reason': 'PAUSED',
         })
 
-        const routerOutput = result.steps.router
+        const routerOutput = result.steps.router as RouterStepOutput
         expect(routerOutput).toBeDefined()
         expect(routerOutput.output).toBeDefined()
         
-        const executedBranches = (routerOutput.output as any)?.branches?.filter((branch: any) => branch.evaluation === true)
+        const executedBranches = routerOutput.output?.branches?.filter((branch) => branch.evaluation === true)
         expect(executedBranches).toHaveLength(2)
         
         expect(result.steps.approval_1).toBeDefined()

--- a/packages/server/api/src/app/ee/authentication/enterprise-local-authn/enterprise-local-authn-controller.ts
+++ b/packages/server/api/src/app/ee/authentication/enterprise-local-authn/enterprise-local-authn-controller.ts
@@ -15,7 +15,7 @@ export const enterpriseLocalAuthnController: FastifyPluginAsyncTypebox = async (
             action: ApplicationEventName.USER_EMAIL_VERIFIED,
             data: {},
         })
-        return await enterpriseLocalAuthnService(req.log).verifyEmail(req.body)
+        return enterpriseLocalAuthnService(req.log).verifyEmail(req.body)
     })
 
     app.post('/reset-password', ResetPasswordRequest, async (req) => {

--- a/packages/server/api/src/app/ee/authentication/enterprise-local-authn/enterprise-local-authn-service.ts
+++ b/packages/server/api/src/app/ee/authentication/enterprise-local-authn/enterprise-local-authn-service.ts
@@ -17,7 +17,7 @@ export const enterpriseLocalAuthnService = (log: FastifyBaseLogger) => ({
             log,
         })
 
-        return await userIdentityService(log).verify(identityId)
+        return userIdentityService(log).verify(identityId)
     },
 
     async resetPassword({

--- a/packages/server/api/src/app/ee/platform/platform-plan/stripe-helper.ts
+++ b/packages/server/api/src/app/ee/platform/platform-plan/stripe-helper.ts
@@ -44,7 +44,7 @@ export const stripeHelper = (log: FastifyBaseLogger) => ({
             description: `Platform ID: ${platformId}, user ${user.id}`,
             metadata: {
                 platformId,
-                customer_key: `ps_cus_key_${user.email}`
+                customer_key: `ps_cus_key_${user.email}`,
             },
         })
 


### PR DESCRIPTION
## What does this PR do?

Fixes #7202 
