### PR TITLE
fix: db logs for runs

### DIFF
--- a/packages/server/api/src/app/workers/engine-controller.ts
+++ b/packages/server/api/src/app/workers/engine-controller.ts
@@ -181,7 +181,6 @@ async function handleUpdateLogsBehavior(request: HandleUpdateLogsBehaviorParams)
     switch (updateLogsBehavior) {
         case UpdateLogsBehavior.UPDATE_LOGS: {
             assertNotNullOrUndefined(executionStateContentLength, 'executionStateContentLength is required')
-            assertNotNullOrUndefined(logsFileId, 'logsFileId is required')
             await flowRunService(request.log).updateLogs({
                 flowRunId: request.runId,
                 logsFileId,


### PR DESCRIPTION
When `AP_FILE_STORAGE_LOCATION` was set to DB, it #was broken