### PR TITLE
feat: add IBM Cognos Analytics piece

### DIFF
--- a/packages/pieces/community/ibm-cognos/README.md
+++ b/packages/pieces/community/ibm-cognos/README.md
@@ -1,0 +1,105 @@
+# IBM Cognos Analytics
+
+IBM Cognos Analytics is an enterprise analytics and reporting platform that provides business intelligence capabilities.
+
+This piece enables you to interact with IBM Cognos Analytics through its REST API to manage data sources and content objects.
+
+## Authentication
+
+This piece uses custom authentication with the following required parameters:
+
+- **Base URL**: Your IBM Cognos Analytics instance URL (e.g., `https://your-instance.cognos.cloud.ibm.com`)
+- **Namespace**: Your CAM namespace (e.g., `LDAP`, `Cognos`, or your custom namespace)
+- **Username**: Your IBM Cognos Analytics username
+- **Password**: Your IBM Cognos Analytics password
+
+## Actions
+
+### Data Source Actions
+
+#### Create Data Source
+Creates a new data source in IBM Cognos Analytics.
+
+**Inputs:**
+- Data Source Name (required)
+- Connection String (required)
+- Disabled (optional)
+- Hidden (optional)
+
+#### Update Data Source
+Updates an existing data source.
+
+**Inputs:**
+- Data Source ID (required)
+- Data Source Name (optional)
+- Disabled (optional)
+- Hidden (optional)
+
+#### Delete Data Source
+Deletes a data source from IBM Cognos Analytics.
+
+**Inputs:**
+- Data Source ID (required)
+- Force Delete (optional)
+
+#### Get Data Source
+Retrieves the details of a specific data source.
+
+**Inputs:**
+- Data Source ID (required)
+
+### Content Object Actions
+
+#### Update Content Object
+Updates an existing content object (report, dashboard, folder, etc.).
+
+**Inputs:**
+- Content Object ID (required)
+- Name (optional)
+- Description (optional)
+- Type (optional)
+- Version (optional)
+
+#### Move Content Object
+Moves a content object to a different folder.
+
+**Inputs:**
+- Content Object ID (required)
+- Target Folder ID (required)
+- Conflict Resolution (optional)
+
+#### Copy Content Object
+Copies a content object to a different location.
+
+**Inputs:**
+- Content Object ID (required)
+- Target Folder ID (required)
+- New Name (optional)
+- Conflict Resolution (optional)
+
+#### Get Content Object
+Retrieves the details of a specific content object.
+
+**Inputs:**
+- Content Object ID (required)
+- Include Metadata (optional)
+
+## API Reference
+
+For more information about the IBM Cognos Analytics REST API, visit:
+https://www.ibm.com/docs/en/cognos-analytics/12.1.x?topic=api-rest-reference
+
+## Getting Started
+
+1. Sign up for an IBM Cognos Analytics trial at: https://www.ibm.com/products/cognos-analytics
+2. Wait for your account to be activated
+3. Obtain your instance URL, namespace, username, and password
+4. Configure the authentication in Activepieces with these credentials
+5. Start using the actions to manage your data sources and content objects
+
+## Support
+
+For issues or questions, please refer to:
+- IBM Cognos Analytics Documentation: https://www.ibm.com/docs/en/cognos-analytics
+- Activepieces Documentation: https://www.activepieces.com/docs
+

--- a/packages/pieces/community/ibm-cognos/package.json
+++ b/packages/pieces/community/ibm-cognos/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@activepieces/piece-ibm-cognos",
+  "version": "0.1.0"
+}
+

--- a/packages/pieces/community/ibm-cognos/project.json
+++ b/packages/pieces/community/ibm-cognos/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "@activepieces/piece-ibm-cognos",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/ibm-cognos/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/ibm-cognos",
+        "main": "packages/pieces/community/ibm-cognos/src/index.ts",
+        "tsConfig": "packages/pieces/community/ibm-cognos/tsconfig.lib.json",
+        "assets": ["packages/pieces/community/ibm-cognos/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": ["type:piece", "scope:community"]
+}
+

