### PR TITLE
fix (hubspot): Batch API validation error

### DIFF
--- a/packages/pieces/community/hubspot/package.json
+++ b/packages/pieces/community/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-hubspot",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "dependencies": {
     "@hubspot/api-client": "12.0.1"
   }

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-contact-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-contact-property-change.ts
@@ -7,6 +7,7 @@ import {
 import { standardObjectPropertiesDropdown } from '../common/props';
 import { OBJECT_TYPE } from '../common/constants';
 import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import { chunk } from '@activepieces/shared';
 
 import { Client } from '@hubspot/api-client';
 import dayjs from 'dayjs';
@@ -72,18 +73,29 @@ const polling: Polling<PiecePropValueSchema<typeof hubspotAuth>, Props> = {
 			return [];
 		}
 
-		// Fetch contacts with property history
-		const updatedContcatsWithPropertyHistory = await client.crm.contacts.batchApi.read({
-			propertiesWithHistory: [propertyToCheck],
-			properties: propertiesToRetrieve,
-			inputs: updatedContacts.map((contact) => {
-				return {
-					id: contact.id,
-				};
-			}),
-		});
+		// Avoid VALIDATION_ERROR: The maximum number of inputs supported in a batch request for property histories is 50
+    const batchApiChunks = chunk(updatedContacts, 50);
 
-		for (const contact of updatedContcatsWithPropertyHistory.results) {
+    // Fetch contacts with property history
+    const batchApiResps = await Promise.all(
+      batchApiChunks.map((batch) => {
+        return client.crm.contacts.batchApi.read({
+          propertiesWithHistory: [propertyToCheck],
+          properties: propertiesToRetrieve,
+          inputs: batch.map((contact) => {
+            return {
+              id: contact.id,
+            };
+          }),
+        });
+      })
+    );
+
+    const updatedContcatsWithPropertyHistory = batchApiResps.flatMap(
+      (resp) => resp.results
+    );
+
+		for (const contact of updatedContcatsWithPropertyHistory) {
 			const history = contact.propertiesWithHistory?.[propertyToCheck];
 			if (!history || history.length === 0) {
 				continue;

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-deal-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-deal-property-change.ts
@@ -7,6 +7,7 @@ import {
 import { standardObjectPropertiesDropdown } from '../common/props';
 import { OBJECT_TYPE } from '../common/constants';
 import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import { chunk } from '@activepieces/shared';
 
 import { Client } from '@hubspot/api-client';
 import dayjs from 'dayjs';
@@ -71,18 +72,29 @@ const polling: Polling<PiecePropValueSchema<typeof hubspotAuth>, Props> = {
 			return [];
 		}
 
-		// Fetch deals with property history
-		const updatedDealsWithPropertyHistory = await client.crm.deals.batchApi.read({
-			propertiesWithHistory: [propertyToCheck],
-			properties: propertiesToRetrieve,
-			inputs: updatedDeals.map((deal) => {
-				return {
-					id: deal.id,
-				};
-			}),
-		});
+    // Avoid VALIDATION_ERROR: The maximum number of inputs supported in a batch request for property histories is 50
+    const batchApiChunks = chunk(updatedDeals, 50);
 
-		for (const deal of updatedDealsWithPropertyHistory.results) {
+    // Fetch deals with property history
+    const batchApiResps = await Promise.all(
+      batchApiChunks.map((batch) => {
+        return client.crm.deals.batchApi.read({
+          propertiesWithHistory: [propertyToCheck],
+          properties: propertiesToRetrieve,
+          inputs: batch.map((deal) => {
+            return {
+              id: deal.id,
+            };
+          }),
+        });
+      })
+    );
+
+    const updatedDealsWithPropertyHistory = batchApiResps.flatMap(
+      (resp) => resp.results
+    );
+
+		for (const deal of updatedDealsWithPropertyHistory) {
 			const history = deal.propertiesWithHistory?.[propertyToCheck];
 			if (!history || history.length === 0) {
 				continue;

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-ticket-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-ticket-property-change.ts
@@ -7,6 +7,7 @@ import {
 import { standardObjectPropertiesDropdown } from '../common/props';
 import { OBJECT_TYPE } from '../common/constants';
 import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import { chunk } from '@activepieces/shared';
 
 import { Client } from '@hubspot/api-client';
 import dayjs from 'dayjs';
@@ -71,18 +72,29 @@ const polling: Polling<PiecePropValueSchema<typeof hubspotAuth>, Props> = {
 			return [];
 		}
 
-		// Fetch tickets with property history
-		const updatedTicketsWithPropertyHistory = await client.crm.tickets.batchApi.read({
-			propertiesWithHistory: [propertyToCheck],
-			properties: propertiesToRetrieve,
-			inputs: updatedTickets.map((ticket) => {
-				return {
-					id: ticket.id,
-				};
-			}),
-		});
+    // Avoid VALIDATION_ERROR: The maximum number of inputs supported in a batch request for property histories is 50
+    const batchApiChunks = chunk(updatedTickets, 50);
 
-		for (const ticket of updatedTicketsWithPropertyHistory.results) {
+    // Fetch tickets with property history
+    const batchApiResps = await Promise.all(
+      batchApiChunks.map((batch) => {
+        return client.crm.tickets.batchApi.read({
+          propertiesWithHistory: [propertyToCheck],
+          properties: propertiesToRetrieve,
+          inputs: batch.map((ticket) => {
+            return {
+              id: ticket.id,
+            };
+          }),
+        });
+      })
+    );
+
+    const updatedTicketsWithPropertyHistory = batchApiResps.flatMap(
+      (resp) => resp.results
+    );
+
+		for (const ticket of updatedTicketsWithPropertyHistory) {
 			const history = ticket.propertiesWithHistory?.[propertyToCheck];
 			if (!history || history.length === 0) {
 				continue;


### PR DESCRIPTION
## What does this PR do?

We've been seeing some trigger failures and AP logs like:
```
Body: {"status":"error","message":"The maximum number of inputs supported in a batch request for property histories is 50. Please reduce the number of items and try again","correlationId":"<redacted>","category":"VALIDATION_ERROR"}
```

This seems to happen with Batch API calls with `propertiesWithHistory` when the number of inputs > 50. This can happen if the polling request returns more than 50 results. This results in subsequent runs being blocked because there’s no way to process the growing backlog of items.

We can see from the [code](https://github.com/search?q=repo%3Aactivepieces%2Factivepieces+path%3A%2F%5Epackages%5C%2Fpieces%5C%2Fcommunity%5C%2Fhubspot%5C%2Fsrc%5C%2Flib%5C%2Ftriggers%5C%2F%2F+propertiesWithHistory&type=code) the potentially affected triggers:

- new-company-property-change
- new-contact-property-change
- new-custom-object-property-change
- new-deal-property-change
- new-ticket-property-change
