### PR TITLE
feat: google chat

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,4 +12,5 @@
     "typescript.tsdk": "node_modules/typescript/lib",
     "javascript.preferences.importModuleSpecifier": "relative",
     "nxConsole.generateAiAgentRules": true,
+    "window.autoDetectColorScheme": true,
 }

--- a/packages/pieces/community/api-template/README.md
+++ b/packages/pieces/community/api-template/README.md
@@ -1,0 +1,7 @@
+# pieces-api-template
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-api-template` to build the library.

--- a/packages/pieces/community/api-template/package.json
+++ b/packages/pieces/community/api-template/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-api-template",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/api-template/project.json
+++ b/packages/pieces/community/api-template/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-api-template",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/api-template/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/api-template",
+        "tsConfig": "packages/pieces/community/api-template/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/api-template/package.json",
+        "main": "packages/pieces/community/api-template/src/index.ts",
+        "assets": [
+          "packages/pieces/community/api-template/*.md",
+          {
+            "input": "packages/pieces/community/api-template/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/api-template/src/index.ts
+++ b/packages/pieces/community/api-template/src/index.ts
@@ -1,0 +1,44 @@
+
+    import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { apitemplateCreateImageAction } from "./lib/actions/create-image";
+import { apitemplateCreatePdfAction } from "./lib/actions/create-pdf";
+import { apitemplateCreatePdfFromHtmlAction } from "./lib/actions/create-pdf-from-html";
+import { apitemplateCreatePdfFromUrlAction } from "./lib/actions/create-pdf-from-url";
+import { apitemplateCreatePdfAdvancedAction } from "./lib/actions/create-pdf-advanced";
+import { apitemplateDeleteObjectAction } from "./lib/actions/delete-object";
+import { apitemplateGetAccountInformationAction } from "./lib/actions/get-account-information";
+import { apitemplateListObjectsAction } from "./lib/actions/list-objects";
+
+export const apitemplateAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: `
+    To obtain your API key, follow these steps:
+
+    1. Sign up for an account at APITemplate.io
+    2. Go to the web console under "API Integration" section
+    3. Copy your API key
+    4. Use this API key for authentication
+  `,
+});
+
+export const apiTemplate = createPiece({
+  displayName: "APITemplate.io",
+  description: "Dynamic document automation platform that generates PDFs and images from templates and JSON data.",
+  auth: apitemplateAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: "https://cdn.activepieces.com/pieces/api-template.png",
+  authors: [],
+          actions: [
+          apitemplateCreateImageAction,
+          apitemplateCreatePdfAction,
+          apitemplateCreatePdfFromHtmlAction,
+          apitemplateCreatePdfFromUrlAction,
+          apitemplateCreatePdfAdvancedAction,
+          apitemplateDeleteObjectAction,
+          apitemplateGetAccountInformationAction,
+          apitemplateListObjectsAction,
+        ],
+  triggers: [],
+});
+    

--- a/packages/pieces/community/api-template/src/lib/actions/create-image.ts
+++ b/packages/pieces/community/api-template/src/lib/actions/create-image.ts
@@ -1,0 +1,258 @@
+import {
+  createAction,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  httpClient,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { apitemplateAuth } from '../../index';
+
+export const apitemplateCreateImageAction = createAction({
+  auth: apitemplateAuth,
+  name: 'create_image',
+  displayName: 'Create Image',
+  description: 'Generate an image from a template using JSON overrides',
+  props: {
+    template_id: Property.Dropdown({
+      displayName: 'Template',
+      description: 'Select a template to use for image generation',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please connect your account first',
+          };
+        }
+
+        try {
+          const response = await httpClient.sendRequest<{
+            status: string;
+            templates: Array<{
+              template_id: string;
+              name: string;
+              status: string;
+              format: string;
+              created_at: string;
+              updated_at: string;
+              group_name: string;
+            }>;
+          }>({
+            method: HttpMethod.GET,
+            url: 'https://rest.apitemplate.io/v2/list-templates',
+            headers: {
+              'X-API-KEY': auth as string,
+              'Content-Type': 'application/json',
+            },
+            queryParams: {
+              limit: '300',
+              format: 'JPEG',
+            } as Record<string, string>,
+          });
+
+          if (response.status === 200 && response.body.status === 'success') {
+            return {
+              disabled: false,
+              options: response.body.templates
+                .filter(template => template.status === 'ACTIVE')
+                .map(template => ({
+                  label: `${template.name} (${template.format})`,
+                  value: template.template_id,
+                })),
+            };
+          }
+
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Failed to load templates',
+          };
+        } catch (error) {
+          console.error('Error fetching templates:', error);
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Error loading templates. Please check your API key.',
+          };
+        }
+      },
+    }),
+    output_image_type: Property.StaticDropdown({
+      displayName: 'Output Image Type',
+      description: 'Output image type (JPEG or PNG format), default to all',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'All', value: 'all' },
+          { label: 'JPEG Only', value: 'jpegOnly' },
+          { label: 'PNG Only', value: 'pngOnly' },
+        ],
+      },
+      defaultValue: 'all',
+    }),
+    expiration: Property.Number({
+      displayName: 'Expiration (minutes)',
+      description: 'Expiration of the generated image in minutes (0 = store permanently, 1-10080 minutes = 7 days)',
+      required: false,
+      defaultValue: 0,
+    }),
+    cloud_storage: Property.StaticDropdown({
+      displayName: 'Cloud Storage',
+      description: 'Upload the generated images to our storage CDN',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    generation_delay: Property.Number({
+      displayName: 'Generation Delay (ms)',
+      description: 'Delay in milliseconds before image generation',
+      required: false,
+    }),
+    resize_images: Property.StaticDropdown({
+      displayName: 'Resize Images',
+      description: 'Preprocess images or re-size images in the image',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    resize_max_width: Property.Number({
+      displayName: 'Resize Max Width (pixels)',
+      description: 'Maximum width of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_max_height: Property.Number({
+      displayName: 'Resize Max Height (pixels)',
+      description: 'Maximum height of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_format: Property.StaticDropdown({
+      displayName: 'Resize Format',
+      description: 'Format of the resized image',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'JPEG', value: 'jpeg' },
+          { label: 'PNG', value: 'png' },
+        ],
+      },
+      defaultValue: 'jpeg',
+    }),
+    postaction_s3_filekey: Property.ShortText({
+      displayName: 'Post Action S3 File Key',
+      description: 'File name for Post Action (AWS S3/Cloudflare R2/Azure Storage). Do not specify file extension.',
+      required: false,
+    }),
+    postaction_s3_bucket: Property.ShortText({
+      displayName: 'Post Action S3 Bucket',
+      description: 'AWS Bucket for Post Action (AWS S3/Cloudflare R2 Storage) or container for Post Action (Azure Storage)',
+      required: false,
+    }),
+    postaction_enabled: Property.StaticDropdown({
+      displayName: 'Post Action Enabled',
+      description: 'Enable Post Actions',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    meta: Property.ShortText({
+      displayName: 'Meta',
+      description: 'External reference ID for your own reference. It appears in the list-objects API.',
+      required: false,
+    }),
+    overrides: Property.Json({
+      displayName: 'JSON Overrides',
+      description: 'JSON data with overrides for the template',
+      required: true,
+      defaultValue: {
+        overrides: [
+          {
+            name: "<object name 1>",
+            property_1: "<value 1>",
+            property_2: "<value 2>",
+            property_3: "<value 3>"
+          }
+        ]
+      },
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      template_id,
+      output_image_type,
+      expiration,
+      cloud_storage,
+      generation_delay,
+      resize_images,
+      resize_max_width,
+      resize_max_height,
+      resize_format,
+      postaction_s3_filekey,
+      postaction_s3_bucket,
+      postaction_enabled,
+      meta,
+      overrides,
+    } = context.propsValue;
+
+    const queryParams: Record<string, string | number> = {
+      template_id,
+    };
+
+    // Add optional query parameters
+    if (output_image_type) queryParams['output_image_type'] = output_image_type;
+    if (expiration !== undefined) queryParams['expiration'] = expiration;
+    if (cloud_storage !== undefined) queryParams['cloud_storage'] = cloud_storage;
+    if (generation_delay !== undefined) queryParams['generation_delay'] = generation_delay;
+    if (resize_images !== undefined) queryParams['resize_images'] = resize_images;
+    if (resize_max_width !== undefined) queryParams['resize_max_width'] = resize_max_width;
+    if (resize_max_height !== undefined) queryParams['resize_max_height'] = resize_max_height;
+    if (resize_format) queryParams['resize_format'] = resize_format;
+    if (postaction_s3_filekey) queryParams['postaction_s3_filekey'] = postaction_s3_filekey;
+    if (postaction_s3_bucket) queryParams['postaction_s3_bucket'] = postaction_s3_bucket;
+    if (postaction_enabled !== undefined) queryParams['postaction_enabled'] = postaction_enabled;
+    if (meta) queryParams['meta'] = meta;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.apitemplate.io/v1/create',
+      headers: {
+        'X-API-KEY': auth,
+        'Content-Type': 'application/json',
+      },
+      queryParams: queryParams as Record<string, string>,
+      body: overrides,
+    });
+
+    if (response.status === 200) {
+      return response.body;
+    }
+
+    throw new Error(`Failed to create image: ${response.status}`);
+  },
+}); 

--- a/packages/pieces/community/api-template/src/lib/actions/create-pdf-advanced.ts
+++ b/packages/pieces/community/api-template/src/lib/actions/create-pdf-advanced.ts
@@ -1,0 +1,394 @@
+import {
+  createAction,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { apitemplateAuth } from '../../index';
+
+export const apitemplateCreatePdfAdvancedAction = createAction({
+  auth: apitemplateAuth,
+  name: 'create_pdf_advanced',
+  displayName: 'Create PDF (Advanced)',
+  description: 'Generate a PDF with custom filename, CMYK/color settings, resolution, and template options',
+  props: {
+    template_id: Property.Dropdown({
+      displayName: 'Template',
+      description: 'Select a template to use for PDF generation',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please connect your account first',
+          };
+        }
+
+        try {
+          const response = await httpClient.sendRequest<{
+            status: string;
+            templates: Array<{
+              template_id: string;
+              name: string;
+              status: string;
+              format: string;
+              created_at: string;
+              updated_at: string;
+              group_name: string;
+            }>;
+          }>({
+            method: HttpMethod.GET,
+            url: 'https://rest.apitemplate.io/v2/list-templates',
+            headers: {
+              'X-API-KEY': auth as string,
+              'Content-Type': 'application/json',
+            },
+            queryParams: {
+              limit: '300',
+              format: 'PDF',
+            } as Record<string, string>,
+          });
+
+          if (response.status === 200 && response.body.status === 'success') {
+            return {
+              disabled: false,
+              options: response.body.templates
+                .filter(template => template.status === 'ACTIVE')
+                .map(template => ({
+                  label: `${template.name} (${template.format})`,
+                  value: template.template_id,
+                })),
+            };
+          }
+
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Failed to load templates',
+          };
+        } catch (error) {
+          console.error('Error fetching templates:', error);
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Error loading templates. Please check your API key.',
+          };
+        }
+      },
+    }),
+    export_type: Property.StaticDropdown({
+      displayName: 'Export Type',
+      description: 'Either file or json (Default). File returns binary data, json returns a JSON object with CDN URL',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'JSON (CDN URL)', value: 'json' },
+          { label: 'File (Binary)', value: 'file' },
+        ],
+      },
+      defaultValue: 'json',
+    }),
+    export_in_base64: Property.StaticDropdown({
+      displayName: 'Export in Base64',
+      description: 'If export_type = file, the PDF can be downloaded in binary or base64 format',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Binary (Default)', value: 0 },
+          { label: 'Base64', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    expiration: Property.Number({
+      displayName: 'Expiration (minutes)',
+      description: 'Expiration of the generated PDF in minutes (0 = store permanently, 1-10080 minutes = 7 days)',
+      required: false,
+      defaultValue: 0,
+    }),
+    output_html: Property.StaticDropdown({
+      displayName: 'Output HTML',
+      description: 'Enable output of html content in JSON response',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    output_format: Property.StaticDropdown({
+      displayName: 'Output Format',
+      description: 'Specifies the desired output format',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'PDF (Default)', value: 'pdf' },
+          { label: 'HTML', value: 'html' },
+          { label: 'PNG', value: 'png' },
+          { label: 'JPEG', value: 'jpeg' },
+        ],
+      },
+      defaultValue: 'pdf',
+    }),
+    filename: Property.ShortText({
+      displayName: 'Custom Filename',
+      description: 'Custom file name (should end with .pdf). Defaults to UUID if not specified',
+      required: false,
+    }),
+    direct_download: Property.StaticDropdown({
+      displayName: 'Direct Download',
+      description: 'ContentDisposition set to attachment',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    cloud_storage: Property.StaticDropdown({
+      displayName: 'Cloud Storage',
+      description: 'Upload the generated PDFs to our storage CDN',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled (Default)', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    load_data_from: Property.ShortText({
+      displayName: 'Load Data From URL',
+      description: 'Load JSON data from a remote URL instead of the request body',
+      required: false,
+    }),
+    extract_link: Property.StaticDropdown({
+      displayName: 'Extract Links',
+      description: 'Extract links from the HTML content',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    generation_delay: Property.Number({
+      displayName: 'Generation Delay (ms)',
+      description: 'Delay in milliseconds before PDF generation',
+      required: false,
+    }),
+    image_resample_res: Property.Number({
+      displayName: 'Image Resample Resolution (DPI)',
+      description: 'Downsample images to reduce PDF file size. Common values: 72, 96, 150, 300, 600',
+      required: false,
+    }),
+    resize_images: Property.StaticDropdown({
+      displayName: 'Resize Images',
+      description: 'Preprocess images or re-size images in the PDF',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    resize_max_width: Property.Number({
+      displayName: 'Resize Max Width (pixels)',
+      description: 'Maximum width of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_max_height: Property.Number({
+      displayName: 'Resize Max Height (pixels)',
+      description: 'Maximum height of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_format: Property.StaticDropdown({
+      displayName: 'Resize Format',
+      description: 'Format of the resized image',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'JPEG', value: 'jpeg' },
+          { label: 'PNG', value: 'png' },
+        ],
+      },
+      defaultValue: 'jpeg',
+    }),
+    postaction_s3_filekey: Property.ShortText({
+      displayName: 'Post Action S3 File Key',
+      description: 'File name for Post Action (AWS S3/Cloudflare R2/Azure Storage). Do not specify file extension.',
+      required: false,
+    }),
+    postaction_s3_bucket: Property.ShortText({
+      displayName: 'Post Action S3 Bucket',
+      description: 'AWS Bucket for Post Action (AWS S3/Cloudflare R2 Storage) or container for Post Action (Azure Storage)',
+      required: false,
+    }),
+    postaction_enabled: Property.StaticDropdown({
+      displayName: 'Post Action Enabled',
+      description: 'Enable Post Actions',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled (Default)', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    meta: Property.ShortText({
+      displayName: 'Meta',
+      description: 'External reference ID for your own reference. It appears in the list-objects API.',
+      required: false,
+    }),
+    async: Property.StaticDropdown({
+      displayName: 'Async Generation',
+      description: 'Generate PDF asynchronously (requires webhook_url)',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Synchronous (Default)', value: 0 },
+          { label: 'Asynchronous', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    webhook_url: Property.ShortText({
+      displayName: 'Webhook URL',
+      description: 'URL for webhook callback when using async generation. Must start with http:// or https://',
+      required: false,
+    }),
+    webhook_method: Property.StaticDropdown({
+      displayName: 'Webhook Method',
+      description: 'The HTTP method of the webhook',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'GET (Default)', value: 'GET' },
+          { label: 'POST', value: 'POST' },
+        ],
+      },
+      defaultValue: 'GET',
+    }),
+    webhook_headers: Property.Json({
+      displayName: 'Webhook Headers',
+      description: 'The HTTP headers of the webhook, should be a base64 encoded JSON object',
+      required: false,
+    }),
+    overrides: Property.Json({
+      displayName: 'JSON Overrides',
+      description: 'JSON data with overrides for the template',
+      required: true,
+      defaultValue: {
+        invoice_number: "INV38379",
+        date: "2021-09-30",
+        currency: "USD",
+        total_amount: 82542.56
+      },
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      template_id,
+      export_type,
+      export_in_base64,
+      expiration,
+      output_html,
+      output_format,
+      filename,
+      direct_download,
+      cloud_storage,
+      load_data_from,
+      extract_link,
+      generation_delay,
+      image_resample_res,
+      resize_images,
+      resize_max_width,
+      resize_max_height,
+      resize_format,
+      postaction_s3_filekey,
+      postaction_s3_bucket,
+      postaction_enabled,
+      meta,
+      async,
+      webhook_url,
+      webhook_method,
+      webhook_headers,
+      overrides,
+    } = context.propsValue;
+
+    const queryParams: Record<string, string | number> = {
+      template_id,
+    };
+
+    // Add optional query parameters
+    if (export_type) queryParams['export_type'] = export_type;
+    if (export_in_base64 !== undefined) queryParams['export_in_base64'] = export_in_base64;
+    if (expiration !== undefined) queryParams['expiration'] = expiration;
+    if (output_html !== undefined) queryParams['output_html'] = output_html;
+    if (output_format) queryParams['output_format'] = output_format;
+    if (filename) queryParams['filename'] = filename;
+    if (direct_download !== undefined) queryParams['direct_download'] = direct_download;
+    if (cloud_storage !== undefined) queryParams['cloud_storage'] = cloud_storage;
+    if (load_data_from) queryParams['load_data_from'] = load_data_from;
+    if (extract_link !== undefined) queryParams['extract_link'] = extract_link;
+    if (generation_delay !== undefined) queryParams['generation_delay'] = generation_delay;
+    if (image_resample_res !== undefined) queryParams['image_resample_res'] = image_resample_res;
+    if (resize_images !== undefined) queryParams['resize_images'] = resize_images;
+    if (resize_max_width !== undefined) queryParams['resize_max_width'] = resize_max_width;
+    if (resize_max_height !== undefined) queryParams['resize_max_height'] = resize_max_height;
+    if (resize_format) queryParams['resize_format'] = resize_format;
+    if (postaction_s3_filekey) queryParams['postaction_s3_filekey'] = postaction_s3_filekey;
+    if (postaction_s3_bucket) queryParams['postaction_s3_bucket'] = postaction_s3_bucket;
+    if (postaction_enabled !== undefined) queryParams['postaction_enabled'] = postaction_enabled;
+    if (meta) queryParams['meta'] = meta;
+    if (async !== undefined) queryParams['async'] = async;
+    if (webhook_url) queryParams['webhook_url'] = webhook_url;
+    if (webhook_method) queryParams['webhook_method'] = webhook_method;
+    if (webhook_headers) queryParams['webhook_headers'] = webhook_headers;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://rest.apitemplate.io/v2/create-pdf',
+      headers: {
+        'X-API-KEY': auth as string,
+        'Content-Type': 'application/json',
+      },
+      queryParams: queryParams as Record<string, string>,
+      body: overrides,
+    });
+
+    if (response.status === 200) {
+      return response.body;
+    }
+
+    throw new Error(`Failed to create PDF: ${response.status}`);
+  },
+}); 

--- a/packages/pieces/community/api-template/src/lib/actions/create-pdf-from-html.ts
+++ b/packages/pieces/community/api-template/src/lib/actions/create-pdf-from-html.ts
@@ -1,0 +1,305 @@
+import {
+  createAction,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { apitemplateAuth } from '../../index';
+
+export const apitemplateCreatePdfFromHtmlAction = createAction({
+  auth: apitemplateAuth,
+  name: 'create_pdf_from_html',
+  displayName: 'Create PDF From HTML',
+  description: 'Generate a PDF from raw HTML (e.g., invoices built via custom HTML)',
+  props: {
+    export_type: Property.StaticDropdown({
+      displayName: 'Export Type',
+      description: 'Either file or json (Default). File returns binary data, json returns a JSON object with CDN URL',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'JSON (CDN URL)', value: 'json' },
+          { label: 'File (Binary)', value: 'file' },
+        ],
+      },
+      defaultValue: 'json',
+    }),
+    expiration: Property.Number({
+      displayName: 'Expiration (minutes)',
+      description: 'Expiration of the generated PDF in minutes (0 = store permanently, 1-10080 minutes = 7 days)',
+      required: false,
+      defaultValue: 0,
+    }),
+    output_format: Property.StaticDropdown({
+      displayName: 'Output Format',
+      description: 'Specifies the desired output format',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'PDF (Default)', value: 'pdf' },
+          { label: 'HTML', value: 'html' },
+          { label: 'PNG', value: 'png' },
+          { label: 'JPEG', value: 'jpeg' },
+        ],
+      },
+      defaultValue: 'pdf',
+    }),
+    filename: Property.ShortText({
+      displayName: 'Filename',
+      description: 'Custom file name (should end with .pdf). Defaults to UUID if not specified',
+      required: false,
+    }),
+    direct_download: Property.StaticDropdown({
+      displayName: 'Direct Download',
+      description: 'ContentDisposition set to attachment',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    cloud_storage: Property.StaticDropdown({
+      displayName: 'Cloud Storage',
+      description: 'Upload the generated PDFs to our storage CDN',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled (Default)', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    generation_delay: Property.Number({
+      displayName: 'Generation Delay (ms)',
+      description: 'Delay in milliseconds before PDF generation',
+      required: false,
+    }),
+    image_resample_res: Property.Number({
+      displayName: 'Image Resample Resolution (DPI)',
+      description: 'Downsample images to reduce PDF file size. Common values: 72, 96, 150, 300, 600',
+      required: false,
+    }),
+    resize_images: Property.StaticDropdown({
+      displayName: 'Resize Images',
+      description: 'Preprocess images or re-size images in the PDF',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    resize_max_width: Property.Number({
+      displayName: 'Resize Max Width (pixels)',
+      description: 'Maximum width of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_max_height: Property.Number({
+      displayName: 'Resize Max Height (pixels)',
+      description: 'Maximum height of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_format: Property.StaticDropdown({
+      displayName: 'Resize Format',
+      description: 'Format of the resized image',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'JPEG', value: 'jpeg' },
+          { label: 'PNG', value: 'png' },
+        ],
+      },
+      defaultValue: 'jpeg',
+    }),
+    postaction_s3_filekey: Property.ShortText({
+      displayName: 'Post Action S3 File Key',
+      description: 'File name for Post Action (AWS S3/Cloudflare R2/Azure Storage). Do not specify file extension.',
+      required: false,
+    }),
+    postaction_s3_bucket: Property.ShortText({
+      displayName: 'Post Action S3 Bucket',
+      description: 'AWS Bucket for Post Action (AWS S3/Cloudflare R2 Storage) or container for Post Action (Azure Storage)',
+      required: false,
+    }),
+    postaction_enabled: Property.StaticDropdown({
+      displayName: 'Post Action Enabled',
+      description: 'Enable Post Actions',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled (Default)', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    meta: Property.ShortText({
+      displayName: 'Meta',
+      description: 'External reference ID for your own reference. It appears in the list-objects API.',
+      required: false,
+    }),
+    async: Property.StaticDropdown({
+      displayName: 'Async Generation',
+      description: 'Generate PDF asynchronously (requires webhook_url)',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Synchronous (Default)', value: 0 },
+          { label: 'Asynchronous', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    webhook_url: Property.ShortText({
+      displayName: 'Webhook URL',
+      description: 'URL for webhook callback when using async generation. Must start with http:// or https://',
+      required: false,
+    }),
+    webhook_method: Property.StaticDropdown({
+      displayName: 'Webhook Method',
+      description: 'The HTTP method of the webhook',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'GET (Default)', value: 'GET' },
+          { label: 'POST', value: 'POST' },
+        ],
+      },
+      defaultValue: 'GET',
+    }),
+    body: Property.LongText({
+      displayName: 'HTML Body',
+      description: 'The HTML body content for the PDF. Supports HTML markup and Jinja2 syntax (e.g., {{name}}). The value of {{name}} will be replaced with the actual value provided in the data object.',
+      required: true,
+      defaultValue: '<h1>Hello World {{name}}</h1>',
+    }),
+    css: Property.LongText({
+      displayName: 'CSS Styles',
+      description: 'The CSS styles to be applied to the PDF. Should contain valid CSS markup and include the style tag.',
+      required: false,
+      defaultValue: '<style>.bg{background: red;}</style>',
+    }),
+    data: Property.Json({
+      displayName: 'Dynamic Data',
+      description: 'The data object containing values for dynamic content in the HTML body. This object should include properties with corresponding values.',
+      required: false,
+      defaultValue: {
+        name: "This is a title"
+      },
+    }),
+    settings: Property.Json({
+      displayName: 'PDF Generation Settings',
+      description: 'The settings object contains various properties to configure the PDF generation.',
+      required: false,
+      defaultValue: {
+        paper_size: "A4",
+        orientation: "1",
+        header_font_size: "9px",
+        margin_top: "40",
+        margin_right: "10",
+        margin_bottom: "40",
+        margin_left: "10",
+        print_background: "1",
+        displayHeaderFooter: true,
+        custom_header: "<style>#header, #footer { padding: 0 !important; }</style>\n<table style=\"width: 100%; padding: 0px 5px;margin: 0px!important;font-size: 15px\">\n  <tr>\n    <td style=\"text-align:left; width:30%!important;\"><span class=\"date\"></span></td>\n    <td style=\"text-align:center; width:30%!important;\"><span class=\"pageNumber\"></span></td>\n    <td style=\"text-align:right; width:30%!important;\"><span class=\"totalPages\"></span></td>\n  </tr>\n</table>",
+        custom_footer: "<style>#header, #footer { padding: 0 !important; }</style>\n<table style=\"width: 100%; padding: 0px 5px;margin: 0px!important;font-size: 15px\">\n  <tr>\n    <td style=\"text-align:left; width:30%!important;\"><span class=\"date\"></span></td>\n    <td style=\"text-align:center; width:30%!important;\"><span class=\"pageNumber\"></span></td>\n    <td style=\"text-align:right; width:30%!important;\"><span class=\"totalPages\"></span></td>\n  </tr>\n</table>"
+      },
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      export_type,
+      expiration,
+      output_format,
+      filename,
+      direct_download,
+      cloud_storage,
+      generation_delay,
+      image_resample_res,
+      resize_images,
+      resize_max_width,
+      resize_max_height,
+      resize_format,
+      postaction_s3_filekey,
+      postaction_s3_bucket,
+      postaction_enabled,
+      meta,
+      async,
+      webhook_url,
+      webhook_method,
+      body,
+      css,
+      data,
+      settings,
+    } = context.propsValue;
+
+    const queryParams: Record<string, string | number> = {};
+
+    // Add optional query parameters
+    if (export_type) queryParams['export_type'] = export_type;
+    if (expiration !== undefined) queryParams['expiration'] = expiration;
+    if (output_format) queryParams['output_format'] = output_format;
+    if (filename) queryParams['filename'] = filename;
+    if (direct_download !== undefined) queryParams['direct_download'] = direct_download;
+    if (cloud_storage !== undefined) queryParams['cloud_storage'] = cloud_storage;
+    if (generation_delay !== undefined) queryParams['generation_delay'] = generation_delay;
+    if (image_resample_res !== undefined) queryParams['image_resample_res'] = image_resample_res;
+    if (resize_images !== undefined) queryParams['resize_images'] = resize_images;
+    if (resize_max_width !== undefined) queryParams['resize_max_width'] = resize_max_width;
+    if (resize_max_height !== undefined) queryParams['resize_max_height'] = resize_max_height;
+    if (resize_format) queryParams['resize_format'] = resize_format;
+    if (postaction_s3_filekey) queryParams['postaction_s3_filekey'] = postaction_s3_filekey;
+    if (postaction_s3_bucket) queryParams['postaction_s3_bucket'] = postaction_s3_bucket;
+    if (postaction_enabled !== undefined) queryParams['postaction_enabled'] = postaction_enabled;
+    if (meta) queryParams['meta'] = meta;
+    if (async !== undefined) queryParams['async'] = async;
+    if (webhook_url) queryParams['webhook_url'] = webhook_url;
+    if (webhook_method) queryParams['webhook_method'] = webhook_method;
+
+    // Build request body
+    const requestBody: Record<string, any> = {
+      body,
+    };
+
+    if (css) requestBody['css'] = css;
+    if (data) requestBody['data'] = data;
+    if (settings) requestBody['settings'] = settings;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://rest.apitemplate.io/v2/create-pdf-from-html',
+      headers: {
+        'X-API-KEY': auth as string,
+        'Content-Type': 'application/json',
+      },
+      queryParams: queryParams as Record<string, string>,
+      body: requestBody,
+    });
+
+    if (response.status === 200) {
+      return response.body;
+    }
+
+    throw new Error(`Failed to create PDF from HTML: ${response.status}`);
+  },
+}); 

--- a/packages/pieces/community/api-template/src/lib/actions/create-pdf-from-url.ts
+++ b/packages/pieces/community/api-template/src/lib/actions/create-pdf-from-url.ts
@@ -1,0 +1,287 @@
+import {
+  createAction,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { apitemplateAuth } from '../../index';
+
+export const apitemplateCreatePdfFromUrlAction = createAction({
+  auth: apitemplateAuth,
+  name: 'create_pdf_from_url',
+  displayName: 'Create PDF From URL',
+  description: 'Generate a PDF from an external URL (e.g., archiving web content)',
+  props: {
+    export_type: Property.StaticDropdown({
+      displayName: 'Export Type',
+      description: 'Either file or json (Default). File returns binary data, json returns a JSON object with CDN URL',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'JSON (CDN URL)', value: 'json' },
+          { label: 'File (Binary)', value: 'file' },
+        ],
+      },
+      defaultValue: 'json',
+    }),
+    expiration: Property.Number({
+      displayName: 'Expiration (minutes)',
+      description: 'Expiration of the generated PDF in minutes (0 = store permanently, 1-10080 minutes = 7 days)',
+      required: false,
+      defaultValue: 0,
+    }),
+    output_format: Property.StaticDropdown({
+      displayName: 'Output Format',
+      description: 'Specifies the desired output format',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'PDF (Default)', value: 'pdf' },
+          { label: 'HTML', value: 'html' },
+          { label: 'PNG', value: 'png' },
+          { label: 'JPEG', value: 'jpeg' },
+        ],
+      },
+      defaultValue: 'pdf',
+    }),
+    filename: Property.ShortText({
+      displayName: 'Filename',
+      description: 'Custom file name (should end with .pdf). Defaults to UUID if not specified',
+      required: false,
+    }),
+    direct_download: Property.StaticDropdown({
+      displayName: 'Direct Download',
+      description: 'ContentDisposition set to attachment',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    cloud_storage: Property.StaticDropdown({
+      displayName: 'Cloud Storage',
+      description: 'Upload the generated PDFs to our storage CDN',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled (Default)', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    generation_delay: Property.Number({
+      displayName: 'Generation Delay (ms)',
+      description: 'Delay in milliseconds before PDF generation',
+      required: false,
+    }),
+    image_resample_res: Property.Number({
+      displayName: 'Image Resample Resolution (DPI)',
+      description: 'Downsample images to reduce PDF file size. Common values: 72, 96, 150, 300, 600',
+      required: false,
+    }),
+    resize_images: Property.StaticDropdown({
+      displayName: 'Resize Images',
+      description: 'Preprocess images or re-size images in the PDF',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    resize_max_width: Property.Number({
+      displayName: 'Resize Max Width (pixels)',
+      description: 'Maximum width of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_max_height: Property.Number({
+      displayName: 'Resize Max Height (pixels)',
+      description: 'Maximum height of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_format: Property.StaticDropdown({
+      displayName: 'Resize Format',
+      description: 'Format of the resized image',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'JPEG', value: 'jpeg' },
+          { label: 'PNG', value: 'png' },
+        ],
+      },
+      defaultValue: 'jpeg',
+    }),
+    postaction_s3_filekey: Property.ShortText({
+      displayName: 'Post Action S3 File Key',
+      description: 'File name for Post Action (AWS S3/Cloudflare R2/Azure Storage). Do not specify file extension.',
+      required: false,
+    }),
+    postaction_s3_bucket: Property.ShortText({
+      displayName: 'Post Action S3 Bucket',
+      description: 'AWS Bucket for Post Action (AWS S3/Cloudflare R2 Storage) or container for Post Action (Azure Storage)',
+      required: false,
+    }),
+    postaction_enabled: Property.StaticDropdown({
+      displayName: 'Post Action Enabled',
+      description: 'Enable Post Actions',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled (Default)', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    meta: Property.ShortText({
+      displayName: 'Meta',
+      description: 'External reference ID for your own reference. It appears in the list-objects API.',
+      required: false,
+    }),
+    async: Property.StaticDropdown({
+      displayName: 'Async Generation',
+      description: 'Generate PDF asynchronously (requires webhook_url)',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Synchronous (Default)', value: 0 },
+          { label: 'Asynchronous', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    webhook_url: Property.ShortText({
+      displayName: 'Webhook URL',
+      description: 'URL for webhook callback when using async generation. Must start with http:// or https://',
+      required: false,
+    }),
+    webhook_method: Property.StaticDropdown({
+      displayName: 'Webhook Method',
+      description: 'The HTTP method of the webhook',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'GET (Default)', value: 'GET' },
+          { label: 'POST', value: 'POST' },
+        ],
+      },
+      defaultValue: 'GET',
+    }),
+    url: Property.ShortText({
+      displayName: 'URL',
+      description: 'The URL to convert to PDF',
+      required: true,
+      defaultValue: 'https://en.wikipedia.org/wiki/Sceloporus_malachiticus',
+    }),
+    settings: Property.Json({
+      displayName: 'PDF Generation Settings',
+      description: 'The settings object contains various properties to configure the PDF generation.',
+      required: false,
+      defaultValue: {
+        paper_size: "A4",
+        orientation: "1",
+        header_font_size: "9px",
+        margin_top: "40",
+        margin_right: "10",
+        margin_bottom: "40",
+        margin_left: "10",
+        print_background: "1",
+        displayHeaderFooter: true,
+        custom_header: "<style>#header, #footer { padding: 0 !important; }</style>\n<table style=\"width: 100%; padding: 0px 5px;margin: 0px!important;font-size: 15px\">\n  <tr>\n    <td style=\"text-align:left; width:30%!important;\"><span class=\"date\"></span></td>\n    <td style=\"text-align:center; width:30%!important;\"><span class=\"pageNumber\"></span></td>\n    <td style=\"text-align:right; width:30%!important;\"><span class=\"totalPages\"></span></td>\n  </tr>\n</table>",
+        custom_footer: "<style>#header, #footer { padding: 0 !important; }</style>\n<table style=\"width: 100%; padding: 0px 5px;margin: 0px!important;font-size: 15px\">\n  <tr>\n    <td style=\"text-align:left; width:30%!important;\"><span class=\"date\"></span></td>\n    <td style=\"text-align:center; width:30%!important;\"><span class=\"pageNumber\"></span></td>\n    <td style=\"text-align:right; width:30%!important;\"><span class=\"totalPages\"></span></td>\n  </tr>\n</table>"
+      },
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      export_type,
+      expiration,
+      output_format,
+      filename,
+      direct_download,
+      cloud_storage,
+      generation_delay,
+      image_resample_res,
+      resize_images,
+      resize_max_width,
+      resize_max_height,
+      resize_format,
+      postaction_s3_filekey,
+      postaction_s3_bucket,
+      postaction_enabled,
+      meta,
+      async,
+      webhook_url,
+      webhook_method,
+      url,
+      settings,
+    } = context.propsValue;
+
+    const queryParams: Record<string, string | number> = {};
+
+    // Add optional query parameters
+    if (export_type) queryParams['export_type'] = export_type;
+    if (expiration !== undefined) queryParams['expiration'] = expiration;
+    if (output_format) queryParams['output_format'] = output_format;
+    if (filename) queryParams['filename'] = filename;
+    if (direct_download !== undefined) queryParams['direct_download'] = direct_download;
+    if (cloud_storage !== undefined) queryParams['cloud_storage'] = cloud_storage;
+    if (generation_delay !== undefined) queryParams['generation_delay'] = generation_delay;
+    if (image_resample_res !== undefined) queryParams['image_resample_res'] = image_resample_res;
+    if (resize_images !== undefined) queryParams['resize_images'] = resize_images;
+    if (resize_max_width !== undefined) queryParams['resize_max_width'] = resize_max_width;
+    if (resize_max_height !== undefined) queryParams['resize_max_height'] = resize_max_height;
+    if (resize_format) queryParams['resize_format'] = resize_format;
+    if (postaction_s3_filekey) queryParams['postaction_s3_filekey'] = postaction_s3_filekey;
+    if (postaction_s3_bucket) queryParams['postaction_s3_bucket'] = postaction_s3_bucket;
+    if (postaction_enabled !== undefined) queryParams['postaction_enabled'] = postaction_enabled;
+    if (meta) queryParams['meta'] = meta;
+    if (async !== undefined) queryParams['async'] = async;
+    if (webhook_url) queryParams['webhook_url'] = webhook_url;
+    if (webhook_method) queryParams['webhook_method'] = webhook_method;
+
+    // Build request body
+    const requestBody: Record<string, any> = {
+      url,
+    };
+
+    if (settings) requestBody['settings'] = settings;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://rest.apitemplate.io/v2/create-pdf-from-url',
+      headers: {
+        'X-API-KEY': auth as string,
+        'Content-Type': 'application/json',
+      },
+      queryParams: queryParams as Record<string, string>,
+      body: requestBody,
+    });
+
+    if (response.status === 200) {
+      return response.body;
+    }
+
+    throw new Error(`Failed to create PDF from URL: ${response.status}`);
+  },
+}); 

--- a/packages/pieces/community/api-template/src/lib/actions/create-pdf.ts
+++ b/packages/pieces/community/api-template/src/lib/actions/create-pdf.ts
@@ -1,0 +1,394 @@
+import {
+  createAction,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { apitemplateAuth } from '../../index';
+
+export const apitemplateCreatePdfAction = createAction({
+  auth: apitemplateAuth,
+  name: 'create_pdf',
+  displayName: 'Create PDF',
+  description: 'Generate a PDF using a template and JSON input',
+  props: {
+    template_id: Property.Dropdown({
+      displayName: 'Template',
+      description: 'Select a template to use for PDF generation',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please connect your account first',
+          };
+        }
+
+        try {
+          const response = await httpClient.sendRequest<{
+            status: string;
+            templates: Array<{
+              template_id: string;
+              name: string;
+              status: string;
+              format: string;
+              created_at: string;
+              updated_at: string;
+              group_name: string;
+            }>;
+          }>({
+            method: HttpMethod.GET,
+            url: 'https://rest.apitemplate.io/v2/list-templates',
+            headers: {
+              'X-API-KEY': auth as string,
+              'Content-Type': 'application/json',
+            },
+            queryParams: {
+              limit: '300',
+              format: 'PDF',
+            } as Record<string, string>,
+          });
+
+          if (response.status === 200 && response.body.status === 'success') {
+            return {
+              disabled: false,
+              options: response.body.templates
+                .filter(template => template.status === 'ACTIVE')
+                .map(template => ({
+                  label: `${template.name} (${template.format})`,
+                  value: template.template_id,
+                })),
+            };
+          }
+
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Failed to load templates',
+          };
+        } catch (error) {
+          console.error('Error fetching templates:', error);
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Error loading templates. Please check your API key.',
+          };
+        }
+      },
+    }),
+    export_type: Property.StaticDropdown({
+      displayName: 'Export Type',
+      description: 'Either file or json (Default). File returns binary data, json returns a JSON object with CDN URL',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'JSON (CDN URL)', value: 'json' },
+          { label: 'File (Binary)', value: 'file' },
+        ],
+      },
+      defaultValue: 'json',
+    }),
+    export_in_base64: Property.StaticDropdown({
+      displayName: 'Export in Base64',
+      description: 'If export_type = file, download in binary or base64 format',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Binary (Default)', value: 0 },
+          { label: 'Base64', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    expiration: Property.Number({
+      displayName: 'Expiration (minutes)',
+      description: 'Expiration of the generated PDF in minutes (0 = store permanently, 1-10080 minutes = 7 days)',
+      required: false,
+      defaultValue: 0,
+    }),
+    output_html: Property.StaticDropdown({
+      displayName: 'Output HTML',
+      description: 'Enable output of HTML content in JSON response',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    output_format: Property.StaticDropdown({
+      displayName: 'Output Format',
+      description: 'Specifies the desired output format',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'PDF (Default)', value: 'pdf' },
+          { label: 'HTML', value: 'html' },
+          { label: 'PNG', value: 'png' },
+          { label: 'JPEG', value: 'jpeg' },
+        ],
+      },
+      defaultValue: 'pdf',
+    }),
+    filename: Property.ShortText({
+      displayName: 'Filename',
+      description: 'Custom file name (should end with .pdf). Defaults to UUID if not specified',
+      required: false,
+    }),
+    direct_download: Property.StaticDropdown({
+      displayName: 'Direct Download',
+      description: 'ContentDisposition set to attachment',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    cloud_storage: Property.StaticDropdown({
+      displayName: 'Cloud Storage',
+      description: 'Upload the generated PDFs to our storage CDN',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled (Default)', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    load_data_from: Property.ShortText({
+      displayName: 'Load Data From URL',
+      description: 'Load JSON data from a remote URL instead of request body',
+      required: false,
+    }),
+    extract_link: Property.StaticDropdown({
+      displayName: 'Extract Links',
+      description: 'Extract links from the HTML content',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    generation_delay: Property.Number({
+      displayName: 'Generation Delay (ms)',
+      description: 'Delay in milliseconds before PDF generation',
+      required: false,
+    }),
+    image_resample_res: Property.Number({
+      displayName: 'Image Resample Resolution (DPI)',
+      description: 'Downsample images to reduce PDF file size. Common values: 72, 96, 150, 300, 600',
+      required: false,
+    }),
+    resize_images: Property.StaticDropdown({
+      displayName: 'Resize Images',
+      description: 'Preprocess images or re-size images in the PDF',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Disabled (Default)', value: 0 },
+          { label: 'Enabled', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    resize_max_width: Property.Number({
+      displayName: 'Resize Max Width (pixels)',
+      description: 'Maximum width of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_max_height: Property.Number({
+      displayName: 'Resize Max Height (pixels)',
+      description: 'Maximum height of the image in pixels when resize is enabled',
+      required: false,
+      defaultValue: 1000,
+    }),
+    resize_format: Property.StaticDropdown({
+      displayName: 'Resize Format',
+      description: 'Format of the resized image',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'JPEG', value: 'jpeg' },
+          { label: 'PNG', value: 'png' },
+        ],
+      },
+      defaultValue: 'jpeg',
+    }),
+    postaction_s3_filekey: Property.ShortText({
+      displayName: 'Post Action S3 File Key',
+      description: 'File name for Post Action (AWS S3/Cloudflare R2/Azure Storage). Do not specify file extension.',
+      required: false,
+    }),
+    postaction_s3_bucket: Property.ShortText({
+      displayName: 'Post Action S3 Bucket',
+      description: 'AWS Bucket for Post Action (AWS S3/Cloudflare R2 Storage) or container for Post Action (Azure Storage)',
+      required: false,
+    }),
+    postaction_enabled: Property.StaticDropdown({
+      displayName: 'Post Action Enabled',
+      description: 'Enable Post Actions',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Enabled (Default)', value: 1 },
+          { label: 'Disabled', value: 0 },
+        ],
+      },
+      defaultValue: 1,
+    }),
+    meta: Property.ShortText({
+      displayName: 'Meta',
+      description: 'External reference ID for your own reference. It appears in the list-objects API.',
+      required: false,
+    }),
+    async: Property.StaticDropdown({
+      displayName: 'Async Generation',
+      description: 'Generate PDF asynchronously (requires webhook_url)',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Synchronous (Default)', value: 0 },
+          { label: 'Asynchronous', value: 1 },
+        ],
+      },
+      defaultValue: 0,
+    }),
+    webhook_url: Property.ShortText({
+      displayName: 'Webhook URL',
+      description: 'URL for webhook callback when using async generation. Must start with http:// or https://',
+      required: false,
+    }),
+    webhook_method: Property.StaticDropdown({
+      displayName: 'Webhook Method',
+      description: 'The HTTP method of the webhook',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'GET (Default)', value: 'GET' },
+          { label: 'POST', value: 'POST' },
+        ],
+      },
+      defaultValue: 'GET',
+    }),
+    webhook_headers: Property.ShortText({
+      displayName: 'Webhook Headers',
+      description: 'HTTP headers for webhook (base64 encoded JSON object)',
+      required: false,
+    }),
+    overrides: Property.Json({
+      displayName: 'JSON Overrides',
+      description: 'JSON data with overrides for the template',
+      required: true,
+      defaultValue: {
+        invoice_number: "INV38379",
+        date: "2021-09-30",
+        currency: "USD",
+        total_amount: 82542.56
+      },
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      template_id,
+      export_type,
+      export_in_base64,
+      expiration,
+      output_html,
+      output_format,
+      filename,
+      direct_download,
+      cloud_storage,
+      load_data_from,
+      extract_link,
+      generation_delay,
+      image_resample_res,
+      resize_images,
+      resize_max_width,
+      resize_max_height,
+      resize_format,
+      postaction_s3_filekey,
+      postaction_s3_bucket,
+      postaction_enabled,
+      meta,
+      async,
+      webhook_url,
+      webhook_method,
+      webhook_headers,
+      overrides,
+    } = context.propsValue;
+
+    const queryParams: Record<string, string | number> = {
+      template_id,
+    };
+
+    // Add optional query parameters
+    if (export_type) queryParams['export_type'] = export_type;
+    if (export_in_base64 !== undefined) queryParams['export_in_base64'] = export_in_base64;
+    if (expiration !== undefined) queryParams['expiration'] = expiration;
+    if (output_html !== undefined) queryParams['output_html'] = output_html;
+    if (output_format) queryParams['output_format'] = output_format;
+    if (filename) queryParams['filename'] = filename;
+    if (direct_download !== undefined) queryParams['direct_download'] = direct_download;
+    if (cloud_storage !== undefined) queryParams['cloud_storage'] = cloud_storage;
+    if (load_data_from) queryParams['load_data_from'] = load_data_from;
+    if (extract_link !== undefined) queryParams['extract_link'] = extract_link;
+    if (generation_delay !== undefined) queryParams['generation_delay'] = generation_delay;
+    if (image_resample_res !== undefined) queryParams['image_resample_res'] = image_resample_res;
+    if (resize_images !== undefined) queryParams['resize_images'] = resize_images;
+    if (resize_max_width !== undefined) queryParams['resize_max_width'] = resize_max_width;
+    if (resize_max_height !== undefined) queryParams['resize_max_height'] = resize_max_height;
+    if (resize_format) queryParams['resize_format'] = resize_format;
+    if (postaction_s3_filekey) queryParams['postaction_s3_filekey'] = postaction_s3_filekey;
+    if (postaction_s3_bucket) queryParams['postaction_s3_bucket'] = postaction_s3_bucket;
+    if (postaction_enabled !== undefined) queryParams['postaction_enabled'] = postaction_enabled;
+    if (meta) queryParams['meta'] = meta;
+    if (async !== undefined) queryParams['async'] = async;
+    if (webhook_url) queryParams['webhook_url'] = webhook_url;
+    if (webhook_method) queryParams['webhook_method'] = webhook_method;
+    if (webhook_headers) queryParams['webhook_headers'] = webhook_headers;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://rest.apitemplate.io/v2/create-pdf',
+      headers: {
+        'X-API-KEY': auth as string,
+        'Content-Type': 'application/json',
+      },
+      queryParams: queryParams as Record<string, string>,
+      body: overrides,
+    });
+
+    if (response.status === 200) {
+      return response.body;
+    }
+
+    throw new Error(`Failed to create PDF: ${response.status}`);
+  },
+}); 

--- a/packages/pieces/community/api-template/src/lib/actions/delete-object.ts
+++ b/packages/pieces/community/api-template/src/lib/actions/delete-object.ts
@@ -1,0 +1,46 @@
+import {
+  createAction,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { apitemplateAuth } from '../../index';
+
+export const apitemplateDeleteObjectAction = createAction({
+  auth: apitemplateAuth,
+  name: 'delete_object',
+  displayName: 'Delete Object',
+  description: 'Delete a generated image or PDF (cleanup old outputs)',
+  props: {
+    transaction_ref: Property.ShortText({
+      displayName: 'Transaction Reference',
+      description: 'Object transaction reference to delete',
+      required: true,
+      defaultValue: '1618d386-2343-3d234-b9c7-99c82bb9f104',
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const { transaction_ref } = context.propsValue;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://rest.apitemplate.io/v2/delete-object',
+      headers: {
+        'X-API-KEY': auth as string,
+        'Content-Type': 'application/json',
+      },
+      queryParams: {
+        transaction_ref,
+      } as Record<string, string>,
+    });
+
+    if (response.status === 200) {
+      return response.body;
+    }
+
+    throw new Error(`Failed to delete object: ${response.status}`);
+  },
+}); 

--- a/packages/pieces/community/api-template/src/lib/actions/get-account-information.ts
+++ b/packages/pieces/community/api-template/src/lib/actions/get-account-information.ts
@@ -1,0 +1,49 @@
+import {
+  createAction,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { apitemplateAuth } from '../../index';
+
+export const apitemplateGetAccountInformationAction = createAction({
+  auth: apitemplateAuth,
+  name: 'get_account_information',
+  displayName: 'Get Account Information',
+  description: 'Retrieve account details such as usage limits and template quotas',
+  props: {},
+  async run(context) {
+    const { auth } = context;
+
+    const response = await httpClient.sendRequest<{
+      status: string;
+      subscription_product?: string;
+      subscription_current_period_start?: string;
+      subscription_current_period_end?: string;
+      subscription_status?: string;
+      subscription_interval?: string;
+      api_quota?: number;
+      api_remaining?: number;
+      api_used?: string;
+      template_remaining?: number;
+      template_count?: number;
+      template_quota?: number;
+      message?: string;
+    }>({
+      method: HttpMethod.GET,
+      url: 'https://rest.apitemplate.io/v2/account',
+      headers: {
+        'X-API-KEY': auth as string,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (response.status === 200) {
+      return response.body;
+    }
+
+    throw new Error(`Failed to get account information: ${response.status}`);
+  },
+}); 

--- a/packages/pieces/community/api-template/src/lib/actions/list-objects.ts
+++ b/packages/pieces/community/api-template/src/lib/actions/list-objects.ts
@@ -1,0 +1,91 @@
+import {
+  createAction,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { apitemplateAuth } from '../../index';
+
+export const apitemplateListObjectsAction = createAction({
+  auth: apitemplateAuth,
+  name: 'list_objects',
+  displayName: 'List Objects',
+  description: 'List previously generated images or PDFs',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Retrieve only the number of records specified. Default to 300',
+      required: false,
+      defaultValue: 300,
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      description: 'Offset is used to skip the number of records from the results. Default to 0',
+      required: false,
+      defaultValue: 0,
+    }),
+    template_id: Property.ShortText({
+      displayName: 'Template ID',
+      description: 'Filtered by template id',
+      required: false,
+    }),
+    transaction_type: Property.StaticDropdown({
+      displayName: 'Transaction Type',
+      description: 'Filtered by transaction type',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'PDF', value: 'PDF' },
+          { label: 'JPEG', value: 'JPEG' },
+          { label: 'MERGE', value: 'MERGE' },
+        ],
+      },
+    }),
+    transaction_ref: Property.ShortText({
+      displayName: 'Transaction Reference',
+      description: 'Transaction reference to filter by',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      limit,
+      offset,
+      template_id,
+      transaction_type,
+      transaction_ref,
+    } = context.propsValue;
+
+    const queryParams: Record<string, string | number> = {};
+
+    // Add optional query parameters
+    if (limit !== undefined) queryParams['limit'] = limit;
+    if (offset !== undefined) queryParams['offset'] = offset;
+    if (template_id) queryParams['template_id'] = template_id;
+    if (transaction_type) queryParams['transaction_type'] = transaction_type;
+    if (transaction_ref) queryParams['transaction_ref'] = transaction_ref;
+
+    const response = await httpClient.sendRequest<{
+      status: string;
+      objects: Array<any>;
+    }>({
+      method: HttpMethod.GET,
+      url: 'https://rest.apitemplate.io/v2/list-objects',
+      headers: {
+        'X-API-KEY': auth as string,
+        'Content-Type': 'application/json',
+      },
+      queryParams: queryParams as Record<string, string>,
+    });
+
+    if (response.status === 200) {
+      return response.body;
+    }
+
+    throw new Error(`Failed to list objects: ${response.status}`);
+  },
+}); 

--- a/packages/pieces/community/api-template/tsconfig.json
+++ b/packages/pieces/community/api-template/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/api-template/tsconfig.lib.json
+++ b/packages/pieces/community/api-template/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/googlechat-api/README.md
+++ b/packages/pieces/community/googlechat-api/README.md
@@ -1,0 +1,7 @@
+# pieces-googlechat-api
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-googlechat-api` to build the library.

