### PR TITLE
fix: apply circle prop to extra icon in piece icon list

### DIFF
--- a/packages/react-ui/src/features/pieces/components/piece-icon-list.tsx
+++ b/packages/react-ui/src/features/pieces/components/piece-icon-list.tsx
@@ -18,7 +18,7 @@ import { stepsHooks } from '../lib/steps-hooks';
 import { PieceIcon } from './piece-icon';
 
 const extraIconVariants = cva(
-  'flex rounded-md items-center justify-center p-2 bg-background border border-solid text-xs select-none',
+  'flex items-center justify-center p-2 bg-background border border-solid text-xs select-none',
   {
     variants: {
       size: {
@@ -28,8 +28,11 @@ const extraIconVariants = cva(
         md: 'size-[36px]',
         sm: 'size-[25px]',
       },
+      circle: {
+        true: 'rounded-full',
+        false: 'rounded-md',
+      },
     },
-    defaultVariants: {},
   },
 );
 
@@ -40,7 +43,6 @@ export function PieceIconList({
   className,
   circle = true,
   background,
-  shadow,
   excludeCore = false,
 }: {
   trigger: FlowTrigger;
@@ -49,7 +51,6 @@ export function PieceIconList({
   className?: string;
   circle?: boolean;
   background?: string;
-  shadow?: boolean;
   excludeCore?: boolean;
 }) {
   const steps = flowStructureUtil.getAllSteps(trigger);
@@ -95,7 +96,7 @@ export function PieceIconList({
       {extraPieces > 0 && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className={extraIconVariants({ size: size ?? 'md' })}>
+            <div className={extraIconVariants({ size: size ?? 'md', circle })}>
               +{extraPieces}
             </div>
           </TooltipTrigger>


### PR DESCRIPTION
## What does this PR do?

Make the extra icon to match the same border radius of the other pieces icons in the list

Before:

<img width="982" height="100" alt="image" src="https://github.com/user-attachments/assets/39009e67-3c6b-4125-946c-4f85f7091ecd" />

After:

<img width="919" height="80" alt="image" src="https://github.com/user-attachments/assets/5a0e09cc-3df9-4e76-87d1-bf3545c2a503" />
