### PR TITLE
feat: add getEvents action to retrieve events over period of time

### DIFF
--- a/packages/pieces/community/dimo/src/lib/actions/telemetry/action.ts
+++ b/packages/pieces/community/dimo/src/lib/actions/telemetry/action.ts
@@ -209,6 +209,52 @@ const getDailyAvgSpeedOfVehicleAction = createAction({
 	},
 });
 
+const getEvents = createAction({
+	auth: dimoAuth,
+	name: 'telemetry-event',
+	displayName: 'Telemetry: Events',
+	description: 'Get the vehicle events over a specific time period.',
+	props: {
+		vehicleTokenId: Property.Number({
+		displayName: 'Vehicle Token ID',
+		required: true,
+	}),
+	...telemetryApiDateInputProps,
+    },
+	async run(context) {
+		const { clientId, apiKey, redirectUri } = context.auth;
+		const { vehicleTokenId, startDate, endDate } = context.propsValue;
+
+		const dimo = new DimoClient({
+			clientId,
+			apiKey,
+			redirectUri,
+		});
+
+        try {
+			const developerJwt = await dimo.getDeveloperJwt();
+
+			const vehicleJwt = await dimo.getVehicleJwt({ developerJwt, tokenId: vehicleTokenId });
+
+			const query = TelemetryQueries.getEvents
+				.replace('<tokenId>', String(vehicleTokenId))
+				.replace('<startDate>', startDate)
+				.replace('<endDate>', endDate);
+
+			const response = await dimo.sendTelemetryGraphQLRequest({
+				vehiclejwt: vehicleJwt,
+				query,
+				variables: {},
+			});
+
+			return response;
+		} catch (err) {
+			const message = (err as HttpError).message;
+			throw new Error(message);
+		}
+    },
+});
+
 const getMaxSpeedOfVehicleAction = createAction({
 	auth: dimoAuth,
 	name: 'telemetry-max-speed',
@@ -304,6 +350,7 @@ export const telemetryApiActions = [
 	availableSignalsAction,
 	signalsAction,
 	getDailyAvgSpeedOfVehicleAction,
+	getEvents,
 	getMaxSpeedOfVehicleAction,
 	getVinVcLatestAction,
 ];

--- a/packages/pieces/community/dimo/src/lib/common/queries.ts
+++ b/packages/pieces/community/dimo/src/lib/common/queries.ts
@@ -224,6 +224,18 @@ export const TelemetryQueries = {
       }
     }
   `,
+  getEvents: `
+    query {
+      events(
+        tokenId: <tokenId>,
+        from: "<startDate>", to: "<endDate>"
+      ) {
+        name
+        metadata
+        timestamp
+      }
+    }
+  `,
 	getMaxSpeedOfVehicle: `
     query {
       signals(


### PR DESCRIPTION
## What does this PR do?

Add new query for `getEvents` under Telemetry API


### Explain How the Feature Works
Gets a list of driving events such as `HarshBraking` or `HarshCornering`.

### Relevant User Scenarios
In use cases such as a teen driving coach, this DIMO-identified event comes in handy.


Fixes # (issue)
