### PR TITLE
fix(youtube): New Video In Channel" always returns old test data

### DIFF
--- a/packages/pieces/community/youtube/src/lib/triggers/new-video.trigger.ts
+++ b/packages/pieces/community/youtube/src/lib/triggers/new-video.trigger.ts
@@ -333,7 +333,7 @@ function getRssItems(channelId: string): Promise<any[]> {
         });
 
         feedparser.on('end', () => {
-          resolve(items);
+          resolve(items.reverse());
         });
 
         feedparser.on('error', (error: any) => {


### PR DESCRIPTION
## What does this PR do?

This PR fixes the YouTube piece so that it shows the newest video items from the rss feed first. This is important for example when pressing "Load Sample Data". For more information regarding the current bug you can refer to #9197.

I tested this fix successfully in the dev environment. However I'm not 100% sure how this will affect [this](https://github.com/activepieces/activepieces/blob/88bba8e814b47a5700dbc7cf67d05d04fb9b7a94/packages/pieces/community/youtube/src/lib/triggers/new-video.trigger.ts#L276-L277) part of the code:

```js
await store.put('lastFetchedYoutubeVideo', items?.[0]?.guid);
await store.put('lastUpdatedYoutubeVideo', getUpdateDate(items?.[0]));
```

In theory it should be fine because with my fix the piece definitely uses the newest video as lastFetched.

Fixes # (issue)
#9197 