### PR TITLE
fix: openapi security access missing for /docs endpoint

### DIFF
--- a/packages/server/api/src/app/helper/openapi/openapi.controller.ts
+++ b/packages/server/api/src/app/helper/openapi/openapi.controller.ts
@@ -1,7 +1,14 @@
+import { securityAccess } from '@activepieces/server-shared'
 import { FastifyInstance } from 'fastify'
 
 export const openapiController = async (fastify: FastifyInstance) => {
-    fastify.get('/', async () => {
+    fastify.get('/', GetOpenApiParams, async () => {
         return JSON.stringify(fastify.swagger(), null, 2)
     })
+}
+
+const GetOpenApiParams = {
+    config: {
+        security: securityAccess.public(),
+    },
 }


### PR DESCRIPTION
## What does this PR do?

Missing to refactor openapiController to follow new Authorization system