### PR TITLE
fix: handshake timing issue

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1758108135968-DeleteHandshakeFromTriggerSource.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1758108135968-DeleteHandshakeFromTriggerSource.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class DeleteHandshakeFromTriggerSource1758108135968 implements MigrationInterface {
+    name = 'DeleteHandshakeFromTriggerSource1758108135968'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "trigger_source" DROP COLUMN "handshakeConfiguration"
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "trigger_source"
+            ADD "handshakeConfiguration" jsonb
+        `)
+    }
+
+}

--- a/packages/server/api/src/app/database/migration/sqlite/1758108281602-DeleteHandshakeFromTriggerSourceSqlite.ts
+++ b/packages/server/api/src/app/database/migration/sqlite/1758108281602-DeleteHandshakeFromTriggerSourceSqlite.ts
@@ -1,0 +1,179 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class DeleteHandshakeFromTriggerSourceSqlite1758108281602 implements MigrationInterface {
+    name = 'DeleteHandshakeFromTriggerSourceSqlite1758108281602'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX "idx_trigger_project_id"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_trigger_flow_id"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_trigger_project_id_flow_id_simulate"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_trigger_flow_id_simulate"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "temporary_trigger_source" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "deleted" datetime,
+                "flowId" varchar NOT NULL,
+                "flowVersionId" varchar NOT NULL,
+                "projectId" varchar NOT NULL,
+                "type" varchar NOT NULL,
+                "schedule" text,
+                "pieceName" varchar NOT NULL,
+                "pieceVersion" varchar NOT NULL,
+                "simulate" boolean NOT NULL,
+                "triggerName" varchar NOT NULL,
+                CONSTRAINT "FK_3d3024c914f2fbf4f9e25029816" FOREIGN KEY ("flowId") REFERENCES "flow" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+                CONSTRAINT "FK_5f28d74a4fdaf3fc91e6a0e7450" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "temporary_trigger_source"(
+                    "id",
+                    "created",
+                    "updated",
+                    "deleted",
+                    "flowId",
+                    "flowVersionId",
+                    "projectId",
+                    "type",
+                    "schedule",
+                    "pieceName",
+                    "pieceVersion",
+                    "simulate",
+                    "triggerName"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "deleted",
+                "flowId",
+                "flowVersionId",
+                "projectId",
+                "type",
+                "schedule",
+                "pieceName",
+                "pieceVersion",
+                "simulate",
+                "triggerName"
+            FROM "trigger_source"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "trigger_source"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "temporary_trigger_source"
+                RENAME TO "trigger_source"
+        `)
+        await queryRunner.query(`
+            CREATE INDEX "idx_trigger_project_id" ON "trigger_source" ("projectId")
+        `)
+        await queryRunner.query(`
+            CREATE INDEX "idx_trigger_flow_id" ON "trigger_source" ("flowId")
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_trigger_project_id_flow_id_simulate" ON "trigger_source" ("projectId", "flowId", "simulate")
+            WHERE deleted IS NULL
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_trigger_flow_id_simulate" ON "trigger_source" ("flowId", "simulate")
+            WHERE deleted IS NULL
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX "idx_trigger_flow_id_simulate"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_trigger_project_id_flow_id_simulate"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_trigger_flow_id"
+        `)
+        await queryRunner.query(`
+            DROP INDEX "idx_trigger_project_id"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "trigger_source"
+                RENAME TO "temporary_trigger_source"
+        `)
+        await queryRunner.query(`
+            CREATE TABLE "trigger_source" (
+                "id" varchar(21) PRIMARY KEY NOT NULL,
+                "created" datetime NOT NULL DEFAULT (datetime('now')),
+                "updated" datetime NOT NULL DEFAULT (datetime('now')),
+                "deleted" datetime,
+                "flowId" varchar NOT NULL,
+                "flowVersionId" varchar NOT NULL,
+                "handshakeConfiguration" text,
+                "projectId" varchar NOT NULL,
+                "type" varchar NOT NULL,
+                "schedule" text,
+                "pieceName" varchar NOT NULL,
+                "pieceVersion" varchar NOT NULL,
+                "simulate" boolean NOT NULL,
+                "triggerName" varchar NOT NULL,
+                CONSTRAINT "FK_3d3024c914f2fbf4f9e25029816" FOREIGN KEY ("flowId") REFERENCES "flow" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+                CONSTRAINT "FK_5f28d74a4fdaf3fc91e6a0e7450" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `)
+        await queryRunner.query(`
+            INSERT INTO "trigger_source"(
+                    "id",
+                    "created",
+                    "updated",
+                    "deleted",
+                    "flowId",
+                    "flowVersionId",
+                    "projectId",
+                    "type",
+                    "schedule",
+                    "pieceName",
+                    "pieceVersion",
+                    "simulate",
+                    "triggerName"
+                )
+            SELECT "id",
+                "created",
+                "updated",
+                "deleted",
+                "flowId",
+                "flowVersionId",
+                "projectId",
+                "type",
+                "schedule",
+                "pieceName",
+                "pieceVersion",
+                "simulate",
+                "triggerName"
+            FROM "temporary_trigger_source"
+        `)
+        await queryRunner.query(`
+            DROP TABLE "temporary_trigger_source"
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_trigger_flow_id_simulate" ON "trigger_source" ("flowId", "simulate")
+            WHERE deleted IS NULL
+        `)
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_trigger_project_id_flow_id_simulate" ON "trigger_source" ("projectId", "flowId", "simulate")
+            WHERE deleted IS NULL
+        `)
+        await queryRunner.query(`
+            CREATE INDEX "idx_trigger_flow_id" ON "trigger_source" ("flowId")
+        `)
+        await queryRunner.query(`
+            CREATE INDEX "idx_trigger_project_id" ON "trigger_source" ("projectId")
+        `)
+    }
+
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -268,6 +268,7 @@ import { RemoveAgentTestPrompt1754863565929 } from './migration/postgres/1754863
 import { RemoveAgentRelationToTables1755954192258 } from './migration/postgres/1755954192258-RemoveAgentRelationToTables'
 import { AddTriggerNameToTriggerSource1757018269905 } from './migration/postgres/1757018269905-AddTriggerNameToTriggerSource'
 import { AddIndexOnTriggerRun1757557714045 } from './migration/postgres/1757557714045-AddIndexOnTriggerRun'
+import { DeleteHandshakeFromTriggerSource1758108135968 } from './migration/postgres/1758108135968-DeleteHandshakeFromTriggerSource'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -457,6 +458,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
         AddTriggerNameToTriggerSource1757018269905,
         AddFlowIndexToTriggerSource1757555419075,
         AddIndexOnTriggerRun1757557714045,
+        DeleteHandshakeFromTriggerSource1758108135968,
     ]
 
     const edition = system.getEdition()

--- a/packages/server/api/src/app/database/sqlite-connection.ts
+++ b/packages/server/api/src/app/database/sqlite-connection.ts
@@ -147,6 +147,7 @@ import { RemoveAgentTestPromptSqlite1754863757450 } from './migration/sqlite/175
 import { RemoveAgentRelationToTablesSqlite1755954639833 } from './migration/sqlite/1755954639833-RemoveAgentRelationToTablesSqlite'
 import { AddTriggerNameToTriggerSourceSqlite1757018637559 } from './migration/sqlite/1757018637559-AddTriggerNameToTriggerSourceSqlite'
 import { AddIndexOnTriggerRunSqlite1757560231246 } from './migration/sqlite/1757560231246-AddIndexOnTriggerRunSqlite'
+import { DeleteHandshakeFromTriggerSourceSqlite1758108281602 } from './migration/sqlite/1758108281602-DeleteHandshakeFromTriggerSourceSqlite'
 
 const getSqliteDatabaseFilePath = (): string => {
     const apConfigDirectoryPath = system.getOrThrow(AppSystemProp.CONFIG_PATH)
@@ -310,6 +311,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
         AddTriggerNameToTriggerSourceSqlite1757018637559,
         AddFlowIndexToTriggerSource1757555419075,
         AddIndexOnTriggerRunSqlite1757560231246,
+        DeleteHandshakeFromTriggerSourceSqlite1758108281602,
     ]
     const edition = system.getEdition()
     if (edition !== ApEdition.COMMUNITY) {

--- a/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
@@ -18,7 +18,6 @@ import {
     ScheduleOptions,
     TriggerHookType,
     TriggerSourceScheduleType,
-    WebhookHandshakeConfiguration,
     WorkerJobType,
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
@@ -41,7 +40,6 @@ export const flowTriggerSideEffect = (log: FastifyBaseLogger) => {
             if (environment === ApEnvironment.TESTING) {
                 return {
                     scheduleOptions: undefined,
-                    webhookHandshakeConfiguration: undefined,
                 }
             }
             const { flowVersion, projectId, simulate, pieceTrigger } = params
@@ -135,7 +133,6 @@ async function handleAppWebhookTrigger({ engineHelperResponse, flowVersion, proj
     }
     return {
         scheduleOptions: undefined,
-        webhookHandshakeConfiguration: undefined,
     }
 }
 
@@ -168,7 +165,6 @@ async function handleWebhookTrigger({ flowVersion, projectId, pieceTrigger, log 
     }
     return {
         scheduleOptions: undefined,
-        webhookHandshakeConfiguration: pieceTrigger.handshakeConfiguration,
     }
 }
 
@@ -199,7 +195,6 @@ async function handlePollingTrigger({ engineHelperResponse, flowVersion, project
     })
     return {
         scheduleOptions: engineHelperResponse.result.scheduleOptions,
-        webhookHandshakeConfiguration: undefined,
     }
 }
 
@@ -237,5 +232,4 @@ type ActiveTriggerParams = EnableFlowTriggerParams & {
 
 type ActiveTriggerReturn = {
     scheduleOptions?: ScheduleOptions
-    webhookHandshakeConfiguration?: WebhookHandshakeConfiguration
 }

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-source-entity.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-source-entity.ts
@@ -28,10 +28,6 @@ export const TriggerSourceEntity = new EntitySchema<TriggerSourceSchema>({
             type: String,
             nullable: false,
         },
-        handshakeConfiguration: {
-            type: JSONB_COLUMN_TYPE,
-            nullable: true,
-        },
         projectId: {
             type: String,
             nullable: false,

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
@@ -14,7 +14,7 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
             const { flowVersion, projectId, simulate } = params
             const pieceTrigger = await triggerUtils(log).getPieceTriggerOrThrow({ flowVersion, projectId })
 
-            const { scheduleOptions, webhookHandshakeConfiguration } = await flowTriggerSideEffect(log).enable({
+            const { scheduleOptions } = await flowTriggerSideEffect(log).enable({
                 flowVersion,
                 projectId,
                 pieceName: flowVersion.trigger.settings.pieceName,
@@ -37,7 +37,6 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
                 flowVersionId: flowVersion.id,
                 pieceName: flowVersion.trigger.settings.pieceName,
                 pieceVersion: flowVersion.trigger.settings.pieceVersion,
-                handshakeConfiguration: webhookHandshakeConfiguration,
                 schedule: scheduleOptions,
                 simulate,
             }

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-utils.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-utils.ts
@@ -35,20 +35,39 @@ export const triggerUtils = (log: FastifyBaseLogger) => ({
         if (flowVersion.trigger.type !== FlowTriggerType.PIECE) {
             return null
         }
+        const { pieceName, pieceVersion, triggerName } = flowVersion.trigger.settings
+        if (isNil(triggerName)) {
+            return null
+        }
+        return this.getPieceTriggerByName({
+            pieceName,
+            pieceVersion,
+            triggerName,
+            projectId,
+        })
+    },
+    async getPieceTriggerByName({ pieceName, pieceVersion, triggerName, projectId }: GetPieceTriggerByNameParams): Promise<TriggerBase | null> {
         const platformId = await projectService.getPlatformId(projectId)
         const piece = await pieceMetadataService(log).get({
             projectId,
             platformId,
-            name: flowVersion.trigger.settings.pieceName,
-            version: flowVersion.trigger.settings.pieceVersion,
+            name: pieceName,
+            version: pieceVersion,
         })
-        if (isNil(piece) || isNil(flowVersion.trigger.settings.triggerName)) {
+        if (isNil(piece) || isNil(triggerName)) {
             return null
         }
-        const pieceTrigger = piece.triggers[flowVersion.trigger.settings.triggerName]
+        const pieceTrigger = piece.triggers[triggerName]
         return pieceTrigger
     },
 })
+
+type GetPieceTriggerByNameParams = {
+    pieceName: string
+    pieceVersion: string
+    triggerName: string
+    projectId: ProjectId
+}
 
 type GetPieceTriggerOrThrowParams = {
     flowVersion: FlowVersion

--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -49,15 +49,15 @@ export const webhookService = {
             })
         }
 
-        const trigger = await triggerSourceService(pinoLogger).getByFlowId({
+        const triggerSource = await triggerSourceService(pinoLogger).getByFlowId({
             flowId: flow.id,
             projectId: flow.projectId,
             simulate: saveSampleData,
         })
-        const response = await handshakeHandler.handleHandshakeRequest({
+
+        const response = await handshakeHandler(pinoLogger).handleHandshakeRequest({
             payload: (payload ?? await data(flow.projectId)) as TriggerPayload,
-            handshakeConfiguration: trigger?.handshakeConfiguration ?? null,
-            log: pinoLogger,
+            handshakeConfiguration: await handshakeHandler(pinoLogger).getWebhookHandshakeConfiguration(triggerSource),
             flowId: flow.id,
             flowVersionId: flowVersionIdToRun,
             projectId: flow.projectId,

--- a/packages/shared/src/lib/trigger/index.ts
+++ b/packages/shared/src/lib/trigger/index.ts
@@ -38,7 +38,6 @@ export const TriggerSource = Type.Object({
     projectId: Type.String(),
     flowId: Type.String(),
     triggerName: Type.String(),
-    handshakeConfiguration: Nullable(WebhookHandshakeConfiguration),
     schedule: Nullable(ScheduleOptions),
     flowVersionId: Type.String(),
     pieceName: Type.String(),


### PR DESCRIPTION

The bug happens because `onEnable` in the trigger is called first, and only afterward we extract the handshake information and save it in `trigger_source`. However, right after `onEnable` runs, the third-party system calls Activepieces while `trigger_source` hasn’t been created yet, which prevents it from responding correctly to the handshake.

The goal is to de-normalize and fetch the handshake configuration directly from the webhook handler.

