### PR TITLE
fix: fixed image cutoff issue for images with a non-square aspect ratio

### DIFF
--- a/packages/react-ui/src/components/ui/image-with-fallback.tsx
+++ b/packages/react-ui/src/components/ui/image-with-fallback.tsx
@@ -42,7 +42,7 @@ const ImageWithFallback = ({
           onLoad={handleLoad}
           onError={handleError}
           className={cn(
-            `transition-opacity duration-500 w-full h-full object-cover`,
+            `transition-opacity duration-500 w-full h-full object-contain`,
             {
               'opacity-0': isLoading,
               'opacity-100': !isLoading,


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->
Fixed an issue where non square images would get cut off because object-cover was set instead of object-contain

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
