### PR TITLE
chore: set tsconfig target for server packages to ES2022

### DIFF
--- a/packages/server/api/src/app/helper/pagination/paginator.ts
+++ b/packages/server/api/src/app/helper/pagination/paginator.ts
@@ -37,7 +37,7 @@ export default class Paginator<Entity extends ObjectLiteral> {
 
     private nextBeforeCursor: string | null = null
 
-    private alias: string = this.entity.options.name
+    private alias: string
 
     private limit = 100
 
@@ -45,7 +45,9 @@ export default class Paginator<Entity extends ObjectLiteral> {
 
     private orderBy: string = PAGINATION_KEY
 
-    public constructor(private readonly entity: EntitySchema) { }
+    public constructor(private readonly entity: EntitySchema) {
+        this.alias = this.entity.options.name
+    }
 
     public setAlias(alias: string): void {
         this.alias = alias

--- a/packages/server/api/tsconfig.app.json
+++ b/packages/server/api/tsconfig.app.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "module": "CommonJS",
     "types": ["node"]
   },
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],

--- a/packages/server/api/tsconfig.json
+++ b/packages/server/api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../tsconfig.server.json",
   "files": [],
   "include": [],
   "references": [
@@ -12,10 +12,6 @@
   ],
   "compilerOptions": {
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "strict": true
+    "noImplicitThis": true
   }
 }

--- a/packages/server/shared/tsconfig.json
+++ b/packages/server/shared/tsconfig.json
@@ -1,13 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../tsconfig.server.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noPropertyAccessFromIndexSignature": true
   },
   "files": [],
   "include": [],

--- a/packages/server/tsconfig.server.json
+++ b/packages/server/tsconfig.server.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "CommonJS",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/server/worker/tsconfig.json
+++ b/packages/server/worker/tsconfig.json
@@ -1,13 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../tsconfig.server.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noPropertyAccessFromIndexSignature": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION

## What does this PR do?

Since the minimum requirement of this project is Node 18.20 (as per the Dockerfile), we can take advantage of the Node modern runtime and avoid transpiling code when native support exists. This also makes stack traces cleaner when looking at async functions errors.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
