### PR TITLE
feat: add rcs-send action to seven piece

### DIFF
--- a/packages/pieces/community/seven/README.md
+++ b/packages/pieces/community/seven/README.md
@@ -13,6 +13,7 @@ Settings -> My Pieces -> Install Piece -> type in `seven`
 - Send SMS
 - Text-To-Speech Call
 - Lookup
+- Send RCS
 
 ## Triggers
 - Inbound SMS

--- a/packages/pieces/community/seven/src/action/rcs-send.ts
+++ b/packages/pieces/community/seven/src/action/rcs-send.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { sevenAuth } from '../index';
+import { callSevenApi } from '../common';
+
+export const sendRcsAction = createAction({
+  auth: sevenAuth,
+  name: 'send-rcs',
+  displayName: 'Send RCS',
+  description: 'Sends a Rich Communication Services message.',
+  props: {
+    to: Property.Array({
+      displayName: 'To',
+      description: 'Recipient number of the RCS.',
+      required: true
+    }),
+    delay: Property.DateTime({
+      displayName: 'Delay',
+      required: false
+    }),
+    from: Property.ShortText({
+      displayName: 'From',
+      required: false
+    }),
+    text: Property.LongText({
+      displayName: 'Message Body',
+      description: 'The body of the message to send.',
+      required: true
+    }),
+
+  },
+  async run(context) {
+    const { delay, from, text, to } = context.propsValue;
+
+    const response =  await callSevenApi({
+      body: {
+        delay: delay ? new Date(delay).toISOString().replace('T', ' ').substring(0, 19) : undefined,
+        from,
+        text,
+        to
+      },
+      method: HttpMethod.POST
+    }, 'rcs/messages', context.auth as string);
+
+    return response.body;
+
+  }
+});

--- a/packages/pieces/community/seven/src/index.ts
+++ b/packages/pieces/community/seven/src/index.ts
@@ -1,5 +1,6 @@
 import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
 import { sendSmsAction } from './action/sms-send';
+import { sendRcsAction } from './action/rcs-send';
 import { sendVoiceCallAction } from './action/send-voice-call';
 import { lookup } from './action/lookup';
 import { smsInbound } from './trigger/sms-inbound';
@@ -20,6 +21,6 @@ export const seven = createPiece({
   logoUrl: 'https://cdn.activepieces.com/pieces/seven.jpg',
   categories: [PieceCategory.MARKETING],
   authors: ['seven-io'],
-  actions: [sendSmsAction, sendVoiceCallAction, lookup],
+  actions: [sendSmsAction, sendVoiceCallAction, lookup, sendRcsAction],
   triggers: [smsInbound],
 });


### PR DESCRIPTION
## What does this PR do?

This PR adds the an action to the **seven** piece for sending RCS messages.

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works

This feature adds the possibility to send Rich Communication Services messages via seven.io.
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

RCS is the successor to traditional text messages (SMS) and opens up a much wider range of possibilities.

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



