### PR TITLE
fix: fixed json processor so invalid json doesn't pass anymore

### DIFF
--- a/packages/engine/src/lib/variables/processors/json.ts
+++ b/packages/engine/src/lib/variables/processors/json.ts
@@ -5,6 +5,9 @@ export const jsonProcessor: ProcessorFn = (_property, value) => {
     if (isNil(value)) {
         return value
     }
+    if (value === '') {
+        return null
+    }
     try {
         if (typeof value === 'object') {
             return value
@@ -13,6 +16,6 @@ export const jsonProcessor: ProcessorFn = (_property, value) => {
     }
     catch (error) {
         console.error(error)
-        return undefined
+        return false
     }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->
Modified the JSON processor so that invalid JSON values don't pass the validation


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
The JSON validation didn't work because the value was set to undefined when the JSON wasn't valid. For props that are not required this failed to catch them as they are allowed to be nullable and are optional. By setting the value to false when the JSON isn't valid this won't happen anymore

<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
