### PR TITLE
feat: new converter for list of items to text table

### DIFF
--- a/packages/pieces/community/text-helper/package.json
+++ b/packages/pieces/community/text-helper/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-text-helper",
-  "version": "0.4.6"
+  "version": "0.4.7"
 }

--- a/packages/pieces/community/text-helper/src/index.ts
+++ b/packages/pieces/community/text-helper/src/index.ts
@@ -9,6 +9,7 @@ import { split } from './lib/actions/split';
 import { stripHtmlContent } from './lib/actions/strip-html';
 import { slugifyAction } from './lib/actions/slugify';
 import { defaultValue } from './lib/actions/default-value';
+import { jsonToAsciiTable } from './lib/actions/json-to-ascii-table';
 
 export const textHelper = createPiece({
   displayName: 'Text Helper',
@@ -24,6 +25,7 @@ export const textHelper = createPiece({
     'abuaboud',
     'AdamSelene',
     'Anmol-Gup',
+    'geekyme'
   ],
   categories: [PieceCategory.CORE],
   actions: [
@@ -36,6 +38,7 @@ export const textHelper = createPiece({
     stripHtmlContent,
     slugifyAction,
     defaultValue,
+    jsonToAsciiTable,
   ],
   triggers: [],
 });

--- a/packages/pieces/community/text-helper/src/lib/actions/json-to-ascii-table.ts
+++ b/packages/pieces/community/text-helper/src/lib/actions/json-to-ascii-table.ts
@@ -1,0 +1,78 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+
+export const jsonToAsciiTable = createAction({
+  description: 'Convert a list of items to a text table',
+  displayName: 'List to Text Table',
+  name: 'json_to_ascii_table',
+  errorHandlingOptions: {
+    continueOnFailure: {
+      hide: true,
+    },
+    retryOnFailure: {
+      hide: true,
+    },
+  },
+  props: {
+    data: Property.Json({
+      displayName: 'List',
+      description: 'List of items to convert to a text table',
+      required: true,
+    }),
+  },
+  run: async (ctx) => {
+    const data = ctx.propsValue.data;
+
+    // Validate input is an array
+    if (!Array.isArray(data)) {
+      throw new Error('Input must be an array of objects');
+    }
+
+    if (data.length === 0) {
+      return '';
+    }
+
+    // Get all unique keys from all objects
+    const keys = Array.from(
+      new Set(data.flatMap((obj) => Object.keys(obj)))
+    );
+
+    // Calculate column widths
+    const columnWidths = keys.map((key) => {
+      const maxDataWidth = Math.max(
+        ...data.map((row) => String(row[key] ?? '').length)
+      );
+      return Math.max(key.length, maxDataWidth);
+    });
+
+    // Create separator line
+    const separator =
+      '+' +
+      columnWidths.map((width) => '-'.repeat(width + 2)).join('+') +
+      '+';
+
+    // Create header row
+    const header =
+      '|' +
+      keys
+        .map((key, i) => ' ' + key.padEnd(columnWidths[i]) + ' ')
+        .join('|') +
+      '|';
+
+    // Create data rows
+    const rows = data.map((row) => {
+      return (
+        '|' +
+        keys
+          .map((key, i) => {
+            const value = String(row[key] ?? '');
+            return ' ' + value.padEnd(columnWidths[i]) + ' ';
+          })
+          .join('|') +
+        '|'
+      );
+    });
+
+    // Combine all parts
+    return [separator, header, separator, ...rows, separator].join('\n');
+  },
+});


### PR DESCRIPTION
## What does this PR do?

New converter for converting a list of json objects to an ASCII table representation


### Explain How the Feature Works
<img width="1118" height="717" alt="Screenshot 2025-09-30 at 11 52 48 PM" src="https://github.com/user-attachments/assets/ec84b736-c0f0-4405-95e5-fcc23b1c7e0d" />


### Relevant User Scenarios

Useful for rendering text tables like this, in situations where there is no native table representations. 

<img width="889" height="142" alt="Screenshot 2025-09-30 at 11 48 22 PM" src="https://github.com/user-attachments/assets/bab62cad-b4a1-408b-bd48-4f2fd76aa3cf" />
