### PR TITLE
fix: correct typo in McpProtocol enum for streamable-http

### DIFF
--- a/packages/shared/src/lib/agents/tools.ts
+++ b/packages/shared/src/lib/agents/tools.ts
@@ -11,7 +11,7 @@ export enum AgentToolType {
 
 export enum McpProtocol {
     SSE = 'sse',
-    STREAMABLE_HTTP = 'streamble-http',
+    STREAMABLE_HTTP = 'streamable-http',
     SIMPLE_HTTP = 'http',
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixed a typo in McpProtocol enum for streamable-http in the packages/shared/src/lib/agents/tool.ts.

Fixes #10744
