### PR TITLE
fix(datadog): fix incorrect application key header for custom api call action

### DIFF
--- a/packages/pieces/community/datadog/package.json
+++ b/packages/pieces/community/datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-datadog",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/packages/pieces/community/datadog/src/lib/common.ts
+++ b/packages/pieces/community/datadog/src/lib/common.ts
@@ -27,6 +27,6 @@ export const constructDatadogBaseHeaders = (auth: DatadogAuthType) => {
   return {
     'Accept': 'application/json',
     'DD-API-KEY': auth.apiKey,
-    ...(auth.appKey ? {'DD-APP-KEY': auth.appKey} : {}),
+    ...(auth.appKey ? {'DD-APPLICATION-KEY': auth.appKey} : {}),
   };
 };


### PR DESCRIPTION
## What does this PR do?

Datadog's custom api call action is using the wrong header for Application Key. It should be `DD-APPLICATION-KEY` instead of `DD-APP-KEY`. That header is not recognized and will produce a 401 error if the API endpoint requires it.

https://docs.datadoghq.com/api/latest/?tab=java#api-reference
> Authenticate to the API with an API key using the header DD-API-KEY. For some endpoints, you also need an Application key, which uses the header DD-APPLICATION-KEY.

Old:
<img width="753" height="422" alt="Screenshot 2025-10-03 at 2 37 49 PM" src="https://github.com/user-attachments/assets/e8d3a428-97ef-4547-bc02-6f2445e1dfa2" />

New:
<img width="278" height="448" alt="Screenshot 2025-10-03 at 2 58 50 PM" src="https://github.com/user-attachments/assets/cfd86590-1b21-4071-ab45-b18c0a474d67" />
