### PR TITLE
feat: allow optional name arg for build piece command

### DIFF
--- a/docs/developers/misc/build-piece.mdx
+++ b/docs/developers/misc/build-piece.mdx
@@ -31,3 +31,8 @@ The CLI will build the piece and you will be given the path to the archive. For 
 ```bash
 Piece 'google-drive' built and packed successfully at dist/packages/pieces/community/google-drive
 ```
+
+You may also build the piece non-interactively by passing the piece name as an argument.  For example:
+```bash
+npm run build-piece google-drive
+```

--- a/packages/cli/src/lib/commands/build-piece.ts
+++ b/packages/cli/src/lib/commands/build-piece.ts
@@ -11,15 +11,19 @@ async function buildPieces(pieceName: string) {
 
 export const buildPieceCommand = new Command('build')
     .description('Build pieces without publishing')
-    .action(async () => {
+    .argument('[name]', 'name of the piece to build')
+    .action(async (name) => {
         const questions = [
             {
                 type: 'input',
                 name: 'name',
                 message: 'Enter the piece folder name',
                 placeholder: 'google-drive',
+                when() {
+                    return !name
+                }
             },
         ];
         const answers = await inquirer.prompt(questions);
-        await buildPieces(answers.name);
+        await buildPieces(name ? name : answers.name);
     });


### PR DESCRIPTION
## What does this PR do?

This allows passing the `name` argument in order to bypass the prompt for the `build-piece` command in the CLI.  The argument is optional; if not provided, the prompt will request the piece name.


### Explain How the Feature Works
Build a piece in a non-interactive way:
```bash
npm run build-piece my-piece-name
```
Build a piece using the interactive prompt as before:
```bash
npm run build-piece
```

### Relevant User Scenarios

This is useful for automating the piece build process in things like GitHub Actions.  The piece can be built non-interactively and then installed on a server through the Activepieces API



Fixes # (issue)
