### PR TITLE
feat(piece-outlook): add new actions for issue #9065

### DIFF
--- a/packages/pieces/community/microsoft-outlook/src/index.ts
+++ b/packages/pieces/community/microsoft-outlook/src/index.ts
@@ -9,11 +9,16 @@ import { removeLabelFromEmailAction } from './lib/actions/remove-label-from-emai
 import { moveEmailToFolderAction } from './lib/actions/move-email-to-folder';
 import { sendDraftEmailAction } from './lib/actions/send-draft-email';
 import { forwardEmailAction } from './lib/actions/forward-email';
+import { findEmailAction } from './lib/actions/find-email';
 
 import { microsoftOutlookAuth } from './lib/common/auth';
 
 import { newEmailTrigger } from './lib/triggers/new-email';
+import { newAttachmentTrigger } from './lib/triggers/new-attachment';
+import { newMatchedEmailTrigger } from './lib/triggers/new-matched-email';
+
 import { replyEmailAction } from './lib/actions/reply-email';
+import { newEmailInFolderTrigger } from './lib/triggers/new-email-in-folder';
 export const microsoftOutlook = createPiece({
 	displayName: 'Microsoft Outlook',
 	auth: microsoftOutlookAuth,
@@ -31,6 +36,7 @@ export const microsoftOutlook = createPiece({
 		moveEmailToFolderAction,
 		sendDraftEmailAction,
 		forwardEmailAction,
+		findEmailAction,
 		createCustomApiCallAction({
 			auth: microsoftOutlookAuth,
 			baseUrl: () => 'https://graph.microsoft.com/v1.0/',
@@ -39,5 +45,10 @@ export const microsoftOutlook = createPiece({
 			}),
 		}),
 	],
-	triggers: [newEmailTrigger],
+	triggers: [newEmailTrigger,
+		newAttachmentTrigger,
+		newMatchedEmailTrigger,
+		newEmailInFolderTrigger,
+
+	],
 });

--- a/packages/pieces/community/microsoft-outlook/src/index.ts
+++ b/packages/pieces/community/microsoft-outlook/src/index.ts
@@ -3,7 +3,15 @@ import { createPiece, OAuth2PropertyValue } from '@activepieces/pieces-framework
 import { PieceCategory } from '@activepieces/shared';
 import { downloadAttachmentAction } from './lib/actions/download-email-attachment';
 import { sendEmailAction } from './lib/actions/send-email';
+import { createDraftEmailAction } from './lib/actions/create-draft-email';
+import { addLabelToEmailAction } from './lib/actions/add-label-to-email';
+import { removeLabelFromEmailAction } from './lib/actions/remove-label-from-email';
+import { moveEmailToFolderAction } from './lib/actions/move-email-to-folder';
+import { sendDraftEmailAction } from './lib/actions/send-draft-email';
+import { forwardEmailAction } from './lib/actions/forward-email';
+
 import { microsoftOutlookAuth } from './lib/common/auth';
+
 import { newEmailTrigger } from './lib/triggers/new-email';
 import { replyEmailAction } from './lib/actions/reply-email';
 export const microsoftOutlook = createPiece({
@@ -17,6 +25,12 @@ export const microsoftOutlook = createPiece({
 		sendEmailAction,
 		downloadAttachmentAction,
 		replyEmailAction,
+		createDraftEmailAction,
+		addLabelToEmailAction,
+		removeLabelFromEmailAction,
+		moveEmailToFolderAction,
+		sendDraftEmailAction,
+		forwardEmailAction,
 		createCustomApiCallAction({
 			auth: microsoftOutlookAuth,
 			baseUrl: () => 'https://graph.microsoft.com/v1.0/',

--- a/packages/pieces/community/microsoft-outlook/src/lib/actions/add-label-to-email.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/actions/add-label-to-email.ts
@@ -1,0 +1,66 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { microsoftOutlookAuth } from '../common/auth';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { Message } from '@microsoft/microsoft-graph-types';
+
+export const addLabelToEmailAction = createAction({
+    auth: microsoftOutlookAuth,
+    name: 'add_label_to_email',
+    displayName: 'Add Label to Email',
+    description: 'Attach one or more labels (categories) to an email.',
+    props: {
+        messageId: Property.ShortText({
+            displayName: 'Message ID',
+            description: 'The ID of the email to which you want to add labels.',
+            required: true,
+        }),
+        labels: Property.Array({
+            displayName: 'Labels',
+            description: 'The labels (categories) to add to the email.',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { messageId, labels } = context.propsValue;
+        const newLabels = labels as string[];
+
+        if (!newLabels || newLabels.length === 0) {
+            return {
+                success: true,
+                message: "No labels were provided to add.",
+            };
+        }
+
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(context.auth.access_token),
+            },
+        });
+
+        try {
+            // First, get the existing categories on the message to avoid overwriting them.
+            const currentMessage: Message = await client
+                .api(`/me/messages/${messageId}`)
+                .select('categories')
+                .get();
+
+            const existingLabels = currentMessage.categories || [];
+
+            // Combine existing labels with new ones, ensuring there are no duplicates.
+            const combinedLabels = [...new Set([...existingLabels, ...newLabels])];
+
+            // Update the message with the new, combined list of labels.
+            const updatedMessage = await client
+                .api(`/me/messages/${messageId}`)
+                .patch({
+                    categories: combinedLabels,
+                });
+            
+            return updatedMessage;
+
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to add labels: ${errorMessage}`);
+        }
+    },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/actions/create-draft-email.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/actions/create-draft-email.ts
@@ -1,0 +1,119 @@
+import { ApFile, createAction, Property } from '@activepieces/pieces-framework';
+import { microsoftOutlookAuth } from '../common/auth';
+import { BodyType, Message } from '@microsoft/microsoft-graph-types';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export const createDraftEmailAction = createAction({
+    auth: microsoftOutlookAuth,
+    name: 'create_draft_email',
+    displayName: 'Create Draft Email',
+    description: 'Create a new draft email.',
+    props: {
+        subject: Property.ShortText({
+            displayName: 'Subject',
+            required: true,
+        }),
+        bodyFormat: Property.StaticDropdown({
+            displayName: 'Body Format',
+            required: true,
+            defaultValue: 'text',
+            options: {
+                disabled: false,
+                options: [
+                    { label: 'HTML', value: 'html' },
+                    { label: 'Text', value: 'text' },
+                ],
+            },
+        }),
+        body: Property.LongText({
+            displayName: 'Body',
+            required: true,
+        }),
+        toRecipients: Property.Array({
+            displayName: 'To Recipients',
+            description: 'The email addresses of the primary recipients.',
+            required: true,
+        }),
+        ccRecipients: Property.Array({
+            displayName: 'CC Recipients',
+            description: 'The email addresses of the CC recipients.',
+            required: false,
+        }),
+        bccRecipients: Property.Array({
+            displayName: 'BCC Recipients',
+            description: 'The email addresses of the BCC recipients.',
+            required: false,
+        }),
+        attachments: Property.Array({
+            displayName: 'Attachments',
+            required: false,
+            defaultValue: [],
+            properties: {
+                file: Property.File({
+                    displayName: 'File',
+                    required: true,
+                }),
+                fileName: Property.ShortText({
+                    displayName: 'File Name',
+                    required: false,
+                }),
+            },
+        }),
+    },
+    async run(context) {
+        const {
+            subject,
+            body,
+            bodyFormat,
+            toRecipients,
+            ccRecipients,
+            bccRecipients,
+            attachments,
+        } = context.propsValue;
+
+        const mailPayload: Message = {
+            subject: subject,
+            body: {
+                content: body,
+                contentType: bodyFormat as BodyType,
+            },
+            toRecipients: (toRecipients as string[]).map((email) => ({
+                emailAddress: { address: email },
+            })),
+            ccRecipients: ((ccRecipients as string[]) || []).map((email) => ({
+                emailAddress: { address: email },
+            })),
+            bccRecipients: ((bccRecipients as string[]) || []).map((email) => ({
+                emailAddress: { address: email },
+            })),
+            attachments: ((attachments as { file: ApFile; fileName: string }[]) || []).map(
+                (attachment) => ({
+                    '@odata.type': '#microsoft.graph.fileAttachment',
+                    name: attachment.fileName || attachment.file.filename,
+                    contentBytes: attachment.file.base64,
+                })
+            ),
+        };
+
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(context.auth.access_token),
+            },
+        });
+
+        try {
+            const response: Message = await client.api('/me/messages').post(mailPayload);
+            const draftId = response.id;
+
+            return {
+                success: true,
+                message: 'Draft created successfully.',
+                draftId: draftId,
+                draftLink: `https://outlook.office.com/mail/drafts/id/${draftId}`,
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to create draft: ${errorMessage}`);
+        }
+    },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/actions/find-email.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/actions/find-email.ts
@@ -1,0 +1,75 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { microsoftOutlookAuth } from '../common/auth';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export const findEmailAction = createAction({
+    auth: microsoftOutlookAuth,
+    name: 'find_email',
+    displayName: 'Find Email',
+    description: 'Search for an email in your mailbox.',
+    props: {
+        in_folder: Property.Dropdown({
+            displayName: 'Folder',
+            description: 'The folder to search in. If left blank, searches all folders in the mailbox.',
+            required: false,
+            refreshers: [],
+            options: async ({ auth }) => {
+                if (!auth) {
+                    return {
+                        disabled: true,
+                        placeholder: 'Please connect your account first.',
+                        options: [],
+                    };
+                }
+                const authProp = auth as OAuth2PropertyValue;
+                const client = Client.initWithMiddleware({
+                    authProvider: {
+                        getAccessToken: () => Promise.resolve(authProp.access_token),
+                    },
+                });
+                
+                const response = await client.api('/me/mailFolders').top(100).get();
+                const customFolders = response.value.map((folder: { displayName: string; id: string }) => ({
+                    label: folder.displayName,
+                    value: folder.id,
+                }));
+                return {
+                    disabled: false,
+                    options: customFolders,
+                };
+            },
+        }),
+        search_term: Property.ShortText({
+            displayName: 'Search Term',
+            description: 'The search query. Searches the "from", "subject", and "body" fields. Example: "subject:Urgent" or "pizza".',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { in_folder, search_term } = context.propsValue;
+
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(context.auth.access_token),
+            },
+        });
+
+        const url = in_folder
+            ? `/me/mailFolders/${in_folder}/messages`
+            : '/me/messages';
+
+        try {
+            const response = await client
+                .api(url)
+                .search(search_term) // The SDK handles proper query formatting
+                .get();
+            
+            // The API returns the results in a 'value' array
+            return response.value;
+
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to find email: ${errorMessage}`);
+        }
+    },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/actions/forward-email.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/actions/forward-email.ts
@@ -1,0 +1,65 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { microsoftOutlookAuth } from '../common/auth';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { Recipient } from '@microsoft/microsoft-graph-types';
+
+export const forwardEmailAction = createAction({
+    auth: microsoftOutlookAuth,
+    name: 'forward_email',
+    displayName: 'Forward Email',
+    description: 'Forwards an email to new recipients.',
+    props: {
+        messageId: Property.ShortText({
+            displayName: 'Message ID',
+            description: 'The ID of the email to forward.',
+            required: true,
+        }),
+        toRecipients: Property.Array({
+            displayName: 'To Recipients',
+            description: 'The email addresses of the recipients.',
+            required: true,
+        }),
+        comment: Property.LongText({
+            displayName: 'Comment',
+            description: 'An optional comment to add to the forwarded message body.',
+            required: false,
+        }),
+    },
+    async run(context) {
+        const { messageId, toRecipients, comment } = context.propsValue;
+        const recipients = toRecipients as string[];
+
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(context.auth.access_token),
+            },
+        });
+
+        const recipientObjects: Recipient[] = recipients.map((email) => ({
+            emailAddress: {
+                address: email,
+            },
+        }));
+
+        const payload = {
+            toRecipients: recipientObjects,
+            comment: comment || '',
+        };
+
+        try {
+            // This API call forwards the message and returns a 202 Accepted response with no body.
+            await client
+                .api(`/me/messages/${messageId}/forward`)
+                .post(payload);
+            
+            return {
+                success: true,
+                message: `Email (ID: ${messageId}) forwarded successfully.`,
+            };
+
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to forward email: ${errorMessage}`);
+        }
+    },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/actions/move-email-to-folder.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/actions/move-email-to-folder.ts
@@ -1,0 +1,42 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { microsoftOutlookAuth } from '../common/auth';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { outlookCommon } from '../common/props';
+
+export const moveEmailToFolderAction = createAction({
+    auth: microsoftOutlookAuth,
+    name: 'move_email_to_folder',
+    displayName: 'Move Email to Folder',
+    description: 'Moves an email to the specified folder.',
+    props: {
+        messageId: Property.ShortText({
+            displayName: 'Message ID',
+            description: 'The ID of the email to move.',
+            required: true,
+        }),
+        destinationFolderId: outlookCommon.folder,
+    },
+    async run(context) {
+        const { messageId, destinationFolderId } = context.propsValue;
+
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(context.auth.access_token),
+            },
+        });
+
+        try {
+            const response = await client
+                .api(`/me/messages/${messageId}/move`)
+                .post({
+                    destinationId: destinationFolderId,
+                });
+            
+            return response;
+
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to move email: ${errorMessage}`);
+        }
+    },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/actions/remove-label-from-email.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/actions/remove-label-from-email.ts
@@ -1,0 +1,72 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { microsoftOutlookAuth } from '../common/auth';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { Message } from '@microsoft/microsoft-graph-types';
+
+export const removeLabelFromEmailAction = createAction({
+    auth: microsoftOutlookAuth,
+    name: 'remove_label_from_email',
+    displayName: 'Remove Label from Email',
+    description: 'Removes one or more labels (categories) from an email.',
+    props: {
+        messageId: Property.ShortText({
+            displayName: 'Message ID',
+            description: 'The ID of the email from which you want to remove labels.',
+            required: true,
+        }),
+        labels: Property.Array({
+            displayName: 'Labels',
+            description: 'The labels (categories) to remove from the email.',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { messageId, labels } = context.propsValue;
+        const labelsToRemove = labels as string[];
+
+        if (!labelsToRemove || labelsToRemove.length === 0) {
+            return {
+                success: true,
+                message: "No labels were provided to remove.",
+            };
+        }
+        
+        const labelsToRemoveSet = new Set(labelsToRemove);
+
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(context.auth.access_token),
+            },
+        });
+
+        try {
+            // Get the existing categories on the message.
+            const currentMessage: Message = await client
+                .api(`/me/messages/${messageId}`)
+                .select('categories')
+                .get();
+
+            const existingLabels = currentMessage.categories || [];
+            if (existingLabels.length === 0) {
+                // If there are no labels, there's nothing to remove.
+                return currentMessage;
+            }
+
+            // Filter the existing labels, keeping only those not in the removal list.
+            const newLabels = existingLabels.filter(label => !labelsToRemoveSet.has(label));
+            
+            // Update the message with the new, filtered list of labels.
+            const updatedMessage = await client
+                .api(`/me/messages/${messageId}`)
+                .patch({
+                    categories: newLabels,
+                });
+            
+            return updatedMessage;
+
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to remove labels: ${errorMessage}`);
+        }
+    },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/actions/send-draft-email.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/actions/send-draft-email.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { microsoftOutlookAuth } from '../common/auth';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { outlookCommon } from '../common/props';
+
+export const sendDraftEmailAction = createAction({
+    auth: microsoftOutlookAuth,
+    name: 'send_draft_email',
+    displayName: 'Send Draft Email',
+    description: 'Sends a previously created draft email.',
+    props: {
+        messageId: outlookCommon.draft,
+    },
+    async run(context) {
+        const { messageId } = context.propsValue;
+
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(context.auth.access_token),
+            },
+        });
+
+        try {
+            // This API call sends the draft and returns a 202 Accepted response with no body.
+            await client
+                .api(`/me/messages/${messageId}/send`)
+                .post({});
+            
+            return {
+                success: true,
+                message: `Draft email (ID: ${messageId}) sent successfully.`,
+            };
+
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to send draft email: ${errorMessage}`);
+        }
+    },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/common/props.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/common/props.ts
@@ -1,0 +1,84 @@
+import { OAuth2PropertyValue, Property } from '@activepieces/pieces-framework';
+import { Client } from '@microsoft/microsoft-graph-client';
+
+export const outlookCommon = {
+    folder: Property.Dropdown({
+        displayName: 'Destination Folder',
+        required: true,
+        refreshers: [],
+        options: async ({ auth }) => {
+            if (!auth) {
+                return {
+                    disabled: true,
+                    placeholder: 'Please connect your account first.',
+                    options: [],
+                };
+            }
+            const authProp = auth as OAuth2PropertyValue;
+            const client = Client.initWithMiddleware({
+                authProvider: {
+                    getAccessToken: () => Promise.resolve(authProp.access_token),
+                },
+            });
+
+            // Add common well-known folders for quick access
+            const wellKnownFolders = [
+                { label: 'Inbox', value: 'inbox' },
+                { label: 'Archive', value: 'archive' },
+                { label: 'Deleted Items', value: 'deleteditems' },
+                { label: 'Drafts', value: 'drafts' },
+                { label: 'Sent Items', value: 'sentitems' },
+                { label: 'Junk Email', value: 'junkemail' },
+            ];
+            
+            // Fetch the user's custom mail folders
+            const response = await client.api('/me/mailFolders').top(100).get();
+            const customFolders = response.value.map((folder: { displayName: string; id: string }) => ({
+                label: folder.displayName,
+                value: folder.id,
+            }));
+
+            return {
+                disabled: false,
+                options: [...wellKnownFolders, ...customFolders],
+            };
+        },
+    }),
+    // Add the new draft property below
+    draft: Property.Dropdown({
+        displayName: 'Draft Email',
+        required: true,
+        refreshers: [],
+        options: async ({ auth }) => {
+            if (!auth) {
+                return {
+                    disabled: true,
+                    placeholder: 'Please connect your account first.',
+                    options: [],
+                };
+            }
+            const authProp = auth as OAuth2PropertyValue;
+            const client = Client.initWithMiddleware({
+                authProvider: {
+                    getAccessToken: () => Promise.resolve(authProp.access_token),
+                },
+            });
+            
+            // Fetch messages from the Drafts folder
+            const response = await client.api('/me/mailFolders/drafts/messages')
+                .select('id,subject')
+                .top(50) // Limit to 50 most recent drafts for performance
+                .get();
+
+            const options = response.value.map((message: { subject: string; id: string }) => ({
+                label: message.subject || '(No Subject)',
+                value: message.id,
+            }));
+
+            return {
+                disabled: false,
+                options: options,
+            };
+        },
+    }),
+};

--- a/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-attachment.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-attachment.ts
@@ -1,0 +1,131 @@
+import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import {
+    OAuth2PropertyValue,
+    PiecePropValueSchema,
+    Property,
+    TriggerStrategy,
+    createTrigger,
+} from '@activepieces/pieces-framework';
+import { Client, PageCollection } from '@microsoft/microsoft-graph-client';
+import { Attachment, Message } from '@microsoft/microsoft-graph-types';
+import dayjs from 'dayjs';
+import { microsoftOutlookAuth } from '../common/auth';
+
+const polling: Polling<PiecePropValueSchema<typeof microsoftOutlookAuth>, { folder?: string }> = {
+    strategy: DedupeStrategy.TIMEBASED,
+    items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(auth.access_token),
+            },
+        });
+
+        const folderId = propsValue.folder || 'inbox';
+        
+        const filter = `hasAttachments eq true` + (lastFetchEpochMS > 0 ? ` and receivedDateTime gt ${dayjs(lastFetchEpochMS).toISOString()}` : '');
+
+        const response: PageCollection = await client
+            .api(`/me/mailFolders/${folderId}/messages`)
+            .filter(filter)
+            .expand('attachments')
+            .orderby('receivedDateTime asc')
+            .get();
+
+        const items: { epochMilliSeconds: number; data: unknown }[] = [];
+
+        for (const message of response.value as Message[]) {
+            if (message.attachments && message.attachments.length > 0) {
+                for (const attachment of message.attachments as Attachment[]) {
+                    // Use attachment's modification time for precise deduplication
+                    const epoch = dayjs(attachment.lastModifiedDateTime).valueOf();
+                    
+                    // Remove bulky/unnecessary message properties before returning
+                    const { attachments, body, bodyPreview, uniqueBody, ...messageInfo } = message;
+
+                    items.push({
+                        epochMilliSeconds: epoch,
+                        data: {
+                            ...attachment,
+                            message: messageInfo, // Nest parent message info
+                        }
+                    });
+                }
+            }
+        }
+        return items;
+    },
+};
+
+export const newAttachmentTrigger = createTrigger({
+    auth: microsoftOutlookAuth,
+    name: 'new_attachment',
+    displayName: 'New Attachment',
+    description: 'Triggers when a new attachment is received in an email.',
+    props: {
+        folder: Property.Dropdown({
+            displayName: 'Folder',
+            description: 'The folder to monitor for new attachments. Defaults to Inbox.',
+            required: false,
+            refreshers: [],
+            options: async ({ auth }) => {
+                if (!auth) {
+                    return { disabled: true, placeholder: 'Connect your account first', options: [] };
+                }
+                const authProp = auth as OAuth2PropertyValue;
+                const client = Client.initWithMiddleware({
+                    authProvider: { getAccessToken: () => Promise.resolve(authProp.access_token) },
+                });
+                const response = await client.api('/me/mailFolders').top(100).get();
+                return {
+                    disabled: false,
+                    options: response.value.map((folder: { displayName: string; id: string }) => ({
+                        label: folder.displayName,
+                        value: folder.id,
+                    })),
+                };
+            },
+        }),
+    },
+    sampleData: {
+        "@odata.type": "#microsoft.graph.fileAttachment",
+        "id": "AAMkAGUzY5QKjAAABEgAQAMkpJI_X-LBFgvrv1PlZYd8=",
+        "lastModifiedDateTime": "2023-01-02T03:41:29Z",
+        "name": "sales-invoice.docx",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "size": 13068,
+        "isInline": false,
+        "contentBytes": "UEsDBBQABgAIAAAAIQ4AAAAA",
+        "message": {
+            "id": "AAMkAGUzY5QKjAAA=",
+            "subject": "Q4 Sales Invoice",
+            "from": {
+                "emailAddress": {
+                    "name": "Adele Vance",
+                    "address": "adelev@contoso.com"
+                }
+            },
+            "receivedDateTime": "2023-01-02T03:40:08Z"
+        }
+    },
+    type: TriggerStrategy.POLLING,
+    async onEnable(context) {
+        await pollingHelper.onEnable(polling, {
+            auth: context.auth,
+            store: context.store,
+            propsValue: context.propsValue,
+        });
+    },
+    async onDisable(context) {
+        await pollingHelper.onDisable(polling, {
+            auth: context.auth,
+            store: context.store,
+            propsValue: context.propsValue,
+        });
+    },
+    async test(context) {
+        return await pollingHelper.test(polling, context);
+    },
+    async run(context) {
+        return await pollingHelper.poll(polling, context);
+    },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-email-in-folder.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-email-in-folder.ts
@@ -1,0 +1,124 @@
+import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import {
+    OAuth2PropertyValue,
+    PiecePropValueSchema,
+    Property,
+    TriggerStrategy,
+    createTrigger,
+} from '@activepieces/pieces-framework';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { Message } from '@microsoft/microsoft-graph-types';
+import dayjs from 'dayjs';
+import { microsoftOutlookAuth } from '../common/auth';
+
+const polling: Polling<
+    PiecePropValueSchema<typeof microsoftOutlookAuth>, 
+    { folders: string[] }
+> = {
+    strategy: DedupeStrategy.TIMEBASED,
+    items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(auth.access_token),
+            },
+        });
+
+        const folders = propsValue.folders;
+        if (!folders || folders.length === 0) {
+            return [];
+        }
+
+        const allNewMessages: Message[] = [];
+        
+        // On the first run, fetch the last 10 emails. On subsequent runs, fetch all new emails since the last run.
+        const filter = lastFetchEpochMS > 0 ? `receivedDateTime gt ${dayjs(lastFetchEpochMS).toISOString()}` : '';
+        const order = lastFetchEpochMS > 0 ? 'asc' : 'desc';
+        const top = lastFetchEpochMS > 0 ? 100 : 10;
+
+        for (const folderId of folders) {
+            const request = client
+                .api(`/me/mailFolders/${folderId}/messages`)
+                .orderby(`receivedDateTime ${order}`)
+                .top(top);
+
+            if (filter) {
+                request.filter(filter);
+            }
+            
+            let response = await request.get();
+
+            // Handle pagination to retrieve all new emails since the last poll
+            if (lastFetchEpochMS > 0) {
+                 while (response.value.length > 0) {
+                    allNewMessages.push(...response.value);
+                    if (response['@odata.nextLink']) {
+                        response = await client.api(response['@odata.nextLink']).get();
+                    } else {
+                        break;
+                    }
+                }
+            } else {
+                allNewMessages.push(...response.value);
+            }
+        }
+        
+        return allNewMessages.map((message) => ({
+            epochMilliSeconds: dayjs(message.receivedDateTime).valueOf(),
+            data: message,
+        }));
+    },
+};
+
+export const newEmailInFolderTrigger = createTrigger({
+    auth: microsoftOutlookAuth,
+    name: 'new_email_in_folder',
+    displayName: 'New Email in Folder',
+    description: 'Triggers when a new email is received in one or more specified folders.',
+    props: {
+        folders: Property.MultiSelectDropdown({
+            displayName: 'Folders',
+            description: 'The folder(s) to monitor for new emails.',
+            required: true,
+            refreshers: [], // This line was missing
+            options: async ({ auth }) => {
+                if (!auth) {
+                    return { disabled: true, placeholder: 'Connect your account first', options: [] };
+                }
+                const authProp = auth as OAuth2PropertyValue;
+                const client = Client.initWithMiddleware({
+                    authProvider: { getAccessToken: () => Promise.resolve(authProp.access_token) },
+                });
+                const response = await client.api('/me/mailFolders').top(100).get();
+                return {
+                    disabled: false,
+                    options: response.value.map((folder: { displayName: string; id: string }) => ({
+                        label: folder.displayName,
+                        value: folder.id,
+                    })),
+                };
+            },
+        }),
+    },
+    sampleData: {},
+    type: TriggerStrategy.POLLING,
+    async onEnable(context) {
+        await pollingHelper.onEnable(polling, {
+            auth: context.auth,
+            store: context.store,
+            propsValue: context.propsValue,
+        });
+    },
+    async onDisable(context) {
+        await pollingHelper.onDisable(polling, {
+            auth: context.auth,
+            store: context.store,
+            propsValue: context.propsValue,
+        });
+    },
+    async test(context) {
+        return await pollingHelper.test(polling, context);
+    },
+    async run(context) {
+        return await pollingHelper.poll(polling, context);
+    },
+});

