### PR TITLE
fix: restrict empty spaces on create/rename folder input

### DIFF
--- a/packages/react-ui/src/features/folders/component/create-folder-dialog.tsx
+++ b/packages/react-ui/src/features/folders/component/create-folder-dialog.tsx
@@ -47,7 +47,7 @@ type CreateFolderDialogProps = {
 const CreateFolderFormSchema = Type.Object({
   displayName: Type.String({
     errorMessage: t('Please enter folder name'),
-    pattern: '.*\\S.*'
+    pattern: '.*\\S.*',
   }),
 });
 

--- a/packages/react-ui/src/features/folders/component/rename-folder-dialog.tsx
+++ b/packages/react-ui/src/features/folders/component/rename-folder-dialog.tsx
@@ -25,7 +25,7 @@ import { foldersApi } from '../lib/folders-api';
 const RenameFolderSchema = Type.Object({
   displayName: Type.String({
     errorMessage: t('Please enter a folder name'),
-    pattern: '.*\\S.*'
+    pattern: '.*\\S.*',
   }),
 });
 


### PR DESCRIPTION
## What does this PR do?

This PR ensures that empty spaces are not allowed as input to folder names

### Explain How the Feature Works

[Screencast from 2025-11-05 03-17-49.webm](https://github.com/user-attachments/assets/27c5dbfd-c753-4a6c-989b-9d2b63c1eb80)


Fixes #9974 
