### PR TITLE
fix: csv export flattening logic for single-column sheets

### DIFF
--- a/packages/pieces/community/google-sheets/src/lib/actions/export-sheet.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/export-sheet.ts
@@ -59,7 +59,29 @@ export const exportSheetAction = createAction({
       });
 
       if (returnAsText) {
-        const textData = Buffer.from(response.body).toString('utf-8');
+        let textData = Buffer.from(response.body).toString('utf-8');
+      
+        if (format === 'csv') {
+          textData = textData.replace(/\r/g, '');
+      
+          const lines = textData.split('\n');
+
+          const parsedRows = lines.map(line => line.split(','));
+      
+          const isSingleColumn = parsedRows.every(row => row.length === 1);
+      
+          if (isSingleColumn) {
+              const cleaned = lines.map(line => {
+                  line = line.replace(/\s+$/, ''); 
+                  return line.replace(/\t/g, ',');
+              });
+      
+              textData = cleaned.join(',');
+          }
+          else {
+              textData = lines.join('\n');
+          }
+        }      
         return {
           text: textData,
           format,


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue in the Google Sheets “Export Sheet” action where exporting a sheet as CSV produces the same TSV format for single-column sheets. The updated logic now correctly converts the response into comma-separated values only for single-column cases, while multi-column CSV and TSV outputs remain unchanged.


### Explain How the Feature Works
CSV output for single-column values
```
{
  "text": "hi,hola,amigos,theek ,ho ,ji",
  "format": "csv"
}
```

CSV output for multi-column values
```
{
  "text": "hi,hola,amigos,theek ,ho ,ji\nhello ji,,,,,",
  "format": "csv"
}
```

Fixes #10370 