### PR TITLE
fix: support WebDAV HTTP methods like PROPFIND and REPORT

### DIFF
--- a/packages/server/api/src/app/webhooks/webhook-module.ts
+++ b/packages/server/api/src/app/webhooks/webhook-module.ts
@@ -2,7 +2,13 @@ import { FastifyPluginAsync } from 'fastify'
 import fastifyXmlBodyParser from 'fastify-xml-body-parser'
 import { webhookController } from './webhook-controller'
 
+const WEBDAV_METHODS = ['PROPFIND', 'PROPPATCH', 'MKCOL', 'COPY', 'MOVE', 'LOCK', 'UNLOCK', 'REPORT'] as const
+
 export const webhookModule: FastifyPluginAsync = async (app) => {
+    for (const method of WEBDAV_METHODS) {
+        app.addHttpMethod(method, { hasBody: true })
+    }
+
     app.addContentTypeParser(
         'application/json',
         { parseAs: 'string' },


### PR DESCRIPTION
## What does this PR do?

Adds support for WebDAV HTTP methods (PROPFIND, REPORT, MKCOL, etc.) to webhook endpoints, enabling CalDAV/CardDAV and other WebDAV-based integrations.

### Explain How the Feature Works

Webhooks now accept all standard and WebDAV HTTP methods instead of being limited to GET/POST/PUT/DELETE/PATCH. This allows users to build flows that respond to WebDAV requests commonly used in calendar, contact sync, and file management applications.

**Technical implementation:**
- Registered WebDAV methods globally with Fastify
- Updated all 5 webhook routes to accept extended HTTP methods
- WebDAV methods include: PROPFIND, PROPPATCH, MKCOL, COPY, MOVE, LOCK, UNLOCK, REPORT

### Relevant User Scenarios

- Building CalDAV/CardDAV servers that sync calendars and contacts
- Implementing WebDAV file storage webhooks
- Creating custom WebDAV-based automation workflows
- Integrating with applications that use WebDAV for data synchronization

fixes #10489
