### PR TITLE
feat(embed): hook for flow progress update

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -190,6 +190,7 @@
               "embedding/customize-pieces",
               "embedding/embed-connections",
               "embedding/navigation",
+              "embedding/flow-progress",
               "embedding/predefined-connection",
               "embedding/sdk-changelog",
               "embedding/sdk-server-requests"

--- a/docs/embedding/embed-builder.mdx
+++ b/docs/embedding/embed-builder.mdx
@@ -45,6 +45,12 @@ activepieces.configure({
       handler: ({ route }) => {
           // The iframe route has changed, make sure you check the navigation section.
         }
+    },
+    flowProgress: {
+      handler: ({ flowId }) => {
+        // Handle flow progress updates
+        console.log('Flow progress update for flow:', flowId);
+      }
     }
   },
 });
@@ -83,6 +89,7 @@ Please check the [navigation](./navigation) section, as it's very important to u
 | embedding.hideDuplicateFlow | ❌ |  boolean | Hides the option to duplicate a flow  (added in [0.5.0](./sdk-changelog#03%2F07%2F2025-0-5-0))|
 | embedding.locale | ❌ |  'en' \| 'nl' \| 'it' \| 'de' \| 'fr' \| 'bg' \| 'uk' \| 'hu' \| 'es' \| 'ja' \| 'id' \| 'vi' \| 'zh' \| 'pt'  | it takes [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) locale codes (added in [0.5.0](./sdk-changelog#03%2F07%2F2025-0-5-0))|
 | navigation.handler  | ❌ | `({route:string}) => void`  | This callback will be triggered each time a route in Activepieces changes, you can read more about it [here](/embedding/navigation) |
+| embedding.flowProgress.handler | ❌ | `({flowId:string}) => void` | This callback will be triggered when flow progress updates occur, you can read more about it [here](/embedding/flow-progress) |
 
 <Tip>
  For the font to be loaded, you need to set both the `fontUrl` and `fontFamily` properties.

--- a/docs/embedding/flow-progress.mdx
+++ b/docs/embedding/flow-progress.mdx
@@ -1,0 +1,105 @@
+---
+title: "Flow Progress Updates"
+description: "Listen to flow progress updates in your embedded Activepieces instance"
+icon: "activity"
+---
+
+The flow progress hook allows you to receive real-time updates when flow progress changes occur in your embedded Activepieces instance. This is useful for updating your parent UI when flows are modified, executed, or their status changes.
+
+## Configuration
+
+You can configure the flow progress handler when setting up the embed SDK:
+
+```js
+const instanceUrl = 'YOUR_INSTANCE_URL';
+const jwtToken = 'YOUR_GENERATED_JWT_TOKEN';
+const containerId = 'YOUR_CONTAINER_ID';
+
+activepieces.configure({
+  instanceUrl,
+  jwtToken,
+  embedding: {
+    containerId,
+    flowProgress: {
+      handler: ({ flowId }) => {
+        // Handle flow progress updates
+        console.log('Flow progress update for flow:', flowId);
+        
+        // You can use this to trigger UI updates in your parent application
+        // For example, refresh flow data, update status indicators, etc.
+      }
+    }
+  }
+});
+```
+
+## Event Data
+
+The flow progress handler receives an object with the following properties:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `flowId` | `string` | The ID of the flow that was updated |
+
+## Use Cases
+
+Common use cases for the flow progress hook include:
+
+- **Real-time UI updates**: Update your parent application's UI when flows are modified
+- **Status synchronization**: Keep your application's flow status in sync with Activepieces
+- **Data refresh**: Trigger data refetching when flows are updated
+- **Notifications**: Show notifications to users when flow changes occur
+
+## Example Implementation
+
+Here's an example of how you might use the flow progress hook to update your application:
+
+```js
+activepieces.configure({
+  instanceUrl,
+  jwtToken,
+  embedding: {
+    containerId,
+    flowProgress: {
+      handler: ({ flowId }) => {
+        // Update your application's flow data
+        refreshFlowData(flowId);
+        
+        // Show a notification to the user
+        showNotification(`Flow ${flowId} has been updated`);
+        
+        // Update any status indicators
+        updateFlowStatus(flowId);
+      }
+    }
+  }
+});
+```
+
+## Integration with Navigation
+
+The flow progress hook works alongside the navigation handler to provide comprehensive flow management:
+
+```js
+activepieces.configure({
+  instanceUrl,
+  jwtToken,
+  embedding: {
+    containerId,
+    navigation: {
+      handler: ({ route }) => {
+        // Handle route changes
+        updateBrowserHistory(route);
+      }
+    },
+    flowProgress: {
+      handler: ({ flowId }) => {
+        // Handle flow progress updates
+        refreshFlowData(flowId);
+      }
+    }
+  }
+});
+```
+
+This combination allows you to maintain a synchronized state between your parent application and the embedded Activepieces instance. 


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->

Implements flowProgressUpdate hooks to embed SDK. 

This allows the embed sdk programmatic hooks to 'sync' state before/during/after a flow run on the embed UI. 
- Sync state for project usage limits
- Flow run UI in other areas of the sites (outside of the embed UI).

Use case: Embed customers show may show their own metering system linked to AP Embed limits (ai_credits, tasks). Without this feature, we would need to 'poll' the sdk to fetch updates about project usage and flow run status.

### Explain How the Feature Works

Note: This was hard to test since I didn't know how to build the SDK bundle to test end-to-end. Please review careefully.

<img width="1285" height="948" alt="Screenshot 2025-08-05 at 11 43 17" src="https://github.com/user-attachments/assets/fa2dc2ec-7f5d-41eb-a00d-4ca51435d8d2" />



### Relevant User Scenarios

NA

Fixes # (issue) 

NA
