### PR TITLE
fix(table): avoid empty/duplicate fields while renaming

### DIFF
--- a/packages/react-ui/src/features/tables/components/rename-field-popovercontent.tsx
+++ b/packages/react-ui/src/features/tables/components/rename-field-popovercontent.tsx
@@ -28,7 +28,7 @@ const RenameFieldPopoverContent = ({ name }: { name: string }) => {
     },
     resolver: (values) => {
       const errors: FieldErrors<{ name: string }> = {};
-      if (values.name.length === 0) {
+      if (values.name.trim().length === 0) {
         errors.name = {
           message: t('Name is required'),
           type: 'required',
@@ -37,8 +37,8 @@ const RenameFieldPopoverContent = ({ name }: { name: string }) => {
       if (
         fields.find(
           (field) =>
-            field.name.toLowerCase() === values.name.toLowerCase() &&
-            field.name.toLowerCase() !== name.toLowerCase(),
+            field.name.trim().toLowerCase() === values.name.trim().toLowerCase() &&
+            field.name.trim().toLowerCase() !== name.trim().toLowerCase(),
         )
       ) {
         errors.name = {


### PR DESCRIPTION
## What does this PR do?

This PR ensures  empty spaces are not allowed during renaming and duplicates are avoided while renaming table fields


### Explain How the Feature Works

[Screencast from 2025-11-02 13-42-53.webm](https://github.com/user-attachments/assets/28b8ae64-a203-4bcc-b50c-33b2b9a50f2d)


Fixes #9947 
