### PR TITLE
feat(slack): allow multi channel filter for new message trigger

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "dependencies": {
     "@slack/web-api": "7.9.0",
     "slackify-markdown": "4.4.0"

--- a/packages/pieces/community/slack/src/lib/triggers/new-message-in-channel.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-message-in-channel.ts
@@ -10,8 +10,8 @@ import { getFirstFiveOrAll } from '../common/utils';
 export const newMessageInChannelTrigger = createTrigger({
 	auth: slackAuth,
 	name: 'new-message-in-channel',
-	displayName: 'New Message Posted to Channel',
-	description: 'Triggers when a new message is posted to a specific #channel you choose.',
+	displayName: 'New Message Posted to Channel (DEPRECATED)',
+	description: 'Triggers when a new message is posted to a specific #channel you choose. This trigger is deprecated: use the "New message posted" trigger instead',
 	props: {
 		info: singleSelectChannelInfo,
 		channel: slackChannel(true),
@@ -42,7 +42,7 @@ export const newMessageInChannelTrigger = createTrigger({
 		if (!['channel','group'].includes(payloadBody.event.channel_type)) {
 			return [];
 		}
-		
+
 		if (payloadBody.event.channel === context.propsValue.channel) {
 			// check for bot messages
 			if (context.propsValue.ignoreBots && payloadBody.event.bot_id) {

--- a/packages/pieces/community/slack/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-message.ts
@@ -1,12 +1,41 @@
-import { Property, TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
+import {
+  Property,
+  TriggerStrategy,
+  createTrigger,
+  OAuth2PropertyValue,
+} from '@activepieces/pieces-framework';
 import { slackAuth } from '../../';
+import { getChannels } from '../common/props';
 
 export const newMessageTrigger = createTrigger({
 	auth: slackAuth,
 	name: 'new-message',
-	displayName: 'New Public Message Posted Anywhere',
-	description: 'Triggers when a new message is posted to any channel.',
+	displayName: 'New message posted',
+	description: 'Triggers when a new message is posted (optionally on one or more channels)',
 	props: {
+    channels: Property.MultiSelectDropdown({
+      displayName: 'Channels',
+      description:
+        'If no channel is selected, the flow will be triggered for messages in all channels',
+      required: false,
+      refreshers: [],
+      async options({ auth }) {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'connect slack account',
+            options: [],
+          };
+        }
+        const authentication = auth as OAuth2PropertyValue;
+        const channels = await getChannels(authentication['access_token']);
+        return {
+          disabled: false,
+          placeholder: 'Select channel(s)',
+          options: channels,
+        };
+      },
+    }),
 		ignoreBots: Property.Checkbox({
 			displayName: 'Ignore Bot Messages ?',
 			required: true,
@@ -34,6 +63,11 @@ export const newMessageTrigger = createTrigger({
 		if (!['channel','group'].includes(payloadBody.event.channel_type)) {
 			return [];
 		}
+
+    // check if the channel is among one of the requested ones
+    if (context.propsValue.channels && !context.propsValue.channels.includes(payloadBody.event.channel)) {
+      return []
+    }
 
 		// check for bot messages
 		if (context.propsValue.ignoreBots && payloadBody.event.bot_id) {


### PR DESCRIPTION
## What does this PR do?

- Allow selecting 0, 1 or more channels to filter new messages (in the new message trigger)
- Deprecate the "new message in channel" trigger

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
