### PR TITLE
feat: whatconverts piece

### DIFF
--- a/packages/pieces/community/whatconverts/.eslintrc.json
+++ b/packages/pieces/community/whatconverts/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/whatconverts/README.md
+++ b/packages/pieces/community/whatconverts/README.md
@@ -1,0 +1,7 @@
+# pieces-whatconverts
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-whatconverts` to build the library.

--- a/packages/pieces/community/whatconverts/package.json
+++ b/packages/pieces/community/whatconverts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-whatconverts",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/whatconverts/project.json
+++ b/packages/pieces/community/whatconverts/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-whatconverts",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/whatconverts/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/whatconverts",
+        "tsConfig": "packages/pieces/community/whatconverts/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/whatconverts/package.json",
+        "main": "packages/pieces/community/whatconverts/src/index.ts",
+        "assets": [
+          "packages/pieces/community/whatconverts/*.md",
+          {
+            "input": "packages/pieces/community/whatconverts/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/whatconverts/src/index.ts
+++ b/packages/pieces/community/whatconverts/src/index.ts
@@ -1,0 +1,39 @@
+
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { whatconvertsAuth } from './lib/common/auth';
+import { createLead } from './lib/actions/create-lead';
+import { updateLead } from './lib/actions/update-lead';
+import { createExport } from './lib/actions/create-export';
+import { findLead } from './lib/actions/find-lead';
+import { newLead } from './lib/triggers/new-lead';
+import { updatedLead } from './lib/triggers/updated-lead';
+
+export const whatconverts = createPiece({
+    displayName: 'WhatConverts',
+    description: 'Lead tracking and analytics platform that captures leads from phone calls, forms, chats, text messages, eCommerce transactions, etc. Create, update, export, and search for leads.',
+    minimumSupportedRelease: '0.36.1',
+    logoUrl: 'https://cdn.activepieces.com/pieces/whatconverts.png',
+    categories: [PieceCategory.SALES_AND_CRM, PieceCategory.MARKETING, PieceCategory.BUSINESS_INTELLIGENCE],
+    authors: [],
+    auth: whatconvertsAuth,
+    actions: [
+        createLead,
+        updateLead,
+        createExport,
+        findLead,
+        createCustomApiCallAction({
+            baseUrl: () => 'https://app.whatconverts.com/api/v1',
+            auth: whatconvertsAuth,
+            authMapping: async (auth: any) => ({
+                Authorization: `Basic ${Buffer.from(`${auth.api_key}`).toString('base64')}`,
+            }),
+        }),
+    ],
+    triggers: [
+        newLead,
+        updatedLead,
+    ],
+});
+    

--- a/packages/pieces/community/whatconverts/src/lib/actions/create-export.ts
+++ b/packages/pieces/community/whatconverts/src/lib/actions/create-export.ts
@@ -1,0 +1,150 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatconvertsAuth } from '../common/auth';
+import { whatconvertsCommon } from '../common/client';
+
+export const createExport = createAction({
+    name: 'create_export',
+    displayName: 'Create Export',
+    description: 'Create a new leads export with filtering and formatting options.',
+    auth: whatconvertsAuth,
+    props: {
+        export_name: Property.ShortText({
+            displayName: 'Export Name',
+            description: 'Optional name for the export',
+            required: false,
+        }),
+        start_date: Property.ShortText({
+            displayName: 'Start Date',
+            description: 'Start date for export (YYYY-MM-DD or ISO 8601 format)',
+            required: false,
+        }),
+        end_date: Property.ShortText({
+            displayName: 'End Date',
+            description: 'End date for export (YYYY-MM-DD or ISO 8601 format)',
+            required: false,
+        }),
+        lead_types: Property.MultiSelectDropdown({
+            displayName: 'Lead Types',
+            description: 'Filter export by specific lead types',
+            required: false,
+            refreshers: [],
+            options: async () => ({
+                options: [
+                    { label: 'Phone Call', value: 'phone_call' },
+                    { label: 'Web Form', value: 'web_form' },
+                    { label: 'Chat', value: 'chat' },
+                    { label: 'Text Message', value: 'text_message' },
+                    { label: 'Email', value: 'email' },
+                    { label: 'Appointment', value: 'appointment' },
+                    { label: 'Event', value: 'event' },
+                    { label: 'Transaction', value: 'transaction' },
+                    { label: 'Other', value: 'other' }
+                ]
+            })
+        }),
+        lead_status: Property.StaticDropdown({
+            displayName: 'Lead Status',
+            description: 'Filter by lead status',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Unique', value: 'unique' },
+                    { label: 'Repeat', value: 'repeat' }
+                ]
+            }
+        }),
+        quotable: Property.StaticDropdown({
+            displayName: 'Quotable',
+            description: 'Filter by quotable status',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Yes', value: 'yes' },
+                    { label: 'No', value: 'no' },
+                    { label: 'Pending', value: 'pending' },
+                    { label: 'Not Set', value: 'not_set' }
+                ]
+            }
+        }),
+        format: Property.StaticDropdown({
+            displayName: 'Export Format',
+            description: 'Format for the exported data',
+            required: false,
+            options: {
+                options: [
+                    { label: 'CSV', value: 'csv' },
+                    { label: 'Excel (XLSX)', value: 'xlsx' },
+                    { label: 'JSON', value: 'json' },
+                    { label: 'XML', value: 'xml' }
+                ]
+            }
+        }),
+        include_custom_fields: Property.Checkbox({
+            displayName: 'Include Custom Fields',
+            description: 'Include custom/additional fields in the export',
+            required: false,
+            defaultValue: true,
+        }),
+        include_attribution: Property.Checkbox({
+            displayName: 'Include Attribution Data',
+            description: 'Include attribution and tracking data in the export',
+            required: false,
+            defaultValue: true,
+        }),
+        include_customer_journey: Property.Checkbox({
+            displayName: 'Include Customer Journey',
+            description: 'Include customer journey data (Elite plans only)',
+            required: false,
+            defaultValue: false,
+        }),
+        email_notification: Property.Checkbox({
+            displayName: 'Email Notification',
+            description: 'Send email notification when export is ready',
+            required: false,
+            defaultValue: true,
+        }),
+        webhook_url: Property.ShortText({
+            displayName: 'Webhook URL',
+            description: 'URL to notify when export is completed',
+            required: false,
+        })
+    },
+    async run(context) {
+        const props = context.propsValue as Record<string, any>;
+        const exportData: Record<string, any> = {
+            export_type: 'leads',
+        };
+
+        if (props['export_name']) exportData['name'] = props['export_name'];
+        if (props['start_date']) exportData['start_date'] = props['start_date'];
+        if (props['end_date']) exportData['end_date'] = props['end_date'];
+        if (props['lead_types'] && props['lead_types'].length > 0) {
+            exportData['lead_types'] = props['lead_types'];
+        }
+        if (props['lead_status']) exportData['lead_status'] = props['lead_status'];
+        if (props['quotable']) exportData['quotable'] = props['quotable'];
+        if (props['format']) exportData['format'] = props['format'];
+        if (props['include_custom_fields'] !== undefined) {
+            exportData['include_custom_fields'] = props['include_custom_fields'];
+        }
+        if (props['include_attribution'] !== undefined) {
+            exportData['include_attribution'] = props['include_attribution'];
+        }
+        if (props['include_customer_journey']) {
+            exportData['include_customer_journey'] = props['include_customer_journey'];
+        }
+        if (props['email_notification'] !== undefined) {
+            exportData['email_notification'] = props['email_notification'];
+        }
+        if (props['webhook_url']) exportData['webhook_url'] = props['webhook_url'];
+        const response = await whatconvertsCommon.apiCall({
+            auth: context.auth,
+            method: HttpMethod.POST,
+            resourceUri: '/exports',
+            body: exportData
+        });
+
+        return response.body;
+    },
+});

--- a/packages/pieces/community/whatconverts/src/lib/actions/create-lead.ts
+++ b/packages/pieces/community/whatconverts/src/lib/actions/create-lead.ts
@@ -1,0 +1,210 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatconvertsAuth } from '../common/auth';
+import { whatconvertsCommon } from '../common/client';
+
+export const createLead = createAction({
+    name: 'create_lead',
+    displayName: 'Create Lead',
+    description: 'Create a new lead in WhatConverts with comprehensive lead information including contact details, attribution, and metadata.',
+    auth: whatconvertsAuth,
+    props: {
+        profile_id: Property.Number({
+            displayName: 'Profile ID',
+            description: 'Unique identifier for the profile in which to add this lead to. Not required when using a Profile Key.',
+            required: false,
+        }),
+        lead_type: Property.StaticDropdown({
+            displayName: 'Lead Type',
+            description: 'The type of lead',
+            required: true,
+            options: {
+                options: [
+                    { label: 'Phone Call', value: 'phone_call' },
+                    { label: 'Web Form', value: 'web_form' },
+                    { label: 'Chat', value: 'chat' },
+                    { label: 'Text Message', value: 'text_message' },
+                    { label: 'Email', value: 'email' },
+                    { label: 'Appointment', value: 'appointment' },
+                    { label: 'Event', value: 'event' },
+                    { label: 'Transaction', value: 'transaction' },
+                    { label: 'Other', value: 'other' }
+                ]
+            }
+        }),
+        send_notification: Property.Checkbox({
+            displayName: 'Send Notification',
+            description: 'Send an email notification for this lead',
+            required: true,
+            defaultValue: false,
+        }),
+        contact_name: Property.ShortText({
+            displayName: 'Contact Name',
+            description: 'Full name of the contact',
+            required: false,
+        }),
+        email_address: Property.ShortText({
+            displayName: 'Email Address',
+            description: 'Email address of the contact',
+            required: false,
+        }),
+        phone_number: Property.ShortText({
+            displayName: 'Phone Number',
+            description: 'Phone number of the contact',
+            required: false,
+        }),
+        quotable: Property.StaticDropdown({
+            displayName: 'Quotable',
+            description: 'The quotable type for this lead',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Yes', value: 'yes' },
+                    { label: 'No', value: 'no' },
+                    { label: 'Pending', value: 'pending' },
+                    { label: 'Not Set', value: 'not_set' }
+                ]
+            }
+        }),
+        quote_value: Property.Number({
+            displayName: 'Quote Value',
+            description: 'The quote value for this lead',
+            required: false,
+        }),
+        sales_value: Property.Number({
+            displayName: 'Sales Value',
+            description: 'The sales value for this lead',
+            required: false,
+        }),
+        notes: Property.LongText({
+            displayName: 'Notes',
+            description: 'Additional notes for the lead',
+            required: false,
+        }),
+        lead_source: Property.ShortText({
+            displayName: 'Lead Source',
+            description: 'The traffic source for the lead (e.g., google, facebook)',
+            required: false,
+        }),
+        lead_medium: Property.ShortText({
+            displayName: 'Lead Medium',
+            description: 'The traffic medium for the lead (e.g., cpc, organic)',
+            required: false,
+        }),
+        lead_campaign: Property.ShortText({
+            displayName: 'Lead Campaign',
+            description: 'The campaign value for the lead',
+            required: false,
+        }),
+        lead_keyword: Property.ShortText({
+            displayName: 'Lead Keyword',
+            description: 'The keyword value for the lead',
+            required: false,
+        }),
+        lead_url: Property.ShortText({
+            displayName: 'Lead URL',
+            description: 'The URL where the lead took place',
+            required: false,
+        }),
+        landing_url: Property.ShortText({
+            displayName: 'Landing URL',
+            description: 'The URL where the user arrived on the website',
+            required: false,
+        }),
+        ip_address: Property.ShortText({
+            displayName: 'IP Address',
+            description: 'The user IP address for the lead',
+            required: false,
+        }),
+        user_id: Property.ShortText({
+            displayName: 'User ID',
+            description: 'The WhatConverts user ID for the lead',
+            required: false,
+        }),
+        message: Property.LongText({
+            displayName: 'Message',
+            description: 'Message content (for text_message, email, chat types)',
+            required: false,
+        }),
+        caller_name: Property.ShortText({
+            displayName: 'Caller Name',
+            description: 'Caller name (for phone_call, text_message types)',
+            required: false,
+        }),
+        caller_number: Property.ShortText({
+            displayName: 'Caller Number',
+            description: 'Caller phone number (for phone_call, text_message types)',
+            required: false,
+        }),
+        tracking_number: Property.ShortText({
+            displayName: 'Tracking Number',
+            description: 'Tracking phone number (for phone_call, text_message types)',
+            required: false,
+        }),
+        destination_number: Property.ShortText({
+            displayName: 'Destination Number',
+            description: 'Destination phone number (for phone_call type)',
+            required: false,
+        }),
+        call_duration_seconds: Property.Number({
+            displayName: 'Call Duration (Seconds)',
+            description: 'Duration of the call in seconds (for phone_call type)',
+            required: false,
+        }),
+        city: Property.ShortText({
+            displayName: 'City',
+            description: 'City location',
+            required: false,
+        }),
+        state: Property.ShortText({
+            displayName: 'State',
+            description: 'State location',
+            required: false,
+        }),
+        zip: Property.ShortText({
+            displayName: 'ZIP Code',
+            description: 'ZIP code',
+            required: false,
+        }),
+        country: Property.ShortText({
+            displayName: 'Country',
+            description: 'Country location',
+            required: false,
+        }),
+        additional_fields: Property.Array({
+            displayName: 'Additional Fields',
+            description: 'Additional custom fields for this lead',
+            required: false,
+            properties: {
+                field_name: Property.ShortText({
+                    displayName: 'Field Name',
+                    required: true,
+                }),
+                field_value: Property.ShortText({
+                    displayName: 'Field Value',
+                    required: true,
+                })
+            }
+        })
+    },
+    async run(context) {
+        const props = context.propsValue as Record<string, any>;
+        const leadData: Record<string, any> = {
+            lead_type: props['lead_type'],
+            send_notification: props['send_notification'],
+        };
+
+        if (props['profile_id']) {
+            leadData['profile_id'] = props['profile_id'];
+        }
+
+        const response = await whatconvertsCommon.apiCall({
+            auth: context.auth,
+            method: HttpMethod.POST,
+            resourceUri: '/leads',
+            body: leadData
+        });
+
+        return response.body;
+    },
+});

--- a/packages/pieces/community/whatconverts/src/lib/actions/find-lead.ts
+++ b/packages/pieces/community/whatconverts/src/lib/actions/find-lead.ts
@@ -1,0 +1,212 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatconvertsAuth } from '../common/auth';
+import { whatconvertsCommon } from '../common/client';
+
+export const findLead = createAction({
+    name: 'find_lead',
+    displayName: 'Find Leads',
+    description: 'Retrieve leads with comprehensive filtering options including pagination, dates, lead types, contact information, attribution data, and more.',
+    auth: whatconvertsAuth,
+    props: {
+        leads_per_page: Property.Number({
+            displayName: 'Leads Per Page',
+            description: 'Number of leads to return (default 25, maximum 2500)',
+            required: false,
+            defaultValue: 25,
+        }),
+        page_number: Property.Number({
+            displayName: 'Page Number',
+            description: 'Page number to return',
+            required: false,
+            defaultValue: 1,
+        }),
+        account_id: Property.Number({
+            displayName: 'Account ID',
+            description: 'Unique identifier for the account (Agency Key only)',
+            required: false,
+        }),
+        profile_id: Property.Number({
+            displayName: 'Profile ID',
+            description: 'Unique identifier for the profile (Agency Key only)',
+            required: false,
+        }),
+        lead_type: Property.StaticDropdown({
+            displayName: 'Lead Type',
+            description: 'Lead type to return',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Phone Call', value: 'phone_call' },
+                    { label: 'Web Form', value: 'web_form' },
+                    { label: 'Chat', value: 'chat' },
+                    { label: 'Text Message', value: 'text_message' },
+                    { label: 'Email', value: 'email' },
+                    { label: 'Appointment', value: 'appointment' },
+                    { label: 'Event', value: 'event' },
+                    { label: 'Transaction', value: 'transaction' },
+                    { label: 'Other', value: 'other' }
+                ]
+            }
+        }),
+        lead_status: Property.StaticDropdown({
+            displayName: 'Lead Status',
+            description: 'Lead status to return',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Unique', value: 'unique' },
+                    { label: 'Repeat', value: 'repeat' }
+                ]
+            }
+        }),
+        start_date: Property.ShortText({
+            displayName: 'Start Date',
+            description: 'Start date in date or date/time ISO 8601 format (UTC); 2015-11-10 or 2015-11-10T00:00:00Z',
+            required: false,
+        }),
+        end_date: Property.ShortText({
+            displayName: 'End Date',
+            description: 'End date in date or date/time ISO 8601 format (UTC); 2015-11-10 or 2015-11-10T00:00:00Z',
+            required: false,
+        }),
+        order: Property.StaticDropdown({
+            displayName: 'Order',
+            description: 'Order in which to return the leads by date created',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Descending (newest first)', value: 'desc' },
+                    { label: 'Ascending (oldest first)', value: 'asc' }
+                ]
+            }
+        }),
+        quotable: Property.StaticDropdown({
+            displayName: 'Quotable',
+            description: 'Quotable type to return',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Yes', value: 'yes' },
+                    { label: 'No', value: 'no' },
+                    { label: 'Pending', value: 'pending' },
+                    { label: 'Not Set', value: 'not_set' }
+                ]
+            }
+        }),
+        quote_value: Property.StaticDropdown({
+            displayName: 'Quote Value Filter',
+            description: 'Return leads that have a quote value',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Has Value', value: 'has_value' },
+                    { label: 'No Value', value: 'no_value' }
+                ]
+            }
+        }),
+        sales_value: Property.StaticDropdown({
+            displayName: 'Sales Value Filter',
+            description: 'Return leads that have a sales value',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Has Value', value: 'has_value' },
+                    { label: 'No Value', value: 'no_value' }
+                ]
+            }
+        }),
+        phone_number: Property.ShortText({
+            displayName: 'Phone Number',
+            description: 'Return leads for contacts with this E.164 formatted phone number',
+            required: false,
+        }),
+        email_address: Property.ShortText({
+            displayName: 'Email Address',
+            description: 'Return leads for contacts with this email address',
+            required: false,
+        }),
+        user_id: Property.ShortText({
+            displayName: 'User ID',
+            description: 'Return leads for contacts with this user ID',
+            required: false,
+        }),
+        spam: Property.Checkbox({
+            displayName: 'Spam Leads Only',
+            description: 'Return only spam leads',
+            required: false,
+        }),
+        duplicate: Property.Checkbox({
+            displayName: 'Duplicate Leads Only',
+            description: 'Return only duplicate leads',
+            required: false,
+        }),
+        lead_source: Property.ShortText({
+            displayName: 'Lead Source',
+            description: 'Return leads that have this lead source',
+            required: false,
+        }),
+        lead_medium: Property.ShortText({
+            displayName: 'Lead Medium',
+            description: 'Return leads that have this lead medium',
+            required: false,
+        }),
+        lead_campaign: Property.ShortText({
+            displayName: 'Lead Campaign',
+            description: 'Return leads that have this lead campaign',
+            required: false,
+        }),
+        lead_content: Property.ShortText({
+            displayName: 'Lead Content',
+            description: 'Return leads that have this lead content',
+            required: false,
+        }),
+        lead_keyword: Property.ShortText({
+            displayName: 'Lead Keyword',
+            description: 'Return leads that have this lead keyword',
+            required: false,
+        }),
+        customer_journey: Property.Checkbox({
+            displayName: 'Include Customer Journey',
+            description: 'Return the customer journey with the lead (Elite plans only)',
+            required: false,
+        })
+    },
+    async run(context) {
+        const props = context.propsValue as Record<string, any>;
+        const queryParams: Record<string, string> = {};
+
+        if (props['leads_per_page']) queryParams['leads_per_page'] = props['leads_per_page'].toString();
+        if (props['page_number']) queryParams['page_number'] = props['page_number'].toString();
+        if (props['account_id']) queryParams['account_id'] = props['account_id'].toString();
+        if (props['profile_id']) queryParams['profile_id'] = props['profile_id'].toString();
+        if (props['lead_type']) queryParams['lead_type'] = props['lead_type'];
+        if (props['lead_status']) queryParams['lead_status'] = props['lead_status'];
+        if (props['start_date']) queryParams['start_date'] = props['start_date'];
+        if (props['end_date']) queryParams['end_date'] = props['end_date'];
+        if (props['order']) queryParams['order'] = props['order'];
+        if (props['quotable']) queryParams['quotable'] = props['quotable'];
+        if (props['quote_value']) queryParams['quote_value'] = props['quote_value'];
+        if (props['sales_value']) queryParams['sales_value'] = props['sales_value'];
+        if (props['phone_number']) queryParams['phone_number'] = props['phone_number'];
+        if (props['email_address']) queryParams['email_address'] = props['email_address'];
+        if (props['user_id']) queryParams['user_id'] = props['user_id'];
+        if (props['spam']) queryParams['spam'] = 'true';
+        if (props['duplicate']) queryParams['duplicate'] = 'true';
+        if (props['lead_source']) queryParams['lead_source'] = props['lead_source'];
+        if (props['lead_medium']) queryParams['lead_medium'] = props['lead_medium'];
+        if (props['lead_campaign']) queryParams['lead_campaign'] = props['lead_campaign'];
+        if (props['lead_content']) queryParams['lead_content'] = props['lead_content'];
+        if (props['lead_keyword']) queryParams['lead_keyword'] = props['lead_keyword'];
+        if (props['customer_journey']) queryParams['customer_journey'] = 'true';
+
+        const response = await whatconvertsCommon.apiCall({
+            auth: context.auth,
+            method: HttpMethod.GET,
+            resourceUri: '/leads',
+            queryParams: queryParams
+        });
+
+        return response.body;
+    },
+});

--- a/packages/pieces/community/whatconverts/src/lib/actions/update-lead.ts
+++ b/packages/pieces/community/whatconverts/src/lib/actions/update-lead.ts
@@ -1,0 +1,75 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatconvertsAuth } from '../common/auth';
+import { whatconvertsCommon } from '../common/client';
+
+export const updateLead = createAction({
+    name: 'update_lead',
+    displayName: 'Update Lead',
+    description: 'Update an existing lead in WhatConverts. Only quotable status, quote/sales values, lead URL, and additional fields can be updated.',
+    auth: whatconvertsAuth,
+    props: {
+        lead_id: Property.Number({
+            displayName: 'Lead ID',
+            description: 'The ID of the lead to update',
+            required: true,
+        }),
+        quotable: Property.StaticDropdown({
+            displayName: 'Quotable Status',
+            description: 'The quotable type for the lead',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Yes', value: 'yes' },
+                    { label: 'No', value: 'no' },
+                    { label: 'Pending', value: 'pending' },
+                    { label: 'Not Set', value: 'not_set' }
+                ]
+            }
+        }),
+        quote_value: Property.Number({
+            displayName: 'Quote Value',
+            description: 'The quote value for the lead',
+            required: false,
+        }),
+        sales_value: Property.Number({
+            displayName: 'Sales Value',
+            description: 'The sales value for the lead',
+            required: false,
+        }),
+        lead_url: Property.ShortText({
+            displayName: 'Lead URL',
+            description: 'The URL where the lead took place',
+            required: false,
+        }),
+        additional_fields: Property.Array({
+            displayName: 'Additional Fields',
+            description: 'Additional fields for the lead',
+            required: false,
+            properties: {
+                field_name: Property.ShortText({
+                    displayName: 'Field Name',
+                    required: true,
+                }),
+                field_value: Property.ShortText({
+                    displayName: 'Field Value',
+                    required: true,
+                })
+            }
+        })
+    },
+    async run(context) {
+        const props = context.propsValue as Record<string, any>;
+        const leadData: Record<string, any> = {};
+
+        
+        const response = await whatconvertsCommon.apiCall({
+            auth: context.auth,
+            method: HttpMethod.POST,
+            resourceUri: `/leads/${props['lead_id']}`,
+            body: leadData
+        });
+
+        return response.body;
+    },
+});

--- a/packages/pieces/community/whatconverts/src/lib/common/auth.ts
+++ b/packages/pieces/community/whatconverts/src/lib/common/auth.ts
@@ -1,0 +1,21 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const whatconvertsAuth = PieceAuth.CustomAuth({
+    description: `
+    To obtain your WhatConverts API credentials:
+
+    1. From your WhatConverts dashboard, navigate to an account then select a profile
+    2. Select the Tracking dropdown and click "Integrations"
+    3. Click on "API Keys" and generate a new API key
+    4. Your API key will be in the format: token:secret
+    5. Enter the full token:secret combination below
+    `,
+    props: {
+        api_key: PieceAuth.SecretText({
+            displayName: 'API Key',
+            required: true,
+            description: 'Your WhatConverts API key in token:secret format',
+        }),
+    },
+    required: true,
+});

--- a/packages/pieces/community/whatconverts/src/lib/common/client.ts
+++ b/packages/pieces/community/whatconverts/src/lib/common/client.ts
@@ -1,0 +1,43 @@
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+
+const WHATCONVERTS_API_BASE_URL = 'https://app.whatconverts.com/api/v1';
+
+export type WhatConvertsAuth = {
+    api_key: string;
+};
+
+export const whatconvertsCommon = {
+    baseUrl: WHATCONVERTS_API_BASE_URL,
+
+    async apiCall({
+        auth,
+        method,
+        resourceUri,
+        body = undefined,
+        queryParams = undefined,
+    }: {
+        auth: WhatConvertsAuth;
+        method: HttpMethod;
+        resourceUri: string;
+        body?: any;
+        queryParams?: Record<string, string>;
+    }) {
+        const [token, secret] = auth.api_key.split(':');
+
+        if (!token || !secret) {
+            throw new Error('Invalid API key format. Expected format: token:secret');
+        }
+
+        return await httpClient.sendRequest({
+            method: method,
+            url: `${WHATCONVERTS_API_BASE_URL}${resourceUri}`,
+            body,
+            queryParams,
+            authentication: {
+                type: AuthenticationType.BASIC,
+                username: token,
+                password: secret,
+            }
+        });
+    }
+};

--- a/packages/pieces/community/whatconverts/src/lib/triggers/new-lead.ts
+++ b/packages/pieces/community/whatconverts/src/lib/triggers/new-lead.ts
@@ -1,0 +1,137 @@
+import { PiecePropValueSchema, createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper, HttpMethod } from '@activepieces/pieces-common';
+import dayjs from 'dayjs';
+import { whatconvertsAuth } from '../common/auth';
+import { whatconvertsCommon } from '../common/client';
+
+type Props = {
+    lead_type?: string;
+};
+
+const props = {
+    lead_type: Property.StaticDropdown({
+        displayName: 'Lead Type Filter',
+        description: 'Only trigger for leads of this specific type. Leave empty to trigger for all lead types.',
+        required: false,
+        options: {
+            options: [
+                { label: 'Phone Call', value: 'phone_call' },
+                { label: 'Web Form', value: 'web_form' },
+                { label: 'Chat', value: 'chat' },
+                { label: 'Text Message', value: 'text_message' },
+                { label: 'Email', value: 'email' },
+                { label: 'Appointment', value: 'appointment' },
+                { label: 'Event', value: 'event' },
+                { label: 'Transaction', value: 'transaction' },
+                { label: 'Other', value: 'other' }
+            ]
+        }
+    })
+};
+
+const polling: Polling<PiecePropValueSchema<typeof whatconvertsAuth>, Props> = {
+    strategy: DedupeStrategy.TIMEBASED,
+    items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+        const lastFetchDate = lastFetchEpochMS ? dayjs(lastFetchEpochMS).format('YYYY-MM-DD') : dayjs().subtract(1, 'hour').format('YYYY-MM-DD');
+
+        const queryParams: Record<string, string> = {
+            start_date: lastFetchDate,
+            end_date: dayjs().format('YYYY-MM-DD'),
+            leads_per_page: '100',
+            order: 'desc'
+        };
+
+        const props = propsValue as any;
+        if (props['lead_type']) {
+            queryParams['lead_type'] = props['lead_type'];
+        }
+
+        try {
+            const response = await whatconvertsCommon.apiCall({
+                auth: auth,
+                method: HttpMethod.GET,
+                resourceUri: '/leads',
+                queryParams: queryParams
+            });
+
+            const leads = response.body?.leads || response.body || [];
+
+            const newLeads = leads.filter((lead: any) => {
+                const createdAt = dayjs(lead.date_created || lead.created_at);
+                return createdAt.isAfter(dayjs(lastFetchEpochMS || 0));
+            });
+
+            return newLeads.map((lead: any) => ({
+                epochMilliSeconds: dayjs(lead.date_created || lead.created_at).valueOf(),
+                data: lead,
+            }));
+        } catch (error) {
+            console.warn('Failed to fetch new leads:', error);
+            return [];
+        }
+    },
+};
+
+export const newLead = createTrigger({
+    auth: whatconvertsAuth,
+    name: 'new_lead',
+    displayName: 'New Lead',
+    description: 'Fires when a new lead is received in WhatConverts. Optionally filter by specific lead type.',
+    props,
+    sampleData: {
+        "account_id": 13744,
+        "profile_id": 42167,
+        "profile": "WhatConverts",
+        "lead_id": 148099,
+        "user_id": "51497-af17340d-62b8-3044-423f-3dc754e621c2",
+        "lead_type": "phone_call",
+        "lead_status": "unique",
+        "date_created": "2025-09-21T16:21:22Z",
+        "quotable": "yes",
+        "quote_value": 251,
+        "sales_value": 750,
+        "lead_score": 50,
+        "lead_source": "google",
+        "lead_medium": "cpc",
+        "lead_campaign": "call tracking general",
+        "lead_url": "https://www.whatconverts.com/contact",
+        "landing_url": "https://www.whatconverts.com/",
+        "contact_name": "Jeremy Helms",
+        "contact_email_address": "hello@whatconverts.com",
+        "contact_phone_number": "+18883435680",
+        "phone_number": "+18883435680",
+        "tracking_number": "+17047349155",
+        "caller_number": "+15432245114",
+        "city": "Charlotte",
+        "state": "NC",
+        "zip": "28226",
+        "country": "US",
+        "call_duration_seconds": 175,
+        "last_updated": "2025-09-21T17:18:20Z"
+    },
+    type: TriggerStrategy.POLLING,
+
+    async test(context) {
+        return await pollingHelper.test(polling, context);
+    },
+
+    async onEnable(context) {
+        await pollingHelper.onEnable(polling, {
+            store: context.store,
+            auth: context.auth,
+            propsValue: context.propsValue,
+        });
+    },
+
+    async onDisable(context) {
+        await pollingHelper.onDisable(polling, {
+            store: context.store,
+            auth: context.auth,
+            propsValue: context.propsValue,
+        });
+    },
+
+    async run(context) {
+        return await pollingHelper.poll(polling, context);
+    },
+});

--- a/packages/pieces/community/whatconverts/src/lib/triggers/updated-lead.ts
+++ b/packages/pieces/community/whatconverts/src/lib/triggers/updated-lead.ts
@@ -1,0 +1,102 @@
+import { PiecePropValueSchema, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper, HttpMethod } from '@activepieces/pieces-common';
+import dayjs from 'dayjs';
+import { whatconvertsAuth } from '../common/auth';
+import { whatconvertsCommon } from '../common/client';
+
+type Props = {};
+
+const polling: Polling<PiecePropValueSchema<typeof whatconvertsAuth>, Props> = {
+    strategy: DedupeStrategy.TIMEBASED,
+    items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+        const lastFetchDate = lastFetchEpochMS ? dayjs(lastFetchEpochMS).format('YYYY-MM-DD') : dayjs().subtract(1, 'hour').format('YYYY-MM-DD');
+
+        const queryParams: Record<string, string> = {
+            start_date: lastFetchDate,
+            end_date: dayjs().format('YYYY-MM-DD'),
+            leads_per_page: '100',
+            order: 'desc'
+        };
+
+        try {
+            const response = await whatconvertsCommon.apiCall({
+                auth: auth,
+                method: HttpMethod.GET,
+                resourceUri: '/leads',
+                queryParams: queryParams
+            });
+
+            const leads = response.body?.leads || response.body || [];
+
+            const updatedLeads = leads.filter((lead: any) => {
+                const updatedAt = dayjs(lead.last_updated || lead.updated_at);
+                return updatedAt.isAfter(dayjs(lastFetchEpochMS || 0));
+            });
+
+            return updatedLeads.map((lead: any) => ({
+                epochMilliSeconds: dayjs(lead.last_updated || lead.updated_at).valueOf(),
+                data: lead,
+            }));
+        } catch (error) {
+            console.warn('Failed to fetch updated leads:', error);
+            return [];
+        }
+    },
+};
+
+export const updatedLead = createTrigger({
+    auth: whatconvertsAuth,
+    name: 'updated_lead',
+    displayName: 'Updated Lead',
+    description: 'Fires when an existing lead is updated in WhatConverts.',
+    props: {},
+    sampleData: {
+        "account_id": 13744,
+        "profile_id": 42167,
+        "profile": "WhatConverts",
+        "lead_id": 148099,
+        "user_id": "51497-af17340d-62b8-3044-423f-3dc754e621c2",
+        "lead_type": "phone_call",
+        "lead_status": "unique",
+        "date_created": "2025-09-20T16:21:22Z",
+        "quotable": "yes",
+        "quote_value": 251,
+        "sales_value": 750,
+        "lead_score": 50,
+        "lead_source": "google",
+        "lead_medium": "cpc",
+        "lead_campaign": "call tracking general",
+        "lead_url": "https://www.whatconverts.com/contact",
+        "landing_url": "https://www.whatconverts.com/",
+        "contact_name": "Jeremy Helms",
+        "contact_email_address": "hello@whatconverts.com",
+        "contact_phone_number": "+18883435680",
+        "phone_number": "+18883435680",
+        "last_updated": "2025-09-21T17:18:20Z"
+    },
+    type: TriggerStrategy.POLLING,
+
+    async test(context) {
+        return await pollingHelper.test(polling, context);
+    },
+
+    async onEnable(context) {
+        await pollingHelper.onEnable(polling, {
+            store: context.store,
+            auth: context.auth,
+            propsValue: context.propsValue,
+        });
+    },
+
+    async onDisable(context) {
+        await pollingHelper.onDisable(polling, {
+            store: context.store,
+            auth: context.auth,
+            propsValue: context.propsValue,
+        });
+    },
+
+    async run(context) {
+        return await pollingHelper.poll(polling, context);
+    },
+});

--- a/packages/pieces/community/whatconverts/tsconfig.json
+++ b/packages/pieces/community/whatconverts/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/whatconverts/tsconfig.lib.json
+++ b/packages/pieces/community/whatconverts/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1141,6 +1141,9 @@
       "@activepieces/piece-wedof": [
         "packages/pieces/community/wedof/src/index.ts"
       ],
+      "@activepieces/piece-whatconverts": [
+        "packages/pieces/community/whatconverts/src/index.ts"
+      ],
       "@activepieces/piece-whatsable": [
         "packages/pieces/community/whatsable/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

WhatConverts is a lead tracking and analytics platform that captures leads from phone calls, forms, chats, text messages, eCommerce transactions, etc., with rich attribution metadata. With this integration, workflows can respond to “new lead” or “lead update” events, manage lead data, export leads, or perform lookups.



Fixes #9316
/claim #9316