### PR TITLE
feat(slack): add thread reply broadcast

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.10.2"
+  "version": "0.10.3"
 }

--- a/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
@@ -32,11 +32,17 @@ export const slackSendMessageAction = createAction({
       required: false,
     }),
     threadTs,
+    replyBroadcast: Property.Checkbox({
+      displayName: 'Broadcast reply to channel',
+      description: 'When replying to a thread, also make the message visible to everyone in the channel (only applicable when Thread Timestamp is provided)',
+      required: false,
+      defaultValue: false,
+    }),
     blocks,
   },
   async run(context) {
     const token = context.auth.access_token;
-    const { text, channel, username, profilePicture, threadTs, file,blocks } =
+    const { text, channel, username, profilePicture, threadTs, file, blocks, replyBroadcast } =
       context.propsValue;
 
     const blockList = blocks ?[{ type: 'section', text: { type: 'mrkdwn', text } }, ...(blocks as unknown as (KnownBlock | Block)[])] :undefined
@@ -50,6 +56,7 @@ export const slackSendMessageAction = createAction({
       threadTs: threadTs ? processMessageTimestamp(threadTs) : undefined,
       file,
       blocks: blockList,
+      replyBroadcast,
     });
   },
 });

--- a/packages/pieces/community/slack/src/lib/common/utils.ts
+++ b/packages/pieces/community/slack/src/lib/common/utils.ts
@@ -10,6 +10,7 @@ export const slackSendMessage = async ({
   threadTs,
   token,
   file,
+  replyBroadcast,
 }: SlackSendMessageParams) => {
   const client = new WebClient(token);
 
@@ -26,14 +27,20 @@ export const slackSendMessage = async ({
       ],
     });
   } else {
-    return await client.chat.postMessage({
+    const messageParams: any = {
       text,
       channel: conversationId,
       username,
       icon_url: profilePicture,
       blocks: blocks as Block[],
       thread_ts: threadTs,
-    });
+    };
+    
+    if (replyBroadcast) {
+      messageParams.reply_broadcast = replyBroadcast;
+    }
+    
+    return await client.chat.postMessage(messageParams);
   }
 };
 
@@ -46,6 +53,7 @@ type SlackSendMessageParams = {
   text: string;
   file?: ApFile;
   threadTs?: string;
+  replyBroadcast?: boolean;
 };
 
 export function processMessageTimestamp(input: string) {


### PR DESCRIPTION
## What does this PR do?

Add reply broadcast for slack. Zapier has this - 

<img width="643" height="349" alt="image-20250819-063842" src="https://github.com/user-attachments/assets/42ecdd02-8c08-477e-937c-4bc6f82367fa" />


### Explain How the Feature Works
<img width="891" height="705" alt="Screenshot 2025-08-21 at 11 08 59 AM" src="https://github.com/user-attachments/assets/a0c1a1be-9caf-4ab9-b592-4e97fdace948" />

<img width="957" height="184" alt="Screenshot 2025-08-21 at 11 08 32 AM" src="https://github.com/user-attachments/assets/37524021-0222-461e-9c31-bdf1f66b42d6" />



### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
