### PR TITLE
feat(slack): add mention of origin flow checkbox to slack message sent (channel, DM)

### DIFF
--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
@@ -8,6 +8,7 @@ import {
   userId,
   username,
   blocks,
+  mentionOriginFlow,
 } from '../common/props';
 import { Block,KnownBlock } from '@slack/web-api';
 
@@ -22,6 +23,7 @@ export const slackSendDirectMessageAction = createAction({
     text,
     username,
     profilePicture,
+    mentionOriginFlow,
     blocks,
   },
   async run(context) {
@@ -32,8 +34,20 @@ export const slackSendDirectMessageAction = createAction({
     assertNotNullOrUndefined(text, 'text');
     assertNotNullOrUndefined(userId, 'userId');
 
-    const blockList = blocks ?[{ type: 'section', text: { type: 'mrkdwn', text } }, ...(blocks as unknown as (KnownBlock | Block)[])] :undefined
+    const blockList: (KnownBlock | Block)[] = [{ type: 'section', text: { type: 'mrkdwn', text } }]
 
+    if(blocks && Array.isArray(blocks)) { 
+      blockList.push(...(blocks as unknown as (KnownBlock | Block)[]))
+    }
+
+    if(mentionOriginFlow) {
+      (blockList as KnownBlock[])?.push({ type: 'context', elements: [
+        {
+          "type": "mrkdwn",
+          "text": `Message sent by <${new URL(context.server.publicUrl).origin}/projects/${context.project.id}/flows/${context.flows.current.id}|this flow>.`
+        }
+      ] })
+    }
 
     return slackSendMessage({
       token,

--- a/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
@@ -6,6 +6,7 @@ import {
   blocks,
   threadTs,
   singleSelectChannelInfo,
+  mentionOriginFlow,
 } from '../common/props';
 import { processMessageTimestamp, slackSendMessage } from '../common/utils';
 import { slackAuth } from '../../';
@@ -38,14 +39,28 @@ export const slackSendMessageAction = createAction({
       required: false,
       defaultValue: false,
     }),
+    mentionOriginFlow,
     blocks,
   },
   async run(context) {
     const token = context.auth.access_token;
-    const { text, channel, username, profilePicture, threadTs, file, blocks, replyBroadcast } =
+    const { text, channel, username, profilePicture, threadTs, file, mentionOriginFlow, blocks, replyBroadcast } =
       context.propsValue;
+    
+    const blockList: (KnownBlock | Block)[] = [{ type: 'section', text: { type: 'mrkdwn', text } }]
 
-    const blockList = blocks && Array.isArray(blocks) ?[{ type: 'section', text: { type: 'mrkdwn', text } }, ...(blocks as unknown as (KnownBlock | Block)[])] :undefined
+    if(blocks && Array.isArray(blocks)) { 
+      blockList.push(...(blocks as unknown as (KnownBlock | Block)[]))
+    }
+
+    if(mentionOriginFlow) {
+      (blockList as KnownBlock[])?.push({ type: 'context', elements: [
+        {
+          "type": "mrkdwn",
+          "text": `Message sent by <${new URL(context.server.publicUrl).origin}/projects/${context.project.id}/flows/${context.flows.current.id}|this flow>.`
+        }
+      ] })
+    }
 
     return slackSendMessage({
       token,

--- a/packages/pieces/community/slack/src/lib/common/props.ts
+++ b/packages/pieces/community/slack/src/lib/common/props.ts
@@ -68,10 +68,19 @@ export const threadTs = Property.ShortText({
   required: false,
 });
 
+export const mentionOriginFlow = Property.Checkbox({
+  displayName: 'Mention flow of origin?',
+  description:
+    'If checked, adds a mention at the end of the Slack message to indicate which flow sent the notification, with a link to said flow.',
+  required: false,
+  defaultValue: false,
+});
+
 export const blocks = Property.Json({
   displayName: 'Block Kit blocks',
   description: 'See https://api.slack.com/block-kit for specs',
   required: false,
+  defaultValue: []
 });
 
 export const userId = Property.Dropdown<string>({


### PR DESCRIPTION

## What does this PR do?

Add a Checkbox that allows a addendum in each message sent by a flow, mentioning the flow of origin

<img width="401" height="101" alt="image" src="https://github.com/user-attachments/assets/f741f140-8472-4658-9d6a-d4e5427ac5e1" />


<img width="221" height="67" alt="image" src="https://github.com/user-attachments/assets/c8a7dcaf-b7b7-483e-9b02-6598fc0105cb" />

