### PR TITLE
fix(engine): use acknowledgment for ENGINE_RESPONSE

### DIFF
--- a/packages/engine/src/lib/worker-socket.ts
+++ b/packages/engine/src/lib/worker-socket.ts
@@ -24,7 +24,7 @@ let socket: Socket | undefined
 async function executeFromSocket(operation: EngineOperation, operationType: EngineOperationType): Promise<void> {
     const result = await execute(operationType, operation)
     const resultParsed = JSON.parse(JSON.stringify(result))
-    socket?.emit(EngineSocketEvent.ENGINE_RESPONSE, resultParsed)
+    await workerSocket.sendToWorkerWithAck(EngineSocketEvent.ENGINE_RESPONSE, resultParsed)
 }
 
 export const workerSocket = {
@@ -76,7 +76,7 @@ export const workerSocket = {
                     error: utils.formatError(resultError),
                 }
                 console.error('Error handling operation:', engineError)
-                socket?.emit(EngineSocketEvent.ENGINE_RESPONSE, engineError)
+                await workerSocket.sendToWorkerWithAck(EngineSocketEvent.ENGINE_RESPONSE, engineError)
             }
         })
 

--- a/packages/server/worker/src/lib/compute/engine-runner-socket.ts
+++ b/packages/server/worker/src/lib/compute/engine-runner-socket.ts
@@ -127,8 +127,9 @@ export const engineRunnerSocket = (log: FastifyBaseLogger) => {
             // Remove any existing listeners before adding new ones
             this.unsubscribe(workerId)
 
-            socket.on(EngineSocketEvent.ENGINE_RESPONSE, (data: EngineResponse<unknown>) => {
+            socket.on(EngineSocketEvent.ENGINE_RESPONSE, (data: EngineResponse<unknown>, callback: () => void) => {
                 onResult(data)
+                callback?.()
             })
 
             socket.on(EngineSocketEvent.ENGINE_STDOUT, (data: EngineStdout) => {


### PR DESCRIPTION

## What does this PR do?
So that engine doesnt exit before sending the response to worker. 
<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
