### PR TITLE
fix(jire): new issue trigger 

### DIFF
--- a/packages/pieces/community/jira-cloud/package.json
+++ b/packages/pieces/community/jira-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jira-cloud",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "dependencies": {
     "@atlaskit/adf-schema": "50.4.0",
     "@atlaskit/editor-json-transformer": "8.27.2",

--- a/packages/pieces/community/jira-cloud/src/lib/common/index.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/common/index.ts
@@ -134,10 +134,10 @@ export async function searchIssuesByJql({
 	maxResults: number;
 	sanitizeJql: boolean;
 }) {
-	return (
+	const respJql = (
 		(await executeJql({
 			auth,
-			url: 'search',
+			url: 'search/jql',
 			method: HttpMethod.POST,
 			jql,
 			body: {
@@ -146,6 +146,22 @@ export async function searchIssuesByJql({
 			sanitizeJql,
 		})) as { issues: any[] }
 	).issues;
+
+	const issueIds = respJql.map(issue => issue['id']);
+	if (issueIds.length === 0) {
+		return [];
+	}
+
+	return (
+    (await sendJiraRequest({
+      auth,
+      url: 'issue/bulkfetch',
+      method: HttpMethod.POST,
+      body: {
+        issueIdsOrKeys: issueIds,
+      },
+    })).body as any as { issues: any[] }
+  ).issues;
 }
 
 export async function createJiraIssue(data: CreateIssueParams) {


### PR DESCRIPTION
## What does this PR do?

`POST /rest/api/3/search` has been deprecated and the endpoint is now removed, resulting in ALL triggers and the Search Issues action to fail.
https://developer.atlassian.com/changelog/#CHANGE-2046

<img width="874" height="501" alt="Screenshot 2025-09-15 at 8 07 34 PM" src="https://github.com/user-attachments/assets/d8a70166-a57e-4fed-a4ad-0def37f39f50" />

This follows the migration docs to migrate to `POST /rest/api/3/search/jql`. This just returns a list of issue ids which then needs `POST /rest/api/3/issue/bulkfetch` to retrieve the issue details.

https://community.atlassian.com/forums/Jira-articles/Avoiding-Pitfalls-A-Guide-to-Smooth-Migration-to-Enhanced-JQL/ba-p/2985433

## Notes
- The outputs should be backwards compatible
- The behaviour might be different now and not be able to find issues immediately after writing. The provided solution of [Search and Reconcile](https://developer.atlassian.com/cloud/jira/platform/search-and-reconcile/) might not always be possible. For polling triggers it should be fine since there's no expectation to be real time.
> The endpoint doesn’t provide immediate search after write consistency. Search results may not incorporate recent changes made by users. If this behaviour is important for your case, please refer to the migration path at the end of this page. The delay for updates to be visible in search is dependent on various factors. The majority of modifications are typically visible within seconds. However, operations that impact numerous issues, such as lexorank rebalancing or bulk editing, may require more time to complete.

## Screenshots

<img width="824" height="584" alt="Screenshot 2025-09-15 at 8 04 52 PM" src="https://github.com/user-attachments/assets/4e4fa03d-ca73-4c34-99b2-4666e65f1f0d" />

<img width="823" height="581" alt="Screenshot 2025-09-15 at 8 04 11 PM" src="https://github.com/user-attachments/assets/90c0d7be-1b80-4a9a-9b30-a7327299f7e1" />

<img width="824" height="597" alt="Screenshot 2025-09-15 at 8 05 19 PM" src="https://github.com/user-attachments/assets/31a8c8fb-4579-42c6-a9ae-fe42042c61aa" />

<img width="831" height="620" alt="Screenshot 2025-09-15 at 8 06 01 PM" src="https://github.com/user-attachments/assets/62804ca4-bb6f-4339-afa1-12f98b6f8b7d" />
