### PR TITLE
feat(mailchimp): custom api call action

### DIFF
--- a/packages/pieces/community/mailchimp/package.json
+++ b/packages/pieces/community/mailchimp/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-mailchimp",
-  "version": "0.3.7"
+  "version": "0.3.8"
 }

--- a/packages/pieces/community/mailchimp/src/index.ts
+++ b/packages/pieces/community/mailchimp/src/index.ts
@@ -1,4 +1,4 @@
-import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { OAuth2PropertyValue, PieceAuth, createPiece } from '@activepieces/pieces-framework';
 import { addMemberToList } from './lib/actions/add-member-to-list';
 import { addNoteToSubscriber } from './lib/actions/add-note-to-subscriber';
 import { removeSubscriberFromTag } from './lib/actions/remove-subscriber-from-tag';
@@ -8,6 +8,7 @@ import { PieceCategory } from '@activepieces/shared';
 import { addSubscriberToTag } from './lib/actions/add-subscriber-to-tag';
 import { mailChimpSubscribeTrigger } from './lib/triggers/subscribe-trigger';
 import { mailChimpUnsubscriberTrigger } from './lib/triggers/unsubscribe-trigger';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
 
 export const mailchimpAuth = PieceAuth.OAuth2({
   description: '',
@@ -32,6 +33,15 @@ export const mailchimp = createPiece({
     addSubscriberToTag,
     removeSubscriberFromTag,
     updateSubscriberInList,
+    createCustomApiCallAction({
+      auth: mailchimpAuth,
+			baseUrl: () => {
+        return `https://{mailChimpServerPrefix}.api.mailchimp.com/3.0/`;
+      },
+			authMapping: async (auth) => ({
+					Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`
+			}),
+    }),
   ],
   triggers: [mailChimpSubscribeTrigger, mailChimpUnsubscriberTrigger],
 });


### PR DESCRIPTION
## What does this PR do?

This PR introduces a custom API call action to the Mailchimp piece in Active Pieces. It empowers users to send arbitrary API requests to Mailchimp, providing greater flexibility beyond the predefined actions.

### Explain How the Feature Works
This custom action lets users define:
- HTTP method (GET, POST, etc.)
- Endpoint path and full URL
- Headers and request body

Due to the asynchronous nature of the getMailChimpServerPrefix function, we cannot use it in the baseUrl property. Instead, the base URL in this action uses a placeholder ({mailChimpServerPrefix}) in documentation only — users must manually replace this with their actual Mailchimp server prefix (e.g., https://us17.api.mailchimp.com). This gives users full control over the API call destination while working within current platform constraints.

### Relevant User Scenarios
- A user needs to call a Mailchimp API endpoint that isn’t yet supported as a built-in action.
- Advanced users want to interact with Mailchimp resources like tags, automations, or campaign analytics.
- Developers testing or debugging Mailchimp endpoints directly within Active Pieces.

### Fixes # (issue)