### PR TITLE
feat: add onCleanup hook for webhook resumable actions

### DIFF
--- a/docs/developers/piece-reference/flow-control.mdx
+++ b/docs/developers/piece-reference/flow-control.mdx
@@ -62,4 +62,128 @@ ctx.run.pause({
 });
 ```
 
-These flow hooks give you control over the execution of the piece by allowing you to stop the flow or pause it until a certain condition is met. You can use these hooks to customize the behavior and flow of your actions.
+## Cleanup Hook
+
+When using pause flow operations (webhook or delay), you may need to perform cleanup if the flow never resumes. The `onCleanup` hook allows you to run code when a paused flow is terminated due to timeout, cancellation, or other reasons.
+
+The cleanup hook is called when:
+- The flow times out (exceeds `AP_PAUSED_FLOW_TIMEOUT_DAYS`)
+- The flow fails while paused (quota exceeded, memory limit, internal error, etc.)
+
+**Example:**
+
+```typescript
+export const waitForWebhookAction = createAction({
+  name: 'waitForExternalWebhook',
+  displayName: 'Wait for an external webhook to resume',
+  async run(context) {
+    const externalApiClient = makeClient({ auth: context.auth });
+
+    // Creates a store key unique to the flow run
+    const webhookIdKey = `webhook_id_${context.run.id}`;
+
+    if (context.executionType === ExecutionType.BEGIN) {
+      // Generate resume URL for the external service to call
+      const resumeUrl = context.generateResumeUrl({
+        queryParams: { runId: context.run.id },
+      });
+
+      // Register webhook with external API
+      const webhook = await externalApiClient.createWebhook({
+        url: resumeUrl,
+        event: 'some.operation.is.successful',
+      });
+
+      // Store webhook ID in the store for later cleanup using the unique
+      // key we created earlier
+      await context.store.put(webhookIdKey, webhook.id, StoreScope.FLOW);
+
+      // Pause and wait for webhook
+      context.run.pause({
+        pauseMetadata: {
+          type: PauseType.WEBHOOK,
+          response: {},
+        },
+      });
+
+      // ...
+      // Do something useful here
+      // ...
+
+      return {};
+    } else {
+      // RESUME phase - flow was resumed by webhook call
+
+      // Fetch the webhook ID back from the store
+      const webhookId = await context.store.get<string>(webhookIdKey, StoreScope.FLOW);
+
+      if (webhookId) {
+        // Unregister webhook from external API
+        await externalApiClient.deleteWebhook({ webhookId });
+
+        // Clean up store entry
+        await context.store.delete(webhookIdKey, StoreScope.FLOW);
+      }
+
+      // Return the webhook payload that triggered the resume phase
+      return context.resumePayload;
+    }
+  },
+
+  // Runs if flow never resumes (timeout/cancellation)
+  async onCleanup(context) {
+    const externalApiClient = makeClient({ auth: context.auth });
+
+    // Builds the same key as in the run hook
+    const webhookIdKey = `webhook_id_${context.run.id}`;
+
+    // Check if webhook ID exists in store
+    const webhookId = await context.store.get<string>(webhookIdKey, StoreScope.FLOW);
+
+    if (webhookId) {
+      try {
+        // Unregister webhook from external API
+        await externalApiClient.deleteWebhook({ webhookId });
+
+        // Clean up store entry
+        await context.store.delete(webhookIdKey, StoreScope.FLOW);
+      } catch (error) {
+        console.error(`Failed to cleanup webhook ${webhookId}:`, error)
+        // Note: Cleanup failures are logged but don't throw
+      }
+    }
+  },
+})
+```
+
+**Cleanup Context:**
+
+The cleanup context provides:
+- `auth`: Authentication credentials (if configured)
+- `propsValue`: The same input properties used during BEGIN phase
+- `store`: Access to flow/project storage
+- `connections`: Connection manager
+- `server`: Server URLs and token
+- `project`: Project information
+- `run.id`: Flow run ID
+- `run.reason`: Why cleanup was triggered (`CleanupReason.TIMEOUT` or `CleanupReason.FAILURE`)
+
+**Important Notes:**
+
+1. The `onCleanup` hook is **optional** - only add it if you need cleanup
+2. Cleanup runs with a 30-second timeout
+3. Cleanup failures are logged but don't prevent flow termination
+4. The hook does NOT have access to `run.pause()` or `run.stop()`
+5. Cleanup is best-effort - network issues may prevent execution
+6. **Store Accessibility:** The store remains accessible in `onCleanup` even after flow run execution data expires, because store data is scoped to the flow/project level and persists independently of flow run execution data.
+
+**Best Practices:**
+
+- Always use a unique store key per flow run (e.g., `webhook_id_${context.run.id}`)
+- Use `StoreScope.FLOW` for run-specific data to avoid conflicts across flow runs
+- Clean up store entries in both the RESUME phase and `onCleanup` hook
+- Handle cleanup failures gracefully with try-catch blocks
+
+## Conclusion
+
+These flow hooks give you control over the execution of the piece by allowing you to stop the flow, pause it until a certain condition is met, or clean up resources when a paused flow terminates.

--- a/packages/engine/src/lib/handler/context/engine-constants.ts
+++ b/packages/engine/src/lib/handler/context/engine-constants.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MCP_DATA, ExecuteFlowOperation, ExecutePropsOptions, ExecuteToolOperation, ExecuteTriggerOperation, ExecutionType, FlowVersionState, ProgressUpdateType, Project, ProjectId, ResumePayload, RunEnvironment, TriggerHookType } from '@activepieces/shared'
+import { DEFAULT_MCP_DATA, ExecuteCleanupOperation, ExecuteFlowOperation, ExecutePropsOptions, ExecuteToolOperation, ExecuteTriggerOperation, ExecutionType, FlowVersionState, ProgressUpdateType, Project, ProjectId, ResumePayload, RunEnvironment, TriggerHookType } from '@activepieces/shared'
 import { EngineGenericError } from '../../helper/execution-errors'
 import { createPropsResolver, PropsResolver } from '../../variables/props-resolver'
 
@@ -190,6 +190,32 @@ export class EngineConstants {
     }
 
     public static fromExecuteTriggerInput(input: ExecuteTriggerOperation<TriggerHookType>): EngineConstants {
+        return new EngineConstants({
+            flowId: input.flowVersion.flowId,
+            flowVersionId: input.flowVersion.id,
+            flowVersionState: input.flowVersion.state,
+            triggerPieceName: input.flowVersion.trigger.settings.pieceName,
+            flowRunId: DEFAULT_TRIGGER_EXECUTION,
+            publicApiUrl: input.publicApiUrl,
+            internalApiUrl: addTrailingSlashIfMissing(input.internalApiUrl),
+            retryConstants: DEFAULT_RETRY_CONSTANTS,
+            engineToken: input.engineToken,
+            projectId: input.projectId,
+            propsResolver: createPropsResolver({
+                projectId: input.projectId,
+                engineToken: input.engineToken,
+                apiUrl: addTrailingSlashIfMissing(input.internalApiUrl),
+            }),
+            progressUpdateType: ProgressUpdateType.NONE,
+            serverHandlerId: null,
+            httpRequestId: null,
+            resumePayload: undefined,
+            runEnvironment: undefined,
+            stepNameToTest: undefined,
+        })
+    }
+
+    public static fromExecuteCleanupInput(input: ExecuteCleanupOperation): EngineConstants {
         return new EngineConstants({
             flowId: input.flowVersion.flowId,
             flowVersionId: input.flowVersion.id,

--- a/packages/engine/src/lib/operations/cleanup.operation.ts
+++ b/packages/engine/src/lib/operations/cleanup.operation.ts
@@ -1,0 +1,36 @@
+import { inspect } from 'util'
+import {
+    EngineResponse,
+    EngineResponseStatus,
+    ExecuteCleanupOperation,
+    ExecuteCleanupResponse,
+} from '@activepieces/shared'
+import { EngineConstants } from '../handler/context/engine-constants'
+import { executeCleanup as pieceExecutorCleanup } from '../handler/piece-executor'
+
+export const cleanupOperation = {
+    execute: async (operation: ExecuteCleanupOperation): Promise<EngineResponse<ExecuteCleanupResponse>> => {
+        try {
+            await pieceExecutorCleanup({
+                operation,
+                pieceSource: EngineConstants.PIECE_SOURCES,
+                constants: EngineConstants.fromExecuteCleanupInput(operation),
+            })
+            return {
+                status: EngineResponseStatus.OK,
+                response: {
+                    success: true,
+                },
+            }
+        }
+        catch (e) {
+            return {
+                status: EngineResponseStatus.OK,
+                response: {
+                    success: false,
+                    message: inspect(e),
+                },
+            }
+        }
+    },
+}

--- a/packages/engine/src/lib/operations/index.ts
+++ b/packages/engine/src/lib/operations/index.ts
@@ -2,16 +2,18 @@ import {
     EngineOperation,
     EngineOperationType,
     EngineResponse,
+    ExecuteCleanupOperation,
     ExecuteExtractPieceMetadataOperation,
     ExecuteFlowOperation,
     ExecutePropsOptions,
     ExecuteToolOperation,
-    ExecuteTriggerOperation,    
+    ExecuteTriggerOperation,
     ExecuteValidateAuthOperation,
     TriggerHookType,
 } from '@activepieces/shared'
 import { ExecutionError, ExecutionErrorType } from '../helper/execution-errors'
 import { authValidationOperation } from './auth-validation.operation'
+import { cleanupOperation } from './cleanup.operation'
 import { flowOperation } from './flow.operation'
 import { pieceMetadataOperation } from './piece-metadata.operation'
 import { propertyOperation } from './property.operation'
@@ -38,6 +40,9 @@ export async function execute(operationType: EngineOperationType, operation: Eng
         }
         case EngineOperationType.EXECUTE_VALIDATE_AUTH: {
             return authValidationOperation.execute(operation as ExecuteValidateAuthOperation)
+        }
+        case EngineOperationType.EXECUTE_CLEANUP: {
+            return cleanupOperation.execute(operation as ExecuteCleanupOperation)
         }
         default: {
             throw new ExecutionError('Unsupported operation type', `Unsupported operation type: ${operationType}`, ExecutionErrorType.ENGINE)

--- a/packages/engine/src/lib/utils.ts
+++ b/packages/engine/src/lib/utils.ts
@@ -98,4 +98,4 @@ export type HookResponse = {
     type: 'none'
     tags: string[]
 }
-type CreateConnectionManagerParams = { projectId: string, engineToken: string, apiUrl: string, target: 'triggers' | 'properties' } | { projectId: string, engineToken: string, apiUrl: string, target: 'actions', hookResponse: HookResponse }
+type CreateConnectionManagerParams = { projectId: string, engineToken: string, apiUrl: string, target: 'triggers' | 'properties' | 'cleanup' } | { projectId: string, engineToken: string, apiUrl: string, target: 'actions', hookResponse: HookResponse }

--- a/packages/engine/test/handler/flow-cleanup.test.ts
+++ b/packages/engine/test/handler/flow-cleanup.test.ts
@@ -1,0 +1,230 @@
+import { CleanupReason, ExecuteCleanupOperation } from '@activepieces/shared'
+import { executeCleanup } from '../../src/lib/handler/piece-executor'
+import { generateMockEngineConstants } from './test-helper'
+
+describe('flow cleanup', () => {
+    const mockCleanupFn = jest.fn()
+
+    beforeEach(() => {
+        mockCleanupFn.mockClear()
+    })
+
+    it('should execute cleanup hook when action has onCleanup', async () => {
+        const operation: ExecuteCleanupOperation = {
+            projectId: 'test-project',
+            engineToken: 'test-token',
+            internalApiUrl: 'http://localhost:3000',
+            publicApiUrl: 'http://localhost:4200',
+            timeoutInSeconds: 30,
+            piece: {
+                pieceName: '@activepieces/piece-webhook',
+                pieceVersion: '1.0.0',
+                pieceType: 'OFFICIAL' as any,
+                packageType: 'REGISTRY' as any,
+            },
+            actionName: 'wait_for_webhook',
+            flowVersion: {
+                id: 'flow-version-id',
+                flowId: 'flow-id',
+                displayName: 'Test Flow',
+                trigger: {
+                    type: 'EMPTY' as any,
+                    name: 'trigger',
+                    settings: {},
+                    valid: false,
+                    displayName: 'Select Trigger',
+                },
+                valid: true,
+                state: 'DRAFT' as any,
+                updatedBy: null,
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+            } as any,
+            cleanupReason: CleanupReason.TIMEOUT,
+            input: {
+                timeout: 3600,
+            },
+        }
+
+        const constants = generateMockEngineConstants({
+            projectId: operation.projectId,
+            engineToken: operation.engineToken,
+            internalApiUrl: operation.internalApiUrl,
+            publicApiUrl: operation.publicApiUrl,
+        })
+
+        // Mock the piece loader to return an action with onCleanup
+        const mockPieceLoader = require('../../src/lib/helper/piece-loader')
+        mockPieceLoader.pieceLoader.getPieceAndActionOrThrow = jest.fn().mockResolvedValue({
+            pieceAction: {
+                name: 'wait_for_webhook',
+                displayName: 'Wait for Webhook',
+                requireAuth: false,
+                props: {},
+                run: jest.fn(),
+                onCleanup: mockCleanupFn,
+            },
+            piece: {
+                displayName: 'Webhook',
+                auth: undefined,
+            },
+        })
+
+        await executeCleanup({
+            operation,
+            constants,
+            pieceSource: 'COMMUNITY',
+        })
+
+        expect(mockCleanupFn).toHaveBeenCalledTimes(1)
+        const cleanupContext = mockCleanupFn.mock.calls[0][0]
+        expect(cleanupContext).toHaveProperty('propsValue')
+        expect(cleanupContext).toHaveProperty('store')
+        expect(cleanupContext).toHaveProperty('server')
+        expect(cleanupContext).toHaveProperty('project')
+        expect(cleanupContext).toHaveProperty('connections')
+        expect(cleanupContext).toHaveProperty('run')
+        expect(cleanupContext.run.reason).toBe(CleanupReason.TIMEOUT)
+        expect(cleanupContext.project.id).toBe(operation.projectId)
+    })
+
+    it('should skip cleanup when action lacks onCleanup hook', async () => {
+        const operation: ExecuteCleanupOperation = {
+            projectId: 'test-project',
+            engineToken: 'test-token',
+            internalApiUrl: 'http://localhost:3000',
+            publicApiUrl: 'http://localhost:4200',
+            timeoutInSeconds: 30,
+            piece: {
+                pieceName: '@activepieces/piece-webhook',
+                pieceVersion: '1.0.0',
+                pieceType: 'OFFICIAL' as any,
+                packageType: 'REGISTRY' as any,
+            },
+            actionName: 'return_response',
+            flowVersion: {
+                id: 'flow-version-id',
+                flowId: 'flow-id',
+                displayName: 'Test Flow',
+                trigger: {
+                    type: 'EMPTY' as any,
+                    name: 'trigger',
+                    settings: {},
+                    valid: false,
+                    displayName: 'Select Trigger',
+                },
+                valid: true,
+                state: 'DRAFT' as any,
+                updatedBy: null,
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+            } as any,
+            cleanupReason: CleanupReason.FAILURE,
+            input: {},
+        }
+
+        const constants = generateMockEngineConstants({
+            projectId: operation.projectId,
+            engineToken: operation.engineToken,
+            internalApiUrl: operation.internalApiUrl,
+            publicApiUrl: operation.publicApiUrl,
+        })
+
+        // Mock the piece loader to return an action WITHOUT onCleanup
+        const mockPieceLoader = require('../../src/lib/helper/piece-loader')
+        mockPieceLoader.pieceLoader.getPieceAndActionOrThrow = jest.fn().mockResolvedValue({
+            pieceAction: {
+                name: 'return_response',
+                displayName: 'Return Response',
+                requireAuth: false,
+                props: {},
+                run: jest.fn(),
+                // No onCleanup hook
+            },
+            piece: {
+                displayName: 'Webhook',
+                auth: undefined,
+            },
+        })
+
+        await executeCleanup({
+            operation,
+            constants,
+            pieceSource: 'COMMUNITY',
+        })
+
+        expect(mockCleanupFn).not.toHaveBeenCalled()
+    })
+
+    it('should pass correct CleanupContext with CleanupReason.FAILURE', async () => {
+        const operation: ExecuteCleanupOperation = {
+            projectId: 'test-project',
+            engineToken: 'test-token',
+            internalApiUrl: 'http://localhost:3000',
+            publicApiUrl: 'http://localhost:4200',
+            timeoutInSeconds: 30,
+            piece: {
+                pieceName: '@activepieces/piece-webhook',
+                pieceVersion: '1.0.0',
+                pieceType: 'OFFICIAL' as any,
+                packageType: 'REGISTRY' as any,
+            },
+            actionName: 'wait_for_webhook',
+            flowVersion: {
+                id: 'flow-version-id',
+                flowId: 'flow-id',
+                displayName: 'Test Flow',
+                trigger: {
+                    type: 'EMPTY' as any,
+                    name: 'trigger',
+                    settings: {},
+                    valid: false,
+                    displayName: 'Select Trigger',
+                },
+                valid: true,
+                state: 'DRAFT' as any,
+                updatedBy: null,
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+            } as any,
+            cleanupReason: CleanupReason.FAILURE,
+            input: {
+                timeout: 3600,
+            },
+        }
+
+        const constants = generateMockEngineConstants({
+            projectId: operation.projectId,
+            engineToken: operation.engineToken,
+            internalApiUrl: operation.internalApiUrl,
+            publicApiUrl: operation.publicApiUrl,
+        })
+
+        // Mock the piece loader to return an action with onCleanup
+        const mockPieceLoader = require('../../src/lib/helper/piece-loader')
+        mockPieceLoader.pieceLoader.getPieceAndActionOrThrow = jest.fn().mockResolvedValue({
+            pieceAction: {
+                name: 'wait_for_webhook',
+                displayName: 'Wait for Webhook',
+                requireAuth: false,
+                props: {},
+                run: jest.fn(),
+                onCleanup: mockCleanupFn,
+            },
+            piece: {
+                displayName: 'Webhook',
+                auth: undefined,
+            },
+        })
+
+        await executeCleanup({
+            operation,
+            constants,
+            pieceSource: 'COMMUNITY',
+        })
+
+        expect(mockCleanupFn).toHaveBeenCalledTimes(1)
+        const cleanupContext = mockCleanupFn.mock.calls[0][0]
+        expect(cleanupContext.run.reason).toBe(CleanupReason.FAILURE)
+    })
+})

--- a/packages/pieces/community/framework/src/lib/context.ts
+++ b/packages/pieces/community/framework/src/lib/context.ts
@@ -1,5 +1,6 @@
 import {
   AppConnectionValue,
+  CleanupReason,
   ExecutionType,
   FlowRunId,
   PopulatedFlow,
@@ -234,4 +235,15 @@ export enum StoreScope {
   // Collection were deprecated in favor of project
   PROJECT = 'COLLECTION',
   FLOW = 'FLOW',
+}
+
+export type CleanupContext<
+  PieceAuth extends PieceAuthProperty = PieceAuthProperty,
+  ActionProps extends InputPropertyMap = InputPropertyMap
+> = Omit<BaseContext<PieceAuth, ActionProps>, 'flows'> & {
+  server: ServerContext;
+  run: {
+    id: FlowRunId;
+    reason: CleanupReason;
+  };
 }

--- a/packages/server/api/src/app/flows/flow-run/flow-run-cleanup.service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-cleanup.service.ts
@@ -1,0 +1,205 @@
+import {
+  CleanupReason,
+  FlowRun,
+  FlowRunStatus,
+  FlowVersion,
+  isNil,
+  PieceAction,
+  StepOutputStatus,
+} from '@activepieces/shared';
+import { FastifyBaseLogger } from 'fastify';
+import { engineRunner } from '@activepieces/server-worker';
+import { flowVersionService } from '../flow-version/flow-version.service';
+import { accessTokenManager } from '../../authentication/lib/access-token-manager';
+import { projectService } from '../../project/project-service';
+
+export const flowRunCleanupService = (log: FastifyBaseLogger) => ({
+  async invokeCleanupForPausedSteps(flowRun: FlowRun): Promise<void> {
+    log.info(
+      {
+        flowRunId: flowRun.id,
+        status: flowRun.status,
+      },
+      '[flowRunCleanupService#invokeCleanupForPausedSteps]',
+    );
+
+    if (isNil(flowRun.pauseMetadata)) {
+      return;
+    }
+
+    const flowVersion = await flowVersionService(log).getOneOrThrow(
+      flowRun.flowVersionId,
+    );
+    const cleanupReason = mapStatusToCleanupReason(flowRun.status);
+    const pausedSteps = findPausedSteps(flowRun, flowVersion);
+
+    if (pausedSteps.length === 0) {
+      log.debug({ flowRunId: flowRun.id }, 'No paused steps found');
+      return;
+    }
+
+    for (const step of pausedSteps) {
+      await invokeCleanupForStep({
+        log,
+        flowRun,
+        flowVersion,
+        step,
+        cleanupReason,
+      });
+    }
+  },
+});
+
+function mapStatusToCleanupReason(status: FlowRunStatus): CleanupReason {
+  if (status === FlowRunStatus.TIMEOUT) {
+    return CleanupReason.TIMEOUT;
+  }
+
+  return CleanupReason.FAILURE;
+}
+
+function findPausedSteps(
+  flowRun: FlowRun,
+  flowVersion: FlowVersion,
+): PieceAction[] {
+  const pausedSteps: PieceAction[] = [];
+
+  if (isNil(flowRun.steps)) {
+    return pausedSteps;
+  }
+
+  for (const [stepName, stepOutput] of Object.entries(flowRun.steps)) {
+    if (stepOutput.status === StepOutputStatus.PAUSED) {
+      const step = findStepInFlowVersion(flowVersion, stepName);
+      if (step && step.type === 'PIECE') {
+        pausedSteps.push(step as PieceAction);
+      }
+    }
+  }
+
+  return pausedSteps;
+}
+
+function findStepInFlowVersion(
+  flowVersion: FlowVersion,
+  stepName: string,
+): PieceAction | undefined {
+  const searchInAction = (action: any): any => {
+    if (isNil(action)) {
+      return undefined;
+    }
+
+    if (action.name === stepName) {
+      return action;
+    }
+
+    if (action.nextAction) {
+      const found = searchInAction(action.nextAction);
+      if (found) return found;
+    }
+
+    if (action.onFailureAction) {
+      const found = searchInAction(action.onFailureAction);
+      if (found) return found;
+    }
+
+    if (action.onSuccessAction) {
+      const found = searchInAction(action.onSuccessAction);
+      if (found) return found;
+    }
+
+    if (action.settings?.branches) {
+      for (const branch of action.settings.branches) {
+        if (branch.branchName === stepName) {
+          return action;
+        }
+        const found = searchInAction(branch.firstAction);
+        if (found) return found;
+      }
+    }
+
+    if (action.settings?.firstLoopAction) {
+      const found = searchInAction(action.settings.firstLoopAction);
+      if (found) return found;
+    }
+
+    return undefined;
+  };
+
+  return searchInAction(flowVersion.trigger.nextAction);
+}
+
+async function invokeCleanupForStep(params: {
+  log: FastifyBaseLogger;
+  flowRun: FlowRun;
+  flowVersion: FlowVersion;
+  step: PieceAction;
+  cleanupReason: CleanupReason;
+}): Promise<void> {
+  const { log, flowRun, flowVersion, step, cleanupReason } = params;
+
+  try {
+    log.info(
+      {
+        flowRunId: flowRun.id,
+        stepName: step.name,
+        pieceName: step.settings.pieceName,
+        actionName: step.settings.actionName,
+        cleanupReason,
+      },
+      '[flowRunCleanupService] Invoking cleanup for step',
+    );
+
+    const stepInput = flowRun.steps?.[step.name]?.input || {};
+    const platformId = await projectService.getPlatformId(flowRun.projectId);
+    const engineToken = await accessTokenManager.generateEngineToken({
+      jobId: `cleanup-${flowRun.id}-${step.name}`,
+      projectId: flowRun.projectId,
+      platformId,
+    });
+
+    const result = await engineRunner(log).executeCleanup(engineToken, {
+      projectId: flowRun.projectId,
+      piece: {
+        pieceName: step.settings.pieceName,
+        pieceVersion: step.settings.pieceVersion,
+        pieceType: step.settings.pieceType,
+        packageType: step.settings.packageType,
+      },
+      actionName: step.settings.actionName!,
+      flowVersion,
+      cleanupReason,
+      input: stepInput as Record<string, unknown>,
+      timeoutInSeconds: 30,
+    });
+
+    if (result.status === 'OK' && result.response.success) {
+      log.info(
+        {
+          flowRunId: flowRun.id,
+          stepName: step.name,
+        },
+        '[flowRunCleanupService] Cleanup completed successfully',
+      );
+    } else {
+      log.warn(
+        {
+          flowRunId: flowRun.id,
+          stepName: step.name,
+          error: result.response.message,
+        },
+        '[flowRunCleanupService] Cleanup failed',
+      );
+    }
+  } catch (error) {
+    log.error(
+      {
+        flowRunId: flowRun.id,
+        stepName: step.name,
+        error,
+      },
+      '[flowRunCleanupService] Error invoking cleanup',
+    );
+    // Cleanup failures should not prevent flow termination.
+  }
+}

--- a/packages/server/api/test/unit/app/flows/flow-run/flow-run-cleanup.service.test.ts
+++ b/packages/server/api/test/unit/app/flows/flow-run/flow-run-cleanup.service.test.ts
@@ -1,0 +1,421 @@
+import { CleanupReason, FlowRunStatus, FlowTriggerType, StepOutputStatus } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { flowRunCleanupService } from '../../../../../src/app/flows/flow-run/flow-run-cleanup.service'
+import { createMockFlowRun, createMockFlowVersion } from '../../../../helpers/mocks'
+
+// Mock dependencies
+jest.mock('@activepieces/server-worker', () => ({
+    engineRunner: jest.fn(() => ({
+        executeCleanup: jest.fn(),
+    })),
+}))
+
+jest.mock('../../../../../src/app/flows/flow-version/flow-version.service', () => ({
+    flowVersionService: jest.fn(() => ({
+        getOneOrThrow: jest.fn(),
+    })),
+}))
+
+jest.mock('../../../../../src/app/authentication/lib/access-token-manager', () => ({
+    accessTokenManager: {
+        generateEngineToken: jest.fn().mockResolvedValue('mock-engine-token'),
+    },
+}))
+
+jest.mock('../../../../../src/app/project/project-service', () => ({
+    projectService: {
+        getPlatformId: jest.fn().mockResolvedValue('mock-platform-id'),
+    },
+}))
+
+describe('flowRunCleanupService', () => {
+    let mockLogger: FastifyBaseLogger
+    let mockEngineRunner: any
+    let mockFlowVersionService: any
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        mockLogger = {
+            info: jest.fn(),
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        } as any
+
+        mockEngineRunner = require('@activepieces/server-worker').engineRunner(mockLogger)
+        mockEngineRunner.executeCleanup.mockResolvedValue({
+            status: 'OK',
+            response: {
+                success: true,
+            },
+        })
+
+        mockFlowVersionService = require('../../../../../src/app/flows/flow-version/flow-version.service').flowVersionService(mockLogger)
+    })
+
+    it('should invoke cleanup for paused steps', async () => {
+        const mockFlowRun = createMockFlowRun({
+            status: FlowRunStatus.TIMEOUT,
+            pauseMetadata: {
+                type: 'WEBHOOK',
+                requestId: 'test-request-id',
+            } as any,
+            steps: {
+                'webhook_step': {
+                    type: 'PIECE',
+                    status: StepOutputStatus.PAUSED,
+                    input: {
+                        timeout: 3600,
+                    },
+                    output: {},
+                },
+            } as any,
+        })
+
+        const mockFlowVersion = createMockFlowVersion({
+            flowId: mockFlowRun.flowId,
+            trigger: {
+                type: FlowTriggerType.PIECE,
+                name: 'trigger',
+                settings: {
+                    pieceName: '@activepieces/piece-webhook',
+                    pieceVersion: '1.0.0',
+                    triggerName: 'catch_webhook',
+                },
+                valid: true,
+                displayName: 'Catch Webhook',
+                nextAction: {
+                    name: 'webhook_step',
+                    displayName: 'Wait for Webhook',
+                    type: 'PIECE',
+                    settings: {
+                        pieceName: '@activepieces/piece-webhook',
+                        pieceVersion: '1.0.0',
+                        actionName: 'wait_for_webhook',
+                        input: {
+                            timeout: 3600,
+                        },
+                        pieceType: 'OFFICIAL',
+                        packageType: 'REGISTRY',
+                    },
+                    valid: true,
+                } as any,
+            } as any,
+        })
+
+        mockFlowVersionService.getOneOrThrow.mockResolvedValue(mockFlowVersion)
+
+        await flowRunCleanupService(mockLogger).invokeCleanupForPausedSteps(mockFlowRun)
+
+        expect(mockEngineRunner.executeCleanup).toHaveBeenCalledTimes(1)
+        expect(mockEngineRunner.executeCleanup).toHaveBeenCalledWith(
+            'mock-engine-token',
+            expect.objectContaining({
+                projectId: mockFlowRun.projectId,
+                piece: expect.objectContaining({
+                    pieceName: '@activepieces/piece-webhook',
+                    pieceVersion: '1.0.0',
+                }),
+                actionName: 'wait_for_webhook',
+                cleanupReason: CleanupReason.TIMEOUT,
+                input: {
+                    timeout: 3600,
+                },
+            })
+        )
+    })
+
+    it('should skip cleanup when no paused steps exist', async () => {
+        const mockFlowRun = createMockFlowRun({
+            status: FlowRunStatus.TIMEOUT,
+            pauseMetadata: {
+                type: 'WEBHOOK',
+                requestId: 'test-request-id',
+            } as any,
+            steps: {
+                'step1': {
+                    type: 'CODE',
+                    status: StepOutputStatus.SUCCEEDED,
+                    input: {},
+                    output: {},
+                },
+            } as any,
+        })
+
+        const mockFlowVersion = createMockFlowVersion({
+            flowId: mockFlowRun.flowId,
+        })
+
+        mockFlowVersionService.getOneOrThrow.mockResolvedValue(mockFlowVersion)
+
+        await flowRunCleanupService(mockLogger).invokeCleanupForPausedSteps(mockFlowRun)
+
+        expect(mockEngineRunner.executeCleanup).not.toHaveBeenCalled()
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+            { flowRunId: mockFlowRun.id },
+            'No paused steps found'
+        )
+    })
+
+    it('should skip cleanup when pauseMetadata is null/undefined', async () => {
+        const mockFlowRun = createMockFlowRun({
+            status: FlowRunStatus.SUCCEEDED,
+            pauseMetadata: undefined,
+        })
+
+        await flowRunCleanupService(mockLogger).invokeCleanupForPausedSteps(mockFlowRun)
+
+        expect(mockFlowVersionService.getOneOrThrow).not.toHaveBeenCalled()
+        expect(mockEngineRunner.executeCleanup).not.toHaveBeenCalled()
+    })
+
+    it('should map TIMEOUT status to CleanupReason.TIMEOUT', async () => {
+        const mockFlowRun = createMockFlowRun({
+            status: FlowRunStatus.TIMEOUT,
+            pauseMetadata: {
+                type: 'WEBHOOK',
+                requestId: 'test-request-id',
+            } as any,
+            steps: {
+                'webhook_step': {
+                    type: 'PIECE',
+                    status: StepOutputStatus.PAUSED,
+                    input: {},
+                    output: {},
+                },
+            } as any,
+        })
+
+        const mockFlowVersion = createMockFlowVersion({
+            flowId: mockFlowRun.flowId,
+            trigger: {
+                type: FlowTriggerType.PIECE,
+                name: 'trigger',
+                settings: {
+                    pieceName: '@activepieces/piece-webhook',
+                    pieceVersion: '1.0.0',
+                    triggerName: 'catch_webhook',
+                },
+                valid: true,
+                displayName: 'Catch Webhook',
+                nextAction: {
+                    name: 'webhook_step',
+                    displayName: 'Wait for Webhook',
+                    type: 'PIECE',
+                    settings: {
+                        pieceName: '@activepieces/piece-webhook',
+                        pieceVersion: '1.0.0',
+                        actionName: 'wait_for_webhook',
+                        input: {},
+                        pieceType: 'OFFICIAL',
+                        packageType: 'REGISTRY',
+                    },
+                    valid: true,
+                } as any,
+            } as any,
+        })
+
+        mockFlowVersionService.getOneOrThrow.mockResolvedValue(mockFlowVersion)
+
+        await flowRunCleanupService(mockLogger).invokeCleanupForPausedSteps(mockFlowRun)
+
+        expect(mockEngineRunner.executeCleanup).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                cleanupReason: CleanupReason.TIMEOUT,
+            })
+        )
+    })
+
+    it('should map FAILED status to CleanupReason.FAILURE', async () => {
+        const mockFlowRun = createMockFlowRun({
+            status: FlowRunStatus.FAILED,
+            pauseMetadata: {
+                type: 'WEBHOOK',
+                requestId: 'test-request-id',
+            } as any,
+            steps: {
+                'webhook_step': {
+                    type: 'PIECE',
+                    status: StepOutputStatus.PAUSED,
+                    input: {},
+                    output: {},
+                },
+            } as any,
+        })
+
+        const mockFlowVersion = createMockFlowVersion({
+            flowId: mockFlowRun.flowId,
+            trigger: {
+                type: FlowTriggerType.PIECE,
+                name: 'trigger',
+                settings: {
+                    pieceName: '@activepieces/piece-webhook',
+                    pieceVersion: '1.0.0',
+                    triggerName: 'catch_webhook',
+                },
+                valid: true,
+                displayName: 'Catch Webhook',
+                nextAction: {
+                    name: 'webhook_step',
+                    displayName: 'Wait for Webhook',
+                    type: 'PIECE',
+                    settings: {
+                        pieceName: '@activepieces/piece-webhook',
+                        pieceVersion: '1.0.0',
+                        actionName: 'wait_for_webhook',
+                        input: {},
+                        pieceType: 'OFFICIAL',
+                        packageType: 'REGISTRY',
+                    },
+                    valid: true,
+                } as any,
+            } as any,
+        })
+
+        mockFlowVersionService.getOneOrThrow.mockResolvedValue(mockFlowVersion)
+
+        await flowRunCleanupService(mockLogger).invokeCleanupForPausedSteps(mockFlowRun)
+
+        expect(mockEngineRunner.executeCleanup).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                cleanupReason: CleanupReason.FAILURE,
+            })
+        )
+    })
+
+    it('should log warning but continue on cleanup failure', async () => {
+        const mockFlowRun = createMockFlowRun({
+            status: FlowRunStatus.TIMEOUT,
+            pauseMetadata: {
+                type: 'WEBHOOK',
+                requestId: 'test-request-id',
+            } as any,
+            steps: {
+                'webhook_step': {
+                    type: 'PIECE',
+                    status: StepOutputStatus.PAUSED,
+                    input: {},
+                    output: {},
+                },
+            } as any,
+        })
+
+        const mockFlowVersion = createMockFlowVersion({
+            flowId: mockFlowRun.flowId,
+            trigger: {
+                type: FlowTriggerType.PIECE,
+                name: 'trigger',
+                settings: {
+                    pieceName: '@activepieces/piece-webhook',
+                    pieceVersion: '1.0.0',
+                    triggerName: 'catch_webhook',
+                },
+                valid: true,
+                displayName: 'Catch Webhook',
+                nextAction: {
+                    name: 'webhook_step',
+                    displayName: 'Wait for Webhook',
+                    type: 'PIECE',
+                    settings: {
+                        pieceName: '@activepieces/piece-webhook',
+                        pieceVersion: '1.0.0',
+                        actionName: 'wait_for_webhook',
+                        input: {},
+                        pieceType: 'OFFICIAL',
+                        packageType: 'REGISTRY',
+                    },
+                    valid: true,
+                } as any,
+            } as any,
+        })
+
+        mockFlowVersionService.getOneOrThrow.mockResolvedValue(mockFlowVersion)
+
+        // Mock cleanup failure
+        mockEngineRunner.executeCleanup.mockResolvedValue({
+            status: 'OK',
+            response: {
+                success: false,
+                message: 'Cleanup failed for some reason',
+            },
+        })
+
+        await flowRunCleanupService(mockLogger).invokeCleanupForPausedSteps(mockFlowRun)
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            expect.objectContaining({
+                flowRunId: mockFlowRun.id,
+                stepName: 'webhook_step',
+                error: 'Cleanup failed for some reason',
+            }),
+            '[flowRunCleanupService] Cleanup failed'
+        )
+    })
+
+    it('should log error but continue when cleanup throws exception', async () => {
+        const mockFlowRun = createMockFlowRun({
+            status: FlowRunStatus.TIMEOUT,
+            pauseMetadata: {
+                type: 'WEBHOOK',
+                requestId: 'test-request-id',
+            } as any,
+            steps: {
+                'webhook_step': {
+                    type: 'PIECE',
+                    status: StepOutputStatus.PAUSED,
+                    input: {},
+                    output: {},
+                },
+            } as any,
+        })
+
+        const mockFlowVersion = createMockFlowVersion({
+            flowId: mockFlowRun.flowId,
+            trigger: {
+                type: FlowTriggerType.PIECE,
+                name: 'trigger',
+                settings: {
+                    pieceName: '@activepieces/piece-webhook',
+                    pieceVersion: '1.0.0',
+                    triggerName: 'catch_webhook',
+                },
+                valid: true,
+                displayName: 'Catch Webhook',
+                nextAction: {
+                    name: 'webhook_step',
+                    displayName: 'Wait for Webhook',
+                    type: 'PIECE',
+                    settings: {
+                        pieceName: '@activepieces/piece-webhook',
+                        pieceVersion: '1.0.0',
+                        actionName: 'wait_for_webhook',
+                        input: {},
+                        pieceType: 'OFFICIAL',
+                        packageType: 'REGISTRY',
+                    },
+                    valid: true,
+                } as any,
+            } as any,
+        })
+
+        mockFlowVersionService.getOneOrThrow.mockResolvedValue(mockFlowVersion)
+
+        // Mock cleanup throwing an error
+        const mockError = new Error('Network error')
+        mockEngineRunner.executeCleanup.mockRejectedValue(mockError)
+
+        await flowRunCleanupService(mockLogger).invokeCleanupForPausedSteps(mockFlowRun)
+
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+                flowRunId: mockFlowRun.id,
+                stepName: 'webhook_step',
+                error: mockError,
+            }),
+            '[flowRunCleanupService] Error invoking cleanup'
+        )
+    })
+})

--- a/packages/server/worker/src/lib/compute/index.ts
+++ b/packages/server/worker/src/lib/compute/index.ts
@@ -1,5 +1,5 @@
 import { webhookSecretsUtils } from '@activepieces/server-shared'
-import { BeginExecuteFlowOperation, EngineOperation, EngineOperationType, ExecuteExtractPieceMetadataOperation, ExecuteFlowOperation, ExecutePropsOptions, ExecuteToolOperation, ExecuteTriggerOperation, ExecuteValidateAuthOperation, FlowActionType, flowStructureUtil, FlowTriggerType, FlowVersion, PackageType, PieceActionSettings, PieceTriggerSettings, ResumeExecuteFlowOperation, TriggerHookType } from '@activepieces/shared'
+import { BeginExecuteFlowOperation, EngineOperation, EngineOperationType, ExecuteCleanupOperation, ExecuteExtractPieceMetadataOperation, ExecuteFlowOperation, ExecutePropsOptions, ExecuteToolOperation, ExecuteTriggerOperation, ExecuteValidateAuthOperation, FlowActionType, flowStructureUtil, FlowTriggerType, FlowVersion, PackageType, PieceActionSettings, PieceTriggerSettings, ResumeExecuteFlowOperation, TriggerHookType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { executionFiles } from '../cache/execution-files'
 import { pieceWorkerCache } from '../cache/piece-worker-cache'
@@ -100,6 +100,28 @@ export const engineRunner = (log: FastifyBaseLogger) => ({
             engineToken,
         }
         return execute(log, input, EngineOperationType.EXECUTE_VALIDATE_AUTH, operation.timeoutInSeconds)
+    },
+    async executeCleanup(engineToken: string, operation: Omit<ExecuteCleanupOperation, EngineConstants>): Promise<EngineHelperResponse<{ success: boolean, message?: string }>> {
+        log.debug({
+            piece: operation.piece,
+            actionName: operation.actionName,
+            cleanupReason: operation.cleanupReason,
+        }, '[threadEngineRunner#executeCleanup]')
+
+        const lockedPiece = await pieceEngineUtil.resolveExactVersion(engineToken, operation.piece)
+        await executionFiles(log).provision({
+            pieces: [lockedPiece],
+            codeSteps: [],
+            customPiecesPath: executionFiles(log).getCustomPiecesPath(operation),
+        })
+
+        const input: ExecuteCleanupOperation = {
+            ...operation,
+            publicApiUrl: workerMachine.getPublicApiUrl(),
+            internalApiUrl: workerMachine.getInternalApiUrl(),
+            engineToken,
+        }
+        return execute(log, input, EngineOperationType.EXECUTE_CLEANUP, operation.timeoutInSeconds)
     },
     async executeProp(engineToken: string, operation: Omit<ExecutePropsOptions, EngineConstants>): Promise<EngineHelperResponse<EngineHelperPropResult>> {
         log.debug({

--- a/packages/shared/src/lib/engine/engine-operation.ts
+++ b/packages/shared/src/lib/engine/engine-operation.ts
@@ -15,6 +15,7 @@ export enum EngineOperationType {
     EXECUTE_PROPERTY = 'EXECUTE_PROPERTY',
     EXECUTE_TRIGGER_HOOK = 'EXECUTE_TRIGGER_HOOK',
     EXECUTE_VALIDATE_AUTH = 'EXECUTE_VALIDATE_AUTH',
+    EXECUTE_CLEANUP = 'EXECUTE_CLEANUP',
 }
 
 export enum TriggerHookType {
@@ -26,6 +27,19 @@ export enum TriggerHookType {
     TEST = 'TEST',
 }
 
+export enum CleanupReason {
+    TIMEOUT = 'TIMEOUT',
+    FAILURE = 'FAILURE',
+}
+
+export type ExecuteCleanupOperation = BaseEngineOperation & {
+    piece: PiecePackage
+    actionName: string
+    flowVersion: FlowVersion
+    cleanupReason: CleanupReason
+    input: Record<string, unknown>
+}
+
 export type EngineOperation =
     | ExecuteToolOperation
     | ExecuteFlowOperation
@@ -33,6 +47,7 @@ export type EngineOperation =
     | ExecuteTriggerOperation<TriggerHookType>
     | ExecuteExtractPieceMetadataOperation
     | ExecuteValidateAuthOperation
+    | ExecuteCleanupOperation
 
 export const enum EngineSocketEvent {
     ENGINE_RESPONSE = 'engine-response',
@@ -212,6 +227,11 @@ export type ExecuteActionResponse = {
     success: boolean
     input: unknown
     output: unknown
+    message?: string
+}
+
+export type ExecuteCleanupResponse = {
+    success: boolean
     message?: string
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR adds an optional `onCleanup` hook to piece actions that automatically runs cleanup code when a paused flow times out or fails before resuming. This prevents resource leaks in webhook-based resumable actions (by allowing webhook unregistering, for instance).

##  Explain How the Feature Works

When a piece action pauses execution (like waiting for a webhook), it usually registers resources with external APIs (e.g. the resume URL). If the flow never resumes—due to timeout exceeding 30 days or failure conditions like quota exhaustion—those resources become orphaned.

The new `onCleanup` hook solves this by:

1. Allowing piece authors to define an optional cleanup function alongside their action's run function
2. Automatically detecting paused steps when a flow run terminates abnormally
3. Invoking each paused step's cleanup hook with a `CleanupContext` containing auth, input props, store access, and the reason for cleanup (`TIMEOUT` or `FAILURE`)
4. Gracefully handling cleanup failures

The cleanup service runs with a 30-second timeout and is "best-effort".

##  Relevant User Scenarios

- External webhook registration: Actions that create webhooks in third-party systems (Discord, Slack, etc.) can now automatically unregister them when flows don't complete
- Temporary resource allocation: Any pause operation that reserves resources (API subscriptions, temporary storage, callback URLs) can clean them up properly
- Store hygiene: Cleanup hooks can delete flow-scoped store entries that would otherwise persist indefinitely