### PR TITLE
fix(mcp): remove duplicated projectId from GET route

### DIFF
--- a/packages/server/api/src/app/mcp/mcp-server-controller.ts
+++ b/packages/server/api/src/app/mcp/mcp-server-controller.ts
@@ -7,7 +7,7 @@ import { mcpServerService } from './mcp-service'
 export const mcpServerController: FastifyPluginAsyncTypebox = async (app) => {
 
 
-    app.get('/:projectId', GetMcpRequest, async (req) => {
+    app.get('/', GetMcpRequest, async (req) => {
         return mcpServerService(req.log).getPopulatedByProjectId(req.projectId)
     })
 


### PR DESCRIPTION
## What changed
- Fixed MCP server GET route by removing duplicated `:projectId` from controller

## Root cause
- Module prefix already includes `:projectId`
- Controller added it again, causing:
  `/v1/projects/:projectId/mcp-server/:projectId`

## Fix
- Changed GET route from `/:projectId` to `/`

## Related issue
Closes #10825