--- a/packages/pieces/community/ibm-cognos/src/i18n/translation.json
+++ b/packages/pieces/community/ibm-cognos/src/i18n/translation.json
@@ -1,0 +1,21 @@
+{
+  "IBM Cognos Analytics": "IBM Cognos Analytics",
+  "Enterprise analytics and reporting platform": "Enterprise analytics and reporting platform",
+  "Create Data Source": "Create Data Source",
+  "Creates a new data source in IBM Cognos Analytics": "Creates a new data source in IBM Cognos Analytics",
+  "Update Data Source": "Update Data Source",
+  "Updates an existing data source in IBM Cognos Analytics": "Updates an existing data source in IBM Cognos Analytics",
+  "Delete Data Source": "Delete Data Source",
+  "Deletes a data source from IBM Cognos Analytics": "Deletes a data source from IBM Cognos Analytics",
+  "Get Data Source": "Get Data Source",
+  "Retrieves the details of a specific data source from IBM Cognos Analytics": "Retrieves the details of a specific data source from IBM Cognos Analytics",
+  "Update Content Object": "Update Content Object",
+  "Updates an existing content object in IBM Cognos Analytics": "Updates an existing content object in IBM Cognos Analytics",
+  "Move Content Object": "Move Content Object",
+  "Moves a content object to a different location in IBM Cognos Analytics": "Moves a content object to a different location in IBM Cognos Analytics",
+  "Copy Content Object": "Copy Content Object",
+  "Copies a content object to a different location in IBM Cognos Analytics": "Copies a content object to a different location in IBM Cognos Analytics",
+  "Get Content Object": "Get Content Object",
+  "Retrieves the details of a specific content object from IBM Cognos Analytics": "Retrieves the details of a specific content object from IBM Cognos Analytics"
+}
+

