### PR TITLE
feat: add invite user option to sidebar menu

### DIFF
--- a/packages/react-ui/src/app/components/sidebar/sidebar-user.tsx
+++ b/packages/react-ui/src/app/components/sidebar/sidebar-user.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
-import { ChevronsUpDown, LogOut, Shield, UserCogIcon } from 'lucide-react';
+import { ChevronsUpDown, LogOut, Shield, UserCogIcon, UserPlus } from 'lucide-react';
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -30,22 +30,26 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { UserAvatar } from '@/components/ui/user-avatar';
-import { useIsPlatformAdmin } from '@/hooks/authorization-hooks';
+import { InviteUserDialog } from '@/features/members/component/invite-user-dialog';
+import { useIsPlatformAdmin, useAuthorization } from '@/hooks/authorization-hooks';
 import { userHooks } from '@/hooks/user-hooks';
 import { authenticationSession } from '@/lib/authentication-session';
-import { PlatformRole } from '@activepieces/shared';
+import { Permission, PlatformRole } from '@activepieces/shared';
 
 import AccountSettingsDialog from '../account-settings';
 import { HelpAndFeedback } from '../help-and-feedback';
 
 export function SidebarUser() {
   const [accountSettingsOpen, setAccountSettingsOpen] = useState(false);
+  const [inviteUserOpen, setInviteUserOpen] = useState(false);
   const { embedState } = useEmbedding();
   const { state } = useSidebar();
   const location = useLocation();
   const { data: user } = userHooks.useCurrentUser();
   const queryClient = useQueryClient();
   const { reset } = useTelemetry();
+  const { checkAccess } = useAuthorization();
+  const canInviteUsers = checkAccess(Permission.WRITE_INVITATION);
   const isInPlatformAdmin = location.pathname.startsWith('/platform');
   const isCollapsed = state === 'collapsed';
 
@@ -135,6 +139,12 @@ export function SidebarUser() {
                 <UserCogIcon className="w-4 h-4 mr-2" />
                 {t('Account Settings')}
               </DropdownMenuItem>
+              {canInviteUsers && (
+                <DropdownMenuItem onClick={() => setInviteUserOpen(true)}>
+                  <UserPlus className="w-4 h-4 mr-2" />
+                  {t('Invite User')}
+                </DropdownMenuItem>
+              )}
               <HelpAndFeedback />
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
@@ -150,6 +160,7 @@ export function SidebarUser() {
         open={accountSettingsOpen}
         onClose={() => setAccountSettingsOpen(false)}
       />
+      <InviteUserDialog open={inviteUserOpen} setOpen={setInviteUserOpen} />
     </SidebarMenu>
   );
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds an "Invite User" option to the sidebar user menu, making user invitation accessible from anywhere in the application for both community and cloud editions.

### Explain How the Feature Works

Previously, inviting users was difficult to access:
- **Community edition**: No clear way to invite users
- **Cloud edition**: Users had to create a new team project to find the invite functionality

Now, users with the appropriate permissions can access "Invite User" directly from the sidebar user dropdown menu (click on user avatar → Invite User), making the feature discoverable and accessible from any page in the application.

**User Flow:**
1. User clicks on their avatar in the sidebar
2. Dropdown menu appears with account options
3. "Invite User" option is visible (if user has `WRITE_INVITATION` permission)
4. Clicking opens the invite user dialog
5. User can immediately invite new team members

### Technical Changes

**File Modified:**
- `packages/react-ui/src/app/components/sidebar/sidebar-user.tsx`

**Changes Made:**
- Added `UserPlus` icon import from lucide-react
- Imported `InviteUserDialog` component from members feature
- Added `useAuthorization` hook to check user permissions
- Added state management for invite dialog (`inviteUserOpen`)
- Added permission check using `Permission.WRITE_INVITATION`
- Added new "Invite User" menu item in dropdown (conditionally rendered based on permissions)
- Integrated `InviteUserDialog` component at the bottom of the sidebar menu
- Used `canInviteUsers` variable for cleaner permission check

Fixes #10441
