### PR TITLE
chore: ellipsis long flow names

### DIFF
--- a/packages/react-ui/src/app/routes/flows/flows-table/columns.tsx
+++ b/packages/react-ui/src/app/routes/flows/flows-table/columns.tsx
@@ -8,6 +8,11 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { RowDataWithActions } from '@/components/ui/data-table';
 import { DataTableColumnHeader } from '@/components/ui/data-table/data-table-column-header';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { FlowStatusToggle } from '@/features/flows/components/flow-status-toggle';
 import { FolderBadge } from '@/features/folders/component/folder-badge';
 import { PieceIconList } from '@/features/pieces/components/piece-icon-list';
@@ -107,8 +112,17 @@ export const flowsTableColumns = ({
       <DataTableColumnHeader column={column} title={t('Name')} />
     ),
     cell: ({ row }) => {
-      const status = row.original.version.displayName;
-      return <div className="text-left">{status}</div>;
+      const displayName = row.original.version.displayName;
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="text-left truncate">{displayName}</div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{displayName}</p>
+          </TooltipContent>
+        </Tooltip>
+      );
     },
   },
   {


### PR DESCRIPTION
## What does this PR do?

This PR resolves a design debt by implementing ellipsis truncation for long flow names in the flows table and displaying the full name in a tooltip on hover. This ensures a cleaner table layout without disrupting the look.

### Explain How the Feature Works

The flow's `displayName` in the flows table is now wrapped within a `Tooltip` component. The visible text is rendered inside a `TooltipTrigger` with the `truncate` Tailwind CSS class, which applies `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` to ensure the name stays on a single line with an ellipsis if it's too long. On hover, the `TooltipContent` displays the complete `displayName`.

### Relevant User Scenarios

*   Users viewing the flows table will experience a more organized and aesthetically pleasing interface, as long flow names will no longer break the table layout.
*   Users can easily view the full name of any truncated flow by simply hovering over it, ensuring all information remains accessible.

Fixes #GIT-1247

---
Linear Issue: [GIT-1247](https://linear.app/activepieces/issue/GIT-1247/design-debt-long-flows-names)

<a href="https://cursor.com/background-agent?bcId=bc-eb197eec-49bb-41ed-b48e-b12726395b8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb197eec-49bb-41ed-b48e-b12726395b8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

