### PR TITLE
fix: reset usage, stop testing from consuming tasks

### DIFF
--- a/packages/ee/shared/src/lib/billing/index.ts
+++ b/packages/ee/shared/src/lib/billing/index.ts
@@ -20,7 +20,7 @@ export const PRICE_PER_EXTRA_5_ACTIVE_FLOWS_MAP = {
     [BillingCycle.MONTHLY]: 15,
 }
 
-export const AI_CREDITS_USAGE_THRESHOLD = 150000
+export const AI_CREDITS_USAGE_THRESHOLD = 15000
 
 export type ProjectPlanLimits = {
     nickname?: string

--- a/packages/react-ui/src/features/billing/components/upgrade-dialog/index.tsx
+++ b/packages/react-ui/src/features/billing/components/upgrade-dialog/index.tsx
@@ -140,8 +140,8 @@ export const UpgradeDialog: FC = () => {
   );
 
   const [dialogState, setDialogState] = useState<DialogState>({
-    selectedPlan: PlanName.FREE,
-    selectedCycle: BillingCycle.MONTHLY,
+    selectedPlan: currentPlanInfo.plan,
+    selectedCycle: currentPlanInfo.cycle,
     selectedSeats: [0],
     selectedActiveFlows: [0],
     selectedProjects: [0],
@@ -149,26 +149,21 @@ export const UpgradeDialog: FC = () => {
   });
 
   useEffect(() => {
-    if (dialog.isOpen) {
-      const initialPlan = currentPlanInfo.isTrial
-        ? PlanName.PLUS
-        : currentPlanInfo.plan;
-      const samePlan = currentPlanInfo.plan === dialogState.selectedPlan;
-      setDialogState({
-        selectedPlan: initialPlan,
-        selectedCycle: currentPlanInfo.cycle,
-        selectedSeats: [samePlan ? currentPlanInfo.seats : DEFAULT_SEATS],
-        selectedActiveFlows: [
-          samePlan
-            ? currentPlanInfo.activeFlows
-            : DEFAULT_ACTIVE_FLOWS[PlanName.PLUS],
-        ],
-        selectedProjects: [
-          samePlan ? currentPlanInfo.projects : DEFAULT_PROJECTS,
-        ],
-        currentStep: !isNil(dialog.step) ? dialog.step : 1,
-      });
-    }
+    const samePlan = currentPlanInfo.plan === dialogState.selectedPlan;
+    setDialogState({
+      selectedPlan: currentPlanInfo.plan,
+      selectedCycle: currentPlanInfo.cycle,
+      selectedSeats: [samePlan ? currentPlanInfo.seats : DEFAULT_SEATS],
+      selectedActiveFlows: [
+        samePlan
+          ? currentPlanInfo.activeFlows
+          : DEFAULT_ACTIVE_FLOWS[PlanName.PLUS],
+      ],
+      selectedProjects: [
+        samePlan ? currentPlanInfo.projects : DEFAULT_PROJECTS,
+      ],
+      currentStep: !isNil(dialog.step) ? dialog.step : 1,
+    });
   }, [dialog.isOpen, dialog.step, currentPlanInfo]);
 
   const pricing = useMemo(
@@ -290,7 +285,7 @@ export const UpgradeDialog: FC = () => {
   };
 
   const message = dialog.metric ? messages[dialog.metric] : undefined;
-  const title = dialog.title || t('Choose Your Plan');
+  const title = dialog.title || t('Customize Your Plan');
   const steps = [{ title: t('Select Plan') }, { title: t('Add-ons') }];
 
   return (

--- a/packages/server/api/src/app/workers/engine-controller.ts
+++ b/packages/server/api/src/app/workers/engine-controller.ts
@@ -101,7 +101,7 @@ export const flowEngineWorker: FastifyPluginAsyncTypebox = async (app) => {
         const runWithoutSteps = await flowRunService(request.log).updateRun({
             flowRunId: runId,
             status: runDetails.status,
-            tasks: runDetails.tasks,
+            tasks: progressUpdateType === ProgressUpdateType.TEST_FLOW ? 0 : runDetails.tasks,
             duration: runDetails.duration,
             projectId: request.principal.projectId,
             tags: runDetails.tags ?? [],

--- a/packages/server/api/src/app/workers/engine-controller.ts
+++ b/packages/server/api/src/app/workers/engine-controller.ts
@@ -101,7 +101,7 @@ export const flowEngineWorker: FastifyPluginAsyncTypebox = async (app) => {
         const runWithoutSteps = await flowRunService(request.log).updateRun({
             flowRunId: runId,
             status: runDetails.status,
-            tasks: progressUpdateType === ProgressUpdateType.TEST_FLOW ? 0 : runDetails.tasks,
+            tasks: runDetails.tasks,
             duration: runDetails.duration,
             projectId: request.principal.projectId,
             tags: runDetails.tags ?? [],


### PR DESCRIPTION
## What does this PR do? 

- decrease ai credits threshold to $15
- show the right plan on business trial
- reset usage to reset untill the start of current month
- never increase tasks on test flow and test step

Fixes #3776 
