### PR TITLE
fix: Twitter Create tweet media type

### DIFF
--- a/packages/pieces/community/twitter/src/lib/actions/create-tweet.ts
+++ b/packages/pieces/community/twitter/src/lib/actions/create-tweet.ts
@@ -44,7 +44,7 @@ export const createTweet = createAction({
       media.forEach((m) => {
         uploadedMedia.push(
           userClient.v1.uploadMedia(Buffer.from(m.base64, 'base64'), {
-            mimeType: 'image/png',
+           mimeType: m.mimeType ?? 'image/png',
             target: 'tweet',
           })
         );


### PR DESCRIPTION
Dynamically taken mimeType from media file property instead of hard hard-coded type.

## What does this PR do?

Takes the media file type dynamically instead of being hard-coded. enabling it to handle video files too, previously it handled images only.

### Explain How the Feature Works

Takes the media file type dynamically instead of being hard-coded. enabling it to handle video files too, previously it handled images only.

### Relevant User Scenarios
Uploading video files to tweets


Fixes #8573


