### PR TITLE
refactor: unify saving execution state behaviors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61432,7 +61432,8 @@
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
     },
     "node_modules/sqlite3": {
       "version": "5.1.7",

--- a/packages/server/worker/src/lib/executors/flow-job-executor.ts
+++ b/packages/server/worker/src/lib/executors/flow-job-executor.ts
@@ -74,12 +74,11 @@ async function handleMemoryIssueError(jobData: ExecuteFlowJobData, engineToken: 
             tasks: 0,
             tags: [],
         },
-        updateLogsBehavior: UpdateLogsBehavior.NONE,
-        executionStateContentLength: null,
         httpRequestId: jobData.httpRequestId,
         progressUpdateType: jobData.progressUpdateType,
         workerHandlerId: jobData.synchronousHandlerId,
         runId: jobData.runId,
+        updateLogsBehavior: UpdateLogsBehavior.NONE,
     })
 }
 
@@ -92,12 +91,11 @@ async function handleTimeoutError(jobData: ExecuteFlowJobData, engineToken: stri
             duration: timeoutFlowInSeconds,
             status: FlowRunStatus.TIMEOUT,
         },
-        executionStateContentLength: null,
-        updateLogsBehavior: UpdateLogsBehavior.NONE,
         httpRequestId: jobData.httpRequestId,
         progressUpdateType: jobData.progressUpdateType,
         workerHandlerId: jobData.synchronousHandlerId,
         runId: jobData.runId,
+        updateLogsBehavior: UpdateLogsBehavior.NONE,
     })
 }
 
@@ -109,12 +107,11 @@ async function handleInternalError(jobData: ExecuteFlowJobData, engineToken: str
             tasks: 0,
             tags: [],
         },
-        executionStateContentLength: null,
-        updateLogsBehavior: UpdateLogsBehavior.NONE,
         httpRequestId: jobData.httpRequestId,
         progressUpdateType: jobData.progressUpdateType,
         workerHandlerId: jobData.synchronousHandlerId,
         runId: jobData.runId,
+        updateLogsBehavior: UpdateLogsBehavior.NONE,
     })
     exceptionHandler.handle(e, log)
     throw e

--- a/packages/server/worker/src/lib/flow-worker.ts
+++ b/packages/server/worker/src/lib/flow-worker.ts
@@ -156,6 +156,8 @@ async function consumeJob(request: ConsumeJobRequest, log: FastifyBaseLogger): P
                             status: ConsumeJobResponseStatus.OK,
                         }
                     case WorkerJobType.EXECUTE_FLOW:
+                        console.log('executing flow')
+                        console.log(jobData)
                         await flowJobExecutor(log).executeFlow({ jobData, attempsStarted, engineToken, timeoutInSeconds })
                         span.setAttribute('worker.completed', true)
                         return {

--- a/packages/shared/src/lib/engine/requests.ts
+++ b/packages/shared/src/lib/engine/requests.ts
@@ -1,30 +1,37 @@
 import { Static, Type } from '@sinclair/typebox'
-import { Nullable } from '../common'
+import { DiscriminatedUnion, Nullable } from '../common'
 import { FlowRunResponse } from '../flow-run/execution/flow-execution'
 import { ProgressUpdateType } from './engine-operation'
 
 export enum UpdateLogsBehavior {
-    UPDATE_LOGS = 'UPDATE_LOGS',
-    UPDATE_LOGS_SIZE = 'UPDATE_LOGS_SIZE',
+    UPDATE_LOGS_METADATA = 'UPDATE_LOGS_METADATA',
     NONE = 'NONE',
 }
 
-export const UpdateRunProgressRequest = Type.Object({
+const BaseUpdateRunProgressRequest = {
     runDetails: Type.Omit(FlowRunResponse, ['steps']),
-    executionStateBuffer: Type.Optional(Type.String()),
-    executionStateContentLength: Type.Union([Type.Number(), Type.Null()]),
-    updateLogsBehavior: Type.Enum(UpdateLogsBehavior),
     runId: Type.String(),
     progressUpdateType: Type.Optional(Type.Enum(ProgressUpdateType)),
     workerHandlerId: Nullable(Type.String()),
     httpRequestId: Nullable(Type.String()),
     failedStepName: Type.Optional(Type.String()),
-    logsFileId: Type.Optional(Type.String()),
     testSingleStepMode: Type.Optional(Type.Boolean()),
-})
+}
+
+export const UpdateRunProgressRequest = DiscriminatedUnion('updateLogsBehavior', [
+    Type.Object({
+        ...BaseUpdateRunProgressRequest,
+        updateLogsBehavior: Type.Literal(UpdateLogsBehavior.UPDATE_LOGS_METADATA),
+        executionStateContentLength: Type.Number(),
+        logsFileId: Type.Optional(Type.String()),
+    }),
+    Type.Object({
+        ...BaseUpdateRunProgressRequest,
+        updateLogsBehavior: Type.Literal(UpdateLogsBehavior.NONE),
+    }),
+])
 
 export type UpdateRunProgressRequest = Static<typeof UpdateRunProgressRequest>
-
 
 export const SendFlowResponseRequest = Type.Object({
     workerHandlerId: Type.String(),
@@ -41,3 +48,12 @@ export const GetFlowVersionForWorkerRequest = Type.Object({
 })
 
 export type GetFlowVersionForWorkerRequest = Static<typeof GetFlowVersionForWorkerRequest>
+
+export const UpdateLogsRequest = Type.Object({
+    flowRunId: Type.String(),
+    logsFileId: Type.Optional(Type.String()),
+    executionStateContentLength: Type.Number(),
+    executionStateString: Type.String(),
+})
+
+export type UpdateLogsRequest = Static<typeof UpdateLogsRequest>


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->
Made an endpoint in the engine controller (same behavior as S3) to decouple run metadata from uploading execution state (logs).


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
