### PR TITLE
fix: edge case of removeConnectionsFromInput function

### DIFF
--- a/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
@@ -386,6 +386,10 @@ function removeConnectionsFromInput(
             replacedObj[key] = removeConnectionsFromInput(value as Record<string, unknown>)
         }
         else if (typeof value === 'string') {
+            if (value.trim() === '') {
+                replacedObj[key] = value;
+                continue;
+            }
             const replacedValue = value.replace(/\{{connections\.[^}]*}}/g, '')
             replacedObj[key] = replacedValue === '' ? undefined : replacedValue
         }


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug in removeConnectionsFromInput where empty strings ("") were incorrectly replaced with undefined during {{connections.*}} placeholder removal.

### Reproduction Steps:

1. Create a flow with a dataMapper piece.
2. config mapping property of dataMapper to `{
  "company": {
    "companyName": "",
    "companyProfile": "",
    "companyWebsite": "https://www.google.com"
  }
}`
3. Export the flow using the “Export Flow” feature.
4. Observe that previously, empty string properties were missing from the exported JSON.
5. After this fix, empty string properties are correctly preserved in the exported JSON.

### Explain How the Feature Works

1. Added a check to preserve empty strings before applying regex replacement.
2. Non-empty strings continue to have {{connections.*}} removed.
3. Handling of arrays, objects, and other value types remains unchanged.

Fixes # (issue)
