### PR TITLE
feat(add piece): add toggl track piece

### DIFF
--- a/packages/pieces/community/toggltrack/package.json
+++ b/packages/pieces/community/toggltrack/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-toggltrack",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/toggltrack/src/index.ts
+++ b/packages/pieces/community/toggltrack/src/index.ts
@@ -1,0 +1,76 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { findUser } from './lib/actions/find-user';
+import { createClient } from './lib/actions/create-client';
+import { newClient } from './lib/triggers/new-client';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { newProject } from './lib/triggers/new-project';
+import { newTag } from './lib/triggers/new-tag';
+import { newTask } from './lib/triggers/new-task';
+import { newTimeEntry } from './lib/triggers/new-time-entry';
+import { newTimeEntryStarted } from './lib/triggers/new-time-entry-started';
+import { newWorkspace } from './lib/triggers/new-workspace-';
+import { createProject } from './lib/actions/create-project-';
+import { createTag } from './lib/actions/create-tag-';
+import { createTask } from './lib/actions/create-task';
+import { createTimeEntry } from './lib/actions/create-time-entry';
+import { startTimeEntry } from './lib/actions/start-time-entry';
+import { stopTimeEntry } from './lib/actions/stop-time-entry';
+import { findClient } from './lib/actions/find-client';
+import { findProject } from './lib/actions/find-project';
+import { findTag } from './lib/actions/find-tag';
+import { findTask } from './lib/actions/find-task';
+import { findTimeEntry } from './lib/actions/find-time-entry';
+
+export const toggleTrackAuth = PieceAuth.SecretText({
+  displayName: 'API Token',
+  description: 'Enter your Toggle Track API token',
+  required: true,
+});
+
+export const toggltrack = createPiece({
+  displayName: 'Toggltrack',
+  auth: toggleTrackAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/toggletrack.png',
+  authors: [],
+  actions: [
+    createCustomApiCallAction({
+      baseUrl: (auth) => {
+        return 'https://api.track.toggl.com/api/v9';
+      },
+      auth: toggleTrackAuth,
+      authMapping: async (auth) => {
+        return {
+          Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+            'base64'
+          )}`,
+          'Content-Type': 'application/json',
+        };
+      },
+    }),
+
+    createClient,
+    createProject,
+    createTask,
+    createTag,
+    createTimeEntry,
+    startTimeEntry,
+    stopTimeEntry,
+    //search actions
+    findUser,
+    findProject,
+    findTask,
+    findClient,
+    findTag,
+    findTimeEntry,
+  ],
+  triggers: [
+    newClient,
+    newWorkspace,
+    newProject,
+    newTask,
+    newTimeEntry,
+    newTimeEntryStarted,
+    newTag,
+  ],
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/create-client.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/create-client.ts
@@ -1,0 +1,92 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const createClient = createAction({
+  auth: toggleTrackAuth,
+  name: 'createClient',
+  displayName: 'Create Client',
+  description: 'Create a new client in a workspace.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace where client will added',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+
+        return { options: [] };
+      },
+    }),
+    name: Property.ShortText({
+      displayName: 'Client Name',
+      description: 'Name of the client to create',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue); 
+    const { workspaceId, name } = props;
+
+    try {
+      const requestBody = {
+        name: name.trim(),
+        wid: workspaceId
+      };
+
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/clients`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+        body: requestBody,
+      });
+
+      if (response.status === 200 || response.status === 201) {
+        const client = response.body;
+
+        return {
+          id: client.id,
+          name: client.name,
+          workspace_id: client.wid,
+          created_at: client.at,
+        };
+      } else {
+        return {
+          success: false,
+          error: `API request failed with status ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/create-project-.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/create-project-.ts
@@ -1,0 +1,146 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const createProject = createAction({
+  auth: toggleTrackAuth,
+  name: 'createProject',
+  displayName: 'Create Project',
+  description:
+    'Create a new project with properties like template, privacy, billable, client.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace where the project will be created',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        return { options: [] };
+      },
+    }),
+    name: Property.ShortText({
+      displayName: 'Project Name',
+      description: 'Name of the project to create',
+      required: true,
+    }),
+    clientId: Property.Dropdown({
+      displayName: 'Client',
+      description:
+        'Select the client to associate with this project (optional)',
+      required: false,
+      refreshers: ['workspaceId'],
+      options: async ({ auth, workspaceId }) => {
+        if (!auth || !workspaceId) {
+          return { options: [] };
+        }
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/clients`,
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+          if (response.status === 200) {
+            const clients = response.body;
+            return {
+              options: clients.map((client: any) => ({
+                label: client.name,
+                value: client.id,
+              })),
+            };
+          }
+        } catch {
+          return { options: [] };
+        }
+        return { options: [] };
+      },
+    }),
+    isPrivate: Property.Checkbox({
+      displayName: 'Private Project',
+      description: 'Make this project private',
+      required: false,
+      defaultValue: false,
+    }),
+    billable: Property.Checkbox({
+      displayName: 'Billable',
+      description: 'Make this project billable',
+      required: false,
+      defaultValue: true,
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId, name, clientId, isPrivate, billable } = props;
+    try {
+      const requestBody: any = {
+        name: name.trim(),
+        workspace_id: workspaceId,
+        is_private: isPrivate,
+        billable: billable,
+      };
+      if (clientId) {
+        requestBody.client_id = clientId;
+      }
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+        body: requestBody,
+      });
+      if (response.status === 200 || response.status === 201) {
+        const project = response.body;
+        return {
+          id: project.id,
+          name: project.name,
+          workspace_id: project.workspace_id,
+          client_id: project.client_id,
+          is_private: project.is_private,
+          billable: project.billable,
+          created_at: project.created_at,
+        };
+      } else {
+        return {
+          success: false,
+          error: `Failed to create project: ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/create-tag-.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/create-tag-.ts
@@ -1,0 +1,89 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const createTag = createAction({
+  auth: toggleTrackAuth,
+  name: 'createTag',
+  displayName: 'Create Tag',
+  description: 'Create a new tag in the workspace.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace where the tag will be created',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        return { options: [] };
+      },
+    }),
+    name: Property.ShortText({
+      displayName: 'Tag Name',
+      description: 'Name of the tag to create',
+      required: true,
+    }),
+  },
+  async run(context) {
+  const props = convertIdsToInt(context.propsValue);
+  const { workspaceId, projectId, name } = props;
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/tags`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+        body: {
+          name: name.trim(),
+          workspace_id: parseInt(workspaceId, 10),
+        },
+      });
+      if (response.status === 200 || response.status === 201) {
+        const tag = response.body;
+        return {
+          id: tag.id,
+          name: tag.name,
+          workspace_id: tag.workspace_id,
+          created_at: tag.created_at,
+        };
+      } else {
+        return {
+          success: false,
+          error: `Failed to create tag: ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/create-task.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/create-task.ts
@@ -1,0 +1,125 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const createTask = createAction({
+  auth: toggleTrackAuth,
+  name: 'createTask',
+  displayName: 'Create Task',
+  description: 'Create a new task under a project.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace where the task will be created',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        return { options: [] };
+      },
+    }),
+    projectId: Property.Dropdown({
+      displayName: 'Project',
+      description: 'Select the project where the task will be created',
+      required: true,
+      refreshers: ['workspaceId'],
+      options: async ({ auth, workspaceId }) => {
+        if (!auth || !workspaceId) {
+          return { options: [] };
+        }
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects`,
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+          if (response.status === 200) {
+            return {
+              options: response.body
+                .filter((project: any) => project.active === true)
+                .map((project: any) => ({
+                  label: project.name,
+                  value: project.id,
+                })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        return { options: [] };
+      },
+    }),
+    name: Property.ShortText({
+      displayName: 'Task Name',
+      description: 'Name of the task to create',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId, projectId, name } = props;
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects/${projectId}/tasks`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+        body: {
+          name: name.trim(),
+          project_id: projectId,
+        },
+      });
+      if (response.status === 200 || response.status === 201) {
+        const task = response.body;
+        return {
+          id: task.id,
+          name: task.name,
+          project_id: task.project_id,
+          workspace_id: task.workspace_id,
+          created_at: task.created_at,
+        };
+      } else {
+        return {
+          success: false,
+          error: `Failed to create task: ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/create-time-entry.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/create-time-entry.ts
@@ -1,0 +1,142 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const createTimeEntry = createAction({
+  auth: toggleTrackAuth,
+  name: 'createTimeEntry',
+  displayName: 'Create Time Entry',
+  description: 'Manually create a time entry with start, duration, description, and tags.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace where the new time entry will be created',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        return { options: [] };
+      },
+    }),
+    description: Property.ShortText({
+      displayName: 'Description',
+      description: 'Description of the time entry',
+      required: true,
+    }),
+    duration: Property.Number({
+      displayName: 'Duration (seconds)',
+      description: 'Duration of the time entry in seconds',
+      required: true,
+    }),
+    projectId: Property.Dropdown({
+      displayName: 'Project',
+      description: 'Select the project where the task will be created',
+      required: true,
+      refreshers: ['workspaceId'],
+      options: async ({ auth, workspaceId }) => {
+        if (!auth || !workspaceId) {
+          return { options: [] };
+        }
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects`,
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+          if (response.status === 200) {
+            return {
+              options: response.body
+                .filter((project: any) => project.active === true)
+                .map((project: any) => ({
+                  label: project.name,
+                  value: project.id,
+                })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        return { options: [] };
+      },
+    }),
+    startTime: Property.DateTime({
+      displayName: 'Start Time',
+      description: 'Start time of the entry (ISO format YYYY-MM-DD)',
+      required: true,
+    }),
+  },
+  async run(context) {
+   const props = convertIdsToInt(context.propsValue);
+    const { workspaceId, description, duration, projectId, startTime } = props;
+
+    
+    try {
+      const requestBody: any = {
+        description: description.trim(),
+        duration: duration,
+        start: startTime,
+        workspace_id: parseInt(workspaceId, 10), 
+        created_with: 'activepieces',
+      };
+      
+      if (projectId) {
+        requestBody.project_id = parseInt(projectId, 10);
+      }
+      
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${parseInt(workspaceId, 10)}/time_entries`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+        body: requestBody,
+      });
+      
+      if (response.status === 200 || response.status === 201) {
+        const timeEntry = response.body;
+        return {
+          id: timeEntry.id,
+          description: timeEntry.description,
+          duration: timeEntry.duration,
+          start: timeEntry.start,
+          project_id: timeEntry.project_id,
+          workspace_id: timeEntry.workspace_id,
+          created_at: timeEntry.at,
+        };
+      } else {
+        return {
+          success: false,
+          error: `Failed to create time entry: ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/find-client.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/find-client.ts
@@ -1,0 +1,104 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const findClient = createAction({
+  auth: toggleTrackAuth,
+  name: 'findClient',
+  displayName: 'Find Client',
+  description: 'Find a client by name or status.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace where you want to find the client',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        return { options: [] };
+      },
+    }),
+    clientName: Property.ShortText({
+      displayName: 'Client Name',
+      required: true,
+    }),
+    activeStatus: Property.StaticDropdown({
+      displayName: 'Status Filter',
+      required: false,
+      options: {
+        options: [
+          { label: 'All', value: '' },
+          { label: 'Active', value: 'active' },
+          { label: 'Archived', value: 'archived' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId, clientName, activeStatus } = props;
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/clients`,
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+      });
+      if (response.status === 200) {
+        let clients = response.body;
+        if (activeStatus) {
+          clients = clients.filter((client: any) => {
+            return activeStatus === 'active'
+              ? client.archived === false
+              : client.archived === true;
+          });
+        }
+        const matchingClients = clients.filter(
+          (client: any) =>
+            client.name.toLowerCase() === clientName.toLowerCase()
+        );
+        return {
+          success: true,
+          clients: matchingClients,
+          count: matchingClients.length,
+        };
+      } else {
+        return {
+          success: false,
+          error: `API request failed with status ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/find-project.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/find-project.ts
@@ -1,0 +1,132 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const findProject = createAction({
+  auth: toggleTrackAuth,
+  name: 'findProject',
+  displayName: 'Find Project',
+  description: 'Find a project by name.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'The workspace to search projects in',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+
+        return { options: [] };
+      },
+    }),
+
+    projectId: Property.Dropdown({
+      displayName: 'Project',
+      description: 'Select the project where the task will be created',
+      required: true,
+      refreshers: ['workspaceId'],
+      options: async ({ auth, workspaceId }) => {
+        if (!auth || !workspaceId) {
+          return { options: [] };
+        }
+
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects`,
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+
+          if (response.status === 200) {
+            return {
+              options: response.body
+                .filter((project: any) => project.active === true) // Only show active projects
+                .map((project: any) => ({
+                  label: project.name,
+                  value: project.id,
+                })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+
+        return { options: [] };
+      },
+    }),
+    projectName: Property.ShortText({
+      displayName: 'Project Name',
+      description: 'Name of the project to find',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId, projectName } = props;
+
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects`,
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+      });
+
+      if (response.status === 200) {
+        const projects = response.body;
+        const matchingProjects = projects.filter(
+          (project: any) =>
+            project.name.toLowerCase() === projectName.toLowerCase()
+        );
+
+        return {
+          success: true,
+          projects: matchingProjects,
+          count: matchingProjects.length,
+        };
+      } else {
+        return {
+          success: false,
+          error: `API request failed with status ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/find-tag.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/find-tag.ts
@@ -1,0 +1,91 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const findTag = createAction({
+  auth: toggleTrackAuth,
+  name: 'findTag',
+  displayName: 'Find Tag',
+  description: 'Find a tag by name.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+
+        return { options: [] };
+      },
+    }),
+    tagName: Property.ShortText({
+      displayName: 'Tag Name',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId, tagName } = props;
+
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/tags`,
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+      });
+
+      if (response.status === 200) {
+        const tags = response.body;
+        const matchingTags = tags.filter(
+          (tag: any) => tag.name.toLowerCase() === tagName.toLowerCase()
+        );
+
+        return {
+          success: true,
+          tags: matchingTags,
+          count: matchingTags.length,
+        };
+      } else {
+        return {
+          success: false,
+          error: `API request failed with status ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/find-task.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/find-task.ts
@@ -1,0 +1,152 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const findTask = createAction({
+  auth: toggleTrackAuth,
+  name: 'findTask',
+  displayName: 'Find Task',
+  description: 'Find a task by name and status.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+
+        return { options: [] };
+      },
+    }),
+
+    projectId: Property.Dropdown({
+      displayName: 'Project',
+      description: 'Select the project',
+      required: true,
+      refreshers: ['workspaceId'],
+      options: async ({ auth, workspaceId }) => {
+        if (!auth || !workspaceId) {
+          return { options: [] };
+        }
+
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects`,
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+
+          if (response.status === 200) {
+            return {
+              options: response.body
+                .filter((project: any) => project.active === true) // Only show active projects
+                .map((project: any) => ({
+                  label: project.name,
+                  value: project.id,
+                })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+
+        return { options: [] };
+      },
+    }),
+    taskName: Property.ShortText({
+      displayName: 'Task Name',
+      required: true,
+    }),
+    activeStatus: Property.StaticDropdown({
+      displayName: 'Status Filter',
+      required: false,
+      options: {
+        options: [
+          { label: 'All', value: 'both' },
+          { label: 'Active', value: 'active' },
+          { label: 'Archived', value: 'archived' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId, projectId, taskName, activeStatus } =props;
+
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects/${projectId}/tasks`,
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+      });
+
+      if (response.status === 200) {
+        let tasks = response.body;
+
+        // Filter by status if specified
+        if (activeStatus && activeStatus !== 'both') {
+          tasks = tasks.filter((task: any) => {
+            return activeStatus === 'active'
+              ? task.active === true
+              : task.active === false;
+          });
+        }
+
+        // Filter by name
+        const matchingTasks = tasks.filter(
+          (task: any) => task.name.toLowerCase() === taskName.toLowerCase()
+        );
+
+        return {
+          success: true,
+          tasks: matchingTasks,
+          count: matchingTasks.length,
+        };
+      } else {
+        return {
+          success: false,
+          error: `API request failed with status ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/find-time-entry.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/find-time-entry.ts
@@ -1,0 +1,101 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const findTimeEntry = createAction({
+  auth: toggleTrackAuth,
+  name: 'findTimeEntry',
+  displayName: 'Find Time Entry',
+  description: 'Finds a time entry by description.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+
+        return { options: [] };
+      },
+    }),
+
+    description: Property.ShortText({
+      displayName: 'Description',
+      description: 'Description to search for in time entries',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId, description } = props;
+
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/me/time_entries`,
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+      });
+
+      if (response.status === 200) {
+        const timeEntries = response.body;
+
+        // Filter by workspace and description
+        const workspaceEntries = timeEntries.filter(
+          (entry: any) => entry.workspace_id === workspaceId
+        );
+
+        const matchingEntries = workspaceEntries.filter(
+          (entry: any) =>
+            entry.description &&
+            entry.description.toLowerCase().includes(description.toLowerCase())
+        );
+
+        return {
+          success: true,
+          time_entries: matchingEntries,
+          count: matchingEntries.length,
+        };
+      } else {
+        return {
+          success: false,
+          error: `API request failed with status ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/find-user.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/find-user.ts
@@ -1,0 +1,98 @@
+import { toggleTrackAuth } from '../../index';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const findUser = createAction({
+  auth: toggleTrackAuth,
+  name: 'findUser',
+  displayName: 'Find User',
+  description: 'Locate a user in a workspace.',
+  props: {
+    organizationId: Property.Dropdown({
+      displayName: 'Organization',
+      description: 'Select organization to search users in',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/organizations',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+          if (response.status === 200) {
+            return {
+              options: response.body.map((item: any) => ({
+                label: item.name,
+                value: item.id,
+              })),
+            };
+          }
+        } catch {
+          return { options: [] };
+        }
+        return { options: [] };
+      },
+    }),
+    searchFilter: Property.ShortText({
+      displayName: 'Search Filter',
+      description: 'Search for users by name or email',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { organizationId, searchFilter } = props;
+
+    try {
+      const queryParams = new URLSearchParams();
+
+      if (searchFilter) {
+        queryParams.append('filter', searchFilter);
+      }
+
+      const queryString = queryParams.toString();
+      const url = `https://api.track.toggl.com/api/v9/organizations/${organizationId}/users${
+        queryString ? '?' + queryString : ''
+      }`;
+
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: url,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+      });
+
+      if (response.status === 200) {
+        const users = response.body;
+
+        return {
+          success: true,
+          users: users,
+          count: Array.isArray(users) ? users.length : 0,
+        };
+      } else {
+        return {
+          success: false,
+          error: `API request failed with status ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/start-time-entry.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/start-time-entry.ts
@@ -1,0 +1,143 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const startTimeEntry = createAction({
+  auth: toggleTrackAuth,
+  name: 'startTimeEntry',
+  displayName: 'Start Time Entry',
+  description: 'Start a live time entry.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace to start time entry',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+
+        return { options: [] };
+      },
+    }),
+    description: Property.ShortText({
+      displayName: 'Description',
+      description: 'Description of the time entry',
+      required: true,
+    }),
+    projectId: Property.Dropdown({
+      displayName: 'Project',
+      description: 'Select the project where the task will be created',
+      required: true,
+      refreshers: ['workspaceId'],
+      options: async ({ auth, workspaceId }) => {
+        if (!auth || !workspaceId) {
+          return { options: [] };
+        }
+
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects`,
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${auth}:api_token`).toString(
+                'base64'
+              )}`,
+            },
+          });
+
+          if (response.status === 200) {
+            return {
+              options: response.body
+                .filter((project: any) => project.active === true) // Only show active projects
+                .map((project: any) => ({
+                  label: project.name,
+                  value: project.id,
+                })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+
+        return { options: [] };
+      },
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId, description, projectId } = props;
+
+    try {
+      const requestBody: any = {
+        description: description.trim(),
+        workspace_id: workspaceId,
+        start: new Date().toISOString(),
+        duration: -1, // Negative value indicates running timer
+        created_with: 'activepieces',
+      };
+
+      if (projectId) {
+        requestBody.project_id = projectId;
+      }
+
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/time_entries`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+        body: requestBody,
+      });
+
+      if (response.status === 200 || response.status === 201) {
+        const timeEntry = response.body;
+        return {
+          id: timeEntry.id,
+          description: timeEntry.description,
+          start: timeEntry.start,
+          project_id: timeEntry.project_id,
+          workspace_id: timeEntry.workspace_id,
+          running: true,
+        };
+      } else {
+        return {
+          success: false,
+          error: `Failed to start time entry: ${response.status}`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/actions/stop-time-entry.ts
+++ b/packages/pieces/community/toggltrack/src/lib/actions/stop-time-entry.ts
@@ -1,0 +1,115 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const stopTimeEntry = createAction({
+  auth: toggleTrackAuth,
+  name: 'stopTimeEntry',
+  displayName: 'Stop Time Entry',
+  description: 'Stops the running time entry.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace where the task will be created',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              'Authorization': `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+          
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        
+        return { options: [] };
+      },
+    }),
+  },
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId } = props;
+    
+    try {
+      // First, get the current running time entry
+      const currentResponse = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://api.track.toggl.com/api/v9/me/time_entries/current',
+        headers: {
+          'Authorization': `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+      });
+      
+      if (currentResponse.status !== 200 || !currentResponse.body) {
+        return {
+          success: false,
+          error: 'No running time entry found',
+        };
+      }
+      
+      const runningEntry = currentResponse.body;
+      
+      // Check if the running entry is in the specified workspace
+      if (runningEntry.workspace_id !== workspaceId) {
+        return {
+          success: false,
+          error: 'Running time entry is not in the specified workspace',
+        };
+      }
+      
+      // Stop the time entry by updating it with stop time
+      const stopResponse = await httpClient.sendRequest({
+        method: HttpMethod.PUT,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/time_entries/${runningEntry.id}`,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+        body: {
+          stop: new Date().toISOString(),
+        },
+      });
+      
+      if (stopResponse.status === 200) {
+        const stoppedEntry = stopResponse.body;
+        return {
+          id: stoppedEntry.id,
+          description: stoppedEntry.description,
+          start: stoppedEntry.start,
+          stop: stoppedEntry.stop,
+          duration: stoppedEntry.duration,
+          project_id: stoppedEntry.project_id,
+          workspace_id: stoppedEntry.workspace_id,
+          running: false,
+        };
+      } else {
+        return {
+          success: false,
+          error: `Failed to stop time entry: ${stopResponse.status}`,
+        };
+      }
+      
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/triggers/new-client.ts
+++ b/packages/pieces/community/toggltrack/src/lib/triggers/new-client.ts
@@ -1,0 +1,151 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const newClient = createTrigger({
+  auth: toggleTrackAuth,
+  name: 'newClient',
+  displayName: 'New Client',
+  description: 'Fires when a new client is created in a workspace.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              'Authorization': `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+          
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        
+        return { options: [] };
+      },
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  
+  async onEnable(context) {
+    try {
+      const currentTime = new Date().toISOString();
+      await context.store?.put('_last_check', currentTime);
+      
+      // Validate the workspace exists
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${context.propsValue.workspaceId}/clients?per_page=1`,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+      });
+      
+    } catch (error) {
+      throw new Error(`Failed to initialize New Client trigger: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  },
+
+  async onDisable(context) {
+    try {
+      await context.store?.delete('_last_check');
+    } catch (error) {
+      console.error('Error during trigger cleanup:', error);
+    }
+  },
+
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId } = props;
+    
+    try {
+      const lastCheckRaw = await context.store?.get('_last_check');
+      
+      let lastCheckDate: Date;
+      
+      if (typeof lastCheckRaw === 'string' && lastCheckRaw.trim() !== '') {
+        try {
+          lastCheckDate = new Date(lastCheckRaw);
+          if (isNaN(lastCheckDate.getTime())) {
+            lastCheckDate = new Date(0);
+          }
+        } catch (error) {
+          lastCheckDate = new Date(0);
+        }
+      } else {
+        lastCheckDate = new Date(0);
+      }
+      
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/clients`,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+      });
+
+      if (response.status !== 200) {
+        throw new Error(`Failed to fetch clients: ${response.status}`);
+      }
+
+      const clients = Array.isArray(response.body) ? response.body : [];
+      
+      const newClients = clients.filter((client: any) => {
+        if (!client.at) return false;
+        const clientCreatedAt = new Date(client.at);
+        return clientCreatedAt > lastCheckDate;
+      });
+
+      const currentTime = new Date().toISOString();
+      await context.store?.put('_last_check', currentTime);
+
+      return newClients.map((client: any) => ({
+        id: client.id,
+        name: client.name,
+        workspace_id: client.wid,
+        created_at: client.at,
+        notes: client.notes || '',
+        external_reference: client.external_reference || '',
+      }));
+
+    } catch (error) {
+      console.error('Error in New Client trigger:', error);
+      return [];
+    }
+  },
+
+  sampleData: {
+    id: 123456789,
+    name: "Acme Corporation",
+    workspace_id: 3134975,
+    created_at: "2025-09-01T10:30:00+00:00",
+    notes: "Important client from the tech sector",
+    external_reference: "CRM-ACC-001",
+    archived: false,
+    creator_id: 9876543,
+    permissions: ["read", "write", "admin"]
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/triggers/new-project.ts
+++ b/packages/pieces/community/toggltrack/src/lib/triggers/new-project.ts
@@ -1,0 +1,116 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const newProject = createTrigger({
+  auth: toggleTrackAuth,
+  name: 'newProject',
+  displayName: 'New Project',
+  description: 'Fires when a new project is added.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              'Authorization': `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+          
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        
+        return { options: [] };
+      },
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  
+  async onEnable(context) {
+    await context.store?.put('_last_check', new Date().toISOString());
+  },
+
+  async onDisable(context) {
+    await context.store?.delete('_last_check');
+  },
+
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId } = props;
+    
+    try {
+      const lastCheckRaw = await context.store?.get('_last_check');
+      const lastCheckDate = typeof lastCheckRaw === 'string' ? new Date(lastCheckRaw) : new Date(0);
+      
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/projects`,
+        headers: {
+          'Authorization': `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+      });
+
+      if (response.status !== 200) return [];
+
+      const projects = Array.isArray(response.body) ? response.body : [];
+      const newProjects = projects.filter((project: any) => {
+        if (!project.created_at) return false;
+        return new Date(project.created_at) > lastCheckDate;
+      });
+
+      await context.store?.put('_last_check', new Date().toISOString());
+
+      return newProjects.map((project: any) => ({
+        id: project.id,
+        name: project.name,
+        workspace_id: project.workspace_id,
+        client_id: project.client_id,
+        created_at: project.created_at,
+      }));
+
+    } catch (error) {
+      return [];
+    }
+  },
+
+  sampleData: {
+    id: 193791763,
+    name: "Website Redesign Project",
+    workspace_id: 3134975,
+    client_id: 123456789,
+    created_at: "2025-09-01T10:30:00+00:00",
+    is_private: false,
+    active: true,
+    color: "#0b83d9",
+    billable: true,
+    template: false,
+    auto_estimates: false,
+    estimated_hours: 160,
+    rate: 75.00,
+    rate_last_updated: "2025-09-01T10:30:00+00:00",
+    currency: "USD",
+    recurring: false
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/triggers/new-tag.ts
+++ b/packages/pieces/community/toggltrack/src/lib/triggers/new-tag.ts
@@ -1,0 +1,105 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const newTag = createTrigger({
+  auth: toggleTrackAuth,
+  name: 'newTag',
+  displayName: 'New Tag',
+  description: 'Triggers when a new tag is created.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              'Authorization': `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+          
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        
+        return { options: [] };
+      },
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  
+  async onEnable(context) {
+    await context.store?.put('_last_check', new Date().toISOString());
+  },
+
+  async onDisable(context) {
+    await context.store?.delete('_last_check');
+  },
+
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId } = props;
+    
+    try {
+      const lastCheckRaw = await context.store?.get('_last_check');
+      const lastCheckDate = typeof lastCheckRaw === 'string' ? new Date(lastCheckRaw) : new Date(0);
+      
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/tags`,
+        headers: {
+          'Authorization': `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+      });
+
+      if (response.status !== 200) return [];
+
+      const tags = Array.isArray(response.body) ? response.body : [];
+      const newTags = tags.filter((tag: any) => {
+        if (!tag.created_at) return false;
+        return new Date(tag.created_at) > lastCheckDate;
+      });
+
+      await context.store?.put('_last_check', new Date().toISOString());
+
+      return newTags.map((tag: any) => ({
+        id: tag.id,
+        name: tag.name,
+        workspace_id: tag.workspace_id,
+        created_at: tag.created_at,
+      }));
+
+    } catch (error) {
+      return [];
+    }
+  },
+
+  sampleData: {
+    id: 1985581,
+    name: "urgent",
+    workspace_id: 3134975,
+    created_at: "2025-09-01T10:30:00+00:00",
+    color: "#ff6b6b",
+    deletable: true
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/triggers/new-task.ts
+++ b/packages/pieces/community/toggltrack/src/lib/triggers/new-task.ts
@@ -1,0 +1,109 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const newTask = createTrigger({
+  auth: toggleTrackAuth,
+  name: 'newTask',
+  displayName: 'New Task',
+  description: 'Fires when a new task is created.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              'Authorization': `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+          
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        
+        return { options: [] };
+      },
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  
+  async onEnable(context) {
+    await context.store?.put('_last_check', new Date().toISOString());
+  },
+
+  async onDisable(context) {
+    await context.store?.delete('_last_check');
+  },
+
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId } = props;
+    
+    try {
+      const lastCheckRaw = await context.store?.get('_last_check');
+      const lastCheckDate = typeof lastCheckRaw === 'string' ? new Date(lastCheckRaw) : new Date(0);
+      
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/workspaces/${workspaceId}/tasks`,
+        headers: {
+          'Authorization': `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+      });
+
+      if (response.status !== 200) return [];
+
+      const tasks = Array.isArray(response.body) ? response.body : [];
+      const newTasks = tasks.filter((task: any) => {
+        if (!task.created_at) return false;
+        return new Date(task.created_at) > lastCheckDate;
+      });
+
+      await context.store?.put('_last_check', new Date().toISOString());
+
+      return newTasks.map((task: any) => ({
+        id: task.id,
+        name: task.name,
+        project_id: task.project_id,
+        workspace_id: task.workspace_id,
+        created_at: task.created_at,
+      }));
+
+    } catch (error) {
+      return [];
+    }
+  },
+
+  sampleData: {
+    id: 13427273,
+    name: "Design homepage mockup",
+    project_id: 193791763,
+    workspace_id: 3134975,
+    created_at: "2025-09-01T10:30:00+00:00",
+    user_id: 9876543,
+    estimated_seconds: 14400,
+    active: true,
+    tracked_seconds: 0
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/triggers/new-time-entry-started.ts
+++ b/packages/pieces/community/toggltrack/src/lib/triggers/new-time-entry-started.ts
@@ -1,0 +1,113 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const newTimeEntryStarted = createTrigger({
+  auth: toggleTrackAuth,
+  name: 'newTimeEntryStarted',
+  displayName: 'New Time Entry Started',
+  description: 'Fires when a time entry is started and is currently running.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              'Authorization': `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+          
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        
+        return { options: [] };
+      },
+    }), 
+  },
+  type: TriggerStrategy.POLLING,
+  
+  async onEnable(context) {
+    await context.store?.put('_last_running_entry', '');
+  },
+
+  async onDisable(context) {
+    await context.store?.delete('_last_running_entry');
+  },
+
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId } = props;
+    
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/me/time_entries/current`,
+        headers: {
+          'Authorization': `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+      });
+
+      if (response.status !== 200 || !response.body) return [];
+
+      const runningEntry = response.body;
+      
+      // Check if this entry is in the specified workspace
+      if (runningEntry.workspace_id !== workspaceId) return [];
+
+      // Check if this is a new running entry
+      const lastRunningId = await context.store?.get('_last_running_entry');
+      if (lastRunningId === runningEntry.id.toString()) return [];
+
+      // Store current running entry ID
+      await context.store?.put('_last_running_entry', runningEntry.id.toString());
+
+      return [{
+        id: runningEntry.id,
+        description: runningEntry.description,
+        project_id: runningEntry.project_id,
+        task_id: runningEntry.task_id,
+        workspace_id: runningEntry.workspace_id,
+        start_time: runningEntry.start,
+      }];
+
+    } catch (error) {
+      return [];
+    }
+  },
+
+  sampleData: {
+    id: 2849422449,
+    description: "Working on design concepts",
+    project_id: 193791763,
+    task_id: 13427273,
+    workspace_id: 3134975,
+    start_time: "2025-09-01T10:30:00+00:00",
+    user_id: 9876543,
+    billable: true,
+    tags: ["design", "active"],
+    duration: -1699695830, // Negative value indicates running timer
+    at: "2025-09-01T10:30:00+00:00"
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/triggers/new-time-entry.ts
+++ b/packages/pieces/community/toggltrack/src/lib/triggers/new-time-entry.ts
@@ -1,0 +1,121 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+import { convertIdsToInt } from '../utils/convert-ids';
+
+export const newTimeEntry = createTrigger({
+  auth: toggleTrackAuth,
+  name: 'newTimeEntry',
+  displayName: 'New Time Entry',
+  description: 'Fires when a new time entry is added.',
+  props: {
+    workspaceId: Property.Dropdown({
+      displayName: 'Workspace',
+      description: 'Select the workspace',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { options: [] };
+        
+        try {
+          const response = await httpClient.sendRequest({
+            method: HttpMethod.GET,
+            url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+            headers: {
+              'Authorization': `Basic ${Buffer.from(`${auth}:api_token`).toString('base64')}`,
+            },
+          });
+          
+          if (response.status === 200) {
+            return {
+              options: response.body.map((workspace: any) => ({
+                label: workspace.name,
+                value: workspace.id,
+              })),
+            };
+          }
+        } catch (error) {
+          return { options: [] };
+        }
+        
+        return { options: [] };
+      },
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  
+  async onEnable(context) {
+    await context.store?.put('_last_check', new Date().toISOString());
+  },
+
+  async onDisable(context) {
+    await context.store?.delete('_last_check');
+  },
+
+  async run(context) {
+    const props = convertIdsToInt(context.propsValue);
+    const { workspaceId } = props;
+    
+    try {
+      const lastCheckRaw = await context.store?.get('_last_check');
+      const lastCheckDate = typeof lastCheckRaw === 'string' ? new Date(lastCheckRaw) : new Date(0);
+      
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.track.toggl.com/api/v9/me/time_entries`,
+        headers: {
+          'Authorization': `Basic ${Buffer.from(`${context.auth}:api_token`).toString('base64')}`,
+        },
+      });
+
+      if (response.status !== 200) return [];
+
+      const timeEntries = Array.isArray(response.body) ? response.body : [];
+      const workspaceEntries = timeEntries.filter((entry: any) => entry.workspace_id === workspaceId);
+      const newEntries = workspaceEntries.filter((entry: any) => {
+        if (!entry.created_at) return false;
+        return new Date(entry.created_at) > lastCheckDate;
+      });
+
+      await context.store?.put('_last_check', new Date().toISOString());
+
+      return newEntries.map((entry: any) => ({
+        id: entry.id,
+        description: entry.description,
+        project_id: entry.project_id,
+        task_id: entry.task_id,
+        workspace_id: entry.workspace_id,
+        duration: entry.duration,
+        created_at: entry.created_at,
+      }));
+
+    } catch (error) {
+      return [];
+    }
+  },
+
+  sampleData: {
+    id: 2849422448,
+    description: "Replying to Emails",
+    project_id: 193791763,
+    task_id: 13427273,
+    workspace_id: 3134975,
+    created_at: "2025-09-01T10:30:00+00:00",
+    start: "2025-09-01T09:30:00+00:00",
+    stop: "2025-09-01T10:30:00+00:00",
+    duration: 3600,
+    user_id: 9876543,
+    uid: 9876543,
+    wid: 3134975,
+    pid: 193791763,
+    tid: 13427273,
+    billable: true,
+    tags: ["retainer", "client-work"],
+    duronly: false,
+    at: "2025-09-01T10:30:00+00:00"
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/triggers/new-workspace-.ts
+++ b/packages/pieces/community/toggltrack/src/lib/triggers/new-workspace-.ts
@@ -1,0 +1,72 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { toggleTrackAuth } from '../../index';
+
+export const newWorkspace = createTrigger({
+  auth: toggleTrackAuth,
+  name: 'newWorkspace',
+  displayName: 'New Workspace',
+  description: 'Fires when a new workspace is created.',
+  props: {},
+  type: TriggerStrategy.POLLING,
+
+  async onEnable(context) {
+    await context.store?.put('_last_check', new Date().toISOString());
+  },
+
+  async onDisable(context) {
+    await context.store?.delete('_last_check');
+  },
+
+  async run(context) {
+    try {
+      const lastCheckRaw = await context.store?.get('_last_check');
+      const lastCheckDate =
+        typeof lastCheckRaw === 'string' ? new Date(lastCheckRaw) : new Date(0);
+
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://api.track.toggl.com/api/v9/me/workspaces',
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${context.auth}:api_token`
+          ).toString('base64')}`,
+        },
+      });
+
+      if (response.status !== 200) return [];
+
+      const workspaces = Array.isArray(response.body) ? response.body : [];
+      const newWorkspaces = workspaces.filter((workspace: any) => {
+        if (!workspace.at) return false;
+        return new Date(workspace.at) > lastCheckDate;
+      });
+
+      await context.store?.put('_last_check', new Date().toISOString());
+
+      return newWorkspaces.map((workspace: any) => ({
+        id: workspace.id,
+        name: workspace.name,
+        organization_id: workspace.organization_id,
+        created_at: workspace.at,
+      }));
+    } catch (error) {
+      return [];
+    }
+  },
+
+  sampleData: {
+    id: 3134975,
+    name: 'Marketing Team Workspace',
+    organization_id: 5318008,
+    created_at: '2025-09-01T10:30:00+00:00',
+    premium: true,
+    admin: true,
+    default_hourly_rate: 50,
+    default_currency: 'USD',
+    only_admins_may_create_projects: false,
+    only_admins_see_billable_rates: true,
+    rounding: 1,
+    rounding_minutes: 0,
+  },
+});

--- a/packages/pieces/community/toggltrack/src/lib/utils/convert-ids.ts
+++ b/packages/pieces/community/toggltrack/src/lib/utils/convert-ids.ts
@@ -1,0 +1,21 @@
+export function convertIdsToInt(props: any): any {
+  const fieldsToConvert = [
+    'workspaceId', 
+    'projectId', 
+    'clientId', 
+    'taskId', 
+    'organizationId', 
+    'tagId', 
+    'timeEntryId'
+  ];
+  
+  const convertedProps = { ...props };
+  
+  for (const field of fieldsToConvert) {
+    if (field in convertedProps && typeof convertedProps[field] === 'string') {
+      convertedProps[field] = parseInt(convertedProps[field], 10);
+    }
+  }
+  
+  return convertedProps;
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new **Toggl Track Piece** to Activepieces, enabling automation around time tracking and project management.  

Includes:  
- **Triggers:** New Client, Workspace, Project, Task, Time Entry, Time Entry Started, Tag  
- **Actions:** Create Client, Project, Task, Tag, Time Entry, Start/Stop Time Entry  
- **Search:** Find User, Project, Task, Client, Tag, Time Entry  

### Explain How the Feature Works
The Piece connects to the **Toggl Track API** to listen for events (triggers), perform operations (actions), and look up entities (search). This enables workflows like syncing clients, auto-logging tasks, and managing time entries.  

here is the link to video of working every actions and triggers

https://drive.google.com/file/d/1iNtcpGqLnbFEZkx2yIulzUND6m5F-do8/view?usp=sharing

suggestions for any improvement and changes are welcome.  

### Relevant User Scenarios

- Sync new clients to CRM  
- Start timers automatically when tasks begin 
- Keep projects and tags consistent across tools  

Fixes #8975
/claim #8975
