### PR TITLE
feat: add last used column to track key usage

### DIFF
--- a/packages/ee/shared/src/lib/api-key/index.ts
+++ b/packages/ee/shared/src/lib/api-key/index.ts
@@ -7,6 +7,7 @@ export const ApiKey = Type.Object({
     displayName: Type.String(),
     hashedValue: Type.String(),
     truncatedValue: Type.String(),
+    lastUsedAt: Type.Optional(Type.String()),
 })
 
 export type ApiKey = Static<typeof ApiKey>

--- a/packages/react-ui/src/app/routes/platform/security/api-keys/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/security/api-keys/index.tsx
@@ -58,6 +58,21 @@ const ApiKeysPage = () => {
         );
       },
     },
+    {
+      accessorKey: 'lastUsedAt',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title={t('Last Used')} />
+      ),
+      cell: ({ row }) => {
+        return (
+          <div className="text-left">
+            {row.original.lastUsedAt
+              ? formatUtils.formatDate(new Date(row.original.lastUsedAt))
+              : t('Never')}
+          </div>
+        );
+      },
+    },
   ];
 
   const { platform } = platformHooks.useCurrentPlatform();

--- a/packages/server/api/src/app/database/migration/postgres/1763378445660-AddLastUsedAtToApiKey.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1763378445660-AddLastUsedAtToApiKey.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddLastUsedAtToApiKey1763378445660 implements MigrationInterface {
+    name = 'AddLastUsedAtToApiKey1763378445660'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "api_key"
+            ADD "lastUsedAt" character varying
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "api_key"
+            DROP COLUMN "lastUsedAt"
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -294,6 +294,8 @@ import { AddFailedStepAndDurationToRunPostgres1762886424449 } from './migration/
 import { AddIconToProject1763377380235 } from './migration/postgres/1763377380235-AddIconToProject'
 import { RemoveDurationAndAddArchivedAtIdxPostgres1763378445659 } from './migration/postgres/1763378445659-RemoveDurationAndAddArchivedAtIdxPostgres'
 
+import { AddLastUsedAtToApiKey1763378445660 } from './migration/postgres/1763378445660-AddLastUsedAtToApiKey'
+
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
     if (useSsl === 'true') {
@@ -605,6 +607,7 @@ const getMigrations = (): (new () => MigrationInterface)[] => {
                 RemoveUserSeatsLimitColumn1761762177701,
                 RemoveMcpAndTablesLimitsAndBillingCycles1762103191643,
                 RemoveUnusedPaymentMethodColoumn1762709208569,
+                AddLastUsedAtToApiKey1763378445660,
             )
             break
         case ApEdition.COMMUNITY:

--- a/packages/server/api/src/app/ee/api-keys/api-key-entity.ts
+++ b/packages/server/api/src/app/ee/api-keys/api-key-entity.ts
@@ -30,6 +30,10 @@ export const ApiKeyEntity = new EntitySchema<ApiKeySchema>({
             type: String,
             nullable: false,
         },
+        lastUsedAt: {
+            type: String,
+            nullable: true,
+        },
     },
     indices: [],
     relations: {

--- a/packages/server/api/src/app/ee/api-keys/api-key-service.ts
+++ b/packages/server/api/src/app/ee/api-keys/api-key-service.ts
@@ -38,9 +38,13 @@ export const apiKeyService = {
     },
     async getByValueOrThrow(key: string): Promise<ApiKey> {
         assertNotNullOrUndefined(key, 'key')
-        return repo().findOneByOrFail({
+        const apiKey = await repo().findOneByOrFail({
             hashedValue: cryptoUtils.hashSHA256(key),
         })
+        await repo().update(apiKey.id, {
+            lastUsedAt: new Date().toISOString(),
+        })
+        return apiKey
     },
     async list({ platformId }: ListParams): Promise<SeekPage<ApiKey>> {
         const data = await repo().findBy({


### PR DESCRIPTION
## What does this PR do?
This PR adds a "Last Used" column to the API Keys table. It tracks and displays the timestamp of when an API key was last successfully used for authentication.


### Explain How the Feature Works
- Database: Added a lastUsedAt column to the api_key table via a new migration.
- Backend: Updated the ApiKeyService to update the lastUsedAt timestamp to the current time whenever a key is successfully validated.
- Frontend: Added a "Last Used" column to the API Keys table UI. It displays the formatted date or "Never" if the key has not been used yet.

### Relevant User Scenarios
- Security Audits: Admins can identify and revoke API keys that have been inactive for a long time.
- Cleanup: Users can easily spot and delete unused keys to keep their environment organized.
- Verification: Developers can confirm if an external integration is successfully using a specific API key.



Fixes #10155
