### PR TITLE
fix: skip flow migration if already on latest version

### DIFF
--- a/packages/server/api/src/app/flows/flow-version/flow-version-migration.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/flow-version-migration.service.ts
@@ -1,4 +1,4 @@
-import { flowMigrations, FlowVersion, spreadIfDefined } from '@activepieces/shared'
+import { flowMigrations, FlowVersion, LATEST_SCHEMA_VERSION, spreadIfDefined } from '@activepieces/shared'
 import { system } from '../../helper/system/system'
 import { flowVersionRepo } from './flow-version.service'
 
@@ -6,6 +6,11 @@ const log = system.globalLogger()
 
 export const flowVersionMigrationService = {
     async migrate(flowVersion: FlowVersion): Promise<FlowVersion> {
+        // Early exit if already at latest version
+        if (flowVersion.schemaVersion === LATEST_SCHEMA_VERSION) {
+            return flowVersion
+        }
+
         log.info('Starting flow version migration')
 
         const migratedFlowVersion: FlowVersion = flowMigrations.apply(flowVersion)


### PR DESCRIPTION
## What does this PR do?

This is a performance regression. By performing the migration first and then only checking the version, thousands of unnecessary DB calls are made each time a flow is accessed (which is all the time).

### Explain How the Feature Works

We early exit if flow schema version is equal to latest schema version.

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
