### PR TITLE
feat: add Netlify piece with initial triggers and actions

### DIFF
--- a/packages/pieces/community/netlify/.eslintrc.json
+++ b/packages/pieces/community/netlify/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/netlify/README.md
+++ b/packages/pieces/community/netlify/README.md
@@ -1,0 +1,7 @@
+# pieces-netlify
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-netlify` to build the library.

--- a/packages/pieces/community/netlify/package.json
+++ b/packages/pieces/community/netlify/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-netlify",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/netlify/project.json
+++ b/packages/pieces/community/netlify/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-netlify",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/netlify/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/netlify",
+        "tsConfig": "packages/pieces/community/netlify/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/netlify/package.json",
+        "main": "packages/pieces/community/netlify/src/index.ts",
+        "assets": [
+          "packages/pieces/community/netlify/*.md",
+          {
+            "input": "packages/pieces/community/netlify/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/netlify/src/index.ts
+++ b/packages/pieces/community/netlify/src/index.ts
@@ -1,13 +1,70 @@
+import { PieceAuth, createPiece } from "@activepieces/pieces-framework";
+import { HttpMethod, httpClient } from "@activepieces/pieces-common";
 
-    import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { getSite } from "./lib/actions/get-site";
+import { startDeploy } from "./lib/actions/start-deploy";
+import { listSiteDeploys } from "./lib/actions/list-site-deploys";
+import { listFiles } from "./lib/actions/list-files";
 
-    export const netlify = createPiece({
-      displayName: "Netlify",
-      auth: PieceAuth.None(),
-      minimumSupportedRelease: '0.36.1',
-      logoUrl: "https://cdn.activepieces.com/pieces/netlify.png",
-      authors: [],
-      actions: [],
-      triggers: [],
-    });
+import { newDeployStarted } from "./lib/triggers/new-deploy-started";
+import { newDeploySucceeded } from "./lib/triggers/new-deploy-succeeded";
+import { newDeployFailed } from "./lib/triggers/new-deploy-failed";
+import { newFormSubmission } from "./lib/triggers/new-form-submission";
+
+export const netlifyAuth = PieceAuth.SecretText({
+    displayName: "Personal Access Token",
+    description: `
+    To get your Personal Access Token (PAT):
+    1. Go to your Netlify User Settings -> Applications.
+    2. Under "Personal access tokens", select "New access token".
+    3. Give it a descriptive name (e.g., "Activepieces").
+    4. Set an expiration date.
+    5. Click "Generate token" and copy it here.
+    `,
+    required: true,
     
+    validate: async ({ auth }) => {
+        try {
+            
+            await httpClient.sendRequest({
+                method: HttpMethod.GET,
+                url: 'https://api.netlify.com/api/v1/sites',
+                headers: {
+                    Authorization: `Bearer ${auth}`,
+                },
+            });
+            return {
+                valid: true,
+            };
+        } catch (error) {
+            return {
+                valid: false,
+                error: "Invalid Personal Access Token.",
+            };
+        }
+    },
+});
+
+
+
+export const netlify = createPiece({
+    displayName: "Netlify",
+    auth: netlifyAuth, 
+    minimumSupportedRelease: '0.36.1',
+    logoUrl: "https://cdn.activepieces.com/pieces/netlify.png",
+    authors: [
+        
+    ],
+    actions: [
+        getSite,
+        startDeploy,
+        listSiteDeploys,
+        listFiles,
+    ],
+    triggers: [
+        newDeployStarted,
+        newDeploySucceeded,
+        newDeployFailed,
+        newFormSubmission,
+    ],
+});

--- a/packages/pieces/community/netlify/src/index.ts
+++ b/packages/pieces/community/netlify/src/index.ts
@@ -1,0 +1,13 @@
+
+    import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+
+    export const netlify = createPiece({
+      displayName: "Netlify",
+      auth: PieceAuth.None(),
+      minimumSupportedRelease: '0.36.1',
+      logoUrl: "https://cdn.activepieces.com/pieces/netlify.png",
+      authors: [],
+      actions: [],
+      triggers: [],
+    });
+    

--- a/packages/pieces/community/netlify/src/lib/actions/get-site.ts
+++ b/packages/pieces/community/netlify/src/lib/actions/get-site.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { HttpMethod } from "@activepieces/pieces-common";
+import { netlifyAuth } from "../../index";
+import { callNetlifyApi } from "../common";
+
+export const getSite = createAction({
+    name: 'get_site',
+    auth: netlifyAuth,
+    displayName: 'Get Site',
+    description: 'Get a specified site.',
+    props: {
+        site_id: Property.Dropdown({
+            displayName: 'Site',
+            description: 'The Netlify site to retrieve.',
+            required: true,
+            refreshers: ["auth"],
+            async options({ auth }) {
+                if (!auth) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Please connect your Netlify account first.',
+                        options: [],
+                    };
+                }
+                
+                const sites = await callNetlifyApi<any[]>(
+                    HttpMethod.GET,
+                    'sites',
+                    auth as string,
+                );
+
+                return {
+                    disabled: false,
+                    options: sites.map((site: any) => ({
+                        label: site.name,
+                        value: site.id,
+                    })),
+                };
+            },
+        }),
+    },
+    async run(context) {
+        const { auth } = context;
+        const { site_id } = context.propsValue;
+
+        return await callNetlifyApi(
+            HttpMethod.GET,
+            `sites/${site_id}`,
+            auth
+        );
+    },
+});

--- a/packages/pieces/community/netlify/src/lib/actions/list-files.ts
+++ b/packages/pieces/community/netlify/src/lib/actions/list-files.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { HttpMethod } from "@activepieces/pieces-common";
+import { netlifyAuth } from "../../index";
+import { callNetlifyApi } from "../common";
+
+export const listFiles = createAction({
+    name: 'list_files',
+    auth: netlifyAuth,
+    displayName: 'List Files',
+    description: 'Returns a list of all the files in the current deploy.',
+    props: {
+        site_id: Property.Dropdown({
+            displayName: 'Site',
+            description: 'The Netlify site to list files from.',
+            required: true,
+            refreshers: ["auth"],
+            async options({ auth }) {
+                if (!auth) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Please connect your Netlify account first.',
+                        options: [],
+                    };
+                }
+                
+                const sites = await callNetlifyApi<any[]>(
+                    HttpMethod.GET,
+                    'sites',
+                    auth as string,
+                );
+
+                return {
+                    disabled: false,
+                    options: sites.map((site: any) => ({
+                        label: site.name,
+                        value: site.id,
+                    })),
+                };
+            },
+        }),
+    },
+    async run(context) {
+        const { auth } = context;
+        const { site_id } = context.propsValue;
+
+        return await callNetlifyApi(
+            HttpMethod.GET,
+            `sites/${site_id}/files`,
+            auth
+        );
+    },
+});

--- a/packages/pieces/community/netlify/src/lib/actions/list-site-deploys.ts
+++ b/packages/pieces/community/netlify/src/lib/actions/list-site-deploys.ts
@@ -1,0 +1,66 @@
+import { createAction, Property } from "@activepieces/pieces-framework";
+import { HttpMethod, QueryParams } from "@activepieces/pieces-common";
+import { netlifyAuth } from "../../index";
+import { callNetlifyApi } from "../common";
+
+export const listSiteDeploys = createAction({
+    name: 'list_site_deploys',
+    auth: netlifyAuth,
+    displayName: 'List Site Deploys',
+    description: 'Returns a list of all deploys for a specific site.',
+    props: {
+        site_id: Property.Dropdown({
+            displayName: 'Site',
+            description: 'The Netlify site to retrieve deploys from.',
+            required: true,
+            refreshers: ["auth"],
+            async options({ auth }) {
+                if (!auth) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Please connect your Netlify account first.',
+                        options: [],
+                    };
+                }
+                const sites = await callNetlifyApi<any[]>(
+                    HttpMethod.GET,
+                    'sites',
+                    auth as string,
+                );
+                return {
+                    disabled: false,
+                    options: sites.map((site: any) => ({
+                        label: site.name,
+                        value: site.id,
+                    })),
+                };
+            },
+        }),
+        page: Property.Number({
+            displayName: 'Page',
+            description: 'The page number to retrieve for pagination.',
+            required: false,
+        }),
+        per_page: Property.Number({
+            displayName: 'Deploys Per Page',
+            description: 'The number of deploys to return per page (max: 100).',
+            required: false,
+        })
+    },
+    async run(context) {
+        const { auth } = context;
+        const { site_id, page, per_page } = context.propsValue;
+
+        const queryParams: QueryParams = {};
+        if (page) queryParams['page'] = page.toString();
+        if (per_page) queryParams['per_page'] = per_page.toString();
+
+        return await callNetlifyApi(
+            HttpMethod.GET,
+            `sites/${site_id}/deploys`,
+            auth,
+            undefined, 
+            queryParams
+        );
+    },
+});

--- a/packages/pieces/community/netlify/src/lib/common/index.ts
+++ b/packages/pieces/community/netlify/src/lib/common/index.ts
@@ -1,0 +1,32 @@
+import { httpClient, HttpMethod, HttpRequest, QueryParams } from "@activepieces/pieces-common";
+
+/**
+ * A helper function to make authenticated API calls to the Netlify API.
+ * @param method The HTTP method (GET, POST, etc.)
+ * @param endpoint The API endpoint to call (e.g., 'sites')
+ * @param auth The user's Personal Access Token (a string)
+ * @param body The request body for POST/PUT requests
+ * @param queryParams The query parameters for the request
+ * @returns The parsed JSON response from the API
+ */
+export const callNetlifyApi = async <T extends object>(
+    method: HttpMethod,
+    endpoint: string,
+    auth: string,
+    body?: object,
+    queryParams?: QueryParams
+): Promise<T> => {
+    const request: HttpRequest = {
+        method: method,
+        url: `https://api.netlify.com/api/v1/${endpoint}`,
+        headers: {
+            Authorization: `Bearer ${auth}`,
+        },
+        body: body,
+        queryParams: queryParams,
+    };
+
+    const response = await httpClient.sendRequest<T>(request);
+    return response.body;
+};
+

