### PR TITLE
feat(slack): add icon_emoji option when sending message

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "dependencies": {
     "@slack/web-api": "7.9.0",
     "slackify-markdown": "4.4.0"

--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
@@ -9,6 +9,7 @@ import {
   username,
   blocks,
   mentionOriginFlow,
+  iconEmoji,
 } from '../common/props';
 import { Block,KnownBlock } from '@slack/web-api';
 
@@ -23,6 +24,7 @@ export const slackSendDirectMessageAction = createAction({
     text,
     username,
     profilePicture,
+    iconEmoji,
     mentionOriginFlow,
     blocks,
     unfurlLinks: Property.Checkbox({
@@ -42,7 +44,7 @@ export const slackSendDirectMessageAction = createAction({
 
     const blockList: (KnownBlock | Block)[] = [{ type: 'section', text: { type: 'mrkdwn', text } }]
 
-    if(blocks && Array.isArray(blocks)) { 
+    if(blocks && Array.isArray(blocks)) {
       blockList.push(...(blocks as unknown as (KnownBlock | Block)[]))
     }
 
@@ -60,6 +62,7 @@ export const slackSendDirectMessageAction = createAction({
       text,
       username: context.propsValue.username,
       profilePicture: context.propsValue.profilePicture,
+      iconEmoji: context.propsValue.iconEmoji,
       conversationId: userId,
       blocks:blockList,
       unfurlLinks,

--- a/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
@@ -7,6 +7,7 @@ import {
   threadTs,
   singleSelectChannelInfo,
   mentionOriginFlow,
+  iconEmoji,
 } from '../common/props';
 import { processMessageTimestamp, slackSendMessage } from '../common/utils';
 import { slackAuth } from '../../';
@@ -34,6 +35,7 @@ export const slackSendMessageAction = createAction({
     threadTs,
     username,
     profilePicture,
+    iconEmoji,
     file: Property.File({
       displayName: 'Attachment',
       required: false,
@@ -54,11 +56,11 @@ export const slackSendMessageAction = createAction({
     blocks,
   },
   async run(context) {
-    const { text, channel,sendAsBot, username, profilePicture, threadTs, file, mentionOriginFlow, blocks, replyBroadcast, unfurlLinks } =
+    const { text, channel,sendAsBot, username, profilePicture, iconEmoji, threadTs, file, mentionOriginFlow, blocks, replyBroadcast, unfurlLinks } =
       context.propsValue;
-    
+
     const token = sendAsBot ?context.auth.access_token :context.auth.data?.authed_user?.access_token ;
-    
+
     if (!text && (!blocks || !Array.isArray(blocks) || blocks.length === 0)) {
       throw new Error('Either Message or Block Kit blocks must be provided');
     }
@@ -70,7 +72,7 @@ export const slackSendMessageAction = createAction({
       blockList.push({ type: 'section', text: { type: 'mrkdwn', text } });
     }
 
-    if(blocks && Array.isArray(blocks) && blocks.length > 0) { 
+    if(blocks && Array.isArray(blocks) && blocks.length > 0) {
       blockList.push(...(blocks as unknown as (KnownBlock | Block)[]))
     }
 
@@ -88,6 +90,7 @@ export const slackSendMessageAction = createAction({
       text: text || undefined,
       username,
       profilePicture,
+      iconEmoji,
       conversationId: channel,
       threadTs: threadTs ? processMessageTimestamp(threadTs) : undefined,
       file,

--- a/packages/pieces/community/slack/src/lib/common/props.ts
+++ b/packages/pieces/community/slack/src/lib/common/props.ts
@@ -62,6 +62,12 @@ export const profilePicture = Property.ShortText({
   required: false,
 });
 
+export const iconEmoji = Property.ShortText({
+  displayName: 'Icon Emoji',
+  description: 'The icon emoji of the bot',
+  required: false,
+});
+
 export const threadTs = Property.ShortText({
   displayName: 'Reply to Thread (Thread Message Link/Timestamp)',
   description:

--- a/packages/pieces/community/slack/src/lib/common/utils.ts
+++ b/packages/pieces/community/slack/src/lib/common/utils.ts
@@ -6,6 +6,7 @@ export const slackSendMessage = async ({
   conversationId,
   username,
   profilePicture,
+  iconEmoji,
   blocks,
   threadTs,
   token,
@@ -33,6 +34,7 @@ export const slackSendMessage = async ({
       channel: conversationId,
       username,
       icon_url: profilePicture,
+      icon_emoji: iconEmoji,
       blocks: blocks as Block[],
       thread_ts: threadTs,
     };
@@ -54,6 +56,7 @@ type SlackSendMessageParams = {
   conversationId: string;
   username?: string;
   profilePicture?: string;
+  iconEmoji?: string;
   blocks?: unknown[] | Record<string, any>;
   text?: string;
   file?: ApFile;


### PR DESCRIPTION
## What does this PR do?

Expose `icon_emoji` parameter for `chat:postMessage`

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
