### PR TITLE
fix: send user id to explore view analytics

### DIFF
--- a/packages/react-ui/src/app/components/sidebar/dashboard/index.tsx
+++ b/packages/react-ui/src/app/components/sidebar/dashboard/index.tsx
@@ -157,6 +157,7 @@ export function ProjectDashboardSidebar() {
   const handleExploreClick = useCallback(() => {
     templatesTelemetryApi.sendEvent({
       eventType: TemplateTelemetryEventType.EXPLORE_VIEW,
+      userId: currentUser?.id,
     });
   }, []);
 


### PR DESCRIPTION
## What does this PR do?

Missing user ID for explore view analytics