--- a/packages/pieces/community/netlify/src/lib/triggers/new-deploy-failed.ts
+++ b/packages/pieces/community/netlify/src/lib/triggers/new-deploy-failed.ts
@@ -1,0 +1,100 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { netlifyAuth } from '../../index';
+import { callNetlifyApi } from '../common';
+
+
+interface Deploy {
+    id: string;
+    state: string; 
+    error_message?: string; 
+}
+
+export const newDeployFailed = createTrigger({
+    name: 'new_deploy_failed',
+    auth: netlifyAuth,
+    displayName: 'New Deploy Failed',
+    description: 'Fires when a site deploy fails.',
+    props: {
+        site_id: Property.Dropdown({
+            displayName: 'Site',
+            description: 'The Netlify site to monitor for failed deploys.',
+            required: true,
+            refreshers: ["auth"],
+            async options({ auth }) {
+                if (!auth) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Please connect your Netlify account first.',
+                        options: [],
+                    };
+                }
+                const sites = await callNetlifyApi<any[]>(HttpMethod.GET, 'sites', auth as string);
+                return {
+                    disabled: false,
+                    options: sites.map((site: any) => ({
+                        label: site.name,
+                        value: site.id,
+                    })),
+                };
+            },
+        }),
+    },
+    type: TriggerStrategy.POLLING,
+    sampleData: {
+        "id": "603f7a4b1e5a5c0007a3b3c6",
+        "site_id": "YOUR_SITE_ID",
+        "build_id": "603f7a4b1e5a5c0007a3b3c7",
+        "state": "error", 
+        "name": "your-site-name",
+        "error_message": "Build script returned non-zero exit code: 1",
+        "created_at": "2025-08-29T12:50:00.111Z",
+        "branch": "main",
+    },
+
+    async onEnable(context) {
+        const deploys = await callNetlifyApi<Deploy[]>(
+            HttpMethod.GET,
+            `sites/${context.propsValue.site_id}/deploys`,
+            context.auth,
+        );
+        
+        const lastFailedDeploy = deploys.find(d => d.state === 'error');
+        await context.store.put('last_failed_deploy_id', lastFailedDeploy?.id ?? null);
+    },
+
+    async onDisable(context) {
+        
+        await context.store.delete('last_failed_deploy_id');
+    },
+
+    async run(context) {
+        const lastId = await context.store.get<string | null>('last_failed_deploy_id');
+        const deploys = await callNetlifyApi<Deploy[]>(
+            HttpMethod.GET,
+            `sites/${context.propsValue.site_id}/deploys`,
+            context.auth
+        );
+        
+        
+        const failedDeploys = deploys.filter(d => d.state === 'error');
+
+        if (failedDeploys.length === 0) {
+            return [];
+        }
+
+        
+        await context.store.put('last_failed_deploy_id', failedDeploys[0].id);
+
+        const newFailedDeploys = [];
+        for (const deploy of failedDeploys) {
+            if (deploy.id === lastId) {
+                break; 
+            }
+            newFailedDeploys.push(deploy);
+        }
+
+        
+        return newFailedDeploys.reverse();
+    },
+});

