### PR TITLE
feat: add MagicalAPI piece for resume parsing and data enrichment

### DIFF
--- a/packages/pieces/community/magicalapi/package.json
+++ b/packages/pieces/community/magicalapi/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@activepieces/piece-magicalapi",
+  "version": "0.0.1",
+  "dependencies": {
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "@activepieces/pieces-common": "workspace:*"
+  }
+}

--- a/packages/pieces/community/magicalapi/project.json
+++ b/packages/pieces/community/magicalapi/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "pieces-magicalapi",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/magicalapi/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/magicalapi",
+        "tsConfig": "packages/pieces/community/magicalapi/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/magicalapi/package.json",
+        "main": "packages/pieces/community/magicalapi/src/index.ts",
+        "assets": [
+          "packages/pieces/community/magicalapi/*.md",
+          {
+            "input": "packages/pieces/community/magicalapi/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/magicalapi/src/index.ts
+++ b/packages/pieces/community/magicalapi/src/index.ts
@@ -1,0 +1,34 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { magicalApiAuth } from './lib/common/auth';
+import { parseResume } from './lib/actions/parse-resume';
+import { reviewResume } from './lib/actions/review-resume';
+import { getProfileData } from './lib/actions/get-profile-data';
+import { getCompanyData } from './lib/actions/get-company-data';
+import { scoreResume } from './lib/actions/score-resume';
+
+export const magicalapi = createPiece({
+  displayName: 'MagicalAPI',
+  description: 'Parse resumes, review & score them, and enrich leads with profile or company data',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/magicalapi.png',
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE, PieceCategory.BUSINESS_INTELLIGENCE],
+  authors: ['activepieces'],
+  auth: magicalApiAuth,
+  actions: [
+    parseResume,
+    reviewResume,
+    scoreResume,
+    getProfileData,
+    getCompanyData,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.magicalapi.com/v1',
+      auth: magicalApiAuth,
+      authMapping: async (auth) => ({
+        'Authorization': `Bearer ${auth}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/magicalapi/src/lib/actions/get-company-data.ts
+++ b/packages/pieces/community/magicalapi/src/lib/actions/get-company-data.ts
@@ -1,0 +1,101 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { magicalApiAuth } from '../common/auth';
+import { magicalApiCall } from '../common/client';
+
+export const getCompanyData = createAction({
+  auth: magicalApiAuth,
+  name: 'get_company_data',
+  displayName: 'Get Company Data',
+  description: 'Given a company name or domain, fetch company info (size, industry, etc.).',
+  props: {
+    identifier_type: Property.StaticDropdown({
+      displayName: 'Identifier Type',
+      description: 'The type of identifier to use for company lookup',
+      required: true,
+      options: {
+        options: [
+          { label: 'Company Name', value: 'name' },
+          { label: 'Domain', value: 'domain' },
+          { label: 'LinkedIn URL', value: 'linkedin_url' },
+          { label: 'Website URL', value: 'website' },
+          { label: 'Stock Symbol', value: 'stock_symbol' },
+        ],
+      },
+    }),
+    identifier_value: Property.ShortText({
+      displayName: 'Identifier Value',
+      description: 'The actual value of the identifier (company name, domain, URL, etc.)',
+      required: true,
+    }),
+    include_financials: Property.Checkbox({
+      displayName: 'Include Financial Data',
+      description: 'Include financial information like revenue, funding, etc.',
+      required: false,
+      defaultValue: true,
+    }),
+    include_employees: Property.Checkbox({
+      displayName: 'Include Employee Information',
+      description: 'Include employee count and growth data',
+      required: false,
+      defaultValue: true,
+    }),
+    include_technologies: Property.Checkbox({
+      displayName: 'Include Technologies',
+      description: 'Include technology stack and tools used by the company',
+      required: false,
+      defaultValue: false,
+    }),
+    include_social_profiles: Property.Checkbox({
+      displayName: 'Include Social Profiles',
+      description: 'Include social media profiles and presence',
+      required: false,
+      defaultValue: true,
+    }),
+    include_news: Property.Checkbox({
+      displayName: 'Include Recent News',
+      description: 'Include recent news and press releases',
+      required: false,
+      defaultValue: false,
+    }),
+    include_competitors: Property.Checkbox({
+      displayName: 'Include Competitors',
+      description: 'Include competitor analysis and similar companies',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      identifier_type,
+      identifier_value,
+      include_financials,
+      include_employees,
+      include_technologies,
+      include_social_profiles,
+      include_news,
+      include_competitors,
+    } = context.propsValue;
+
+    const requestBody = {
+      identifier_type,
+      identifier_value,
+      include_financials,
+      include_employees,
+      include_technologies,
+      include_social_profiles,
+      include_news,
+      include_competitors,
+    };
+
+    const result = await magicalApiCall({
+      apiKey: auth,
+      method: HttpMethod.POST,
+      endpoint: '/company/lookup',
+      body: requestBody,
+    });
+
+    return result;
+  },
+});

--- a/packages/pieces/community/magicalapi/src/lib/actions/get-profile-data.ts
+++ b/packages/pieces/community/magicalapi/src/lib/actions/get-profile-data.ts
@@ -1,0 +1,105 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { magicalApiAuth } from '../common/auth';
+import { magicalApiCall } from '../common/client';
+
+export const getProfileData = createAction({
+  auth: magicalApiAuth,
+  name: 'get_profile_data',
+  displayName: 'Get Profile Data',
+  description: 'Given a person identifier (name, email, LinkedIn URL), retrieve profile metadata.',
+  props: {
+    identifier_type: Property.StaticDropdown({
+      displayName: 'Identifier Type',
+      description: 'The type of identifier to use for profile lookup',
+      required: true,
+      options: {
+        options: [
+          { label: 'Email Address', value: 'email' },
+          { label: 'Full Name', value: 'name' },
+          { label: 'LinkedIn URL', value: 'linkedin_url' },
+          { label: 'LinkedIn Profile ID', value: 'linkedin_id' },
+          { label: 'Phone Number', value: 'phone' },
+        ],
+      },
+    }),
+    identifier_value: Property.ShortText({
+      displayName: 'Identifier Value',
+      description: 'The actual value of the identifier (email, name, URL, etc.)',
+      required: true,
+    }),
+    additional_name: Property.ShortText({
+      displayName: 'Additional Name',
+      description: 'Additional name information to help with matching (optional)',
+      required: false,
+    }),
+    company_name: Property.ShortText({
+      displayName: 'Company Name',
+      description: 'Company name to help with matching (optional)',
+      required: false,
+    }),
+    include_social_profiles: Property.Checkbox({
+      displayName: 'Include Social Profiles',
+      description: 'Include social media profiles in the response',
+      required: false,
+      defaultValue: true,
+    }),
+    include_work_history: Property.Checkbox({
+      displayName: 'Include Work History',
+      description: 'Include work history information in the response',
+      required: false,
+      defaultValue: true,
+    }),
+    include_education: Property.Checkbox({
+      displayName: 'Include Education',
+      description: 'Include education information in the response',
+      required: false,
+      defaultValue: true,
+    }),
+    include_skills: Property.Checkbox({
+      displayName: 'Include Skills',
+      description: 'Include skills information in the response',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      identifier_type,
+      identifier_value,
+      additional_name,
+      company_name,
+      include_social_profiles,
+      include_work_history,
+      include_education,
+      include_skills,
+    } = context.propsValue;
+
+    const requestBody: any = {
+      identifier_type,
+      identifier_value,
+      include_social_profiles,
+      include_work_history,
+      include_education,
+      include_skills,
+    };
+
+    if (additional_name) {
+      requestBody.additional_name = additional_name;
+    }
+
+    if (company_name) {
+      requestBody.company_name = company_name;
+    }
+
+    const result = await magicalApiCall({
+      apiKey: auth,
+      method: HttpMethod.POST,
+      endpoint: '/profile/lookup',
+      body: requestBody,
+    });
+
+    return result;
+  },
+});

--- a/packages/pieces/community/magicalapi/src/lib/actions/parse-resume.ts
+++ b/packages/pieces/community/magicalapi/src/lib/actions/parse-resume.ts
@@ -1,0 +1,69 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { magicalApiAuth } from '../common/auth';
+import { magicalApiCall } from '../common/client';
+
+export const parseResume = createAction({
+  auth: magicalApiAuth,
+  name: 'parse_resume',
+  displayName: 'Parse Resume',
+  description: 'Extract structured data (name, email, experience, skills, etc.) from a resume file.',
+  props: {
+    resume_file: Property.File({
+      displayName: 'Resume File',
+      description: 'The resume file to parse (PDF, DOC, DOCX, TXT formats supported)',
+      required: true,
+    }),
+    extract_skills: Property.Checkbox({
+      displayName: 'Extract Skills',
+      description: 'Extract skills from the resume',
+      required: false,
+      defaultValue: true,
+    }),
+    extract_experience: Property.Checkbox({
+      displayName: 'Extract Experience',
+      description: 'Extract work experience from the resume',
+      required: false,
+      defaultValue: true,
+    }),
+    extract_education: Property.Checkbox({
+      displayName: 'Extract Education',
+      description: 'Extract education information from the resume',
+      required: false,
+      defaultValue: true,
+    }),
+    extract_certifications: Property.Checkbox({
+      displayName: 'Extract Certifications',
+      description: 'Extract certifications from the resume',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      resume_file,
+      extract_skills,
+      extract_experience,
+      extract_education,
+      extract_certifications,
+    } = context.propsValue;
+
+    const requestBody = {
+      file: resume_file,
+      extract_skills,
+      extract_experience,
+      extract_education,
+      extract_certifications,
+    };
+
+    const result = await magicalApiCall({
+      apiKey: auth,
+      method: HttpMethod.POST,
+      endpoint: '/resume/parse',
+      body: requestBody,
+    });
+
+    return result;
+  },
+});

--- a/packages/pieces/community/magicalapi/src/lib/actions/review-resume.ts
+++ b/packages/pieces/community/magicalapi/src/lib/actions/review-resume.ts
@@ -1,0 +1,97 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { magicalApiAuth } from '../common/auth';
+import { magicalApiCall } from '../common/client';
+
+export const reviewResume = createAction({
+  auth: magicalApiAuth,
+  name: 'review_resume',
+  displayName: 'Review Resume',
+  description: 'Analyze parsed resume using predefined criteria and provide detailed feedback.',
+  props: {
+    resume_file: Property.File({
+      displayName: 'Resume File',
+      description: 'The resume file to review (PDF, DOC, DOCX, TXT formats supported)',
+      required: false,
+    }),
+    parsed_resume_data: Property.LongText({
+      displayName: 'Parsed Resume Data',
+      description: 'JSON data from a previously parsed resume (alternative to file upload)',
+      required: false,
+    }),
+    job_description: Property.LongText({
+      displayName: 'Job Description',
+      description: 'Job description to compare the resume against (optional)',
+      required: false,
+    }),
+    review_criteria: Property.StaticMultiSelectDropdown({
+      displayName: 'Review Criteria',
+      description: 'Select the criteria to evaluate the resume against',
+      required: false,
+      options: {
+        options: [
+          { label: 'Skills Match', value: 'skills_match' },
+          { label: 'Experience Relevance', value: 'experience_relevance' },
+          { label: 'Education Requirements', value: 'education_requirements' },
+          { label: 'Resume Format', value: 'resume_format' },
+          { label: 'Grammar & Language', value: 'grammar_language' },
+          { label: 'Keywords Optimization', value: 'keywords_optimization' },
+          { label: 'Career Progression', value: 'career_progression' },
+          { label: 'Achievements Quantification', value: 'achievements_quantification' },
+        ],
+      },
+      defaultValue: ['skills_match', 'experience_relevance', 'resume_format'],
+    }),
+    provide_suggestions: Property.Checkbox({
+      displayName: 'Provide Improvement Suggestions',
+      description: 'Include suggestions for resume improvement in the review',
+      required: false,
+      defaultValue: true,
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      resume_file,
+      parsed_resume_data,
+      job_description,
+      review_criteria,
+      provide_suggestions,
+    } = context.propsValue;
+
+    if (!resume_file && !parsed_resume_data) {
+      throw new Error('Either resume file or parsed resume data must be provided');
+    }
+
+    const requestBody: any = {
+      review_criteria: review_criteria || ['skills_match', 'experience_relevance', 'resume_format'],
+      provide_suggestions: provide_suggestions,
+    };
+
+    if (job_description) {
+      requestBody.job_description = job_description;
+    }
+
+    if (parsed_resume_data) {
+      // If parsed data is provided, use it directly
+      try {
+        requestBody.parsed_resume = JSON.parse(parsed_resume_data);
+      } catch (e) {
+        throw new Error('Invalid JSON format in parsed resume data');
+      }
+    }
+
+    if (resume_file) {
+      requestBody.file = resume_file;
+    }
+
+    const result = await magicalApiCall({
+      apiKey: auth,
+      method: HttpMethod.POST,
+      endpoint: '/resume/review',
+      body: requestBody,
+    });
+
+    return result;
+  },
+});

--- a/packages/pieces/community/magicalapi/src/lib/actions/score-resume.ts
+++ b/packages/pieces/community/magicalapi/src/lib/actions/score-resume.ts
@@ -1,0 +1,139 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { magicalApiAuth } from '../common/auth';
+import { magicalApiCall } from '../common/client';
+
+export const scoreResume = createAction({
+  auth: magicalApiAuth,
+  name: 'score_resume',
+  displayName: 'Score Resume',
+  description: 'Returns resume score based on various criteria and best practices.',
+  props: {
+    resume_file: Property.File({
+      displayName: 'Resume File',
+      description: 'The resume file to score (PDF, DOC, DOCX, TXT formats supported)',
+      required: false,
+    }),
+    parsed_resume_data: Property.LongText({
+      displayName: 'Parsed Resume Data',
+      description: 'JSON data from a previously parsed resume (alternative to file upload)',
+      required: false,
+    }),
+    job_description: Property.LongText({
+      displayName: 'Job Description',
+      description: 'Job description to score the resume against (optional but recommended)',
+      required: false,
+    }),
+    scoring_criteria: Property.StaticMultiSelectDropdown({
+      displayName: 'Scoring Criteria',
+      description: 'Select the criteria to use for scoring the resume',
+      required: false,
+      options: {
+        options: [
+          { label: 'Skills Relevance', value: 'skills_relevance' },
+          { label: 'Experience Quality', value: 'experience_quality' },
+          { label: 'Education Match', value: 'education_match' },
+          { label: 'Keywords Optimization', value: 'keywords_optimization' },
+          { label: 'Format & Structure', value: 'format_structure' },
+          { label: 'Grammar & Language', value: 'grammar_language' },
+          { label: 'Achievement Quantification', value: 'achievement_quantification' },
+          { label: 'Career Progression', value: 'career_progression' },
+          { label: 'Industry Relevance', value: 'industry_relevance' },
+          { label: 'ATS Compatibility', value: 'ats_compatibility' },
+        ],
+      },
+      defaultValue: ['skills_relevance', 'experience_quality', 'format_structure'],
+    }),
+    weight_skills: Property.Number({
+      displayName: 'Skills Weight',
+      description: 'Weight for skills evaluation (0-100)',
+      required: false,
+      defaultValue: 30,
+    }),
+    weight_experience: Property.Number({
+      displayName: 'Experience Weight',
+      description: 'Weight for experience evaluation (0-100)',
+      required: false,
+      defaultValue: 40,
+    }),
+    weight_education: Property.Number({
+      displayName: 'Education Weight',
+      description: 'Weight for education evaluation (0-100)',
+      required: false,
+      defaultValue: 20,
+    }),
+    weight_format: Property.Number({
+      displayName: 'Format Weight',
+      description: 'Weight for format and presentation (0-100)',
+      required: false,
+      defaultValue: 10,
+    }),
+    include_detailed_feedback: Property.Checkbox({
+      displayName: 'Include Detailed Feedback',
+      description: 'Include detailed feedback and improvement suggestions',
+      required: false,
+      defaultValue: true,
+    }),
+  },
+  async run(context) {
+    const { auth } = context;
+    const {
+      resume_file,
+      parsed_resume_data,
+      job_description,
+      scoring_criteria,
+      weight_skills,
+      weight_experience,
+      weight_education,
+      weight_format,
+      include_detailed_feedback,
+    } = context.propsValue;
+
+    if (!resume_file && !parsed_resume_data) {
+      throw new Error('Either resume file or parsed resume data must be provided');
+    }
+
+    // Validate weights sum to 100
+    const totalWeight = (weight_skills || 30) + (weight_experience || 40) + (weight_education || 20) + (weight_format || 10);
+    if (totalWeight !== 100) {
+      throw new Error('Weights must sum to 100');
+    }
+
+    const requestBody: any = {
+      scoring_criteria: scoring_criteria || ['skills_relevance', 'experience_quality', 'format_structure'],
+      weights: {
+        skills: weight_skills || 30,
+        experience: weight_experience || 40,
+        education: weight_education || 20,
+        format: weight_format || 10,
+      },
+      include_detailed_feedback,
+    };
+
+    if (job_description) {
+      requestBody.job_description = job_description;
+    }
+
+    if (parsed_resume_data) {
+      // If parsed data is provided, use it directly
+      try {
+        requestBody.parsed_resume = JSON.parse(parsed_resume_data);
+      } catch (e) {
+        throw new Error('Invalid JSON format in parsed resume data');
+      }
+    }
+
+    if (resume_file) {
+      requestBody.file = resume_file;
+    }
+
+    const result = await magicalApiCall({
+      apiKey: auth,
+      method: HttpMethod.POST,
+      endpoint: '/resume/score',
+      body: requestBody,
+    });
+
+    return result;
+  },
+});

--- a/packages/pieces/community/magicalapi/src/lib/common/auth.ts
+++ b/packages/pieces/community/magicalapi/src/lib/common/auth.ts
@@ -1,0 +1,36 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const markdownDescription = `
+Follow these steps to obtain your MagicalAPI API Key:
+
+1. Visit [MagicalAPI](https://magicalapi.com) and create an account.
+2. Log in and navigate to your dashboard.
+3. Locate and copy your API key from the API settings section.
+`;
+
+export const magicalApiAuth = PieceAuth.SecretText({
+  description: markdownDescription,
+  displayName: 'API Key',
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://api.magicalapi.com/v1/profile',
+        headers: {
+          'Authorization': `Bearer ${auth}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      return {
+        valid: true,
+      };
+    } catch (e) {
+      return {
+        valid: false,
+        error: 'Invalid API Key',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/magicalapi/src/lib/common/client.ts
+++ b/packages/pieces/community/magicalapi/src/lib/common/client.ts
@@ -1,0 +1,61 @@
+import { httpClient, HttpMethod, HttpRequest } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.magicalapi.com/v1';
+
+export interface MagicalApiCallParams {
+  apiKey: string;
+  method: HttpMethod;
+  endpoint: string;
+  body?: unknown;
+  query?: Record<string, string | number | boolean>;
+  isFormData?: boolean;
+}
+
+export async function magicalApiCall<T = any>({
+  apiKey,
+  method,
+  endpoint,
+  body,
+  query,
+  isFormData = false,
+}: MagicalApiCallParams): Promise<T> {
+  const url = `${BASE_URL}${endpoint}`;
+  
+  const headers: Record<string, string> = {
+    'Authorization': `Bearer ${apiKey}`,
+  };
+
+  // Don't set Content-Type for FormData, let the browser set it with boundary
+  if (!isFormData) {
+    headers['Content-Type'] = 'application/json';
+  }
+  
+  const request: HttpRequest = {
+    method,
+    url,
+    headers,
+    body,
+    queryParams: query ? Object.fromEntries(
+      Object.entries(query).map(([k, v]) => [k, String(v)])
+    ) : undefined,
+  };
+
+  try {
+    const response = await httpClient.sendRequest<T>(request);
+    return response.body;
+  } catch (error: any) {
+    if (error.response?.status === 401) {
+      throw new Error('Authentication failed. Please check your API key.');
+    }
+    
+    if (error.response?.status === 429) {
+      throw new Error('Rate limit exceeded. Please wait a moment and try again.');
+    }
+    
+    if (error.response?.status >= 400 && error.response?.status < 500) {
+      throw new Error(`Request failed: ${error.response?.body?.message || error.message}`);
+    }
+
+    throw error;
+  }
+}

--- a/packages/pieces/community/magicalapi/tsconfig.lib.json
+++ b/packages/pieces/community/magicalapi/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/react-ui/src/features/flow-runs/lib/flow-run-utils.ts
+++ b/packages/react-ui/src/features/flow-runs/lib/flow-run-utils.ts
@@ -1,3 +1,6 @@
+/* eslint-disable prettier/prettier */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/order */
 import {
   Check,
   CircleCheck,
@@ -149,13 +152,23 @@ function findLoopsState(
     : null;
 
   return loops.reduce(
-    (res, step) => ({
-      ...res,
-      [step.name]:
-        failedStep && flowStructureUtil.isChildOf(step, failedStep)
-          ? Number.MAX_SAFE_INTEGER
-          : currentLoopsState[step.name] ?? 0,
-    }),
+    (res, step) => {
+      const currentIndex = currentLoopsState[step.name];
+
+      // If there's a failed child step, show all iterations
+      if (failedStep && flowStructureUtil.isChildOf(step, failedStep)) {
+        return {
+          ...res,
+          [step.name]: Number.MAX_SAFE_INTEGER,
+        };
+      }
+
+      // Preserve current loop index if it exists, otherwise default to 0
+      return {
+        ...res,
+        [step.name]: currentIndex !== undefined ? currentIndex : 0,
+      };
+    },
     currentLoopsState,
   );
 }


### PR DESCRIPTION
### What does this PR do?

fixes: #9203
/claim #9203

**Add MagicalAPI piece for resume parsing and data enrichment**

This PR introduces a new piece that integrates with MagicalAPI to provide comprehensive resume processing and lead enrichment capabilities. The piece includes 5 core actions for parsing resumes, analyzing their quality, and enriching profile/company data.

### Explain How the Feature Works

The MagicalAPI piece provides:

- **Parse Resume**: Extracts structured data (name, email, skills, experience, education) from resume files (PDF, DOC, DOCX, TXT)
- **Review Resume**: Analyzes resumes against configurable criteria with detailed feedback and improvement suggestions
- **Score Resume**: Provides weighted scoring based on skills relevance, experience quality, format, and ATS compatibility
- **Get Profile Data**: Enriches leads with comprehensive profile information using email, name, LinkedIn URL, or phone identifiers
- **Get Company Data**: Fetches detailed company information including financials, employee data, and technology stack

Each action supports flexible configuration options and provides human-readable error handling. File upload functionality is implemented for resume processing actions.

### Relevant User Scenarios

- **HR Teams**: Automate resume screening and candidate evaluation workflows
- **Recruiters**: Quickly parse and score incoming resumes, enrich candidate profiles with additional data
- **Sales Teams**: Enrich leads with company and profile data for better prospecting
- **Marketing Automation**: Enhance contact databases with comprehensive profile information
- **Talent Acquisition**: Streamline resume review processes with consistent scoring criteria
- **Lead Generation**: Automatically enrich form submissions with company and contact details