### PR TITLE
fix: reset pinned navigation tab when switching projects

### DIFF
--- a/packages/react-ui/src/app/components/project-layout/index.tsx
+++ b/packages/react-ui/src/app/components/project-layout/index.tsx
@@ -86,7 +86,7 @@ export function ProjectDashboardLayout({
           <div className="flex flex-col">
             {!hideHeader && (
               <>
-                <ProjectDashboardLayoutHeader />
+                <ProjectDashboardLayoutHeader key={currentProjectId} />
                 <Separator className="mb-5" />
               </>
             )}


### PR DESCRIPTION
## What does this PR do?

When switching between projects, the pinned navigation item (e.g., Connections) was persisting across project changes, causing navigation to route to the previous project's pages instead of the current one.

This fix ensures that the pinned item state is reset whenever the project changes, so navigation correctly routes to the current project's pages.