### PR TITLE
fix(formstack): Trigger timezone

### DIFF
--- a/packages/pieces/community/formstack/package.json
+++ b/packages/pieces/community/formstack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-formstack",
-  "version": "0.0.9"
+  "version": "0.0.10"
 }

--- a/packages/pieces/community/formstack/src/lib/triggers/new-submission.ts
+++ b/packages/pieces/community/formstack/src/lib/triggers/new-submission.ts
@@ -34,6 +34,14 @@ const polling: Polling<PiecePropValueSchema<typeof formStackAuth>, any> = {
     try {
       const isTest = lastFetchEpochMS === 0;
 
+      // use form timezone for storing epochMilliSeconds
+      const formResponse = await makeRequest(
+        accessToken,
+        HttpMethod.GET,
+        `/form/${formId}.json`
+      );
+      const formTimezone = formResponse.timezone;
+
       const queryParams: Record<string, any> = {
         data: 'true',
         sort: 'DESC',
@@ -66,7 +74,9 @@ const polling: Polling<PiecePropValueSchema<typeof formStackAuth>, any> = {
         const submissions: any[] = submissionsResponse.submissions || [];
         submissions.forEach((submission: any) => {
           detailedSubmissions.push({
-            epochMilliSeconds: dayjs(submission.timestamp).valueOf(),
+            epochMilliSeconds: dayjs
+              .tz(submission.timestamp, formTimezone)
+              .valueOf(),
             data: {
               id: submission.id,
               form_id: formId,


### PR DESCRIPTION
## What does this PR do?

Follow up on:
- https://github.com/activepieces/activepieces/pull/9472
- https://github.com/activepieces/activepieces/pull/9480

The submission timestamp returned is in the timezone configured for each form. This matters when saving `epochMilliSeconds` because it is in turn [used for lastFetchEpochMS](https://github.com/activepieces/activepieces/blob/1b25397651fca7cc2f6cc100a55442b3f287f3b7/packages/pieces/community/common/src/lib/polling/index.ts#L74-L78) in the next run, which is assumed to be UTC and used in the query param.

Since this is timezone sensitive, and can be inconsistent depending on the system time, explicitly use form timezone when saving `epochMilliSeconds`.
