### PR TITLE
chore: cleanup personal project labels and remove redundant UI elements

### DIFF
--- a/packages/react-ui/src/app/components/project-layout/project-dashboard-page-header.tsx
+++ b/packages/react-ui/src/app/components/project-layout/project-dashboard-page-header.tsx
@@ -1,10 +1,16 @@
-import { UserPlus, UsersRound, Settings, LockIcon } from 'lucide-react';
+import { UserPlus, UsersRound, Settings, Lock } from 'lucide-react';
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useEmbedding } from '@/components/embed-provider';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar-shadcn';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { InviteUserDialog } from '@/features/members/component/invite-user-dialog';
 import { projectMembersHooks } from '@/features/members/lib/project-members-hooks';
 import { useAuthorization } from '@/hooks/authorization-hooks';
@@ -33,7 +39,6 @@ export const ProjectDashboardPageHeader = ({
   description?: React.ReactNode;
 }) => {
   const { project } = projectHooks.useCurrentProject();
-  const { data: currentUser } = userHooks.useCurrentUser();
   const { platform } = platformHooks.useCurrentPlatform();
   const [inviteOpen, setInviteOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -112,21 +117,20 @@ export const ProjectDashboardPageHeader = ({
                     : title
                 }
                 maxLengthToNotShowTooltip={30}
-                titleClassName="text-lg font-semibold"
+                titleClassName="text-base"
                 projectType={project.type}
               />
-              {showSettingsButton && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6"
-                  onClick={() => {
-                    setSettingsInitialTab(getFirstAvailableTab());
-                    setSettingsOpen(true);
-                  }}
-                >
-                  <Settings className="w-4 h-4" />
-                </Button>
+              {project.type === ProjectType.PERSONAL && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Lock className="w-4 h-4" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>This is your private project. Only you can see and access it.</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               )}
             </div>
             {description && (
@@ -155,6 +159,19 @@ export const ProjectDashboardPageHeader = ({
               >
                 <UserPlus className="w-4 h-4" />
                 <span className="text-sm font-medium">Invite</span>
+              </Button>
+            )}
+            {showSettingsButton && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => {
+                  setSettingsInitialTab(getFirstAvailableTab());
+                  setSettingsOpen(true);
+                }}
+              >
+                <Settings className="w-4 h-4" />
               </Button>
             )}
           </div>

--- a/packages/react-ui/src/app/components/sidebar/project/index.tsx
+++ b/packages/react-ui/src/app/components/sidebar/project/index.tsx
@@ -55,7 +55,7 @@ const ProjectSideBarItem = ({
     | 'environment' => {
     const hasGeneralSettings =
       project.type === ProjectType.TEAM ||
-      (platform.plan.embeddingEnabled &&  user?.platformRole === PlatformRole.ADMIN);
+      (platform.plan.embeddingEnabled && user?.platformRole === PlatformRole.ADMIN);
 
     if (hasGeneralSettings) return 'general';
     return 'pieces';


### PR DESCRIPTION
Fixes # ([issue](https://github.com/activepieces/activepieces/issues/10454))

Remove Private and You and Always name it Personal Project

Instead of You show lock icon in page header right side and say you are the only person who can see it.

Updated UI screenshot:
<img width="681" height="322" alt="Screenshot 2025-12-11 at 10 48 53 PM" src="https://github.com/user-attachments/assets/272a56ef-8803-499d-bb05-f77ae6eda009" />


Updated Files:

1. packages/react-ui/src/app/components/project-layout/project-dashboard-page-header.tsx
2. packages/react-ui/src/app/components/sidebar/project/index.tsx