### PR TITLE
fix: typo in migration command doc

### DIFF
--- a/docs/handbook/engineering/playbooks/database-migration.mdx
+++ b/docs/handbook/engineering/playbooks/database-migration.mdx
@@ -68,7 +68,7 @@ If you are generating a migration for an entity that will only be used in Cloud 
   <Step title="Generate Migration">
     Run the migration generation command:
     ```bash
-    nx db-migration server-api name=<MIGRATION_NAME>
+    nx db-migration server-api --name=<MIGRATION_NAME>
     ```
     Replace `<MIGRATION_NAME>` with a descriptive name for your migration.
   </Step>


### PR DESCRIPTION
## What does this PR do?

Fix typo in migration command docs