--- a/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-matched-email.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-matched-email.ts
@@ -1,0 +1,125 @@
+import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import {
+    OAuth2PropertyValue,
+    PiecePropValueSchema,
+    Property,
+    TriggerStrategy,
+    createTrigger,
+} from '@activepieces/pieces-framework';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { Message } from '@microsoft/microsoft-graph-types';
+import dayjs from 'dayjs';
+import { microsoftOutlookAuth } from '../common/auth';
+
+const polling: Polling<
+    PiecePropValueSchema<typeof microsoftOutlookAuth>, 
+    { folder?: string; from?: string; subject_contains?: string }
+> = {
+    strategy: DedupeStrategy.TIMEBASED,
+    items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+        const client = Client.initWithMiddleware({
+            authProvider: {
+                getAccessToken: () => Promise.resolve(auth.access_token),
+            },
+        });
+
+        const folderId = propsValue.folder || 'inbox';
+
+        const filters = [];
+        if (lastFetchEpochMS > 0) {
+            filters.push(`receivedDateTime gt ${dayjs(lastFetchEpochMS).toISOString()}`);
+        }
+        if (propsValue.from) {
+            // OData requires escaping single quotes in the filter value
+            const fromEmail = propsValue.from.replace(/'/g, "''");
+            filters.push(`from/emailAddress/address eq '${fromEmail}'`);
+        }
+        if (propsValue.subject_contains) {
+            const subject = propsValue.subject_contains.replace(/'/g, "''");
+            filters.push(`contains(subject, '${subject}')`);
+        }
+        
+        const filterString = filters.join(' and ');
+
+        const request = client
+            .api(`/me/mailFolders/${folderId}/messages`)
+            .orderby('receivedDateTime asc')
+            .top(25); // Limit batch size to avoid timeouts
+
+        if (filterString) {
+            request.filter(filterString);
+        }
+
+        const response = await request.get();
+        const messages: Message[] = response.value;
+
+        return messages.map((message) => ({
+            epochMilliSeconds: dayjs(message.receivedDateTime).valueOf(),
+            data: message,
+        }));
+    },
+};
+
+export const newMatchedEmailTrigger = createTrigger({
+    auth: microsoftOutlookAuth,
+    name: 'new_matched_email',
+    displayName: 'New Matched Email',
+    description: 'Triggers when a new email is received that matches the specified criteria.',
+    props: {
+        folder: Property.Dropdown({
+            displayName: 'Folder',
+            description: 'The folder to monitor for new emails. Defaults to Inbox.',
+            required: false,
+            refreshers: [],
+            options: async ({ auth }) => {
+                if (!auth) {
+                    return { disabled: true, placeholder: 'Connect your account first', options: [] };
+                }
+                const authProp = auth as OAuth2PropertyValue;
+                const client = Client.initWithMiddleware({
+                    authProvider: { getAccessToken: () => Promise.resolve(authProp.access_token) },
+                });
+                const response = await client.api('/me/mailFolders').top(100).get();
+                return {
+                    disabled: false,
+                    options: response.value.map((folder: { displayName: string; id: string }) => ({
+                        label: folder.displayName,
+                        value: folder.id,
+                    })),
+                };
+            },
+        }),
+        from: Property.ShortText({
+            displayName: 'From',
+            description: "The sender's email address to match against.",
+            required: false,
+        }),
+        subject_contains: Property.ShortText({
+            displayName: 'Subject Contains',
+            description: 'Text that the subject of the email must contain.',
+            required: false,
+        }),
+    },
+    sampleData: {},
+    type: TriggerStrategy.POLLING,
+    async onEnable(context) {
+        await pollingHelper.onEnable(polling, {
+            auth: context.auth,
+            store: context.store,
+            propsValue: context.propsValue,
+        });
+    },
+    async onDisable(context) {
+        await pollingHelper.onDisable(polling, {
+            auth: context.auth,
+            store: context.store,
+            propsValue: context.propsValue,
+        });
+    },
+    async test(context) {
+        return await pollingHelper.test(polling, context);
+    },
+    async run(context) {
+        return await pollingHelper.poll(polling, context);
+    },
+});


### PR DESCRIPTION
## ✨ What does this PR do?

This PR extends the Microsoft Outlook Piece by adding new triggers and actions that enhance email and calendar workflow automation. It builds on the existing implementation and follows the established coding patterns of Activepieces.

## ⚙️ How the Feature Works

### New Triggers

- New Attachment → Fires when an incoming email has an attachment.

- New Matched Email → Fires when an email matches specified criteria.

- New Email in Folder → Fires when an email is received in a designated folder.

### New Actions

- Create Draft Email → Generate a draft email in Outlook.

- Send Draft Email → Send a previously created draft.

- Forward Email → Forward an existing email.

- Move Email to Folder → Relocate an email to a specified folder.

- Add Label to Email → Categorize or label an email.

- Remove Label from Email → Remove a category/label from an email.

### New Search Action

- Find Email → Search for specific emails based on filters.

These new capabilities integrate seamlessly into the Activepieces automation builder and MCP clients, enabling more dynamic email and calendar workflows.

✅ Relevant User Scenarios

- Automatically forwarding invoices from vendors to the finance team.

- Tagging important client emails with custom labels for easy tracking.

- Detecting new attachments in shared folders and uploading them to cloud storage.

- Moving promotional or non-priority emails to a secondary folder.

- Scheduling reminders by drafting and sending automated Outlook messages.

### 🔗 References

Official Outlook API Documentation

[Activepieces Piece Development Guidelines](https://www.activepieces.com/docs/developers/building-pieces/overview?utm_source=chatgpt.com)

### 📌 Issue Tracking

Fixes #9065
/claim #9065
