### PR TITLE
feat: add SimplyBook.me Piece integration

### DIFF
--- a/packages/pieces/community/simplybook-me/README.md
+++ b/packages/pieces/community/simplybook-me/README.md
@@ -1,0 +1,44 @@
+# SimplyBook.me Piece for Activepieces
+
+This Piece provides integration with SimplyBook.me, an online appointment & scheduling platform. It enables Activepieces workflows to respond to scheduling events and manage related objects like clients, offers, and invoices.
+
+## Features
+
+### Triggers
+- **New Booking** - Fires when a new booking is created
+- **Booking Change** - Fires when booking details change (date, time, service, provider, status, intake form answers)
+- **Booking Cancellation** - Fires when a booking is canceled
+- **New Client** - Fires when a new client is added (via booking or manually)
+- **New Offer** - Fires when a new offer (proposal or quote) is created
+- **New Invoice** - Fires when a new invoice is generated/paid (with Accept Payments feature)
+
+### Actions
+
+#### Write Actions
+- **Cancel a Booking** - Cancel an existing booking
+- **Create a Booking** - Create a new booking with required booking parameters
+- **Create a Booking's Comment** - Add a comment or note to a booking
+- **Create a Client** - Create a new client record
+- **Create a Detailed Report** - Generate a detailed report (metrics, bookings, revenue)
+- **Create a Note** - Create a note (generic) in the system
+- **Delete a Client** - Delete an existing client
+
+#### Search/Read Actions
+- **Find Booking** - Find bookings based on search criteria
+- **Find Client** - Find clients based on search criteria
+- **Find Invoice** - Find invoices based on search criteria
+
+## Setup
+
+1. Sign up for a free account at [SimplyBook.me](https://simplybook.me/en/)
+2. In your admin panel, go to 'Custom Features' and enable the 'API' feature
+3. Copy your Company Login and API Key from the API settings
+4. Use these credentials when configuring the SimplyBook.me Piece in Activepieces
+
+## API Reference
+
+- [SimplyBook.me API Documentation](https://simplybook.net/en/api/developer-api)
+
+## Test Account Access
+
+You can sign up for free at https://simplybook.me/en/ to test the integration.

--- a/packages/pieces/community/simplybook-me/package.json
+++ b/packages/pieces/community/simplybook-me/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-simplybook-me",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/simplybook-me/project.json
+++ b/packages/pieces/community/simplybook-me/project.json
@@ -1,0 +1,26 @@
+{
+  "name": "simplybook-me",
+  "sourceRoot": "src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist",
+        "main": "src/index.ts",
+        "tsConfig": "tsconfig.lib.json",
+        "assets": []
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": ["scope:community", "type:piece"]
+}

--- a/packages/pieces/community/simplybook-me/src/i18n/translation.json
+++ b/packages/pieces/community/simplybook-me/src/i18n/translation.json
@@ -1,0 +1,120 @@
+{
+  "actions": {
+    "create_booking": {
+      "displayName": "Create Booking",
+      "description": "Create a new booking in SimplyBook.me"
+    },
+    "cancel_booking": {
+      "displayName": "Cancel Booking",
+      "description": "Cancel an existing booking"
+    },
+    "create_booking_comment": {
+      "displayName": "Create Booking Comment",
+      "description": "Add a comment or note to a booking"
+    },
+    "create_client": {
+      "displayName": "Create Client",
+      "description": "Create a new client in SimplyBook.me"
+    },
+    "delete_client": {
+      "displayName": "Delete Client",
+      "description": "Delete an existing client"
+    },
+    "create_note": {
+      "displayName": "Create Note",
+      "description": "Create a generic note in the system"
+    },
+    "create_detailed_report": {
+      "displayName": "Create Detailed Report",
+      "description": "Generate a detailed report with metrics, bookings, and revenue"
+    },
+    "find_booking": {
+      "displayName": "Find Booking",
+      "description": "Find bookings based on search criteria"
+    },
+    "find_client": {
+      "displayName": "Find Client",
+      "description": "Find clients based on search criteria"
+    },
+    "find_invoice": {
+      "displayName": "Find Invoice",
+      "description": "Find invoices based on search criteria"
+    }
+  },
+  "triggers": {
+    "new_booking": {
+      "displayName": "New Booking",
+      "description": "Triggers when a new booking is created"
+    },
+    "booking_change": {
+      "displayName": "Booking Change",
+      "description": "Triggers when booking details change"
+    },
+    "booking_cancellation": {
+      "displayName": "Booking Cancellation",
+      "description": "Triggers when a booking is canceled"
+    },
+    "new_client": {
+      "displayName": "New Client",
+      "description": "Triggers when a new client is added"
+    },
+    "new_offer": {
+      "displayName": "New Offer",
+      "description": "Triggers when a new offer is created"
+    },
+    "new_invoice": {
+      "displayName": "New Invoice",
+      "description": "Triggers when a new invoice is generated/paid"
+    }
+  },
+  "props": {
+    "clientId": {
+      "displayName": "Client ID",
+      "description": "ID of the client"
+    },
+    "serviceId": {
+      "displayName": "Service ID",
+      "description": "ID of the service"
+    },
+    "providerId": {
+      "displayName": "Provider ID",
+      "description": "ID of the service provider"
+    },
+    "bookingId": {
+      "displayName": "Booking ID",
+      "description": "ID of the booking"
+    },
+    "firstName": {
+      "displayName": "First Name",
+      "description": "First name"
+    },
+    "lastName": {
+      "displayName": "Last Name",
+      "description": "Last name"
+    },
+    "email": {
+      "displayName": "Email",
+      "description": "Email address"
+    },
+    "phone": {
+      "displayName": "Phone",
+      "description": "Phone number"
+    },
+    "startDateTime": {
+      "displayName": "Start Date & Time",
+      "description": "Start date and time"
+    },
+    "endDateTime": {
+      "displayName": "End Date & Time",
+      "description": "End date and time"
+    },
+    "notes": {
+      "displayName": "Notes",
+      "description": "Additional notes"
+    },
+    "status": {
+      "displayName": "Status",
+      "description": "Status"
+    }
+  }
+}

--- a/packages/pieces/community/simplybook-me/src/index.ts
+++ b/packages/pieces/community/simplybook-me/src/index.ts
@@ -1,0 +1,71 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { simplyBookAuth, API_BASE_URL } from './lib/common';
+import {
+  createBookingAction,
+  cancelBookingAction,
+  createBookingCommentAction,
+  createClientAction,
+  deleteClientAction,
+  createNoteAction,
+  createDetailedReportAction,
+  findBookingAction,
+  findClientAction,
+  findInvoiceAction,
+} from './lib/actions';
+import {
+  newBookingTrigger,
+  bookingChangeTrigger,
+  bookingCancellationTrigger,
+  newClientTrigger,
+  newOfferTrigger,
+  newInvoiceTrigger,
+} from './lib/triggers';
+
+const markdown = `
+## Obtain your SimplyBook.me API credentials
+
+1. Go to https://simplybook.me/en/ and sign up for a free account
+2. In your admin panel, go to 'Custom Features' and enable the 'API' feature
+3. Copy your Company Login and API Key from the API settings
+4. Paste them in the fields below
+`;
+
+export const simplyBookMe = createPiece({
+  displayName: 'SimplyBook.me',
+  description: 'Online appointment & scheduling platform integration',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/simplybook-me.png',
+  categories: [PieceCategory.PRODUCTIVITY, PieceCategory.SALES_AND_CRM],
+  authors: ['activepieces'],
+  auth: simplyBookAuth,
+  actions: [
+    createBookingAction,
+    cancelBookingAction,
+    createBookingCommentAction,
+    createClientAction,
+    deleteClientAction,
+    createNoteAction,
+    createDetailedReportAction,
+    findBookingAction,
+    findClientAction,
+    findInvoiceAction,
+    createCustomApiCallAction({
+      baseUrl: () => API_BASE_URL,
+      auth: simplyBookAuth,
+      authMapping: async (auth) => ({
+        'X-Company-Login': auth.companyLogin,
+        'X-Token': auth.accessToken || '',
+      }),
+    }),
+  ],
+  triggers: [
+    newBookingTrigger,
+    bookingChangeTrigger,
+    bookingCancellationTrigger,
+    newClientTrigger,
+    newOfferTrigger,
+    newInvoiceTrigger,
+  ],
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/cancel-booking.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/cancel-booking.ts
@@ -1,0 +1,31 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const cancelBookingAction = createAction({
+  auth: simplyBookAuth,
+  name: 'cancel_booking',
+  displayName: 'Cancel Booking',
+  description: 'Cancel an existing booking',
+  props: {
+    bookingId: Property.Number({
+      displayName: 'Booking ID',
+      description: 'ID of the booking to cancel',
+      required: true,
+    }),
+    reason: Property.ShortText({
+      displayName: 'Cancellation Reason',
+      description: 'Reason for cancellation',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { bookingId, reason } = context.propsValue;
+    
+    const params = {
+      booking_id: bookingId,
+      ...(reason && { reason }),
+    };
+
+    return await makeApiRequest(context.auth, 'cancelBooking', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/create-booking-comment.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/create-booking-comment.ts
@@ -1,0 +1,38 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest, SimplyBookAuth } from '../common';
+
+export const createBookingCommentAction = createAction({
+  auth: simplyBookAuth,
+  name: 'create_booking_comment',
+  displayName: 'Create Booking Comment',
+  description: 'Add a comment or note to a booking',
+  props: {
+    bookingId: Property.Number({
+      displayName: 'Booking ID',
+      description: 'ID of the booking to add a comment to',
+      required: true,
+    }),
+    comment: Property.LongText({
+      displayName: 'Comment',
+      description: 'Comment or note to add to the booking',
+      required: true,
+    }),
+    isInternal: Property.Checkbox({
+      displayName: 'Internal Comment',
+      description: 'Whether this is an internal comment (not visible to client)',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context: { propsValue: any; auth: SimplyBookAuth }) {
+    const { bookingId, comment, isInternal } = context.propsValue;
+    
+    const params = {
+      booking_id: bookingId,
+      comment: comment,
+      is_internal: isInternal || false,
+    };
+
+    return await makeApiRequest(context.auth, 'addBookingComment', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/create-booking.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/create-booking.ts
@@ -1,0 +1,69 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest, SimplyBookAuth } from '../common';
+
+export const createBookingAction = createAction({
+  auth: simplyBookAuth,
+  name: 'create_booking',
+  displayName: 'Create Booking',
+  description: 'Create a new booking in SimplyBook.me',
+  props: {
+    clientId: Property.Number({
+      displayName: 'Client ID',
+      description: 'ID of the client making the booking',
+      required: true,
+    }),
+    serviceId: Property.Number({
+      displayName: 'Service ID',
+      description: 'ID of the service to book',
+      required: true,
+    }),
+    providerId: Property.Number({
+      displayName: 'Provider ID',
+      description: 'ID of the service provider',
+      required: true,
+    }),
+    startDateTime: Property.DateTime({
+      displayName: 'Start Date & Time',
+      description: 'Start date and time of the booking',
+      required: true,
+    }),
+    endDateTime: Property.DateTime({
+      displayName: 'End Date & Time',
+      description: 'End date and time of the booking',
+      required: true,
+    }),
+    notes: Property.LongText({
+      displayName: 'Notes',
+      description: 'Additional notes for the booking',
+      required: false,
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      description: 'Booking status',
+      required: false,
+      options: {
+        options: [
+          { label: 'Confirmed', value: 'confirmed' },
+          { label: 'Pending', value: 'pending' },
+          { label: 'Cancelled', value: 'cancelled' },
+        ],
+      },
+      defaultValue: 'confirmed',
+    }),
+  },
+  async run(context) {
+    const { clientId, serviceId, providerId, startDateTime, endDateTime, notes, status } = context.propsValue;
+    
+    const params = {
+      client_id: clientId,
+      service_id: serviceId,
+      provider_id: providerId,
+      start_datetime: startDateTime,
+      end_datetime: endDateTime,
+      status: status || 'confirmed',
+      ...(notes && { notes }),
+    };
+
+    return await makeApiRequest(context.auth, 'addBooking', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/create-client.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/create-client.ts
@@ -1,0 +1,79 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const createClientAction = createAction({
+  auth: simplyBookAuth,
+  name: 'create_client',
+  displayName: 'Create Client',
+  description: 'Create a new client in SimplyBook.me',
+  props: {
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      description: 'Client\'s first name',
+      required: true,
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      description: 'Client\'s last name',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Client\'s email address',
+      required: true,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      description: 'Client\'s phone number',
+      required: false,
+    }),
+    address: Property.LongText({
+      displayName: 'Address',
+      description: 'Client\'s address',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      description: 'Client\'s city',
+      required: false,
+    }),
+    state: Property.ShortText({
+      displayName: 'State/Province',
+      description: 'Client\'s state or province',
+      required: false,
+    }),
+    zipCode: Property.ShortText({
+      displayName: 'ZIP/Postal Code',
+      description: 'Client\'s ZIP or postal code',
+      required: false,
+    }),
+    country: Property.ShortText({
+      displayName: 'Country',
+      description: 'Client\'s country',
+      required: false,
+    }),
+    notes: Property.LongText({
+      displayName: 'Notes',
+      description: 'Additional notes about the client',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { firstName, lastName, email, phone, address, city, state, zipCode, country, notes } = context.propsValue;
+    
+    const params = {
+      first_name: firstName,
+      last_name: lastName,
+      email: email,
+      ...(phone && { phone }),
+      ...(address && { address }),
+      ...(city && { city }),
+      ...(state && { state }),
+      ...(zipCode && { zip_code: zipCode }),
+      ...(country && { country }),
+      ...(notes && { notes }),
+    };
+
+    return await makeApiRequest(context.auth, 'addClient', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/create-detailed-report.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/create-detailed-report.ts
@@ -1,0 +1,72 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const createDetailedReportAction = createAction({
+  auth: simplyBookAuth,
+  name: 'create_detailed_report',
+  displayName: 'Create Detailed Report',
+  description: 'Generate a detailed report with metrics, bookings, and revenue',
+  props: {
+    reportType: Property.StaticDropdown({
+      displayName: 'Report Type',
+      description: 'Type of report to generate',
+      required: true,
+      options: {
+        options: [
+          { label: 'Bookings Report', value: 'bookings' },
+          { label: 'Revenue Report', value: 'revenue' },
+          { label: 'Client Report', value: 'clients' },
+          { label: 'Provider Report', value: 'providers' },
+          { label: 'Service Report', value: 'services' },
+        ],
+      },
+    }),
+    startDate: Property.DateTime({
+      displayName: 'Start Date',
+      description: 'Start date for the report',
+      required: true,
+    }),
+    endDate: Property.DateTime({
+      displayName: 'End Date',
+      description: 'End date for the report',
+      required: true,
+    }),
+    providerId: Property.Number({
+      displayName: 'Provider ID',
+      description: 'Filter by specific provider (optional)',
+      required: false,
+    }),
+    serviceId: Property.Number({
+      displayName: 'Service ID',
+      description: 'Filter by specific service (optional)',
+      required: false,
+    }),
+    format: Property.StaticDropdown({
+      displayName: 'Report Format',
+      description: 'Format of the generated report',
+      required: false,
+      options: {
+        options: [
+          { label: 'JSON', value: 'json' },
+          { label: 'CSV', value: 'csv' },
+          { label: 'PDF', value: 'pdf' },
+        ],
+      },
+      defaultValue: 'json',
+    }),
+  },
+  async run(context) {
+    const { reportType, startDate, endDate, providerId, serviceId, format } = context.propsValue;
+    
+    const params = {
+      report_type: reportType,
+      start_date: startDate,
+      end_date: endDate,
+      ...(providerId && { provider_id: providerId }),
+      ...(serviceId && { service_id: serviceId }),
+      format: format || 'json',
+    };
+
+    return await makeApiRequest(context.auth, 'generateReport', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/create-note.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/create-note.ts
@@ -1,0 +1,44 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const createNoteAction = createAction({
+  auth: simplyBookAuth,
+  name: 'create_note',
+  displayName: 'Create Note',
+  description: 'Create a generic note in the system',
+  props: {
+    title: Property.ShortText({
+      displayName: 'Note Title',
+      description: 'Title of the note',
+      required: true,
+    }),
+    content: Property.LongText({
+      displayName: 'Note Content',
+      description: 'Content of the note',
+      required: true,
+    }),
+    category: Property.ShortText({
+      displayName: 'Category',
+      description: 'Category for the note',
+      required: false,
+    }),
+    isImportant: Property.Checkbox({
+      displayName: 'Important',
+      description: 'Mark this note as important',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { title, content, category, isImportant } = context.propsValue;
+    
+    const params = {
+      title: title,
+      content: content,
+      ...(category && { category }),
+      is_important: isImportant || false,
+    };
+
+    return await makeApiRequest(context.auth, 'addNote', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/delete-client.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/delete-client.ts
@@ -1,0 +1,25 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const deleteClientAction = createAction({
+  auth: simplyBookAuth,
+  name: 'delete_client',
+  displayName: 'Delete Client',
+  description: 'Delete an existing client',
+  props: {
+    clientId: Property.Number({
+      displayName: 'Client ID',
+      description: 'ID of the client to delete',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { clientId } = context.propsValue;
+    
+    const params = {
+      client_id: clientId,
+    };
+
+    return await makeApiRequest(context.auth, 'deleteClient', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/find-booking.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/find-booking.ts
@@ -1,0 +1,81 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const findBookingAction = createAction({
+  auth: simplyBookAuth,
+  name: 'find_booking',
+  displayName: 'Find Booking',
+  description: 'Find bookings based on search criteria',
+  props: {
+    bookingId: Property.Number({
+      displayName: 'Booking ID',
+      description: 'Specific booking ID to find (optional)',
+      required: false,
+    }),
+    clientId: Property.Number({
+      displayName: 'Client ID',
+      description: 'Filter by client ID (optional)',
+      required: false,
+    }),
+    providerId: Property.Number({
+      displayName: 'Provider ID',
+      description: 'Filter by provider ID (optional)',
+      required: false,
+    }),
+    serviceId: Property.Number({
+      displayName: 'Service ID',
+      description: 'Filter by service ID (optional)',
+      required: false,
+    }),
+    startDate: Property.DateTime({
+      displayName: 'Start Date',
+      description: 'Filter bookings from this date (optional)',
+      required: false,
+    }),
+    endDate: Property.DateTime({
+      displayName: 'End Date',
+      description: 'Filter bookings until this date (optional)',
+      required: false,
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      description: 'Filter by booking status (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Confirmed', value: 'confirmed' },
+          { label: 'Pending', value: 'pending' },
+          { label: 'Cancelled', value: 'cancelled' },
+          { label: 'Completed', value: 'completed' },
+        ],
+      },
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of bookings to return',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { bookingId, clientId, providerId, serviceId, startDate, endDate, status, limit } = context.propsValue;
+    
+    // If specific booking ID is provided, get that booking
+    if (bookingId) {
+      return await makeApiRequest(context.auth, 'getBooking', { booking_id: bookingId });
+    }
+    
+    // Otherwise, search for bookings
+    const params: Record<string, any> = {
+      ...(clientId && { client_id: clientId }),
+      ...(providerId && { provider_id: providerId }),
+      ...(serviceId && { service_id: serviceId }),
+      ...(startDate && { start_date: startDate }),
+      ...(endDate && { end_date: endDate }),
+      ...(status && { status }),
+      limit: limit || 50,
+    };
+
+    return await makeApiRequest(context.auth, 'getBookings', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/find-client.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/find-client.ts
@@ -1,0 +1,61 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const findClientAction = createAction({
+  auth: simplyBookAuth,
+  name: 'find_client',
+  displayName: 'Find Client',
+  description: 'Find clients based on search criteria',
+  props: {
+    clientId: Property.Number({
+      displayName: 'Client ID',
+      description: 'Specific client ID to find (optional)',
+      required: false,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Search by email address (optional)',
+      required: false,
+    }),
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      description: 'Search by first name (optional)',
+      required: false,
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      description: 'Search by last name (optional)',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      description: 'Search by phone number (optional)',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of clients to return',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { clientId, email, firstName, lastName, phone, limit } = context.propsValue;
+    
+    // If specific client ID is provided, get that client
+    if (clientId) {
+      return await makeApiRequest(context.auth, 'getClient', { client_id: clientId });
+    }
+    
+    // Otherwise, search for clients
+    const params: Record<string, any> = {
+      ...(email && { email }),
+      ...(firstName && { first_name: firstName }),
+      ...(lastName && { last_name: lastName }),
+      ...(phone && { phone }),
+      limit: limit || 50,
+    };
+
+    return await makeApiRequest(context.auth, 'getClients', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/find-invoice.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/find-invoice.ts
@@ -1,0 +1,76 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const findInvoiceAction = createAction({
+  auth: simplyBookAuth,
+  name: 'find_invoice',
+  displayName: 'Find Invoice',
+  description: 'Find invoices based on search criteria',
+  props: {
+    invoiceId: Property.Number({
+      displayName: 'Invoice ID',
+      description: 'Specific invoice ID to find (optional)',
+      required: false,
+    }),
+    clientId: Property.Number({
+      displayName: 'Client ID',
+      description: 'Filter by client ID (optional)',
+      required: false,
+    }),
+    bookingId: Property.Number({
+      displayName: 'Booking ID',
+      description: 'Filter by booking ID (optional)',
+      required: false,
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      description: 'Filter by invoice status (optional)',
+      required: false,
+      options: {
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Sent', value: 'sent' },
+          { label: 'Paid', value: 'paid' },
+          { label: 'Overdue', value: 'overdue' },
+          { label: 'Cancelled', value: 'cancelled' },
+        ],
+      },
+    }),
+    startDate: Property.DateTime({
+      displayName: 'Start Date',
+      description: 'Filter invoices from this date (optional)',
+      required: false,
+    }),
+    endDate: Property.DateTime({
+      displayName: 'End Date',
+      description: 'Filter invoices until this date (optional)',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of invoices to return',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { invoiceId, clientId, bookingId, status, startDate, endDate, limit } = context.propsValue;
+    
+    // If specific invoice ID is provided, get that invoice
+    if (invoiceId) {
+      return await makeApiRequest(context.auth, 'getInvoice', { invoice_id: invoiceId });
+    }
+    
+    // Otherwise, search for invoices
+    const params: Record<string, any> = {
+      ...(clientId && { client_id: clientId }),
+      ...(bookingId && { booking_id: bookingId }),
+      ...(status && { status }),
+      ...(startDate && { start_date: startDate }),
+      ...(endDate && { end_date: endDate }),
+      limit: limit || 50,
+    };
+
+    return await makeApiRequest(context.auth, 'getInvoices', params);
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/actions/index.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/actions/index.ts
@@ -1,0 +1,10 @@
+export { createBookingAction } from './create-booking';
+export { cancelBookingAction } from './cancel-booking';
+export { createBookingCommentAction } from './create-booking-comment';
+export { createClientAction } from './create-client';
+export { deleteClientAction } from './delete-client';
+export { createNoteAction } from './create-note';
+export { createDetailedReportAction } from './create-detailed-report';
+export { findBookingAction } from './find-booking';
+export { findClientAction } from './find-client';
+export { findInvoiceAction } from './find-invoice';

--- a/packages/pieces/community/simplybook-me/src/lib/common/index.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/common/index.ts
@@ -1,0 +1,113 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import { AuthenticationType, HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+export const API_BASE_URL = 'https://user-api.simplybook.me';
+
+export interface SimplyBookAuth {
+  companyLogin: string;
+  apiKey: string;
+  accessToken?: string;
+  tokenExpiry?: number;
+}
+
+export const simplyBookAuth = PieceAuth.CustomAuth({
+  required: true,
+  props: {
+    companyLogin: Property.ShortText({
+      displayName: 'Company Login',
+      description: 'Your SimplyBook.me company login',
+      required: true,
+    }),
+    apiKey: Property.ShortText({
+      displayName: 'API Key',
+      description: 'Your SimplyBook.me API key (found in Custom Features > API)',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      const token = await getAccessToken(auth.companyLogin, auth.apiKey);
+      return {
+        valid: true,
+      };
+    } catch (error) {
+      return {
+        valid: false,
+        error: 'Invalid credentials. Please check your company login and API key.',
+      };
+    }
+  },
+});
+
+export async function getAccessToken(companyLogin: string, apiKey: string): Promise<string> {
+  const response = await httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: `${API_BASE_URL}/login`,
+    headers: {
+      'X-Company-Login': companyLogin,
+      'Content-Type': 'application/json',
+    },
+    body: {
+      jsonrpc: '2.0',
+      method: 'getToken',
+      params: {
+        apiKey: apiKey,
+      },
+      id: 1,
+    },
+  });
+
+  if (response.body && response.body.result) {
+    return response.body.result;
+  }
+  
+  throw new Error('Failed to get access token');
+}
+
+export async function makeApiRequest(
+  auth: SimplyBookAuth,
+  method: string,
+  params: Record<string, any> = {}
+): Promise<any> {
+  let accessToken = auth.accessToken;
+  
+  // Check if token is expired or doesn't exist
+  if (!accessToken || !auth.tokenExpiry || Date.now() >= auth.tokenExpiry) {
+    accessToken = await getAccessToken(auth.companyLogin, auth.apiKey);
+    auth.accessToken = accessToken;
+    auth.tokenExpiry = Date.now() + 50 * 60 * 1000; // 50 minutes (token expires in 1 hour)
+  }
+
+  const response = await httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: `${API_BASE_URL}/admin/`,
+    headers: {
+      'X-Company-Login': auth.companyLogin,
+      'X-Token': accessToken,
+      'Content-Type': 'application/json',
+    },
+    body: {
+      jsonrpc: '2.0',
+      method: method,
+      params: params,
+      id: Math.floor(Math.random() * 1000000),
+    },
+  });
+
+  if (response.body && response.body.error) {
+    throw new Error(`API Error: ${response.body.error.message || 'Unknown error'}`);
+  }
+
+  return response.body.result;
+}
+
+export function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+export function formatDateTime(date: Date): string {
+  return date.toISOString();
+}
+
+// Export types
+export * from './types';

--- a/packages/pieces/community/simplybook-me/src/lib/common/types.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/common/types.ts
@@ -1,0 +1,159 @@
+// SimplyBook.me API Types
+
+export interface Booking {
+  id: number;
+  client_id: number;
+  service_id: number;
+  provider_id: number;
+  start_datetime: string;
+  end_datetime: string;
+  status: 'confirmed' | 'pending' | 'cancelled' | 'completed';
+  notes?: string;
+  created_at: string;
+  updated_at?: string;
+  cancelled_at?: string;
+  cancellation_reason?: string;
+}
+
+export interface Client {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone?: string;
+  address?: string;
+  city?: string;
+  state?: string;
+  zip_code?: string;
+  country?: string;
+  notes?: string;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface Invoice {
+  id: number;
+  client_id: number;
+  booking_id?: number;
+  invoice_number: string;
+  amount: number;
+  currency: string;
+  status: 'draft' | 'sent' | 'paid' | 'overdue' | 'cancelled';
+  due_date: string;
+  paid_at?: string;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface Offer {
+  id: number;
+  client_id: number;
+  title: string;
+  description: string;
+  amount: number;
+  currency: string;
+  status: 'pending' | 'accepted' | 'rejected' | 'expired';
+  valid_until: string;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface Service {
+  id: number;
+  name: string;
+  description?: string;
+  duration: number; // in minutes
+  price: number;
+  currency: string;
+  active: boolean;
+}
+
+export interface Provider {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone?: string;
+  active: boolean;
+}
+
+export interface Note {
+  id: number;
+  title: string;
+  content: string;
+  category?: string;
+  is_important: boolean;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface Report {
+  id: string;
+  type: 'bookings' | 'revenue' | 'clients' | 'providers' | 'services';
+  start_date: string;
+  end_date: string;
+  data: any;
+  generated_at: string;
+}
+
+// API Request/Response Types
+export interface ApiResponse<T = any> {
+  jsonrpc: '2.0';
+  result?: T;
+  error?: {
+    code: number;
+    message: string;
+    data?: any;
+  };
+  id: number;
+}
+
+export interface CreateBookingParams {
+  client_id: number;
+  service_id: number;
+  provider_id: number;
+  start_datetime: string;
+  end_datetime: string;
+  status?: string;
+  notes?: string;
+}
+
+export interface CreateClientParams {
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone?: string;
+  address?: string;
+  city?: string;
+  state?: string;
+  zip_code?: string;
+  country?: string;
+  notes?: string;
+}
+
+export interface SearchBookingsParams {
+  client_id?: number;
+  provider_id?: number;
+  service_id?: number;
+  start_date?: string;
+  end_date?: string;
+  status?: string;
+  limit?: number;
+}
+
+export interface SearchClientsParams {
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  phone?: string;
+  limit?: number;
+}
+
+export interface SearchInvoicesParams {
+  client_id?: number;
+  booking_id?: number;
+  status?: string;
+  start_date?: string;
+  end_date?: string;
+  limit?: number;
+}

--- a/packages/pieces/community/simplybook-me/src/lib/triggers/booking-cancellation.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/triggers/booking-cancellation.ts
@@ -1,0 +1,65 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const bookingCancellationTrigger = createTrigger({
+  auth: simplyBookAuth,
+  name: 'booking_cancellation',
+  displayName: 'Booking Cancellation',
+  description: 'Triggers when a booking is canceled',
+  props: {
+    providerId: Property.Number({
+      displayName: 'Provider ID',
+      description: 'Filter by specific provider (optional)',
+      required: false,
+    }),
+    serviceId: Property.Number({
+      displayName: 'Service ID',
+      description: 'Filter by specific service (optional)',
+      required: false,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: 12345,
+    client_id: 67890,
+    service_id: 111,
+    provider_id: 222,
+    start_datetime: '2023-12-01T10:00:00Z',
+    end_datetime: '2023-12-01T11:00:00Z',
+    status: 'cancelled',
+    cancellation_reason: 'Client requested cancellation',
+    cancelled_at: '2023-11-28T16:30:00Z',
+  },
+  async onEnable(context) {
+    // Store the current timestamp to track cancellations
+    await context.store.put('last_cancellation_check', new Date().toISOString());
+  },
+  async onDisable(context) {
+    // Clean up if needed
+    await context.store.delete('last_cancellation_check');
+  },
+  async run(context) {
+    const lastCheck = await context.store.get<string>('last_cancellation_check');
+    const now = new Date().toISOString();
+    
+    const params: Record<string, any> = {
+      start_date: lastCheck || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      end_date: now,
+      status: 'cancelled',
+      ...(context.propsValue.providerId && { provider_id: context.propsValue.providerId }),
+      ...(context.propsValue.serviceId && { service_id: context.propsValue.serviceId }),
+    };
+
+    const bookings = await makeApiRequest(context.auth, 'getBookings', params);
+    
+    // Filter for bookings that were cancelled since last check
+    const cancelledBookings = (bookings || []).filter((booking: any) => 
+      booking.cancelled_at && booking.cancelled_at > lastCheck
+    );
+    
+    // Update the last check timestamp
+    await context.store.put('last_cancellation_check', now);
+    
+    return cancelledBookings;
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/triggers/booking-change.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/triggers/booking-change.ts
@@ -1,0 +1,69 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const bookingChangeTrigger = createTrigger({
+  auth: simplyBookAuth,
+  name: 'booking_change',
+  displayName: 'Booking Change',
+  description: 'Triggers when booking details change (date, time, service, provider, status, intake form answers)',
+  props: {
+    providerId: Property.Number({
+      displayName: 'Provider ID',
+      description: 'Filter by specific provider (optional)',
+      required: false,
+    }),
+    serviceId: Property.Number({
+      displayName: 'Service ID',
+      description: 'Filter by specific service (optional)',
+      required: false,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: 12345,
+    client_id: 67890,
+    service_id: 111,
+    provider_id: 222,
+    start_datetime: '2023-12-01T10:00:00Z',
+    end_datetime: '2023-12-01T11:00:00Z',
+    status: 'confirmed',
+    notes: 'Updated appointment time',
+    updated_at: '2023-11-28T16:30:00Z',
+    changes: {
+      start_datetime: '2023-12-01T09:00:00Z',
+      end_datetime: '2023-12-01T10:00:00Z',
+    },
+  },
+  async onEnable(context) {
+    // Store the current timestamp to track booking changes
+    await context.store.put('last_change_check', new Date().toISOString());
+  },
+  async onDisable(context) {
+    // Clean up if needed
+    await context.store.delete('last_change_check');
+  },
+  async run(context) {
+    const lastCheck = await context.store.get<string>('last_change_check');
+    const now = new Date().toISOString();
+    
+    const params: Record<string, any> = {
+      start_date: lastCheck || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      end_date: now,
+      include_changes: true,
+      ...(context.propsValue.providerId && { provider_id: context.propsValue.providerId }),
+      ...(context.propsValue.serviceId && { service_id: context.propsValue.serviceId }),
+    };
+
+    const bookings = await makeApiRequest(context.auth, 'getBookings', params);
+    
+    // Filter for bookings that have been updated
+    const changedBookings = (bookings || []).filter((booking: any) => 
+      booking.updated_at && booking.updated_at > lastCheck
+    );
+    
+    // Update the last check timestamp
+    await context.store.put('last_change_check', now);
+    
+    return changedBookings;
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/triggers/index.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/triggers/index.ts
@@ -1,0 +1,6 @@
+export { newBookingTrigger } from './new-booking';
+export { bookingChangeTrigger } from './booking-change';
+export { bookingCancellationTrigger } from './booking-cancellation';
+export { newClientTrigger } from './new-client';
+export { newOfferTrigger } from './new-offer';
+export { newInvoiceTrigger } from './new-invoice';

--- a/packages/pieces/community/simplybook-me/src/lib/triggers/new-booking.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/triggers/new-booking.ts
@@ -1,0 +1,59 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest, SimplyBookAuth } from '../common';
+
+export const newBookingTrigger = createTrigger({
+  auth: simplyBookAuth,
+  name: 'new_booking',
+  displayName: 'New Booking',
+  description: 'Triggers when a new booking is created',
+  props: {
+    providerId: Property.Number({
+      displayName: 'Provider ID',
+      description: 'Filter by specific provider (optional)',
+      required: false,
+    }),
+    serviceId: Property.Number({
+      displayName: 'Service ID',
+      description: 'Filter by specific service (optional)',
+      required: false,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: 12345,
+    client_id: 67890,
+    service_id: 111,
+    provider_id: 222,
+    start_datetime: '2023-12-01T10:00:00Z',
+    end_datetime: '2023-12-01T11:00:00Z',
+    status: 'confirmed',
+    notes: 'First appointment',
+    created_at: '2023-11-28T14:30:00Z',
+  },
+  async onEnable(context: { store: any }) {
+    // Store the current timestamp to track new bookings
+    await context.store.put('last_check', new Date().toISOString());
+  },
+  async onDisable(context: { store: any }) {
+    // Clean up if needed
+    await context.store.delete('last_check');
+  },
+  async run(context: { propsValue: any; auth: SimplyBookAuth; store: any }) {
+    const lastCheck = await context.store.get('last_check');
+    const now = new Date().toISOString();
+    
+    const params: Record<string, any> = {
+      start_date: lastCheck || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // Default to last 24 hours
+      end_date: now,
+      ...(context.propsValue.providerId && { provider_id: context.propsValue.providerId }),
+      ...(context.propsValue.serviceId && { service_id: context.propsValue.serviceId }),
+    };
+
+    const bookings = await makeApiRequest(context.auth, 'getBookings', params);
+    
+    // Update the last check timestamp
+    await context.store.put('last_check', now);
+    
+    return bookings || [];
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/triggers/new-client.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/triggers/new-client.ts
@@ -1,0 +1,52 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const newClientTrigger = createTrigger({
+  auth: simplyBookAuth,
+  name: 'new_client',
+  displayName: 'New Client',
+  description: 'Triggers when a new client is added (via booking or manually)',
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: 67890,
+    first_name: 'John',
+    last_name: 'Doe',
+    email: 'john.doe@example.com',
+    phone: '+1234567890',
+    address: '123 Main St',
+    city: 'New York',
+    state: 'NY',
+    zip_code: '10001',
+    country: 'USA',
+    created_at: '2023-11-28T14:30:00Z',
+  },
+  async onEnable(context) {
+    // Store the current timestamp to track new clients
+    await context.store.put('last_client_check', new Date().toISOString());
+  },
+  async onDisable(context) {
+    // Clean up if needed
+    await context.store.delete('last_client_check');
+  },
+  async run(context) {
+    const lastCheck = await context.store.get<string>('last_client_check');
+    const now = new Date().toISOString();
+    
+    const params: Record<string, any> = {
+      start_date: lastCheck || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      end_date: now,
+    };
+
+    const clients = await makeApiRequest(context.auth, 'getClients', params);
+    
+    // Filter for clients created since last check
+    const newClients = (clients || []).filter((client: any) => 
+      client.created_at && client.created_at > lastCheck
+    );
+    
+    // Update the last check timestamp
+    await context.store.put('last_client_check', now);
+    
+    return newClients;
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/triggers/new-invoice.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/triggers/new-invoice.ts
@@ -1,0 +1,51 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const newInvoiceTrigger = createTrigger({
+  auth: simplyBookAuth,
+  name: 'new_invoice',
+  displayName: 'New Invoice',
+  description: 'Triggers when a new invoice is generated/paid (with Accept Payments feature)',
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: 98765,
+    client_id: 67890,
+    booking_id: 12345,
+    invoice_number: 'INV-2023-001',
+    amount: 150.00,
+    currency: 'USD',
+    status: 'paid',
+    due_date: '2023-12-15T23:59:59Z',
+    paid_at: '2023-11-28T14:30:00Z',
+    created_at: '2023-11-28T14:30:00Z',
+  },
+  async onEnable(context) {
+    // Store the current timestamp to track new invoices
+    await context.store.put('last_invoice_check', new Date().toISOString());
+  },
+  async onDisable(context) {
+    // Clean up if needed
+    await context.store.delete('last_invoice_check');
+  },
+  async run(context) {
+    const lastCheck = await context.store.get<string>('last_invoice_check');
+    const now = new Date().toISOString();
+    
+    const params: Record<string, any> = {
+      start_date: lastCheck || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      end_date: now,
+    };
+
+    const invoices = await makeApiRequest(context.auth, 'getInvoices', params);
+    
+    // Filter for invoices created since last check
+    const newInvoices = (invoices || []).filter((invoice: any) => 
+      invoice.created_at && invoice.created_at > lastCheck
+    );
+    
+    // Update the last check timestamp
+    await context.store.put('last_invoice_check', now);
+    
+    return newInvoices;
+  },
+});

--- a/packages/pieces/community/simplybook-me/src/lib/triggers/new-offer.ts
+++ b/packages/pieces/community/simplybook-me/src/lib/triggers/new-offer.ts
@@ -1,0 +1,50 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { simplyBookAuth, makeApiRequest } from '../common';
+
+export const newOfferTrigger = createTrigger({
+  auth: simplyBookAuth,
+  name: 'new_offer',
+  displayName: 'New Offer',
+  description: 'Triggers when a new offer (proposal or quote) is created',
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: 54321,
+    client_id: 67890,
+    title: 'Website Development Proposal',
+    description: 'Complete website development for small business',
+    amount: 5000.00,
+    currency: 'USD',
+    status: 'pending',
+    valid_until: '2023-12-15T23:59:59Z',
+    created_at: '2023-11-28T14:30:00Z',
+  },
+  async onEnable(context) {
+    // Store the current timestamp to track new offers
+    await context.store.put('last_offer_check', new Date().toISOString());
+  },
+  async onDisable(context) {
+    // Clean up if needed
+    await context.store.delete('last_offer_check');
+  },
+  async run(context) {
+    const lastCheck = await context.store.get<string>('last_offer_check');
+    const now = new Date().toISOString();
+    
+    const params: Record<string, any> = {
+      start_date: lastCheck || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      end_date: now,
+    };
+
+    const offers = await makeApiRequest(context.auth, 'getOffers', params);
+    
+    // Filter for offers created since last check
+    const newOffers = (offers || []).filter((offer: any) => 
+      offer.created_at && offer.created_at > lastCheck
+    );
+    
+    // Update the last check timestamp
+    await context.store.put('last_offer_check', now);
+    
+    return newOffers;
+  },
+});

--- a/packages/pieces/community/simplybook-me/tsconfig.json
+++ b/packages/pieces/community/simplybook-me/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "lib": ["ES2021", "DOM"],
+    "target": "ES2021"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/simplybook-me/tsconfig.lib.json
+++ b/packages/pieces/community/simplybook-me/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["src/**/*"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
- Add comprehensive SimplyBook.me Piece with 6 triggers and 10 actions
- Implement all required triggers: New Booking, Booking Change, Booking Cancellation, New Client, New Offer, New Invoice
- Implement all required actions: Cancel Booking, Create Booking, Create Booking Comment, Create Client, Delete Client, Create Note, Create Detailed Report, Find Booking, Find Client, Find Invoice
- Add custom authentication with token management
- Include TypeScript types and comprehensive error handling
- Add internationalization support
- Follow Activepieces Piece development guidelines

Closes #9541
