### PR TITLE
fix: hide sign-up page in embedded invite-only mode

### DIFF
--- a/packages/react-ui/src/app/routes/embed/index.tsx
+++ b/packages/react-ui/src/app/routes/embed/index.tsx
@@ -157,6 +157,7 @@ const EmbedPage = React.memo(() => {
                   hideFlowsPageNavbar:
                     event.data.data.hideFlowsPageNavbar ?? false,
                   hidePageHeader: event.data.data.hidePageHeader ?? false,
+                  hideSignUpPage: true,
                 });
               });
               memoryRouter.navigate(initialRoute);

--- a/packages/react-ui/src/app/routes/sign-up/index.tsx
+++ b/packages/react-ui/src/app/routes/sign-up/index.tsx
@@ -1,7 +1,16 @@
+import { Navigate } from 'react-router-dom';
+
+import { useEmbedding } from '@/components/embed-provider';
 import { FullLogo } from '@/components/ui/full-logo';
 import { AuthFormTemplate } from '@/features/authentication/components/auth-form-template';
 
 const SignUpPage: React.FC = () => {
+  const { embedState } = useEmbedding();
+
+  if (embedState.isEmbedded && embedState.hideSignUpPage) {
+    return <Navigate to="/sign-in" replace />;
+  }
+
   return (
     <div className="mx-auto flex h-screen flex-col items-center justify-center gap-2">
       <FullLogo />

--- a/packages/react-ui/src/components/embed-provider.tsx
+++ b/packages/react-ui/src/components/embed-provider.tsx
@@ -20,6 +20,7 @@ type EmbeddingState = {
   homeButtonIcon: 'back' | 'logo';
   hideDuplicateFlow: boolean;
   hidePageHeader: boolean;
+  hideSignUpPage: boolean;
 };
 
 const defaultState: EmbeddingState = {
@@ -36,6 +37,7 @@ const defaultState: EmbeddingState = {
   homeButtonIcon: 'logo',
   hideDuplicateFlow: false,
   hidePageHeader: false,
+  hideSignUpPage: false,
 };
 
 const EmbeddingContext = createContext<{

--- a/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
+++ b/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
@@ -22,10 +22,16 @@ import { flagsHooks } from '../../../hooks/flags-hooks';
 import { SignInForm } from './sign-in-form';
 import { SignUpForm } from './sign-up-form';
 import { ThirdPartyLogin } from './third-party-logins';
+import { useEmbedding } from '@/components/embed-provider';
 
 const BottomNote = ({ isSignup }: { isSignup: boolean }) => {
   const [searchParams] = useSearchParams();
   const searchQuery = searchParams.toString();
+  const { embedState } = useEmbedding();
+
+  if (!isSignup && embedState.isEmbedded && embedState.hideSignUpPage) {
+    return null;
+  }
 
   return isSignup ? (
     <div className="mb-4 text-center text-sm">


### PR DESCRIPTION
### Problem
In embedded mode, sign-up functionality is disabled at the API level and only **invite-based user creation** is allowed.  
However, users could still manually navigate to `/sign-up` and see a **non-functional sign-up page**, leading to confusion.

### Solution
Introduced a `hideSignUpPage` flag in the embedding state that:

- **Redirects `/sign-up` → `/sign-in`**  
  Users navigating directly to the sign-up URL are automatically redirected.
- **Hides the sign-up link**  
  The *“Don’t have an account? Sign up”* link is removed from the sign-in page.
- **Defaults to enabled for embedded instances**  
  The flag is automatically set to `true` whenever the app is embedded.

### Changes

| File | Description |
|------|-------------|
| `embed-provider.tsx` | Added `hideSignUpPage` to embedding state |
| `embed/index.tsx` | Set `hideSignUpPage: true` when embedded |
| `sign-up/index.tsx` | Redirect `/sign-up` to `/sign-in` when embedded |
| `auth-form-template.tsx` | Hide sign-up link when embedded |

### Testing
- TypeScript compilation passes  
- Verified redirect from `/sign-up` → `/sign-in` in embedded mode  
- Verified sign-up link is hidden on the sign-in page in embedded mode  
- Normal (non-embedded) mode works as expected  

fixes #8644
