### PR TITLE
feat: support more template types in google template

### DIFF
--- a/packages/pieces/community/google-docs/package.json
+++ b/packages/pieces/community/google-docs/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-docs",
-  "version": "0.2.9"
+  "version": "0.2.10"
 }

--- a/packages/pieces/community/google-docs/src/lib/actions/create-document-based-on-template.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-document-based-on-template.action.ts
@@ -31,12 +31,14 @@ export const createDocumentBasedOnTemplate = createAction({
       displayName: 'Placeholder Format',
       description: 'Choose the format of placeholders in your template',
       required: true,
-      defaultValue: '[[]]',
+      defaultValue: '[[KEY]]',
       options: {
           disabled: false,
           options: [
-              { label: 'Curly Braces {{}}', value: '{{}}' },
-              { label: 'Square Brackets [[]]', value: '[[]]' }
+              { label: 'Curly Braces {{}}', value: '{{KEY}}' },
+              { label: 'Square Brackets [[]]', value: '[[KEY]]' },
+              { label: 'Single Curly Braces {}', value: '{KEY}' },
+              { label: 'Single Square Brackets []', value: '[KEY]' }
           ],
         },
   }),
@@ -54,9 +56,8 @@ export const createDocumentBasedOnTemplate = createAction({
 
     for (const key in values) {
       const value = values[key];
-      const new_key = placeholder_format === '[[]]' 
-                        ? `[[${key}]]` 
-                        : `{{${key}}}`;
+      const new_key = placeholder_format.replace('KEY', key);
+
       requests.push({
         replaceAllText: {
           containsText: {


### PR DESCRIPTION
## What does this PR do?

- Add single square bracket and single braces to template
- Template replacement code so that it no longer hardcodes `[[]]`

### Explain How the Feature Works
<img width="657" height="523" alt="Screenshot 2025-09-24 at 1 19 36 PM" src="https://github.com/user-attachments/assets/c7ffa67f-144c-446e-b33b-e53649faa4b9" />

### Relevant User Scenarios

- when user has a different template pattern

Fixes # (issue)
