### PR TITLE
feat: one-note action and trigger

### DIFF
--- a/packages/pieces/community/onepiece/.eslintrc.json
+++ b/packages/pieces/community/onepiece/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/onepiece/README.md
+++ b/packages/pieces/community/onepiece/README.md
@@ -1,0 +1,7 @@
+# pieces-onepiece
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-onepiece` to build the library.

--- a/packages/pieces/community/onepiece/package.json
+++ b/packages/pieces/community/onepiece/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-onepiece",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/onepiece/project.json
+++ b/packages/pieces/community/onepiece/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-onepiece",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/onepiece/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/onepiece",
+        "tsConfig": "packages/pieces/community/onepiece/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/onepiece/package.json",
+        "main": "packages/pieces/community/onepiece/src/index.ts",
+        "assets": [
+          "packages/pieces/community/onepiece/*.md",
+          {
+            "input": "packages/pieces/community/onepiece/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/onepiece/src/index.ts
+++ b/packages/pieces/community/onepiece/src/index.ts
@@ -1,0 +1,38 @@
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { createSection } from './lib/actions/create-section';
+import { createNotebook } from './lib/actions/create-notebook';
+import { createImageNote } from './lib/actions/create-image-note';
+import { appendNote } from './lib/actions/append-note';
+import { newNoteInSectionTrigger } from './lib/triggers/new-note-in-section';
+import { createNoteInSection } from './lib/actions/create-note-in-section';
+import { createPage } from './lib/actions/create-page';
+
+export const oneNoteAuth = PieceAuth.OAuth2({
+	description:
+		'Authenticate with your Microsoft Account. You will need to register an application in the Microsoft Entra admin center. Add **Notes.ReadWrite**, **User.Read**, **offline_access** scopes.',
+	authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+	tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+	required: true,
+	scope: ['Notes.ReadWrite', 'User.Read', 'offline_access'],
+	prompt: 'omit'
+});
+
+export const onepiece = createPiece({
+	displayName: "Onepiece",
+	auth: oneNoteAuth,
+	minimumSupportedRelease: '0.36.1',
+	logoUrl: "https://cdn.activepieces.com/pieces/onepiece.png",
+	authors: [],
+	actions: [
+		createNotebook,
+		createSection,
+		createNoteInSection,
+		createPage,
+		createImageNote,
+		appendNote,
+	],
+	triggers: [
+		newNoteInSectionTrigger,
+	],
+});
+    

--- a/packages/pieces/community/onepiece/src/lib/actions/append-note.ts
+++ b/packages/pieces/community/onepiece/src/lib/actions/append-note.ts
@@ -1,0 +1,116 @@
+import { Property, createAction, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { getPagesDropdown } from '../common';
+import { oneNoteAuth } from '../../index';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export const appendNote = createAction({
+	auth: oneNoteAuth,
+	name: 'append_note',
+	displayName: 'Append Note',
+	description: 'Append content to the end of an existing OneNote page.',
+	props: {
+		page_id: Property.Dropdown({
+			displayName: 'Page',
+			description: 'The page to append content to.',
+			required: true,
+			refreshers: [],
+			options: async ({ auth }) => {
+				if (!(auth as OAuth2PropertyValue)?.access_token) {
+					return {
+						disabled: true,
+						placeholder: 'Connect your account first',
+						options: [],
+					};
+				}
+				return await getPagesDropdown(auth as OAuth2PropertyValue);
+			},
+		}),
+		content_type: Property.StaticDropdown({
+			displayName: 'Content Type',
+			description: 'The type of content to append.',
+			required: true,
+			options: {
+				options: [
+					{ label: 'Paragraph', value: 'paragraph' },
+					{ label: 'List Item', value: 'list_item' },
+					{ label: 'Heading', value: 'heading' },
+					{ label: 'Custom HTML', value: 'html' },
+				],
+			},
+			defaultValue: 'paragraph',
+		}),
+		content: Property.LongText({
+			displayName: 'Content',
+			description: 'The content to append to the page.',
+			required: true,
+		}),
+		heading_level: Property.StaticDropdown({
+			displayName: 'Heading Level',
+			description: 'The heading level (only for heading content type).',
+			required: false,
+			options: {
+				options: [
+					{ label: 'H1', value: 'h1' },
+					{ label: 'H2', value: 'h2' },
+					{ label: 'H3', value: 'h3' },
+					{ label: 'H4', value: 'h4' },
+					{ label: 'H5', value: 'h5' },
+					{ label: 'H6', value: 'h6' },
+				],
+			},
+			defaultValue: 'h2',
+		}),
+	},
+	async run(context) {
+		const { auth, propsValue } = context;
+		const { page_id, content_type, content, heading_level } = propsValue;
+
+		const client = Client.initWithMiddleware({
+			authProvider: {
+				getAccessToken: () => Promise.resolve((auth as OAuth2PropertyValue).access_token),
+			},
+		});
+
+		// Construct HTML content based on content type
+		let htmlContent: string;
+		
+		switch (content_type) {
+			case 'paragraph':
+				htmlContent = `<p>${content}</p>`;
+				break;
+			case 'list_item':
+				htmlContent = `<ul><li>${content}</li></ul>`;
+				break;
+			case 'heading':
+				const level = heading_level || 'h2';
+				htmlContent = `<${level}>${content}</${level}>`;
+				break;
+			case 'html':
+				htmlContent = content;
+				break;
+			default:
+				htmlContent = `<p>${content}</p>`;
+		}
+
+		// Create the update command to append content to the end of the page
+		const updateCommand = [
+			{
+				target: 'body',
+				action: 'append',
+				content: htmlContent,
+			},
+		];
+
+		const response = await client
+			.api(`/me/onenote/pages/${page_id}/content`)
+			.update(updateCommand);
+
+		return {
+			success: true,
+			message: 'Content successfully appended to the page',
+			pageId: page_id,
+			contentType: content_type,
+			appendedContent: htmlContent,
+		};
+	},
+});

--- a/packages/pieces/community/onepiece/src/lib/actions/create-image-note.ts
+++ b/packages/pieces/community/onepiece/src/lib/actions/create-image-note.ts
@@ -1,0 +1,105 @@
+import { Property, createAction, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { getSectionsDropdown } from '../common';
+import { oneNoteAuth } from '../../index';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export const createImageNote = createAction({
+	auth: oneNoteAuth,
+	name: 'create_image_note',
+	displayName: 'Create Image Note',
+	description: 'Create a OneNote page containing an embedded image from a public URL.',
+	props: {
+		section_id: Property.Dropdown({
+			displayName: 'Section',
+			description: 'The section to create the image note in.',
+			required: true,
+			refreshers: [],
+			options: async ({ auth }) => {
+				if (!(auth as OAuth2PropertyValue)?.access_token) {
+					return {
+						disabled: true,
+						placeholder: 'Connect your account first',
+						options: [],
+					};
+				}
+				return await getSectionsDropdown(auth as OAuth2PropertyValue);
+			},
+		}),
+		title: Property.ShortText({
+			displayName: 'Page Title',
+			description: 'The title of the image note page.',
+			required: true,
+		}),
+		image_url: Property.ShortText({
+			displayName: 'Image URL',
+			description: 'The public URL of the image to embed (must be publicly accessible).',
+			required: true,
+		}),
+		image_width: Property.Number({
+			displayName: 'Image Width',
+			description: 'The width of the image in pixels (optional).',
+			required: false,
+			defaultValue: 300,
+		}),
+		image_alt_text: Property.ShortText({
+			displayName: 'Image Alt Text',
+			description: 'Alternative text for the image (for accessibility).',
+			required: false,
+			defaultValue: 'Embedded image',
+		}),
+		description: Property.LongText({
+			displayName: 'Description',
+			description: 'Optional description text to include with the image.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { auth, propsValue } = context;
+		const { section_id, title, image_url, image_width, image_alt_text, description } = propsValue;
+
+		const client = Client.initWithMiddleware({
+			authProvider: {
+				getAccessToken: () => Promise.resolve((auth as OAuth2PropertyValue).access_token),
+			},
+		});
+
+		// Build the image tag with optional width
+		const imageTag = image_width 
+			? `<img src="${image_url}" alt="${image_alt_text || 'Embedded image'}" width="${image_width}" />`
+			: `<img src="${image_url}" alt="${image_alt_text || 'Embedded image'}" />`;
+
+		// Create the HTML structure for OneNote page with embedded image
+		const htmlContent = `
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<title>${title}</title>
+			</head>
+			<body>
+				<h1>${title}</h1>
+				${description ? `<p>${description}</p>` : ''}
+				${imageTag}
+			</body>
+			</html>
+		`;
+
+		const response = await client
+			.api(`/me/onenote/sections/${section_id}/pages`)
+			.header('Content-Type', 'text/html')
+			.post(htmlContent);
+
+		return {
+			id: response.id,
+			title: response.title,
+			createdDateTime: response.createdDateTime,
+			lastModifiedDateTime: response.lastModifiedDateTime,
+			contentUrl: response.contentUrl,
+			createdByAppId: response.createdByAppId,
+			imageUrl: image_url,
+			imageWidth: image_width,
+			imageAltText: image_alt_text,
+			links: response.links,
+			self: response.self,
+		};
+	},
+});

--- a/packages/pieces/community/onepiece/src/lib/actions/create-note-in-section.ts
+++ b/packages/pieces/community/onepiece/src/lib/actions/create-note-in-section.ts
@@ -1,0 +1,105 @@
+import { Property, createAction, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { getNotebooksDropdown, getSectionsByNotebookDropdown } from '../common';
+import { oneNoteAuth } from '../../index';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export const createNoteInSection = createAction({
+	auth: oneNoteAuth,
+	name: 'create_note_in_section',
+	displayName: 'Create Note in Section',
+	description: 'Create a new note in a specific notebook and section with title and content.',
+	props: {
+		notebook_id: Property.Dropdown({
+			displayName: 'Notebook',
+			description: 'The notebook to create the note in.',
+			required: true,
+			refreshers: ['section_id'],
+			options: async ({ auth }) => {
+				if (!(auth as OAuth2PropertyValue)?.access_token) {
+					return {
+						disabled: true,
+						placeholder: 'Connect your account first',
+						options: [],
+					};
+				}
+				return await getNotebooksDropdown(auth as OAuth2PropertyValue);
+			},
+		}),
+		section_id: Property.Dropdown({
+			displayName: 'Section',
+			description: 'The section to create the note in.',
+			required: true,
+			refreshers: [],
+			options: async ({ auth, notebook_id }) => {
+				if (!(auth as OAuth2PropertyValue)?.access_token) {
+					return {
+						disabled: true,
+						placeholder: 'Connect your account first',
+						options: [],
+					};
+				}
+				if (!notebook_id) {
+					return {
+						disabled: true,
+						placeholder: 'Select a notebook first',
+						options: [],
+					};
+				}
+				return await getSectionsByNotebookDropdown(auth as OAuth2PropertyValue, notebook_id as string);
+			},
+		}),
+		title: Property.ShortText({
+			displayName: 'Note Title',
+			description: 'The title of the note.',
+			required: true,
+		}),
+		content: Property.LongText({
+			displayName: 'Note Content',
+			description: 'The content of the note. Use basic HTML tags like <p>, <h1>, <h2>, <ul>, <li>, etc.',
+			required: false,
+			defaultValue: '<p>Your note content here...</p>',
+		}),
+	},
+	async run(context) {
+		const { auth, propsValue } = context;
+		const { section_id, title, content } = propsValue;
+
+		const client = Client.initWithMiddleware({
+			authProvider: {
+				getAccessToken: () => Promise.resolve((auth as OAuth2PropertyValue).access_token),
+			},
+		});
+
+		// Create the HTML structure for OneNote page
+		const htmlContent = `
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<title>${title}</title>
+			</head>
+			<body>
+				<h1>${title}</h1>
+				${content || '<p>New note created via Activepieces</p>'}
+			</body>
+			</html>
+		`;
+
+		const response = await client
+			.api(`/me/onenote/sections/${section_id}/pages`)
+			.header('Content-Type', 'text/html')
+			.post(htmlContent);
+
+		return {
+			id: response.id,
+			title: response.title,
+			createdDateTime: response.createdDateTime,
+			lastModifiedDateTime: response.lastModifiedDateTime,
+			contentUrl: response.contentUrl,
+			createdByAppId: response.createdByAppId,
+			level: response.level,
+			order: response.order,
+			links: response.links,
+			self: response.self,
+		};
+	},
+});

--- a/packages/pieces/community/onepiece/src/lib/actions/create-notebook.ts
+++ b/packages/pieces/community/onepiece/src/lib/actions/create-notebook.ts
@@ -1,0 +1,49 @@
+import { Property, createAction, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { oneNoteAuth } from '../../index';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export const createNotebook = createAction({
+	auth: oneNoteAuth,
+	name: 'create_notebook',
+	displayName: 'Create Notebook',
+	description: 'Creates a new OneNote notebook.',
+	props: {
+		displayName: Property.ShortText({
+			displayName: 'Notebook Name',
+			description: 'The name of the notebook. Must be unique and cannot contain more than 128 characters or the following characters: ?*/:<>|\'"%~',
+			required: true,
+		}),
+	},
+	async run(context) {
+		const { auth, propsValue } = context;
+		const { displayName } = propsValue;
+
+		const client = Client.initWithMiddleware({
+			authProvider: {
+				getAccessToken: () => Promise.resolve((auth as OAuth2PropertyValue).access_token),
+			},
+		});
+
+		const notebookBody = {
+			displayName,
+		};
+
+		const response = await client.api('/me/onenote/notebooks').post(notebookBody);
+
+		return {
+			id: response.id,
+			displayName: response.displayName,
+			userRole: response.userRole,
+			isShared: response.isShared,
+			isDefault: response.isDefault,
+			createdDateTime: response.createdDateTime,
+			lastModifiedDateTime: response.lastModifiedDateTime,
+			createdBy: response.createdBy,
+			lastModifiedBy: response.lastModifiedBy,
+			sectionsUrl: response.sectionsUrl,
+			sectionGroupsUrl: response.sectionGroupsUrl,
+			links: response.links,
+			self: response.self,
+		};
+	},
+});

--- a/packages/pieces/community/onepiece/src/lib/actions/create-page.ts
+++ b/packages/pieces/community/onepiece/src/lib/actions/create-page.ts
@@ -1,0 +1,77 @@
+import { Property, createAction, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { oneNoteAuth } from '../../index';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export const createPage = createAction({
+	auth: oneNoteAuth,
+	name: 'create_page',
+	displayName: 'Create Page',
+	description: 'Creates a page in the default notebook. Optionally specify a section name.',
+	props: {
+		title: Property.ShortText({
+			displayName: 'Page Title',
+			description: 'The title of the page.',
+			required: true,
+		}),
+		content: Property.LongText({
+			displayName: 'Page Content',
+			description: 'The HTML content of the page. Use basic HTML tags like <p>, <h1>, <h2>, <ul>, <li>, etc.',
+			required: false,
+			defaultValue: '<p>Your page content here...</p>',
+		}),
+		section_name: Property.ShortText({
+			displayName: 'Section Name',
+			description: 'Optional: Name of the section to create the page in. If the section doesn\'t exist, it will be created.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { auth, propsValue } = context;
+		const { title, content, section_name } = propsValue;
+
+		const client = Client.initWithMiddleware({
+			authProvider: {
+				getAccessToken: () => Promise.resolve((auth as OAuth2PropertyValue).access_token),
+			},
+		});
+
+		// Create the HTML structure for OneNote page
+		const htmlContent = `
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<title>${title}</title>
+			</head>
+			<body>
+				<h1>${title}</h1>
+				${content || '<p>New page created via Activepieces</p>'}
+			</body>
+			</html>
+		`;
+
+		// Build API endpoint with optional section name query parameter
+		let apiEndpoint = '/me/onenote/pages';
+		if (section_name) {
+			apiEndpoint += `?sectionName=${encodeURIComponent(section_name)}`;
+		}
+
+		const response = await client
+			.api(apiEndpoint)
+			.header('Content-Type', 'text/html')
+			.post(htmlContent);
+
+		return {
+			id: response.id,
+			title: response.title,
+			createdDateTime: response.createdDateTime,
+			lastModifiedDateTime: response.lastModifiedDateTime,
+			contentUrl: response.contentUrl,
+			createdByAppId: response.createdByAppId,
+			level: response.level,
+			order: response.order,
+			links: response.links,
+			self: response.self,
+			sectionName: section_name || 'Default section',
+		};
+	},
+});

--- a/packages/pieces/community/onepiece/src/lib/actions/create-section.ts
+++ b/packages/pieces/community/onepiece/src/lib/actions/create-section.ts
@@ -1,0 +1,63 @@
+import { Property, createAction, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { getNotebooksDropdown } from '../common';
+import { oneNoteAuth } from '../../index';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export const createSection = createAction({
+	auth: oneNoteAuth,
+	name: 'create_section',
+	displayName: 'Create Section',
+	description: 'Creates a new section in a OneNote notebook.',
+	props: {
+		notebook_id: Property.Dropdown({
+			displayName: 'Notebook',
+			description: 'The notebook to create the section in.',
+			required: true,
+			refreshers: [],
+			options: async ({ auth }) => {
+				if (!(auth as OAuth2PropertyValue)?.access_token) {
+					return {
+						disabled: true,
+						placeholder: 'Connect your account first',
+						options: [],
+					};
+				}
+				return await getNotebooksDropdown(auth as OAuth2PropertyValue);
+			},
+		}),
+		displayName: Property.ShortText({
+			displayName: 'Section Name',
+			description: 'The name of the section. Must be unique within the notebook and cannot contain more than 50 characters or the following characters: ?*/:<>|&#\'\'%~',
+			required: true,
+		}),
+	},
+	async run(context) {
+		const { auth, propsValue } = context;
+		const { notebook_id, displayName } = propsValue;
+
+		const client = Client.initWithMiddleware({
+			authProvider: {
+				getAccessToken: () => Promise.resolve((auth as OAuth2PropertyValue).access_token),
+			},
+		});
+
+		const sectionBody = {
+			displayName,
+		};
+
+		const response = await client.api(`/me/onenote/notebooks/${notebook_id}/sections`).post(sectionBody);
+
+		return {
+			id: response.id,
+			displayName: response.displayName,
+			isDefault: response.isDefault,
+			pagesUrl: response.pagesUrl,
+			createdDateTime: response.createdDateTime,
+			lastModifiedDateTime: response.lastModifiedDateTime,
+			createdBy: response.createdBy,
+			lastModifiedBy: response.lastModifiedBy,
+			links: response.links,
+			self: response.self,
+		};
+	},
+});

--- a/packages/pieces/community/onepiece/src/lib/common/index.ts
+++ b/packages/pieces/community/onepiece/src/lib/common/index.ts
@@ -1,0 +1,110 @@
+import { OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export async function getNotebooksDropdown(auth: OAuth2PropertyValue) {
+	const client = Client.initWithMiddleware({
+		authProvider: {
+			getAccessToken: () => Promise.resolve(auth.access_token),
+		},
+	});
+
+	try {
+		const response = await client.api('/me/onenote/notebooks').get();
+		
+		return {
+			disabled: false,
+			options: response.value.map((notebook: any) => ({
+				label: notebook.displayName,
+				value: notebook.id,
+			})),
+		};
+	} catch (error) {
+		console.error('Error fetching notebooks:', error);
+		return {
+			disabled: true,
+			placeholder: 'Failed to load notebooks',
+			options: [],
+		};
+	}
+}
+
+export async function getSectionsDropdown(auth: OAuth2PropertyValue) {
+	const client = Client.initWithMiddleware({
+		authProvider: {
+			getAccessToken: () => Promise.resolve(auth.access_token),
+		},
+	});
+
+	try {
+		const response = await client.api('/me/onenote/sections').get();
+		
+		return {
+			disabled: false,
+			options: response.value.map((section: any) => ({
+				label: section.displayName,
+				value: section.id,
+			})),
+		};
+	} catch (error) {
+		console.error('Error fetching sections:', error);
+		return {
+			disabled: true,
+			placeholder: 'Failed to load sections',
+			options: [],
+		};
+	}
+}
+
+export async function getPagesDropdown(auth: OAuth2PropertyValue) {
+	const client = Client.initWithMiddleware({
+		authProvider: {
+			getAccessToken: () => Promise.resolve(auth.access_token),
+		},
+	});
+
+	try {
+		const response = await client.api('/me/onenote/pages').get();
+		
+		return {
+			disabled: false,
+			options: response.value.map((page: any) => ({
+				label: page.title,
+				value: page.id,
+			})),
+		};
+	} catch (error) {
+		console.error('Error fetching pages:', error);
+		return {
+			disabled: true,
+			placeholder: 'Failed to load pages',
+			options: [],
+		};
+	}
+}
+
+export async function getSectionsByNotebookDropdown(auth: OAuth2PropertyValue, notebookId: string) {
+	const client = Client.initWithMiddleware({
+		authProvider: {
+			getAccessToken: () => Promise.resolve(auth.access_token),
+		},
+	});
+
+	try {
+		const response = await client.api(`/me/onenote/notebooks/${notebookId}/sections`).get();
+		
+		return {
+			disabled: false,
+			options: response.value.map((section: any) => ({
+				label: section.displayName,
+				value: section.id,
+			})),
+		};
+	} catch (error) {
+		console.error('Error fetching sections for notebook:', error);
+		return {
+			disabled: true,
+			placeholder: 'Failed to load sections',
+			options: [],
+		};
+	}
+}

--- a/packages/pieces/community/onepiece/src/lib/triggers/new-note-in-section.ts
+++ b/packages/pieces/community/onepiece/src/lib/triggers/new-note-in-section.ts
@@ -1,0 +1,146 @@
+import { OAuth2PropertyValue, Property } from '@activepieces/pieces-framework';
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import { getNotebooksDropdown, getSectionsByNotebookDropdown } from '../common';
+import { oneNoteAuth } from '../../index';
+import { Client, PageCollection } from '@microsoft/microsoft-graph-client';
+import dayjs from 'dayjs';
+
+const polling: Polling<OAuth2PropertyValue, { notebook_id: string; section_id: string }> = {
+	strategy: DedupeStrategy.TIMEBASED,
+	items: async ({ auth, propsValue, store, lastFetchEpochMS }) => {
+		const sectionId = propsValue.section_id;
+		const client = Client.initWithMiddleware({
+			authProvider: {
+				getAccessToken: () => Promise.resolve(auth.access_token),
+			},
+		});
+
+		const pages = [];
+
+		const filter =
+			lastFetchEpochMS === 0
+				? '$top=10'
+				: `$filter=createdDateTime gt ${dayjs(lastFetchEpochMS).toISOString()}`;
+
+		let response: PageCollection = await client
+			.api(`/me/onenote/sections/${sectionId}/pages?${filter}`)
+			.get();
+
+		if (lastFetchEpochMS === 0) {
+			for (const page of response.value) {
+				pages.push(page);
+			}
+		} else {
+			while (response.value.length > 0) {
+				for (const page of response.value) {
+					pages.push(page);
+				}
+
+				if (response['@odata.nextLink']) {
+					response = await client.api(response['@odata.nextLink']).get();
+				} else {
+					break;
+				}
+			}
+		}
+
+		return pages.map((page) => ({
+			epochMilliSeconds: dayjs(page.createdDateTime).valueOf(),
+			data: page,
+		}));
+	},
+};
+
+export const newNoteInSectionTrigger = createTrigger({
+	name: 'new_note_in_section',
+	displayName: 'New Note in Section',
+	description: 'Fires when a new note is created in a specified notebook and section.',
+	auth: oneNoteAuth,
+	props: {
+		notebook_id: Property.Dropdown({
+			displayName: 'Notebook',
+			description: 'The notebook to monitor for new notes.',
+			required: true,
+			refreshers: ['section_id'],
+			options: async ({ auth }) => {
+				if (!(auth as OAuth2PropertyValue)?.access_token) {
+					return {
+						disabled: true,
+						placeholder: 'Connect your account first',
+						options: [],
+					};
+				}
+				return await getNotebooksDropdown(auth as OAuth2PropertyValue);
+			},
+		}),
+		section_id: Property.Dropdown({
+			displayName: 'Section',
+			description: 'The section to monitor for new notes.',
+			required: true,
+			refreshers: [],
+			options: async ({ auth, notebook_id }) => {
+				if (!(auth as OAuth2PropertyValue)?.access_token) {
+					return {
+						disabled: true,
+						placeholder: 'Connect your account first',
+						options: [],
+					};
+				}
+				if (!notebook_id) {
+					return {
+						disabled: true,
+						placeholder: 'Select a notebook first',
+						options: [],
+					};
+				}
+				return await getSectionsByNotebookDropdown(auth as OAuth2PropertyValue, notebook_id as string);
+			},
+		}),
+	},
+	type: TriggerStrategy.POLLING,
+	async onEnable(context) {
+		await pollingHelper.onEnable(polling, {
+			auth: context.auth,
+			store: context.store,
+			propsValue: context.propsValue,
+		});
+	},
+	async onDisable(context) {
+		await pollingHelper.onDisable(polling, {
+			auth: context.auth,
+			store: context.store,
+			propsValue: context.propsValue,
+		});
+	},
+	async test(context) {
+		return await pollingHelper.test(polling, context);
+	},
+	async run(context) {
+		return await pollingHelper.poll(polling, context);
+	},
+	sampleData: {
+		id: 'page-id-example',
+		title: 'Sample Page Title',
+		createdDateTime: '2025-01-09T01:00:00Z',
+		lastModifiedDateTime: '2025-01-09T01:00:00Z',
+		createdByAppId: 'app-id-example',
+		contentUrl: 'https://graph.microsoft.com/v1.0/me/onenote/pages/page-id-example/content',
+		links: {
+			oneNoteClientUrl: {
+				href: 'onenote:https://example.com/page'
+			},
+			oneNoteWebUrl: {
+				href: 'https://example.com/page'
+			}
+		},
+		level: 0,
+		order: 1,
+		self: 'https://graph.microsoft.com/v1.0/me/onenote/pages/page-id-example',
+		parentSection: {
+			id: 'section-id-example',
+			displayName: 'Sample Section',
+			self: 'https://graph.microsoft.com/v1.0/me/onenote/sections/section-id-example'
+		}
+	},
+});

--- a/packages/pieces/community/onepiece/tsconfig.json
+++ b/packages/pieces/community/onepiece/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/onepiece/tsconfig.lib.json
+++ b/packages/pieces/community/onepiece/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
What does this PR do?
This PR adds a polling trigger for Microsoft OneNote that fires when a new note (page) is created in a specified notebook section. It allows users to select a notebook and section via dropdowns, then continuously checks for new notes using the Microsoft Graph API and the note creation timestamp. This enables automations and workflows to react to new notes in real time.

/claim #8689
/closes #8689