--- a/packages/pieces/community/netlify/src/lib/triggers/new-deploy-started.ts
+++ b/packages/pieces/community/netlify/src/lib/triggers/new-deploy-started.ts
@@ -1,0 +1,101 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { netlifyAuth } from '../../index';
+import { callNetlifyApi } from '../common';
+
+
+interface Deploy {
+    id: string;
+    created_at: string;
+}
+
+export const newDeployStarted = createTrigger({
+    name: 'new_deploy_started',
+    auth: netlifyAuth,
+    displayName: 'New Deploy Started',
+    description: 'Fires immediately when a deploy job starts on your Netlify site.',
+    props: {
+        site_id: Property.Dropdown({
+            displayName: 'Site',
+            description: 'The Netlify site to monitor for new deploys.',
+            required: true,
+            refreshers: ["auth"], 
+            async options({ auth }) {
+                if (!auth) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Please connect your Netlify account first.',
+                        options: [],
+                    };
+                }
+                const sites = await callNetlifyApi<any[]>(HttpMethod.GET, 'sites', auth as string);
+                return {
+                    disabled: false,
+                    options: sites.map((site: any) => ({
+                        label: site.name,
+                        value: site.id,
+                    })),
+                };
+            },
+        }),
+    },
+    type: TriggerStrategy.POLLING,
+    sampleData: {
+        "id": "603f7a4b1e5a5c0007a3b3c6",
+        "site_id": "YOUR_SITE_ID",
+        "build_id": "603f7a4b1e5a5c0007a3b3c7",
+        "state": "building", 
+        "name": "your-site-name",
+        "created_at": "2025-08-29T12:50:00.111Z",
+        "branch": "main",
+    },
+
+    
+    async onEnable(context) {
+        
+        const deploys = await callNetlifyApi<Deploy[]>(
+            HttpMethod.GET,
+            `sites/${context.propsValue.site_id}/deploys`,
+            context.auth,
+        );
+
+        
+        const lastDeployId = deploys.length > 0 ? deploys[0].id : null;
+        await context.store.put('last_deploy_id', lastDeployId);
+    },
+
+    
+    async onDisable(context) {
+        
+        await context.store.delete('last_deploy_id');
+    },
+
+    
+    async run(context) {
+        const lastId = await context.store.get<string | null>('last_deploy_id');
+        const deploys = await callNetlifyApi<Deploy[]>(
+            HttpMethod.GET,
+            `sites/${context.propsValue.site_id}/deploys`,
+            context.auth
+        );
+
+        if (deploys.length === 0) {
+            return []; 
+        }
+
+        
+        await context.store.put('last_deploy_id', deploys[0].id);
+
+        const newDeploys = [];
+        
+        for (const deploy of deploys) {
+            if (deploy.id === lastId) {
+                break; 
+            }
+            newDeploys.push(deploy);
+        }
+
+        
+        return newDeploys.reverse();
+    },
+});

