### PR TITLE
fix: breaking change 0.77.0

### DIFF
--- a/docs/install/configuration/breaking-changes.mdx
+++ b/docs/install/configuration/breaking-changes.mdx
@@ -4,7 +4,7 @@ description: "This list shows all versions that include breaking changes and how
 icon: "hammer"
 ---
 
-## 0.76.2
+## 0.77.0
 ### What has changed?
 - If you are on the embed plan, the "Use a Template" dialog is no longer shown when clicking the "New Flow" button.
 - We removed /flow-templates endpoints and replaced them with /templates 


### PR DESCRIPTION
## What does this PR do?

Updates the breaking changes documentation to reflect the correct next release version: 0.77.0 instead of 0.76.2.