### PR TITLE
fix: disable UI for creating/reconnecting connections in the builder when user doesn't have permission

### DIFF
--- a/packages/react-ui/src/app/builder/step-settings/piece-settings/connection-select.tsx
+++ b/packages/react-ui/src/app/builder/step-settings/piece-settings/connection-select.tsx
@@ -5,6 +5,7 @@ import { ControllerRenderProps, useFormContext } from 'react-hook-form';
 
 import { AutoFormFieldWrapper } from '@/app/builder/piece-properties/auto-form-field-wrapper';
 import { CreateOrEditConnectionDialog } from '@/app/connections/create-edit-connection-dialog';
+import { PermissionNeededTooltip } from '@/components/custom/permission-needed-tooltip';
 import { SearchableSelect } from '@/components/custom/searchable-select';
 import { Button } from '@/components/ui/button';
 import { FormField, FormLabel } from '@/components/ui/form';
@@ -17,7 +18,12 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { appConnectionsQueries } from '@/features/connections/lib/app-connections-hooks';
+import {
+  useAuthorization,
+  useIsPlatformAdmin,
+} from '@/hooks/authorization-hooks';
 import { authenticationSession } from '@/lib/authentication-session';
+import { cn } from '@/lib/utils';
 import {
   PieceMetadataModel,
   PieceMetadataModelSummary,
@@ -25,6 +31,7 @@ import {
 import {
   AppConnectionScope,
   AppConnectionWithoutSensitiveData,
+  Permission,
   PieceAction,
   PieceTrigger,
   PropertyExecutionType,
@@ -52,7 +59,9 @@ const ConnectionSelect = memo((params: ConnectionSelectProps) => {
   const [reconnectConnection, setReconnectConnection] =
     useState<AppConnectionWithoutSensitiveData | null>(null);
   const form = useFormContext<PieceAction | PieceTrigger>();
-
+  const hasPermissionToCreateConnection = useAuthorization().checkAccess(
+    Permission.WRITE_APP_CONNECTION,
+  );
   const {
     data: connections,
     isLoading: isLoadingConnections,
@@ -78,6 +87,7 @@ const ConnectionSelect = memo((params: ConnectionSelectProps) => {
   const dynamicInputModeToggled =
     form.getValues().settings.propertySettings['auth']?.type ===
     PropertyExecutionType.DYNAMIC;
+  const isPLatformAdmin = useIsPlatformAdmin();
   return (
     <FormField
       control={form.control}
@@ -136,30 +146,30 @@ const ConnectionSelect = memo((params: ConnectionSelectProps) => {
                 disabled={params.disabled}
               >
                 <div className="relative">
-                  {field.value && !field.disabled && (
-                    <>
-                      {connections?.data?.find(
-                        (connection) =>
-                          connection.externalId ===
-                            removeBrackets(field.value) &&
-                          connection.scope !== AppConnectionScope.PLATFORM,
-                      ) && (
-                        <Button
-                          variant="ghost"
-                          size="xs"
-                          className="z-50 absolute right-8 top-2 "
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setReconnectConnection(selectedConnection ?? null);
-                            setSelectConnectionOpen(false);
-                            setConnectionDialogOpen(true);
-                          }}
+                  {field.value &&
+                    !field.disabled &&
+                    selectedConnection &&
+                    (!isGlobalConnection || isPLatformAdmin) && (
+                      <div className="z-50 absolute right-8 top-2 ">
+                        <PermissionNeededTooltip
+                          hasPermission={hasPermissionToCreateConnection}
                         >
-                          {t('Reconnect')}
-                        </Button>
-                      )}
-                    </>
-                  )}
+                          <Button
+                            variant="ghost"
+                            size="xs"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setReconnectConnection(selectedConnection);
+                              setSelectConnectionOpen(false);
+                              setConnectionDialogOpen(true);
+                            }}
+                            disabled={!hasPermissionToCreateConnection}
+                          >
+                            {t('Reconnect')}
+                          </Button>
+                        </PermissionNeededTooltip>
+                      </div>
+                    )}
 
                   <SelectTrigger className="flex gap-2 items-center">
                     <SelectValue
@@ -212,18 +222,31 @@ const ConnectionSelect = memo((params: ConnectionSelectProps) => {
                 </div>
 
                 <SelectContent>
-                  <SelectAction
-                    onClick={() => {
-                      setSelectConnectionOpen(false);
-                      setReconnectConnection(null);
-                      setConnectionDialogOpen(true);
-                    }}
+                  <PermissionNeededTooltip
+                    hasPermission={hasPermissionToCreateConnection}
                   >
-                    <span className="flex items-center gap-1 text-primary w-full">
-                      <Plus size={16} />
-                      {t('Create Connection')}
-                    </span>
-                  </SelectAction>
+                    <SelectAction
+                      onClick={() => {
+                        setSelectConnectionOpen(false);
+                        setReconnectConnection(null);
+                        setConnectionDialogOpen(true);
+                      }}
+                      disabled={!hasPermissionToCreateConnection}
+                    >
+                      <span
+                        className={cn(
+                          'flex items-center gap-1 text-primary w-full',
+                          {
+                            'text-muted-foreground cursor-not-allowed':
+                              !hasPermissionToCreateConnection,
+                          },
+                        )}
+                      >
+                        <Plus size={16} />
+                        {t('Create Connection')}
+                      </span>
+                    </SelectAction>
+                  </PermissionNeededTooltip>
 
                   {connections &&
                     connections.data &&

--- a/packages/react-ui/src/app/components/platform-layout.tsx
+++ b/packages/react-ui/src/app/components/platform-layout.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router-dom';
 
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar-shadcn';
 import { PurchaseExtraFlowsDialog } from '@/features/billing/components/active-flows-addon/purchase-active-flows-dialog';
-import { useShowPlatformAdminDashboard } from '@/hooks/authorization-hooks';
+import { useIsPlatformAdmin } from '@/hooks/authorization-hooks';
 import { flagsHooks } from '@/hooks/flags-hooks';
 import { ApEdition, ApFlagId } from '@activepieces/shared';
 
@@ -12,7 +12,7 @@ import { PlatformSidebar } from './sidebar/platform';
 
 export function PlatformLayout({ children }: { children: React.ReactNode }) {
   const { data: edition } = flagsHooks.useFlag<ApEdition>(ApFlagId.EDITION);
-  const showPlatformAdminDashboard = useShowPlatformAdminDashboard();
+  const showPlatformAdminDashboard = useIsPlatformAdmin();
 
   return (
     <AllowOnlyLoggedInUserOnlyGuard>

--- a/packages/react-ui/src/app/components/sidebar/sidebar-user.tsx
+++ b/packages/react-ui/src/app/components/sidebar/sidebar-user.tsx
@@ -30,7 +30,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { UserAvatar } from '@/components/ui/user-avatar';
-import { useShowPlatformAdminDashboard } from '@/hooks/authorization-hooks';
+import { useIsPlatformAdmin } from '@/hooks/authorization-hooks';
 import { userHooks } from '@/hooks/user-hooks';
 import { authenticationSession } from '@/lib/authentication-session';
 import { PlatformRole } from '@activepieces/shared';
@@ -154,7 +154,7 @@ export function SidebarUser() {
 }
 
 function SidebarPlatformAdminButton() {
-  const showPlatformAdminDashboard = useShowPlatformAdminDashboard();
+  const showPlatformAdminDashboard = useIsPlatformAdmin();
   const { embedState } = useEmbedding();
   const navigate = useNavigate();
   const messages = notificationHooks.useNotifications();

--- a/packages/react-ui/src/components/ui/select.tsx
+++ b/packages/react-ui/src/components/ui/select.tsx
@@ -138,15 +138,27 @@ SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectAction = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }
->(({ className, children, ...props }, ref) => (
+  React.HTMLAttributes<HTMLDivElement> & {
+    children: React.ReactNode;
+    disabled?: boolean;
+  }
+>(({ className, children, disabled, ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
       'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
       className,
+      { 'text-muted-foreground cursor-not-allowed': disabled },
     )}
     {...props}
+    onClick={(e) => {
+      if (disabled) {
+        e.preventDefault();
+        e.stopPropagation();
+      } else {
+        props.onClick?.(e);
+      }
+    }}
   >
     {children}
   </div>

--- a/packages/react-ui/src/hooks/authorization-hooks.ts
+++ b/packages/react-ui/src/hooks/authorization-hooks.ts
@@ -42,7 +42,7 @@ export const useAuthorization = () => {
   return { checkAccess };
 };
 
-export const useShowPlatformAdminDashboard = () => {
+export const useIsPlatformAdmin = () => {
   const platformRole = userHooks.getCurrentUserPlatformRole();
   return platformRole === PlatformRole.ADMIN;
 };


### PR DESCRIPTION

<img width="535" height="232" alt="image" src="https://github.com/user-attachments/assets/1abe8355-d0a7-4e31-9c5f-42210f64dd29" />

<img width="558" height="318" alt="image" src="https://github.com/user-attachments/assets/c2dfe6d2-81a7-4845-b385-212c6891159b" />
