### PR TITLE
fix(hubspot): Avoid triggering on non-stage related changes

### DIFF
--- a/packages/pieces/community/hubspot/package.json
+++ b/packages/pieces/community/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-hubspot",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "dependencies": {
     "@hubspot/api-client": "12.0.1"
   }

--- a/packages/pieces/community/hubspot/src/lib/triggers/deal-stage-updated.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/deal-stage-updated.ts
@@ -61,6 +61,11 @@ const polling: Polling<PiecePropValueSchema<typeof hubspotAuth>, Props> = {
 								operator: FilterOperatorEnum.Eq,
 								value: propsValue.stageId,
 							},
+							{
+								propertyName: 'hs_v2_date_entered_current_stage',
+								operator: FilterOperatorEnum.Gt,
+								value: lastFetchEpochMS.toString(),
+							},
 						],
 					},
 				],

--- a/packages/pieces/community/hubspot/src/lib/triggers/deal-stage-updated.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/deal-stage-updated.ts
@@ -35,7 +35,8 @@ const polling: Polling<PiecePropValueSchema<typeof hubspotAuth>, Props> = {
 
 		const additionalProperties = propsValue.additionalPropertiesToRetrieve ?? [];
 		const defaultDealProperties = getDefaultPropertiesForObject(OBJECT_TYPE.DEAL);
-		const propertiesToRetrieve = [...defaultDealProperties, ...additionalProperties];
+		const triggerProperties = ['hs_v2_date_entered_current_stage'];
+		const propertiesToRetrieve = [...defaultDealProperties, ...additionalProperties, ...triggerProperties];
 
 		const items = [];
 		let after;
@@ -45,7 +46,7 @@ const polling: Polling<PiecePropValueSchema<typeof hubspotAuth>, Props> = {
 			const response = await client.crm.deals.searchApi.doSearch({
 				limit: isTest ? 10 : 100,
 				properties: propertiesToRetrieve,
-				sorts: ['-hs_lastmodifieddate'],
+				sorts: ['-hs_v2_date_entered_current_stage'],
 				after,
 				filterGroups: [
 					{
@@ -72,7 +73,7 @@ const polling: Polling<PiecePropValueSchema<typeof hubspotAuth>, Props> = {
 		} while (after);
 
 		return items.map((item) => ({
-			epochMilliSeconds: dayjs(item.properties['hs_lastmodifieddate']).valueOf(),
+			epochMilliSeconds: dayjs(item.properties['hs_v2_date_entered_current_stage']).valueOf(),
 			data: item,
 		}));
 	},
@@ -98,7 +99,7 @@ export const dealStageUpdatedTrigger = createTrigger({
 			variant: MarkdownVariant.INFO,
 			value: `### Properties to retrieve:
 																
-							dealtype, dealname, amount, description, closedate, createdate, num_associated_contacts, hs_forecast_amount, hs_forecast_probability, hs_manual_forecast_category, hs_next_step, hs_object_id, hs_lastmodifieddate, hubspot_owner_id, hubspot_team_id
+							dealtype, dealname, amount, description, closedate, createdate, num_associated_contacts, hs_forecast_amount, hs_forecast_probability, hs_manual_forecast_category, hs_next_step, hs_object_id, hs_lastmodifieddate, hubspot_owner_id, hubspot_team_id, hs_v2_date_entered_current_stage
 									
 							**Specify here a list of additional properties to retrieve**`,
 		}),
@@ -140,6 +141,7 @@ export const dealStageUpdatedTrigger = createTrigger({
 			hs_lastmodifieddate: '2024-03-13T11:29:16.078Z',
 			hs_object_id: '18011922225',
 			pipeline: 'default',
+			hs_v2_date_entered_current_stage: '2024-03-13T11:29:16.078Z',
 		},
 		createdAt: '2024-03-13T11:28:40.586Z',
 		updatedAt: '2024-03-13T11:29:16.078Z',


### PR DESCRIPTION
## What does this PR do?

Currently the `Updated Deal Stage` trigger doesn't work the way as described
> Triggers when a deal enters a specified stage.

This triggers when **any properties are updated** while the deal is in the specified stage. The technical cause is because `hs_lastmodifieddate` is used for deduplication, and that value updates when any properties are updated.

The correct field to use is `hs_v2_date_entered_current_stage`. Note that this is only available for `Professional and Enterprise only`, but otherwise this trigger would not be able to work as intended anyway.
- https://knowledge.hubspot.com/properties/stage-calculated-properties#understand-stage-calculated-properties
- https://knowledge.hubspot.com/properties/hubspots-default-deal-properties?hubs_content=knowledge.hubspot.com/properties/stage-calculated-properties&hubs_content-cta=default-deal-properties#:~:text=Deal%20Stage%20Properties%20(Professional%20and%20Enterprise%20only)

This is added on as an additional property just for this trigger without adding to default deal properties because it's not that useful in other scenarios.

### Misc

- Add date filter condition to prevent overfetching and unnecessarily using up API quota. Similar approach to [other triggers](https://github.com/activepieces/activepieces/blob/cf678312900bf1518b5814228104b630202a1680/packages/pieces/community/hubspot/src/lib/triggers/new-deal-property-change.ts#L57-L61).