### PR TITLE
feat: add new action set-metadata to image-helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activepieces",
-  "version": "0.66.3",
+  "version": "0.66.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activepieces",
-      "version": "0.66.3",
+      "version": "0.66.4",
       "dependencies": {
         "@activepieces/import-fresh-webpack": "3.3.0",
         "@ai-sdk/anthropic": "1.2.12",
@@ -205,6 +205,7 @@
         "nanoid": "3.3.8",
         "next-themes": "0.4.6",
         "node-cron": "3.0.3",
+        "node-exiftool": "2.3.0",
         "nodemailer": "6.9.9",
         "notion-to-md": "3.1.1",
         "nx-cloud": "19.1.0",
@@ -26407,6 +26408,12 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
+    "node_modules/catchment": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/catchment/-/catchment-1.0.0.tgz",
+      "integrity": "sha512-6sTXWtTXI+MTHrHVnvZnOM8q2ujbQ+qJF0Mu8NM3jifMBCiZssjol/nBHQqOEiKSZKf1e4+wCrgmTXzWzvZs5w==",
+      "license": "MIT"
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -41966,6 +41973,12 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/makepromise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/makepromise/-/makepromise-1.0.0.tgz",
+      "integrity": "sha512-M1q31Q56rlA+gwvmfWj7QFDMIJOuj527fQx/rN3dlzUtsopC9ZjtyekIBW4Fw0HZP6O6Azuw3/Vtk5O59bXz7A==",
+      "license": "MIT"
+    },
     "node_modules/map-obj": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -44374,6 +44387,26 @@
       ],
       "engines": {
         "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-exiftool": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-exiftool/-/node-exiftool-2.3.0.tgz",
+      "integrity": "sha512-UZd+k07thqXqp/1udsZghAFrjrsYfP8Kg48I9uv02FZAmT1Wasr8aAPMCObnYkJiWoD/V8UrGjiSzgfNQy9zBw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "1.1.0",
+        "restream": "1.2.0",
+        "wrote": "0.6.1"
+      }
+    },
+    "node_modules/node-exiftool/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/node-fetch": {
@@ -54295,6 +54328,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/restream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/restream/-/restream-1.2.0.tgz",
+      "integrity": "sha512-RpnOjVCRrc/jO6j1U+E0X9mPjMUUitjEms/IaR18wb8AdPHg46UBmB2aEA6JKgpGbhOcHsDLyurmeZhd4kQXgg==",
+      "license": "MIT"
+    },
     "node_modules/ret": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
@@ -63858,6 +63897,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/wrote": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/wrote/-/wrote-0.6.1.tgz",
+      "integrity": "sha512-5vDwEuRou4yCOzR08bUdY+n/HuOA21L7A4tVsm/kEu2R2APN8tYWvxQbM1hFJk49lR7x47KZMtCu2k8S9WISUA==",
+      "license": "MIT",
+      "dependencies": {
+        "catchment": "1.0.0",
+        "makepromise": "1.0.0"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "nanoid": "3.3.8",
     "next-themes": "0.4.6",
     "node-cron": "3.0.3",
+    "node-exiftool": "2.3.0",
     "nodemailer": "6.9.9",
     "notion-to-md": "3.1.1",
     "nx-cloud": "19.1.0",

--- a/packages/pieces/community/image-helper/package.json
+++ b/packages/pieces/community/image-helper/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@activepieces/piece-image-helper",
   "version": "0.1.2",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "jimp": "^0.22.12"
   }

--- a/packages/pieces/community/image-helper/src/helpers/index.ts
+++ b/packages/pieces/community/image-helper/src/helpers/index.ts
@@ -1,0 +1,6 @@
+import fs from 'fs';
+
+export function is_exiftool_installed(): boolean {
+  const exiftoolPath = '/usr/bin/exiftool';
+  return fs.existsSync(exiftoolPath);
+}

--- a/packages/pieces/community/image-helper/src/index.ts
+++ b/packages/pieces/community/image-helper/src/index.ts
@@ -5,7 +5,9 @@ import { getMetaData } from './lib/actions/get-metadata.action';
 import { cropImage } from './lib/actions/crop-image.action';
 import { rotateImage } from './lib/actions/rotate-image.action';
 import { resizeImage } from './lib/actions/resize-Image.action';
+import { setMetaData } from './lib/actions/set-metadata.action';
 import { compressImage } from './lib/actions/compress-image.actions';
+import { is_exiftool_installed } from './helpers';
 
 export const imageHelper = createPiece({
   displayName: 'Image Helper',
@@ -14,8 +16,16 @@ export const imageHelper = createPiece({
   auth: PieceAuth.None(),
   minimumSupportedRelease: '0.30.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/image-helper.png',
-  authors: ["AbdullahBitar","kishanprmr","abuaboud"],
+  authors: ['AbdullahBitar', 'kishanprmr', 'abuaboud'],
   categories: [PieceCategory.CORE],
-  actions: [imageToBase64, getMetaData, cropImage, rotateImage, resizeImage, compressImage],
+  actions: [
+    imageToBase64,
+    getMetaData,
+    cropImage,
+    rotateImage,
+    resizeImage,
+    compressImage,
+    ...(is_exiftool_installed() ? [setMetaData] : []),
+  ],
   triggers: [],
 });

--- a/packages/pieces/community/image-helper/src/lib/actions/set-metadata.action.ts
+++ b/packages/pieces/community/image-helper/src/lib/actions/set-metadata.action.ts
@@ -1,0 +1,45 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import jimp from 'jimp';
+import exiftool from 'node-exiftool';
+
+export const setMetaData = createAction({
+  name: 'set_meta_data',
+  description: 'Sets metadata to an image',
+  displayName: 'Set image metadata',
+  props: {
+    image: Property.File({
+      displayName: 'Image',
+      required: true,
+    }),
+    metadata: Property.Json({
+      displayName: 'Metadata',
+      required: true,
+    }),
+    resultFileName: Property.ShortText({
+      displayName: 'Result File Name',
+      description:
+        'Specifies the output file name for the result image (without extension).',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const image = await jimp.read(context.propsValue.image.data);
+    const fileName =
+      (context.propsValue.resultFileName ?? 'image') +
+      '.' +
+      image.getExtension();
+    const imageBuffer = await image.getBufferAsync(image.getMIME());
+    const imageReference = await context.files.write({
+      fileName: fileName,
+      data: imageBuffer,
+    });
+
+    const exifProcess = new exiftool.ExiftoolProcess();
+    await exifProcess.open();
+    await exifProcess.writeMetadata(fileName, context.propsValue.metadata);
+
+    await exifProcess.close();
+
+    return imageReference;
+  },
+});

--- a/packages/pieces/community/image-helper/src/types.d.ts
+++ b/packages/pieces/community/image-helper/src/types.d.ts
@@ -1,0 +1,7 @@
+declare module 'node-exiftool' {
+  export class ExiftoolProcess {
+    open(): Promise<void>;
+    writeMetadata(fileName: string, metadata: Record<string, unknown>): Promise<void>;
+    close(): Promise<void>;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Add a setter that is the counterpart of the getter for image metadata.

### Explain How the Feature Works

1. Get the image data and write a file.
2. Edit that file with `node-exiftool`.

### Relevant User Scenarios

Add metadata like dates, flow ID or prompt for AI generated images.