### PR TITLE
feat: one-note action and trigger

### DIFF
--- a/packages/pieces/community/onenote-api/.eslintrc.json
+++ b/packages/pieces/community/onenote-api/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/onenote-api/README.md
+++ b/packages/pieces/community/onenote-api/README.md
@@ -1,0 +1,7 @@
+# pieces-onenote-api
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-onenote-api` to build the library.

--- a/packages/pieces/community/onenote-api/package.json
+++ b/packages/pieces/community/onenote-api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-onenote-api",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/onenote-api/project.json
+++ b/packages/pieces/community/onenote-api/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-onenote-api",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/onenote-api/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/onenote-api",
+        "tsConfig": "packages/pieces/community/onenote-api/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/onenote-api/package.json",
+        "main": "packages/pieces/community/onenote-api/src/index.ts",
+        "assets": [
+          "packages/pieces/community/onenote-api/*.md",
+          {
+            "input": "packages/pieces/community/onenote-api/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/onenote-api/src/index.ts
+++ b/packages/pieces/community/onenote-api/src/index.ts
@@ -1,0 +1,45 @@
+import { createPiece, PieceAuth, Property } from "@activepieces/pieces-framework";
+
+const markdown = `
+To authenticate your OneNote API connection:
+
+1. Go to [Microsoft Entra admin center](https://entra.microsoft.com/)
+2. Register a new application
+3. Add the following permissions:
+   - Notes.Read
+   - Notes.ReadWrite
+4. Get your Client ID and Client Secret
+`;
+
+export const onenoteApiAuth = PieceAuth.OAuth2({
+    description: markdown,
+    
+    // Auth configuration
+    authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    scope: ["Notes.Read", "Notes.ReadWrite", "offline_access"],
+    
+    // Required properties
+    props: {
+        client_id: Property.ShortText({
+            displayName: 'Client ID',
+            description: 'Application (client) ID from your app registration',
+            required: true,
+        }),
+        client_secret: PieceAuth.SecretText({
+            displayName: 'Client Secret',
+            description: 'Client secret from your app registration',
+            required: true,
+        }),
+    }
+});
+
+export const onenoteApi = createPiece({
+    displayName: "OneNote API",
+    auth: onenoteApiAuth,
+    minimumSupportedRelease: '0.36.1',
+    logoUrl: "https://cdn.activepieces.com/pieces/onenote-api.png",
+    authors: [],
+    actions: [],
+    triggers: [],
+});

--- a/packages/pieces/community/onenote-api/src/lib/actions/append-note.ts
+++ b/packages/pieces/community/onenote-api/src/lib/actions/append-note.ts
@@ -1,0 +1,92 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { onenoteApiAuth } from "../../index";
+import { httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export const appendNote = createAction({
+    name: 'append_note',
+    displayName: 'Append Note',
+    description: 'Appends content to the end of an existing OneNote page (note).',
+    auth: onenoteApiAuth,
+    props: {
+        page_id: Property.Dropdown({
+            displayName: 'Page',
+            description: 'Select the page (note) to append content to',
+            required: true,
+            refreshers: [],
+            options: async ({ auth }) => {
+                const response = await httpClient.sendRequest({
+                    method: HttpMethod.GET,
+                    url: 'https://graph.microsoft.com/v1.0/me/onenote/pages',
+                    headers: {
+                        'Authorization': `Bearer ${(auth as { access_token: string }).access_token}`
+                    }
+                });
+                return (response.body.value ?? []).map((page: { id: string; title: string }) => ({
+                    label: page.title,
+                    value: page.id
+                }));
+            }
+        }),
+        target: Property.StaticDropdown({
+            displayName: 'Append To',
+            description: 'Where to append the content',
+            required: true,
+            options: {
+                options: [
+                    { label: 'Page Body (end of first div)', value: 'body' },
+                    { label: 'Specific Element by data-id', value: 'data-id' }
+                ]
+            }
+        }),
+        data_id: Property.ShortText({
+            displayName: 'Element data-id (if applicable)',
+            description: 'The data-id of the element to append to (required if "Specific Element by data-id" is selected)',
+            required: false,
+            visible: (props) => props.target === 'data-id'
+        }),
+        html_content: Property.LongText({
+            displayName: 'HTML Content',
+            description: 'The HTML content to append (e.g., <p>New content</p>)',
+            required: true
+        })
+    },
+    async run(context) {
+        const { page_id, target, data_id, html_content } = context.propsValue;
+
+        // Determine the target for the patch command
+        let patchTarget = 'body';
+        if (target === 'data-id') {
+            if (!data_id) {
+                throw new Error('Element data-id is required when appending to a specific element.');
+            }
+            patchTarget = `#${data_id}`;
+        }
+
+        // Build the patch command (always appends as last child)
+        const patchCommand = {
+            target: patchTarget,
+            action: 'append',
+            content: html_content
+        };
+
+        // Send PATCH request to append content
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.PATCH,
+            url: `https://graph.microsoft.com/v1.0/me/onenote/pages/${page_id}/content`,
+            headers: {
+                'Authorization': `Bearer ${context.auth.access_token}`,
+                'Content-Type': 'application/json'
+            },
+            body: [patchCommand]
+        });
+
+        if (response.status !== 204) {
+            throw new Error(`Failed to append content: ${JSON.stringify(response.body)}`);
+        }
+
+        return {
+            success: true,
+            message: 'Content appended successfully.'
+        };
+    }
+});