--- a/packages/pieces/community/netlify/src/lib/triggers/new-deploy-succeeded.ts
+++ b/packages/pieces/community/netlify/src/lib/triggers/new-deploy-succeeded.ts
@@ -1,0 +1,99 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { netlifyAuth } from '../../index';
+import { callNetlifyApi } from '../common';
+
+
+interface Deploy {
+    id: string;
+    state: string; 
+}
+
+export const newDeploySucceeded = createTrigger({
+    name: 'new_deploy_succeeded',
+    auth: netlifyAuth,
+    displayName: 'New Deploy Succeeded',
+    description: 'Fires when a new site version has successfully deployed.',
+    props: {
+        site_id: Property.Dropdown({
+            displayName: 'Site',
+            description: 'The Netlify site to monitor for successful deploys.',
+            required: true,
+            refreshers: ["auth"],
+            async options({ auth }) {
+                if (!auth) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Please connect your Netlify account first.',
+                        options: [],
+                    };
+                }
+                const sites = await callNetlifyApi<any[]>(HttpMethod.GET, 'sites', auth as string);
+                return {
+                    disabled: false,
+                    options: sites.map((site: any) => ({
+                        label: site.name,
+                        value: site.id,
+                    })),
+                };
+            },
+        }),
+    },
+    type: TriggerStrategy.POLLING,
+    sampleData: {
+        "id": "603f7a4b1e5a5c0007a3b3c4",
+        "site_id": "YOUR_SITE_ID",
+        "build_id": "603f7a4b1e5a5c0007a3b3c5",
+        "state": "ready", 
+        "name": "your-site-name",
+        "url": "https://603f7a4b1e5a5c0007a3b3c4--your-site-name.netlify.app",
+        "published_at": "2025-08-29T12:30:33.222Z",
+        "branch": "main",
+    },
+
+    async onEnable(context) {
+        const deploys = await callNetlifyApi<Deploy[]>(
+            HttpMethod.GET,
+            `sites/${context.propsValue.site_id}/deploys`,
+            context.auth,
+        );
+        
+        const lastSuccessfulDeploy = deploys.find(d => d.state === 'ready');
+        await context.store.put('last_succeeded_deploy_id', lastSuccessfulDeploy?.id ?? null);
+    },
+
+    async onDisable(context) {
+        
+        await context.store.delete('last_succeeded_deploy_id');
+    },
+
+    async run(context) {
+        const lastId = await context.store.get<string | null>('last_succeeded_deploy_id');
+        const deploys = await callNetlifyApi<Deploy[]>(
+            HttpMethod.GET,
+            `sites/${context.propsValue.site_id}/deploys`,
+            context.auth
+        );
+        
+        
+        const successfulDeploys = deploys.filter(d => d.state === 'ready');
+
+        if (successfulDeploys.length === 0) {
+            return [];
+        }
+
+        
+        await context.store.put('last_succeeded_deploy_id', successfulDeploys[0].id);
+
+        const newSuccessfulDeploys = [];
+        for (const deploy of successfulDeploys) {
+            if (deploy.id === lastId) {
+                break; 
+            }
+            newSuccessfulDeploys.push(deploy);
+        }
+
+        
+        return newSuccessfulDeploys.reverse();
+    },
+});

