### PR TITLE
feat: added browserless piece with actions - screenshot, PDF, scrape,…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activepieces",
-  "version": "0.68.1",
+  "version": "0.68.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activepieces",
-      "version": "0.68.1",
+      "version": "0.68.2",
       "dependencies": {
         "@activepieces/import-fresh-webpack": "3.3.0",
         "@ai-sdk/anthropic": "2.0.3",

--- a/packages/pieces/community/browserless/.eslintrc.json
+++ b/packages/pieces/community/browserless/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/browserless/README.md
+++ b/packages/pieces/community/browserless/README.md
@@ -1,0 +1,7 @@
+# pieces-browserless
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-browserless` to build the library.

--- a/packages/pieces/community/browserless/package.json
+++ b/packages/pieces/community/browserless/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-browserless",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/browserless/project.json
+++ b/packages/pieces/community/browserless/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-browserless",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/browserless/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/browserless",
+        "tsConfig": "packages/pieces/community/browserless/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/browserless/package.json",
+        "main": "packages/pieces/community/browserless/src/index.ts",
+        "assets": [
+          "packages/pieces/community/browserless/*.md",
+          {
+            "input": "packages/pieces/community/browserless/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/browserless/src/index.ts
+++ b/packages/pieces/community/browserless/src/index.ts
@@ -1,0 +1,31 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { capture_screenshot } from './lib/actions/capture-a-screenshot';
+import { generate_pdf } from './lib/actions/generate-pdf';
+import { scrapeUrl } from './lib/actions/scrape-url';
+import { run_bql_query } from './lib/actions/run-bql-query';
+import { get_website_performance } from './lib/actions/get-website-performance';
+import { PieceCategory } from '@activepieces/shared';
+
+export const browserlessAuth = PieceAuth.SecretText({
+  displayName: 'API Token',
+  description: 'Enter your Browserless API token from your dashboard',
+  required: true
+});
+
+export const browserless = createPiece({
+  displayName: 'Browserless',
+  description: 'Cloud-based browser automation platform for screenshots, PDFs, scraping, and performance analysis',
+  minimumSupportedRelease: '0.5.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/browserless.png',
+  authors:['rk-1620'],
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  auth: browserlessAuth,
+  actions: [
+    capture_screenshot,
+    generate_pdf,
+    scrapeUrl,
+    run_bql_query,
+    get_website_performance
+  ],
+  triggers: []
+});

--- a/packages/pieces/community/browserless/src/lib/actions/capture-a-screenshot.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/capture-a-screenshot.ts
@@ -1,0 +1,34 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { screenshot_props } from '../common/props';
+import { makeRequest, handleBinaryResponse } from '../common/requests';
+import { validate_props } from '../common/validations';
+
+export const capture_screenshot = createAction({
+  name: 'capture_screenshot',
+  displayName: 'Capture Screenshot',
+  description: 'Take a screenshot of a page.',
+  props: screenshot_props,
+  async run(context) {
+    // Add validation without changing structure
+    await validate_props.capture_screenshot(context.propsValue);
+
+    const url = context.propsValue.page_url;
+    const fullPage = context.propsValue.capture_full_page;
+    const type = context.propsValue.image_type;
+    const token = context.auth as string;
+
+    const response = await makeRequest('/screenshot', token, {
+      url,
+      options: {
+        fullPage,
+        type: type || 'png'
+      }
+    });
+
+    const screenshot = await handleBinaryResponse(response);
+    return {
+      screenshot,
+      type: type || 'png'
+    };
+  }
+});

--- a/packages/pieces/community/browserless/src/lib/actions/generate-pdf.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/generate-pdf.ts
@@ -1,0 +1,42 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { pdf_props } from '../common/props';
+import { makeRequest, handleBinaryResponse } from '../common/requests';
+import { validate_props } from '../common/validations';
+
+export const generate_pdf = createAction({
+  name: 'generate_pdf',
+  displayName: 'Generate PDF',
+  description: 'Generate a PDF of the given URL or HTML.',
+  props: pdf_props,
+  async run(context) {
+    // Add validation without changing structure
+    await validate_props.generate_pdf(context.propsValue);
+
+    const url = context.propsValue.page_url;
+    const html = context.propsValue.raw_html;
+    const displayHeaderFooter = context.propsValue.display_header_footer;
+    const printBackground = context.propsValue.print_background_graphics;
+    const format = context.propsValue.page_format || 'A4';
+    const token = context.auth as string;
+
+    if (!url && !html) {
+      throw new Error('Either URL or HTML must be provided');
+    }
+
+    const response = await makeRequest('/pdf', token, {
+      url,
+      html,
+      options: {
+        displayHeaderFooter,
+        printBackground,
+        format
+      }
+    });
+
+    const pdf_base64 = await handleBinaryResponse(response);
+    return {
+      pdf_base64,
+      format
+    };
+  }
+});

--- a/packages/pieces/community/browserless/src/lib/actions/get-website-performance.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/get-website-performance.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { performance_props } from '../common/props';
+import { makeRequest } from '../common/requests';
+import { validate_props } from '../common/validations';
+
+export const get_website_performance = createAction({
+  name: 'get_website_performance',
+  displayName: 'Get Website Performance',
+  description: 'Fetch website performance data using Browserless performance API.',
+  props: performance_props,
+  async run(context) {
+    // Add validation
+    await validate_props.get_website_performance(context.propsValue);
+
+    const url = context.propsValue.page_url;
+    const token = context.auth as string;
+
+    const response = await makeRequest('/performance', token, { url });
+    const result = await response.json();
+    return result;
+  }
+});

--- a/packages/pieces/community/browserless/src/lib/actions/run-bql-query.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/run-bql-query.ts
@@ -1,0 +1,41 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { bql_props } from '../common/props';
+import { validate_props } from '../common/validations';
+
+export const run_bql_query = createAction({
+  name: 'run_bql_query',
+  displayName: 'Run BQL Query',
+  description: 'Run a Browser Query Lang (BQL) mutation.',
+  props: bql_props,
+  async run(context) {
+    // Add validation
+    await validate_props.run_bql_query(context.propsValue);
+
+    const query = context.propsValue.add_query;
+    const token = context.auth as string;
+
+    // Fix 1: Use correct BQL endpoint
+    const bqlEndpoint = `https://production-sfo.browserless.io/chromium/bql?token=${token}`;
+
+    const response = await fetch(bqlEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // Remove Authorization header - token is in URL
+      },
+      body: JSON.stringify({ 
+        query: query,
+        // Add variables if needed
+        variables: {}
+      })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to run BQL query: ${errorText}`);
+    }
+
+    const result = await response.json();
+    return result;
+  }
+});

--- a/packages/pieces/community/browserless/src/lib/actions/scrape-url.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/scrape-url.ts
@@ -1,0 +1,43 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { scrape_props } from '../common/props';
+import { makeRequest } from '../common/requests';
+import { validate_props } from '../common/validations';
+
+export const scrapeUrl = createAction({
+  name: 'scrape_url',
+  displayName: 'Scrape URL',
+  description: 'Scrape content from a page using selectors.',
+  props: scrape_props,
+  async run(context) {
+    // Add validation
+    await validate_props.scrape_url(context.propsValue);
+
+    const url = context.propsValue.page_url;
+    let elements = context.propsValue.css_selectors;
+    const waitForSelector = context.propsValue.wait_for_selector;
+    const token = context.auth as string;
+
+    // Handle case where elements might be a stringified JSON
+    if (typeof elements === 'string') {
+      try {
+        elements = JSON.parse(elements);
+      } catch (e) {
+        throw new Error('Invalid JSON format for css_selectors. Expected format: [{"selector": "h1"}, {"selector": ".class"}]');
+      }
+    }
+
+    // Ensure elements is an array
+    if (!Array.isArray(elements)) {
+      throw new Error('css_selectors must be an array of objects with selector property');
+    }
+
+    const body: any = { url, elements };
+    if (waitForSelector) {
+      body.waitForSelector = { selector: waitForSelector };
+    }
+
+    const response = await makeRequest('/scrape', token, body);
+    const result = await response.json();
+    return result;
+  }
+});

--- a/packages/pieces/community/browserless/src/lib/common/constants.ts
+++ b/packages/pieces/community/browserless/src/lib/common/constants.ts
@@ -1,0 +1,20 @@
+export const BROWSERLESS_BASE_URL = 'https://production-sfo.browserless.io';
+export const BROWSERLESS_BQL_ENDPOINT = 'https://production-sfo.browserless.io/chromium/bql';
+
+export const IMAGE_TYPES = {
+  PNG: 'png',
+  JPEG: 'jpeg',
+  WEBP: 'webp'
+} as const;
+
+export const PDF_FORMATS = {
+  A0: 'A0',
+  A1: 'A1',
+  A2: 'A2',
+  A3: 'A3',
+  A4: 'A4',
+  A5: 'A5',
+  LEGAL: 'Legal',
+  LETTER: 'Letter',
+  TABLOID: 'Tabloid'
+} as const;

--- a/packages/pieces/community/browserless/src/lib/common/props.ts
+++ b/packages/pieces/community/browserless/src/lib/common/props.ts
@@ -1,0 +1,110 @@
+import { Property } from '@activepieces/pieces-framework';
+
+export const common_props = {
+  page_url: Property.ShortText({
+    displayName: 'page_url',
+    description: 'the url of the page to process',
+    required: true
+  })
+};
+
+export const screenshot_props = {
+  ...common_props,
+  capture_full_page: Property.Checkbox({
+    displayName: 'capture_full_page',
+    description: 'whether to capture the full page or only the viewport',
+    required: false,
+    defaultValue: false
+  }),
+  image_type: Property.StaticDropdown({
+    displayName: 'image_type',
+    description: 'the format of the screenshot',
+    required: false,
+    defaultValue: 'png',
+    options: {
+      options: [
+        { label: 'PNG', value: 'png' },
+        { label: 'JPEG', value: 'jpeg' },
+        { label: 'WebP', value: 'webp' }
+      ]
+    }
+  })
+};
+
+export const scrape_props = {
+  page_url: Property.ShortText({
+    displayName: 'page_url',
+    description: 'the url of the page to scrape',
+    required: true
+  }),
+  css_selectors: Property.Json({
+    displayName: 'css_selectors',
+    description: 'array of css selectors for content to scrape, e.g. [{ "selector": "h1" }]',
+    required: true
+  }),
+  wait_for_selector: Property.ShortText({
+    displayName: 'wait_for_selector',
+    description: '(optional) css selector to wait for before scraping',
+    required: false
+  })
+};
+
+export const bql_props = {
+  add_query: Property.LongText({
+    displayName: 'add_query',
+    description: 'graphql mutation representing the bql query',
+    required: true
+  })
+};
+
+export const pdf_props = {
+  page_url: Property.ShortText({
+    displayName: 'page_url',
+    description: 'url of the page to generate pdf from',
+    required: false
+  }),
+  raw_html: Property.LongText({
+    displayName: 'raw_html',
+    description: 'if url is not provided, raw html can be supplied',
+    required: false
+  }),
+  display_header_footer: Property.Checkbox({
+    displayName: 'display_header_footer',
+    description: 'display header and footer in pdf',
+    required: false,
+    defaultValue: false
+  }),
+  print_background_graphics: Property.Checkbox({
+    displayName: 'print_background_graphics',
+    description: 'include background graphics in pdf',
+    required: false,
+    defaultValue: true
+  }),
+  page_format: Property.StaticDropdown({
+    displayName: 'page_format',
+    description: 'the page format for the pdf',
+    defaultValue: 'A4',
+    required: false,
+    options: {
+      options: [
+        { label: 'A0', value: 'A0' },
+        { label: 'A1', value: 'A1' },
+        { label: 'A2', value: 'A2' },
+        { label: 'A3', value: 'A3' },
+        { label: 'A4', value: 'A4' },
+        { label: 'A5', value: 'A5' },
+        { label: 'Legal', value: 'Legal' },
+        { label: 'Letter', value: 'Letter' },
+        { label: 'Tabloid', value: 'Tabloid' }
+      ]
+    }
+  })
+};
+
+export const performance_props = {
+  page_url: Property.ShortText({
+    displayName: 'page_url',
+    description: 'url of the website to analyze',
+    required: true
+  })
+};

--- a/packages/pieces/community/browserless/src/lib/common/requests.ts
+++ b/packages/pieces/community/browserless/src/lib/common/requests.ts
@@ -1,0 +1,23 @@
+import { BROWSERLESS_BASE_URL } from './constants';
+
+export const makeRequest = async (endpoint: string, token: string, body?: any) => {
+  const response = await fetch(`${BROWSERLESS_BASE_URL}${endpoint}?token=${token}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: body ? JSON.stringify(body) : undefined
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Browserless API error: ${errorText}`);
+  }
+
+  return response;
+};
+
+export const handleBinaryResponse = async (response: Response) => {
+  const buffer = await response.arrayBuffer();
+  return Buffer.from(buffer).toString('base64');
+};

--- a/packages/pieces/community/browserless/src/lib/common/validations.ts
+++ b/packages/pieces/community/browserless/src/lib/common/validations.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+// Define Zod schemas
+export const capture_screenshot_schema = z.object({
+  page_url: z.string().url('Invalid URL format for page_url'),
+  capture_full_page: z.boolean().optional(),
+  image_type: z.enum(['png', 'jpeg', 'webp']).optional(),
+});
+
+export const generate_pdf_schema = z.object({
+  page_url: z.string().url().optional(),
+  raw_html: z.string().optional(),
+  display_header_footer: z.boolean().optional(),
+  print_background_graphics: z.boolean().optional(),
+  page_format: z.enum(['A0','A1','A2','A3','A4','A5','Legal','Letter','Tabloid']).optional(),
+}).refine(data => data.page_url || data.raw_html, {
+  message: 'Either page_url or raw_html must be provided',
+});
+
+export const scrape_url_schema = z.object({
+  page_url: z.string().url('Invalid URL format for page_url'),
+  css_selectors: z.array(z.object({ selector: z.string().min(1) })).min(1, 'At least one CSS selector is required'),
+  wait_for_selector: z.string().optional(),
+});
+
+export const run_bql_query_schema = z.object({
+  add_query: z.string().min(1, 'Query cannot be empty'),
+});
+
+export const get_website_performance_schema = z.object({
+  page_url: z.string().url('Invalid URL format for page_url'),
+});
+
+// Validation functions using direct Zod parsing (not propsValidation.validateZod)
+export const validate_props = {
+  capture_screenshot: async (propsValue: any) => {
+    return capture_screenshot_schema.parseAsync(propsValue);
+  },
+
+  generate_pdf: async (propsValue: any) => {
+    return generate_pdf_schema.parseAsync(propsValue);
+  },
+
+  scrape_url: async (propsValue: any) => {
+    return scrape_url_schema.parseAsync(propsValue);
+  },
+
+  run_bql_query: async (propsValue: any) => {
+    return run_bql_query_schema.parseAsync(propsValue);
+  },
+
+  get_website_performance: async (propsValue: any) => {
+    return get_website_performance_schema.parseAsync(propsValue);
+  }
+};

--- a/packages/pieces/community/browserless/tsconfig.json
+++ b/packages/pieces/community/browserless/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/browserless/tsconfig.lib.json
+++ b/packages/pieces/community/browserless/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -160,6 +160,9 @@
       "@activepieces/piece-browse-ai": [
         "packages/pieces/community/browse-ai/src/index.ts"
       ],
+      "@activepieces/piece-browserless": [
+        "packages/pieces/community/browserless/src/index.ts"
+      ],
       "@activepieces/piece-bubble": [
         "packages/pieces/community/bubble/src/index.ts"
       ],
@@ -798,7 +801,7 @@
       "@activepieces/piece-retable": [
         "packages/pieces/community/retable/src/index.ts"
       ],
-        "@activepieces/piece-retell-ai": [
+      "@activepieces/piece-retell-ai": [
         "packages/pieces/community/retell-ai/src/index.ts"
       ],
       "@activepieces/piece-retune": [


### PR DESCRIPTION
fixes #9012 
/claim #9012 

---
labels: piece
---

## 🧩 Browserless Piece  
Actions: Screenshot, PDF, Scrape URL, BQL, Performance

## What does this PR do?

This PR adds a new **Browserless piece** to Activepieces.  
It includes the following actions:  
- Capture a Screenshot  
- Generate PDF  
- Scrape URL  
- Run BQL Query  
- Get Website Performance  

### 🎥 Demo Video
[Watch the demo here](https://drive.google.com/file/d/1sKdU8GxzF5yNl1QDf6pSPot9TqqfzfLy/view?usp=sharing)

### Explain How the Feature Works
This piece integrates with the **Browserless API** to perform browser automation tasks such as:  
- Capturing screenshots and PDFs  
- Scraping structured content from URLs  
- Running Browser Query Language (BQL) queries  
- Measuring website performance metrics  