--- a/packages/pieces/community/onenote-api/src/lib/actions/create-image-note.ts
+++ b/packages/pieces/community/onenote-api/src/lib/actions/create-image-note.ts
@@ -1,0 +1,95 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { onenoteApiAuth } from "../../index";
+import { httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export const createImageNote = createAction({
+    name: 'create_image_note',
+    displayName: 'Create Image Note',
+    description: 'Creates a new note (page) in a section with an embedded image from a public URL.',
+    auth: onenoteApiAuth,
+    props: {
+        section_id: Property.Dropdown({
+            displayName: 'Section',
+            description: 'Select the section to create the image note in',
+            required: true,
+            refreshers: [],
+            options: async ({ auth }) => {
+                const response = await httpClient.sendRequest({
+                    method: HttpMethod.GET,
+                    url: 'https://graph.microsoft.com/v1.0/me/onenote/sections',
+                    headers: {
+                        'Authorization': `Bearer ${(auth as { access_token: string }).access_token}`
+                    }
+                });
+                return (response.body.value ?? []).map((section: { id: string; displayName: string }) => ({
+                    label: section.displayName,
+                    value: section.id
+                }));
+            }
+        }),
+        title: Property.ShortText({
+            displayName: 'Title',
+            description: 'The title of the note',
+            required: true
+        }),
+        image_url: Property.ShortText({
+            displayName: 'Image URL',
+            description: 'Publicly accessible image URL (must start with http or https)',
+            required: true,
+            validation: (value: string) => {
+                if (!/^https?:\/\/.+/i.test(value)) {
+                    return { valid: false, error: 'Please enter a valid public image URL (http or https).' };
+                }
+                return { valid: true };
+            }
+        }),
+        image_width: Property.Number({
+            displayName: 'Image Width (px)',
+            description: 'Width of the image in pixels (optional)',
+            required: false
+        })
+    },
+    async run(context) {
+        const { section_id, title, image_url, image_width } = context.propsValue;
+
+        // Build HTML content for the note
+        const html = `
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>${title}</title>
+    <meta name="created" content="${new Date().toISOString()}"/>
+  </head>
+  <body>
+    <p>This page displays an image from the web.</p>
+    <img src="${image_url}"${image_width ? ` width="${image_width}"` : ''} />
+  </body>
+</html>
+        `.trim();
+
+        // Prepare multipart form data
+        const boundary = "MyAppPartBoundary" + Date.now();
+        const body =
+            `--${boundary}\r\n` +
+            `Content-Disposition: form-data; name="Presentation"\r\n` +
+            `Content-Type: text/html\r\n\r\n` +
+            html + `\r\n` +
+            `--${boundary}--`;
+
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `https://graph.microsoft.com/v1.0/me/onenote/sections/${section_id}/pages`,
+            headers: {
+                'Authorization': `Bearer ${context.auth.access_token}`,
+                'Content-Type': `multipart/form-data; boundary=${boundary}`
+            },
+            body
+        });
+
+        if (response.status !== 201) {
+            throw new Error(`Failed to create image note: ${JSON.stringify(response.body)}`);
+        }
+
+        return response.body;
+    }
+});

