### PR TITLE
fix(google-drive): team drive update permission not working

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.42"
+  "version": "0.5.43"
 }

--- a/packages/pieces/community/google-drive/src/lib/action/add-permission.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/add-permission.action.ts
@@ -70,7 +70,8 @@ export const addPermission = createAction({
         const result = await drive.permissions.create({
             requestBody: permission,
             fileId: fileId,
-            sendNotificationEmail: send_invitation_email
+            sendNotificationEmail: send_invitation_email,
+            supportsAllDrives: true,
         });
 
         return result.data;

--- a/packages/pieces/community/google-drive/src/lib/action/add-permission.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/add-permission.action.ts
@@ -2,6 +2,7 @@ import { Property, createAction } from "@activepieces/pieces-framework";
 import { googleDriveAuth } from "../../";
 import { google } from 'googleapis';
 import { OAuth2Client } from 'googleapis-common';
+import { common } from "../common";
 
 export const addPermission = createAction({
     auth: googleDriveAuth,
@@ -49,16 +50,16 @@ export const addPermission = createAction({
             ]
             }
         }),
+        include_team_drives: common.properties.include_team_drives,
         send_invitation_email: Property.Checkbox({
             displayName: 'Send invitation email',
             description: 'Send an email to the user to notify them of the new permissions',
             required: true,
         }),
-
        },
 
     async run(context) {
-        const [fileId, user_email, permission_name, send_invitation_email] = [context.propsValue.fileId, context.propsValue.user_email, context.propsValue.permission_name, context.propsValue.send_invitation_email];
+        const {fileId, user_email, permission_name, send_invitation_email,include_team_drives} = context.propsValue;
 
         const authClient = new OAuth2Client();
         authClient.setCredentials(context.auth)
@@ -71,7 +72,7 @@ export const addPermission = createAction({
             requestBody: permission,
             fileId: fileId,
             sendNotificationEmail: send_invitation_email,
-            supportsAllDrives: true,
+            supportsAllDrives: include_team_drives,
         });
 
         return result.data;


### PR DESCRIPTION
## What does this PR do?

fixes update permission for team google drive


### Explain How the Feature Works
#### Before
<img width="1900" height="350" alt="Screenshot 2025-08-03 at 19 22 48" src="https://github.com/user-attachments/assets/70e176b5-55df-4a66-b3f0-44c1ad8647bc" />

#### After
<img width="1211" height="730" alt="Screenshot 2025-08-04 at 3 19 03 PM" src="https://github.com/user-attachments/assets/0172972e-362a-4fd3-ab42-373e4c965255" />


### Relevant User Scenarios

Bug fix on existing feature

Fixes #8374 