--- a/packages/pieces/community/netlify/src/lib/triggers/new-form-submission.ts
+++ b/packages/pieces/community/netlify/src/lib/triggers/new-form-submission.ts
@@ -1,0 +1,126 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { netlifyAuth } from '../../index';
+import { callNetlifyApi } from '../common';
+
+
+interface Submission {
+    id: string;
+}
+
+export const newFormSubmission = createTrigger({
+    name: 'new_form_submission',
+    auth: netlifyAuth,
+    displayName: 'New Form Submission',
+    description: 'Fires when a Netlify form submission is received.',
+    props: {
+        site_id: Property.Dropdown({
+            displayName: 'Site',
+            description: 'The Netlify site to monitor.',
+            required: true,
+            refreshers: ["auth"],
+            async options({ auth }) {
+                if (!auth) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Please connect your Netlify account first.',
+                        options: [],
+                    };
+                }
+                const sites = await callNetlifyApi<any[]>(HttpMethod.GET, 'sites', auth as string);
+                return {
+                    disabled: false,
+                    options: sites.map((site: any) => ({
+                        label: site.name,
+                        value: site.id,
+                    })),
+                };
+            },
+        }),
+        form_id: Property.Dropdown({
+            displayName: 'Form',
+            description: 'The form to monitor for new submissions.',
+            required: true,
+            refreshers: ['site_id'], 
+            async options(propsValue) {
+                const { auth, site_id } = propsValue;
+                if (!auth || !site_id) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Please select a site first.',
+                        options: [],
+                    };
+                }
+                
+                const forms = await callNetlifyApi<any[]>(HttpMethod.GET, `sites/${site_id}/forms`, auth as string);
+                return {
+                    disabled: false,
+                    options: forms.map((form: any) => ({
+                        label: form.name,
+                        value: form.id,
+                    })),
+                };
+            },
+        })
+    },
+    type: TriggerStrategy.POLLING,
+    sampleData: {
+        "id": "603f7a4b1e5a5c0007a3b3c8",
+        "number": 1,
+        "email": "test@example.com",
+        "name": "Test User",
+        "first_name": "Test",
+        "last_name": "User",
+        "company": "ACME Inc.",
+        "summary": "This is a test submission.",
+        "body": "Message body here.",
+        "data": { "ip": "192.168.1.1", "user_agent": "Mozilla/5.0" },
+        "created_at": "2025-08-31T05:30:00.000Z",
+        "site_url": "https://your-site-name.netlify.app"
+    },
+
+    async onEnable(context) {
+        const { form_id } = context.propsValue;
+        const submissions = await callNetlifyApi<Submission[]>(
+            HttpMethod.GET,
+            `forms/${form_id}/submissions`,
+            context.auth
+        );
+        const lastId = submissions.length > 0 ? submissions[0].id : null;
+        
+        await context.store.put(`last_submission_${form_id}`, lastId);
+    },
+
+    async onDisable(context) {
+        const { form_id } = context.propsValue;
+        
+        await context.store.delete(`last_submission_${form_id}`);
+    },
+
+    async run(context) {
+        const { form_id } = context.propsValue;
+        const lastId = await context.store.get<string | null>(`last_submission_${form_id}`);
+        
+        const submissions = await callNetlifyApi<Submission[]>(
+            HttpMethod.GET,
+            `forms/${form_id}/submissions`,
+            context.auth
+        );
+        
+        if (submissions.length === 0) {
+            return [];
+        }
+
+        await context.store.put(`last_submission_${form_id}`, submissions[0].id);
+
+        const newSubmissions = [];
+        for (const submission of submissions) {
+            if (submission.id === lastId) {
+                break;
+            }
+            newSubmissions.push(submission);
+        }
+
+        return newSubmissions.reverse();
+    },
+});