--- a/packages/pieces/community/onenote-api/src/lib/actions/create-note-in-section.ts
+++ b/packages/pieces/community/onenote-api/src/lib/actions/create-note-in-section.ts
@@ -1,0 +1,83 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { onenoteApiAuth } from "../../index";
+import { httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export const createNoteInSection = createAction({
+    name: 'create_note_in_section',
+    displayName: 'Create Note in Section',
+    description: 'Creates a new note (page) in a specific notebook section with title and content.',
+    auth: onenoteApiAuth,
+    props: {
+        section_id: Property.Dropdown({
+            displayName: 'Section',
+            description: 'Select the section to create the note in',
+            required: true,
+            refreshers: [],
+            options: async ({ auth }) => {
+                const response = await httpClient.sendRequest({
+                    method: HttpMethod.GET,
+                    url: 'https://graph.microsoft.com/v1.0/me/onenote/sections',
+                    headers: {
+                        'Authorization': `Bearer ${(auth as { access_token: string }).access_token}`
+                    }
+                });
+                return (response.body.value ?? []).map((section: { id: string; displayName: string }) => ({
+                    label: section.displayName,
+                    value: section.id
+                }));
+            }
+        }),
+        title: Property.ShortText({
+            displayName: 'Title',
+            description: 'The title of the note',
+            required: true
+        }),
+        html_content: Property.LongText({
+            displayName: 'HTML Content',
+            description: 'The HTML content of the note (inside <body>...</body>)',
+            required: true
+        })
+    },
+    async run(context) {
+        const { section_id, title, html_content } = context.propsValue;
+
+        // Build HTML for the note
+        const html = `
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>${title}</title>
+    <meta name="created" content="${new Date().toISOString()}"/>
+  </head>
+  <body>
+    ${html_content}
+  </body>
+</html>
+        `.trim();
+
+        // Prepare multipart form data
+        const boundary = "NotePartBoundary" + Date.now();
+        const body =
+            `--${boundary}\r\n` +
+            `Content-Disposition: form-data; name="Presentation"\r\n` +
+            `Content-Type: text/html\r\n\r\n` +
+            html + `\r\n` +
+            `--${boundary}--`;
+
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `https://graph.microsoft.com/v1.0/me/onenote/sections/${section_id}/pages`,
+            headers: {
+                'Authorization': `Bearer ${context.auth.access_token}`,
+                'Content-Type': `multipart/form-data; boundary=${boundary}`
+            },
+            body
+        });
+
+        if (response.status !== 201) {
+            throw new Error(`Failed to create note: ${JSON.stringify(response.body)}`);
+        }
+
+        return response.body;
+    }
+});

--- a/packages/pieces/community/onenote-api/src/lib/actions/create-notebook.ts
+++ b/packages/pieces/community/onenote-api/src/lib/actions/create-notebook.ts
@@ -1,0 +1,50 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { onenoteApiAuth } from "../../index";
+import { httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export const createNotebook = createAction({
+    name: 'create_notebook',
+    displayName: 'Create Notebook',
+    description: 'Creates a new OneNote notebook',
+    auth: onenoteApiAuth,
+    props: {
+        display_name: Property.ShortText({
+            displayName: 'Notebook Name',
+            description: 'The name of the notebook (max 128 characters, cannot contain ?*/:<>|\'")',
+            required: true,
+            validation: (value: string) => {
+                if (!value) {
+                    return { valid: false, error: 'Notebook name is required' };
+                }
+                if (value.length > 128) {
+                    return { valid: false, error: 'Notebook name cannot be longer than 128 characters' };
+                }
+                if (/[?*\/:<>|'""]/.test(value)) {
+                    return { valid: false, error: 'Notebook name contains invalid characters' };
+                }
+                return { valid: true };
+            }
+        })
+    },
+    async run(context) {
+        const { display_name } = context.propsValue;
+
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `https://graph.microsoft.com/v1.0/me/onenote/notebooks`,
+            headers: {
+                'Authorization': `Bearer ${context.auth.access_token}`,
+                'Content-Type': 'application/json'
+            },
+            body: {
+                displayName: display_name
+            }
+        });
+
+        if (response.status !== 201) {
+            throw new Error(`Failed to create notebook: ${JSON.stringify(response.body)}`);
+        }
+
+        return response.body;
+    }
+});

