### PR TITLE
feat(straico): dynamic image models; default size square (0.1.7)

### DIFF
--- a/packages/pieces/community/straico/package.json
+++ b/packages/pieces/community/straico/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-straico",
-  "version": "0.1.6"
+  "version": "0.1.7"
 }


### PR DESCRIPTION
### What does this PR do?
- Dynamic image model dropdown via v1 /models (search/refresh), default size square, bump to 0.1.7.

### Explain How the Feature Works
- Fetches `image` models from `v1/models`.

### Relevant User Scenarios
- Users can select new image models.

Fixes # (issue)