### PR TITLE
fix: safari datagrid content disappearing when clicking outside

### DIFF
--- a/packages/react-ui/src/app/routes/tables/id/react-data-grid.css
+++ b/packages/react-ui/src/app/routes/tables/id/react-data-grid.css
@@ -1,5 +1,6 @@
 
 * {
+    content-visibility: visible !important;
     --rdg-row-selected-background-color: none !important;
     --rdg-row-selected-hover-background-color: none !important;
     --rdg-selection-color: none !important;


### PR DESCRIPTION
## What does this PR do?

When clicking outside the DataGrid (header, sidebar, etc.), the entire DataGrid disappears. When clicking back on its area, it appears again. This issue happens in the Safari browser.

<img width="1478" height="755" alt="image" src="https://github.com/user-attachments/assets/74942027-1f0b-40db-8ada-333eaa317272" />

