### PR TITLE
feat: add CUSTOM handshake strategy for dynamic webhook validation

### DIFF
--- a/packages/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/engine/src/lib/helper/trigger-helper.ts
@@ -180,6 +180,28 @@ export const triggerHelper = {
                     response: handshakeResponse,
                 }
             }
+            case TriggerHookType.SHOULD_HANDSHAKE: {
+                const { data: shouldHandshakeResult, error: shouldHandshakeError } = await utils.tryCatchAndThrowOnEngineError(
+                    () => pieceTrigger.shouldHandshake?.(context) ?? Promise.resolve(false)
+                )
+
+                if (shouldHandshakeError) {
+                    console.error(shouldHandshakeError)
+                    return {
+                        shouldHandshake: false,
+                    }
+                }
+                if (shouldHandshakeResult && typeof shouldHandshakeResult === 'object' && 'status' in shouldHandshakeResult) {
+                    return {
+                        shouldHandshake: false,
+                        response: shouldHandshakeResult,
+                    }
+                }
+
+                return {
+                    shouldHandshake: shouldHandshakeResult === true,
+                }
+            }
             case TriggerHookType.TEST: {
                 const { data: testResponse, error: testResponseError } = await utils.tryCatchAndThrowOnEngineError(() => pieceTrigger.test({
                     ...context,

--- a/packages/pieces/community/framework/src/lib/trigger/trigger.ts
+++ b/packages/pieces/community/framework/src/lib/trigger/trigger.ts
@@ -63,6 +63,7 @@ TS extends TriggerStrategy,
 > = BaseTriggerParams<PieceAuth, TriggerProps, TS> & {
   handshakeConfiguration?: WebhookHandshakeConfiguration
   onHandshake?: (context: TriggerHookContext<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, TriggerProps, TS>) => Promise<WebhookResponse>,
+  shouldHandshake?: (context: TriggerHookContext<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, TriggerProps, TS>) => Promise<boolean | WebhookResponse>,
   renewConfiguration?: WebhookRenewConfiguration
   onRenew?(context: TriggerHookContext<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, TriggerProps, TS>): Promise<void>,
 }
@@ -89,6 +90,7 @@ export class ITrigger<
     public readonly type: TS,
     public readonly handshakeConfiguration: WebhookHandshakeConfiguration,
     public readonly onHandshake: (ctx: TriggerHookContext<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, TriggerProps, TS>) => Promise<WebhookResponse>,
+    public readonly shouldHandshake: (ctx: TriggerHookContext<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, TriggerProps, TS>) => Promise<boolean | WebhookResponse>,
     public readonly renewConfiguration: WebhookRenewConfiguration,
     public readonly onRenew: (ctx: TriggerHookContext<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, TriggerProps, TS>) => Promise<void>,
     public readonly onEnable: (ctx: TriggerHookContext<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, TriggerProps, TS>) => Promise<void>,
@@ -124,6 +126,7 @@ export const createTrigger = <
         params.type,
         params.handshakeConfiguration ?? { strategy: WebhookHandshakeStrategy.NONE },
         params.onHandshake ?? (async () => ({ status: 200 })),
+        params.shouldHandshake ?? (async () => false),
         params.renewConfiguration ?? { strategy: WebhookRenewStrategy.NONE },
         params.onRenew ?? (async () => Promise.resolve()),
         params.onEnable,
@@ -144,6 +147,7 @@ export const createTrigger = <
         params.type,
         { strategy: WebhookHandshakeStrategy.NONE },
         async () => ({ status: 200 }),
+        async () => false,
         { strategy: WebhookRenewStrategy.NONE },
         (async () => Promise.resolve()),
         params.onEnable,
@@ -164,6 +168,7 @@ export const createTrigger = <
         params.type,
         { strategy: WebhookHandshakeStrategy.NONE },
         async () => ({ status: 200 }),
+        async () => false,
         { strategy: WebhookRenewStrategy.NONE },
         (async () => Promise.resolve()),
         params.onEnable,

--- a/packages/shared/src/lib/engine/engine-operation.ts
+++ b/packages/shared/src/lib/engine/engine-operation.ts
@@ -21,6 +21,7 @@ export enum TriggerHookType {
     ON_ENABLE = 'ON_ENABLE',
     ON_DISABLE = 'ON_DISABLE',
     HANDSHAKE = 'HANDSHAKE',
+    SHOULD_HANDSHAKE = 'SHOULD_HANDSHAKE',
     RENEW = 'RENEW',
     RUN = 'RUN',
     TEST = 'TEST',
@@ -197,6 +198,15 @@ type ExecuteOnEnableTriggerResponse = {
     scheduleOptions?: ScheduleOptions
 }
 
+type ExecuteShouldHandshakeTriggerResponse = {
+    shouldHandshake: boolean
+    response?: {
+        status: number
+        body?: unknown
+        headers?: Record<string, string>
+    }
+}
+
 export const EngineHttpResponse = Type.Object({
     status: Type.Number(),
     body: Type.Unknown(),
@@ -207,10 +217,11 @@ export type EngineHttpResponse = Static<typeof EngineHttpResponse>
 
 export type ExecuteTriggerResponse<H extends TriggerHookType> = H extends TriggerHookType.RUN ? ExecuteTestOrRunTriggerResponse :
     H extends TriggerHookType.HANDSHAKE ? ExecuteHandshakeTriggerResponse :
-        H extends TriggerHookType.TEST ? ExecuteTestOrRunTriggerResponse :
-            H extends TriggerHookType.RENEW ? Record<string, never> :
-                H extends TriggerHookType.ON_DISABLE ? Record<string, never> :
-                    ExecuteOnEnableTriggerResponse
+        H extends TriggerHookType.SHOULD_HANDSHAKE ? ExecuteShouldHandshakeTriggerResponse :
+            H extends TriggerHookType.TEST ? ExecuteTestOrRunTriggerResponse :
+                H extends TriggerHookType.RENEW ? Record<string, never> :
+                    H extends TriggerHookType.ON_DISABLE ? Record<string, never> :
+                        ExecuteOnEnableTriggerResponse
 
 export type ExecuteToolResponse = {
     status: ExecutionToolStatus

--- a/packages/shared/src/lib/trigger/index.ts
+++ b/packages/shared/src/lib/trigger/index.ts
@@ -12,6 +12,7 @@ export enum WebhookHandshakeStrategy {
     HEADER_PRESENT = 'HEADER_PRESENT',
     QUERY_PRESENT = 'QUERY_PRESENT',
     BODY_PARAM_PRESENT = 'BODY_PARAM_PRESENT',
+    CUSTOM = 'CUSTOM',
 }
 
 export enum TriggerSourceScheduleType {


### PR DESCRIPTION
### Summary

Adds `WebhookHandshakeStrategy.CUSTOM` that allows triggers to dynamically evaluate webhook requests and return custom responses (e.g., 401 for auth failures).

### Problem

Triggers need to validate incoming webhooks (e.g., auth headers) and respond with appropriate status codes before flow execution. The existing handshake mechanism only supports static detection strategies.

### Solution

Added `shouldHandshake` function that:
- Evaluates at runtime whether a request should trigger handshake
- Returns `boolean | WebhookResponse` to either continue processing or return a custom error response directly

### Changes

| File | Change |
|------|--------|
| [packages/shared/src/lib/trigger/index.ts](cci:7://file:///home/akram/activepieces/packages/shared/src/lib/trigger/index.ts:0:0-0:0) | Added `CUSTOM` to `WebhookHandshakeStrategy` |
| [packages/shared/src/lib/engine/engine-operation.ts](cci:7://file:///home/akram/activepieces/packages/shared/src/lib/engine/engine-operation.ts:0:0-0:0) | Added `SHOULD_HANDSHAKE` hook type and response type |
| [packages/pieces/community/framework/src/lib/trigger/trigger.ts](cci:7://file:///home/akram/activepieces/packages/pieces/community/framework/src/lib/trigger/trigger.ts:0:0-0:0) | Added `shouldHandshake` to trigger params |
| [packages/engine/src/lib/helper/trigger-helper.ts](cci:7://file:///home/akram/activepieces/packages/engine/src/lib/helper/trigger-helper.ts:0:0-0:0) | Added `SHOULD_HANDSHAKE` case handler |
| [packages/server/api/src/app/webhooks/handshake-handler.ts](cci:7://file:///home/akram/activepieces/packages/server/api/src/app/webhooks/handshake-handler.ts:0:0-0:0) | Added `CUSTOM` strategy handling |

Closes #9294