### PR TITLE
fix: migrate to http return response to webhook return response

### DIFF
--- a/packages/shared/src/lib/flows/flow-version.ts
+++ b/packages/shared/src/lib/flows/flow-version.ts
@@ -6,7 +6,7 @@ import { FlowTrigger } from './triggers/trigger'
 
 export type FlowVersionId = ApId
 
-export const LATEST_SCHEMA_VERSION = '5'
+export const LATEST_SCHEMA_VERSION = '6'
 
 export enum FlowVersionState {
     LOCKED = 'LOCKED',

--- a/packages/shared/src/lib/flows/operations/migrations/index.ts
+++ b/packages/shared/src/lib/flows/operations/migrations/index.ts
@@ -4,6 +4,7 @@ import { migrateConnectionIds } from './migrate-v1-connection-ids'
 import { migrateAgentPieceV2 } from './migrate-v2-agent-piece'
 import { migrateAgentPieceV3 } from './migrate-v3-agent-piece'
 import { migrateAgentPieceV4 } from './migrate-v4-agent-piece'
+import { migrateHttpToWebhookV5 } from './migrate-v5-http-to-webhook'
 
 export type Migration = {
     targetSchemaVersion: string | undefined
@@ -16,6 +17,7 @@ const migrations: Migration[] = [
     migrateAgentPieceV2,
     migrateAgentPieceV3,
     migrateAgentPieceV4,
+    migrateHttpToWebhookV5,
 ]
 
 const apply = (flowVersion: FlowVersion) => {

--- a/packages/shared/src/lib/flows/operations/migrations/migrate-v5-http-to-webhook.ts
+++ b/packages/shared/src/lib/flows/operations/migrations/migrate-v5-http-to-webhook.ts
@@ -1,0 +1,61 @@
+import { FlowActionType } from '../../actions/action'
+import { FlowVersion } from '../../flow-version'
+import { flowStructureUtil } from '../../util/flow-structure-util'
+import { Migration } from '.'
+
+const HTTP_PIECE_NAME = '@activepieces/piece-http'
+const WEBHOOK_PIECE_NAME = '@activepieces/piece-webhook'
+const HTTP_RETURN_RESPONSE_ACTION = 'return_response'
+const WEBHOOK_RETURN_RESPONSE_ACTION = 'return_response'
+
+export const migrateHttpToWebhookV5: Migration = {
+    targetSchemaVersion: '5',
+    migrate: (flowVersion: FlowVersion): FlowVersion => {
+        const newVersion = flowStructureUtil.transferFlow(flowVersion, (step) => {
+            if (
+                step.type === FlowActionType.PIECE &&
+                step.settings.pieceName === HTTP_PIECE_NAME &&
+                step.settings.actionName === HTTP_RETURN_RESPONSE_ACTION
+            ) {
+                const httpInput = step.settings.input || {}
+                const fields: Record<string, unknown> = {}
+                
+                if (httpInput['body'] && typeof httpInput['body'] === 'object' && 'data' in httpInput['body']) {
+                    fields['body'] = (httpInput['body'] as Record<string, unknown>)['data']
+                }
+                if (httpInput['status'] !== undefined) {
+                    fields['status'] = httpInput['status']
+                }
+                if (httpInput['headers']) {
+                    fields['headers'] = httpInput['headers']
+                }
+                
+                const webhookInput = {
+                    respond: 'stop',
+                    responseType: httpInput['body_type'] || 'json',
+                    fields,
+                }
+                
+                return {
+                    ...step,
+                    settings: {
+                        ...step.settings,
+                        pieceName: WEBHOOK_PIECE_NAME,
+                        pieceVersion: '0.1.20',
+                        actionName: WEBHOOK_RETURN_RESPONSE_ACTION,
+                        input: webhookInput,
+                        inputUiInfo: {
+                            customizedInputs: {},
+                        },
+                    },
+                }
+            }
+            return step
+        })
+        
+        return {
+            ...newVersion,
+            schemaVersion: '6',
+        }
+    },
+}


### PR DESCRIPTION
It fixes a regression. Historically, HTTP used to return a response for the webhook, but later it was changed to be handled within the same part of the webhook.

This caused a regression when we restricted the engine to respond only if the trigger and action names matched: https://github.com/activepieces/activepieces/pull/8769

As a result, the flow can be paused for different reasons, such as call flow.

Thanks @kamal for pointing this out 