### PR TITLE
fix(netsuite): signature query params

### DIFF
--- a/packages/pieces/community/netsuite/package.json
+++ b/packages/pieces/community/netsuite/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-netsuite",
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/packages/pieces/community/netsuite/src/index.ts
+++ b/packages/pieces/community/netsuite/src/index.ts
@@ -59,17 +59,13 @@ export const netsuite = createPiece({
       authMapping: async (auth, propsValue) => {
         const authValue = auth as PiecePropValueSchema<typeof netsuiteAuth>;
 
-        const parsedUrl = new URL(propsValue['url']['url']);
-        // sanitize cases where params etc are entered directly in the url field
-        const baseUrl = `${parsedUrl.origin}${parsedUrl.pathname}`;
-
         const authHeader = createOAuthHeader(
           authValue.accountId,
           authValue.consumerKey,
           authValue.consumerSecret,
           authValue.tokenId,
           authValue.tokenSecret,
-          baseUrl,
+          propsValue['url']['url'],
           propsValue['method']
         );
 

--- a/packages/pieces/community/netsuite/src/index.ts
+++ b/packages/pieces/community/netsuite/src/index.ts
@@ -66,7 +66,8 @@ export const netsuite = createPiece({
           authValue.tokenId,
           authValue.tokenSecret,
           propsValue['url']['url'],
-          propsValue['method']
+          propsValue['method'],
+          propsValue['queryParams']
         );
 
         return {

--- a/packages/pieces/community/netsuite/src/lib/actions/get-customer.ts
+++ b/packages/pieces/community/netsuite/src/lib/actions/get-customer.ts
@@ -16,10 +16,11 @@ export const getCustomer = createAction({
     }),
   },
   async run(context) {
-    const { accountId, consumerKey, consumerSecret, tokenId, tokenSecret } = context.auth;
+    const { accountId, consumerKey, consumerSecret, tokenId, tokenSecret } =
+      context.auth;
     const { customerId } = context.propsValue;
 
-    const baseUrl = `https://${accountId}.suitetalk.api.netsuite.com/services/rest/record/v1/customer/${customerId}`;
+    const requestUrl = `https://${accountId}.suitetalk.api.netsuite.com/services/rest/record/v1/customer/${customerId}`;
     const httpMethod = HttpMethod.GET;
 
     const authHeader = createOAuthHeader(
@@ -28,20 +29,20 @@ export const getCustomer = createAction({
       consumerSecret,
       tokenId,
       tokenSecret,
-      baseUrl,
+      requestUrl,
       httpMethod
     );
 
     const response = await httpClient.sendRequest({
       method: httpMethod,
-      url: baseUrl,
+      url: requestUrl,
       headers: {
         Authorization: authHeader,
-        'prefer': 'transient',
-        'Cookie': 'NS_ROUTING_VERSION=LAGGING',
+        prefer: 'transient',
+        Cookie: 'NS_ROUTING_VERSION=LAGGING',
       },
     });
 
     return response.body;
   },
-}); 
+});

--- a/packages/pieces/community/netsuite/src/lib/actions/get-vendor.ts
+++ b/packages/pieces/community/netsuite/src/lib/actions/get-vendor.ts
@@ -16,10 +16,11 @@ export const getVendor = createAction({
     }),
   },
   async run(context) {
-    const { accountId, consumerKey, consumerSecret, tokenId, tokenSecret } = context.auth;
+    const { accountId, consumerKey, consumerSecret, tokenId, tokenSecret } =
+      context.auth;
     const { vendorId } = context.propsValue;
 
-    const baseUrl = `https://${accountId}.suitetalk.api.netsuite.com/services/rest/record/v1/vendor/${vendorId}`;
+    const requestUrl = `https://${accountId}.suitetalk.api.netsuite.com/services/rest/record/v1/vendor/${vendorId}`;
     const httpMethod = HttpMethod.GET;
 
     const authHeader = createOAuthHeader(
@@ -28,17 +29,17 @@ export const getVendor = createAction({
       consumerSecret,
       tokenId,
       tokenSecret,
-      baseUrl,
+      requestUrl,
       httpMethod
     );
 
     const response = await httpClient.sendRequest({
       method: httpMethod,
-      url: baseUrl,
+      url: requestUrl,
       headers: {
         Authorization: authHeader,
-        'prefer': 'transient',
-        'Cookie': 'NS_ROUTING_VERSION=LAGGING',
+        prefer: 'transient',
+        Cookie: 'NS_ROUTING_VERSION=LAGGING',
       },
     });
 

--- a/packages/pieces/community/netsuite/src/lib/oauth.ts
+++ b/packages/pieces/community/netsuite/src/lib/oauth.ts
@@ -1,18 +1,20 @@
-import crypto from 'crypto';
 import { createHmac } from 'crypto';
-import { URL } from 'url';
 
 const SIGN_METHOD = 'HMAC-SHA256';
 const OAUTH_VERSION = '1.0';
 
-export function generateNonce(): string {
+function generateNonce(): string {
   const length = 11;
-  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  return Array.from({ length }, () => possible[Math.floor(Math.random() * possible.length)]).join('');
+  const possible =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  return Array.from(
+    { length },
+    () => possible[Math.floor(Math.random() * possible.length)]
+  ).join('');
 }
 
-export function generateSignature(
-  baseUrl: string,
+function generateSignature(
+  requestUrl: string,
   httpMethod: string,
   oauthNonce: string,
   timestamp: number,
@@ -30,6 +32,9 @@ export function generateSignature(
     oauth_version: OAUTH_VERSION,
   });
 
+  const parsedUrl = new URL(requestUrl);
+  const baseUrl = `${parsedUrl.origin}${parsedUrl.pathname}`;
+
   const signatureBaseString = [
     httpMethod,
     encodeURIComponent(baseUrl),
@@ -44,7 +49,7 @@ export function generateSignature(
   const hmac = createHmac('sha256', signingKey);
   hmac.update(signatureBaseString);
   const signature = hmac.digest('base64');
-  
+
   return encodeURIComponent(signature);
 }
 
@@ -54,13 +59,13 @@ export function createOAuthHeader(
   consumerSecret: string,
   tokenId: string,
   tokenSecret: string,
-  baseUrl: string,
+  requestUrl: string,
   httpMethod: string
 ): string {
   const oauthNonce = generateNonce();
   const timestamp = Math.floor(Date.now() / 1000);
   const signature = generateSignature(
-    baseUrl,
+    requestUrl,
     httpMethod,
     oauthNonce,
     timestamp,
@@ -82,4 +87,4 @@ export function createOAuthHeader(
   ].join(',');
 
   return `OAuth ${headerParams}`;
-} 
+}


### PR DESCRIPTION
## What does this PR do?

Currently using query params do not work because they need to be added to the signature. If query params are used, the API would throw 401 with InvalidSignature.
https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_157651396916.html#subsect_157652037988

### Explain How the Feature Works
Support signature calculation from query params either directly extracted from the URL and/or in a queryParams Record.