### PR TITLE
feat: add lemlist-piece

### DIFF
--- a/packages/pieces/community/lemlist/.eslintrc.json
+++ b/packages/pieces/community/lemlist/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/lemlist/README.md
+++ b/packages/pieces/community/lemlist/README.md
@@ -1,0 +1,7 @@
+# pieces-lemlist
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-lemlist` to build the library.

--- a/packages/pieces/community/lemlist/package.json
+++ b/packages/pieces/community/lemlist/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-lemlist",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/lemlist/project.json
+++ b/packages/pieces/community/lemlist/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-lemlist",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/lemlist/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/lemlist",
+        "tsConfig": "packages/pieces/community/lemlist/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/lemlist/package.json",
+        "main": "packages/pieces/community/lemlist/src/index.ts",
+        "assets": [
+          "packages/pieces/community/lemlist/*.md",
+          {
+            "input": "packages/pieces/community/lemlist/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/lemlist/src/index.ts
+++ b/packages/pieces/community/lemlist/src/index.ts
@@ -1,0 +1,41 @@
+
+    import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+    import { lemlistAuth } from './lib/common/auth';
+    import { newActivity } from './lib/triggers/new-activity';
+    import { unsubscribedRecipient } from './lib/triggers/unsubscribed-recipient';
+    import { markLeadAsInterested } from './lib/actions/mark-lead-interested';
+    import { markLeadAsNotInterested } from './lib/actions/mark-lead-notinterested';
+    import { markLeadInAllCampaignsAsInterested } from './lib/actions/mark-lead-allcampaigns-interested';
+    import { markLeadInAllCampaignsAsNotInterested } from './lib/actions/mark-lead-allcampaigns-notinterested';
+    import { pauseLead } from './lib/actions/pause-lead';
+    import { resumeLead } from './lib/actions/resume-lead';
+    import { addLeadToCampaign } from './lib/actions/add-lead-to-campaign';
+    import { removeLeadFromCampaign } from './lib/actions/remove-lead-from-campaign';
+    import { removeLeadFromUnsubscribe } from './lib/actions/removelead-from-unsubscribe';
+    import { unsubscribeLead } from './lib/actions/unsubscribe-lead';
+    import { updateLeadFromCampaign } from './lib/actions/update-lead-from-campaign';
+    import { searchLead } from './lib/actions/search-lead';
+
+    export const lemlist = createPiece({
+      displayName: 'Lemlist',
+      auth: lemlistAuth,
+      minimumSupportedRelease: '0.36.1',
+      logoUrl: 'https://cdn.activepieces.com/pieces/lemlist.png',
+      authors: ['Prabhukiran161'],
+      actions: [
+        markLeadAsInterested,
+        markLeadAsNotInterested,
+        markLeadInAllCampaignsAsInterested,
+        markLeadInAllCampaignsAsNotInterested,
+        pauseLead,
+        resumeLead,
+        addLeadToCampaign,
+        removeLeadFromCampaign,
+        removeLeadFromUnsubscribe,
+        unsubscribeLead,
+        updateLeadFromCampaign,
+        searchLead
+      ],
+      triggers: [newActivity, unsubscribedRecipient],
+    });
+    

--- a/packages/pieces/community/lemlist/src/lib/actions/add-lead-to-campaign.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/add-lead-to-campaign.ts
@@ -1,0 +1,76 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const addLeadToCampaign = createAction({
+  name: 'add_lead_to_campaign',
+  description: 'Adds a lead to a specific campaign.',
+  displayName: 'Add Lead To Campaign',
+  props: {
+    auth: Property.ShortText({
+      displayName: 'API Key / Password',
+      required: true,
+    }),
+    leadEmail: Property.ShortText({
+      displayName: 'Lead Email',
+      required: true,
+    }),
+    campaign: Property.Dropdown<string>({
+      displayName: 'Select Campaign',
+      required: true,
+      refreshers: ['auth'],
+      options: async ({
+        auth,
+      }): Promise<{ options: { label: string; value: string }[] }> => {
+        const response = await httpClient.sendRequest<Campaign[]>({
+          method: HttpMethod.GET,
+          url: 'https://api.lemlist.com/api/campaigns',
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+        });
+
+        const campaigns = response.body ?? [];
+
+        return {
+          options: campaigns.map((c) => ({
+            label: c.name,
+            value: c._id,
+          })),
+        };
+      },
+    }),
+  },
+
+  async run({ propsValue }) {
+    const { auth, leadEmail, campaign } = propsValue;
+
+    await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `https://api.lemlist.com/api/campaigns/${campaign}/leads`,
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: {
+        email: leadEmail,
+      },
+    });
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/mark-lead-allcampaigns-interested.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/mark-lead-allcampaigns-interested.ts
@@ -1,0 +1,76 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const markLeadInAllCampaignsAsInterested = createAction({
+  name: 'mark_lead_all_campaigns_interested',
+  displayName: 'Mark Lead as Interested in All Campaigns',
+  description: 'Mark a lead as interested in every campaign they exist in.',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Lead Email',
+      description: 'Email address of the lead to mark as interested.',
+      required: true,
+    }),
+  },
+
+  async run(context) {
+    const { auth, propsValue } = context;
+
+    const campaignsResponse = await httpClient.sendRequest<Campaign[]>({
+      method: HttpMethod.GET,
+      url: 'https://api.lemlist.com/api/campaigns',
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+    });
+
+    const campaigns = campaignsResponse.body ?? [];
+
+    if (campaigns.length === 0) {
+      return { success: false, message: 'No campaigns found in Lemlist.' };
+    }
+
+    const results = [];
+    for (const campaign of campaigns) {
+      try {
+        const response = await httpClient.sendRequest({
+          method: HttpMethod.PUT,
+          url: `https://api.lemlist.com/api/campaigns/${campaign._id}/leads/${propsValue.email}/interested`,
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        results.push({
+          campaign: campaign.name,
+          status: 'success',
+          response: response.body,
+        });
+      } catch (error) {
+        results.push({
+          campaign: campaign.name,
+          status: 'failed',
+          error: error,
+        });
+      }
+    }
+
+    return { success: true, results };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/mark-lead-allcampaigns-notinterested.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/mark-lead-allcampaigns-notinterested.ts
@@ -1,0 +1,76 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const markLeadInAllCampaignsAsNotInterested = createAction({
+  name: 'mark_lead_all_campaigns_not_interested',
+  displayName: 'Mark Lead as Not Interested in All Campaigns',
+  description: 'Mark a lead as not interested in every campaign they exist in.',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Lead Email',
+      description: 'Email address of the lead to mark as not interested.',
+      required: true,
+    }),
+  },
+
+  async run(context) {
+    const { auth, propsValue } = context;
+
+    const campaignsResponse = await httpClient.sendRequest<Campaign[]>({
+      method: HttpMethod.GET,
+      url: 'https://api.lemlist.com/api/campaigns',
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+    });
+
+    const campaigns = campaignsResponse.body ?? [];
+
+    if (campaigns.length === 0) {
+      return { success: false, message: 'No campaigns found in Lemlist.' };
+    }
+
+    const results = [];
+    for (const campaign of campaigns) {
+      try {
+        const response = await httpClient.sendRequest({
+          method: HttpMethod.PUT,
+          url: `https://api.lemlist.com/api/campaigns/${campaign._id}/leads/${propsValue.email}/notInterested`,
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        results.push({
+          campaign: campaign.name,
+          status: 'success',
+          response: response.body,
+        });
+      } catch (error) {
+        results.push({
+          campaign: campaign.name,
+          status: 'failed',
+          error: error,
+        });
+      }
+    }
+
+    return { success: true, results };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/mark-lead-interested.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/mark-lead-interested.ts
@@ -1,0 +1,74 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const markLeadAsInterested = createAction({
+  name: 'mark_lead_as_interested',
+  displayName: 'Mark Lead as Interested',
+  description: 'Mark a specific lead in a campaign as interested.',
+  props: {
+    campaignId: Property.Dropdown({
+      displayName: 'Campaign',
+      description: 'Select a campaign from Lemlist.',
+      required: true,
+      refreshers: [], 
+      async options({ auth }) {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please connect your Lemlist account first',
+            options: [],
+          };
+        }
+
+        const response = await httpClient.sendRequest<Campaign[]>({
+          method: HttpMethod.GET,
+          url: 'https://api.lemlist.com/api/campaigns',
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string, 
+          },
+        });
+
+        const campaigns = response.body ?? [];
+        return {
+          options: campaigns.map((c) => ({
+            label: c.name,
+            value: c._id,
+          })),
+        };
+      },
+    }),
+    email: Property.ShortText({
+      displayName: 'Lead Email',
+      description: 'Email address of the lead to mark as interested.',
+      required: true,
+    }),
+  },
+
+  async run(context) {
+    const { auth, propsValue } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: `https://api.lemlist.com/api/campaigns/${propsValue.campaignId}/leads/${propsValue.email}/interested`,
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return (
+      response.body ?? { success: true, message: 'Lead marked as interested' }
+    );
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/mark-lead-notinterested.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/mark-lead-notinterested.ts
@@ -1,0 +1,81 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const markLeadAsNotInterested = createAction({
+  name: 'mark_lead_as_not_interested',
+  displayName: 'Mark Lead as Not Interested',
+  description: 'Mark a specific lead in a campaign as not interested.',
+  props: {
+    campaignId: Property.Dropdown({
+      displayName: 'Campaign',
+      description: 'Select a campaign from Lemlist.',
+      required: true,
+      refreshers: [],
+      async options({ auth }) {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please connect your Lemlist account first',
+            options: [],
+          };
+        }
+
+        const response = await httpClient.sendRequest<Campaign[]>({
+          method: HttpMethod.GET,
+          url: 'https://api.lemlist.com/api/campaigns',
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+        });
+
+        const campaigns = response.body ?? [];
+        return {
+          options: campaigns.map((c) => ({
+            label: c.name,
+            value: c._id,
+          })),
+        };
+      },
+    }),
+    email: Property.ShortText({
+      displayName: 'Lead Email',
+      description: 'Email address of the lead to mark as not interested.',
+      required: true,
+    }),
+  },
+
+  async run(context) {
+    const { auth, propsValue } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: `https://api.lemlist.com/api/campaigns/${propsValue.campaignId}/leads/${propsValue.email}/notInterested`,
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return (
+      response.body ?? {
+        success: true,
+        message: 'Lead marked as not interested',
+      }
+    );
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/pause-lead.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/pause-lead.ts
@@ -1,0 +1,84 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const pauseLead = createAction({
+  name: 'pause_lead',
+  description: 'Pause a lead’s outreach across all or specific campaigns.',
+  displayName: 'Pause Lead From Campaign(s)',
+  props: {
+    auth: Property.ShortText({
+      displayName: 'API Key / Password',
+      required: true,
+    }),
+    leadEmail: Property.ShortText({
+      displayName: 'Lead Email',
+      required: true,
+    }),
+    campaign: Property.Dropdown<Campaign>({
+      displayName: 'Select Campaign (optional)',
+      required: false,
+      refreshers: ['auth'],
+      options: async ({
+        auth,
+      }): Promise<{ options: { label: string; value: Campaign }[] }> => {
+        const response = await httpClient.sendRequest<Campaign[]>({
+          method: HttpMethod.GET,
+          url: 'https://api.lemlist.com/api/campaigns',
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+        });
+
+        const campaigns = response.body ?? [];
+
+        return {
+          options: campaigns.map((c) => ({
+            label: c.name,
+            value: c,
+          })),
+        };
+      },
+    }),
+  },
+
+  async run({ propsValue }) {
+    const { auth, leadEmail, campaign } = propsValue;
+
+    if (campaign) {
+      await httpClient.sendRequest({
+        method: HttpMethod.PUT,
+        url: `https://api.lemlist.com/api/campaigns/${campaign._id}/pause/${leadEmail}`,
+        authentication: {
+          type: AuthenticationType.BASIC,
+          username: '',
+          password: auth as string,
+        },
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } else {
+      await httpClient.sendRequest({
+        method: HttpMethod.PUT,
+        url: `https://api.lemlist.com/api/leads/${leadEmail}/pause`,
+        authentication: {
+          type: AuthenticationType.BASIC,
+          username: '',
+          password: auth as string,
+        },
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/remove-lead-from-campaign.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/remove-lead-from-campaign.ts
@@ -1,0 +1,73 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const removeLeadFromCampaign = createAction({
+  name: 'remove_lead_from_campaign',
+  description: 'Removes a lead from a specific campaign.',
+  displayName: 'Remove Lead From Campaign',
+  props: {
+    auth: Property.ShortText({
+      displayName: 'API Key / Password',
+      required: true,
+    }),
+    leadEmail: Property.ShortText({
+      displayName: 'Lead Email',
+      required: true,
+    }),
+    campaign: Property.Dropdown<string>({
+      displayName: 'Select Campaign',
+      required: true,
+      refreshers: ['auth'],
+      options: async ({
+        auth,
+      }): Promise<{ options: { label: string; value: string }[] }> => {
+        const response = await httpClient.sendRequest<Campaign[]>({
+          method: HttpMethod.GET,
+          url: 'https://api.lemlist.com/api/campaigns',
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+        });
+
+        const campaigns = response.body ?? [];
+
+        return {
+          options: campaigns.map((c) => ({
+            label: c.name,
+            value: c._id, 
+          })),
+        };
+      },
+    }),
+  },
+
+  async run({ propsValue }) {
+    const { auth, leadEmail, campaign } = propsValue;
+
+    await httpClient.sendRequest({
+      method: HttpMethod.DELETE,
+      url: `https://api.lemlist.com/api/campaigns/${campaign}/leads/${leadEmail}`,
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/removelead-from-unsubscribe.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/removelead-from-unsubscribe.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+export const removeLeadFromUnsubscribe = createAction({
+  name: 'remove_lead_from_unsubscribe',
+  description: 'Removes a lead from the unsubscribe list.',
+  displayName: 'Remove Lead From Unsubscribe',
+  props: {
+    auth: Property.ShortText({
+      displayName: 'API Key / Password',
+      required: true,
+    }),
+    leadEmail: Property.ShortText({
+      displayName: 'Lead Email',
+      required: true,
+    }),
+  },
+
+  async run({ propsValue }) {
+    const { auth, leadEmail } = propsValue;
+
+    await httpClient.sendRequest({
+      method: HttpMethod.DELETE,
+      url: `https://api.lemlist.com/api/unsubscribes/${leadEmail}`,
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/resume-lead.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/resume-lead.ts
@@ -1,0 +1,88 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const resumeLead = createAction({
+  name: 'resume_lead',
+  description: 'Resume a lead’s outreach across all or specific campaigns.',
+  displayName: 'Resume Lead From Campaign(s)',
+  props: {
+    auth: Property.ShortText({
+      displayName: 'API Key / Password',
+      required: true,
+    }),
+    leadEmail: Property.ShortText({
+      displayName: 'Lead Email',
+      required: true,
+    }),
+    campaign: Property.Dropdown<Campaign>({
+      displayName: 'Select Campaign (optional)',
+      required: false,
+      refreshers: ['auth'],
+      options: async ({
+        auth,
+      }): Promise<{ options: { label: string; value: Campaign }[] }> => {
+        const response = await httpClient.sendRequest<Campaign[]>({
+          method: HttpMethod.GET,
+          url: 'https://api.lemlist.com/api/campaigns',
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+        });
+
+        const campaigns = response.body ?? [];
+
+        return {
+          options: campaigns.map((c) => ({
+            label: c.name,
+            value: c, 
+          })),
+        };
+      },
+    }),
+  },
+
+  async run({ propsValue }) {
+    const { auth, leadEmail, campaign } = propsValue;
+
+    if (campaign) {
+      await httpClient.sendRequest({
+        method: HttpMethod.PUT,
+        url: `https://api.lemlist.com/api/campaigns/${campaign._id}/resume/${leadEmail}`,
+        authentication: {
+          type: AuthenticationType.BASIC,
+          username: '',
+          password: auth as string,
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    } else {
+      await httpClient.sendRequest({
+        method: HttpMethod.PUT,
+        url: `https://api.lemlist.com/api/leads/${leadEmail}/resume`,
+        authentication: {
+          type: AuthenticationType.BASIC,
+          username: '',
+          password: auth as string,
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    }
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/search-lead.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/search-lead.ts
@@ -1,0 +1,86 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const searchLead = createAction({
+  name: 'search_lead',
+  displayName: 'Search Lead',
+  description: 'Look up a lead by email and campaign.',
+  props: {
+    auth: Property.ShortText({
+      displayName: 'API Key / Password',
+      required: true,
+    }),
+    leadEmail: Property.ShortText({
+      displayName: 'Lead Email',
+      required: true,
+    }),
+    campaign: Property.Dropdown<Campaign>({
+      displayName: 'Select Campaign',
+      required: false,
+      refreshers: ['auth'],
+      options: async ({
+        auth,
+      }): Promise<{ options: { label: string; value: Campaign }[] }> => {
+        const response = await httpClient.sendRequest<Campaign[]>({
+          method: HttpMethod.GET,
+          url: 'https://api.lemlist.com/api/campaigns',
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+        });
+
+        const campaigns = response.body ?? [];
+
+        return {
+          options: campaigns.map((c) => ({
+            label: c.name,
+            value: c,
+          })),
+        };
+      },
+    }),
+  },
+
+  async run({ propsValue }) {
+    const auth = propsValue['auth'];
+    const leadEmail = propsValue['leadEmail'];
+    const campaign = propsValue['campaign'];
+
+    let url: string;
+
+    if (campaign) {
+      url = `https://api.lemlist.com/api/campaigns/${campaign._id}/leads/${leadEmail}`;
+    } else {
+      url = `https://api.lemlist.com/api/leads/${leadEmail}`;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return {
+      success: true,
+      lead: response.body,
+    };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/unsubscribe-lead.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/unsubscribe-lead.ts
@@ -1,0 +1,77 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const unsubscribeLead = createAction({
+  name: 'unsubscribe_lead',
+  description: 'Unsubscribe a lead from a campaign.',
+  displayName: 'Unsubscribe Lead From Campaign',
+  props: {
+    auth: Property.ShortText({
+      displayName: 'API Key / Password',
+      required: true,
+    }),
+    leadEmail: Property.ShortText({
+      displayName: 'Lead Email',
+      required: true,
+    }),
+    campaign: Property.Dropdown<Campaign>({
+      displayName: 'Select Campaign',
+      required: true,
+      refreshers: ['auth'],
+      options: async ({
+        auth,
+      }): Promise<{ options: { label: string; value: Campaign }[] }> => {
+        const response = await httpClient.sendRequest<Campaign[]>({
+          method: HttpMethod.GET,
+          url: 'https://api.lemlist.com/api/campaigns',
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+        });
+
+        const campaigns = response.body ?? [];
+
+        return {
+          options: campaigns.map((c) => ({
+            label: c.name,
+            value: c,
+          })),
+        };
+      },
+    }),
+  },
+
+  async run({ propsValue }) {
+    const { auth, leadEmail, campaign } = propsValue;
+
+    if (!campaign) {
+      throw new Error('Campaign must be selected.');
+    }
+
+    await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `https://api.lemlist.com/api/campaigns/${campaign._id}/unsubscribe/${leadEmail}`,
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/actions/update-lead-from-campaign.ts
+++ b/packages/pieces/community/lemlist/src/lib/actions/update-lead-from-campaign.ts
@@ -1,0 +1,112 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+interface Campaign {
+  _id: string;
+  name: string;
+}
+
+export const updateLeadFromCampaign = createAction({
+  name: 'update_lead_from_campaign',
+  description:
+    'Update lead fields (name, icebreaker, screenshot URL, etc.) in a campaign; supports enrichment flags.',
+  displayName: 'Update Lead From Campaign',
+  props: {
+    auth: Property.ShortText({
+      displayName: 'API Key / Password',
+      required: true,
+    }),
+    leadEmail: Property.ShortText({
+      displayName: 'Lead Email',
+      required: true,
+    }),
+    campaign: Property.Dropdown<Campaign>({
+      displayName: 'Select Campaign',
+      required: true,
+      refreshers: ['auth'],
+      options: async ({
+        auth,
+      }): Promise<{ options: { label: string; value: Campaign }[] }> => {
+        const response = await httpClient.sendRequest<Campaign[]>({
+          method: HttpMethod.GET,
+          url: 'https://api.lemlist.com/api/campaigns',
+          authentication: {
+            type: AuthenticationType.BASIC,
+            username: '',
+            password: auth as string,
+          },
+        });
+
+        const campaigns = response.body ?? [];
+
+        return {
+          options: campaigns.map((c) => ({
+            label: c.name,
+            value: c,
+          })),
+        };
+      },
+    }),
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    icebreaker: Property.LongText({
+      displayName: 'Icebreaker Text',
+      required: false,
+    }),
+    screenshotUrl: Property.ShortText({
+      displayName: 'Screenshot URL',
+      required: false,
+    }),
+    enrich: Property.Checkbox({
+      displayName: 'Enrich Lead',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+
+  async run({ propsValue }) {
+    const campaign = propsValue['campaign'];
+    const leadEmail = propsValue['leadEmail'];
+    const auth = propsValue['auth'];
+
+    if (!campaign) {
+      throw new Error('Campaign must be selected.');
+    }
+
+    const body: Record<string, string | boolean> = {};
+
+    if (propsValue['firstName']) body['firstName'] = propsValue['firstName'];
+    if (propsValue['lastName']) body['lastName'] = propsValue['lastName'];
+    if (propsValue['icebreaker']) body['icebreaker'] = propsValue['icebreaker'];
+    if (propsValue['screenshotUrl'])
+      body['screenshotUrl'] = propsValue['screenshotUrl'];
+    if (propsValue['enrich'] !== undefined)
+      body['enrich'] = propsValue['enrich'];
+
+    await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: `https://api.lemlist.com/api/campaigns/${campaign._id}/leads/${leadEmail}`,
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/common/auth.ts
+++ b/packages/pieces/community/lemlist/src/lib/common/auth.ts
@@ -1,0 +1,11 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const lemlistAuth = PieceAuth.SecretText({
+  displayName: 'Lemlist API Key',
+  description: `
+    Enter your Lemlist API key.  
+    You can find it in Lemlist → Settings → Integrations → API.  
+    (username left empty, password = API key).
+  `,
+  required: true,
+});

--- a/packages/pieces/community/lemlist/src/lib/triggers/new-activity.ts
+++ b/packages/pieces/community/lemlist/src/lib/triggers/new-activity.ts
@@ -1,0 +1,81 @@
+import { createTrigger,TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { lemlistAuth } from '../common/auth';
+
+export const newActivity = createTrigger({
+  name: 'new_activity',
+  displayName: 'New Activity',
+  description: 'Triggers when a new activity occurs in Lemlist',
+  auth: lemlistAuth,
+  type: TriggerStrategy.WEBHOOK,
+  props: {
+    eventType: Property.StaticDropdown({
+      displayName: 'Event Type',
+      description: 'Choose which Lemlist activity should trigger this workflow',
+      required: true,
+      options: {
+        options: [
+          { label: 'Emails Opened', value: 'emailsOpened' },
+          { label: 'Emails Clicked', value: 'emailsClicked' },
+          { label: 'Emails Replied', value: 'emailsReplied' },
+          { label: 'Emails Bounced', value: 'emailsBounced' },
+          { label: 'Emails Unsubscribed', value: 'emailsUnsubscribed' },
+          { label: 'LinkedIn Replied', value: 'linkedinReplied' },
+          { label: 'LinkedIn Sent', value: 'linkedinSent' },
+          { label: 'LinkedIn Interested', value: 'linkedinInterested' },
+          { label: 'LinkedIn Not Interested', value: 'linkedinNotInterested' },
+          // you can add more from Lemlist’s docs if needed
+        ],
+      },
+    }),
+  },
+  sampleData: {
+    type: 'emailsOpened',
+    campaignId: 'cam_123',
+    recipient: 'test@example.com',
+    createdAt: '2025-09-06T12:00:00Z',
+  },
+
+  async onEnable(context) {
+    const apiKey = context.auth as string;
+    const eventType = context.propsValue.eventType;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.lemlist.com/api/hooks',
+      body: {
+        targetUrl: context.webhookUrl,
+        type: eventType, 
+      },
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '', 
+        password: apiKey, 
+      },
+    });
+
+    const hook = response.body;
+    await context.store.put('hookId', hook._id);
+  },
+
+  async onDisable(context) {
+    const apiKey = context.auth as string;
+    const hookId = await context.store.get('hookId');
+
+    if (hookId) {
+      await httpClient.sendRequest({
+        method: HttpMethod.DELETE,
+        url: `https://api.lemlist.com/api/hooks/${hookId}`,
+        authentication: {
+          type: AuthenticationType.BASIC,
+          username: '',
+          password: apiKey,
+        },
+      });
+    }
+  },
+
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/lemlist/src/lib/triggers/unsubscribed-recipient.ts
+++ b/packages/pieces/community/lemlist/src/lib/triggers/unsubscribed-recipient.ts
@@ -1,0 +1,78 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { lemlistAuth } from '../common/auth';
+
+export const unsubscribedRecipient = createTrigger({
+  name: 'unsubscribed_recipient',
+  displayName: 'Unsubscribed Recipient',
+  description: 'Triggers when a recipient unsubscribes from Lemlist emails',
+  auth: lemlistAuth,
+  type: TriggerStrategy.WEBHOOK,
+  props: {
+    eventType: Property.StaticDropdown({
+      displayName: 'Event Type',
+      description: 'Choose the Lemlist event type to listen for',
+      required: true,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Emails Unsubscribed', value: 'emailsUnsubscribed' },
+          { label: 'Emails Opened', value: 'emailsOpened' },
+          { label: 'Emails Clicked', value: 'emailsClicked' },
+          { label: 'Emails Bounced', value: 'emailsBounced' },
+          { label: 'Emails Replied', value: 'emailsReplied' },
+          { label: 'LinkedIn Message Sent', value: 'linkedinMessageSent' },
+          { label: 'LinkedIn Replied', value: 'linkedinReplied' },
+        ],
+      },
+    }),
+  },
+  sampleData: {
+    type: 'emailsUnsubscribed',
+    campaignId: 'cam_123',
+    recipient: 'unsubscribe@example.com',
+    createdAt: '2025-09-06T12:00:00Z',
+  },
+
+  async onEnable(context) {
+    const { auth, webhookUrl, propsValue } = context;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.lemlist.com/api/hooks',
+      body: {
+        targetUrl: webhookUrl,
+        type: propsValue.eventType,
+      },
+      authentication: {
+        type: AuthenticationType.BASIC,
+        username: '',
+        password: auth as string,
+      },
+    });
+
+    const hook = response.body;
+    await context.store.put('hookId', hook._id);
+  },
+
+  async onDisable(context) {
+    const { auth } = context;
+    const hookId = await context.store.get('hookId');
+
+    if (hookId) {
+      await httpClient.sendRequest({
+        method: HttpMethod.DELETE,
+        url: `https://api.lemlist.com/api/hooks/${hookId}`,
+        authentication: {
+          type: AuthenticationType.BASIC,
+          username: '',
+          password: auth as string,
+        },
+      });
+    }
+  },
+
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/lemlist/tsconfig.json
+++ b/packages/pieces/community/lemlist/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/lemlist/tsconfig.lib.json
+++ b/packages/pieces/community/lemlist/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -534,6 +534,9 @@
       "@activepieces/piece-lead-connector": [
         "packages/pieces/community/lead-connector/src/index.ts"
       ],
+      "@activepieces/piece-lemlist": [
+        "packages/pieces/community/lemlist/src/index.ts"
+      ],
       "@activepieces/piece-line": [
         "packages/pieces/community/line/src/index.ts"
       ],
@@ -835,7 +838,7 @@
       "@activepieces/piece-serp-api": [
         "packages/pieces/community/serp-api/src/index.ts"
       ],
-      "@activepieces/piece-serpstat":[
+      "@activepieces/piece-serpstat": [
         "packages/pieces/community/serpstat/src/index.ts"
       ],
       "@activepieces/piece-sessions-us": [


### PR DESCRIPTION
# Add Lemlist Piece with Lead Management and Search Actions

## Description
This PR introduces a new Lemlist integration as an Activepieces Piece, enabling automation and lead management within campaigns. It includes the following functionality:

### Triggers
- **New Activity** – fires for each new prospect activity.  
- **Unsubscribed Recipient** – triggers when a recipient unsubscribes.  

### Actions
- Mark Lead From One Campaign as Interested / Not Interested  
- Mark Lead From All Campaigns as Interested / Not Interested  
- Pause / Resume Lead From All or Specific Campaigns  
- Add Lead to a Campaign  
- Remove Lead From a Campaign  
- Remove Lead From Unsubscribe  
- Unsubscribe a Lead  
- Update Lead From Campaign  

### Search Actions
- Search Lead by email and campaign  

This piece follows the Activepieces architecture and allows automations based on Lemlist prospect activity or campaign updates.  

### Reference
[Lemlist API Documentation](https://www.lemlist.com/)

---
/claim #9088
