### PR TITLE
feat: add undo redo using zundo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -302,6 +302,7 @@
         "xmlrpc": "1.3.2",
         "yaml": "2.4.1",
         "zone.js": "0.14.4",
+        "zundo": "2.3.0",
         "zustand": "4.5.4"
       },
       "devDependencies": {
@@ -68493,6 +68494,24 @@
       "integrity": "sha512-NtTUvIlNELez7Q1DzKVIFZBzNb646boQMgpATo9z3Ftuu/gWvzxCW7jdjcUDoRGxRikrhVHB/zLXh1hxeJawvw==",
       "dependencies": {
         "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/zundo": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/zundo/-/zundo-2.3.0.tgz",
+      "integrity": "sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/charkour"
+      },
+      "peerDependencies": {
+        "zustand": "^4.3.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zustand": {
+          "optional": false
+        }
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -322,6 +322,7 @@
     "xmlrpc": "1.3.2",
     "yaml": "2.4.1",
     "zone.js": "0.14.4",
+    "zundo": "2.3.0",
     "zustand": "4.5.4"
   },
   "devDependencies": {

--- a/packages/react-ui/src/app/builder/flow-canvas/canvas-controls.tsx
+++ b/packages/react-ui/src/app/builder/flow-canvas/canvas-controls.tsx
@@ -7,6 +7,8 @@ import {
   MousePointer,
   Plus,
   RotateCw,
+  Undo2,
+  Redo2,
 } from 'lucide-react';
 import { useCallback, useEffect } from 'react';
 
@@ -18,7 +20,10 @@ import {
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
-import { useBuilderStateContext } from '../builder-hooks';
+import {
+  useBuilderStateContext,
+  useTemporalBuilderStateContext,
+} from '../builder-hooks';
 
 import { flowUtilConsts } from './utils/consts';
 import { flowCanvasUtils } from './utils/flow-canvas-utils';
@@ -102,6 +107,12 @@ const CanvasControls = ({
     getNode,
     getViewport,
   } = useReactFlow();
+
+  const [undo, redo] = useTemporalBuilderStateContext((state) => [
+    state.undo,
+    state.redo,
+  ]);
+
   const handleZoomIn = useCallback(() => {
     zoomIn({
       duration,
@@ -278,6 +289,31 @@ const CanvasControls = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="top">{t('Fit to View')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="accent"
+              size="sm"
+              onClick={() => undo()}
+            >
+              <Undo2 className="w-5 h-5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">{t('Undo')} ⌘Z</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="accent"
+              size="sm"
+              onClick={() => redo()}
+            >
+              <Redo2 className="w-5 h-5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">{t('Redo')} ⌘Y</TooltipContent>
         </Tooltip>
       </div>
     </>


### PR DESCRIPTION
## What does this PR do?
The [zundo](https://github.com/charkour/zundo) lib is used to quickly add undo redo capabilities. The history item is saved when the steps size changes. This makes undo redo simple to use.


### Explain How the Feature Works
https://drive.google.com/file/d/1piChF1_Hyyl-XgT1PhHhACDS0QpIrJNi/view?usp=sharing

### Relevant User Scenarios
Deleted step by mistake and want to revert back
If some changes need to be reverted, it’s faster to click undo




Fixes #8618 