--- a/packages/pieces/community/onenote-api/src/lib/actions/create-page.ts
+++ b/packages/pieces/community/onenote-api/src/lib/actions/create-page.ts
@@ -1,0 +1,78 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { onenoteApiAuth } from "../../index";
+import { httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export const createPage = createAction({
+    name: 'create_page',
+    displayName: 'Create Page',
+    description: 'Creates a new page in a section',
+    auth: onenoteApiAuth,
+    props: {
+        section_id: Property.Dropdown({
+            displayName: 'Section',
+            description: 'The section to create the page in',
+            required: true,
+            refreshers: [],
+            options: async ({ auth }) => {
+                const response = await httpClient.sendRequest({
+                    method: HttpMethod.GET,
+                    url: 'https://graph.microsoft.com/v1.0/me/onenote/sections',
+                    headers: {
+                        'Authorization': `Bearer ${(auth as { access_token: string }).access_token}`
+                    }
+                });
+                return response.body.value.map((section: { id: string; displayName: string }) => ({
+                    label: section.displayName,
+                    value: section.id
+                }));
+            }
+        }),
+        title: Property.ShortText({
+            displayName: 'Title',
+            description: 'The title of the page',
+            required: true,
+        }),
+        content: Property.LongText({
+            displayName: 'Content',
+            description: 'The HTML content of the page',
+            required: true,
+        }),
+        image_url: Property.ShortText({
+            displayName: 'Image URL',
+            description: 'Optional URL of an image to include in the page',
+            required: false,
+        })
+    },
+    async run(context) {
+        const { section_id, title, content, image_url } = context.propsValue;
+
+        // Create basic HTML structure
+        const htmlContent = `
+            <!DOCTYPE html>
+            <html>
+                <head>
+                    <title>${title}</title>
+                    <meta name="created" content="${new Date().toISOString()}" />
+                </head>
+                <body>
+                    ${content}
+                    ${image_url ? `<img src="${image_url}" alt="Included image" />` : ''}
+                </body>
+            </html>
+        `;
+
+        // Make the API request to create page
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `https://graph.microsoft.com/v1.0/me/onenote/sections/${section_id}/pages`,
+            headers: {
+                'Authorization': `Bearer ${context.auth.access_token}`,
+                'Content-Type': 'text/html'
+            },
+            body: htmlContent
+        });
+
+        // Return the created page
+        return response.body;
+    }
+});

--- a/packages/pieces/community/onenote-api/src/lib/actions/create-section.ts
+++ b/packages/pieces/community/onenote-api/src/lib/actions/create-section.ts
@@ -1,0 +1,69 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { onenoteApiAuth } from "../../index";
+import { httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export const createSection = createAction({
+    name: 'create_section',
+    displayName: 'Create Section',
+    description: 'Creates a new section in a notebook',
+    auth: onenoteApiAuth,
+    props: {
+        notebook_id: Property.Dropdown({
+            displayName: 'Notebook',
+            description: 'Select the notebook to create the section in',
+            required: true,
+            refreshers: [],
+            options: async ({ auth }) => {
+                const response = await httpClient.sendRequest({
+                    method: HttpMethod.GET,
+                    url: `https://graph.microsoft.com/v1.0/me/onenote/notebooks`,
+                    headers: {
+                        'Authorization': `Bearer ${(auth as { access_token: string }).access_token}`
+                    }
+                });
+                return (response.body.value ?? []).map((notebook: { id: string; displayName: string }) => ({
+                    label: notebook.displayName,
+                    value: notebook.id
+                }));
+            }
+        }),
+        display_name: Property.ShortText({
+            displayName: 'Section Name',
+            description: 'The name of the section (max 50 characters, cannot contain ?*/:<>|&#\'\'%~)',
+            required: true,
+            validation: (value: string) => {
+                if (!value) {
+                    return { valid: false, error: 'Section name is required' };
+                }
+                if (value.length > 50) {
+                    return { valid: false, error: 'Section name cannot be longer than 50 characters' };
+                }
+                if (/[?*\/:<>|&#'%~]/.test(value)) {
+                    return { valid: false, error: 'Section name contains invalid characters' };
+                }
+                return { valid: true };
+            }
+        })
+    },
+    async run(context) {
+        const { notebook_id, display_name } = context.propsValue;
+
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `https://graph.microsoft.com/v1.0/me/onenote/notebooks/${notebook_id}/sections`,
+            headers: {
+                'Authorization': `Bearer ${context.auth.access_token}`,
+                'Content-Type': 'application/json'
+            },
+            body: {
+                displayName: display_name
+            }
+        });
+
+        if (response.status !== 201) {
+            throw new Error(`Failed to create section: ${JSON.stringify(response.body)}`);
+        }
+
+        return response.body;
+    }
+});

