### PR TITLE
fix(google-docs): resolve curly braces placeholder bug

### DIFF
--- a/packages/pieces/community/google-docs/src/lib/actions/create-document-based-on-template.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-document-based-on-template.action.ts
@@ -35,7 +35,7 @@ export const createDocumentBasedOnTemplate = createAction({
       options: {
           disabled: false,
           options: [
-              { label: 'Curly Braces {{}}', value: '{{KEY}}' },
+              { label: 'Curly Braces {{}}', value: 'curly_braces' },
               { label: 'Square Brackets [[]]', value: '[[KEY]]' },
               { label: 'Single Curly Braces {}', value: '{KEY}' },
               { label: 'Single Square Brackets []', value: '[KEY]' }
@@ -46,7 +46,10 @@ export const createDocumentBasedOnTemplate = createAction({
   async run(context) {
     const documentId: string = context.propsValue.template;
     const values = context.propsValue.values;
-    const placeholder_format = context.propsValue.placeholder_format;
+    let placeholder_format = context.propsValue.placeholder_format;
+    if (placeholder_format === 'curly_braces') {
+      placeholder_format = '{{KEY}}';
+    }
 
     const authClient = new OAuth2Client();
     authClient.setCredentials(context.auth);


### PR DESCRIPTION
## What does this PR do?

# Google Docs: Fix Curly Braces Placeholder Bug

## Issue
The "Edit template file" action in the **Google Docs** piece was failing when "Curly Braces {{}}" was selected.
- **Error**: `The substring match text should not be empty`.
- **Cause**: Activepieces treats `{{KEY}}` as variable interpolation. Since the variable `KEY` does not exist, it resolves to an empty string. This caused the search pattern in the Google Docs API to be empty.

## Fix
Updated [packages/pieces/community/google-docs/src/lib/actions/create-document-based-on-template.action.ts](file:///home/kunal/Documents/activepieces/packages/pieces/community/google-docs/src/lib/actions/create-document-based-on-template.action.ts):
1.  Changed the dropdown value for "Curly Braces" from `{{KEY}}` to `curly_braces`.
2.  Added logic in the [run](file:///home/kunal/Documents/activepieces/packages/pieces/community/gelato/src/lib/triggers/new-flavor-created.ts#59-62) function to map `curly_braces` back to `{{KEY}}`.

```typescript
// Old
{ label: 'Curly Braces {{}}', value: '{{KEY}}' }

// New
{ label: 'Curly Braces {{}}', value: 'curly_braces' }


// In run()
let placeholder_format = context.propsValue.placeholder_format;
if (placeholder_format === 'curly_braces') {
  placeholder_format = '{{KEY}}';
}
```

## Verification
- Built `pieces-google-docs` successfully.



### Relevant User Scenarios

- Existing flows using `[[KEY]]` (Square Brackets) continue to work as expected.
- Users encountering the issue will need to re-select "Curly Braces" in the "Placeholder Format" dropdown for the fix to take effect.



Fixes # (issue)
https://github.com/activepieces/activepieces/issues/10634
