### PR TITLE
chore: remove folder sort icon

### DIFF
--- a/packages/react-ui/src/features/folders/component/folder-filter-list.tsx
+++ b/packages/react-ui/src/features/folders/component/folder-filter-list.tsx
@@ -5,7 +5,7 @@ import {
   Shapes,
   TableProperties,
 } from 'lucide-react';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
 import { PermissionNeededTooltip } from '@/components/custom/permission-needed-tooltip';
@@ -115,10 +115,6 @@ const FolderFilterList = ({ refresh }: { refresh: number }) => {
     queryFn: flowsApi.count,
   });
 
-  const sortedFolders = useMemo(() => {
-    return folders;
-  }, [folders]);
-
   useEffect(() => {
     refetchFolders();
     refetchAllFlowsCount();
@@ -198,8 +194,8 @@ const FolderFilterList = ({ refresh }: { refresh: number }) => {
                 ))}
               </div>
             )}
-            {sortedFolders &&
-              sortedFolders.map((folder) => {
+            {folders &&
+              folders.map((folder) => {
                 return (
                   <FolderItem
                     key={folder.id}


### PR DESCRIPTION
## What does this PR do?

This PR addresses design debt by removing the unnecessary folder sorting functionality from the UI.

### Explain How the Feature Works
The sorting button (with arrow icons) next to the "Create Folder" button has been removed. Consequently, all associated sorting logic, state management, and unused imports have also been eliminated. Folders will now display without any explicit sorting controls.

### Relevant User Scenarios

This change simplifies the user interface by removing a feature that was deemed unnecessary, as per the design debt issue.

Fixes #GIT-1243

---
Linear Issue: [GIT-1243](https://linear.app/activepieces/issue/GIT-1243/design-debt-remove-sorting-folders)

<a href="https://cursor.com/background-agent?bcId=bc-7c9655c9-956a-405f-b6a9-821446a998de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c9655c9-956a-405f-b6a9-821446a998de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