--- a/packages/pieces/community/netlify/tsconfig.json
+++ b/packages/pieces/community/netlify/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/netlify/tsconfig.lib.json
+++ b/packages/pieces/community/netlify/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -662,6 +662,9 @@
       "@activepieces/piece-mysql": [
         "packages/pieces/community/mysql/src/index.ts"
       ],
+      "@activepieces/piece-netlify": [
+        "packages/pieces/community/netlify/src/index.ts"
+      ],
       "@activepieces/piece-netsuite": [
         "packages/pieces/community/netsuite/src/index.ts"
       ],
@@ -798,7 +801,7 @@
       "@activepieces/piece-retable": [
         "packages/pieces/community/retable/src/index.ts"
       ],
-        "@activepieces/piece-retell-ai": [
+      "@activepieces/piece-retell-ai": [
         "packages/pieces/community/retell-ai/src/index.ts"
       ],
       "@activepieces/piece-retune": [


### PR DESCRIPTION
## What does this PR do?

This PR adds the Netlify Piece for Activepieces, fully implementing the triggers and actions described in issue #8974. With this integration, users can automate workflows based on Netlify deployment events and form submissions, as well as perform site and deployment management actions.

### 🚨 Triggers Implemented

- New Deploy Started – Fires immediately when a deploy job starts on a Netlify site.

- New Deploy Succeeded – Fires when a new site version has been successfully deployed.

- New Deploy Failed – Fires when a site deployment fails.

- New Form Submission – Fires when a new form submission is received on a Netlify site.

### 🛠️ Actions Implemented


- Start Deploy – Triggers a new build for a specified site, with optional cache clearing.

- Get Site – Retrieves details of a specific site.

- List Site Deploys – Returns a list of all deploys for a given site.

- List Files – Returns a list of all files in the current deploy.

### Relevant User Scenarios

Send Slack/Email notifications whenever a deploy starts, succeeds, or fails.

Trigger workflows automatically when a Netlify form submission is received.

Programmatically start new site builds as part of a CI/CD workflow.

Retrieve deployment history and files for reporting, monitoring, or integrations.

### Linked Issue

Fixes #8974
/claim #8974
