### PR TITLE
fix(markdown): properly render tables in markdown output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -257,6 +257,7 @@
         "react-use": "17.5.1",
         "recharts": "2.12.7",
         "redlock": "5.0.0-beta.2",
+        "remark-breaks": "4.0.0",
         "remark-gfm": "4.0.0",
         "replicate": "0.34.1",
         "rollup": "4.22.5",
@@ -46261,6 +46262,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -57413,6 +57428,72 @@
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -277,6 +277,7 @@
     "react-use": "17.5.1",
     "recharts": "2.12.7",
     "redlock": "5.0.0-beta.2",
+    "remark-breaks": "4.0.0",
     "remark-gfm": "4.0.0",
     "replicate": "0.34.1",
     "rollup": "4.22.5",

--- a/packages/react-ui/src/components/custom/markdown.tsx
+++ b/packages/react-ui/src/components/custom/markdown.tsx
@@ -4,6 +4,7 @@ import { Check, Copy, Info, AlertTriangle, Lightbulb } from 'lucide-react';
 import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import gfm from 'remark-gfm';
+import breaks from 'remark-breaks';
 
 import { cn } from '@/lib/utils';
 import { MarkdownVariant } from '@activepieces/shared';
@@ -102,17 +103,12 @@ const ApMarkdown = React.memo(
     }
 
     let markdownProcessed = applyVariables(markdown, variables ?? {});
-    markdownProcessed = markdownProcessed
-      .split('\n')
-      .map((line) => line.trim())
-      .join('\n');
-    markdownProcessed = markdownProcessed.split('\n').join('\n\n');
 
     return (
       <Container variant={variant}>
         <ReactMarkdown
           className={cn('flex-grow w-full ', className)}
-          remarkPlugins={[gfm]}
+          remarkPlugins={[gfm, breaks]}
           components={{
             code(props) {
               const isLanguageText = props.className?.includes('language-text');
@@ -194,6 +190,21 @@ const ApMarkdown = React.memo(
             img: ({ node, ...props }) => <img className="my-8" {...props} />,
             b: ({ node, ...props }) => <b {...props} />,
             em: ({ node, ...props }) => <em {...props} />,
+            table: ({ node, ...props }) => (
+              <table className="w-full my-4 border-collapse" {...props} />
+            ),
+            thead: ({ node, ...props }) => (
+              <thead className="bg-muted" {...props} />
+            ),
+            tr: ({ node, ...props }) => (
+              <tr className="border-b border-border" {...props} />
+            ),
+            th: ({ node, ...props }) => (
+              <th className="text-left p-2 font-medium" {...props} />
+            ),
+            td: ({ node, ...props }) => (
+              <td className="p-2" {...props} />
+            ),
           }}
         >
           {markdownProcessed.trim()}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the UI bug where the tables in markdown don't render. Instead the raw markdown is rendered. 


### Explain How the Feature Works

The bug was due to new line manipulation done for rendering paragraphs properly. This breaks the tables as single new lines are converted to double. The markdown renderer is updated to use remark-breaks. Also the ReactMarkdown is provided table style to improve the output quality.
This fix also improves code blocks and block elements.

For example, for a markdown (generated by AI):
[sample.md](https://github.com/user-attachments/files/21606577/sample.md)

Current prod:
<img width="3456" height="4692" alt="Screenshot 2025-08-06 at 01-40-44 Activepieces" src="https://github.com/user-attachments/assets/d08f8993-a7a9-4cd8-96df-17a175c3311f" />

After fix:

<img width="3456" height="4362" alt="Screenshot 2025-08-06 at 01-44-46 Activepieces" src="https://github.com/user-attachments/assets/603c9156-7009-46db-8229-999c1a2c3b0e" />

### Relevant User Scenarios

- Users using pieces that can show rendered markdown - for example `Respond on UI` piece.


Fixes #8649 
