### PR TITLE
fix: add loading state to bulk actions buttons in runs table

### DIFF
--- a/packages/react-ui/src/features/flow-runs/components/runs-table/index.tsx
+++ b/packages/react-ui/src/features/flow-runs/components/runs-table/index.tsx
@@ -277,6 +277,7 @@ export const RunsTable = () => {
                 disabled={isDisabled}
                 variant="outline"
                 className="h-9 w-full"
+                loading={archiveRuns.isPending}
                 onClick={() => {
                   archiveRuns.mutate({
                     runIds: selectedRows.map((row) => row.id),
@@ -327,6 +328,7 @@ export const RunsTable = () => {
                     disabled={isDisabled}
                     variant="outline"
                     className="h-9 w-full"
+                    loading={cancelRuns.isPending}
                     onClick={() => {
                       cancelRuns.mutate({
                         runIds: selectedRows.map((row) => row.id),
@@ -366,7 +368,11 @@ export const RunsTable = () => {
               >
                 <DropdownMenu modal={false}>
                   <DropdownMenuTrigger asChild disabled={isDisabled}>
-                    <Button disabled={isDisabled} className="h-9 w-full">
+                    <Button
+                      disabled={isDisabled}
+                      className="h-9 w-full"
+                      loading={retryRuns.isPending}
+                    >
                       <RotateCw className="size-4 mr-1" />
                       {selectedRows.length > 0
                         ? `${t('Retry')} ${


### PR DESCRIPTION
## What does this PR do?
Cancel, retry, and archive.

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
