### PR TITLE
fix: google drive read file from shared drive

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.49"
+  "version": "0.5.50"
 }

--- a/packages/pieces/community/google-drive/src/lib/common/get-file-content.ts
+++ b/packages/pieces/community/google-drive/src/lib/common/get-file-content.ts
@@ -14,7 +14,7 @@ async function getMimeType(
 ): Promise<string> {
   const mimeType = (
     await fetch(
-      `https://www.googleapis.com/drive/v3/files/${fileId}?fields=mimeType`,
+      `https://www.googleapis.com/drive/v3/files/${fileId}?fields=mimeType&supportsAllDrives=true`,
       {
         headers: {
           Authorization: `Bearer ${auth.access_token}`,
@@ -52,7 +52,8 @@ const googledlCall = async (
       )
     );
 
-  const fileExtension = '.' + extension(mimeType);
+  const extensionResult = extension(mimeType);
+  const fileExtension = extensionResult ? '.' + extensionResult : '';
   const srcFileName = fileName ?? fileId + fileExtension;
   // const name =
   //   (srcFileName
@@ -96,7 +97,7 @@ export async function downloadFileFromDrive(
         break;
     }
     return await googledlCall(
-      `https://www.googleapis.com/drive/v3/files/${fileId}/export?mimeType=${mimeType}`,
+      `https://www.googleapis.com/drive/v3/files/${fileId}/export?mimeType=${mimeType}&supportsAllDrives=true`,
       auth,
       fileId,
       files,
@@ -104,7 +105,7 @@ export async function downloadFileFromDrive(
     );
   } else {
     return await googledlCall(
-      `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`,
+      `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media&supportsAllDrives=true`,
       auth,
       fileId,
       files,


### PR DESCRIPTION
## What does this PR do?

Google Drive `read file` action was not able to read a file properly and keeps outputting a file with `.false` extension


### Explain How the Feature Works
Fixed the bug. The first call to google drive to fetch metadata about the file / mimeType requires the `supportsAllDrives` to be set. Otherwise, it will be 404 for a file in the shared drive and so the extension concatenation logic will result in a `.false`. 

I've also set `supportsAllDrives` in other parts of the action to maintain that clarity and consistency. 

### Relevant User Scenarios

#### before:
<img width="166" height="34" alt="Screenshot 2025-09-02 at 11 27 13 PM" src="https://github.com/user-attachments/assets/b2544118-ac31-4f53-83f5-7766c3e9cd39" />

#### after:
<img width="137" height="29" alt="Screenshot 2025-09-02 at 11 27 26 PM" src="https://github.com/user-attachments/assets/9f6bde98-8ce6-442b-96b6-13317b2418d8" />

https://developers.google.com/workspace/drive/api/guides/enable-shareddrives
