### PR TITLE
feat: Add Nuelink Integration Piece to Automate Multi-Channel Content Posting

### DIFF
--- a/packages/pieces/community/nuelink/.eslintrc.json
+++ b/packages/pieces/community/nuelink/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/nuelink/README.md
+++ b/packages/pieces/community/nuelink/README.md
@@ -1,0 +1,7 @@
+# pieces-nuelink
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-nuelink` to build the library.

--- a/packages/pieces/community/nuelink/package.json
+++ b/packages/pieces/community/nuelink/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-nuelink",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/nuelink/project.json
+++ b/packages/pieces/community/nuelink/project.json
@@ -1,0 +1,50 @@
+{
+  "name": "pieces-nuelink",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/nuelink/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/nuelink",
+        "tsConfig": "packages/pieces/community/nuelink/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/nuelink/package.json",
+        "main": "packages/pieces/community/nuelink/src/index.ts",
+        "assets": [
+          "packages/pieces/community/nuelink/*.md",
+          {
+            "input": "packages/pieces/community/nuelink/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/nuelink/src/index.ts
+++ b/packages/pieces/community/nuelink/src/index.ts
@@ -1,0 +1,19 @@
+
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { createPost } from "./lib/actions/create-post";
+
+export const nuelinkAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: 'Please use **Nuelink API Key**',
+});
+
+export const nuelink = createPiece({
+  displayName: "Nuelink",
+  auth: nuelinkAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: "https://nuelink.com/img/logo.svg",
+  authors: [],
+  actions: [createPost],
+  triggers: [],
+});

--- a/packages/pieces/community/nuelink/src/lib/actions/create-post.ts
+++ b/packages/pieces/community/nuelink/src/lib/actions/create-post.ts
@@ -1,0 +1,65 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { nuelinkAuth } from '../..';
+
+export const createPost = createAction({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'createPost',
+  auth: nuelinkAuth,
+  displayName: 'create post',
+  description: 'create a post on nuelink',
+  props: {
+    body: Property.LongText({
+      displayName: 'Caption (Required)',
+      required: true,
+      description: 'The your post caption here',
+    }),
+    media: Property.LongText({
+      displayName: 'Media (Optional)',
+      required: false,
+      description: 'Enter the media URL here',
+    }),
+    title: Property.LongText({
+      displayName: 'Title (Optional)',
+      required: false,
+      description: 'Enter a title to use for your Reels, videos and/or Pinterest posts.',
+    }),
+    altText: Property.LongText({
+      displayName: 'Alt Text (Optional)',
+      required: false,
+      description: 'Enter an alt text for your image or video.',
+    }),
+    shareToFeed: Property.Checkbox({
+      displayName: 'Share Instagram Reel to Feed (Optional)',
+      required: false,
+      description: 'Share your Instagram Reel to your feed as well.',
+      defaultValue: false,
+    }),
+    postAsShort: Property.Checkbox({
+      displayName: 'Treat videos as short-form vertical videos (Optional)',
+      required: false,
+      description: 'We will treat the videos imported as short-form vertical videos (Reels, Shorts, Tiktoks etc...).',
+      defaultValue: false,
+    }),
+  },
+
+  async run(context) {
+    const res = await httpClient.sendRequest<string[]>({
+      method: HttpMethod.POST,
+      url: 'https://nuelink.com/api/v1/pabbly',
+      headers: {
+        Authorization: `Bearer ${context.auth}`,
+      },
+      body: {
+        body: context.propsValue.body,
+        media: context.propsValue.media,
+        title: context.propsValue.title,
+        altText: context.propsValue.altText,
+        shareToFeed: context.propsValue.shareToFeed,
+        postAsShort: context.propsValue.postAsShort
+      },
+    });
+    return res.body;
+  },
+
+});

--- a/packages/pieces/community/nuelink/tsconfig.json
+++ b/packages/pieces/community/nuelink/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/nuelink/tsconfig.lib.json
+++ b/packages/pieces/community/nuelink/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new Nuelink integration piece for Activepieces.
The Nuelink piece allows users to create and schedule posts on Nuelink, which can then be automatically shared across 10+ connected channels (e.g., social media platforms, communities, etc.).

With this integration, Activepieces users can easily automate content distribution without manually posting on each platform.

### Explain How the Feature Works

**Requirements**: You need an active [Nuelink](https://nuelink.com/) account.
**Setup**:
- Create a new automation in Activepieces from the Automation page.
- Copy your Nuelink API key from your account settings.
- Add the Nuelink piece in Activepieces and paste the API key to connect.

**Usage**:
- Configure the piece to create and publish posts on Nuelink.
- Posts will be automatically shared across all connected channels.

📹 **Demo Video**: [Watch here](https://www.loom.com/share/5481d949af194d29a504f0ae406a45cf?sid=f076fa9e-6203-4695-9217-0019565876a9)

### Relevant User Scenarios

- Social Media Managers: Automate publishing content to multiple platforms at once.
- Marketing Teams: Schedule campaigns across various channels without repetitive manual posting.
- Small Businesses: Keep all social media accounts active with minimal effort.