--- a/packages/pieces/community/onenote-api/src/lib/triggers/new-note-in-section.ts
+++ b/packages/pieces/community/onenote-api/src/lib/triggers/new-note-in-section.ts
@@ -1,0 +1,118 @@
+import { createPiece, OAuth2Property, OAuth2Props, TriggerStrategy, Property } from "@activepieces/pieces-framework";
+import { onenoteApiAuth } from "../../index";
+import { httpClient, HttpMethod } from "@activepieces/pieces-common";
+
+export const newNoteInSection = createTrigger({
+    name: 'new_note_in_section',
+    displayName: 'New Note in Section',
+    description: 'Fires when a new note (page) is created in a specified notebook and section.',
+    auth: onenoteApiAuth,
+    type: TriggerStrategy.POLLING,
+    props: {
+        notebook_id: Property.Dropdown({
+            displayName: 'Notebook',
+            description: 'Select the notebook',
+            required: true,
+            refreshers: [],
+            options: async ({ auth }) => {
+                const response = await httpClient.sendRequest({
+                    method: HttpMethod.GET,
+                    url: 'https://graph.microsoft.com/v1.0/me/onenote/notebooks',
+                    headers: {
+                        'Authorization': `Bearer ${(auth as { access_token: string }).access_token}`
+                    }
+                });
+                return (response.body.value ?? []).map((notebook: { id: string; displayName: string }) => ({
+                    label: notebook.displayName,
+                    value: notebook.id
+                }));
+            }
+        }),
+        section_id: Property.Dropdown({
+            displayName: 'Section',
+            description: 'Select the section to watch for new notes',
+            required: true,
+            refreshers: ['notebook_id'],
+            options: async ({ auth, notebook_id }) => {
+                if (!notebook_id) return [];
+                const response = await httpClient.sendRequest({
+                    method: HttpMethod.GET,
+                    url: `https://graph.microsoft.com/v1.0/me/onenote/notebooks/${notebook_id}/sections`,
+                    headers: {
+                        'Authorization': `Bearer ${(auth as { access_token: string }).access_token}`
+                    }
+                });
+                return (response.body.value ?? []).map((section: { id: string; displayName: string }) => ({
+                    label: section.displayName,
+                    value: section.id
+                }));
+            }
+        })
+    },
+    async onEnable(context) {
+        await context.store.put('sectionId', context.propsValue.section_id);
+        await context.store.put('lastCheckTime', new Date().toISOString());
+    },
+    async run(context) {
+        const sectionId = await context.store.get<string>('sectionId');
+        const lastCheckTime = await context.store.get<string>('lastCheckTime');
+        if (!sectionId) return [];
+
+        // Get pages from the section
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: `https://graph.microsoft.com/v1.0/me/onenote/sections/${sectionId}/pages?$orderby=createdDateTime desc&$top=20`,
+            headers: {
+                'Authorization': `Bearer ${context.auth.access_token}`,
+                'Accept': 'application/json'
+            }
+        });
+
+        const currentTime = new Date().toISOString();
+
+        // Filter pages created after the last check
+        const newPages = (response.body.value ?? []).filter((page: any) => {
+            if (!page.createdDateTime) return false;
+            const pageCreatedTime = new Date(page.createdDateTime);
+            const lastCheck = new Date(lastCheckTime || '');
+            return pageCreatedTime > lastCheck;
+        });
+
+        // Update the last check time
+        await context.store.put('lastCheckTime', currentTime);
+
+        return newPages.map((page: any) => ({
+            id: page.id,
+            title: page.title,
+            contentUrl: page.contentUrl,
+            createdDateTime: page.createdDateTime,
+            lastModifiedDateTime: page.lastModifiedDateTime,
+            links: page.links,
+        }));
+    },
+    async onDisable(context) {
+        await context.store.delete('sectionId');
+        await context.store.delete('lastCheckTime');
+    },
+    sampleData: {
+        id: "page-id-123",
+        title: "New Note",
+        contentUrl: "https://graph.microsoft.com/v1.0/me/onenote/pages/page-id-123/content",
+        createdDateTime: "2024-01-23T10:37:00Z",
+        lastModifiedDateTime: "2024-01-23T10:37:00Z",
+        links: {
+            oneNoteClientUrl: "https://onenote.com/notebookId/page-id-123",
+            oneNoteWebUrl: "https://www.onenote.com/notebookId/page-id-123"
+        }
+    }
+});
+
+export const onenoteApi = createPiece({
+    auth: onenoteApiAuth,
+    displayName: "OneNote",
+    description: "Integrate with Microsoft OneNote",
+    triggers: [
+        newNoteInSection
+    ],
+    actions: []
+});

--- a/packages/pieces/community/onenote-api/tsconfig.json
+++ b/packages/pieces/community/onenote-api/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/onenote-api/tsconfig.lib.json
+++ b/packages/pieces/community/onenote-api/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
What does this PR do?
This PR adds a polling trigger for Microsoft OneNote that fires when a new note (page) is created in a specified notebook section. It allows users to select a notebook and section via dropdowns, then continuously checks for new notes using the Microsoft Graph API and the note creation timestamp. This enables automations and workflows to react to new notes in real time.

/claim #8689
/closes #8689

