### PR TITLE
fix: track template view event for official templates only

### DIFF
--- a/packages/react-ui/src/app/routes/templates/index.tsx
+++ b/packages/react-ui/src/app/routes/templates/index.tsx
@@ -43,10 +43,12 @@ const TemplatesPage = () => {
 
   const handleTemplateSelect = (template: Template) => {
     navigate(`/templates/${template.id}`);
-    templatesTelemetryApi.sendEvent({
-      eventType: TemplateTelemetryEventType.VIEW,
-      templateId: template.id,
-    });
+    if (template.type === TemplateType.OFFICIAL) {
+      templatesTelemetryApi.sendEvent({
+        eventType: TemplateTelemetryEventType.VIEW,
+        templateId: template.id,
+      });
+    }
   };
 
   const templatesByCategory = useMemo(() => {


### PR DESCRIPTION
## What does this PR do?

Track only official templates