### PR TITLE
fix: test-step results that were string were getting stringified again

### DIFF
--- a/packages/pieces/community/json/package.json
+++ b/packages/pieces/community/json/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-json",
-  "version": "0.0.7"
+  "version": "0.0.8"
 }

--- a/packages/pieces/community/json/src/lib/actions/convert-json-to-text.ts
+++ b/packages/pieces/community/json/src/lib/actions/convert-json-to-text.ts
@@ -3,7 +3,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 export const convertJsonToText = createAction({
   name: 'convert_json_to_text',
   displayName: 'Convert Json to Text',
-  description: '',
+  description: 'Stringifies JSON.',
   props: {
     json: Property.Json({
       displayName: 'JSON',

--- a/packages/pieces/community/json/src/lib/actions/convert-text-to-json.ts
+++ b/packages/pieces/community/json/src/lib/actions/convert-text-to-json.ts
@@ -3,7 +3,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 export const convertTextToJson = createAction({
   name: 'convert_text_to_json',
   displayName: 'Convert Text to Json',
-  description: '',
+  description: 'Parses text into JSON.',
   props: {
     text: Property.LongText({
       displayName: 'Text',

--- a/packages/react-ui/src/app/builder/pieces-selector/generic-piece-selector-item.tsx
+++ b/packages/react-ui/src/app/builder/pieces-selector/generic-piece-selector-item.tsx
@@ -42,6 +42,7 @@ const GenericActionOrTriggerItem = ({
     : {
         minHeight: '54px',
       };
+  const pieceSelectorItemInfo = getPieceSelectorItemInfo(item);
   return (
     <CardListItem
       className={cn('p-2 w-full ', {
@@ -64,12 +65,12 @@ const GenericActionOrTriggerItem = ({
           />
         </div>
         <div className="flex flex-col gap-0.5">
-          <div className="text-sm">
-            {getPieceSelectorItemInfo(item).displayName}
-          </div>
+          <div className="text-sm">{pieceSelectorItemInfo.displayName}</div>
           {!hidePieceIconAndDescription && (
             <div className="text-xs text-muted-foreground">
-              {getPieceSelectorItemInfo(item).description}
+              {pieceSelectorItemInfo.description.endsWith('.')
+                ? pieceSelectorItemInfo.description.slice(0, -1)
+                : pieceSelectorItemInfo.description}
             </div>
           )}
         </div>

--- a/packages/server/api/src/app/flows/step-run/sample-data.service.ts
+++ b/packages/server/api/src/app/flows/step-run/sample-data.service.ts
@@ -105,7 +105,7 @@ export async function saveSampleData({
     const step = flowStructureUtil.getStepOrThrow(stepName, flowVersion.trigger)
     const fileType = type === SampleDataFileType.INPUT ? FileType.SAMPLE_DATA_INPUT : FileType.SAMPLE_DATA
     const fileId = await useExistingOrCreateNewSampleId(projectId, flowVersion, step, fileType, log)
-    const data = Buffer.from(JSON.stringify(payload))
+    const data = dataType === SampleDataDataType.STRING && typeof payload === 'string' ? Buffer.from(payload) : Buffer.from(JSON.stringify(payload))
     return fileService(log).save({
         projectId,
         fileId,


### PR DESCRIPTION
If you had a (JSON to text) step and tested it, then passed the result to a (Text to JSON) step, the result would still be string, because the first step was stringifying the result that was already a string.

This only happens in testing steps, not flows.
<img width="160" height="633" alt="image" src="https://github.com/user-attachments/assets/557583da-25c2-4f61-8b0e-7d92deb53a5a" />
