### PR TITLE
feat: add Google Calendar actions and triggers

### DIFF
--- a/packages/pieces/community/google-calendar/src/index.ts
+++ b/packages/pieces/community/google-calendar/src/index.ts
@@ -13,6 +13,14 @@ import { updateEventAction } from './lib/actions/update-event.action';
 import { googleCalendarCommon } from './lib/common';
 import { calendarEventChanged } from './lib/triggers/calendar-event';
 import { addAttendeesToEventAction } from './lib/actions/add-attendees.action';
+import { findFreeBusy } from './lib/actions/find-busy-free-periods';
+import { getEventById } from './lib/actions/get-event-by-id';
+import { newEvent } from './lib/triggers/new-event';
+import { eventEnds } from './lib/triggers/event-ends';
+import { eventStartTimeBefore } from './lib/triggers/event-start-time-before';
+import { newEventMatchingSearch } from './lib/triggers/new-event-matching-search';
+import { eventCancelled } from './lib/triggers/event-cancelled';
+import { newCalendar } from './lib/triggers/new-calendar';
 
 export const googleCalendarAuth = PieceAuth.OAuth2({
   description: '',
@@ -52,6 +60,8 @@ export const googleCalendar = createPiece({
     getEvents,
     updateEventAction,
     deleteEventAction,
+    findFreeBusy,
+    getEventById,
     createCustomApiCallAction({
       auth: googleCalendarAuth,
       baseUrl() {
@@ -64,5 +74,12 @@ export const googleCalendar = createPiece({
       },
     }),
   ],
-  triggers: [calendarEventChanged],
+  triggers: [calendarEventChanged,
+    newEvent,
+    eventEnds,
+    eventStartTimeBefore,
+    newEventMatchingSearch,
+    eventCancelled,
+    newCalendar
+  ],
 });

--- a/packages/pieces/community/google-calendar/src/lib/actions/find-busy-free-periods.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/find-busy-free-periods.ts
@@ -1,0 +1,97 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { HttpRequest, HttpMethod, AuthenticationType, httpClient } from '@activepieces/pieces-common';
+import { googleCalendarAuth } from '../../'; 
+import { googleCalendarCommon } from '../common';
+import { getCalendars } from '../common/helper';
+import dayjs from 'dayjs';
+
+
+interface FreeBusyResponse {
+  kind: 'calendar#freeBusy';
+  timeMin: string;
+  timeMax: string;
+  calendars: {
+    [calendarId: string]: {
+      busy: {
+        start: string;
+        end: string;
+      }[];
+      errors?: {
+        domain: string;
+        reason: string;
+      }[];
+    };
+  };
+}
+
+export const findFreeBusy = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_find_busy_free_periods',
+  displayName: 'Find Busy/Free Periods in Calendar',
+  description: 'Finds free/busy calendar details from Google Calendar.',
+  props: {
+    calendar_ids: Property.MultiSelectDropdown({
+      displayName: 'Calendars',
+      description: 'Select the calendars to check for busy periods.',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Connect your account first',
+            options: [],
+          };
+        }
+        const authProp = auth as OAuth2PropertyValue;
+        const calendars = await getCalendars(authProp);
+        return {
+          disabled: false,
+          options: calendars.map((calendar) => {
+            return {
+              label: calendar.summary,
+              value: calendar.id,
+            };
+          }),
+        };
+      },
+    }),
+    start_date: Property.DateTime({
+      displayName: 'Start Time',
+      description: 'The start of the time range to check.',
+      required: true,
+    }),
+    end_date: Property.DateTime({
+      displayName: 'End Time',
+      description: 'The end of the time range to check.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { calendar_ids, start_date, end_date } = context.propsValue;
+    const { access_token } = context.auth;
+
+    const requestBody = {
+      
+      timeMin: dayjs(start_date).toISOString(),
+      timeMax: dayjs(end_date).toISOString(),
+      
+      items: calendar_ids.map((id) => ({ id })),
+    };
+
+    const request: HttpRequest = {
+      method: HttpMethod.POST,
+      url: `${googleCalendarCommon.baseUrl}/freeBusy`,
+      body: requestBody,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: access_token,
+      },
+    };
+
+    const response = await httpClient.sendRequest<FreeBusyResponse>(request);
+    
+    
+    return response.body;
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/get-event-by-id.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/get-event-by-id.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  HttpRequest,
+  HttpMethod,
+  AuthenticationType,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { googleCalendarCommon } from '../common';
+import { googleCalendarAuth } from '../../'; 
+import { GoogleCalendarEvent } from '../common/types';
+
+export const getEventById = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_get_event_by_id',
+  displayName: 'Get Event by ID',
+  description: 'Fetch event details by its unique ID.',
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'), 
+    event_id: Property.ShortText({
+      displayName: 'Event ID',
+      description: 'The unique ID of the event to fetch.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { calendar_id: calendarId, event_id: eventId } = context.propsValue;
+    const { access_token: token } = context.auth;
+
+   
+    const url = `${googleCalendarCommon.baseUrl}/calendars/${calendarId}/events/${eventId}`;
+
+    const request: HttpRequest = {
+      method: HttpMethod.GET,
+      url: url,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: token,
+      },
+    };
+
+    const response = await httpClient.sendRequest<GoogleCalendarEvent>(request);
+
+    
+    return response.body;
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/triggers/event-cancelled.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/event-cancelled.ts
@@ -1,0 +1,110 @@
+import {
+  createTrigger,
+  PiecePropValueSchema,
+  Property,
+} from '@activepieces/pieces-framework';
+import { TriggerStrategy } from '@activepieces/pieces-framework';
+import { googleCalendarCommon } from '../common';
+import { GoogleCalendarEvent } from '../common/types';
+import { googleCalendarAuth } from '../../';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import { getEvents } from '../common/helper';
+
+const polling: Polling<
+  PiecePropValueSchema<typeof googleCalendarAuth>,
+  {
+    calendar_id: string | undefined;
+  }
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+    const calendarId = propsValue.calendar_id;
+
+    if (!calendarId) {
+      return [];
+    }
+    
+    
+    let minUpdated: Date;
+    if (lastFetchEpochMS === 0) {
+      
+      minUpdated = new Date();
+      minUpdated.setDate(minUpdated.getDate() - 1);
+    } else {
+      minUpdated = new Date(lastFetchEpochMS);
+    }
+
+    
+    const events = await getEvents(calendarId, true, auth, minUpdated);
+
+    
+    const cancelledEvents = events.filter(event => event.status === 'cancelled');
+
+    
+    return cancelledEvents.map((event) => {
+        return {
+            epochMilliSeconds: new Date(event.updated!).getTime(),
+            data: event,
+        };
+    });
+  },
+};
+
+export const eventCancelled = createTrigger({
+  auth: googleCalendarAuth,
+  name: 'event_cancelled',
+  displayName: 'Event Cancelled',
+  description: 'Fires when an event is canceled or deleted.',
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+      "id": "abc123def456_cancelled",
+      "summary": "Cancelled: Q3 Planning Session",
+      "status": "cancelled",
+      "created": "2025-07-20T10:00:00.000Z",
+      "updated": "2025-08-14T09:30:00.000Z",
+      "organizer": { "email": "project.manager@example.com" },
+      "start": { "dateTime": "2025-08-25T10:00:00-07:00" },
+      "end": { "dateTime": "2025-08-25T11:30:00-07:00" },
+  },
+
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+
+  async run(context) {
+    return await pollingHelper.poll(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+
+  async test(context) {
+    return await pollingHelper.test(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/triggers/event-ends.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/event-ends.ts
@@ -1,0 +1,153 @@
+import {
+  createTrigger,
+  PiecePropValueSchema,
+  Property,
+} from '@activepieces/pieces-framework';
+import { TriggerStrategy } from '@activepieces/pieces-framework';
+import { googleCalendarCommon } from '../common';
+import { GoogleCalendarEvent } from '../common/types';
+import { googleCalendarAuth } from '../../';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+
+
+interface GoogleCalendarEventList {
+  items: GoogleCalendarEvent[];
+}
+
+const polling: Polling<
+  PiecePropValueSchema<typeof googleCalendarAuth>,
+  { calendar_id: string | undefined }
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+    if (lastFetchEpochMS === 0) {
+      return [];
+    }
+    
+    const calendarId = propsValue.calendar_id;
+    
+    if (!calendarId) {
+      return [];
+    }
+
+    const request: HttpRequest = {
+      method: HttpMethod.GET,
+      url: `${googleCalendarCommon.baseUrl}/calendars/${calendarId}/events`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.access_token,
+      },
+      queryParams: {
+        singleEvents: 'true',
+        orderBy: 'startTime',
+        timeMin: new Date(lastFetchEpochMS).toISOString(),
+      },
+    };
+
+    const response = await httpClient.sendRequest<GoogleCalendarEventList>(
+      request
+    );
+    const events = response.body.items;
+    const endedEvents: { epochMilliSeconds: number; data: GoogleCalendarEvent }[] = [];
+    const now = Date.now();
+
+    for (const event of events) {
+      const endTimeString = event.end?.dateTime ?? event.end?.date;
+      if (!endTimeString) continue;
+
+      const endTime = new Date(endTimeString).getTime();
+
+      if (endTime > lastFetchEpochMS && endTime <= now) {
+        endedEvents.push({
+          epochMilliSeconds: endTime,
+          data: event,
+        });
+      }
+    }
+
+    return endedEvents;
+  },
+};
+
+export const eventEnds = createTrigger({
+  auth: googleCalendarAuth,
+  name: 'event_ends',
+  displayName: 'Event Ends',
+  description: 'Fires when an event ends.',
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    kind: 'calendar#event',
+    etag: '"3419997894982000"',
+    id: 'sample_event_id_67890',
+    status: 'confirmed',
+    htmlLink:
+      'https://www.google.com/calendar/event?eid=c2FtcGxlX2V2ZW50X2lkXzY3ODkw',
+    created: '2025-08-14T09:00:00.000Z',
+    updated: '2025-08-14T09:00:00.000Z',
+    summary: 'Project Deadline',
+    creator: { email: 'manager@example.com' },
+    organizer: {
+      email: 'manager@example.com',
+      self: true,
+    },
+    start: {
+      dateTime: '2025-08-14T14:30:00+05:30',
+      timeZone: 'Asia/Kolkata',
+    },
+    end: {
+      dateTime: '2025-08-14T15:30:00+05:30',
+      timeZone: 'Asia/Kolkata',
+    },
+    iCalUID: 'sample_event_id_67890@google.com',
+    sequence: 0,
+    reminders: { useDefault: true },
+    eventType: 'default',
+  },
+
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+
+  async run(context) {
+    return await pollingHelper.poll(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+
+  async test(context) {
+    return await pollingHelper.test(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/triggers/event-start-time-before.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/event-start-time-before.ts
@@ -1,0 +1,153 @@
+import {
+  createTrigger,
+  PiecePropValueSchema,
+  Property,
+} from '@activepieces/pieces-framework';
+import { TriggerStrategy } from '@activepieces/pieces-framework';
+import { googleCalendarCommon } from '../common';
+import { GoogleCalendarEvent } from '../common/types';
+import { googleCalendarAuth } from '../../';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+
+
+interface GoogleCalendarEventList {
+  items: GoogleCalendarEvent[];
+}
+
+const polling: Polling<
+  PiecePropValueSchema<typeof googleCalendarAuth>,
+  {
+    calendar_id: string | undefined;
+    time_value: number | undefined;
+    time_unit: string | undefined;
+  }
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue }) => {
+    const { calendar_id, time_value, time_unit } = propsValue;
+
+    if (!calendar_id || !time_value || !time_unit) {
+      
+      return [];
+    }
+    
+    
+    let offset_ms = time_value * 60 * 1000; 
+    if (time_unit === 'hours') {
+        offset_ms = time_value * 60 * 60 * 1000;
+    } else if (time_unit === 'days') {
+        offset_ms = time_value * 24 * 60 * 60 * 1000;
+    }
+
+    const now = Date.now();
+    
+    const pollingIntervalMs = 5 * 60 * 1000; 
+
+    
+    const timeMin = new Date(now + offset_ms).toISOString();
+    const timeMax = new Date(now + offset_ms + pollingIntervalMs).toISOString();
+
+    const request: HttpRequest = {
+      method: HttpMethod.GET,
+      url: `${googleCalendarCommon.baseUrl}/calendars/${calendar_id}/events`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.access_token,
+      },
+      queryParams: {
+        singleEvents: 'true',
+        orderBy: 'startTime',
+        timeMin: timeMin,
+        timeMax: timeMax,
+      },
+    };
+
+    const response = await httpClient.sendRequest<GoogleCalendarEventList>(request);
+    const events = response.body.items;
+
+    
+    return events.map((event) => {
+        const startTime = new Date(event.start?.dateTime ?? event.start?.date ?? 0).getTime();
+        
+        const triggerTime = startTime - offset_ms;
+        return {
+            epochMilliSeconds: triggerTime,
+            data: event,
+        };
+    });
+  },
+};
+
+export const eventStartTimeBefore = createTrigger({
+  auth: googleCalendarAuth,
+  name: 'event_starts_in',
+  displayName: 'Event Start (Time Before)',
+  description: 'Fires at a specified amount of time before an event starts (e.g., a reminder).',
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+    time_value: Property.Number({
+        displayName: 'Time Before',
+        description: 'The amount of time before the event starts.',
+        required: true,
+        defaultValue: 15,
+    }),
+    time_unit: Property.StaticDropdown({
+        displayName: 'Time Unit',
+        required: true,
+        options: {
+            options: [
+                { label: 'Minutes', value: 'minutes' },
+                { label: 'Hours', value: 'hours' },
+                { label: 'Days', value: 'days' },
+            ]
+        },
+        defaultValue: 'minutes',
+    })
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {},
+
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+
+  async run(context) {
+    return await pollingHelper.poll(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+
+  async test(context) {
+    return await pollingHelper.test(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/triggers/new-calendar.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/new-calendar.ts
@@ -1,0 +1,100 @@
+import {
+  createTrigger,
+  PiecePropValueSchema,
+} from '@activepieces/pieces-framework';
+import { TriggerStrategy } from '@activepieces/pieces-framework';
+import { googleCalendarAuth } from '../../';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import { getCalendars } from '../common/helper';
+import { CalendarObject } from '../common/types';
+
+const polling: Polling<
+  PiecePropValueSchema<typeof googleCalendarAuth>,
+  Record<string, never> 
+> = {
+  strategy: DedupeStrategy.LAST_ITEM,
+  items: async ({ auth, store }) => {
+    
+    const currentCalendars = await getCalendars(auth);
+    const currentCalendarIds = currentCalendars.map((cal) => cal.id);
+
+    
+    const oldCalendarIds = (await store.get<string[]>('calendars')) || [];
+    const oldCalendarIdsSet = new Set(oldCalendarIds);
+    
+    
+    const newCalendars = currentCalendars.filter(
+      (cal) => !oldCalendarIdsSet.has(cal.id)
+    );
+
+    
+    await store.put('calendars', currentCalendarIds);
+
+    
+    return newCalendars.map((cal) => ({
+      id: cal.id,
+      data: cal,
+    }));
+  },
+};
+
+export const newCalendar = createTrigger({
+  auth: googleCalendarAuth,
+  name: 'new_calendar',
+  displayName: 'New Calendar',
+  description: 'Fires when a new calendar is created.',
+  props: {}, 
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: 'sample_calendar_id@group.calendar.google.com',
+    summary: 'New Project Team Calendar',
+    description: 'A shared calendar for the new project team.',
+    timeZone: 'Asia/Kolkata',
+    backgroundColor: '#9fe1e7',
+    foregroundColor: '#000000',
+    accessRole: 'owner',
+  },
+
+  async onEnable(context) {
+    
+    const calendars = await getCalendars(context.auth);
+    await context.store.put(
+      'calendars',
+      calendars.map((cal) => cal.id)
+    );
+    
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: {},
+    });
+  },
+
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: {},
+    });
+  },
+
+  async run(context) {
+    return await pollingHelper.poll(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+
+  async test(context) {
+    
+    const calendars = await getCalendars(context.auth);
+    const recentCalendars = calendars.slice(-1);
+    return recentCalendars.map((cal: CalendarObject) => ({ id: cal.id, data: cal }));
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/triggers/new-event-matching-search.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/new-event-matching-search.ts
@@ -1,0 +1,148 @@
+import {
+  createTrigger,
+  PiecePropValueSchema,
+  Property,
+} from '@activepieces/pieces-framework';
+import { TriggerStrategy } from '@activepieces/pieces-framework';
+import { googleCalendarCommon } from '../common';
+import { GoogleCalendarEvent } from '../common/types';
+import { googleCalendarAuth } from '../../';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+
+
+interface GoogleCalendarEventList {
+  items: GoogleCalendarEvent[];
+}
+
+const polling: Polling<
+  PiecePropValueSchema<typeof googleCalendarAuth>,
+  {
+    calendar_id: string | undefined;
+    search_term: string | undefined;
+  }
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+    const { calendar_id, search_term } = propsValue;
+
+    if (!calendar_id || !search_term) {
+      
+      return [];
+    }
+    
+   
+    let minUpdated: Date;
+    if (lastFetchEpochMS === 0) {
+      
+      minUpdated = new Date();
+      minUpdated.setDate(minUpdated.getDate() - 1);
+    } else {
+      minUpdated = new Date(lastFetchEpochMS);
+    }
+
+    const request: HttpRequest = {
+      method: HttpMethod.GET,
+      url: `${googleCalendarCommon.baseUrl}/calendars/${calendar_id}/events`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.access_token,
+      },
+      queryParams: {
+        singleEvents: 'true',
+        orderBy: 'updated',
+        updatedMin: minUpdated.toISOString(),
+        q: search_term, 
+      },
+    };
+
+    const response = await httpClient.sendRequest<GoogleCalendarEventList>(request);
+    const events = response.body.items;
+
+    
+    const newEvents = events.filter(event => {
+        const created = new Date(event.created ?? 0).getTime();
+        const updated = new Date(event.updated ?? 0).getTime();
+        
+        return (updated - created < 5000);
+    })
+
+    
+    return newEvents.map((event) => {
+        return {
+            epochMilliSeconds: new Date(event.updated!).getTime(),
+            data: event,
+        };
+    });
+  },
+};
+
+export const newEventMatchingSearch = createTrigger({
+  auth: googleCalendarAuth,
+  name: 'new_event_matching_search',
+  displayName: 'New Event Matching Search',
+  description: 'Fires when a new event is created that matches a specified search term.',
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+    search_term: Property.ShortText({
+        displayName: 'Search Term',
+        description: 'The keyword(s) to search for in new events.',
+        required: true,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+      "id": "abc123def456",
+      "summary": "Final Project Review",
+      "description": "Review of the Q3 final project deliverables.",
+      "status": "confirmed",
+      "created": "2025-08-14T09:05:00.000Z",
+      "updated": "2025-08-14T09:05:01.000Z",
+      "start": { "dateTime": "2025-09-01T10:00:00-07:00" },
+      "end": { "dateTime": "2025-09-01T11:30:00-07:00" },
+      "organizer": { "email": "project.manager@example.com" }
+  },
+
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+
+  async run(context) {
+    return await pollingHelper.poll(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+
+  async test(context) {
+    return await pollingHelper.test(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+      files: context.files,
+    });
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/triggers/new-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/new-event.ts
@@ -1,0 +1,106 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  OAuth2PropertyValue,
+} from '@activepieces/pieces-framework';
+import { googleCalendarAuth } from '../../';
+import { googleCalendarCommon } from '../common';
+import {
+  stopWatchEvent,
+  watchEvent,
+  getLatestEvent,
+} from '../common/helper';
+import { GoogleWatchResponse } from '../common/types';
+
+export const newEvent = createTrigger({
+  auth: googleCalendarAuth,
+  name: 'new_event',
+  displayName: 'New Event',
+  description: 'Fires when a new event is created in a calendar.',
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+  },
+  type: TriggerStrategy.WEBHOOK,
+  sampleData: {
+    kind: 'calendar#event',
+    etag: '"3419997894982000"',
+    id: 'sample_event_id_12345',
+    status: 'confirmed',
+    htmlLink:
+      'https://www.google.com/calendar/event?eid=c2FtcGxlX2V2ZW50X2lkXzEyMzQ1',
+    created: '2025-08-15T11:02:27.000Z',
+    updated: '2025-08-15T11:02:27.491Z',
+    summary: 'Team Sync',
+    creator: { email: 'creator@example.com' },
+    organizer: {
+      email: 'creator@example.com',
+      self: true,
+    },
+    start: {
+      dateTime: '2025-08-18T10:00:00-07:00',
+      timeZone: 'America/Los_Angeles',
+    },
+    end: {
+      dateTime: '2025-08-18T11:00:00-07:00',
+      timeZone: 'America/Los_Angeles',
+    },
+    iCalUID: 'sample_event_id_12345@google.com',
+    sequence: 0,
+    reminders: { useDefault: true },
+    eventType: 'default',
+  },
+
+  
+  async onEnable(context) {
+    const calendarId = context.propsValue.calendar_id!;
+    const auth = context.auth as OAuth2PropertyValue;
+
+    
+    const response = await watchEvent(calendarId, context.webhookUrl, auth);
+
+    
+    await context.store.put<GoogleWatchResponse>(
+      'google_calendar_watch',
+      response
+    );
+  },
+
+  
+  async onDisable(context) {
+    const auth = context.auth as OAuth2PropertyValue;
+    const watch = await context.store.get<GoogleWatchResponse>(
+      'google_calendar_watch'
+    );
+
+    
+    if (watch) {
+      await stopWatchEvent(watch, auth);
+    }
+  },
+
+  
+  async run(context) {
+    const payload = context.payload;
+    const headers = payload.headers as Record<string, string>;
+
+    
+    if (headers['x-goog-resource-state'] === 'add') {
+      
+      return [payload.body];
+    } else {
+      return [];
+    }
+  },
+
+  async test(context) {
+    const auth = context.auth as OAuth2PropertyValue;
+
+    
+    const latestEvent = await getLatestEvent(
+      context.propsValue.calendar_id!,
+      auth
+    );
+
+    return [latestEvent];
+  },
+});


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes #8775 
/claim #8775 

https://github.com/user-attachments/assets/630c946c-80c8-4f74-a5df-e44b4269560d

This PR add the 
##Action

1.Find Busy/Free Periods in Calendar
2.Get Event by ID

##Triggers

1.New Event
2.Event Ends
3.Event Start (Time Before)
4.New Event Matching Search
5.Event Cancelled
6.New Calendar
