### PR TITLE
feat(rabbitmq): add SSL option for authentication

### DIFF
--- a/packages/pieces/community/rabbitmq/src/index.ts
+++ b/packages/pieces/community/rabbitmq/src/index.ts
@@ -32,6 +32,11 @@ export const rabbitmqAuth = PieceAuth.CustomAuth({
       description: "Virtual Host",
       required: false,
     }),
+    ssl: Property.Checkbox({
+      displayName: "SSL",
+      description: "Use SSL",
+      required: false,
+    }),
   },
 });
 

--- a/packages/pieces/community/rabbitmq/src/lib/common/index.ts
+++ b/packages/pieces/community/rabbitmq/src/lib/common/index.ts
@@ -15,7 +15,7 @@ export async function rabbitmqConnect(
 }
 
 function createAmqpURI(auth: PiecePropValueSchema<typeof rabbitmqAuth>): string {
-  const uri = `amqp://${auth.username}:${auth.password}@${auth.host}:${auth.port}`;
+  const uri = `amqp${auth.ssl ? 's' : ''}://${auth.username}:${auth.password}@${auth.host}:${auth.port}`;
 
   if (!auth.vhost) {
     return uri;


### PR DESCRIPTION
Introduces an SSL checkbox to the RabbitMQ authentication properties and updates the AMQP URI construction to support SSL connections when enabled.

## What does this PR do?
This PR adds SSL/TLS connection support to the RabbitMQ piece by introducing an SSL checkbox option in the authentication configuration and updating the AMQP URI construction to use the appropriate protocol scheme.


### Explain How the Feature Works
The implementation adds:
- A new [ssl] checkbox property to the RabbitMQ authentication configuration that allows users to enable SSL/TLS connections
- Dynamic URI construction that switches between amqp:// (standard) and amqps:// (SSL/TLS) protocols based on the SSL checkbox state
- The SSL option is optional (not required) to maintain backward compatibility with existing configurations

When the SSL checkbox is enabled, the connection URI will use the amqps:// scheme instead of amqp://, enabling secure encrypted connections to RabbitMQ servers that support SSL/TLS.

### Relevant User Scenarios

This feature is valuable for users who need to:
- Connect to RabbitMQ servers in production environments that require encrypted connections
- Comply with security policies that mandate SSL/TLS for message broker communications
- Connect to cloud-hosted RabbitMQ services (like CloudAMQP, AWS MQ, etc.) that typically require SSL connections
- Integrate with RabbitMQ instances behind corporate firewalls that enforce encrypted traffic
- Meet compliance requirements (HIPAA, PCI-DSS, etc.) that require data in transit to be encrypted
