### PR TITLE
fix: track template view event

### DIFF
--- a/packages/react-ui/src/app/routes/templates/index.tsx
+++ b/packages/react-ui/src/app/routes/templates/index.tsx
@@ -8,9 +8,11 @@ import { Button } from '@/components/ui/button';
 import { SidebarTrigger } from '@/components/ui/sidebar-shadcn';
 import { flowHooks } from '@/features/flows/lib/flow-hooks';
 import { templatesHooks } from '@/features/templates/hooks/templates-hook';
+import { templatesTelemetryApi } from '@/features/templates/lib/templates-telemetry-api';
 import { platformHooks } from '@/hooks/platform-hooks';
 import {
   Template,
+  TemplateTelemetryEventType,
   TemplateType,
   UncategorizedFolderId,
 } from '@activepieces/shared';
@@ -41,6 +43,10 @@ const TemplatesPage = () => {
 
   const handleTemplateSelect = (template: Template) => {
     navigate(`/templates/${template.id}`);
+    templatesTelemetryApi.sendEvent({
+      eventType: TemplateTelemetryEventType.VIEW,
+      templateId: template.id,
+    });
   };
 
   const templatesByCategory = useMemo(() => {


### PR DESCRIPTION
## What does this PR do?

Send the view event to the template manager when clicking on a specific template
