### PR TITLE
feat: add option to ignore redirects with custom API call

### DIFF
--- a/packages/pieces/community/common/package.json
+++ b/packages/pieces/community/common/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "commonjs"
 }

--- a/packages/pieces/community/common/src/lib/helpers/index.ts
+++ b/packages/pieces/community/common/src/lib/helpers/index.ts
@@ -273,6 +273,11 @@ i.e ${getBaseUrlForDescription(baseUrl, auth)}/resource or /resource`,
         required: false,
         ...(props?.timeout ?? {}),
       }),
+      followRedirects: Property.Checkbox({
+        displayName: 'Follow redirects',
+        required: false,
+        defaultValue: true,
+      }),
       ...extraProps,
     },
 
@@ -287,6 +292,7 @@ i.e ${getBaseUrlForDescription(baseUrl, auth)}/resource or /resource`,
         failsafe,
         timeout,
         response_is_binary,
+        followRedirects,
       } = context.propsValue;
       assertNotNullOrUndefined(method, 'Method');
       assertNotNullOrUndefined(url, 'URL');
@@ -317,6 +323,7 @@ i.e ${getBaseUrlForDescription(baseUrl, auth)}/resource or /resource`,
           ...((queryParams as QueryParams) ?? {}),
         },
         timeout: timeout ? timeout * 1000 : 0,
+        followRedirects,
       };
 
       // Set response type to arraybuffer if binary response is expected

--- a/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
+++ b/packages/pieces/community/common/src/lib/http/axios/axios-http-client.ts
@@ -25,11 +25,12 @@ export class AxiosHttpClient extends BaseHttpClient {
     try {
       const axiosInstance = axiosClient || axios;
       process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
-      const { urlWithoutQueryParams, queryParams: urlQueryParams } = this.getUrl(request);
+      const { urlWithoutQueryParams, queryParams: urlQueryParams } =
+        this.getUrl(request);
       const headers = this.getHeaders(request);
       const axiosRequestMethod = this.getAxiosRequestMethod(request.method);
       const timeout = request.timeout ? request.timeout : 0;
-      const queryParams = request.queryParams || {}
+      const queryParams = request.queryParams || {};
       const responseType = request.responseType || 'json';
 
       for (const [key, value] of Object.entries(queryParams)) {
@@ -44,6 +45,10 @@ export class AxiosHttpClient extends BaseHttpClient {
         data: request.body,
         timeout,
         responseType,
+        maxRedirects: request.followRedirects ?? true ? undefined : 0,
+        validateStatus: !request.followRedirects
+          ? (status) => status >= 200 && status < 400
+          : undefined,
       };
 
       if (request.retries && request.retries > 0) {
@@ -51,7 +56,11 @@ export class AxiosHttpClient extends BaseHttpClient {
           retries: request.retries,
           retryDelay: axiosRetry.exponentialDelay,
           retryCondition: (error) => {
-            return axiosRetry.isNetworkOrIdempotentRequestError(error) || (error.response && error.response.status >= 500) || false;
+            return (
+              axiosRetry.isNetworkOrIdempotentRequestError(error) ||
+              (error.response && error.response.status >= 500) ||
+              false
+            );
           },
         });
       }
@@ -65,7 +74,7 @@ export class AxiosHttpClient extends BaseHttpClient {
       };
     } catch (e) {
       if (axios.isAxiosError(e)) {
-        const httpError =  new HttpError(request.body, e);
+        const httpError = new HttpError(request.body, e);
         console.error(
           '[HttpClient#(sanitized error message)] Request failed:',
           httpError
@@ -75,7 +84,6 @@ export class AxiosHttpClient extends BaseHttpClient {
       throw e;
     }
   }
-
 
   private getAxiosRequestMethod(httpMethod: HttpMethod): string {
     return httpMethod.toString();

--- a/packages/pieces/community/common/src/lib/http/core/http-request.ts
+++ b/packages/pieces/community/common/src/lib/http/core/http-request.ts
@@ -14,4 +14,5 @@ export type HttpRequest<RequestBody extends HttpRequestBody = any> = {
   timeout?: number;
   retries?: number;
   responseType?: 'arraybuffer' | 'json' | 'blob' | 'text';
+  followRedirects?: boolean;
 };


### PR DESCRIPTION
## What does this PR do?

Sometimes we don't want to follow redirects in order to intercept the `Location` header

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
