### PR TITLE
fix: show official templates when manage templates is disabled

### DIFF
--- a/packages/react-ui/src/app/routes/templates/index.tsx
+++ b/packages/react-ui/src/app/routes/templates/index.tsx
@@ -24,7 +24,7 @@ const TemplatesPage = () => {
   const navigate = useNavigate();
   const { data: templateCategories } = templatesHooks.useTemplateCategories();
   const { platform } = platformHooks.useCurrentPlatform();
-  const isShowingOfficialTemplates = platform.plan.manageTemplatesEnabled;
+  const isShowingOfficialTemplates = !platform.plan.manageTemplatesEnabled;
   const { templates, isLoading, search, setSearch, category, setCategory } =
     templatesHooks.useTemplates(
       isShowingOfficialTemplates ? TemplateType.OFFICIAL : TemplateType.CUSTOM,


### PR DESCRIPTION
## What does this PR do?

Incorrect condition to show official templates when his plan doesn't include manageTemplates (Embedding People)
