### PR TITLE
fix: log piece-utils error message if no response present

### DIFF
--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -102,9 +102,9 @@ export async function publishPieceFromFolder(
     } catch (error) {
      
         if (axios.isAxiosError(error)) {
-            if (error.response.status === 409) {
+            if (error.response?.status === 409) {
                 console.info(chalk.yellow(`Piece '${packageJson.name}' and '${packageJson.version}' already published.`));
-            } else if (Math.floor(error.response.status / 100) !== 2) {
+            } else if (error.response && Math.floor(error.response.status / 100) !== 2) {
                 console.info(chalk.red(`Error publishing piece '${packageJson.name}',  ${error}` ));
                 if (failOnError) {
                     console.info(chalk.yellow(`Terminating process due to publish failure for piece '${packageJson.name}' (fail-on-error is enabled)`));


### PR DESCRIPTION
## What does this PR do?

AxiosError.response has a nice `?` in its definition. So, it can be undefined. However, the error handling in piece-utils does not take that into account. Resulting in cryptic logging such as 
```
TypeError: Cannot read properties of undefined (reading 'status')
    at /srv/github/actions-runner/2.314.1/_work/..../activepieces/packages/cli/src/lib/utils/piece-utils.ts:105:32
    at Generator.throw (<anonymous>)
    at rejected (/srv/github/actions-runner/2.314.1/_work/..../activepieces/node_modules/tslib/tslib.js:167:69)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Which is very unhelpful. This PR fixes that problem, hopefully revealing the actual error. It now logs the message.

Potential improvement: log the entire stack trace. But I am not knowledgable enough about axios errors to know whether that is necessary with axios.

### Explain How the Feature Works

run piece-utils against something that does not respond, or does not open a connection. See error appear in log.

### Relevant User Scenarios

Any scenario where something goes wrong with piece-utils without a response
