### PR TITLE
fix: drop dependent constraints before dropping tables

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1766015156683-DropLegacyTables.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1766015156683-DropLegacyTables.ts
@@ -4,9 +4,9 @@ export class DropLegacyTables1766015156683 implements MigrationInterface {
     name = 'DropLegacyTables1766015156683'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query('DROP TABLE IF EXISTS "mcp_server"')
-        await queryRunner.query('DROP TABLE IF EXISTS "mcp_tool"')
         await queryRunner.query('DROP TABLE IF EXISTS "mcp_run"')
+        await queryRunner.query('DROP TABLE IF EXISTS "mcp_tool"')
+        await queryRunner.query('DROP TABLE IF EXISTS "mcp_server"')
         await queryRunner.query('DROP TABLE IF EXISTS "issue"')
         await queryRunner.query('DROP TABLE IF EXISTS "ai_usage"')
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a migration error by removing dependent constraints before dropping legacy tables.
