### PR TITLE
fix: remove duplicate null check in TokenCheckerWrapper

### DIFF
--- a/packages/react-ui/src/app/router/project-route-wrapper.tsx
+++ b/packages/react-ui/src/app/router/project-route-wrapper.tsx
@@ -28,7 +28,7 @@ export const TokenCheckerWrapper: React.FC<{ children: React.ReactNode }> = ({
 
   const { checkAccess } = useAuthorization();
 
-  if (isNil(projectIdFromParams) || isNil(projectIdFromParams)) {
+  if (isNil(projectIdFromParams)) {
     return <Navigate to="/sign-in" replace />;
   }
   const failedToSwitchToProject =


### PR DESCRIPTION
## What does this PR do?

This PR removes a redundant `isNil(projectIdFromParams)` check in the `TokenCheckerWrapper` component.
Previously, the same condition was checked twice unnecessarily.

Fixes #9789 
