### PR TITLE
refactor: change template telemetry endpoints to be event based

### DIFF
--- a/packages/server/api/src/app/template/template-telemetry/template-telemetry.controller.ts
+++ b/packages/server/api/src/app/template/template-telemetry/template-telemetry.controller.ts
@@ -1,17 +1,11 @@
 import { securityAccess } from '@activepieces/server-shared'
-import { ApEdition, TemplateTelemetryEvent } from '@activepieces/shared'
+import { TemplateTelemetryEvent } from '@activepieces/shared'
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
 import { StatusCodes } from 'http-status-codes'
-import { system } from '../../helper/system/system'
 import { templateTelemetryService } from './template-telemetry.service'
-
-const edition = system.getEdition()
 
 export const templateTelemetryController: FastifyPluginAsyncTypebox = async (app) => {
     app.post('/event', SendEventParams, async (request, reply) => {
-        if (edition !== ApEdition.CLOUD) {
-            return reply.status(StatusCodes.OK).send()
-        }
         templateTelemetryService(app.log).sendEvent(request.body)
         return reply.status(StatusCodes.OK).send()
     })

--- a/packages/server/api/src/app/template/template-telemetry/template-telemetry.service.ts
+++ b/packages/server/api/src/app/template/template-telemetry/template-telemetry.service.ts
@@ -4,7 +4,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { system } from '../../helper/system/system'
 
 const CLOUD_TELEMETRY_URL = 'https://cloud.activepieces.com/api/v1/templates-telemetry'
-const INTERNAL_TELEMETRY_URL = 'https://template-manager.activepieces.com/api/public/analytics'
+const INTERNAL_TELEMETRY_URL = 'https://template-manager.activepieces.com/api/public/analytics/event'
 const TEMPLATE_TELEMETRY_API_KEY = system.get(AppSystemProp.TEMPLATE_MANAGER_API_KEY)
 const TEMPLATE_TELEMETRY_API_KEY_HEADER = 'X-API-Key'
 
@@ -61,27 +61,13 @@ async function sendToInternal(event: TemplateTelemetryEvent, log: FastifyBaseLog
 function getEventConfig(event: TemplateTelemetryEvent): { url: string, body?: Record<string, unknown> } {
     switch (event.eventType) {
         case TemplateTelemetryEventType.VIEW:
-            return {
-                url: `${INTERNAL_TELEMETRY_URL}/templates/${event.templateId}/view`,
-            }
         case TemplateTelemetryEventType.INSTALL:
-            return {
-                url: `${INTERNAL_TELEMETRY_URL}/templates/${event.templateId}/install`,
-                body: event,
-            }
         case TemplateTelemetryEventType.ACTIVATE:
-            return {
-                url: `${INTERNAL_TELEMETRY_URL}/templates/${event.templateId}/activate`,
-                body: event,
-            }
         case TemplateTelemetryEventType.DEACTIVATE:
-            return {
-                url: `${INTERNAL_TELEMETRY_URL}/templates/${event.templateId}/deactivate`,
-                body: event,
-            }
         case TemplateTelemetryEventType.EXPLORE_VIEW:
             return {
-                url: `${INTERNAL_TELEMETRY_URL}/explore/view`,
+                url: INTERNAL_TELEMETRY_URL,
+                body: event,
             }
         default:
             throw new Error(`Unknown template telemetry event type: ${(event as { eventType: string }).eventType}`)

--- a/packages/shared/src/lib/template/template-telemetry.ts
+++ b/packages/shared/src/lib/template/template-telemetry.ts
@@ -33,6 +33,7 @@ const DeactivateEvent = Type.Object({
 
 const ExploreViewEvent = Type.Object({
     eventType: Type.Literal(TemplateTelemetryEventType.EXPLORE_VIEW),
+    userId: Type.Optional(Type.String()),
 })
 
 export const TemplateTelemetryEvent = Type.Union([


### PR DESCRIPTION
## What does this PR do?

Endpoints changed in template manager (internal tool)