### PR TITLE
feat: remove redundant folder column

### DIFF
--- a/packages/react-ui/src/app/routes/flows/flows-table/columns.tsx
+++ b/packages/react-ui/src/app/routes/flows/flows-table/columns.tsx
@@ -9,7 +9,6 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { RowDataWithActions } from '@/components/ui/data-table';
 import { DataTableColumnHeader } from '@/components/ui/data-table/data-table-column-header';
 import { FlowStatusToggle } from '@/features/flows/components/flow-status-toggle';
-import { FolderBadge } from '@/features/folders/component/folder-badge';
 import { PieceIconList } from '@/features/pieces/components/piece-icon-list';
 import { formatUtils } from '@/lib/utils';
 import { PopulatedFlow } from '@activepieces/shared';
@@ -122,24 +121,6 @@ export const flowsTableColumns = ({
           trigger={row.original.version.trigger}
           maxNumberOfIconsToShow={2}
         />
-      );
-    },
-  },
-  {
-    accessorKey: 'folderId',
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title={t('Folder')} />
-    ),
-    cell: ({ row }) => {
-      const folderId = row.original.folderId;
-      return (
-        <div className="text-left min-w-[150px]">
-          {folderId ? (
-            <FolderBadge folderId={folderId} />
-          ) : (
-            <span>{t('Uncategorized')}</span>
-          )}
-        </div>
       );
     },
   },

--- a/packages/react-ui/src/app/routes/flows/flows-table/index.tsx
+++ b/packages/react-ui/src/app/routes/flows/flows-table/index.tsx
@@ -147,10 +147,7 @@ export const FlowsTable = ({ refetch: parentRefetch }: FlowsTableProps) => {
           emptyStateTextTitle={t('No flows found')}
           emptyStateTextDescription={t('Create a workflow to start automating')}
           emptyStateIcon={<Workflow className="size-14" />}
-          columns={columns.filter(
-            (column) =>
-              !embedState.hideFolders || column.accessorKey !== 'folderId',
-          )}
+          columns={columns}
           page={data}
           isLoading={isLoading || isLoadingConnections}
           filters={filters}


### PR DESCRIPTION
## What does this PR do?

Removes the redundant "Folder" column from the flows table in the UI.

### Explain How the Feature Works

The "Folder" column definition and its conditional rendering logic have been removed from `packages/react-ui/src/app/routes/flows/flows-table/columns.tsx` and `packages/react-ui/src/app/routes/flows/flows-table/index.tsx` respectively. The flows table now directly uses the defined columns without any filtering for the folder column.

### Relevant User Scenarios

This addresses design debt by simplifying the flows table UI, removing a column that was deemed redundant.

Fixes # GIT-1239

---
Linear Issue: [GIT-1239](https://linear.app/activepieces/issue/GIT-1239/design-debt-folder-in-the-flows-tables)

<a href="https://cursor.com/background-agent?bcId=bc-0d44bec9-bd78-4e1e-81fc-4eb52f55d746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0d44bec9-bd78-4e1e-81fc-4eb52f55d746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

