### PR TITLE
Tag Drupal Release 1.0.0

### DIFF
--- a/packages/pieces/community/drupal/package.json
+++ b/packages/pieces/community/drupal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-drupal",
-  "version": "0.0.8",
+  "version": "1.0.0",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",


### PR DESCRIPTION
Now that the official announcement of this integration is just 2 days away, it's time to tag this as a 1.0.0 release.