### PR TITLE
fix: remove redundant deleted filter on entities that have soft deletion enabled

### DIFF
--- a/packages/server/api/src/app/ee/projects/platform-project-service.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-service.ts
@@ -17,7 +17,7 @@ import {
     UserStatus,
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { EntityManager, Equal, ILike, In, IsNull } from 'typeorm'
+import { EntityManager, Equal, ILike, In } from 'typeorm'
 import { appConnectionService } from '../../app-connection/app-connection-service/app-connection-service'
 import { repoFactory } from '../../core/db/repo-factory'
 import { transaction } from '../../core/db/transaction'
@@ -81,7 +81,6 @@ export const platformProjectService = (log: FastifyBaseLogger) => ({
         return enrichProject(
             await projectRepo().findOneByOrFail({
                 id: projectId,
-                deleted: IsNull(),
             }),
             log,
         )
@@ -129,7 +128,6 @@ async function getProjects(params: GetAllParams & { projectIds?: string[] }, log
     const displayNameFilter = displayName ? ILike(`%${displayName}%`) : undefined
     const filters = {
         platformId: Equal(platformId),
-        deleted: IsNull(),
         ...spreadIfDefined('externalId', externalId),
         ...spreadIfDefined('displayName', displayNameFilter),
         ...(projectIds ? { id: In(projectIds) } : {}),
@@ -247,7 +245,6 @@ const softDeleteOrThrow = async ({
     const deleteResult = await projectRepo(entityManager).softDelete({
         id,
         platformId,
-        deleted: IsNull(),
     })
 
     if (deleteResult.affected !== 1) {

--- a/packages/server/api/src/app/project/project-service.ts
+++ b/packages/server/api/src/app/project/project-service.ts
@@ -47,7 +47,6 @@ export const projectService = {
         return projectRepo().findOneBy({
             ownerId: params.ownerId,
             platformId: params.platformId,
-            deleted: IsNull(),
         })
     },
 
@@ -58,7 +57,6 @@ export const projectService = {
 
         return projectRepo().findOneBy({
             id: projectId,
-            deleted: IsNull(),
         })
     },
 
@@ -69,7 +67,6 @@ export const projectService = {
             },
             where: {
                 platformId,
-                deleted: IsNull(),
             },
         })
 
@@ -83,7 +80,6 @@ export const projectService = {
         await projectRepo().update(
             {
                 id: projectId,
-                deleted: IsNull(),
             },
             {
                 ...spreadIfDefined('externalId', externalId),
@@ -162,7 +158,6 @@ export const projectService = {
     async addProjectToPlatform({ projectId, platformId }: AddProjectToPlatformParams): Promise<void> {
         const query = {
             id: projectId,
-            deleted: IsNull(),
         }
 
         const update = {
@@ -179,7 +174,6 @@ export const projectService = {
         return projectRepo().findOneBy({
             platformId,
             externalId,
-            deleted: IsNull(),
         })
     },
 }
@@ -193,7 +187,6 @@ async function getUsersFilters(params: GetAllForUserParams): Promise<FindOptions
     if (isPrivilegedUser) {
         // Platform admins and operators can see all projects in their platform
         return [{
-            deleted: IsNull(),
             platformId: params.platformId,
             ...displayNameFilter,
         }]
@@ -207,7 +200,6 @@ async function getUsersFilters(params: GetAllForUserParams): Promise<FindOptions
     
     // Regular members can only see projects they're members of
     return [{
-        deleted: IsNull(),
         platformId: params.platformId,
         id: In(projectIds),
         ...displayNameFilter,
@@ -218,7 +210,6 @@ async function assertExternalIdIsUnique(externalId: string | undefined | null, p
         const externalIdAlreadyExists = await projectRepo().existsBy({
             id: Not(projectId),
             externalId,
-            deleted: IsNull(),
         })
 
         if (externalIdAlreadyExists) {

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
@@ -1,6 +1,5 @@
 import { ActivepiecesError, apId, ErrorCode, FlowVersion, isNil, TriggerSource } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { IsNull } from 'typeorm'
 import { repoFactory } from '../../core/db/repo-factory'
 import { flowVersionService } from '../../flows/flow-version/flow-version.service'
 import { flowTriggerSideEffect } from './flow-trigger-side-effect'
@@ -42,7 +41,6 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
                 where: {
                     id,
                     projectId,
-                    deleted: IsNull(),
                 },
             })
         },
@@ -52,7 +50,6 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
                 where: {
                     flowId,
                     simulate,
-                    deleted: IsNull(),
                 },
             })
         },
@@ -61,7 +58,6 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
                 where: {
                     id,
                     projectId,
-                    deleted: IsNull(),
                 },
             })
             if (isNil(triggerSource)) {
@@ -80,7 +76,6 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
             return triggerSourceRepo().existsBy({
                 flowId,
                 simulate,
-                deleted: IsNull(),
             })
         },
         async disable(params: DisableTriggerParams): Promise<void> {
@@ -89,7 +84,6 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
                 flowId,
                 projectId,
                 simulate,
-                deleted: IsNull(),
             })
             if (isNil(triggerSource)) {
                 return


### PR DESCRIPTION
## What does this PR do?

Cuts down on redundant where conditions that can mess with the query planner. For example,

```sql
SELECT project.id
FROM project project
WHERE ((project.platformId = ? AND project.deleted IS ?))
AND (project.deleted IS ?)
```

should now become

```sql
SELECT project.id
FROM project project
WHERE (project.platformId = ?)
AND (project.deleted IS ?)
```


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