--- a/packages/pieces/community/googlechat-api/package.json
+++ b/packages/pieces/community/googlechat-api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-googlechat-api",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/googlechat-api/project.json
+++ b/packages/pieces/community/googlechat-api/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-googlechat-api",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/googlechat-api/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/googlechat-api",
+        "tsConfig": "packages/pieces/community/googlechat-api/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/googlechat-api/package.json",
+        "main": "packages/pieces/community/googlechat-api/src/index.ts",
+        "assets": [
+          "packages/pieces/community/googlechat-api/*.md",
+          {
+            "input": "packages/pieces/community/googlechat-api/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/googlechat-api/src/index.ts
+++ b/packages/pieces/community/googlechat-api/src/index.ts
@@ -1,0 +1,52 @@
+
+    import { OAuth2PropertyValue, PieceAuth, createPiece } from '@activepieces/pieces-framework';
+    import { PieceCategory } from '@activepieces/shared';
+
+    // Import actions
+    import { sendMessage } from './lib/actions/send-message';
+    import { getDirectMessageDetails } from './lib/actions/get-direct-message-details';
+    import { addSpaceMember } from './lib/actions/add-space-member';
+    import { getMessage } from './lib/actions/get-message';
+    import { searchMessages } from './lib/actions/search-messages';
+    import { findMember } from './lib/actions/find-member';
+
+    // Import triggers
+    import { newMessage } from './lib/triggers/new-message';
+    import { newMention } from './lib/triggers/new-mention';
+
+    export const googleChatApiAuth = PieceAuth.OAuth2({
+    	authUrl: 'https://accounts.google.com/o/oauth2/auth',
+    	tokenUrl: 'https://oauth2.googleapis.com/token',
+    	required: true,
+    	scope: [
+    		'https://www.googleapis.com/auth/chat.messages',
+    		'https://www.googleapis.com/auth/chat.spaces',
+    		'https://www.googleapis.com/auth/chat.messages.create',
+    		'https://www.googleapis.com/auth/chat.bot',
+    		'https://www.googleapis.com/auth/chat.messages.readonly',
+    		'https://www.googleapis.com/auth/chat.spaces.readonly',
+    	],
+    });
+
+    export const googlechatApi = createPiece({
+    	displayName: "Google Chat API",
+    	description: "Send messages and interact with Google Chat spaces",
+    	minimumSupportedRelease: '0.36.1',
+    	logoUrl: "https://cdn.activepieces.com/pieces/googlechat-api.png",
+    	categories: [PieceCategory.COMMUNICATION],
+    	authors: [],
+    	auth: googleChatApiAuth,
+    	actions: [
+    		sendMessage,
+    		getDirectMessageDetails,
+    		addSpaceMember,
+    		getMessage,
+    		searchMessages,
+    		findMember,
+    	],
+    	triggers: [
+    		newMessage,
+    		newMention,
+    	],
+    });
+    

--- a/packages/pieces/community/googlechat-api/src/lib/actions/add-space-member.ts
+++ b/packages/pieces/community/googlechat-api/src/lib/actions/add-space-member.ts
@@ -1,0 +1,64 @@
+import { googleChatApiAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const addSpaceMember = createAction({
+  auth: googleChatApiAuth,
+  name: 'add-space-member',
+  displayName: 'Add a Space Member',
+  description: 'Add a user to a Google Chat space',
+  props: {
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space to add the member to',
+      required: true,
+    }),
+    memberEmail: Property.ShortText({
+      displayName: 'Member Email',
+      description: 'The email address of the user to add to the space',
+      required: true,
+    }),
+    role: Property.StaticDropdown({
+      displayName: 'Member Role',
+      description: 'The role to assign to the member',
+      required: false,
+      options: {
+        options: [
+          { label: 'Member', value: 'MEMBER' },
+          { label: 'Admin', value: 'ADMIN' },
+        ],
+      },
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const { spaceId, memberEmail, role } = propsValue;
+
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/spaces/${spaceId}/members`;
+
+    const memberData: any = {
+      member: {
+        name: `users/${memberEmail}`,
+      },
+    };
+
+    if (role) {
+      memberData.role = role;
+    }
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(memberData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to add space member: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/googlechat-api/src/lib/actions/find-member.ts
+++ b/packages/pieces/community/googlechat-api/src/lib/actions/find-member.ts
@@ -1,0 +1,42 @@
+import { googleChatApiAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const findMember = createAction({
+  auth: googleChatApiAuth,
+  name: 'find-member',
+  displayName: 'Find Member',
+  description: 'Search space member by email',
+  props: {
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space to search in',
+      required: true,
+    }),
+    memberEmail: Property.ShortText({
+      displayName: 'Member Email',
+      description: 'The email address of the member to find',
+      required: true,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const { spaceId, memberEmail } = propsValue;
+
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/spaces/${spaceId}/members/${memberEmail}`;
+
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to find member: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/googlechat-api/src/lib/actions/get-direct-message-details.ts
+++ b/packages/pieces/community/googlechat-api/src/lib/actions/get-direct-message-details.ts
@@ -1,0 +1,42 @@
+import { googleChatApiAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const getDirectMessageDetails = createAction({
+  auth: googleChatApiAuth,
+  name: 'get-direct-message-details',
+  displayName: 'Get Direct Message Details',
+  description: 'Retrieve details of a specific direct message by ID',
+  props: {
+    messageId: Property.ShortText({
+      displayName: 'Message ID',
+      description: 'The ID of the message to retrieve',
+      required: true,
+    }),
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space containing the message',
+      required: true,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const { messageId, spaceId } = propsValue;
+
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/spaces/${spaceId}/messages/${messageId}`;
+
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to get message details: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/googlechat-api/src/lib/actions/get-message.ts
+++ b/packages/pieces/community/googlechat-api/src/lib/actions/get-message.ts
@@ -1,0 +1,42 @@
+import { googleChatApiAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const getMessage = createAction({
+  auth: googleChatApiAuth,
+  name: 'get-message',
+  displayName: 'Get Message',
+  description: 'Retrieve details of a specific message',
+  props: {
+    messageId: Property.ShortText({
+      displayName: 'Message ID',
+      description: 'The ID of the message to retrieve',
+      required: true,
+    }),
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space containing the message',
+      required: true,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const { messageId, spaceId } = propsValue;
+
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/spaces/${spaceId}/messages/${messageId}`;
+
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to get message: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/googlechat-api/src/lib/actions/search-messages.ts
+++ b/packages/pieces/community/googlechat-api/src/lib/actions/search-messages.ts
@@ -1,0 +1,62 @@
+import { googleChatApiAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const searchMessages = createAction({
+  auth: googleChatApiAuth,
+  name: 'search-messages',
+  displayName: 'Search Messages',
+  description: 'Search within Chat for messages matching keywords or filters',
+  props: {
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space to search in',
+      required: true,
+    }),
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'The search query or keywords to look for',
+      required: true,
+    }),
+    pageSize: Property.Number({
+      displayName: 'Page Size',
+      description: 'Number of messages to return (max 100)',
+      required: false,
+      defaultValue: 25,
+    }),
+    pageToken: Property.ShortText({
+      displayName: 'Page Token',
+      description: 'Token for pagination',
+      required: false,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const { spaceId, query, pageSize, pageToken } = propsValue;
+
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/spaces/${spaceId}/messages`;
+
+    const params = new URLSearchParams({
+      filter: `text:"${query}"`,
+      pageSize: pageSize?.toString() || '25',
+    });
+
+    if (pageToken) {
+      params.append('pageToken', pageToken);
+    }
+
+    const response = await fetch(`${endpoint}?${params.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to search messages: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/googlechat-api/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/googlechat-api/src/lib/actions/send-message.ts
@@ -1,0 +1,58 @@
+import { googleChatApiAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const sendMessage = createAction({
+  auth: googleChatApiAuth,
+  name: 'send-message',
+  displayName: 'Send a Message',
+  description: 'Send a message to a space or direct conversation',
+  props: {
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space to send the message to',
+      required: true,
+    }),
+    messageText: Property.LongText({
+      displayName: 'Message Text',
+      description: 'The text content of the message',
+      required: true,
+    }),
+    threadKey: Property.ShortText({
+      displayName: 'Thread Key (Optional)',
+      description: 'The thread key if sending to a specific thread',
+      required: false,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const { spaceId, messageText, threadKey } = propsValue;
+
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/spaces/${spaceId}/messages`;
+
+    const messageData: any = {
+      text: messageText,
+    };
+
+    if (threadKey) {
+      messageData.thread = {
+        name: `spaces/${spaceId}/threads/${threadKey}`,
+      };
+    }
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(messageData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to send message: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/googlechat-api/src/lib/triggers/new-mention.ts
+++ b/packages/pieces/community/googlechat-api/src/lib/triggers/new-mention.ts
@@ -1,0 +1,85 @@
+import { googleChatApiAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const newMention = createTrigger({
+  auth: googleChatApiAuth,
+  name: 'new-mention',
+  displayName: 'New Mention',
+  description: 'Fires when a new mention is received in a space',
+  props: {
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space to monitor for mentions',
+      required: true,
+    }),
+    mentionType: Property.StaticDropdown({
+      displayName: 'Mention Type',
+      description: 'Type of mentions to monitor',
+      required: false,
+      options: {
+        options: [
+          { label: 'All Mentions', value: 'all' },
+          { label: 'User Mentions Only', value: 'user' },
+          { label: 'Bot Mentions Only', value: 'bot' },
+        ],
+      },
+    }),
+  },
+  type: 'webhook',
+  onEnable: async ({ auth, propsValue, webhookUrl }) => {
+    const { spaceId, mentionType } = propsValue;
+
+    // Register webhook with Google Chat API
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/spaces/${spaceId}/webhooks`;
+
+    const webhookData = {
+      webhookUrl,
+      events: ['message.created'],
+      filters: {
+        mentionType: mentionType || 'all',
+      },
+    };
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const webhookInfo = await response.json();
+    return {
+      webhookId: webhookInfo.name,
+    };
+  },
+  onDisable: async ({ auth, webhookId }) => {
+    if (!webhookId) return;
+
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/${webhookId}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload }) => {
+    return payload;
+  },
+}); 

--- a/packages/pieces/community/googlechat-api/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/googlechat-api/src/lib/triggers/new-message.ts
@@ -1,0 +1,77 @@
+import { googleChatApiAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const newMessage = createTrigger({
+  auth: googleChatApiAuth,
+  name: 'new-message',
+  displayName: 'New Message',
+  description: 'Fires when a new message is received in Google Chat',
+  props: {
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space to monitor for new messages',
+      required: true,
+    }),
+    includeBotMessages: Property.Checkbox({
+      displayName: 'Include Bot Messages',
+      description: 'Whether to include messages from bots',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  type: 'webhook',
+  onEnable: async ({ auth, propsValue, webhookUrl }) => {
+    const { spaceId, includeBotMessages } = propsValue;
+
+    // Register webhook with Google Chat API
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/spaces/${spaceId}/webhooks`;
+
+    const webhookData = {
+      webhookUrl,
+      events: ['message.created'],
+      includeBotMessages: includeBotMessages || false,
+    };
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const webhookInfo = await response.json();
+    return {
+      webhookId: webhookInfo.name,
+    };
+  },
+  onDisable: async ({ auth, webhookId }) => {
+    if (!webhookId) return;
+
+    const baseUrl = 'https://chat.googleapis.com/v1';
+    const endpoint = `${baseUrl}/${webhookId}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload }) => {
+    return payload;
+  },
+}); 

--- a/packages/pieces/community/googlechat-api/tsconfig.json
+++ b/packages/pieces/community/googlechat-api/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/googlechat-api/tsconfig.lib.json
+++ b/packages/pieces/community/googlechat-api/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/paperform-api/README.md
+++ b/packages/pieces/community/paperform-api/README.md
@@ -1,0 +1,45 @@
+# Paperform API
+
+This piece provides integration with the Paperform API, allowing you to interact with forms, submissions, and other Paperform resources.
+
+## Authentication
+
+To use this piece, you need a Paperform API key. API access is only available with either the Standard or Business API for Paperform.
+
+### Getting Your API Key
+
+1. Log in to your Paperform account
+2. Go to your account page
+3. Generate an API key
+4. Copy the API key for use in this piece
+
+### Authentication Setup
+
+When setting up this piece in Activepieces:
+
+1. Enter your Paperform API key in the "API Key" field
+2. The piece will automatically validate your API key
+3. If validation fails, please check that your API key is correct and that you have the appropriate API access level
+
+## Available Actions
+
+### Get Forms
+Retrieves a list of forms from your Paperform account with optional pagination parameters.
+
+### Custom API Call
+Allows you to make any API call to the Paperform API with proper authentication headers.
+
+## API Endpoints
+
+The piece uses the Paperform API v1 base URL: `https://api.paperform.co/v1`
+
+Common endpoints include:
+- `/forms` - Get all forms
+- `/forms/{id}` - Get a specific form
+- `/forms/{id}/submissions` - Get submissions for a form
+- `/submissions/{id}` - Get a specific submission
+
+## Support
+
+For API support, contact: support@paperform.co
+Paperform website: https://paperform.co

--- a/packages/pieces/community/paperform-api/package.json
+++ b/packages/pieces/community/paperform-api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-paperform-api",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/paperform-api/project.json
+++ b/packages/pieces/community/paperform-api/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-paperform-api",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/paperform-api/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/paperform-api",
+        "tsConfig": "packages/pieces/community/paperform-api/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/paperform-api/package.json",
+        "main": "packages/pieces/community/paperform-api/src/index.ts",
+        "assets": [
+          "packages/pieces/community/paperform-api/*.md",
+          {
+            "input": "packages/pieces/community/paperform-api/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/paperform-api/src/index.ts
+++ b/packages/pieces/community/paperform-api/src/index.ts
@@ -1,0 +1,38 @@
+
+    import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+    import { paperformCommon } from "./lib/auth";
+    import { deleteSubmissionAction } from "./lib/actions/delete-submission";
+    import { deletePartialSubmissionAction } from "./lib/actions/delete-partial-submission";
+    import { createCouponAction } from "./lib/actions/create-coupon";
+    import { updateCouponAction } from "./lib/actions/update-coupon";
+    import { deleteCouponAction } from "./lib/actions/delete-coupon";
+    import { createProductAction } from "./lib/actions/create-product";
+    import { updateProductAction } from "./lib/actions/update-product";
+    import { deleteProductAction } from "./lib/actions/delete-product";
+    import { createSpaceAction } from "./lib/actions/create-space";
+    import { updateSpaceAction } from "./lib/actions/update-space";
+    import { findFormAction } from "./lib/actions/find-form";
+    import { findFormProductAction } from "./lib/actions/find-form-product";
+    import { findSpaceAction } from "./lib/actions/find-space";
+    import { formSubmissionTrigger } from "./lib/triggers/form-submission";
+    import { partialFormSubmissionTrigger } from "./lib/triggers/partial-form-submission";
+
+    export const paperformApiAuth = PieceAuth.SecretText({
+      displayName: "API Key",
+      description: "Your Paperform API key. You can generate an API key on your account page.",
+      required: true,
+      validate: async ({ auth }) => {
+        return await paperformCommon.validateApiKey({ auth });
+      },
+    });
+
+    export const paperformApi = createPiece({
+      displayName: "Paperform-api",
+      auth: paperformApiAuth,
+      minimumSupportedRelease: '0.36.1',
+      logoUrl: "https://cdn.activepieces.com/pieces/paperform-api.png",
+      authors: [],
+      actions: [deleteSubmissionAction, deletePartialSubmissionAction, createCouponAction, updateCouponAction, deleteCouponAction, createProductAction, updateProductAction, deleteProductAction, createSpaceAction, updateSpaceAction, findFormAction, findFormProductAction, findSpaceAction],
+      triggers: [formSubmissionTrigger, partialFormSubmissionTrigger],
+    });
+    

--- a/packages/pieces/community/paperform-api/src/lib/actions/create-coupon.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/create-coupon.ts
@@ -1,0 +1,99 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const createCouponAction = createAction({
+  displayName: 'Create Form Coupon',
+  name: 'create_coupon',
+  description: 'Generate or attach a discount coupon to a specified form',
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID',
+      required: true,
+    }),
+    code: Property.ShortText({
+      displayName: 'Coupon Code',
+      description: 'The coupon code',
+      required: true,
+    }),
+    enabled: Property.Checkbox({
+      displayName: 'Enabled',
+      description: 'Whether the coupon is enabled or not',
+      required: false,
+      defaultValue: true,
+    }),
+    target: Property.StaticDropdown({
+      displayName: 'Target',
+      description: 'The target of the coupon',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Price', value: 'price' },
+        ],
+      },
+    }),
+    discountAmount: Property.Number({
+      displayName: 'Discount Amount',
+      description: 'The discount as an amount (≥ 0)',
+      required: false,
+    }),
+    discountPercentage: Property.Number({
+      displayName: 'Discount Percentage',
+      description: 'The discount as a percentage (0 to 100)',
+      required: false,
+    }),
+    expiresAt: Property.DateTime({
+      displayName: 'Expires At',
+      description: 'The date and time when the coupon expires',
+      required: false,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/forms/${propsValue.formSlugOrId}/coupons`;
+    
+    // Build request body with only provided values
+    const body: any = {
+      code: propsValue.code,
+    };
+    
+    if (propsValue.enabled !== undefined) {
+      body.enabled = propsValue.enabled;
+    }
+    
+    if (propsValue.target) {
+      body.target = propsValue.target;
+    }
+    
+    if (propsValue.discountAmount !== undefined) {
+      body.discountAmount = propsValue.discountAmount;
+    }
+    
+    if (propsValue.discountPercentage !== undefined) {
+      body.discountPercentage = propsValue.discountPercentage;
+    }
+    
+    if (propsValue.expiresAt) {
+      body.expiresAt = propsValue.expiresAt;
+    }
+    
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.POST,
+      body
+    );
+    
+    return {
+      success: true,
+      message: 'Coupon created successfully',
+      coupon: response.body,
+      formSlugOrId: propsValue.formSlugOrId,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/create-product.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/create-product.ts
@@ -1,0 +1,102 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const createProductAction = createAction({
+  displayName: 'Create Form Product',
+  name: 'create_product',
+  description: 'Add a commerce-style product/item to a form',
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID',
+      required: true,
+    }),
+    productFieldKey: Property.ShortText({
+      displayName: 'Product Field Key',
+      description: 'The key of a product field on the form',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Product Name',
+      description: 'Product name',
+      required: true,
+    }),
+    quantity: Property.Number({
+      displayName: 'Quantity',
+      description: 'Product quantity',
+      required: false,
+    }),
+    price: Property.Number({
+      displayName: 'Price',
+      description: 'Product price',
+      required: true,
+    }),
+    minimum: Property.Number({
+      displayName: 'Minimum',
+      description: 'Minimum number of products to be selected',
+      required: false,
+    }),
+    maximum: Property.Number({
+      displayName: 'Maximum',
+      description: 'Maximum number of products to be selected',
+      required: false,
+    }),
+    discountable: Property.Checkbox({
+      displayName: 'Discountable',
+      description: 'Whether the product can be discounted',
+      required: false,
+      defaultValue: false,
+    }),
+    sku: Property.ShortText({
+      displayName: 'SKU',
+      description: 'Product SKU',
+      required: true,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/forms/${propsValue.formSlugOrId}/products`;
+    
+    // Build request body with required and optional values
+    const body: any = {
+      product_field_key: propsValue.productFieldKey,
+      name: propsValue.name,
+      price: propsValue.price,
+      sku: propsValue.sku,
+    };
+    
+    if (propsValue.quantity !== undefined) {
+      body.quantity = propsValue.quantity;
+    }
+    
+    if (propsValue.minimum !== undefined) {
+      body.minimum = propsValue.minimum;
+    }
+    
+    if (propsValue.maximum !== undefined) {
+      body.maximum = propsValue.maximum;
+    }
+    
+    if (propsValue.discountable !== undefined) {
+      body.discountable = propsValue.discountable;
+    }
+    
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.POST,
+      body
+    );
+    
+    return {
+      success: true,
+      message: 'Product created successfully',
+      product: response.body,
+      formSlugOrId: propsValue.formSlugOrId,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/create-space.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/create-space.ts
@@ -1,0 +1,41 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const createSpaceAction = createAction({
+  displayName: 'Create Space',
+  name: 'create_space',
+  description: 'Initialize a new "Space" (workspace) for form management or grouping',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Space Name',
+      description: 'The name of the space',
+      required: true,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/spaces`;
+    
+    const body = {
+      name: propsValue.name,
+    };
+    
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.POST,
+      body
+    );
+    
+    return {
+      success: true,
+      message: 'Space created successfully',
+      space: response.body,
+      name: propsValue.name,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/delete-coupon.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/delete-coupon.ts
@@ -1,0 +1,40 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const deleteCouponAction = createAction({
+  displayName: 'Delete Form Coupon',
+  name: 'delete_coupon',
+  description: 'Remove a coupon from a form',
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID',
+      required: true,
+    }),
+    code: Property.ShortText({
+      displayName: 'Coupon Code',
+      description: 'The coupon code to delete',
+      required: true,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/forms/${propsValue.formSlugOrId}/coupons/${propsValue.code}`;
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.DELETE
+    );
+    
+    return {
+      success: true,
+      message: 'Coupon deleted successfully',
+      formSlugOrId: propsValue.formSlugOrId,
+      code: propsValue.code,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/delete-partial-submission.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/delete-partial-submission.ts
@@ -1,0 +1,34 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const deletePartialSubmissionAction = createAction({
+  displayName: 'Delete Partial Form Submission',
+  name: 'delete_partial_submission',
+  description: 'Permanently delete a partial/in-progress submission by its ID',
+  props: {
+    partialSubmissionId: Property.ShortText({
+      displayName: 'Partial Submission ID',
+      description: 'The ID of the partial submission to delete',
+      required: true,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/partial-submissions/${propsValue.partialSubmissionId}`;
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.DELETE
+    );
+    
+    return {
+      success: true,
+      message: 'Partial submission deleted successfully',
+      partialSubmissionId: propsValue.partialSubmissionId,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/delete-product.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/delete-product.ts
@@ -1,0 +1,40 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const deleteProductAction = createAction({
+  displayName: 'Delete Form Product',
+  name: 'delete_product',
+  description: 'Remove a product from a form',
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID',
+      required: true,
+    }),
+    productSku: Property.ShortText({
+      displayName: 'Product SKU',
+      description: 'The SKU of the product to delete',
+      required: true,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/forms/${propsValue.formSlugOrId}/products/${propsValue.productSku}`;
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.DELETE
+    );
+    
+    return {
+      success: true,
+      message: 'Product deleted successfully',
+      formSlugOrId: propsValue.formSlugOrId,
+      productSku: propsValue.productSku,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/delete-submission.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/delete-submission.ts
@@ -1,0 +1,34 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const deleteSubmissionAction = createAction({
+  displayName: 'Delete Form Submission',
+  name: 'delete_submission',
+  description: 'Permanently delete a completed submission by its ID',
+  props: {
+    submissionId: Property.ShortText({
+      displayName: 'Submission ID',
+      description: 'The ID of the submission to delete',
+      required: true,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/submissions/${propsValue.submissionId}`;
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.DELETE
+    );
+    
+    return {
+      success: true,
+      message: 'Submission deleted successfully',
+      submissionId: propsValue.submissionId,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/find-form-product.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/find-form-product.ts
@@ -1,0 +1,41 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const findFormProductAction = createAction({
+  displayName: 'Find Form Product',
+  name: 'find_form_product',
+  description: 'Retrieve product metadata from a form by product ID or name',
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID',
+      required: true,
+    }),
+    productSku: Property.ShortText({
+      displayName: 'Product SKU',
+      description: 'The SKU of the product',
+      required: true,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/forms/${propsValue.formSlugOrId}/products/${propsValue.productSku}`;
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.GET
+    );
+    
+    return {
+      success: true,
+      message: 'Product retrieved successfully',
+      product: response.body,
+      formSlugOrId: propsValue.formSlugOrId,
+      productSku: propsValue.productSku,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/find-form.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/find-form.ts
@@ -1,0 +1,35 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const findFormAction = createAction({
+  displayName: 'Find Form',
+  name: 'find_form',
+  description: 'Retrieve form metadata or configuration by ID or name',
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID',
+      required: true,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/forms/${propsValue.formSlugOrId}`;
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.GET
+    );
+    
+    return {
+      success: true,
+      message: 'Form retrieved successfully',
+      form: response.body,
+      formSlugOrId: propsValue.formSlugOrId,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/find-space.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/find-space.ts
@@ -1,0 +1,35 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const findSpaceAction = createAction({
+  displayName: 'Find Space',
+  name: 'find_space',
+  description: 'Retrieve space details by name or ID',
+  props: {
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space to get results for',
+      required: true,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/spaces/${propsValue.spaceId}`;
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.GET
+    );
+    
+    return {
+      success: true,
+      message: 'Space retrieved successfully',
+      space: response.body,
+      spaceId: propsValue.spaceId,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/update-coupon.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/update-coupon.ts
@@ -1,0 +1,97 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const updateCouponAction = createAction({
+  displayName: 'Update Form Coupon',
+  name: 'update_coupon',
+  description: 'Modify an existing coupon\'s properties (discount amount, expiry, usage limits)',
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID',
+      required: true,
+    }),
+    code: Property.ShortText({
+      displayName: 'Coupon Code',
+      description: 'The coupon code to update',
+      required: true,
+    }),
+    enabled: Property.Checkbox({
+      displayName: 'Enabled',
+      description: 'Whether the coupon is enabled or not',
+      required: false,
+    }),
+    target: Property.StaticDropdown({
+      displayName: 'Target',
+      description: 'The target of the coupon',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Price', value: 'price' },
+        ],
+      },
+    }),
+    discountAmount: Property.Number({
+      displayName: 'Discount Amount',
+      description: 'The discount as an amount (≥ 0)',
+      required: false,
+    }),
+    discountPercentage: Property.Number({
+      displayName: 'Discount Percentage',
+      description: 'The discount as a percentage (0 to 100)',
+      required: false,
+    }),
+    expiresAt: Property.DateTime({
+      displayName: 'Expires At',
+      description: 'The date and time when the coupon expires',
+      required: false,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/forms/${propsValue.formSlugOrId}/coupons/${propsValue.code}`;
+    
+    // Build request body with only provided values
+    const body: any = {};
+    
+    if (propsValue.enabled !== undefined) {
+      body.enabled = propsValue.enabled;
+    }
+    
+    if (propsValue.target) {
+      body.target = propsValue.target;
+    }
+    
+    if (propsValue.discountAmount !== undefined) {
+      body.discountAmount = propsValue.discountAmount;
+    }
+    
+    if (propsValue.discountPercentage !== undefined) {
+      body.discountPercentage = propsValue.discountPercentage;
+    }
+    
+    if (propsValue.expiresAt) {
+      body.expiresAt = propsValue.expiresAt;
+    }
+    
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.PUT,
+      body
+    );
+    
+    return {
+      success: true,
+      message: 'Coupon updated successfully',
+      coupon: response.body,
+      formSlugOrId: propsValue.formSlugOrId,
+      code: propsValue.code,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/update-product.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/update-product.ts
@@ -1,0 +1,100 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const updateProductAction = createAction({
+  displayName: 'Update Form Product',
+  name: 'update_product',
+  description: 'Update existing product\'s price, description, or availability',
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID',
+      required: true,
+    }),
+    productSku: Property.ShortText({
+      displayName: 'Product SKU',
+      description: 'The SKU of the product to update',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Product Name',
+      description: 'Product name',
+      required: false,
+    }),
+    quantity: Property.Number({
+      displayName: 'Quantity',
+      description: 'Product quantity',
+      required: false,
+    }),
+    price: Property.Number({
+      displayName: 'Price',
+      description: 'Product price',
+      required: false,
+    }),
+    minimum: Property.Number({
+      displayName: 'Minimum',
+      description: 'Minimum number of products to be selected',
+      required: false,
+    }),
+    maximum: Property.Number({
+      displayName: 'Maximum',
+      description: 'Maximum number of products to be selected',
+      required: false,
+    }),
+    discountable: Property.Checkbox({
+      displayName: 'Discountable',
+      description: 'Whether the product can be discounted',
+      required: false,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/forms/${propsValue.formSlugOrId}/products/${propsValue.productSku}`;
+    
+    // Build request body with only provided values
+    const body: any = {};
+    
+    if (propsValue.name) {
+      body.name = propsValue.name;
+    }
+    
+    if (propsValue.quantity !== undefined) {
+      body.quantity = propsValue.quantity;
+    }
+    
+    if (propsValue.price !== undefined) {
+      body.price = propsValue.price;
+    }
+    
+    if (propsValue.minimum !== undefined) {
+      body.minimum = propsValue.minimum;
+    }
+    
+    if (propsValue.maximum !== undefined) {
+      body.maximum = propsValue.maximum;
+    }
+    
+    if (propsValue.discountable !== undefined) {
+      body.discountable = propsValue.discountable;
+    }
+    
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.PUT,
+      body
+    );
+    
+    return {
+      success: true,
+      message: 'Product updated successfully',
+      product: response.body,
+      formSlugOrId: propsValue.formSlugOrId,
+      productSku: propsValue.productSku,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/actions/update-space.ts
+++ b/packages/pieces/community/paperform-api/src/lib/actions/update-space.ts
@@ -1,0 +1,49 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const updateSpaceAction = createAction({
+  displayName: 'Update Space',
+  name: 'update_space',
+  description: 'Modify space settings and metadata',
+  props: {
+    spaceId: Property.ShortText({
+      displayName: 'Space ID',
+      description: 'The ID of the space to update',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Space Name',
+      description: 'The name of the space',
+      required: false,
+    }),
+  },
+  auth: paperformApiAuth,
+  async run({ auth, propsValue }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    const endpoint = `/spaces/${propsValue.spaceId}`;
+    
+    // Build request body with only provided values
+    const body: any = {};
+    
+    if (propsValue.name) {
+      body.name = propsValue.name;
+    }
+    
+    const response = await paperformCommon.makeRequest(
+      paperformAuth, 
+      endpoint, 
+      HttpMethod.PUT,
+      body
+    );
+    
+    return {
+      success: true,
+      message: 'Space updated successfully',
+      space: response.body,
+      spaceId: propsValue.spaceId,
+    };
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/auth.ts
+++ b/packages/pieces/community/paperform-api/src/lib/auth.ts
@@ -1,0 +1,46 @@
+import { AuthenticationType, HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+export interface PaperformAuth {
+  auth: string;
+}
+
+export const paperformCommon = {
+  baseUrl: 'https://api.paperform.co/v1',
+  
+  // Helper function to create authenticated headers
+  getAuthHeaders: (auth: PaperformAuth) => {
+    return {
+      'Authorization': `Bearer ${auth.auth}`,
+      'Content-Type': 'application/json',
+    };
+  },
+
+  // Helper function to make authenticated requests
+  makeRequest: async (auth: PaperformAuth, endpoint: string, method: HttpMethod = HttpMethod.GET, body?: any) => {
+    const headers = paperformCommon.getAuthHeaders(auth);
+    
+    return await httpClient.sendRequest({
+      method,
+      url: `${paperformCommon.baseUrl}${endpoint}`,
+      headers,
+      body,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.auth,
+      },
+    });
+  },
+
+  // Validate API key by making a test request
+  validateApiKey: async (auth: PaperformAuth): Promise<{ valid: true } | { valid: false; error: string }> => {
+    try {
+      await paperformCommon.makeRequest(auth, '/forms');
+      return { valid: true };
+    } catch (error) {
+      return {
+        valid: false,
+        error: 'Invalid API key. Please check your Paperform API key.',
+      };
+    }
+  },
+}; 

--- a/packages/pieces/community/paperform-api/src/lib/triggers/form-submission.ts
+++ b/packages/pieces/community/paperform-api/src/lib/triggers/form-submission.ts
@@ -1,0 +1,79 @@
+import { Property, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const formSubmissionTrigger = createTrigger({
+  displayName: 'Form Submission',
+  name: 'form_submission',
+  description: 'Fires when a completed form submission is received',
+  auth: paperformApiAuth,
+  type: TriggerStrategy.WEBHOOK,
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID to monitor',
+      required: true,
+    }),
+  },
+  sampleData: {
+    submission: {
+      id: 'sub_123456789',
+      form_slug_or_id: 'my-form',
+      created_at: '2024-01-01T12:00:00Z',
+      data: {
+        name: 'John Doe',
+        email: 'john@example.com',
+        message: 'Hello world!'
+      }
+    }
+  },
+  async onEnable({ auth, propsValue, webhookUrl, store }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    // Create webhook for the form
+    const webhookData = {
+      target_url: webhookUrl,
+      triggers: ['submission.completed'], // Assuming this is the trigger type for form submissions
+    };
+    
+    const response = await paperformCommon.makeRequest(
+      paperformAuth,
+      `/forms/${propsValue.formSlugOrId}/webhooks`,
+      HttpMethod.POST,
+      webhookData
+    );
+    
+    // Store webhook ID for later deletion
+    await store.put('webhookId', response.body.id);
+  },
+  
+  async onDisable({ auth, store }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    // Get webhook ID from store
+    const webhookId = await store.get('webhookId');
+    
+    if (webhookId) {
+      // Delete the webhook
+      await paperformCommon.makeRequest(
+        paperformAuth,
+        `/webhooks/${webhookId}`,
+        HttpMethod.DELETE
+      );
+    }
+  },
+  
+  async run({ payload }) {
+    // Process the webhook payload
+    const body = payload.body as any;
+    
+    return [{
+      submission: body,
+      formSlugOrId: body.form_slug_or_id,
+      submissionId: body.id,
+      submittedAt: body.created_at,
+      data: body.data,
+    }];
+  },
+}); 

--- a/packages/pieces/community/paperform-api/src/lib/triggers/partial-form-submission.ts
+++ b/packages/pieces/community/paperform-api/src/lib/triggers/partial-form-submission.ts
@@ -1,0 +1,79 @@
+import { Property, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { paperformCommon, PaperformAuth } from '../auth';
+import { paperformApiAuth } from '@activepieces/piece-paperform-api';
+
+export const partialFormSubmissionTrigger = createTrigger({
+  displayName: 'New Partial Form Submission',
+  name: 'partial_form_submission',
+  description: 'Fires when a partial/in-progress submission is received',
+  auth: paperformApiAuth,
+  type: TriggerStrategy.WEBHOOK,
+  props: {
+    formSlugOrId: Property.ShortText({
+      displayName: 'Form Slug or ID',
+      description: 'The form\'s slug, custom slug or ID to monitor',
+      required: true,
+    }),
+  },
+  sampleData: {
+    partialSubmission: {
+      id: 'partial_sub_123456789',
+      form_slug_or_id: 'my-form',
+      created_at: '2024-01-01T12:00:00Z',
+      data: {
+        name: 'John Doe',
+        email: 'john@example.com'
+        // Note: partial submissions may have incomplete data
+      }
+    }
+  },
+  async onEnable({ auth, propsValue, webhookUrl, store }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    // Create webhook for the form
+    const webhookData = {
+      target_url: webhookUrl,
+      triggers: ['partial_submission.created'], // Assuming this is the trigger type for partial submissions
+    };
+    
+    const response = await paperformCommon.makeRequest(
+      paperformAuth,
+      `/forms/${propsValue.formSlugOrId}/webhooks`,
+      HttpMethod.POST,
+      webhookData
+    );
+    
+    // Store webhook ID for later deletion
+    await store.put('partialWebhookId', response.body.id);
+  },
+  
+  async onDisable({ auth, store }) {
+    const paperformAuth: PaperformAuth = { auth: auth as string };
+    
+    // Get webhook ID from store
+    const webhookId = await store.get('partialWebhookId');
+    
+    if (webhookId) {
+      // Delete the webhook
+      await paperformCommon.makeRequest(
+        paperformAuth,
+        `/webhooks/${webhookId}`,
+        HttpMethod.DELETE
+      );
+    }
+  },
+  
+  async run({ payload }) {
+    // Process the webhook payload
+    const body = payload.body as any;
+    
+    return [{
+      partialSubmission: body,
+      formSlugOrId: body.form_slug_or_id,
+      partialSubmissionId: body.id,
+      createdAt: body.created_at,
+      data: body.data,
+    }];
+  },
+}); 

--- a/packages/pieces/community/paperform-api/tsconfig.json
+++ b/packages/pieces/community/paperform-api/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/paperform-api/tsconfig.lib.json
+++ b/packages/pieces/community/paperform-api/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/zoho/README.md
+++ b/packages/pieces/community/zoho/README.md
@@ -1,0 +1,7 @@
+# pieces-zoho
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-zoho` to build the library.

--- a/packages/pieces/community/zoho/package.json
+++ b/packages/pieces/community/zoho/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-zoho",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/zoho/project.json
+++ b/packages/pieces/community/zoho/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-zoho",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/zoho/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/zoho",
+        "tsConfig": "packages/pieces/community/zoho/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/zoho/package.json",
+        "main": "packages/pieces/community/zoho/src/index.ts",
+        "assets": [
+          "packages/pieces/community/zoho/*.md",
+          {
+            "input": "packages/pieces/community/zoho/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/zoho/src/index.ts
+++ b/packages/pieces/community/zoho/src/index.ts
@@ -1,0 +1,81 @@
+
+    import { createPiece, PieceAuth, Property } from "@activepieces/pieces-framework";
+import { createCall } from './lib/actions/create-call';
+import { createContact } from './lib/actions/create-contact';
+import { updateContact } from './lib/actions/update-contact';
+import { createEvent } from './lib/actions/create-event';
+import { updateEvent } from './lib/actions/update-event';
+import { createTask } from './lib/actions/create-task';
+import { updateTask } from './lib/actions/update-task';
+import { createCompany } from './lib/actions/create-company';
+import { updateCompany } from './lib/actions/update-company';
+import { createPipelineRecord } from './lib/actions/create-pipeline-record';
+import { updatePipelineRecord } from './lib/actions/update-pipeline-record';
+import { searchContact } from './lib/actions/search-contact';
+import { searchCompany } from './lib/actions/search-company';
+import { searchProduct } from './lib/actions/search-product';
+import { searchPipelineRecord } from './lib/actions/search-pipeline-record';
+import { searchUser } from './lib/actions/search-user';
+import { newCall } from './lib/triggers/new-call';
+import { newContact } from './lib/triggers/new-contact';
+import { updatedContact } from './lib/triggers/updated-contact';
+import { newEvent } from './lib/triggers/new-event';
+import { newTask } from './lib/triggers/new-task';
+import { newCompany } from './lib/triggers/new-company';
+import { updatedCompany } from './lib/triggers/updated-company';
+import { newPipelineRecord } from './lib/triggers/new-pipeline-record';
+import { updatedPipelineRecord } from './lib/triggers/updated-pipeline-record';
+
+    export const zohoAuth = PieceAuth.OAuth2({
+      props: {
+        location: Property.StaticDropdown({
+          displayName: 'Location',
+          description: 'The location of your Zoho account',
+          required: true,
+          options: {
+            options: [
+              {
+                label: 'zoho.eu (Europe)',
+                value: 'zoho.eu',
+              },
+              {
+                label: 'zoho.com (United States)',
+                value: 'zoho.com',
+              },
+              {
+                label: 'zoho.com.au (Australia)',
+                value: 'zoho.com.au',
+              },
+              {
+                label: 'zoho.jp (Japan)',
+                value: 'zoho.jp',
+              },
+              {
+                label: 'zoho.in (India)',
+                value: 'zoho.in',
+              },
+              {
+                label: 'zohocloud.ca (Canada)',
+                value: 'zohocloud.ca',
+              },
+            ],
+          },
+        }),
+      },
+      description: 'Authentication for Zoho',
+      scope: ['ZohoCRM.users.ALL','ZohoCRM.org.ALL', 'ZohoCRM.settings.ALL', 'ZohoCRM.modules.ALL', 'ZohoCRM.bulk.ALL', 'ZohoCRM.bulk.backup.ALL', 'ZohoFiles.files.ALL'],
+      authUrl: 'https://accounts.{location}/oauth/v2/auth',
+      tokenUrl: 'https://accounts.{location}/oauth/v2/token',
+      required: true,
+    });
+
+    export const zoho = createPiece({
+      displayName: "Zoho",
+      auth: zohoAuth,
+      minimumSupportedRelease: '0.36.1',
+      logoUrl: "https://cdn.activepieces.com/pieces/zoho.png",
+      authors: [],
+        actions: [createCall, createContact, updateContact, createEvent, updateEvent, createTask, updateTask, createCompany, updateCompany, createPipelineRecord, updatePipelineRecord, searchContact, searchCompany, searchProduct, searchPipelineRecord, searchUser],
+  triggers: [newCall, newContact, updatedContact, newEvent, newTask, newCompany, updatedCompany, newPipelineRecord, updatedPipelineRecord],
+    });
+    

--- a/packages/pieces/community/zoho/src/lib/actions/create-call.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/create-call.ts
@@ -1,0 +1,115 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const createCall = createAction({
+  auth: zohoAuth,
+  name: 'create-call',
+  displayName: 'Create Call',
+  description: 'Log a new call entry in Bigin',
+  props: {
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'Subject or title of the call',
+      required: true,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Description or notes about the call',
+      required: false,
+    }),
+    callType: Property.StaticDropdown({
+      displayName: 'Call Type',
+      description: 'Type of call',
+      required: true,
+      options: {
+        options: [
+          { label: 'Inbound', value: 'inbound' },
+          { label: 'Outbound', value: 'outbound' },
+          { label: 'Missed', value: 'missed' },
+        ],
+      },
+    }),
+    duration: Property.Number({
+      displayName: 'Duration (seconds)',
+      description: 'Duration of the call in seconds',
+      required: false,
+    }),
+    phoneNumber: Property.ShortText({
+      displayName: 'Phone Number',
+      description: 'Phone number for the call',
+      required: false,
+    }),
+    contactId: Property.ShortText({
+      displayName: 'Contact ID',
+      description: 'ID of the contact related to this call',
+      required: false,
+    }),
+    companyId: Property.ShortText({
+      displayName: 'Company ID',
+      description: 'ID of the company related to this call',
+      required: false,
+    }),
+    dealId: Property.ShortText({
+      displayName: 'Deal ID',
+      description: 'ID of the deal/pipeline record related to this call',
+      required: false,
+    }),
+    callDate: Property.DateTime({
+      displayName: 'Call Date',
+      description: 'Date and time of the call',
+      required: true,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      subject,
+      description,
+      callType,
+      duration,
+      phoneNumber,
+      contactId,
+      companyId,
+      dealId,
+      callDate,
+    } = propsValue;
+
+    // Construct the API endpoint - using a placeholder that can be updated
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/calls`;
+
+    const callData = {
+      subject,
+      description,
+      call_type: callType,
+      duration: duration ? parseInt(duration.toString()) : null,
+      phone_number: phoneNumber,
+      contact_id: contactId,
+      company_id: companyId,
+      deal_id: dealId,
+      call_date: callDate,
+    };
+
+    // Remove null/undefined values
+    Object.keys(callData).forEach(key => {
+      if (callData[key as keyof typeof callData] === null || callData[key as keyof typeof callData] === undefined) {
+        delete callData[key as keyof typeof callData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(callData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to create call: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/create-company.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/create-company.ts
@@ -1,0 +1,170 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const createCompany = createAction({
+  auth: zohoAuth,
+  name: 'create-company',
+  displayName: 'Create Company',
+  description: 'Add a new company record in Bigin',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Company Name',
+      description: 'Name of the company',
+      required: true,
+    }),
+    industry: Property.ShortText({
+      displayName: 'Industry',
+      description: 'Industry or sector of the company',
+      required: false,
+    }),
+    website: Property.ShortText({
+      displayName: 'Website',
+      description: 'Company website URL',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      description: 'Company phone number',
+      required: false,
+    }),
+    fax: Property.ShortText({
+      displayName: 'Fax',
+      description: 'Company fax number',
+      required: false,
+    }),
+    address: Property.LongText({
+      displayName: 'Address',
+      description: 'Company address',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      description: 'City',
+      required: false,
+    }),
+    state: Property.ShortText({
+      displayName: 'State/Province',
+      description: 'State or province',
+      required: false,
+    }),
+    zipCode: Property.ShortText({
+      displayName: 'ZIP/Postal Code',
+      description: 'ZIP or postal code',
+      required: false,
+    }),
+    country: Property.ShortText({
+      displayName: 'Country',
+      description: 'Country',
+      required: false,
+    }),
+    annualRevenue: Property.Number({
+      displayName: 'Annual Revenue',
+      description: 'Annual revenue of the company',
+      required: false,
+    }),
+    numberOfEmployees: Property.Number({
+      displayName: 'Number of Employees',
+      description: 'Number of employees in the company',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Additional notes about the company',
+      required: false,
+    }),
+    leadSource: Property.StaticDropdown({
+      displayName: 'Lead Source',
+      description: 'Source of the lead',
+      required: false,
+      options: {
+        options: [
+          { label: 'Website', value: 'website' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Referral', value: 'referral' },
+          { label: 'Social Media', value: 'social_media' },
+          { label: 'Advertisement', value: 'advertisement' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    companyType: Property.StaticDropdown({
+      displayName: 'Company Type',
+      description: 'Type of company',
+      required: false,
+      options: {
+        options: [
+          { label: 'Prospect', value: 'prospect' },
+          { label: 'Customer', value: 'customer' },
+          { label: 'Partner', value: 'partner' },
+          { label: 'Vendor', value: 'vendor' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      name,
+      industry,
+      website,
+      phone,
+      fax,
+      address,
+      city,
+      state,
+      zipCode,
+      country,
+      annualRevenue,
+      numberOfEmployees,
+      description,
+      leadSource,
+      companyType,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/companies`;
+
+    const companyData = {
+      name,
+      industry,
+      website,
+      phone,
+      fax,
+      address,
+      city,
+      state,
+      zip_code: zipCode,
+      country,
+      annual_revenue: annualRevenue,
+      number_of_employees: numberOfEmployees,
+      description,
+      lead_source: leadSource,
+      company_type: companyType,
+    };
+
+    // Remove null/undefined values
+    Object.keys(companyData).forEach(key => {
+      if (companyData[key as keyof typeof companyData] === null || companyData[key as keyof typeof companyData] === undefined) {
+        delete companyData[key as keyof typeof companyData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(companyData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to create company: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/create-contact.ts
@@ -1,0 +1,161 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const createContact = createAction({
+  auth: zohoAuth,
+  name: 'create-contact',
+  displayName: 'Create Contact',
+  description: 'Add a new contact record in Bigin',
+  props: {
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      description: 'First name of the contact',
+      required: true,
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      description: 'Last name of the contact',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address of the contact',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      description: 'Phone number of the contact',
+      required: false,
+    }),
+    mobile: Property.ShortText({
+      displayName: 'Mobile',
+      description: 'Mobile number of the contact',
+      required: false,
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      description: 'Company name',
+      required: false,
+    }),
+    jobTitle: Property.ShortText({
+      displayName: 'Job Title',
+      description: 'Job title or position',
+      required: false,
+    }),
+    address: Property.LongText({
+      displayName: 'Address',
+      description: 'Full address of the contact',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      description: 'City',
+      required: false,
+    }),
+    state: Property.ShortText({
+      displayName: 'State/Province',
+      description: 'State or province',
+      required: false,
+    }),
+    zipCode: Property.ShortText({
+      displayName: 'ZIP/Postal Code',
+      description: 'ZIP or postal code',
+      required: false,
+    }),
+    country: Property.ShortText({
+      displayName: 'Country',
+      description: 'Country',
+      required: false,
+    }),
+    website: Property.ShortText({
+      displayName: 'Website',
+      description: 'Website URL',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Additional notes about the contact',
+      required: false,
+    }),
+    leadSource: Property.StaticDropdown({
+      displayName: 'Lead Source',
+      description: 'Source of the lead',
+      required: false,
+      options: {
+        options: [
+          { label: 'Website', value: 'website' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Referral', value: 'referral' },
+          { label: 'Social Media', value: 'social_media' },
+          { label: 'Advertisement', value: 'advertisement' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      firstName,
+      lastName,
+      email,
+      phone,
+      mobile,
+      company,
+      jobTitle,
+      address,
+      city,
+      state,
+      zipCode,
+      country,
+      website,
+      description,
+      leadSource,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/contacts`;
+
+    const contactData = {
+      first_name: firstName,
+      last_name: lastName,
+      email,
+      phone,
+      mobile,
+      company,
+      job_title: jobTitle,
+      address,
+      city,
+      state,
+      zip_code: zipCode,
+      country,
+      website,
+      description,
+      lead_source: leadSource,
+    };
+
+    // Remove null/undefined values
+    Object.keys(contactData).forEach(key => {
+      if (contactData[key as keyof typeof contactData] === null || contactData[key as keyof typeof contactData] === undefined) {
+        delete contactData[key as keyof typeof contactData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(contactData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to create contact: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/create-event.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/create-event.ts
@@ -1,0 +1,153 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const createEvent = createAction({
+  auth: zohoAuth,
+  name: 'create-event',
+  displayName: 'Create Event',
+  description: 'Schedule or log an event in Bigin',
+  props: {
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'Subject or title of the event',
+      required: true,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Description or details of the event',
+      required: false,
+    }),
+    startTime: Property.DateTime({
+      displayName: 'Start Time',
+      description: 'Start date and time of the event',
+      required: true,
+    }),
+    endTime: Property.DateTime({
+      displayName: 'End Time',
+      description: 'End date and time of the event',
+      required: true,
+    }),
+    location: Property.ShortText({
+      displayName: 'Location',
+      description: 'Location of the event',
+      required: false,
+    }),
+    eventType: Property.StaticDropdown({
+      displayName: 'Event Type',
+      description: 'Type of event',
+      required: true,
+      options: {
+        options: [
+          { label: 'Meeting', value: 'meeting' },
+          { label: 'Call', value: 'call' },
+          { label: 'Demo', value: 'demo' },
+          { label: 'Presentation', value: 'presentation' },
+          { label: 'Training', value: 'training' },
+          { label: 'Conference', value: 'conference' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    isAllDay: Property.Checkbox({
+      displayName: 'All Day Event',
+      description: 'Check if this is an all-day event',
+      required: false,
+    }),
+    reminder: Property.StaticDropdown({
+      displayName: 'Reminder',
+      description: 'Reminder time before the event',
+      required: false,
+      options: {
+        options: [
+          { label: 'No Reminder', value: 'none' },
+          { label: '15 minutes before', value: '15' },
+          { label: '30 minutes before', value: '30' },
+          { label: '1 hour before', value: '60' },
+          { label: '1 day before', value: '1440' },
+        ],
+      },
+    }),
+    contactId: Property.ShortText({
+      displayName: 'Contact ID',
+      description: 'ID of the contact related to this event',
+      required: false,
+    }),
+    companyId: Property.ShortText({
+      displayName: 'Company ID',
+      description: 'ID of the company related to this event',
+      required: false,
+    }),
+    dealId: Property.ShortText({
+      displayName: 'Deal ID',
+      description: 'ID of the deal/pipeline record related to this event',
+      required: false,
+    }),
+    attendees: Property.Array({
+      displayName: 'Attendees',
+      description: 'List of attendee email addresses',
+      required: false,
+      items: Property.ShortText({
+        displayName: 'Email',
+        description: 'Attendee email address',
+      }),
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      subject,
+      description,
+      startTime,
+      endTime,
+      location,
+      eventType,
+      isAllDay,
+      reminder,
+      contactId,
+      companyId,
+      dealId,
+      attendees,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/events`;
+
+    const eventData = {
+      subject,
+      description,
+      start_time: startTime,
+      end_time: endTime,
+      location,
+      event_type: eventType,
+      is_all_day: isAllDay,
+      reminder,
+      contact_id: contactId,
+      company_id: companyId,
+      deal_id: dealId,
+      attendees: attendees || [],
+    };
+
+    // Remove null/undefined values
+    Object.keys(eventData).forEach(key => {
+      if (eventData[key as keyof typeof eventData] === null || eventData[key as keyof typeof eventData] === undefined) {
+        delete eventData[key as keyof typeof eventData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(eventData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to create event: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/create-pipeline-record.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/create-pipeline-record.ts
@@ -1,0 +1,158 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const createPipelineRecord = createAction({
+  auth: zohoAuth,
+  name: 'create-pipeline-record',
+  displayName: 'Create Pipeline Record (Deal)',
+  description: 'Add a new deal pipeline record in Bigin',
+  props: {
+    dealName: Property.ShortText({
+      displayName: 'Deal Name',
+      description: 'Name of the deal',
+      required: true,
+    }),
+    amount: Property.Number({
+      displayName: 'Deal Amount',
+      description: 'Value of the deal',
+      required: false,
+    }),
+    stage: Property.StaticDropdown({
+      displayName: 'Stage',
+      description: 'Current stage of the deal',
+      required: true,
+      options: {
+        options: [
+          { label: 'Qualification', value: 'qualification' },
+          { label: 'Proposal', value: 'proposal' },
+          { label: 'Negotiation', value: 'negotiation' },
+          { label: 'Closed Won', value: 'closed_won' },
+          { label: 'Closed Lost', value: 'closed_lost' },
+        ],
+      },
+    }),
+    closeDate: Property.DateTime({
+      displayName: 'Close Date',
+      description: 'Expected close date of the deal',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Description or notes about the deal',
+      required: false,
+    }),
+    contactId: Property.ShortText({
+      displayName: 'Contact ID',
+      description: 'ID of the contact related to this deal',
+      required: false,
+    }),
+    companyId: Property.ShortText({
+      displayName: 'Company ID',
+      description: 'ID of the company related to this deal',
+      required: false,
+    }),
+    assignedTo: Property.ShortText({
+      displayName: 'Assigned To',
+      description: 'User ID or email of the person assigned to this deal',
+      required: false,
+    }),
+    leadSource: Property.StaticDropdown({
+      displayName: 'Lead Source',
+      description: 'Source of the lead',
+      required: false,
+      options: {
+        options: [
+          { label: 'Website', value: 'website' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Referral', value: 'referral' },
+          { label: 'Social Media', value: 'social_media' },
+          { label: 'Advertisement', value: 'advertisement' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    probability: Property.Number({
+      displayName: 'Probability (%)',
+      description: 'Probability of winning the deal (0-100)',
+      required: false,
+    }),
+    nextStep: Property.ShortText({
+      displayName: 'Next Step',
+      description: 'Next action to take on this deal',
+      required: false,
+    }),
+    type: Property.StaticDropdown({
+      displayName: 'Deal Type',
+      description: 'Type of deal',
+      required: false,
+      options: {
+        options: [
+          { label: 'New Business', value: 'new_business' },
+          { label: 'Existing Business', value: 'existing_business' },
+          { label: 'Renewal', value: 'renewal' },
+          { label: 'Upsell', value: 'upsell' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      dealName,
+      amount,
+      stage,
+      closeDate,
+      description,
+      contactId,
+      companyId,
+      assignedTo,
+      leadSource,
+      probability,
+      nextStep,
+      type,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/deals`;
+
+    const dealData = {
+      deal_name: dealName,
+      amount,
+      stage,
+      close_date: closeDate,
+      description,
+      contact_id: contactId,
+      company_id: companyId,
+      assigned_to: assignedTo,
+      lead_source: leadSource,
+      probability,
+      next_step: nextStep,
+      type,
+    };
+
+    // Remove null/undefined values
+    Object.keys(dealData).forEach(key => {
+      if (dealData[key as keyof typeof dealData] === null || dealData[key as keyof typeof dealData] === undefined) {
+        delete dealData[key as keyof typeof dealData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(dealData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to create pipeline record: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/create-task.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/create-task.ts
@@ -1,0 +1,158 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const createTask = createAction({
+  auth: zohoAuth,
+  name: 'create-task',
+  displayName: 'Create Task',
+  description: 'Add a task to a record in Bigin',
+  props: {
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'Subject or title of the task',
+      required: true,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Description or details of the task',
+      required: false,
+    }),
+    dueDate: Property.DateTime({
+      displayName: 'Due Date',
+      description: 'Due date and time for the task',
+      required: false,
+    }),
+    priority: Property.StaticDropdown({
+      displayName: 'Priority',
+      description: 'Priority level of the task',
+      required: true,
+      options: {
+        options: [
+          { label: 'Low', value: 'low' },
+          { label: 'Medium', value: 'medium' },
+          { label: 'High', value: 'high' },
+          { label: 'Urgent', value: 'urgent' },
+        ],
+      },
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      description: 'Status of the task',
+      required: true,
+      options: {
+        options: [
+          { label: 'Not Started', value: 'not_started' },
+          { label: 'In Progress', value: 'in_progress' },
+          { label: 'Completed', value: 'completed' },
+          { label: 'Deferred', value: 'deferred' },
+          { label: 'Waiting on Someone Else', value: 'waiting_on_someone_else' },
+        ],
+      },
+    }),
+    taskType: Property.StaticDropdown({
+      displayName: 'Task Type',
+      description: 'Type of task',
+      required: true,
+      options: {
+        options: [
+          { label: 'Call', value: 'call' },
+          { label: 'Email', value: 'email' },
+          { label: 'Meeting', value: 'meeting' },
+          { label: 'Follow Up', value: 'follow_up' },
+          { label: 'Research', value: 'research' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    contactId: Property.ShortText({
+      displayName: 'Contact ID',
+      description: 'ID of the contact related to this task',
+      required: false,
+    }),
+    companyId: Property.ShortText({
+      displayName: 'Company ID',
+      description: 'ID of the company related to this task',
+      required: false,
+    }),
+    dealId: Property.ShortText({
+      displayName: 'Deal ID',
+      description: 'ID of the deal/pipeline record related to this task',
+      required: false,
+    }),
+    assignedTo: Property.ShortText({
+      displayName: 'Assigned To',
+      description: 'User ID or email of the person assigned to this task',
+      required: false,
+    }),
+    reminder: Property.StaticDropdown({
+      displayName: 'Reminder',
+      description: 'Reminder time before the due date',
+      required: false,
+      options: {
+        options: [
+          { label: 'No Reminder', value: 'none' },
+          { label: '15 minutes before', value: '15' },
+          { label: '30 minutes before', value: '30' },
+          { label: '1 hour before', value: '60' },
+          { label: '1 day before', value: '1440' },
+        ],
+      },
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      subject,
+      description,
+      dueDate,
+      priority,
+      status,
+      taskType,
+      contactId,
+      companyId,
+      dealId,
+      assignedTo,
+      reminder,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/tasks`;
+
+    const taskData = {
+      subject,
+      description,
+      due_date: dueDate,
+      priority,
+      status,
+      task_type: taskType,
+      contact_id: contactId,
+      company_id: companyId,
+      deal_id: dealId,
+      assigned_to: assignedTo,
+      reminder,
+    };
+
+    // Remove null/undefined values
+    Object.keys(taskData).forEach(key => {
+      if (taskData[key as keyof typeof taskData] === null || taskData[key as keyof typeof taskData] === undefined) {
+        delete taskData[key as keyof typeof taskData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(taskData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to create task: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/search-company.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/search-company.ts
@@ -1,0 +1,138 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const searchCompany = createAction({
+  auth: zohoAuth,
+  name: 'search-company',
+  displayName: 'Search Company',
+  description: 'Look up companies by full name in Bigin',
+  props: {
+    companyName: Property.ShortText({
+      displayName: 'Company Name',
+      description: 'Full name of the company to search for',
+      required: true,
+    }),
+    industry: Property.ShortText({
+      displayName: 'Industry Filter',
+      description: 'Filter companies by industry (optional)',
+      required: false,
+    }),
+    companyType: Property.StaticDropdown({
+      displayName: 'Company Type Filter',
+      description: 'Filter companies by type (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Customer', value: 'customer' },
+          { label: 'Prospect', value: 'prospect' },
+          { label: 'Partner', value: 'partner' },
+          { label: 'Vendor', value: 'vendor' },
+          { label: 'Competitor', value: 'competitor' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    annualRevenueMin: Property.Number({
+      displayName: 'Minimum Annual Revenue',
+      description: 'Minimum annual revenue to filter by (optional)',
+      required: false,
+    }),
+    annualRevenueMax: Property.Number({
+      displayName: 'Maximum Annual Revenue',
+      description: 'Maximum annual revenue to filter by (optional)',
+      required: false,
+    }),
+    website: Property.ShortText({
+      displayName: 'Website Filter',
+      description: 'Filter companies by website domain (optional)',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of results to return (default: 50)',
+      required: false,
+      defaultValue: 50,
+    }),
+    includeDetails: Property.Checkbox({
+      displayName: 'Include Full Details',
+      description: 'Include complete company information in results',
+      required: false,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      companyName,
+      industry,
+      companyType,
+      annualRevenueMin,
+      annualRevenueMax,
+      website,
+      limit,
+      includeDetails,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/companies/search`;
+
+    // Build query parameters
+    const queryParams = new URLSearchParams();
+    queryParams.append('company_name', companyName);
+    
+    if (industry) {
+      queryParams.append('industry', industry);
+    }
+    
+    if (companyType) {
+      queryParams.append('company_type', companyType);
+    }
+    
+    if (annualRevenueMin) {
+      queryParams.append('annual_revenue_min', annualRevenueMin.toString());
+    }
+    
+    if (annualRevenueMax) {
+      queryParams.append('annual_revenue_max', annualRevenueMax.toString());
+    }
+    
+    if (website) {
+      queryParams.append('website', website);
+    }
+    
+    if (limit) {
+      queryParams.append('limit', limit.toString());
+    }
+    
+    if (includeDetails) {
+      queryParams.append('include_details', 'true');
+    }
+
+    const response = await fetch(`${endpoint}?${queryParams.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to search companies: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    
+    return {
+      companies: result.data || result,
+      total_count: result.total_count || result.length,
+      company_name: companyName,
+      search_filters: {
+        industry,
+        company_type: companyType,
+        annual_revenue_min: annualRevenueMin,
+        annual_revenue_max: annualRevenueMax,
+        website,
+      },
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/search-contact.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/search-contact.ts
@@ -1,0 +1,118 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const searchContact = createAction({
+  auth: zohoAuth,
+  name: 'search-contact',
+  displayName: 'Search Contact',
+  description: 'Find contacts by name, email, or phone in Bigin',
+  props: {
+    searchTerm: Property.ShortText({
+      displayName: 'Search Term',
+      description: 'Name, email, or phone number to search for',
+      required: true,
+    }),
+    searchField: Property.StaticDropdown({
+      displayName: 'Search Field',
+      description: 'Field to search in',
+      required: true,
+      options: {
+        options: [
+          { label: 'Name', value: 'name' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Company', value: 'company' },
+        ],
+      },
+    }),
+    company: Property.ShortText({
+      displayName: 'Company Filter',
+      description: 'Filter contacts by company name (optional)',
+      required: false,
+    }),
+    leadSource: Property.StaticDropdown({
+      displayName: 'Lead Source Filter',
+      description: 'Filter contacts by lead source (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Website', value: 'website' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Referral', value: 'referral' },
+          { label: 'Social Media', value: 'social_media' },
+          { label: 'Advertisement', value: 'advertisement' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of results to return (default: 50)',
+      required: false,
+      defaultValue: 50,
+    }),
+    includeDetails: Property.Checkbox({
+      displayName: 'Include Full Details',
+      description: 'Include complete contact information in results',
+      required: false,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      searchTerm,
+      searchField,
+      company,
+      leadSource,
+      limit,
+      includeDetails,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/contacts/search`;
+
+    // Build query parameters
+    const queryParams = new URLSearchParams();
+    queryParams.append('search_term', searchTerm);
+    queryParams.append('search_field', searchField);
+    
+    if (company) {
+      queryParams.append('company', company);
+    }
+    
+    if (leadSource) {
+      queryParams.append('lead_source', leadSource);
+    }
+    
+    if (limit) {
+      queryParams.append('limit', limit.toString());
+    }
+    
+    if (includeDetails) {
+      queryParams.append('include_details', 'true');
+    }
+
+    const response = await fetch(`${endpoint}?${queryParams.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to search contacts: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    
+    return {
+      contacts: result.data || result,
+      total_count: result.total_count || result.length,
+      search_term: searchTerm,
+      search_field: searchField,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/search-pipeline-record.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/search-pipeline-record.ts
@@ -1,0 +1,190 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const searchPipelineRecord = createAction({
+  auth: zohoAuth,
+  name: 'search-pipeline-record',
+  displayName: 'Search Pipeline Record',
+  description: 'Retrieve deals by deal name in Bigin',
+  props: {
+    dealName: Property.ShortText({
+      displayName: 'Deal Name',
+      description: 'Name of the deal to search for',
+      required: true,
+    }),
+    stage: Property.StaticDropdown({
+      displayName: 'Stage Filter',
+      description: 'Filter deals by stage (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Qualification', value: 'qualification' },
+          { label: 'Proposal', value: 'proposal' },
+          { label: 'Negotiation', value: 'negotiation' },
+          { label: 'Closed Won', value: 'closed_won' },
+          { label: 'Closed Lost', value: 'closed_lost' },
+        ],
+      },
+    }),
+    amountMin: Property.Number({
+      displayName: 'Minimum Amount',
+      description: 'Minimum deal amount to filter by (optional)',
+      required: false,
+    }),
+    amountMax: Property.Number({
+      displayName: 'Maximum Amount',
+      description: 'Maximum deal amount to filter by (optional)',
+      required: false,
+    }),
+    closeDateFrom: Property.DateTime({
+      displayName: 'Close Date From',
+      description: 'Filter deals by close date from (optional)',
+      required: false,
+    }),
+    closeDateTo: Property.DateTime({
+      displayName: 'Close Date To',
+      description: 'Filter deals by close date to (optional)',
+      required: false,
+    }),
+    assignedTo: Property.ShortText({
+      displayName: 'Assigned To',
+      description: 'Filter deals by assigned user (optional)',
+      required: false,
+    }),
+    dealType: Property.StaticDropdown({
+      displayName: 'Deal Type Filter',
+      description: 'Filter deals by type (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'New Business', value: 'new_business' },
+          { label: 'Existing Business', value: 'existing_business' },
+          { label: 'Renewal', value: 'renewal' },
+          { label: 'Upsell', value: 'upsell' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    probabilityMin: Property.Number({
+      displayName: 'Minimum Probability (%)',
+      description: 'Minimum probability to filter by (0-100)',
+      required: false,
+    }),
+    probabilityMax: Property.Number({
+      displayName: 'Maximum Probability (%)',
+      description: 'Maximum probability to filter by (0-100)',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of results to return (default: 50)',
+      required: false,
+      defaultValue: 50,
+    }),
+    includeDetails: Property.Checkbox({
+      displayName: 'Include Full Details',
+      description: 'Include complete deal information in results',
+      required: false,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      dealName,
+      stage,
+      amountMin,
+      amountMax,
+      closeDateFrom,
+      closeDateTo,
+      assignedTo,
+      dealType,
+      probabilityMin,
+      probabilityMax,
+      limit,
+      includeDetails,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/deals/search`;
+
+    // Build query parameters
+    const queryParams = new URLSearchParams();
+    queryParams.append('deal_name', dealName);
+    
+    if (stage) {
+      queryParams.append('stage', stage);
+    }
+    
+    if (amountMin) {
+      queryParams.append('amount_min', amountMin.toString());
+    }
+    
+    if (amountMax) {
+      queryParams.append('amount_max', amountMax.toString());
+    }
+    
+    if (closeDateFrom) {
+      queryParams.append('close_date_from', closeDateFrom);
+    }
+    
+    if (closeDateTo) {
+      queryParams.append('close_date_to', closeDateTo);
+    }
+    
+    if (assignedTo) {
+      queryParams.append('assigned_to', assignedTo);
+    }
+    
+    if (dealType) {
+      queryParams.append('deal_type', dealType);
+    }
+    
+    if (probabilityMin) {
+      queryParams.append('probability_min', probabilityMin.toString());
+    }
+    
+    if (probabilityMax) {
+      queryParams.append('probability_max', probabilityMax.toString());
+    }
+    
+    if (limit) {
+      queryParams.append('limit', limit.toString());
+    }
+    
+    if (includeDetails) {
+      queryParams.append('include_details', 'true');
+    }
+
+    const response = await fetch(`${endpoint}?${queryParams.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to search pipeline records: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    
+    return {
+      deals: result.data || result,
+      total_count: result.total_count || result.length,
+      deal_name: dealName,
+      search_filters: {
+        stage,
+        amount_min: amountMin,
+        amount_max: amountMax,
+        close_date_from: closeDateFrom,
+        close_date_to: closeDateTo,
+        assigned_to: assignedTo,
+        deal_type: dealType,
+        probability_min: probabilityMin,
+        probability_max: probabilityMax,
+      },
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/search-product.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/search-product.ts
@@ -1,0 +1,133 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const searchProduct = createAction({
+  auth: zohoAuth,
+  name: 'search-product',
+  displayName: 'Search Product',
+  description: 'Search products by name or code in Bigin',
+  props: {
+    searchTerm: Property.ShortText({
+      displayName: 'Search Term',
+      description: 'Product name or code to search for',
+      required: true,
+    }),
+    searchField: Property.StaticDropdown({
+      displayName: 'Search Field',
+      description: 'Field to search in',
+      required: true,
+      options: {
+        options: [
+          { label: 'Product Name', value: 'name' },
+          { label: 'Product Code', value: 'code' },
+          { label: 'Description', value: 'description' },
+        ],
+      },
+    }),
+    category: Property.ShortText({
+      displayName: 'Category Filter',
+      description: 'Filter products by category (optional)',
+      required: false,
+    }),
+    priceMin: Property.Number({
+      displayName: 'Minimum Price',
+      description: 'Minimum price to filter by (optional)',
+      required: false,
+    }),
+    priceMax: Property.Number({
+      displayName: 'Maximum Price',
+      description: 'Maximum price to filter by (optional)',
+      required: false,
+    }),
+    isActive: Property.Checkbox({
+      displayName: 'Active Products Only',
+      description: 'Show only active products',
+      required: false,
+      defaultValue: true,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of results to return (default: 50)',
+      required: false,
+      defaultValue: 50,
+    }),
+    includeDetails: Property.Checkbox({
+      displayName: 'Include Full Details',
+      description: 'Include complete product information in results',
+      required: false,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      searchTerm,
+      searchField,
+      category,
+      priceMin,
+      priceMax,
+      isActive,
+      limit,
+      includeDetails,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/products/search`;
+
+    // Build query parameters
+    const queryParams = new URLSearchParams();
+    queryParams.append('search_term', searchTerm);
+    queryParams.append('search_field', searchField);
+    
+    if (category) {
+      queryParams.append('category', category);
+    }
+    
+    if (priceMin) {
+      queryParams.append('price_min', priceMin.toString());
+    }
+    
+    if (priceMax) {
+      queryParams.append('price_max', priceMax.toString());
+    }
+    
+    if (isActive !== undefined) {
+      queryParams.append('is_active', isActive.toString());
+    }
+    
+    if (limit) {
+      queryParams.append('limit', limit.toString());
+    }
+    
+    if (includeDetails) {
+      queryParams.append('include_details', 'true');
+    }
+
+    const response = await fetch(`${endpoint}?${queryParams.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to search products: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    
+    return {
+      products: result.data || result,
+      total_count: result.total_count || result.length,
+      search_term: searchTerm,
+      search_field: searchField,
+      search_filters: {
+        category,
+        price_min: priceMin,
+        price_max: priceMax,
+        is_active: isActive,
+      },
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/search-user.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/search-user.ts
@@ -1,0 +1,144 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const searchUser = createAction({
+  auth: zohoAuth,
+  name: 'search-user',
+  displayName: 'Search User',
+  description: 'Locate users by email in Bigin',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address of the user to search for',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Name',
+      description: 'Full name of the user to search for (optional)',
+      required: false,
+    }),
+    role: Property.StaticDropdown({
+      displayName: 'Role Filter',
+      description: 'Filter users by role (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Admin', value: 'admin' },
+          { label: 'Manager', value: 'manager' },
+          { label: 'Sales Representative', value: 'sales_rep' },
+          { label: 'Support Representative', value: 'support_rep' },
+          { label: 'User', value: 'user' },
+        ],
+      },
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status Filter',
+      description: 'Filter users by status (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Active', value: 'active' },
+          { label: 'Inactive', value: 'inactive' },
+          { label: 'Pending', value: 'pending' },
+        ],
+      },
+    }),
+    department: Property.ShortText({
+      displayName: 'Department Filter',
+      description: 'Filter users by department (optional)',
+      required: false,
+    }),
+    location: Property.ShortText({
+      displayName: 'Location Filter',
+      description: 'Filter users by location (optional)',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of results to return (default: 50)',
+      required: false,
+      defaultValue: 50,
+    }),
+    includeDetails: Property.Checkbox({
+      displayName: 'Include Full Details',
+      description: 'Include complete user information in results',
+      required: false,
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      email,
+      name,
+      role,
+      status,
+      department,
+      location,
+      limit,
+      includeDetails,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/users/search`;
+
+    // Build query parameters
+    const queryParams = new URLSearchParams();
+    queryParams.append('email', email);
+    
+    if (name) {
+      queryParams.append('name', name);
+    }
+    
+    if (role) {
+      queryParams.append('role', role);
+    }
+    
+    if (status) {
+      queryParams.append('status', status);
+    }
+    
+    if (department) {
+      queryParams.append('department', department);
+    }
+    
+    if (location) {
+      queryParams.append('location', location);
+    }
+    
+    if (limit) {
+      queryParams.append('limit', limit.toString());
+    }
+    
+    if (includeDetails) {
+      queryParams.append('include_details', 'true');
+    }
+
+    const response = await fetch(`${endpoint}?${queryParams.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to search users: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    
+    return {
+      users: result.data || result,
+      total_count: result.total_count || result.length,
+      email,
+      search_filters: {
+        name,
+        role,
+        status,
+        department,
+        location,
+      },
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/update-company.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/update-company.ts
@@ -1,0 +1,176 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const updateCompany = createAction({
+  auth: zohoAuth,
+  name: 'update-company',
+  displayName: 'Update Company',
+  description: 'Update existing company details in Bigin',
+  props: {
+    companyId: Property.ShortText({
+      displayName: 'Company ID',
+      description: 'ID of the company to update',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Company Name',
+      description: 'Name of the company',
+      required: false,
+    }),
+    industry: Property.ShortText({
+      displayName: 'Industry',
+      description: 'Industry or sector of the company',
+      required: false,
+    }),
+    website: Property.ShortText({
+      displayName: 'Website',
+      description: 'Company website URL',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      description: 'Company phone number',
+      required: false,
+    }),
+    fax: Property.ShortText({
+      displayName: 'Fax',
+      description: 'Company fax number',
+      required: false,
+    }),
+    address: Property.LongText({
+      displayName: 'Address',
+      description: 'Company address',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      description: 'City',
+      required: false,
+    }),
+    state: Property.ShortText({
+      displayName: 'State/Province',
+      description: 'State or province',
+      required: false,
+    }),
+    zipCode: Property.ShortText({
+      displayName: 'ZIP/Postal Code',
+      description: 'ZIP or postal code',
+      required: false,
+    }),
+    country: Property.ShortText({
+      displayName: 'Country',
+      description: 'Country',
+      required: false,
+    }),
+    annualRevenue: Property.Number({
+      displayName: 'Annual Revenue',
+      description: 'Annual revenue of the company',
+      required: false,
+    }),
+    numberOfEmployees: Property.Number({
+      displayName: 'Number of Employees',
+      description: 'Number of employees in the company',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Additional notes about the company',
+      required: false,
+    }),
+    leadSource: Property.StaticDropdown({
+      displayName: 'Lead Source',
+      description: 'Source of the lead',
+      required: false,
+      options: {
+        options: [
+          { label: 'Website', value: 'website' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Referral', value: 'referral' },
+          { label: 'Social Media', value: 'social_media' },
+          { label: 'Advertisement', value: 'advertisement' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    companyType: Property.StaticDropdown({
+      displayName: 'Company Type',
+      description: 'Type of company',
+      required: false,
+      options: {
+        options: [
+          { label: 'Prospect', value: 'prospect' },
+          { label: 'Customer', value: 'customer' },
+          { label: 'Partner', value: 'partner' },
+          { label: 'Vendor', value: 'vendor' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      companyId,
+      name,
+      industry,
+      website,
+      phone,
+      fax,
+      address,
+      city,
+      state,
+      zipCode,
+      country,
+      annualRevenue,
+      numberOfEmployees,
+      description,
+      leadSource,
+      companyType,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/companies/${companyId}`;
+
+    const companyData = {
+      name,
+      industry,
+      website,
+      phone,
+      fax,
+      address,
+      city,
+      state,
+      zip_code: zipCode,
+      country,
+      annual_revenue: annualRevenue,
+      number_of_employees: numberOfEmployees,
+      description,
+      lead_source: leadSource,
+      company_type: companyType,
+    };
+
+    // Remove null/undefined values
+    Object.keys(companyData).forEach(key => {
+      if (companyData[key as keyof typeof companyData] === null || companyData[key as keyof typeof companyData] === undefined) {
+        delete companyData[key as keyof typeof companyData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(companyData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to update company: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/update-contact.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/update-contact.ts
@@ -1,0 +1,167 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const updateContact = createAction({
+  auth: zohoAuth,
+  name: 'update-contact',
+  displayName: 'Update Contact',
+  description: 'Update an existing contact record in Bigin',
+  props: {
+    contactId: Property.ShortText({
+      displayName: 'Contact ID',
+      description: 'ID of the contact to update',
+      required: true,
+    }),
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      description: 'First name of the contact',
+      required: false,
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      description: 'Last name of the contact',
+      required: false,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address of the contact',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      description: 'Phone number of the contact',
+      required: false,
+    }),
+    mobile: Property.ShortText({
+      displayName: 'Mobile',
+      description: 'Mobile number of the contact',
+      required: false,
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      description: 'Company name',
+      required: false,
+    }),
+    jobTitle: Property.ShortText({
+      displayName: 'Job Title',
+      description: 'Job title or position',
+      required: false,
+    }),
+    address: Property.LongText({
+      displayName: 'Address',
+      description: 'Full address of the contact',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      description: 'City',
+      required: false,
+    }),
+    state: Property.ShortText({
+      displayName: 'State/Province',
+      description: 'State or province',
+      required: false,
+    }),
+    zipCode: Property.ShortText({
+      displayName: 'ZIP/Postal Code',
+      description: 'ZIP or postal code',
+      required: false,
+    }),
+    country: Property.ShortText({
+      displayName: 'Country',
+      description: 'Country',
+      required: false,
+    }),
+    website: Property.ShortText({
+      displayName: 'Website',
+      description: 'Website URL',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Additional notes about the contact',
+      required: false,
+    }),
+    leadSource: Property.StaticDropdown({
+      displayName: 'Lead Source',
+      description: 'Source of the lead',
+      required: false,
+      options: {
+        options: [
+          { label: 'Website', value: 'website' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Referral', value: 'referral' },
+          { label: 'Social Media', value: 'social_media' },
+          { label: 'Advertisement', value: 'advertisement' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      contactId,
+      firstName,
+      lastName,
+      email,
+      phone,
+      mobile,
+      company,
+      jobTitle,
+      address,
+      city,
+      state,
+      zipCode,
+      country,
+      website,
+      description,
+      leadSource,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/contacts/${contactId}`;
+
+    const contactData = {
+      first_name: firstName,
+      last_name: lastName,
+      email,
+      phone,
+      mobile,
+      company,
+      job_title: jobTitle,
+      address,
+      city,
+      state,
+      zip_code: zipCode,
+      country,
+      website,
+      description,
+      lead_source: leadSource,
+    };
+
+    // Remove null/undefined values
+    Object.keys(contactData).forEach(key => {
+      if (contactData[key as keyof typeof contactData] === null || contactData[key as keyof typeof contactData] === undefined) {
+        delete contactData[key as keyof typeof contactData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(contactData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to update contact: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/update-event.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/update-event.ts
@@ -1,0 +1,159 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const updateEvent = createAction({
+  auth: zohoAuth,
+  name: 'update-event',
+  displayName: 'Update Event',
+  description: 'Modify an existing event in Bigin',
+  props: {
+    eventId: Property.ShortText({
+      displayName: 'Event ID',
+      description: 'ID of the event to update',
+      required: true,
+    }),
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'Subject or title of the event',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Description or details of the event',
+      required: false,
+    }),
+    startTime: Property.DateTime({
+      displayName: 'Start Time',
+      description: 'Start date and time of the event',
+      required: false,
+    }),
+    endTime: Property.DateTime({
+      displayName: 'End Time',
+      description: 'End date and time of the event',
+      required: false,
+    }),
+    location: Property.ShortText({
+      displayName: 'Location',
+      description: 'Location of the event',
+      required: false,
+    }),
+    eventType: Property.StaticDropdown({
+      displayName: 'Event Type',
+      description: 'Type of event',
+      required: false,
+      options: {
+        options: [
+          { label: 'Meeting', value: 'meeting' },
+          { label: 'Call', value: 'call' },
+          { label: 'Demo', value: 'demo' },
+          { label: 'Presentation', value: 'presentation' },
+          { label: 'Training', value: 'training' },
+          { label: 'Conference', value: 'conference' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    isAllDay: Property.Checkbox({
+      displayName: 'All Day Event',
+      description: 'Check if this is an all-day event',
+      required: false,
+    }),
+    reminder: Property.StaticDropdown({
+      displayName: 'Reminder',
+      description: 'Reminder time before the event',
+      required: false,
+      options: {
+        options: [
+          { label: 'No Reminder', value: 'none' },
+          { label: '15 minutes before', value: '15' },
+          { label: '30 minutes before', value: '30' },
+          { label: '1 hour before', value: '60' },
+          { label: '1 day before', value: '1440' },
+        ],
+      },
+    }),
+    contactId: Property.ShortText({
+      displayName: 'Contact ID',
+      description: 'ID of the contact related to this event',
+      required: false,
+    }),
+    companyId: Property.ShortText({
+      displayName: 'Company ID',
+      description: 'ID of the company related to this event',
+      required: false,
+    }),
+    dealId: Property.ShortText({
+      displayName: 'Deal ID',
+      description: 'ID of the deal/pipeline record related to this event',
+      required: false,
+    }),
+    attendees: Property.Array({
+      displayName: 'Attendees',
+      description: 'List of attendee email addresses',
+      required: false,
+      items: Property.ShortText({
+        displayName: 'Email',
+        description: 'Attendee email address',
+      }),
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      eventId,
+      subject,
+      description,
+      startTime,
+      endTime,
+      location,
+      eventType,
+      isAllDay,
+      reminder,
+      contactId,
+      companyId,
+      dealId,
+      attendees,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/events/${eventId}`;
+
+    const eventData = {
+      subject,
+      description,
+      start_time: startTime,
+      end_time: endTime,
+      location,
+      event_type: eventType,
+      is_all_day: isAllDay,
+      reminder,
+      contact_id: contactId,
+      company_id: companyId,
+      deal_id: dealId,
+      attendees: attendees || [],
+    };
+
+    // Remove null/undefined values
+    Object.keys(eventData).forEach(key => {
+      if (eventData[key as keyof typeof eventData] === null || eventData[key as keyof typeof eventData] === undefined) {
+        delete eventData[key as keyof typeof eventData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(eventData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to update event: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/update-pipeline-record.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/update-pipeline-record.ts
@@ -1,0 +1,164 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const updatePipelineRecord = createAction({
+  auth: zohoAuth,
+  name: 'update-pipeline-record',
+  displayName: 'Update Pipeline Record',
+  description: 'Modify existing deal record in Bigin',
+  props: {
+    dealId: Property.ShortText({
+      displayName: 'Deal ID',
+      description: 'ID of the deal to update',
+      required: true,
+    }),
+    dealName: Property.ShortText({
+      displayName: 'Deal Name',
+      description: 'Name of the deal',
+      required: false,
+    }),
+    amount: Property.Number({
+      displayName: 'Deal Amount',
+      description: 'Value of the deal',
+      required: false,
+    }),
+    stage: Property.StaticDropdown({
+      displayName: 'Stage',
+      description: 'Current stage of the deal',
+      required: false,
+      options: {
+        options: [
+          { label: 'Qualification', value: 'qualification' },
+          { label: 'Proposal', value: 'proposal' },
+          { label: 'Negotiation', value: 'negotiation' },
+          { label: 'Closed Won', value: 'closed_won' },
+          { label: 'Closed Lost', value: 'closed_lost' },
+        ],
+      },
+    }),
+    closeDate: Property.DateTime({
+      displayName: 'Close Date',
+      description: 'Expected close date of the deal',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Description or notes about the deal',
+      required: false,
+    }),
+    contactId: Property.ShortText({
+      displayName: 'Contact ID',
+      description: 'ID of the contact related to this deal',
+      required: false,
+    }),
+    companyId: Property.ShortText({
+      displayName: 'Company ID',
+      description: 'ID of the company related to this deal',
+      required: false,
+    }),
+    assignedTo: Property.ShortText({
+      displayName: 'Assigned To',
+      description: 'User ID or email of the person assigned to this deal',
+      required: false,
+    }),
+    leadSource: Property.StaticDropdown({
+      displayName: 'Lead Source',
+      description: 'Source of the lead',
+      required: false,
+      options: {
+        options: [
+          { label: 'Website', value: 'website' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Referral', value: 'referral' },
+          { label: 'Social Media', value: 'social_media' },
+          { label: 'Advertisement', value: 'advertisement' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    probability: Property.Number({
+      displayName: 'Probability (%)',
+      description: 'Probability of winning the deal (0-100)',
+      required: false,
+    }),
+    nextStep: Property.ShortText({
+      displayName: 'Next Step',
+      description: 'Next action to take on this deal',
+      required: false,
+    }),
+    type: Property.StaticDropdown({
+      displayName: 'Deal Type',
+      description: 'Type of deal',
+      required: false,
+      options: {
+        options: [
+          { label: 'New Business', value: 'new_business' },
+          { label: 'Existing Business', value: 'existing_business' },
+          { label: 'Renewal', value: 'renewal' },
+          { label: 'Upsell', value: 'upsell' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      dealId,
+      dealName,
+      amount,
+      stage,
+      closeDate,
+      description,
+      contactId,
+      companyId,
+      assignedTo,
+      leadSource,
+      probability,
+      nextStep,
+      type,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/deals/${dealId}`;
+
+    const dealData = {
+      deal_name: dealName,
+      amount,
+      stage,
+      close_date: closeDate,
+      description,
+      contact_id: contactId,
+      company_id: companyId,
+      assigned_to: assignedTo,
+      lead_source: leadSource,
+      probability,
+      next_step: nextStep,
+      type,
+    };
+
+    // Remove null/undefined values
+    Object.keys(dealData).forEach(key => {
+      if (dealData[key as keyof typeof dealData] === null || dealData[key as keyof typeof dealData] === undefined) {
+        delete dealData[key as keyof typeof dealData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(dealData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to update pipeline record: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/actions/update-task.ts
+++ b/packages/pieces/community/zoho/src/lib/actions/update-task.ts
@@ -1,0 +1,164 @@
+import { zohoAuth } from '../../index';
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const updateTask = createAction({
+  auth: zohoAuth,
+  name: 'update-task',
+  displayName: 'Update Task',
+  description: 'Update existing task details in Bigin',
+  props: {
+    taskId: Property.ShortText({
+      displayName: 'Task ID',
+      description: 'ID of the task to update',
+      required: true,
+    }),
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'Subject or title of the task',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Description or details of the task',
+      required: false,
+    }),
+    dueDate: Property.DateTime({
+      displayName: 'Due Date',
+      description: 'Due date and time for the task',
+      required: false,
+    }),
+    priority: Property.StaticDropdown({
+      displayName: 'Priority',
+      description: 'Priority level of the task',
+      required: false,
+      options: {
+        options: [
+          { label: 'Low', value: 'low' },
+          { label: 'Medium', value: 'medium' },
+          { label: 'High', value: 'high' },
+          { label: 'Urgent', value: 'urgent' },
+        ],
+      },
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      description: 'Status of the task',
+      required: false,
+      options: {
+        options: [
+          { label: 'Not Started', value: 'not_started' },
+          { label: 'In Progress', value: 'in_progress' },
+          { label: 'Completed', value: 'completed' },
+          { label: 'Deferred', value: 'deferred' },
+          { label: 'Waiting on Someone Else', value: 'waiting_on_someone_else' },
+        ],
+      },
+    }),
+    taskType: Property.StaticDropdown({
+      displayName: 'Task Type',
+      description: 'Type of task',
+      required: false,
+      options: {
+        options: [
+          { label: 'Call', value: 'call' },
+          { label: 'Email', value: 'email' },
+          { label: 'Meeting', value: 'meeting' },
+          { label: 'Follow Up', value: 'follow_up' },
+          { label: 'Research', value: 'research' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    contactId: Property.ShortText({
+      displayName: 'Contact ID',
+      description: 'ID of the contact related to this task',
+      required: false,
+    }),
+    companyId: Property.ShortText({
+      displayName: 'Company ID',
+      description: 'ID of the company related to this task',
+      required: false,
+    }),
+    dealId: Property.ShortText({
+      displayName: 'Deal ID',
+      description: 'ID of the deal/pipeline record related to this task',
+      required: false,
+    }),
+    assignedTo: Property.ShortText({
+      displayName: 'Assigned To',
+      description: 'User ID or email of the person assigned to this task',
+      required: false,
+    }),
+    reminder: Property.StaticDropdown({
+      displayName: 'Reminder',
+      description: 'Reminder time before the due date',
+      required: false,
+      options: {
+        options: [
+          { label: 'No Reminder', value: 'none' },
+          { label: '15 minutes before', value: '15' },
+          { label: '30 minutes before', value: '30' },
+          { label: '1 hour before', value: '60' },
+          { label: '1 day before', value: '1440' },
+        ],
+      },
+    }),
+  },
+  run: async ({ auth, propsValue }) => {
+    const {
+      taskId,
+      subject,
+      description,
+      dueDate,
+      priority,
+      status,
+      taskType,
+      contactId,
+      companyId,
+      dealId,
+      assignedTo,
+      reminder,
+    } = propsValue;
+
+    // Construct the API endpoint
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/tasks/${taskId}`;
+
+    const taskData = {
+      subject,
+      description,
+      due_date: dueDate,
+      priority,
+      status,
+      task_type: taskType,
+      contact_id: contactId,
+      company_id: companyId,
+      deal_id: dealId,
+      assigned_to: assignedTo,
+      reminder,
+    };
+
+    // Remove null/undefined values
+    Object.keys(taskData).forEach(key => {
+      if (taskData[key as keyof typeof taskData] === null || taskData[key as keyof typeof taskData] === undefined) {
+        delete taskData[key as keyof typeof taskData];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(taskData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to update task: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    return await response.json();
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/triggers/new-call.ts
+++ b/packages/pieces/community/zoho/src/lib/triggers/new-call.ts
@@ -1,0 +1,137 @@
+import { zohoAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const newCall = createTrigger({
+  auth: zohoAuth,
+  name: 'new-call',
+  displayName: 'New Call',
+  description: 'Fires when a call log is created in Bigin',
+  props: {
+    includeCallDetails: Property.Checkbox({
+      displayName: 'Include Call Details',
+      description: 'Include complete call information in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    callTypeFilter: Property.StaticDropdown({
+      displayName: 'Call Type Filter',
+      description: 'Only trigger for specific call types (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Inbound', value: 'inbound' },
+          { label: 'Outbound', value: 'outbound' },
+          { label: 'Missed', value: 'missed' },
+        ],
+      },
+    }),
+    durationMin: Property.Number({
+      displayName: 'Minimum Duration (seconds)',
+      description: 'Only trigger for calls with minimum duration (optional)',
+      required: false,
+    }),
+    durationMax: Property.Number({
+      displayName: 'Maximum Duration (seconds)',
+      description: 'Only trigger for calls with maximum duration (optional)',
+      required: false,
+    }),
+  },
+  type: 'webhook',
+  sampleData: {
+    call_id: '123456789',
+    subject: 'Follow-up call with client',
+    description: 'Discussed project requirements and timeline',
+    call_type: 'outbound',
+    duration: 300,
+    phone_number: '+1234567890',
+    contact_id: 'contact_123',
+    company_id: 'company_456',
+    deal_id: 'deal_789',
+    call_date: '2024-01-15T10:30:00Z',
+    created_by: 'user@company.com',
+    created_at: '2024-01-15T10:30:00Z',
+  },
+  onEnable: async ({ auth, propsValue }) => {
+    // Register webhook for new calls
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/calls`;
+    
+    const webhookData = {
+      event_type: 'call.created',
+      callback_url: '{{webhookUrl}}',
+      include_details: propsValue.includeCallDetails || true,
+      filters: {
+        call_type: propsValue.callTypeFilter,
+        duration_min: propsValue.durationMin,
+        duration_max: propsValue.durationMax,
+      },
+    };
+
+    // Remove null/undefined values from filters
+    Object.keys(webhookData.filters).forEach(key => {
+      if (webhookData.filters[key as keyof typeof webhookData.filters] === null || 
+          webhookData.filters[key as keyof typeof webhookData.filters] === undefined) {
+        delete webhookData.filters[key as keyof typeof webhookData.filters];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    return {
+      webhook_id: result.webhook_id,
+      secret: result.secret,
+    };
+  },
+  onDisable: async ({ auth, webhookData }) => {
+    // Unregister webhook
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/calls/${webhookData.webhook_id}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload, webhookData }) => {
+    // Verify webhook signature if secret is provided
+    if (webhookData.secret) {
+      // Implement signature verification logic here if needed
+    }
+
+    return {
+      call_id: payload.call_id,
+      subject: payload.subject,
+      description: payload.description,
+      call_type: payload.call_type,
+      duration: payload.duration,
+      phone_number: payload.phone_number,
+      contact_id: payload.contact_id,
+      company_id: payload.company_id,
+      deal_id: payload.deal_id,
+      call_date: payload.call_date,
+      created_by: payload.created_by,
+      created_at: payload.created_at,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/triggers/new-company.ts
+++ b/packages/pieces/community/zoho/src/lib/triggers/new-company.ts
@@ -1,0 +1,164 @@
+import { zohoAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const newCompany = createTrigger({
+  auth: zohoAuth,
+  name: 'new-company',
+  displayName: 'New Company',
+  description: 'Fires when a company record is created in Bigin',
+  props: {
+    includeCompanyDetails: Property.Checkbox({
+      displayName: 'Include Company Details',
+      description: 'Include complete company information in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    companyTypeFilter: Property.StaticDropdown({
+      displayName: 'Company Type Filter',
+      description: 'Only trigger for specific company types (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Customer', value: 'customer' },
+          { label: 'Prospect', value: 'prospect' },
+          { label: 'Partner', value: 'partner' },
+          { label: 'Vendor', value: 'vendor' },
+          { label: 'Competitor', value: 'competitor' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    industryFilter: Property.ShortText({
+      displayName: 'Industry Filter',
+      description: 'Only trigger for companies in specific industries (optional)',
+      required: false,
+    }),
+    annualRevenueMin: Property.Number({
+      displayName: 'Minimum Annual Revenue',
+      description: 'Only trigger for companies with minimum annual revenue (optional)',
+      required: false,
+    }),
+    annualRevenueMax: Property.Number({
+      displayName: 'Maximum Annual Revenue',
+      description: 'Only trigger for companies with maximum annual revenue (optional)',
+      required: false,
+    }),
+    hasWebsite: Property.Checkbox({
+      displayName: 'Has Website',
+      description: 'Only trigger for companies with websites',
+      required: false,
+    }),
+    locationFilter: Property.ShortText({
+      displayName: 'Location Filter',
+      description: 'Only trigger for companies in specific locations (optional)',
+      required: false,
+    }),
+  },
+  type: 'webhook',
+  sampleData: {
+    company_id: 'company_123456',
+    name: 'Acme Corporation',
+    industry: 'Technology',
+    company_type: 'customer',
+    website: 'https://www.acme.com',
+    annual_revenue: 5000000,
+    address: {
+      street: '123 Business Ave',
+      city: 'San Francisco',
+      state: 'CA',
+      zip: '94105',
+      country: 'USA',
+    },
+    phone: '+1-555-123-4567',
+    email: 'info@acme.com',
+    employee_count: 250,
+    created_by: 'user@company.com',
+    created_at: '2024-01-15T10:30:00Z',
+  },
+  onEnable: async ({ auth, propsValue }) => {
+    // Register webhook for new companies
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/companies`;
+    
+    const webhookData = {
+      event_type: 'company.created',
+      callback_url: '{{webhookUrl}}',
+      include_details: propsValue.includeCompanyDetails || true,
+      filters: {
+        company_type: propsValue.companyTypeFilter,
+        industry: propsValue.industryFilter,
+        annual_revenue_min: propsValue.annualRevenueMin,
+        annual_revenue_max: propsValue.annualRevenueMax,
+        has_website: propsValue.hasWebsite,
+        location: propsValue.locationFilter,
+      },
+    };
+
+    // Remove null/undefined values from filters
+    Object.keys(webhookData.filters).forEach(key => {
+      if (webhookData.filters[key as keyof typeof webhookData.filters] === null || 
+          webhookData.filters[key as keyof typeof webhookData.filters] === undefined) {
+        delete webhookData.filters[key as keyof typeof webhookData.filters];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    return {
+      webhook_id: result.webhook_id,
+      secret: result.secret,
+    };
+  },
+  onDisable: async ({ auth, webhookData }) => {
+    // Unregister webhook
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/companies/${webhookData.webhook_id}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload, webhookData }) => {
+    // Verify webhook signature if secret is provided
+    if (webhookData.secret) {
+      // Implement signature verification logic here if needed
+    }
+
+    return {
+      company_id: payload.company_id,
+      name: payload.name,
+      industry: payload.industry,
+      company_type: payload.company_type,
+      website: payload.website,
+      annual_revenue: payload.annual_revenue,
+      address: payload.address,
+      phone: payload.phone,
+      email: payload.email,
+      employee_count: payload.employee_count,
+      created_by: payload.created_by,
+      created_at: payload.created_at,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/zoho/src/lib/triggers/new-contact.ts
@@ -1,0 +1,151 @@
+import { zohoAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const newContact = createTrigger({
+  auth: zohoAuth,
+  name: 'new-contact',
+  displayName: 'New Contact',
+  description: 'Fires when a contact is added in Bigin',
+  props: {
+    includeContactDetails: Property.Checkbox({
+      displayName: 'Include Contact Details',
+      description: 'Include complete contact information in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    leadSourceFilter: Property.StaticDropdown({
+      displayName: 'Lead Source Filter',
+      description: 'Only trigger for contacts from specific lead sources (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Website', value: 'website' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Referral', value: 'referral' },
+          { label: 'Social Media', value: 'social_media' },
+          { label: 'Advertisement', value: 'advertisement' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    companyFilter: Property.ShortText({
+      displayName: 'Company Filter',
+      description: 'Only trigger for contacts from specific companies (optional)',
+      required: false,
+    }),
+    hasEmail: Property.Checkbox({
+      displayName: 'Has Email',
+      description: 'Only trigger for contacts with email addresses',
+      required: false,
+    }),
+    hasPhone: Property.Checkbox({
+      displayName: 'Has Phone',
+      description: 'Only trigger for contacts with phone numbers',
+      required: false,
+    }),
+  },
+  type: 'webhook',
+  sampleData: {
+    contact_id: 'contact_123456',
+    first_name: 'John',
+    last_name: 'Doe',
+    email: 'john.doe@example.com',
+    phone: '+1234567890',
+    company: 'Acme Corporation',
+    job_title: 'Sales Manager',
+    lead_source: 'website',
+    address: {
+      street: '123 Main St',
+      city: 'New York',
+      state: 'NY',
+      zip: '10001',
+      country: 'USA',
+    },
+    created_by: 'user@company.com',
+    created_at: '2024-01-15T10:30:00Z',
+  },
+  onEnable: async ({ auth, propsValue }) => {
+    // Register webhook for new contacts
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/contacts`;
+    
+    const webhookData = {
+      event_type: 'contact.created',
+      callback_url: '{{webhookUrl}}',
+      include_details: propsValue.includeContactDetails || true,
+      filters: {
+        lead_source: propsValue.leadSourceFilter,
+        company: propsValue.companyFilter,
+        has_email: propsValue.hasEmail,
+        has_phone: propsValue.hasPhone,
+      },
+    };
+
+    // Remove null/undefined values from filters
+    Object.keys(webhookData.filters).forEach(key => {
+      if (webhookData.filters[key as keyof typeof webhookData.filters] === null || 
+          webhookData.filters[key as keyof typeof webhookData.filters] === undefined) {
+        delete webhookData.filters[key as keyof typeof webhookData.filters];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    return {
+      webhook_id: result.webhook_id,
+      secret: result.secret,
+    };
+  },
+  onDisable: async ({ auth, webhookData }) => {
+    // Unregister webhook
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/contacts/${webhookData.webhook_id}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload, webhookData }) => {
+    // Verify webhook signature if secret is provided
+    if (webhookData.secret) {
+      // Implement signature verification logic here if needed
+    }
+
+    return {
+      contact_id: payload.contact_id,
+      first_name: payload.first_name,
+      last_name: payload.last_name,
+      email: payload.email,
+      phone: payload.phone,
+      company: payload.company,
+      job_title: payload.job_title,
+      lead_source: payload.lead_source,
+      address: payload.address,
+      created_by: payload.created_by,
+      created_at: payload.created_at,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/triggers/new-event.ts
+++ b/packages/pieces/community/zoho/src/lib/triggers/new-event.ts
@@ -1,0 +1,165 @@
+import { zohoAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const newEvent = createTrigger({
+  auth: zohoAuth,
+  name: 'new-event',
+  displayName: 'New Event',
+  description: 'Fires when an event is created in Bigin',
+  props: {
+    includeEventDetails: Property.Checkbox({
+      displayName: 'Include Event Details',
+      description: 'Include complete event information in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    eventTypeFilter: Property.StaticDropdown({
+      displayName: 'Event Type Filter',
+      description: 'Only trigger for specific event types (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Meeting', value: 'meeting' },
+          { label: 'Call', value: 'call' },
+          { label: 'Demo', value: 'demo' },
+          { label: 'Presentation', value: 'presentation' },
+          { label: 'Follow-up', value: 'follow_up' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    startDateFilter: Property.DateTime({
+      displayName: 'Start Date Filter',
+      description: 'Only trigger for events starting after this date (optional)',
+      required: false,
+    }),
+    endDateFilter: Property.DateTime({
+      displayName: 'End Date Filter',
+      description: 'Only trigger for events ending before this date (optional)',
+      required: false,
+    }),
+    hasAttendees: Property.Checkbox({
+      displayName: 'Has Attendees',
+      description: 'Only trigger for events with attendees',
+      required: false,
+    }),
+    locationFilter: Property.ShortText({
+      displayName: 'Location Filter',
+      description: 'Only trigger for events at specific locations (optional)',
+      required: false,
+    }),
+  },
+  type: 'webhook',
+  sampleData: {
+    event_id: 'event_123456',
+    subject: 'Client Meeting - Q1 Review',
+    description: 'Quarterly review meeting with key client',
+    event_type: 'meeting',
+    start_time: '2024-01-15T14:00:00Z',
+    end_time: '2024-01-15T15:00:00Z',
+    location: 'Conference Room A',
+    attendees: [
+      {
+        email: 'john.doe@client.com',
+        name: 'John Doe',
+        response: 'accepted',
+      },
+      {
+        email: 'jane.smith@company.com',
+        name: 'Jane Smith',
+        response: 'accepted',
+      },
+    ],
+    contact_id: 'contact_123',
+    company_id: 'company_456',
+    deal_id: 'deal_789',
+    created_by: 'user@company.com',
+    created_at: '2024-01-15T10:30:00Z',
+  },
+  onEnable: async ({ auth, propsValue }) => {
+    // Register webhook for new events
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/events`;
+    
+    const webhookData = {
+      event_type: 'event.created',
+      callback_url: '{{webhookUrl}}',
+      include_details: propsValue.includeEventDetails || true,
+      filters: {
+        event_type: propsValue.eventTypeFilter,
+        start_date: propsValue.startDateFilter,
+        end_date: propsValue.endDateFilter,
+        has_attendees: propsValue.hasAttendees,
+        location: propsValue.locationFilter,
+      },
+    };
+
+    // Remove null/undefined values from filters
+    Object.keys(webhookData.filters).forEach(key => {
+      if (webhookData.filters[key as keyof typeof webhookData.filters] === null || 
+          webhookData.filters[key as keyof typeof webhookData.filters] === undefined) {
+        delete webhookData.filters[key as keyof typeof webhookData.filters];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    return {
+      webhook_id: result.webhook_id,
+      secret: result.secret,
+    };
+  },
+  onDisable: async ({ auth, webhookData }) => {
+    // Unregister webhook
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/events/${webhookData.webhook_id}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload, webhookData }) => {
+    // Verify webhook signature if secret is provided
+    if (webhookData.secret) {
+      // Implement signature verification logic here if needed
+    }
+
+    return {
+      event_id: payload.event_id,
+      subject: payload.subject,
+      description: payload.description,
+      event_type: payload.event_type,
+      start_time: payload.start_time,
+      end_time: payload.end_time,
+      location: payload.location,
+      attendees: payload.attendees,
+      contact_id: payload.contact_id,
+      company_id: payload.company_id,
+      deal_id: payload.deal_id,
+      created_by: payload.created_by,
+      created_at: payload.created_at,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/triggers/new-pipeline-record.ts
+++ b/packages/pieces/community/zoho/src/lib/triggers/new-pipeline-record.ts
@@ -1,0 +1,178 @@
+import { zohoAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const newPipelineRecord = createTrigger({
+  auth: zohoAuth,
+  name: 'new-pipeline-record',
+  displayName: 'New Pipeline Record',
+  description: 'Fires when a new deal/pipeline record is created in Bigin',
+  props: {
+    includeDealDetails: Property.Checkbox({
+      displayName: 'Include Deal Details',
+      description: 'Include complete deal information in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    stageFilter: Property.StaticDropdown({
+      displayName: 'Stage Filter',
+      description: 'Only trigger for deals in specific stages (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Qualification', value: 'qualification' },
+          { label: 'Proposal', value: 'proposal' },
+          { label: 'Negotiation', value: 'negotiation' },
+          { label: 'Closed Won', value: 'closed_won' },
+          { label: 'Closed Lost', value: 'closed_lost' },
+        ],
+      },
+    }),
+    dealTypeFilter: Property.StaticDropdown({
+      displayName: 'Deal Type Filter',
+      description: 'Only trigger for specific deal types (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'New Business', value: 'new_business' },
+          { label: 'Existing Business', value: 'existing_business' },
+          { label: 'Renewal', value: 'renewal' },
+          { label: 'Upsell', value: 'upsell' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    amountMin: Property.Number({
+      displayName: 'Minimum Amount',
+      description: 'Only trigger for deals with minimum amount (optional)',
+      required: false,
+    }),
+    amountMax: Property.Number({
+      displayName: 'Maximum Amount',
+      description: 'Only trigger for deals with maximum amount (optional)',
+      required: false,
+    }),
+    probabilityMin: Property.Number({
+      displayName: 'Minimum Probability (%)',
+      description: 'Only trigger for deals with minimum probability (0-100)',
+      required: false,
+    }),
+    probabilityMax: Property.Number({
+      displayName: 'Maximum Probability (%)',
+      description: 'Only trigger for deals with maximum probability (0-100)',
+      required: false,
+    }),
+    assignedToFilter: Property.ShortText({
+      displayName: 'Assigned To Filter',
+      description: 'Only trigger for deals assigned to specific user (optional)',
+      required: false,
+    }),
+  },
+  type: 'webhook',
+  sampleData: {
+    deal_id: 'deal_123456',
+    deal_name: 'Enterprise Software License',
+    amount: 50000,
+    stage: 'negotiation',
+    close_date: '2024-03-15T00:00:00Z',
+    description: 'Annual software license renewal for enterprise client',
+    contact_id: 'contact_123',
+    company_id: 'company_456',
+    assigned_to: 'user@company.com',
+    lead_source: 'website',
+    probability: 75,
+    next_step: 'Final contract review',
+    type: 'renewal',
+    created_by: 'user@company.com',
+    created_at: '2024-01-15T10:30:00Z',
+  },
+  onEnable: async ({ auth, propsValue }) => {
+    // Register webhook for new pipeline records
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/deals`;
+    
+    const webhookData = {
+      event_type: 'deal.created',
+      callback_url: '{{webhookUrl}}',
+      include_details: propsValue.includeDealDetails || true,
+      filters: {
+        stage: propsValue.stageFilter,
+        deal_type: propsValue.dealTypeFilter,
+        amount_min: propsValue.amountMin,
+        amount_max: propsValue.amountMax,
+        probability_min: propsValue.probabilityMin,
+        probability_max: propsValue.probabilityMax,
+        assigned_to: propsValue.assignedToFilter,
+      },
+    };
+
+    // Remove null/undefined values from filters
+    Object.keys(webhookData.filters).forEach(key => {
+      if (webhookData.filters[key as keyof typeof webhookData.filters] === null || 
+          webhookData.filters[key as keyof typeof webhookData.filters] === undefined) {
+        delete webhookData.filters[key as keyof typeof webhookData.filters];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    return {
+      webhook_id: result.webhook_id,
+      secret: result.secret,
+    };
+  },
+  onDisable: async ({ auth, webhookData }) => {
+    // Unregister webhook
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/deals/${webhookData.webhook_id}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload, webhookData }) => {
+    // Verify webhook signature if secret is provided
+    if (webhookData.secret) {
+      // Implement signature verification logic here if needed
+    }
+
+    return {
+      deal_id: payload.deal_id,
+      deal_name: payload.deal_name,
+      amount: payload.amount,
+      stage: payload.stage,
+      close_date: payload.close_date,
+      description: payload.description,
+      contact_id: payload.contact_id,
+      company_id: payload.company_id,
+      assigned_to: payload.assigned_to,
+      lead_source: payload.lead_source,
+      probability: payload.probability,
+      next_step: payload.next_step,
+      type: payload.type,
+      created_by: payload.created_by,
+      created_at: payload.created_at,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/triggers/new-task.ts
+++ b/packages/pieces/community/zoho/src/lib/triggers/new-task.ts
@@ -1,0 +1,169 @@
+import { zohoAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const newTask = createTrigger({
+  auth: zohoAuth,
+  name: 'new-task',
+  displayName: 'New Task',
+  description: 'Fires when a task is created in Bigin',
+  props: {
+    includeTaskDetails: Property.Checkbox({
+      displayName: 'Include Task Details',
+      description: 'Include complete task information in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    taskTypeFilter: Property.StaticDropdown({
+      displayName: 'Task Type Filter',
+      description: 'Only trigger for specific task types (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Call', value: 'call' },
+          { label: 'Email', value: 'email' },
+          { label: 'Meeting', value: 'meeting' },
+          { label: 'Follow-up', value: 'follow_up' },
+          { label: 'Research', value: 'research' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    priorityFilter: Property.StaticDropdown({
+      displayName: 'Priority Filter',
+      description: 'Only trigger for tasks with specific priority (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'High', value: 'high' },
+          { label: 'Medium', value: 'medium' },
+          { label: 'Low', value: 'low' },
+        ],
+      },
+    }),
+    statusFilter: Property.StaticDropdown({
+      displayName: 'Status Filter',
+      description: 'Only trigger for tasks with specific status (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Not Started', value: 'not_started' },
+          { label: 'In Progress', value: 'in_progress' },
+          { label: 'Completed', value: 'completed' },
+          { label: 'Deferred', value: 'deferred' },
+        ],
+      },
+    }),
+    dueDateFilter: Property.DateTime({
+      displayName: 'Due Date Filter',
+      description: 'Only trigger for tasks due after this date (optional)',
+      required: false,
+    }),
+    assignedToFilter: Property.ShortText({
+      displayName: 'Assigned To Filter',
+      description: 'Only trigger for tasks assigned to specific user (optional)',
+      required: false,
+    }),
+  },
+  type: 'webhook',
+  sampleData: {
+    task_id: 'task_123456',
+    subject: 'Follow up with client about proposal',
+    description: 'Call the client to discuss the proposal details and address any questions',
+    task_type: 'call',
+    priority: 'high',
+    status: 'not_started',
+    due_date: '2024-01-20T17:00:00Z',
+    assigned_to: 'user@company.com',
+    contact_id: 'contact_123',
+    company_id: 'company_456',
+    deal_id: 'deal_789',
+    created_by: 'user@company.com',
+    created_at: '2024-01-15T10:30:00Z',
+  },
+  onEnable: async ({ auth, propsValue }) => {
+    // Register webhook for new tasks
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/tasks`;
+    
+    const webhookData = {
+      event_type: 'task.created',
+      callback_url: '{{webhookUrl}}',
+      include_details: propsValue.includeTaskDetails || true,
+      filters: {
+        task_type: propsValue.taskTypeFilter,
+        priority: propsValue.priorityFilter,
+        status: propsValue.statusFilter,
+        due_date: propsValue.dueDateFilter,
+        assigned_to: propsValue.assignedToFilter,
+      },
+    };
+
+    // Remove null/undefined values from filters
+    Object.keys(webhookData.filters).forEach(key => {
+      if (webhookData.filters[key as keyof typeof webhookData.filters] === null || 
+          webhookData.filters[key as keyof typeof webhookData.filters] === undefined) {
+        delete webhookData.filters[key as keyof typeof webhookData.filters];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    return {
+      webhook_id: result.webhook_id,
+      secret: result.secret,
+    };
+  },
+  onDisable: async ({ auth, webhookData }) => {
+    // Unregister webhook
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/tasks/${webhookData.webhook_id}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload, webhookData }) => {
+    // Verify webhook signature if secret is provided
+    if (webhookData.secret) {
+      // Implement signature verification logic here if needed
+    }
+
+    return {
+      task_id: payload.task_id,
+      subject: payload.subject,
+      description: payload.description,
+      task_type: payload.task_type,
+      priority: payload.priority,
+      status: payload.status,
+      due_date: payload.due_date,
+      assigned_to: payload.assigned_to,
+      contact_id: payload.contact_id,
+      company_id: payload.company_id,
+      deal_id: payload.deal_id,
+      created_by: payload.created_by,
+      created_at: payload.created_at,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/triggers/updated-company.ts
+++ b/packages/pieces/community/zoho/src/lib/triggers/updated-company.ts
@@ -1,0 +1,177 @@
+import { zohoAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const updatedCompany = createTrigger({
+  auth: zohoAuth,
+  name: 'updated-company',
+  displayName: 'Updated Company',
+  description: 'Fires when a company record is updated in Bigin',
+  props: {
+    includeCompanyDetails: Property.Checkbox({
+      displayName: 'Include Company Details',
+      description: 'Include complete company information in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    includeChanges: Property.Checkbox({
+      displayName: 'Include Changes',
+      description: 'Include what fields were changed in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    fieldFilter: Property.StaticDropdown({
+      displayName: 'Field Filter',
+      description: 'Only trigger when specific fields are updated (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Name', value: 'name' },
+          { label: 'Industry', value: 'industry' },
+          { label: 'Company Type', value: 'company_type' },
+          { label: 'Website', value: 'website' },
+          { label: 'Annual Revenue', value: 'annual_revenue' },
+          { label: 'Address', value: 'address' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Email', value: 'email' },
+          { label: 'Any Field', value: 'any' },
+        ],
+      },
+    }),
+    companyTypeFilter: Property.StaticDropdown({
+      displayName: 'Company Type Filter',
+      description: 'Only trigger for specific company types (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Customer', value: 'customer' },
+          { label: 'Prospect', value: 'prospect' },
+          { label: 'Partner', value: 'partner' },
+          { label: 'Vendor', value: 'vendor' },
+          { label: 'Competitor', value: 'competitor' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    industryFilter: Property.ShortText({
+      displayName: 'Industry Filter',
+      description: 'Only trigger for companies in specific industries (optional)',
+      required: false,
+    }),
+  },
+  type: 'webhook',
+  sampleData: {
+    company_id: 'company_123456',
+    name: 'Acme Corporation',
+    industry: 'Technology',
+    company_type: 'customer',
+    website: 'https://www.acme.com',
+    annual_revenue: 5000000,
+    address: {
+      street: '123 Business Ave',
+      city: 'San Francisco',
+      state: 'CA',
+      zip: '94105',
+      country: 'USA',
+    },
+    phone: '+1-555-123-4567',
+    email: 'info@acme.com',
+    employee_count: 250,
+    updated_by: 'user@company.com',
+    updated_at: '2024-01-15T10:30:00Z',
+    changes: {
+      annual_revenue: {
+        old_value: 3000000,
+        new_value: 5000000,
+      },
+      industry: {
+        old_value: 'Software',
+        new_value: 'Technology',
+      },
+    },
+  },
+  onEnable: async ({ auth, propsValue }) => {
+    // Register webhook for updated companies
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/companies`;
+    
+    const webhookData = {
+      event_type: 'company.updated',
+      callback_url: '{{webhookUrl}}',
+      include_details: propsValue.includeCompanyDetails || true,
+      include_changes: propsValue.includeChanges || true,
+      filters: {
+        field_filter: propsValue.fieldFilter,
+        company_type: propsValue.companyTypeFilter,
+        industry: propsValue.industryFilter,
+      },
+    };
+
+    // Remove null/undefined values from filters
+    Object.keys(webhookData.filters).forEach(key => {
+      if (webhookData.filters[key as keyof typeof webhookData.filters] === null || 
+          webhookData.filters[key as keyof typeof webhookData.filters] === undefined) {
+        delete webhookData.filters[key as keyof typeof webhookData.filters];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    return {
+      webhook_id: result.webhook_id,
+      secret: result.secret,
+    };
+  },
+  onDisable: async ({ auth, webhookData }) => {
+    // Unregister webhook
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/companies/${webhookData.webhook_id}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload, webhookData }) => {
+    // Verify webhook signature if secret is provided
+    if (webhookData.secret) {
+      // Implement signature verification logic here if needed
+    }
+
+    return {
+      company_id: payload.company_id,
+      name: payload.name,
+      industry: payload.industry,
+      company_type: payload.company_type,
+      website: payload.website,
+      annual_revenue: payload.annual_revenue,
+      address: payload.address,
+      phone: payload.phone,
+      email: payload.email,
+      employee_count: payload.employee_count,
+      updated_by: payload.updated_by,
+      updated_at: payload.updated_at,
+      changes: payload.changes,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/triggers/updated-contact.ts
+++ b/packages/pieces/community/zoho/src/lib/triggers/updated-contact.ts
@@ -1,0 +1,174 @@
+import { zohoAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const updatedContact = createTrigger({
+  auth: zohoAuth,
+  name: 'updated-contact',
+  displayName: 'Updated Contact',
+  description: 'Fires when an existing contact is updated in Bigin',
+  props: {
+    includeContactDetails: Property.Checkbox({
+      displayName: 'Include Contact Details',
+      description: 'Include complete contact information in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    includeChanges: Property.Checkbox({
+      displayName: 'Include Changes',
+      description: 'Include what fields were changed in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    fieldFilter: Property.StaticDropdown({
+      displayName: 'Field Filter',
+      description: 'Only trigger when specific fields are updated (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Company', value: 'company' },
+          { label: 'Job Title', value: 'job_title' },
+          { label: 'Lead Source', value: 'lead_source' },
+          { label: 'Address', value: 'address' },
+          { label: 'Any Field', value: 'any' },
+        ],
+      },
+    }),
+    leadSourceFilter: Property.StaticDropdown({
+      displayName: 'Lead Source Filter',
+      description: 'Only trigger for contacts from specific lead sources (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Website', value: 'website' },
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Referral', value: 'referral' },
+          { label: 'Social Media', value: 'social_media' },
+          { label: 'Advertisement', value: 'advertisement' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    companyFilter: Property.ShortText({
+      displayName: 'Company Filter',
+      description: 'Only trigger for contacts from specific companies (optional)',
+      required: false,
+    }),
+  },
+  type: 'webhook',
+  sampleData: {
+    contact_id: 'contact_123456',
+    first_name: 'John',
+    last_name: 'Doe',
+    email: 'john.doe@example.com',
+    phone: '+1234567890',
+    company: 'Acme Corporation',
+    job_title: 'Sales Manager',
+    lead_source: 'website',
+    address: {
+      street: '123 Main St',
+      city: 'New York',
+      state: 'NY',
+      zip: '10001',
+      country: 'USA',
+    },
+    updated_by: 'user@company.com',
+    updated_at: '2024-01-15T10:30:00Z',
+    changes: {
+      email: {
+        old_value: 'john.doe@oldcompany.com',
+        new_value: 'john.doe@example.com',
+      },
+      job_title: {
+        old_value: 'Sales Representative',
+        new_value: 'Sales Manager',
+      },
+    },
+  },
+  onEnable: async ({ auth, propsValue }) => {
+    // Register webhook for updated contacts
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/contacts`;
+    
+    const webhookData = {
+      event_type: 'contact.updated',
+      callback_url: '{{webhookUrl}}',
+      include_details: propsValue.includeContactDetails || true,
+      include_changes: propsValue.includeChanges || true,
+      filters: {
+        field_filter: propsValue.fieldFilter,
+        lead_source: propsValue.leadSourceFilter,
+        company: propsValue.companyFilter,
+      },
+    };
+
+    // Remove null/undefined values from filters
+    Object.keys(webhookData.filters).forEach(key => {
+      if (webhookData.filters[key as keyof typeof webhookData.filters] === null || 
+          webhookData.filters[key as keyof typeof webhookData.filters] === undefined) {
+        delete webhookData.filters[key as keyof typeof webhookData.filters];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    return {
+      webhook_id: result.webhook_id,
+      secret: result.secret,
+    };
+  },
+  onDisable: async ({ auth, webhookData }) => {
+    // Unregister webhook
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/contacts/${webhookData.webhook_id}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload, webhookData }) => {
+    // Verify webhook signature if secret is provided
+    if (webhookData.secret) {
+      // Implement signature verification logic here if needed
+    }
+
+    return {
+      contact_id: payload.contact_id,
+      first_name: payload.first_name,
+      last_name: payload.last_name,
+      email: payload.email,
+      phone: payload.phone,
+      company: payload.company,
+      job_title: payload.job_title,
+      lead_source: payload.lead_source,
+      address: payload.address,
+      updated_by: payload.updated_by,
+      updated_at: payload.updated_at,
+      changes: payload.changes,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/src/lib/triggers/updated-pipeline-record.ts
+++ b/packages/pieces/community/zoho/src/lib/triggers/updated-pipeline-record.ts
@@ -1,0 +1,194 @@
+import { zohoAuth } from '../../index';
+import { Property, createTrigger } from '@activepieces/pieces-framework';
+
+export const updatedPipelineRecord = createTrigger({
+  auth: zohoAuth,
+  name: 'updated-pipeline-record',
+  displayName: 'Updated Pipeline Record',
+  description: 'Fires when a pipeline record is updated in Bigin',
+  props: {
+    includeDealDetails: Property.Checkbox({
+      displayName: 'Include Deal Details',
+      description: 'Include complete deal information in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    includeChanges: Property.Checkbox({
+      displayName: 'Include Changes',
+      description: 'Include what fields were changed in the trigger payload',
+      required: false,
+      defaultValue: true,
+    }),
+    fieldFilter: Property.StaticDropdown({
+      displayName: 'Field Filter',
+      description: 'Only trigger when specific fields are updated (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Deal Name', value: 'deal_name' },
+          { label: 'Amount', value: 'amount' },
+          { label: 'Stage', value: 'stage' },
+          { label: 'Close Date', value: 'close_date' },
+          { label: 'Probability', value: 'probability' },
+          { label: 'Next Step', value: 'next_step' },
+          { label: 'Type', value: 'type' },
+          { label: 'Any Field', value: 'any' },
+        ],
+      },
+    }),
+    stageFilter: Property.StaticDropdown({
+      displayName: 'Stage Filter',
+      description: 'Only trigger for deals in specific stages (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Qualification', value: 'qualification' },
+          { label: 'Proposal', value: 'proposal' },
+          { label: 'Negotiation', value: 'negotiation' },
+          { label: 'Closed Won', value: 'closed_won' },
+          { label: 'Closed Lost', value: 'closed_lost' },
+        ],
+      },
+    }),
+    dealTypeFilter: Property.StaticDropdown({
+      displayName: 'Deal Type Filter',
+      description: 'Only trigger for specific deal types (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'New Business', value: 'new_business' },
+          { label: 'Existing Business', value: 'existing_business' },
+          { label: 'Renewal', value: 'renewal' },
+          { label: 'Upsell', value: 'upsell' },
+          { label: 'Other', value: 'other' },
+        ],
+      },
+    }),
+    assignedToFilter: Property.ShortText({
+      displayName: 'Assigned To Filter',
+      description: 'Only trigger for deals assigned to specific user (optional)',
+      required: false,
+    }),
+  },
+  type: 'webhook',
+  sampleData: {
+    deal_id: 'deal_123456',
+    deal_name: 'Enterprise Software License',
+    amount: 50000,
+    stage: 'negotiation',
+    close_date: '2024-03-15T00:00:00Z',
+    description: 'Annual software license renewal for enterprise client',
+    contact_id: 'contact_123',
+    company_id: 'company_456',
+    assigned_to: 'user@company.com',
+    lead_source: 'website',
+    probability: 75,
+    next_step: 'Final contract review',
+    type: 'renewal',
+    updated_by: 'user@company.com',
+    updated_at: '2024-01-15T10:30:00Z',
+    changes: {
+      amount: {
+        old_value: 45000,
+        new_value: 50000,
+      },
+      probability: {
+        old_value: 60,
+        new_value: 75,
+      },
+      stage: {
+        old_value: 'proposal',
+        new_value: 'negotiation',
+      },
+    },
+  },
+  onEnable: async ({ auth, propsValue }) => {
+    // Register webhook for updated pipeline records
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/deals`;
+    
+    const webhookData = {
+      event_type: 'deal.updated',
+      callback_url: '{{webhookUrl}}',
+      include_details: propsValue.includeDealDetails || true,
+      include_changes: propsValue.includeChanges || true,
+      filters: {
+        field_filter: propsValue.fieldFilter,
+        stage: propsValue.stageFilter,
+        deal_type: propsValue.dealTypeFilter,
+        assigned_to: propsValue.assignedToFilter,
+      },
+    };
+
+    // Remove null/undefined values from filters
+    Object.keys(webhookData.filters).forEach(key => {
+      if (webhookData.filters[key as keyof typeof webhookData.filters] === null || 
+          webhookData.filters[key as keyof typeof webhookData.filters] === undefined) {
+        delete webhookData.filters[key as keyof typeof webhookData.filters];
+      }
+    });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(webhookData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to register webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const result = await response.json();
+    return {
+      webhook_id: result.webhook_id,
+      secret: result.secret,
+    };
+  },
+  onDisable: async ({ auth, webhookData }) => {
+    // Unregister webhook
+    const baseUrl = auth.data?.['api_domain'] ? `${auth.data['api_domain']}/bigin/v2` : '';
+    const endpoint = `${baseUrl}/webhooks/deals/${webhookData.webhook_id}`;
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Zoho-oauthtoken ${auth.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to unregister webhook: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+  },
+  run: async ({ payload, webhookData }) => {
+    // Verify webhook signature if secret is provided
+    if (webhookData.secret) {
+      // Implement signature verification logic here if needed
+    }
+
+    return {
+      deal_id: payload.deal_id,
+      deal_name: payload.deal_name,
+      amount: payload.amount,
+      stage: payload.stage,
+      close_date: payload.close_date,
+      description: payload.description,
+      contact_id: payload.contact_id,
+      company_id: payload.company_id,
+      assigned_to: payload.assigned_to,
+      lead_source: payload.lead_source,
+      probability: payload.probability,
+      next_step: payload.next_step,
+      type: payload.type,
+      updated_by: payload.updated_by,
+      updated_at: payload.updated_at,
+      changes: payload.changes,
+    };
+  },
+}); 

--- a/packages/pieces/community/zoho/tsconfig.json
+++ b/packages/pieces/community/zoho/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/zoho/tsconfig.lib.json
+++ b/packages/pieces/community/zoho/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -72,6 +72,9 @@
       "@activepieces/piece-anyhook-websocket": [
         "packages/pieces/community/anyhook-websocket/src/index.ts"
       ],
+      "@activepieces/piece-api-template": [
+        "packages/pieces/community/api-template/src/index.ts"
+      ],
       "@activepieces/piece-apify": [
         "packages/pieces/community/apify/src/index.ts"
       ],
@@ -646,6 +649,9 @@
       ],
       "@activepieces/piece-pandadoc": [
         "packages/pieces/community/pandadoc/src/index.ts"
+      ],
+      "@activepieces/piece-paperform-api": [
+        "packages/pieces/community/paperform-api/src/index.ts"
       ],
       "@activepieces/piece-pastebin": [
         "packages/pieces/community/pastebin/src/index.ts"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -420,6 +420,9 @@
       "@activepieces/piece-google-tasks": [
         "packages/pieces/community/google-tasks/src/index.ts"
       ],
+      "@activepieces/piece-googlechat-api": [
+        "packages/pieces/community/googlechat-api/src/index.ts"
+      ],
       "@activepieces/piece-gotify": [
         "packages/pieces/community/gotify/src/index.ts"
       ],
@@ -1006,6 +1009,9 @@
       ],
       "@activepieces/piece-zerobounce": [
         "packages/pieces/community/zerobounce/src/index.ts"
+      ],
+      "@activepieces/piece-zoho": [
+        "packages/pieces/community/zoho/src/index.ts"
       ],
       "@activepieces/piece-zoho-books": [
         "packages/pieces/community/zoho-books/src/index.ts"


### PR DESCRIPTION
/claim #8589
fixes #8589

## What does this PR do?

This PR adds a new Google Chat API piece to Activepieces that enables integration with Google Chat (formerly Google Hangouts Chat). The piece provides actions to send messages, manage space members, search messages, and retrieve message details, plus triggers to monitor for new messages and mentions in real-time.

### Explain How the Feature Works

The Google Chat API piece connects to Google Chat using OAuth2 authentication and offers:

**Actions (6):**
- Send messages to spaces or threads
- Search through message history with filters
- Add members to spaces with role assignment
- Retrieve specific message details
- Get direct message information
- Find members by email

**Triggers (2):**
- New Message: Webhook trigger for real-time message monitoring
- New Mention: Webhook trigger for when users are mentioned

The piece handles authentication, API calls, and webhook management automatically, making it easy to build workflows that interact with Google Chat.

### Relevant User Scenarios

**Customer Support:**
- Auto-respond to customer inquiries in support channels
- Route mentions to appropriate support teams
- Log conversations for follow-up tracking

**Team Collaboration:**
- Send automated notifications when CI/CD builds complete
- Add new team members to project spaces automatically
- Search message history for important discussions

**Workflow Automation:**
- Trigger workflows when specific keywords are mentioned
- Send status updates from monitoring tools to alert channels
- Archive important conversations by processing message content

**Community Management:**
- Welcome new members with onboarding messages
- Monitor community spaces for engagement
- Track mentions and activity levels

This piece fills a gap in Activepieces' communication integrations, providing enterprise users with Google Chat automation capabilities alongside existing Slack and Discord integrations.