### PR TITLE
fix: prevent oom during sync

### DIFF
--- a/packages/server/api/src/app/pieces/metadata/local-piece-cache.ts
+++ b/packages/server/api/src/app/pieces/metadata/local-piece-cache.ts
@@ -23,7 +23,7 @@ type State = {
 export const localPieceCache = (log: FastifyBaseLogger) => ({
     async setup(): Promise<void> {
         await updateCache(log)
-        cron.schedule('*/15 * * * *', () => {
+        cron.schedule('15,30,45 * * * *', () => {
             log.info('[localPieceCache] Refreshing pieces cache via cron job')
             rejectedPromiseHandler(updateCache(log), log)
         })


### PR DESCRIPTION
## What does this PR do?

This PR optimizes the piece synchronization process to prevent "Out of Memory" (OOM) crashes. It removes the forced memory cache refresh that occurred immediately after syncing with the cloud registry, decoupling the "download" phase from the "load into memory" phase.


### Explain How the Feature Works
Currently, the pieces-sync job (which runs hourly) forces a localPieceCache.refresh() immediately after it finishes downloading updates. This is a memory-intensive operation that parses metadata for ~6,000+ pieces.
The issue is that this forced refresh often overlaps with the scheduled 15-minute cron job that also refreshes the cache. When these two heavy operations run concurrently (or in close succession on limited resources), the Node.js heap limit is exceeded, causing the container to crash.

The Fix:
We removed the explicit refresh calls from the sync service. The system will now rely solely on the scheduled localPieceCache cron job (every 15 mins) to load new pieces into memory. This ensures that memory spikes are predictable and non-concurrent.

### Relevant User Scenarios

Users running Activepieces on instances with standard memory limits will no longer experience crashes at round hours (e.g., 12:00, 13:00) when the sync job aligns with the cache refresh cron.

Fixes # (issue)
https://github.com/activepieces/activepieces/issues/10194