### PR TITLE
fix: persist run step expansion state to prevent collapse

### DIFF
--- a/packages/react-ui/src/app/builder/builder-hooks.ts
+++ b/packages/react-ui/src/app/builder/builder-hooks.ts
@@ -99,6 +99,7 @@ export type BuilderState = {
   outputSampleData: Record<string, unknown>;
   inputSampleData: Record<string, unknown>;
   loopsIndexes: Record<string, number>;
+  expandedSteps: Record<string, boolean>;
   run: FlowRun | null;
   leftSidebar: LeftSideBarType;
   rightSidebar: RightSideBarType;
@@ -140,6 +141,7 @@ export type BuilderState = {
   setReadOnly: (readOnly: boolean) => void;
   setInsertMentionHandler: (handler: InsertMentionHandler | null) => void;
   setLoopIndex: (stepName: string, index: number) => void;
+  setStepExpanded: (stepName: string, isExpanded: boolean) => void;
   operationListeners: Array<
     (flowVersion: FlowVersion, operation: FlowOperationRequest) => void
   >;
@@ -232,6 +234,7 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
               {},
             )
           : {},
+      expandedSteps: {},
       outputSampleData: initialState.outputSampleData,
       inputSampleData: initialState.inputSampleData,
       flow: initialState.flow,
@@ -369,6 +372,7 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
           run: null,
           readonly: !userHasPermissionToEditFlow,
           loopsIndexes: {},
+          expandedSteps: {},
           leftSidebar: LeftSideBarType.NONE,
           selectedBranchIndex: null,
         }),
@@ -399,6 +403,7 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
               run,
               state.loopsIndexes,
             ),
+            expandedSteps: state.expandedSteps,
             run,
             flowVersion,
             leftSidebar: LeftSideBarType.RUN_DETAILS,
@@ -464,6 +469,16 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
           });
           return {
             loopsIndexes,
+          };
+        });
+      },
+      setStepExpanded: (stepName: string, expanded: boolean) => {
+        set((state) => {
+          return {
+            expandedSteps: {
+              ...state.expandedSteps,
+              [stepName]: expanded,
+            },
           };
         });
       },

--- a/packages/react-ui/src/app/builder/run-details/run-step-card-item.tsx
+++ b/packages/react-ui/src/app/builder/run-details/run-step-card-item.tsx
@@ -34,6 +34,8 @@ const RunStepCardItem = ({ stepName, depth }: RunStepCardProps) => {
     selectStepByName,
     run,
     flowVersion,
+    expandedSteps,
+    setStepExpanded,
   ] = useBuilderStateContext((state) => {
     const step = flowStructureUtil.getStepOrThrow(
       stepName,
@@ -51,6 +53,8 @@ const RunStepCardItem = ({ stepName, depth }: RunStepCardProps) => {
       state.selectStepByName,
       state.run,
       state.flowVersion,
+      state.expandedSteps,
+      state.setStepExpanded,
     ];
   });
   const { fitView } = useReactFlow();
@@ -83,7 +87,7 @@ const RunStepCardItem = ({ stepName, depth }: RunStepCardProps) => {
   const { stepMetadata } = stepsHooks.useStepMetadata({
     step: step,
   });
-  const [isOpen, setIsOpen] = React.useState(true);
+  const isOpen = expandedSteps[stepName] ?? true;
 
   const isLoopStep =
     stepOutput && stepOutput.type === FlowActionType.LOOP_ON_ITEMS;
@@ -98,9 +102,9 @@ const RunStepCardItem = ({ stepName, depth }: RunStepCardProps) => {
             if (!isStepSelected) {
               selectStepByName(stepName);
               fitView(flowCanvasUtils.createFocusStepInGraphParams(stepName));
-              setIsOpen(true);
+              setStepExpanded(stepName, true);
             } else {
-              setIsOpen(!isOpen);
+              setStepExpanded(stepName, !isOpen);
             }
           }}
           className={cn('cursor-pointer select-none px-4 py-3 h-14', {
@@ -120,7 +124,7 @@ const RunStepCardItem = ({ stepName, depth }: RunStepCardProps) => {
                 size={'icon'}
                 className="w-4 h-4"
                 onClick={(e) => {
-                  setIsOpen(!isOpen);
+                  setStepExpanded(stepName, !isOpen);
                   e.stopPropagation();
                 }}
               >


### PR DESCRIPTION
Fixes #9165

The Issue Loop items in the run details sidebar were collapsing automatically whenever the flow run updated. This happened because the expansion state was stored in local useState, which reset every time the component re-rendered due to flow progress updates.

The Fix I moved the expansion state to the global BuilderState context.
- Added expandedSteps to the global store to persist visibility across re-renders.
- Updated setRun to preserve this state when new run data arrives.
- Updated RunStepCardItem to read/write from this global state instead of local state.

Result Users can now expand or collapse loop items while a flow is running, and the UI will maintain that state even as new steps complete.
