### PR TITLE
feat(timelines-ai): implement piece

### DIFF
--- a/packages/pieces/community/timelines-ai/.eslintrc.json
+++ b/packages/pieces/community/timelines-ai/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/timelines-ai/README.md
+++ b/packages/pieces/community/timelines-ai/README.md
@@ -1,0 +1,7 @@
+# pieces-timelines-ai
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-timelines-ai` to build the library.

--- a/packages/pieces/community/timelines-ai/package.json
+++ b/packages/pieces/community/timelines-ai/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-timelines-ai",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/timelines-ai/project.json
+++ b/packages/pieces/community/timelines-ai/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "pieces-timelines-ai",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/timelines-ai/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/timelines-ai",
+        "tsConfig": "packages/pieces/community/timelines-ai/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/timelines-ai/package.json",
+        "main": "packages/pieces/community/timelines-ai/src/index.ts",
+        "assets": [
+          "packages/pieces/community/timelines-ai/*.md",
+          {
+            "input": "packages/pieces/community/timelines-ai/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/timelines-ai/src/index.ts
+++ b/packages/pieces/community/timelines-ai/src/index.ts
@@ -1,13 +1,52 @@
 
-    import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+    import { createPiece } from "@activepieces/pieces-framework";
+    import { timelinesAiAuth } from '../src/lib/common/auth';
+    import { closeChatAction } from '../src/lib/actions/close-chat';
+    import { findChatAction } from '../src/lib/actions/find-chat';
+    import { findMessageStatusAction } from '../src/lib/actions/find-message-status';
+    import { findMessageAction } from '../src/lib/actions/find-message';
+    import { findUploadedFileAction } from '../src/lib/actions/find-uploaded-file';
+    import { findWhatsappAccountAction } from '../src/lib/actions/find-whatsapp-account';
+    import { sendFileToExistingChatAction } from '../src/lib/actions/send-file-to-existing-chat';
+    import { sendMessageToNewChatAction } from '../src/lib/actions/send-message-to-new-chat';
+    import { sendMessageToExistingChatAction } from '../src/lib/actions/send-message-to-existing-chat';
+    import { sendUploadedFileToExistingChatAction } from '../src/lib/actions/send-uploaded-file-to-existing-chat';
+    import { chatClosedTrigger } from '../src/lib/triggers/chat-closed';
+    import { chatRenamedTrigger } from '../src/lib/triggers/chat-renamed';
+    import { newIncomingChatTrigger } from '../src/lib/triggers/new-incoming-chat';
+    import { newOutgoingChatTrigger } from '../src/lib/triggers/new-outgoing-chat';
+    import { newReceivedMessageTrigger } from '../src/lib/triggers/new-received-message';
+    import { newSentMessageTrigger } from '../src/lib/triggers/new-sent-message';
+    import { newUploadedFileTrigger } from '../src/lib/triggers/new-uploaded-file';
+    import { newWhatsappAccountTrigger } from '../src/lib/triggers/new-whatsapp-account';
 
     export const timelinesAi = createPiece({
-      displayName: "Timelines-ai",
-      auth: PieceAuth.None(),
+      displayName: 'Timelines-ai',
+      auth: timelinesAiAuth,
       minimumSupportedRelease: '0.36.1',
-      logoUrl: "https://cdn.activepieces.com/pieces/timelines-ai.png",
-      authors: [],
-      actions: [],
-      triggers: [],
+      logoUrl: 'https://cdn.activepieces.com/pieces/timelines-ai.png',
+      authors: ['Prabhukiran161'],
+      actions: [
+        closeChatAction,
+        findChatAction,
+        findMessageStatusAction,
+        findMessageAction,
+        findUploadedFileAction,
+        findWhatsappAccountAction,
+        sendFileToExistingChatAction,
+        sendMessageToNewChatAction,
+        sendMessageToExistingChatAction,
+        sendUploadedFileToExistingChatAction,
+      ],
+      triggers: [
+        chatClosedTrigger,
+        chatRenamedTrigger,
+        newIncomingChatTrigger,
+        newOutgoingChatTrigger,
+        newReceivedMessageTrigger,
+        newSentMessageTrigger,
+        newUploadedFileTrigger,
+        newWhatsappAccountTrigger,
+      ],
     });
     

--- a/packages/pieces/community/timelines-ai/src/index.ts
+++ b/packages/pieces/community/timelines-ai/src/index.ts
@@ -1,0 +1,13 @@
+
+    import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+
+    export const timelinesAi = createPiece({
+      displayName: "Timelines-ai",
+      auth: PieceAuth.None(),
+      minimumSupportedRelease: '0.36.1',
+      logoUrl: "https://cdn.activepieces.com/pieces/timelines-ai.png",
+      authors: [],
+      actions: [],
+      triggers: [],
+    });
+    

--- a/packages/pieces/community/timelines-ai/src/lib/actions/close-chat.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/close-chat.ts
@@ -1,0 +1,30 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+import { timelinesAiProps } from '../common/props';
+import { UpdateChatRequest } from '../common/types';
+
+export const closeChatAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'close_chat',
+  displayName: 'Close Chat',
+  description: 'Programmatically marks an existing chat as closed.',
+  props: {
+    chat_id: timelinesAiProps.chatId,
+  },
+  async run(context) {
+    const { auth, propsValue } = context;
+    const { chat_id } = propsValue;
+    const payload: UpdateChatRequest = {
+      state: 'closed',
+    };
+    const numericChatId =
+      typeof chat_id === 'string' ? parseInt(chat_id, 10) : (chat_id as number);
+
+    return await timelinesAiClient.updateChatState(
+      auth,
+      numericChatId,
+      payload
+    );
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/actions/find-chat.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/find-chat.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+import { FindChatRequest } from '../common/types';
+
+export const findChatAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'find_chat',
+  displayName: 'Find Chat',
+  description:
+    'Finds a chat by a specific criterion like phone number, name, or ID.',
+  props: {
+    searchBy: Property.StaticDropdown({
+      displayName: 'Search By',
+      description: 'The field to search for a chat by.',
+      required: true,
+      options: {
+        options: [
+          { label: 'Chat ID', value: 'chat_id' },
+          { label: 'Phone Number', value: 'phone' },
+          { label: 'Contact Name', value: 'name' },
+          { label: 'Label', value: 'label' },
+        ],
+      },
+    }),
+    searchTerm: Property.ShortText({
+      displayName: 'Search Term',
+      description: 'The value to search for.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue } = context;
+    const { searchBy, searchTerm } = propsValue;
+    const params: FindChatRequest = {};
+    if (searchBy === 'chat_id') {
+      params.chat_id = parseInt(searchTerm, 10);
+    } else if (searchBy === 'phone') {
+      params.phone = searchTerm;
+    } else if (searchBy === 'name') {
+      params.name = searchTerm;
+    } else if (searchBy === 'label') {
+      params.label = searchTerm;
+    }
+    const chats = await timelinesAiClient.findChat(auth, params);
+    return chats;
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/actions/find-message-status.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/find-message-status.ts
@@ -1,0 +1,23 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+
+export const findMessageStatusAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'find_message_status',
+  displayName: 'Find Message Status',
+  description:
+    'Finds the status history (e.g., sent, delivered, read) for a specific message.',
+  props: {
+    message_uid: Property.ShortText({
+      displayName: 'Message UID',
+      description: 'The unique identifier of the message.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue } = context;
+    const { message_uid } = propsValue;
+    return await timelinesAiClient.getMessageStatusHistory(auth, message_uid);
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/actions/find-message.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/find-message.ts
@@ -1,0 +1,24 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+
+export const findMessageAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'find_message',
+  displayName: 'Find Message',
+  description: 'Finds a specific message by its unique ID (UID).',
+  props: {
+    message_uid: Property.ShortText({
+      displayName: 'Message UID',
+      description:
+        'The unique identifier of the message (e.g., from a trigger or another step).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue } = context;
+    const { message_uid } = propsValue;
+    const response = await timelinesAiClient.getMessageById(auth, message_uid);
+    return response.data;
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/actions/find-uploaded-file.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/find-uploaded-file.ts
@@ -1,0 +1,29 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+import { FindFileRequest } from '../common/types';
+
+export const findUploadedFileAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'find_uploaded_file',
+  displayName: 'Find Uploaded File',
+  description: 'Finds uploaded files, optionally filtering by filename.',
+  props: {
+    filename: Property.ShortText({
+      displayName: 'Filename (Optional)',
+      description:
+        "Part of a filename to search for (e.g., 'report.pdf' or '.pdf'). Leave blank to retrieve all files.",
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue } = context;
+    const { filename } = propsValue;
+    const params: FindFileRequest = {};
+    if (filename) {
+      params.filename = filename;
+    }
+    const response = await timelinesAiClient.findFiles(auth, params);
+    return response.data;
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/actions/find-whatsapp-account.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/find-whatsapp-account.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+
+export const findWhatsappAccountAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'find_whatsapp_account',
+  displayName: 'Find WhatsApp Account',
+  description: 'Finds a connected WhatsApp account by its ID or phone number.',
+  props: {
+    searchBy: Property.StaticDropdown({
+      displayName: 'Search By',
+      description: 'The field to search for an account by.',
+      required: true,
+      options: {
+        options: [
+          { label: 'Account ID', value: 'id' },
+          { label: 'Phone Number', value: 'phone' },
+        ],
+      },
+    }),
+    searchTerm: Property.ShortText({
+      displayName: 'Search Term',
+      description: 'The ID or phone number of the account to find.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue } = context;
+    const { searchBy, searchTerm } = propsValue;
+    const allAccounts = await timelinesAiClient.getWhatsAppAccounts(auth);
+    const foundAccounts = allAccounts.filter((account) => {
+      if (searchBy === 'id') {
+        return account.id === searchTerm;
+      }
+      if (searchBy === 'phone') {
+        return account.phone === searchTerm;
+      }
+      return false;
+    });
+    return foundAccounts;
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/actions/send-file-to-existing-chat.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/send-file-to-existing-chat.ts
@@ -1,0 +1,97 @@
+import {
+  createAction,
+  Property,
+  DynamicPropsValue,
+} from '@activepieces/pieces-framework';
+import { Buffer } from 'node:buffer';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+import { timelinesAiProps } from '../common/props';
+
+type FileData = { filename: string; data: Buffer };
+
+export const sendFileToExistingChatAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'send_file_to_existing_chat',
+  displayName: 'Send File to Existing Chat',
+  description:
+    'Uploads a file from a URL or file input and sends it to a chat.',
+  props: {
+    chat_id: timelinesAiProps.chatId,
+    source: Property.StaticDropdown({
+      displayName: 'File Source',
+      description:
+        'Choose whether to upload from a URL or use a file from a previous step.',
+      required: true,
+      options: {
+        options: [
+          { label: 'File URL', value: 'url' },
+          { label: 'File Content', value: 'file' },
+        ],
+      },
+    }),
+    file_or_url: Property.DynamicProperties({
+      displayName: 'File Input',
+      required: true,
+      refreshers: ['source'],
+      props: async (propsValue) => {
+        const source = propsValue['source'] as unknown as string;
+        const fields: DynamicPropsValue = {};
+
+        if (source === 'url') {
+          fields['download_url'] = Property.ShortText({
+            displayName: 'File URL',
+            description:
+              'A publicly accessible URL for the file to upload and send.',
+            required: true,
+          });
+        } else if (source === 'file') {
+          fields['file'] = Property.File({
+            displayName: 'File',
+            description:
+              'The file to upload and send (e.g., from a trigger or another action).',
+            required: true,
+          });
+        }
+        return fields;
+      },
+    }),
+    caption: Property.LongText({
+      displayName: 'Caption',
+      description: 'An optional text caption to send along with the file.',
+      required: false,
+    }),
+  },
+
+  async run(context) {
+    const { auth, propsValue } = context;
+    let fileUid: string;
+    const fileOrUrlProps = propsValue.file_or_url as {
+      download_url?: string;
+      file?: FileData;
+    };
+    if (propsValue.source === 'url') {
+      const uploadPayload = {
+        download_url: fileOrUrlProps.download_url as string,
+      };
+      const response = await timelinesAiClient.uploadFileByUrl(
+        auth,
+        uploadPayload
+      );
+      fileUid = response.data.uid;
+    } else {
+      const file = fileOrUrlProps.file as FileData;
+      const response = await timelinesAiClient.uploadFileByContent(auth, file);
+      fileUid = response.file_uid;
+    }
+    const sendMessagePayload = {
+      file_uid: fileUid,
+      text: propsValue.caption as string | undefined,
+    };
+    return await timelinesAiClient.sendMessage(
+      auth,
+      propsValue.chat_id as number,
+      sendMessagePayload
+    );
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/actions/send-message-to-existing-chat.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/send-message-to-existing-chat.ts
@@ -1,0 +1,51 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+import { timelinesAiProps } from '../common/props';
+import { SendMessageRequest } from '../common/types';
+
+export const sendMessageToExistingChatAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'send_message_to_existing_chat',
+  displayName: 'Send Message to Existing Chat',
+  description: 'Sends a text message to an existing WhatsApp chat.',
+  props: {
+    chat_id: timelinesAiProps.chatId,
+    text: Property.LongText({
+      displayName: 'Message',
+      description:
+        'The content of the message to send. Use "\\n" for line breaks.',
+      required: true,
+    }),
+    label: Property.ShortText({
+      displayName: 'Label',
+      description:
+        'Assign a label to the chat (creates a new label if it does not exist).',
+      required: false,
+    }),
+    file_uid: Property.ShortText({
+      displayName: 'File UID',
+      description:
+        'UID of a file previously uploaded to TimelinesAI to attach to the message.',
+      required: false,
+    }),
+    attachment_template_id: Property.Number({
+      displayName: 'Attachment Template ID',
+      description: 'ID of an attachment template to be sent.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue } = context;
+    const { chat_id, text, label, file_uid, attachment_template_id } =
+      propsValue;
+    const payload: SendMessageRequest = { text };
+    if (label) payload.label = label;
+    if (file_uid) payload.file_uid = file_uid;
+    if (attachment_template_id)
+      payload.attachment_template_id = attachment_template_id;
+
+    const numericChatId = typeof chat_id === 'string' ? parseInt(chat_id, 10) : (chat_id as number);
+    return await timelinesAiClient.sendMessage(auth, numericChatId, payload);
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/actions/send-message-to-new-chat.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/send-message-to-new-chat.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+import { timelinesAiProps } from '../common/props';
+import { SendMessageToNewChatRequest } from '../common/types';
+
+export const sendMessageToNewChatAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'send_message_to_new_chat',
+  displayName: 'Send Message to New Chat',
+  description: 'Creates a new chat by sending a message to a phone number.',
+  props: {
+    whatsapp_account_phone: timelinesAiProps.whatsappAccountPhone,
+    phone: Property.ShortText({
+      displayName: "Recipient's Phone Number",
+      description:
+        "The recipient's phone number in international format (e.g., +14155552671).",
+      required: true,
+    }),
+    text: Property.LongText({
+      displayName: 'Message',
+      description: 'The content of the message to send.',
+      required: true,
+    }),
+    label: Property.ShortText({
+      displayName: 'Label',
+      description: 'Assign a label to the new chat.',
+      required: false,
+    }),
+    file_uid: Property.ShortText({
+      displayName: 'File UID',
+      description:
+        'UID of a file previously uploaded to TimelinesAI to attach to the message.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { auth, propsValue } = context;
+    const payload: SendMessageToNewChatRequest = {
+      whatsapp_account_phone: propsValue.whatsapp_account_phone,
+      phone: propsValue.phone,
+      text: propsValue.text,
+      label: propsValue.label,
+      file_uid: propsValue.file_uid,
+    };
+    return await timelinesAiClient.sendMessageToNewChat(auth, payload);
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/actions/send-uploaded-file-to-existing-chat.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/actions/send-uploaded-file-to-existing-chat.ts
@@ -1,0 +1,63 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from '../common/auth';
+import { timelinesAiClient } from '../common/client';
+import { timelinesAiProps } from '../common/props';
+import { SendMessageRequest, UploadFileByUrlRequest } from '../common/types';
+
+export const sendUploadedFileToExistingChatAction = createAction({
+  auth: timelinesAiAuth,
+  name: 'send_uploaded_file_to_existing_chat',
+  displayName: 'Send File to Existing Chat',
+  description:
+    'Uploads a file from a URL and sends it to an existing WhatsApp chat.',
+  props: {
+    chat_id: timelinesAiProps.chatId,
+    download_url: Property.ShortText({
+      displayName: 'File URL',
+      description: 'A publicly accessible URL for the file to upload and send.',
+      required: true,
+    }),
+    caption: Property.LongText({
+      displayName: 'Caption',
+      description: 'An optional text caption to send along with the file.',
+      required: false,
+    }),
+    filename: Property.ShortText({
+      displayName: 'Filename (Optional)',
+      description: 'An optional filename to use instead of the original.',
+      required: false,
+    }),
+    content_type: Property.ShortText({
+      displayName: 'MIME Type (Optional)',
+      description: 'An optional mime-type for the file (e.g., image/jpeg).',
+      required: false,
+    }),
+  },
+
+  async run(context) {
+    const { auth, propsValue } = context;
+    const { chat_id, download_url, caption, filename, content_type } =
+      propsValue;
+
+    const uploadPayload: UploadFileByUrlRequest = { download_url };
+    if (filename) uploadPayload.filename = filename;
+    if (content_type) uploadPayload.content_type = content_type;
+
+    const uploadResponse = await timelinesAiClient.uploadFileByUrl(
+      auth,
+      uploadPayload
+    );
+    const fileUid = uploadResponse.data.uid;
+
+    const sendMessagePayload: SendMessageRequest = {
+      file_uid: fileUid,
+    };
+    if (caption) sendMessagePayload.text = caption;
+    const numericChatId = typeof chat_id === 'string' ? parseInt(chat_id, 10) : (chat_id as number);
+    return await timelinesAiClient.sendMessage(
+      auth,
+      numericChatId,
+      sendMessagePayload
+    );
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/common/auth.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/common/auth.ts
@@ -1,0 +1,33 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+
+export const timelinesAiAuth = PieceAuth.SecretText({
+  displayName: 'API Token',
+  description:
+    'Your TimelinesAI API token, found in your account under the Public API section.',
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://app.timelines.ai/integrations/api/whatsapp_accounts',
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: auth, 
+        },
+      });
+      return {
+        valid: true,
+      };
+    } catch (e) {
+      return {
+        valid: false,
+        error: 'Invalid API Token',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/common/client.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/common/client.ts
@@ -1,0 +1,210 @@
+import {
+  HttpMethod,
+  HttpMessageBody,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { Buffer } from 'node:buffer';
+import {
+  TimelinesAiAuthType,
+  Chat,
+  FindChatRequest,
+  GetMessageResponse,
+  MessageStatus,
+  FindFileRequest,
+  GetFilesResponse,
+  GetFileResponse,
+  SendMessageRequest,
+  SendMessageResponse,
+  UploadFileByUrlRequest,
+  UploadFileResponse,
+  UploadFileByFormDataResponse,
+  WhatsAppAccount,
+  SendMessageToNewChatRequest,
+  UpdateChatRequest,
+  UpdateChatResponse,
+} from './types';
+
+const TIMELINES_API_URL = 'https://app.timelines.ai/integrations/api';
+
+export const timelinesAiClient = {
+  async getChats(auth: TimelinesAiAuthType): Promise<Chat[]> {
+    const response = await httpClient.sendRequest<Chat[]>({
+      method: HttpMethod.GET,
+      url: `${TIMELINES_API_URL}/chats`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+
+  async uploadFileByUrl(
+    auth: TimelinesAiAuthType,
+    payload: UploadFileByUrlRequest
+  ): Promise<UploadFileResponse> {
+    const response = await httpClient.sendRequest<UploadFileResponse>({
+      method: HttpMethod.POST,
+      url: `${TIMELINES_API_URL}/files`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: payload,
+    });
+    return response.body;
+  },
+
+  async uploadFileByContent(
+    auth: TimelinesAiAuthType,
+    file: { filename: string; data: Buffer }
+  ): Promise<UploadFileByFormDataResponse> {
+    const body: HttpMessageBody = {
+      file: {
+        value: file.data,
+        filename: file.filename,
+      },
+    };
+    const response = await httpClient.sendRequest<UploadFileByFormDataResponse>(
+      {
+        method: HttpMethod.POST,
+        url: `${TIMELINES_API_URL}/files/upload`,
+        body: body,
+        headers: {
+          Authorization: `Bearer ${auth}`,
+        },
+      }
+    );
+    return response.body;
+  },
+
+  async getWhatsAppAccounts(
+    auth: TimelinesAiAuthType
+  ): Promise<WhatsAppAccount[]> {
+    const response = await httpClient.sendRequest<WhatsAppAccount[]>({
+      method: HttpMethod.GET,
+      url: `${TIMELINES_API_URL}/whatsapp_accounts`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+
+  async sendMessageToNewChat(
+    auth: TimelinesAiAuthType,
+    payload: SendMessageToNewChatRequest
+  ): Promise<SendMessageResponse> {
+    const response = await httpClient.sendRequest<SendMessageResponse>({
+      method: HttpMethod.POST,
+      url: `${TIMELINES_API_URL}/chats/send`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: payload,
+    });
+    return response.body;
+  },
+
+  async sendMessage(
+    auth: TimelinesAiAuthType,
+    chatId: number,
+    payload: SendMessageRequest
+  ): Promise<SendMessageResponse> {
+    const response = await httpClient.sendRequest<SendMessageResponse>({
+      method: HttpMethod.POST,
+      url: `${TIMELINES_API_URL}/chats/${chatId}/messages`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: payload,
+    });
+    return response.body;
+  },
+
+  async getMessageById(
+    auth: TimelinesAiAuthType,
+    messageUid: string
+  ): Promise<GetMessageResponse> {
+    const response = await httpClient.sendRequest<GetMessageResponse>({
+      method: HttpMethod.GET,
+      url: `${TIMELINES_API_URL}/messages/${messageUid}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+
+  async updateChatState(
+    auth: TimelinesAiAuthType,
+    chatId: number,
+    payload: UpdateChatRequest
+  ): Promise<UpdateChatResponse> {
+    const response = await httpClient.sendRequest<UpdateChatResponse>({
+      method: HttpMethod.PATCH,
+      url: `${TIMELINES_API_URL}/chats/${chatId}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      body: payload,
+    });
+    return response.body;
+  },
+
+  async findChat(
+    auth: TimelinesAiAuthType,
+    params: FindChatRequest
+  ): Promise<Chat[]> {
+    const response = await httpClient.sendRequest<Chat[]>({
+      method: HttpMethod.GET,
+      url: `${TIMELINES_API_URL}/chats`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: params as Record<string, string>,
+    });
+    return response.body;
+  },
+
+  async getFileById(
+    auth: TimelinesAiAuthType,
+    fileUid: string
+  ): Promise<GetFileResponse> {
+    const response = await httpClient.sendRequest<GetFileResponse>({
+      method: HttpMethod.GET,
+      url: `${TIMELINES_API_URL}/files/${fileUid}`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+
+  async findFiles(
+    auth: TimelinesAiAuthType,
+    params: FindFileRequest
+  ): Promise<GetFilesResponse> {
+    const response = await httpClient.sendRequest<GetFilesResponse>({
+      method: HttpMethod.GET,
+      url: `${TIMELINES_API_URL}/files`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: params as Record<string, string>,
+    });
+    return response.body;
+  },
+
+  async getMessageStatusHistory(
+    auth: TimelinesAiAuthType,
+    messageUid: string
+  ): Promise<MessageStatus[]> {
+    const response = await httpClient.sendRequest<MessageStatus[]>({
+      method: HttpMethod.GET,
+      url: `${TIMELINES_API_URL}/messages/${messageUid}/status_history`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+    });
+    return response.body;
+  },
+};

--- a/packages/pieces/community/timelines-ai/src/lib/common/props.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/common/props.ts
@@ -1,0 +1,72 @@
+import { Property } from '@activepieces/pieces-framework';
+import { timelinesAiClient } from './client';
+import { TimelinesAiAuthType } from './types';
+
+export const timelinesAiProps = {
+  chatId: Property.Dropdown({
+    displayName: 'Chat',
+    description: 'The chat to send the message to.',
+    required: true,
+    refreshers: [],
+    options: async ({ auth }) => {
+      if (!auth) {
+        return {
+          disabled: true,
+          placeholder: 'Please connect your account first',
+          options: [],
+        };
+      }
+      try {
+        const chats = await timelinesAiClient.getChats(
+          auth as TimelinesAiAuthType
+        );
+        return {
+          disabled: false,
+          options: chats.map((chat) => ({
+            label: chat.name,
+            value: chat.id,
+          })),
+        };
+      } catch (error) {
+        return {
+          disabled: true,
+          placeholder: 'Error fetching chats. Check connection and token.',
+          options: [],
+        };
+      }
+    },
+  }),
+  whatsappAccountPhone: Property.Dropdown({
+    displayName: 'From WhatsApp Account',
+    description: 'The connected WhatsApp account to send the message from.',
+    required: true,
+    refreshers: [],
+    options: async ({ auth }) => {
+      if (!auth) {
+        return {
+          disabled: true,
+          placeholder: 'Please connect your account first',
+          options: [],
+        };
+      }
+      try {
+        const accounts = await timelinesAiClient.getWhatsAppAccounts(
+          auth as TimelinesAiAuthType
+        );
+        return {
+          disabled: false,
+          options: accounts.map((account) => ({
+            label: `${account.name} (${account.phone})`,
+            value: account.phone,
+          })),
+        };
+      } catch (error) {
+        return {
+          disabled: true,
+          placeholder: 'Error fetching accounts.',
+          options: [],
+        };
+      }
+    },
+  }),
+};

--- a/packages/pieces/community/timelines-ai/src/lib/common/trigger.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/common/trigger.ts
@@ -1,0 +1,52 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { timelinesAiAuth } from './auth';
+import { AnyWebhookPayload } from './types';
+
+export const createTimelinesAiTrigger = ({
+  name,
+  displayName,
+  description,
+  eventType,
+  sampleData,
+}: {
+  name: string;
+  displayName: string;
+  description: string;
+  eventType: string; 
+  sampleData: unknown;
+}) => {
+  return createTrigger({
+    auth: timelinesAiAuth,
+    name: name,
+    displayName: displayName,
+    description: description,
+    props: {},
+    type: TriggerStrategy.WEBHOOK,
+    sampleData: sampleData,
+
+    async onEnable(_context) {
+      return;
+    },
+
+    async onDisable(_context) {
+      return;
+    },
+
+    async run(context) {
+      const payload = context.payload.body as AnyWebhookPayload;
+      if (payload.event_type !== eventType) {
+        return [];
+      }
+      if ('account' in payload) {
+        return [payload.account];
+      } else if ('file' in payload) {
+        return [{ ...payload.file, chat: payload.chat }];
+      } else if ('message' in payload) {
+        return [{ ...payload.message, chat: payload.chat }];
+      } else if ('chat' in payload) {
+        return [payload.chat];
+      }
+      return [payload];
+    },
+  });
+};

--- a/packages/pieces/community/timelines-ai/src/lib/common/types.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/common/types.ts
@@ -1,0 +1,183 @@
+export type TimelinesAiAuthType = string;
+
+export type AnyWebhookPayload =
+  | WebhookPayload
+  | NewMessageWebhookPayload
+  | NewFileWebhookPayload
+  | NewAccountWebhookPayload;
+
+export interface SendMessageRequest {
+  text?: string;
+  label?: string;
+  file_uid?: string;
+  attachment_template_id?: number;
+}
+
+export interface ResponsibleUser {
+    id: string;
+    email: string;
+    name: string;
+}
+
+export interface Chat {
+  id: number | string;
+  name: string;
+  previous_name?: string; 
+  phone?: string;
+  jid?: string;
+  is_group?: boolean;
+  closed?: boolean;
+  read?: boolean;
+  labels?: string[];
+  responsible_email?: string;
+  responsible_name?: string;
+  whatsapp_account_id?: string;
+  chat_url?: string;
+  created_timestamp?: string;
+  last_message_uid?: string;
+  last_message_timestamp?: string;
+  photo?: string;
+  is_allowed_to_message?: boolean;
+  whatsapp_account_phone?: string;
+  responsible?: ResponsibleUser;
+}
+
+export interface FindChatRequest {
+  phone?: string;
+  name?: string;
+  chat_id?: number;
+  whatsapp_account_phone?: string;
+  responsible_email?: string;
+  label?: string;
+}
+
+export interface SendMessageResponse {
+  status: string;
+  data: {
+    message_uid: string;
+  };
+}
+
+export interface UploadFileByUrlRequest {
+  download_url: string;
+  filename?: string;
+  content_type?: string;
+}
+
+export interface UploadFileResponse {
+  status: string;
+  data: {
+    uid: string;
+    filename: string;
+    size: number;
+    mimetype: string;
+  };
+}
+
+export interface UploadFileByFormDataResponse {
+  file_uid: string;
+}
+
+export interface WhatsAppAccount {
+  id: string;
+  phone: string;
+  name: string;
+  status?: string;
+  is_active?: boolean;
+}
+
+export interface SendMessageToNewChatRequest {
+    whatsapp_account_phone: string;
+    phone: string;
+    text: string;
+    label?: string;
+    file_uid?: string;
+}
+
+export interface UpdateChatRequest {
+    state: 'closed' | 'open';
+}
+
+export interface UpdateChatResponse {
+    status: string;
+    data: {
+        chat: Chat;
+    };
+}
+
+export interface Message {
+  uid: string;
+  chat_id: number | string;
+  text: string;
+  is_outgoing?: boolean;
+  is_read?: boolean;
+  created_timestamp?: string;
+  sender?: Sender;
+  timestamp?: number;
+}
+
+export interface GetMessageResponse {
+    status: string;
+    data: Message;
+}
+
+export interface UploadedFile {
+  uid: string;
+  name: string;
+  size: number;
+  mimetype: string;
+  url?: string;
+  temporary_download_url?: string;
+  uploaded_by_email?: string;
+  uploaded_at?: string;
+}
+
+export interface GetFilesResponse {
+    status: string;
+    data: UploadedFile[];
+}
+
+export interface GetFileResponse {
+    status: string;
+    data: UploadedFile;
+}
+
+export interface FindFileRequest {
+    filename?: string;
+}
+
+export interface MessageStatus {
+    status: string;
+    timestamp: string;
+}
+
+export interface WebhookPayload {
+    event_type: string;
+    timestamp: string;
+    chat: Chat;
+}
+
+export interface Sender {
+  name: string;
+  is_me: boolean;
+}
+
+export interface NewMessageWebhookPayload {
+  event_type: string;
+  timestamp: string;
+  message: Message;
+  chat: Chat;
+}
+
+export interface NewFileWebhookPayload {
+  event_type: string;
+  timestamp: string;
+  file: UploadedFile;
+  chat: Chat;
+}
+
+export interface NewAccountWebhookPayload {
+  event_type: string;
+  timestamp: string;
+  account: WhatsAppAccount;
+}

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/chat-closed.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/chat-closed.ts
@@ -1,0 +1,20 @@
+import { createTimelinesAiTrigger } from '../common/trigger';
+
+export const chatClosedTrigger = createTimelinesAiTrigger({
+  name: 'chat_closed',
+  displayName: 'Chat Closed',
+  description: 'Fires when a chat is marked as closed.',
+  eventType: 'chat_closed',
+  sampleData: {
+    id: 'chat_123456789',
+    name: 'John Doe',
+    phone: '14155552671',
+    state: 'closed',
+    whatsapp_account_phone: '14155552670',
+    responsible: {
+      id: 'user_abcde12345',
+      email: 'agent@example.com',
+      name: 'Jane Smith',
+    },
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/chat-renamed.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/chat-renamed.ts
@@ -1,0 +1,13 @@
+import { createTimelinesAiTrigger } from '../common/trigger';
+
+export const chatRenamedTrigger = createTimelinesAiTrigger({
+  name: 'chat_renamed',
+  displayName: 'Chat Renamed',
+  description: 'Fires when the name of a chat is updated.',
+  eventType: 'chat_renamed',
+  sampleData: {
+    id: 'chat_123456789',
+    name: 'John Doe - Priority',
+    previous_name: 'John Doe',
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/new-incoming-chat.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/new-incoming-chat.ts
@@ -1,0 +1,14 @@
+import { createTimelinesAiTrigger } from '../common/trigger';
+
+export const newIncomingChatTrigger = createTimelinesAiTrigger({
+  name: 'new_incoming_chat',
+  displayName: 'New Incoming Chat',
+  description: 'Fires when a new chat is initiated by an incoming message.',
+  eventType: 'new_incoming_chat',
+  sampleData: {
+    id: 'chat_135792468',
+    name: 'Potential Customer',
+    phone: '14155552674',
+    whatsapp_account_phone: '14155552670',
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/new-outgoing-chat.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/new-outgoing-chat.ts
@@ -1,0 +1,14 @@
+import { createTimelinesAiTrigger } from '../common/trigger';
+
+export const newOutgoingChatTrigger = createTimelinesAiTrigger({
+  name: 'new_outgoing_chat',
+  displayName: 'New Outgoing Chat',
+  description: 'Fires when a new outgoing chat is initiated from your account.',
+  eventType: 'new_outgoing_chat',
+  sampleData: {
+    id: 'chat_987654321',
+    name: 'New Customer',
+    phone: '14155552673',
+    whatsapp_account_phone: '14155552670',
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/new-received-message.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/new-received-message.ts
@@ -1,0 +1,23 @@
+import { createTimelinesAiTrigger } from '../common/trigger';
+
+export const newReceivedMessageTrigger = createTimelinesAiTrigger({
+  name: 'new_received_message',
+  displayName: 'New Received Message',
+  description: 'Fires when a new message is received from a contact.',
+  eventType: 'new_received_message',
+  sampleData: {
+    uid: 'msg_fedcba654321',
+    chat_id: 'chat_135792468',
+    text: 'Hello, I have a question about my order.',
+    sender: {
+      name: 'Potential Customer',
+      is_me: false,
+    },
+    timestamp: 1727364600,
+    chat: {
+      id: 'chat_135792468',
+      name: 'Potential Customer',
+      phone: '14155552674',
+    },
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/new-sent-message.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/new-sent-message.ts
@@ -1,0 +1,23 @@
+import { createTimelinesAiTrigger } from '../common/trigger';
+
+export const newSentMessageTrigger = createTimelinesAiTrigger({
+  name: 'new_sent_message',
+  displayName: 'New Sent Message',
+  description: 'Fires when a new message is sent from your account.',
+  eventType: 'new_sent_message',
+  sampleData: {
+    uid: 'msg_abcdef123456',
+    chat_id: 'chat_987654321',
+    text: 'Thank you for your inquiry. We will get back to you shortly.',
+    sender: {
+      name: 'Support Team',
+      is_me: true,
+    },
+    timestamp: 1727360100,
+    chat: {
+      id: 'chat_987654321',
+      name: 'New Customer',
+      phone: '14155552673',
+    },
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/new-uploaded-file.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/new-uploaded-file.ts
@@ -1,0 +1,18 @@
+import { createTimelinesAiTrigger } from '../common/trigger';
+
+export const newUploadedFileTrigger = createTimelinesAiTrigger({
+  name: 'new_uploaded_file',
+  displayName: 'New Uploaded File',
+  description: 'Fires when a new file is uploaded in a chat.',
+  eventType: 'new_uploaded_file',
+  sampleData: {
+    uid: 'file_xyz789123',
+    name: 'invoice_september.pdf',
+    mimetype: 'application/pdf',
+    size: 123456,
+    url: 'https://timelines.ai/files/temp/xyz789123/invoice_september.pdf',
+    chat: {
+      id: 'chat_123456789',
+    },
+  },
+});

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/new-whatsapp-account.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/new-whatsapp-account.ts
@@ -1,0 +1,14 @@
+import { createTimelinesAiTrigger } from '../common/trigger';
+
+export const newWhatsappAccountTrigger = createTimelinesAiTrigger({
+  name: 'new_whatsapp_account',
+  displayName: 'New WhatsApp Account',
+  description:
+    'Fires when a new WhatsApp account is connected to the workspace.',
+  eventType: 'whatsapp_account_connected',
+  sampleData: {
+    id: 'wa_account_54321',
+    phone: '14155552675',
+    name: 'Marketing Team',
+  },
+});

--- a/packages/pieces/community/timelines-ai/tsconfig.json
+++ b/packages/pieces/community/timelines-ai/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/timelines-ai/tsconfig.lib.json
+++ b/packages/pieces/community/timelines-ai/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1087,6 +1087,9 @@
       "@activepieces/piece-tidycal": [
         "packages/pieces/community/tidycal/src/index.ts"
       ],
+      "@activepieces/piece-timelines-ai": [
+        "packages/pieces/community/timelines-ai/src/index.ts"
+      ],
       "@activepieces/piece-todoist": [
         "packages/pieces/community/todoist/src/index.ts"
       ],


### PR DESCRIPTION
## 📝 PR Description
This PR adds the **TimelinesAI Integration Piece** for Activepieces.  
It enables workflows to automate around **WhatsApp communication and synchronization** in TimelinesAI, including:

- **🚨 Triggers** – monitor chat lifecycle events, incoming/outgoing messages, uploaded files, and new WhatsApp accounts.  
- **🛠️ Write Actions** – send messages or files to existing/new chats, and close chats programmatically.  
- **🔍 Search Actions** – look up chats, messages, files, message statuses, and WhatsApp accounts with filters.  

## 🔗 Complete Implementation Demo :  **Press Here** 👉 [ ▶️ Watch HQ Video ](https://drive.google.com/file/d/10VXDEJL7XZ8GL7Hbye6Qcy6MKERwM5gJ/view?usp=sharing)


https://github.com/user-attachments/assets/ca6fce15-d24a-4e36-92bc-1909818cb709

Note: My WhatsApp account was frozen after testing the actions, so I wasn’t able to demonstrate them live in the recording. Instead, I included the results captured during my earlier tests.

Fixes #9430
/claim #9430