### PR TITLE
fix: preserve template category order on template page

### DIFF
--- a/packages/react-ui/src/app/routes/templates/all-categories-view.tsx
+++ b/packages/react-ui/src/app/routes/templates/all-categories-view.tsx
@@ -21,6 +21,7 @@ const AllCategoriesViewSkeleton = ({
 
 type AllCategoriesViewProps = {
   templatesByCategory: Record<string, Template[]>;
+  categories: string[];
   onCategorySelect: (category: string) => void;
   onTemplateSelect: (template: Template) => void;
   isLoading?: boolean;
@@ -29,6 +30,7 @@ type AllCategoriesViewProps = {
 
 export const AllCategoriesView = ({
   templatesByCategory,
+  categories,
   onCategorySelect,
   onTemplateSelect,
   isLoading = false,
@@ -40,7 +42,7 @@ export const AllCategoriesView = ({
 
   return (
     <div className="space-y-6">
-      {Object.keys(templatesByCategory).map((category) => {
+      {categories.map((category) => {
         const categoryTemplates = templatesByCategory[category];
 
         return (

--- a/packages/react-ui/src/app/routes/templates/index.tsx
+++ b/packages/react-ui/src/app/routes/templates/index.tsx
@@ -124,6 +124,7 @@ const TemplatesPage = () => {
         ) : showAllCategories ? (
           <AllCategoriesView
             templatesByCategory={templatesByCategory}
+            categories={categories}
             onCategorySelect={setCategory}
             onTemplateSelect={handleTemplateSelect}
             isLoading={showLoading}


### PR DESCRIPTION
## What does this PR do?

Display all categories in the template page with the same order as the categories
