### PR TITLE
fix: missing display name when importing/updating flow template

### DIFF
--- a/packages/server/api/src/app/flows/flow-version/migrations/index.ts
+++ b/packages/server/api/src/app/flows/flow-version/migrations/index.ts
@@ -51,12 +51,12 @@ export const flowMigrations = {
     },
 }
 
-export const migrateFlowVersionTemplate = async ({ trigger, schemaVersion, notes, valid }: Pick<FlowVersionTemplate, 'trigger' | 'schemaVersion' | 'notes' | 'valid'>): Promise<FlowVersionTemplate> => {
+export const migrateFlowVersionTemplate = async ({ trigger, schemaVersion, notes, valid, displayName }: Pick<FlowVersionTemplate, 'trigger' | 'schemaVersion' | 'notes' | 'valid' | 'displayName'>): Promise<FlowVersionTemplate> => {
     return flowMigrations.apply({
         agentIds: [],
         connectionIds: [],
         created: new Date().toISOString(),
-        displayName: '',
+        displayName,
         flowId: '',
         id: '',
         updated: new Date().toISOString(),

--- a/packages/server/api/src/app/flows/flow/flow.controller.ts
+++ b/packages/server/api/src/app/flows/flow/flow.controller.ts
@@ -82,6 +82,7 @@ export const flowController: FastifyPluginAsyncTypebox = async (app) => {
         preValidation: async (request) => {
             if (request.body?.type === FlowOperationType.IMPORT_FLOW) {
                 const migratedFlowTemplate = await migrateFlowVersionTemplate({
+                    displayName: request.body.request.displayName,
                     trigger: request.body.request.trigger,
                     schemaVersion: request.body.request.schemaVersion,
                     notes: request.body.request.notes ?? [],
@@ -89,6 +90,7 @@ export const flowController: FastifyPluginAsyncTypebox = async (app) => {
                 })
                 request.body.request = {
                     ...request.body.request,
+                    displayName: migratedFlowTemplate.displayName,
                     trigger: migratedFlowTemplate.trigger,
                     schemaVersion: migratedFlowTemplate.schemaVersion,
                     notes: migratedFlowTemplate.notes,

--- a/packages/server/api/test/integration/cloud/global-connection/global-connection.test.ts
+++ b/packages/server/api/test/integration/cloud/global-connection/global-connection.test.ts
@@ -150,7 +150,7 @@ describe('GlobalConnection API', () => {
 
         it('Fails if project ids are invalid', async () => {
             // arrange
-            const { mockPlatform, mockProject, mockOwner } = await setupWithGlobalConnections()
+            const { mockPlatform, mockOwner } = await setupWithGlobalConnections()
 
             const mockPieceMetadata = createMockPieceMetadata({
                 platformId: mockPlatform.id,


### PR DESCRIPTION
## What does this PR do?

Override the flows display name with empty string (fixed)