### PR TITLE
fix(predict-leads): update api used for technology

### DIFF
--- a/packages/pieces/community/predict-leads/src/index.ts
+++ b/packages/pieces/community/predict-leads/src/index.ts
@@ -7,7 +7,7 @@ import { PieceCategory } from '@activepieces/shared';
 import { findCompaniesAction, findCompanyByDomainAction } from './lib/actions/companies';
 import { findJobOpeningsAction, getAJobOpeningByIdAction, getCompanyJobOpeningsActions } from './lib/actions/jobs';
 import { makeClient } from './lib/common';
-import { findTechnologiesAction, findTechnologyByIdAction } from './lib/actions/technology';
+import { findTechnologiesByCompanyAction, findCompaniesByTechnologyIdAction } from './lib/actions/technology';
 import { findNewsEventByIdAction, findNewsEventsByDomainAction } from './lib/actions/news-events';
 import { findConnectionsAction, findConnectionsByDomainAction } from './lib/actions/connections';
 import { prepareQuery } from './lib/common/client';
@@ -70,8 +70,8 @@ export const predictLeads = createPiece({
     findJobOpeningsAction,
     getCompanyJobOpeningsActions,
     getAJobOpeningByIdAction,
-    findTechnologiesAction,
-    findTechnologyByIdAction,
+    findTechnologiesByCompanyAction,
+    findCompaniesByTechnologyIdAction,
     findNewsEventsByDomainAction,
     findNewsEventByIdAction,
     findConnectionsAction,

--- a/packages/pieces/community/predict-leads/src/lib/actions/technology.ts
+++ b/packages/pieces/community/predict-leads/src/lib/actions/technology.ts
@@ -3,33 +3,36 @@ import {
   Property,
   createAction,
 } from '@activepieces/pieces-framework';
-import { limitField, makeClient, pageField } from '../common';
+import { firstSeenAtFromField, firstSeenAtUntilField, lastSeenAtFromField, lastSeenAtUntilField, limitField, makeClient, pageField } from '../common';
 import { PredictLeadsAuth } from '../../index';
 import { prepareQuery } from '../common/client';
 
-export const findTechnologiesAction = createAction({
+export const findTechnologiesByCompanyAction = createAction({
   auth: PredictLeadsAuth,
-  name: 'predict-leads_find_technologies',
-  displayName: 'List Technologies',
-  description: 'Retrieves all tracked technologies',
+  name: 'predict-leads_find_technologies_by_domain',
+  displayName: 'List Technologies by domain',
+  description: 'Retrieve technologies used by specific company',
   props: {
-    order_by: Property.StaticDropdown({
-      displayName: 'Order By',
-      required: false,
-      options: {
-        options: [
-          { value: 'created_at_asc', label: 'Created At - Ascending' },
-          { value: 'created_at_desc', label: 'Created At - Descending' },
-        ]
-      }
+    domain: Property.ShortText({
+      displayName: 'Domain',
+      description: 'The domain of the company to find.',
+      required: true,
     }),
+    first_seen_at_from: firstSeenAtFromField,
+    first_seen_at_until: firstSeenAtUntilField,
+    last_seen_at_from: lastSeenAtFromField,
+    last_seen_at_until: lastSeenAtUntilField,
     page: pageField,
     limit: limitField,
   },
   async run(context) {
+    const domain = context.propsValue.domain;
+    const first_seen_at_from = context.propsValue.first_seen_at_from;
+    const first_seen_at_until = context.propsValue.first_seen_at_until;
+    const last_seen_at_from = context.propsValue.last_seen_at_from;
+    const last_seen_at_until = context.propsValue.last_seen_at_until;
     const page = context.propsValue.page ?? 1;
     const limit = context.propsValue.limit ?? 1000;
-    const order_by = context.propsValue.order_by ?? undefined;
 
     const client = makeClient(
       context.auth as PiecePropValueSchema<typeof PredictLeadsAuth>
@@ -37,8 +40,12 @@ export const findTechnologiesAction = createAction({
 
     try {
       const response = await client.findTechnologies(
+        domain,
         prepareQuery({
-          order_by,
+          first_seen_at_from,
+          first_seen_at_until,
+          last_seen_at_from,
+          last_seen_at_until,
           page,
           limit,
         })
@@ -50,27 +57,48 @@ export const findTechnologiesAction = createAction({
   },
 });
 
-export const findTechnologyByIdAction = createAction({
+export const findCompaniesByTechnologyIdAction = createAction({
   auth: PredictLeadsAuth,
-  name: 'predict-leads_find_technology_by_id',
-  displayName: 'Get Technology',
-  description: 'Retrieves a single technology by ID.',
+  name: 'predict-leads_find_companies_by_technology_id',
+  displayName: 'Retrieve companies by technology ID',
+  description: 'Retrieves company using specific technology ID',
   props: {
     id: Property.ShortText({
       displayName: 'ID',
       description: 'The ID of the technology to find.',
       required: true,
     }),
+    first_seen_at_from: firstSeenAtFromField,
+    first_seen_at_until: firstSeenAtUntilField,
+    last_seen_at_from: lastSeenAtFromField,
+    last_seen_at_until: lastSeenAtUntilField,
+    page: pageField,
+    limit: limitField,
   },
   async run(context) {
     const id = context.propsValue.id;
+    const first_seen_at_from = context.propsValue.first_seen_at_from;
+    const first_seen_at_until = context.propsValue.first_seen_at_until;
+    const last_seen_at_from = context.propsValue.last_seen_at_from;
+    const last_seen_at_until = context.propsValue.last_seen_at_until;
+    const page = context.propsValue.page ?? 1;
+    const limit = context.propsValue.limit ?? 1000;
 
     const client = makeClient(
       context.auth as PiecePropValueSchema<typeof PredictLeadsAuth>
     );
 
     try {
-      const response = await client.findTechnologyById(id);
+      const response = await client.findCompaniesTechnologyById(id,
+        prepareQuery({
+          first_seen_at_from,
+          first_seen_at_until,
+          last_seen_at_from,
+          last_seen_at_until,
+          page,
+          limit,
+        })
+      );
       return response;
     } catch (error) {
       throw new Error(JSON.stringify(error, undefined, 2));

--- a/packages/pieces/community/predict-leads/src/lib/common/client.ts
+++ b/packages/pieces/community/predict-leads/src/lib/common/client.ts
@@ -82,12 +82,12 @@ export class PredictLeadsClient {
     return await this.makeRequest<ResponseSchema>(HttpMethod.GET, `/v3/discover/job_openings`, query);
   }
 
-  async findTechnologies(query?: QueryParams) {
-    return await this.makeRequest<ResponseSchema>(HttpMethod.GET, `/v3/technologies`, query);
+  async findTechnologies(domain: string, query?: QueryParams) {
+    return await this.makeRequest<ResponseSchema>(HttpMethod.GET, `/v3/companies/${domain}/technology_detections`, query);
   }
 
-  async findTechnologyById(technologyId: string) {
-    return await this.makeRequest<ResponseSchema>(HttpMethod.GET, `/v3/technologies/${technologyId}`);
+  async findCompaniesTechnologyById(technologyId: string, query?: QueryParams) {
+    return await this.makeRequest<ResponseSchema>(HttpMethod.GET, `/v3/discover/technologies/${technologyId}/technology_detections`, query);
   }
 
   async findNewsByDomain(domain: string, query?: QueryParams) {


### PR DESCRIPTION
## What does this PR do?

This PR replaces the technologies action withs the API that provides more business value to API users. _The old technology API is better to be used with the custom API action._

- Retrieve all Tracked Technologies -> List technologies by domain
- Retrieve a single technology by id -> Retrieves companies by technology ID

## Screenshots
### [List technologies by domain](https://docs.predictleads.com/v3/api_endpoints/technology_detections_dataset/retrieve_technologies_used_by_specific_company)
<img width="1152" height="913" alt="image" src="https://github.com/user-attachments/assets/2452bafa-40b3-425f-ad1d-a37a1984da06" />

### [Retrieves companies by technology ID](https://docs.predictleads.com/v3/api_endpoints/technology_detections_dataset/retrieve_companies_using_specific_technology)
<img width="1152" height="913" alt="image" src="https://github.com/user-attachments/assets/575bba97-a532-437c-ba43-be7b4844782c" />




Fixes # (issue)
