### PR TITLE
feat: add Image Toolkit community piece (resize, crop, convert, compress, metadata)

### DIFF
--- a/packages/pieces/community/image-toolkit/.eslintrc.json
+++ b/packages/pieces/community/image-toolkit/.eslintrc.json
@@ -1,0 +1,32 @@
+{
+  "extends": ["../../../../.eslintrc.base.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": [
+              "{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/pieces/community/image-toolkit/README.md
+++ b/packages/pieces/community/image-toolkit/README.md
@@ -1,0 +1,7 @@
+# pieces-image-toolkit
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-image-toolkit` to build the library.

--- a/packages/pieces/community/image-toolkit/package.json
+++ b/packages/pieces/community/image-toolkit/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@activepieces/piece-image-toolkit",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "sharp": "^0.34.5",
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/image-toolkit/pnpm-lock.yaml
+++ b/packages/pieces/community/image-toolkit/pnpm-lock.yaml
@@ -1,0 +1,314 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+
+packages:
+
+  '@emnapi/runtime@1.7.1':
+    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
+  '@img/colour@1.0.0':
+    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+snapshots:
+
+  '@emnapi/runtime@1.7.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@img/colour@1.0.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.7.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  detect-libc@2.1.2: {}
+
+  semver@7.7.3: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.0.0
+      detect-libc: 2.1.2
+      semver: 7.7.3
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  tslib@2.8.1: {}

--- a/packages/pieces/community/image-toolkit/project.json
+++ b/packages/pieces/community/image-toolkit/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "pieces-image-toolkit",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/image-toolkit/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/image-toolkit",
+        "tsConfig": "packages/pieces/community/image-toolkit/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/image-toolkit/package.json",
+        "main": "packages/pieces/community/image-toolkit/src/index.ts",
+        "assets": ["packages/pieces/community/image-toolkit/*.md"]
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    }
+  }
+}

--- a/packages/pieces/community/image-toolkit/src/index.ts
+++ b/packages/pieces/community/image-toolkit/src/index.ts
@@ -1,0 +1,34 @@
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { PieceCategory } from "@activepieces/shared";
+
+import { resizeImage } from "./lib/actions/resize.action";
+import { cropImage } from "./lib/actions/crop.action";
+import { convertImage } from "./lib/actions/convert.action";
+import { compressImage } from "./lib/actions/compress.action";
+import { extractMetadata } from "./lib/actions/extract-metadata.action";
+import { removeMetadata } from "./lib/actions/remove-metadata.action";
+
+export const imageToolkit = createPiece({
+  displayName: "Image Toolkit",
+  description: "Image processing toolkit: resize, crop, convert, compress, and metadata tools.",
+  auth: PieceAuth.None(),
+
+  minimumSupportedRelease: "0.0.0",
+
+  categories: [PieceCategory.CONTENT_AND_FILES],
+
+  logoUrl: "https://cdn.activepieces.com/pieces/image-toolkit.png",
+
+  authors: ["@lau90eth"],
+
+  actions: [
+    resizeImage,
+    cropImage,
+    convertImage,
+    compressImage,
+    extractMetadata,
+    removeMetadata,
+  ],
+
+  triggers: [],
+});

--- a/packages/pieces/community/image-toolkit/src/lib/actions/compress.action.ts
+++ b/packages/pieces/community/image-toolkit/src/lib/actions/compress.action.ts
@@ -1,0 +1,65 @@
+import sharp from "sharp";
+import { createAction, Property } from "@activepieces/pieces-framework";
+
+export const compressImage = createAction({
+  name: "compress_image",
+  displayName: "Compress Image",
+  description: "Compress an image using the specified quality (1-100).",
+
+  props: {
+    inputFile: Property.File({
+      displayName: "Input Image",
+      required: true,
+    }),
+
+    quality: Property.Number({
+      displayName: "Quality (1-100)",
+      required: true,
+    }),
+  },
+
+  async run(context) {
+    const p = context.propsValue as any;
+    const file = p["inputFile"];
+    const quality = p["quality"];
+
+    const raw = file.data;
+    const buffer =
+      typeof raw === "string" ? Buffer.from(raw, "base64") : Buffer.from(raw);
+
+    const ext = file.extension?.toLowerCase() || "jpeg";
+
+    let pipeline = sharp(buffer);
+
+    switch (ext) {
+      case "jpg":
+      case "jpeg":
+        pipeline = pipeline.jpeg({ quality });
+        break;
+      case "png":
+        pipeline = pipeline.png({ compressionLevel: 9 });
+        break;
+      case "webp":
+        pipeline = pipeline.webp({ quality });
+        break;
+      case "avif":
+        pipeline = pipeline.avif({ quality });
+        break;
+      default:
+        pipeline = pipeline.jpeg({ quality });
+    }
+
+    const output = await pipeline.toBuffer();
+
+    return {
+      outputFile: {
+        data: output.toString("base64"),
+        type: `image/${ext}`,
+        extension: ext,
+      },
+      originalSize: buffer.length,
+      newSize: output.length,
+      quality,
+    };
+  },
+});

--- a/packages/pieces/community/image-toolkit/src/lib/actions/convert.action.ts
+++ b/packages/pieces/community/image-toolkit/src/lib/actions/convert.action.ts
@@ -1,0 +1,65 @@
+import sharp from "sharp";
+import { createAction, Property } from "@activepieces/pieces-framework";
+
+export const convertImage = createAction({
+  name: "convert_image",
+  displayName: "Convert Image Format",
+  description: "Convert an image to PNG, JPEG, WEBP or AVIF.",
+
+  props: {
+    inputFile: Property.File({
+      displayName: "Input Image",
+      required: true,
+    }),
+
+    format: Property.StaticDropdown({
+      displayName: "Output Format",
+      required: true,
+      options: {
+        options: [
+          { label: "PNG", value: "png" },
+          { label: "JPEG", value: "jpeg" },
+          { label: "WEBP", value: "webp" },
+          { label: "AVIF", value: "avif" },
+        ],
+      },
+    }),
+  },
+
+  async run(context) {
+    const p = context.propsValue as any;
+    const file = p["inputFile"];
+    const format = p["format"];
+
+    const raw = file.data;
+    const buffer =
+      typeof raw === "string" ? Buffer.from(raw, "base64") : Buffer.from(raw);
+
+    let pipeline = sharp(buffer);
+
+    switch (format) {
+      case "png":
+        pipeline = pipeline.png();
+        break;
+      case "jpeg":
+        pipeline = pipeline.jpeg();
+        break;
+      case "webp":
+        pipeline = pipeline.webp();
+        break;
+      case "avif":
+        pipeline = pipeline.avif();
+        break;
+    }
+
+    const output = await pipeline.toBuffer();
+
+    return {
+      outputFile: {
+        data: output.toString("base64"),
+        type: `image/${format}`,
+        extension: format,
+      },
+    };
+  },
+});

--- a/packages/pieces/community/image-toolkit/src/lib/actions/crop.action.ts
+++ b/packages/pieces/community/image-toolkit/src/lib/actions/crop.action.ts
@@ -1,0 +1,45 @@
+import sharp from "sharp";
+import { createAction, Property } from "@activepieces/pieces-framework";
+
+export const cropImage = createAction({
+  name: "crop_image",
+  displayName: "Crop Image",
+  description: "Crop a region from the image.",
+
+  props: {
+    inputFile: Property.File({
+      displayName: "Input Image",
+      required: true,
+    }),
+    left: Property.Number({ displayName: "Left", required: true }),
+    top: Property.Number({ displayName: "Top", required: true }),
+    width: Property.Number({ displayName: "Width", required: true }),
+    height: Property.Number({ displayName: "Height", required: true }),
+  },
+
+  async run(context) {
+    const p = context.propsValue as any;
+    const file = p["inputFile"];
+
+    const raw = file.data;
+    const buffer =
+      typeof raw === "string" ? Buffer.from(raw, "base64") : Buffer.from(raw);
+
+    const output = await sharp(buffer)
+      .extract({
+        left: p["left"],
+        top: p["top"],
+        width: p["width"],
+        height: p["height"],
+      })
+      .toBuffer();
+
+    return {
+      outputFile: {
+        data: output.toString("base64"),
+        type: file.type ?? "image/png",
+        extension: file.extension ?? "png",
+      },
+    };
+  },
+});

--- a/packages/pieces/community/image-toolkit/src/lib/actions/extract-metadata.action.ts
+++ b/packages/pieces/community/image-toolkit/src/lib/actions/extract-metadata.action.ts
@@ -1,0 +1,30 @@
+import sharp from "sharp";
+import { createAction, Property } from "@activepieces/pieces-framework";
+
+export const extractMetadata = createAction({
+  name: "extract_metadata",
+  displayName: "Extract Metadata",
+  description: "Extract EXIF / metadata from the image.",
+
+  props: {
+    inputFile: Property.File({
+      displayName: "Input Image",
+      required: true,
+    }),
+  },
+
+  async run(context) {
+    const p = context.propsValue as any;
+    const file = p["inputFile"];
+
+    const raw = file.data;
+    const buffer =
+      typeof raw === "string" ? Buffer.from(raw, "base64") : Buffer.from(raw);
+
+    const metadata = await sharp(buffer).metadata();
+
+    return {
+      metadata,
+    };
+  },
+});

--- a/packages/pieces/community/image-toolkit/src/lib/actions/remove-metadata.action.ts
+++ b/packages/pieces/community/image-toolkit/src/lib/actions/remove-metadata.action.ts
@@ -1,0 +1,36 @@
+import sharp from "sharp";
+import { createAction, Property } from "@activepieces/pieces-framework";
+
+export const removeMetadata = createAction({
+  name: "remove_metadata",
+  displayName: "Remove Metadata",
+  description: "Remove all EXIF and metadata from the image.",
+
+  props: {
+    inputFile: Property.File({
+      displayName: "Input Image",
+      required: true,
+    }),
+  },
+
+  async run(context) {
+    const p = context.propsValue as any;
+    const inputFile = p["inputFile"];
+    const raw = inputFile.data;
+
+    const buffer =
+      typeof raw === "string" ? Buffer.from(raw, "base64") : Buffer.from(raw);
+
+    // Sharpen the buffer without metadata
+    const output = await sharp(buffer).toBuffer(); // metadata removed by default
+
+    return {
+      success: true,
+      outputFile: {
+        data: output.toString("base64"),
+        type: inputFile.type ?? "image/png",
+        extension: inputFile.extension ?? "png",
+      },
+    };
+  },
+});

--- a/packages/pieces/community/image-toolkit/src/lib/actions/resize.action.ts
+++ b/packages/pieces/community/image-toolkit/src/lib/actions/resize.action.ts
@@ -1,0 +1,44 @@
+import sharp from "sharp";
+import { createAction, Property } from "@activepieces/pieces-framework";
+
+export const resizeImage = createAction({
+  name: "resize_image",
+  displayName: "Resize Image",
+  description: "Resize an image to the specified width and height.",
+
+  props: {
+    inputFile: Property.File({
+      displayName: "Input Image",
+      required: true,
+    }),
+    width: Property.Number({
+      displayName: "Width",
+      required: true,
+    }),
+    height: Property.Number({
+      displayName: "Height",
+      required: true,
+    }),
+  },
+
+  async run(context) {
+    const p = context.propsValue as any;
+    const file = p["inputFile"];
+
+    const raw = file.data;
+    const buffer =
+      typeof raw === "string" ? Buffer.from(raw, "base64") : Buffer.from(raw);
+
+    const output = await sharp(buffer)
+      .resize(p["width"], p["height"])
+      .toBuffer();
+
+    return {
+      outputFile: {
+        data: output.toString("base64"),
+        type: file.type ?? "image/png",
+        extension: file.extension ?? "png",
+      },
+    };
+  },
+});

--- a/packages/pieces/community/image-toolkit/tsconfig.json
+++ b/packages/pieces/community/image-toolkit/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/image-toolkit/tsconfig.lib.json
+++ b/packages/pieces/community/image-toolkit/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
This PR introduces the new **Image Toolkit** community piece.

### ✅ Features included
- Resize image
- Crop image
- Convert image format (png, jpeg, webp, avif)
- Compress image
- Extract metadata
- Remove metadata

### 🛠️ Implementation notes
- Uses `sharp` for image processing.
- Follows the updated Activepieces File API.
- Includes all actions under: `packages/pieces/community/image-toolkit/`.

This piece is fully tested locally and ready for review.

