### PR TITLE
feat: add flow templates breaking change documentation

### DIFF
--- a/docs/install/configuration/breaking-changes.mdx
+++ b/docs/install/configuration/breaking-changes.mdx
@@ -7,9 +7,11 @@ icon: "hammer"
 ## 0.76.2
 ### What has changed?
 - If you are on the embed plan, the "Use a Template" dialog is no longer shown when clicking the "New Flow" button.
+- We removed /flow-templates endpoints and replaced them with /templates 
 
 ### Do you need to take action?
 - If you are on the embed plan, update your implementation to redirect your users to the `/templates` page instead.
+- Check out new endpoints https://www.activepieces.com/docs/endpoints/templates/schema
 
 ## 0.75.0
 


### PR DESCRIPTION
## What does this PR do?

We have deprected flow-templates endpoints