--- a/packages/pieces/community/ibm-cognos/src/index.ts
+++ b/packages/pieces/community/ibm-cognos/src/index.ts
@@ -1,0 +1,91 @@
+import { PieceAuth, Property, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+
+// Import actions
+import { createDataSource } from './lib/action/create-data-source';
+import { updateDataSource } from './lib/action/update-data-source';
+import { deleteDataSource } from './lib/action/delete-data-source';
+import { getDataSource } from './lib/action/get-data-source';
+import { updateContentObject } from './lib/action/update-content-object';
+import { moveContentObject } from './lib/action/move-content-object';
+import { copyContentObject } from './lib/action/copy-content-object';
+import { getContentObject } from './lib/action/get-content-object';
+import { CognosAuthValue, createCognosSession } from './lib/common';
+
+export const ibmCognosAuth = PieceAuth.CustomAuth({
+    description: 'Authenticate with IBM Cognos Analytics',
+    props: {
+        baseUrl: Property.ShortText({
+            displayName: 'Base URL',
+            description: 'Your IBM Cognos Analytics instance URL (e.g., https://your-instance.cognos.cloud.ibm.com)',
+            required: true,
+        }),
+        namespace: Property.ShortText({
+            displayName: 'Namespace',
+            description: 'CAM namespace (e.g., LDAP, Cognos, or your custom namespace)',
+            required: true,
+        }),
+        username: Property.ShortText({
+            displayName: 'Username',
+            description: 'Your IBM Cognos Analytics username',
+            required: true,
+        }),
+        password: Property.ShortText({
+            displayName: 'Password',
+            description: 'Your IBM Cognos Analytics password',
+            required: true,
+        }),
+    },
+    required: true,
+    validate: async ({ auth }) => {
+        try {
+            const cognosAuth = auth as CognosAuthValue;
+            await createCognosSession(cognosAuth);
+            return {
+                valid: true,
+            };
+        } catch (error) {
+            return {
+                valid: false,
+                error: 'Invalid credentials or unable to connect to IBM Cognos Analytics',
+            };
+        }
+    },
+});
+
+export const ibmCognos = createPiece({
+    displayName: 'IBM Cognos Analytics',
+    description: 'Enterprise analytics and reporting platform',
+    minimumSupportedRelease: '0.36.1',
+    logoUrl: 'https://cdn.activepieces.com/pieces/ibm-cognos.png',
+    authors: ['RaghavArora14'],
+    categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+    auth: ibmCognosAuth,
+    actions: [
+        createDataSource,
+        updateDataSource,
+        deleteDataSource,
+        getDataSource,
+        updateContentObject,
+        moveContentObject,
+        copyContentObject,
+        getContentObject,
+        createCustomApiCallAction({
+            baseUrl: (auth) => {
+                const cognosAuth = auth as CognosAuthValue;
+                return `${cognosAuth.baseUrl}/api/v1`;
+            },
+            auth: ibmCognosAuth,
+            authMapping: async (auth) => {
+                const cognosAuth = auth as CognosAuthValue;
+                const sessionKey = await createCognosSession(cognosAuth);
+                return {
+                    'IBM-BA-Authorization': `CAM ${sessionKey}`,
+                };
+            },
+        }),
+    ],
+    triggers: [],
+});
+

--- a/packages/pieces/community/ibm-cognos/src/lib/action/copy-content-object.ts
+++ b/packages/pieces/community/ibm-cognos/src/lib/action/copy-content-object.ts
@@ -1,0 +1,65 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { callCognosApi, CognosAuthValue } from '../common';
+
+export const copyContentObject = createAction({
+    name: 'copy_content_object',
+    displayName: 'Copy Content Object',
+    description: 'Copies a content object to a different location in IBM Cognos Analytics',
+    props: {
+        contentId: Property.ShortText({
+            displayName: 'Content Object ID',
+            description: 'The ID of the content object to copy',
+            required: true,
+        }),
+        targetFolderId: Property.ShortText({
+            displayName: 'Target Folder ID',
+            description: 'The ID of the folder to copy the content object to',
+            required: true,
+        }),
+        newName: Property.ShortText({
+            displayName: 'New Name',
+            description: 'Optional new name for the copied object',
+            required: false,
+        }),
+        conflictResolution: Property.StaticDropdown({
+            displayName: 'Conflict Resolution',
+            description: 'How to handle conflicts if an object with the same name exists',
+            required: false,
+            defaultValue: 'rename',
+            options: {
+                options: [
+                    { label: 'Rename', value: 'rename' },
+                    { label: 'Replace', value: 'replace' },
+                    { label: 'Skip', value: 'skip' },
+                ],
+            },
+        }),
+    },
+    async run(context) {
+        const { contentId, targetFolderId, newName, conflictResolution } = context.propsValue;
+        const auth = context.auth as CognosAuthValue;
+
+        const body: Record<string, unknown> = {
+            targetFolder: targetFolderId,
+            conflictResolution: conflictResolution || 'rename',
+        };
+
+        if (newName) {
+            body.newName = newName;
+        }
+
+        const response = await callCognosApi(
+            HttpMethod.POST,
+            auth,
+            `/content/${contentId}`,
+            body,
+            {
+                action: 'copy',
+            }
+        );
+
+        return response.body;
+    },
+});
+

--- a/packages/pieces/community/ibm-cognos/src/lib/action/create-data-source.ts
+++ b/packages/pieces/community/ibm-cognos/src/lib/action/create-data-source.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { callCognosApi, CognosAuthValue } from '../common';
+
+export const createDataSource = createAction({
+    name: 'create_data_source',
+    displayName: 'Create Data Source',
+    description: 'Creates a new data source in IBM Cognos Analytics',
+    props: {
+        name: Property.ShortText({
+            displayName: 'Data Source Name',
+            description: 'The name of the data source',
+            required: true,
+        }),
+        connectionString: Property.LongText({
+            displayName: 'Connection String',
+            description: 'The connection string for the data source',
+            required: true,
+        }),
+        disabled: Property.Checkbox({
+            displayName: 'Disabled',
+            description: 'Set to true to create the data source in a disabled state',
+            required: false,
+            defaultValue: false,
+        }),
+        hidden: Property.Checkbox({
+            displayName: 'Hidden',
+            description: 'Set to true to hide the data source',
+            required: false,
+            defaultValue: false,
+        }),
+    },
+    async run(context) {
+        const { name, connectionString, disabled, hidden } = context.propsValue;
+        const auth = context.auth as CognosAuthValue;
+
+        const response = await callCognosApi(
+            HttpMethod.POST,
+            auth,
+            '/datasources',
+            {
+                defaultName: name,
+                connectionString: connectionString,
+                disabled: disabled || false,
+                hidden: hidden || false,
+            }
+        );
+
+        return response.body;
+    },
+});
+

--- a/packages/pieces/community/ibm-cognos/src/lib/action/delete-data-source.ts
+++ b/packages/pieces/community/ibm-cognos/src/lib/action/delete-data-source.ts
@@ -1,0 +1,42 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { callCognosApi, CognosAuthValue } from '../common';
+
+export const deleteDataSource = createAction({
+    name: 'delete_data_source',
+    displayName: 'Delete Data Source',
+    description: 'Deletes a data source from IBM Cognos Analytics',
+    props: {
+        dataSourceId: Property.ShortText({
+            displayName: 'Data Source ID',
+            description: 'The ID of the data source to delete',
+            required: true,
+        }),
+        force: Property.Checkbox({
+            displayName: 'Force Delete',
+            description: 'Force delete even if the data source is in use',
+            required: false,
+            defaultValue: false,
+        }),
+    },
+    async run(context) {
+        const { dataSourceId, force } = context.propsValue;
+        const auth = context.auth as CognosAuthValue;
+
+        const queryParams = force ? { force: 'true' } : undefined;
+
+        const response = await callCognosApi(
+            HttpMethod.DELETE,
+            auth,
+            `/datasources/${dataSourceId}`,
+            undefined,
+            queryParams
+        );
+
+        return {
+            success: true,
+            message: `Data source ${dataSourceId} deleted successfully`,
+        };
+    },
+});
+

--- a/packages/pieces/community/ibm-cognos/src/lib/action/get-content-object.ts
+++ b/packages/pieces/community/ibm-cognos/src/lib/action/get-content-object.ts
@@ -1,0 +1,39 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { callCognosApi, CognosAuthValue } from '../common';
+
+export const getContentObject = createAction({
+    name: 'get_content_object',
+    displayName: 'Get Content Object',
+    description: 'Retrieves the details of a specific content object from IBM Cognos Analytics',
+    props: {
+        contentId: Property.ShortText({
+            displayName: 'Content Object ID',
+            description: 'The ID of the content object to retrieve',
+            required: true,
+        }),
+        includeMetadata: Property.Checkbox({
+            displayName: 'Include Metadata',
+            description: 'Include additional metadata in the response',
+            required: false,
+            defaultValue: false,
+        }),
+    },
+    async run(context) {
+        const { contentId, includeMetadata } = context.propsValue;
+        const auth = context.auth as CognosAuthValue;
+
+        const queryParams = includeMetadata ? { metadata: 'true' } : undefined;
+
+        const response = await callCognosApi(
+            HttpMethod.GET,
+            auth,
+            `/content/${contentId}`,
+            undefined,
+            queryParams
+        );
+
+        return response.body;
+    },
+});
+

--- a/packages/pieces/community/ibm-cognos/src/lib/action/get-data-source.ts
+++ b/packages/pieces/community/ibm-cognos/src/lib/action/get-data-source.ts
@@ -1,0 +1,29 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { callCognosApi, CognosAuthValue } from '../common';
+
+export const getDataSource = createAction({
+    name: 'get_data_source',
+    displayName: 'Get Data Source',
+    description: 'Retrieves the details of a specific data source from IBM Cognos Analytics',
+    props: {
+        dataSourceId: Property.ShortText({
+            displayName: 'Data Source ID',
+            description: 'The ID of the data source to retrieve',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { dataSourceId } = context.propsValue;
+        const auth = context.auth as CognosAuthValue;
+
+        const response = await callCognosApi(
+            HttpMethod.GET,
+            auth,
+            `/datasources/${dataSourceId}`
+        );
+
+        return response.body;
+    },
+});
+

--- a/packages/pieces/community/ibm-cognos/src/lib/action/move-content-object.ts
+++ b/packages/pieces/community/ibm-cognos/src/lib/action/move-content-object.ts
@@ -1,0 +1,54 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { callCognosApi, CognosAuthValue } from '../common';
+
+export const moveContentObject = createAction({
+    name: 'move_content_object',
+    displayName: 'Move Content Object',
+    description: 'Moves a content object to a different location in IBM Cognos Analytics',
+    props: {
+        contentId: Property.ShortText({
+            displayName: 'Content Object ID',
+            description: 'The ID of the content object to move',
+            required: true,
+        }),
+        targetFolderId: Property.ShortText({
+            displayName: 'Target Folder ID',
+            description: 'The ID of the folder to move the content object to',
+            required: true,
+        }),
+        conflictResolution: Property.StaticDropdown({
+            displayName: 'Conflict Resolution',
+            description: 'How to handle conflicts if an object with the same name exists',
+            required: false,
+            defaultValue: 'rename',
+            options: {
+                options: [
+                    { label: 'Rename', value: 'rename' },
+                    { label: 'Replace', value: 'replace' },
+                    { label: 'Skip', value: 'skip' },
+                ],
+            },
+        }),
+    },
+    async run(context) {
+        const { contentId, targetFolderId, conflictResolution } = context.propsValue;
+        const auth = context.auth as CognosAuthValue;
+
+        const response = await callCognosApi(
+            HttpMethod.POST,
+            auth,
+            `/content/${contentId}`,
+            {
+                targetFolder: targetFolderId,
+                conflictResolution: conflictResolution || 'rename',
+            },
+            {
+                action: 'move',
+            }
+        );
+
+        return response.body;
+    },
+});
+

--- a/packages/pieces/community/ibm-cognos/src/lib/action/update-content-object.ts
+++ b/packages/pieces/community/ibm-cognos/src/lib/action/update-content-object.ts
@@ -1,0 +1,65 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { callCognosApi, CognosAuthValue } from '../common';
+
+export const updateContentObject = createAction({
+    name: 'update_content_object',
+    displayName: 'Update Content Object',
+    description: 'Updates an existing content object in IBM Cognos Analytics',
+    props: {
+        contentId: Property.ShortText({
+            displayName: 'Content Object ID',
+            description: 'The ID of the content object to update',
+            required: true,
+        }),
+        name: Property.ShortText({
+            displayName: 'Name',
+            description: 'The new name of the content object',
+            required: false,
+        }),
+        description: Property.LongText({
+            displayName: 'Description',
+            description: 'The new description of the content object',
+            required: false,
+        }),
+        type: Property.ShortText({
+            displayName: 'Type',
+            description: 'The type of the content object (e.g., report, dashboard, folder)',
+            required: false,
+        }),
+        version: Property.Number({
+            displayName: 'Version',
+            description: 'Object version for optimistic concurrency control',
+            required: false,
+        }),
+    },
+    async run(context) {
+        const { contentId, name, description, type, version } = context.propsValue;
+        const auth = context.auth as CognosAuthValue;
+
+        const updateBody: Record<string, unknown> = {};
+        
+        if (name !== undefined) {
+            updateBody.defaultName = name;
+        }
+        if (description !== undefined) {
+            updateBody.defaultDescriptions = description;
+        }
+        if (type !== undefined) {
+            updateBody.type = type;
+        }
+        if (version !== undefined) {
+            updateBody.version = version;
+        }
+
+        const response = await callCognosApi(
+            HttpMethod.PATCH,
+            auth,
+            `/content/${contentId}`,
+            updateBody
+        );
+
+        return response.body;
+    },
+});
+

--- a/packages/pieces/community/ibm-cognos/src/lib/action/update-data-source.ts
+++ b/packages/pieces/community/ibm-cognos/src/lib/action/update-data-source.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { callCognosApi, cognosCommon, CognosAuthValue } from '../common';
+
+export const updateDataSource = createAction({
+    name: 'update_data_source',
+    displayName: 'Update Data Source',
+    description: 'Updates an existing data source in IBM Cognos Analytics',
+    props: {
+        dataSourceId: Property.ShortText({
+            displayName: 'Data Source ID',
+            description: 'The ID of the data source to update',
+            required: true,
+        }),
+        name: Property.ShortText({
+            displayName: 'Data Source Name',
+            description: 'The new name of the data source',
+            required: false,
+        }),
+        disabled: Property.Checkbox({
+            displayName: 'Disabled',
+            description: 'Set the disabled state of the data source',
+            required: false,
+        }),
+        hidden: Property.Checkbox({
+            displayName: 'Hidden',
+            description: 'Set the hidden state of the data source',
+            required: false,
+        }),
+    },
+    async run(context) {
+        const { dataSourceId, name, disabled, hidden } = context.propsValue;
+        const auth = context.auth as CognosAuthValue;
+
+        const updateBody: Record<string, unknown> = {};
+        
+        if (name !== undefined) {
+            updateBody.defaultName = name;
+        }
+        if (disabled !== undefined) {
+            updateBody.disabled = disabled;
+        }
+        if (hidden !== undefined) {
+            updateBody.hidden = hidden;
+        }
+
+        const response = await callCognosApi(
+            HttpMethod.PATCH,
+            auth,
+            `/datasources/${dataSourceId}`,
+            updateBody
+        );
+
+        return response.body;
+    },
+});
+

--- a/packages/pieces/community/ibm-cognos/src/lib/common/index.ts
+++ b/packages/pieces/community/ibm-cognos/src/lib/common/index.ts
@@ -1,0 +1,145 @@
+import {
+    HttpMethod,
+    HttpMessageBody,
+    HttpResponse,
+    httpClient,
+    AuthenticationType,
+} from '@activepieces/pieces-common';
+import { Property } from '@activepieces/pieces-framework';
+
+export interface CognosAuthValue {
+    baseUrl: string;
+    namespace: string;
+    username: string;
+    password: string;
+}
+
+export interface CognosSession {
+    session_key: string;
+}
+
+/**
+ * Creates a session with IBM Cognos Analytics and returns the session key
+ */
+export async function createCognosSession(auth: CognosAuthValue): Promise<string> {
+    const response = await httpClient.sendRequest<{ session_key: string }>({
+        method: HttpMethod.POST,
+        url: `${auth.baseUrl}/api/v1/session`,
+        body: {
+            parameters: [
+                {
+                    name: 'CAMNamespace',
+                    value: auth.namespace,
+                },
+                {
+                    name: 'CAMUsername',
+                    value: auth.username,
+                },
+                {
+                    name: 'CAMPassword',
+                    value: auth.password,
+                },
+            ],
+        },
+    });
+    return response.body.session_key;
+}
+
+/**
+ * Makes an authenticated API call to IBM Cognos Analytics
+ */
+export async function callCognosApi<T extends HttpMessageBody>(
+    method: HttpMethod,
+    auth: CognosAuthValue,
+    endpoint: string,
+    body?: HttpMessageBody,
+    queryParams?: Record<string, string>
+): Promise<HttpResponse<T>> {
+    const sessionKey = await createCognosSession(auth);
+    
+    return await httpClient.sendRequest<T>({
+        method: method,
+        url: `${auth.baseUrl}/api/v1${endpoint}`,
+        body,
+        queryParams,
+        headers: {
+            'IBM-BA-Authorization': `CAM ${sessionKey}`,
+        },
+    });
+}
+
+/**
+ * Common property definitions for IBM Cognos
+ */
+export const cognosCommon = {
+    dataSource: Property.Dropdown({
+        displayName: 'Data Source',
+        required: true,
+        refreshers: [],
+        options: async ({ auth }) => {
+            if (!auth) {
+                return {
+                    disabled: true,
+                    placeholder: 'Connect your account first',
+                    options: [],
+                };
+            }
+            try {
+                const response = await callCognosApi<{ datasources: { id: string; defaultName: string }[] }>(
+                    HttpMethod.GET,
+                    auth as CognosAuthValue,
+                    '/datasources'
+                );
+                return {
+                    disabled: false,
+                    options: (response.body.datasources || []).map((ds) => ({
+                        label: ds.defaultName || ds.id,
+                        value: ds.id,
+                    })),
+                };
+            } catch (error) {
+                return {
+                    disabled: true,
+                    placeholder: 'Failed to load data sources',
+                    options: [],
+                };
+            }
+        },
+    }),
+    
+    contentObject: Property.Dropdown({
+        displayName: 'Content Object',
+        required: true,
+        refreshers: [],
+        options: async ({ auth }) => {
+            if (!auth) {
+                return {
+                    disabled: true,
+                    placeholder: 'Connect your account first',
+                    options: [],
+                };
+            }
+            try {
+                const response = await callCognosApi<{ content: { id: string; defaultName: string }[] }>(
+                    HttpMethod.GET,
+                    auth as CognosAuthValue,
+                    '/content'
+                );
+                return {
+                    disabled: false,
+                    options: (response.body.content || []).map((obj) => ({
+                        label: obj.defaultName || obj.id,
+                        value: obj.id,
+                    })),
+                };
+            } catch (error) {
+                return {
+                    disabled: true,
+                    placeholder: 'Failed to load content objects',
+                    options: [],
+                };
+            }
+        },
+    }),
+};
+

--- a/packages/pieces/community/ibm-cognos/tsconfig.json
+++ b/packages/pieces/community/ibm-cognos/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}
+

--- a/packages/pieces/community/ibm-cognos/tsconfig.lib.json
+++ b/packages/pieces/community/ibm-cognos/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}
+


### PR DESCRIPTION
This PR adds IBM Cognos Analytics piece with 8 actions for managing data sources and content objects


### Explain How the Feature Works
Data Source Actions:
Create Data Source - Creates a new data source with connection string configuration
Update Data Source - Updates existing data source properties including name, disabled and hidden states
Delete Data Source - Deletes a data source with optional force delete parameter
Get Data Source - Retrieves details of a specific data source by ID
Content Object Actions:
Update Content Object - Updates content object properties like name, description, type and version
Move Content Object - Moves content objects between folders with conflict resolution options
Copy Content Object - Copies content objects to different locations with optional renaming
Get Content Object - Retrieves content object details with optional metadata inclusion
Authentication uses session-based CAM (Cognos Access Manager) with base URL, namespace, username and password. All actions include proper error handling and validation. Custom API call action included for advanced use cases.

### Video demonstration
Video demonstration being recorded and will be uploaded.




/claim #9733
/fixes #9733
