### PR TITLE
fix: change tag input emails separator to comma & trailing email validation

### DIFF
--- a/packages/react-ui/src/components/ui/tag-input.tsx
+++ b/packages/react-ui/src/components/ui/tag-input.tsx
@@ -33,15 +33,18 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
 
   const [pendingDataPoint, setPendingDataPoint] = useState('');
   const internalInputRef = useRef<HTMLInputElement | null>(null);
-  
-  const handleRef = useCallback((node: HTMLInputElement | null) => {
-    internalInputRef.current = node;
-    if (typeof ref === 'function') {
-      ref(node);
-    } else if (ref) {
-      (ref as React.MutableRefObject<HTMLInputElement | null>).current = node;
-    }
-  }, [ref]);
+
+  const handleRef = useCallback(
+    (node: HTMLInputElement | null) => {
+      internalInputRef.current = node;
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLInputElement | null>).current = node;
+      }
+    },
+    [ref],
+  );
 
   useEffect(() => {
     if (pendingDataPoint.includes(SEPARATOR)) {

--- a/packages/react-ui/src/features/members/component/invite-user-dialog.tsx
+++ b/packages/react-ui/src/features/members/component/invite-user-dialog.tsx
@@ -152,7 +152,8 @@ export const InviteUserDialog = ({
   });
 
   const roles = rolesData?.data ?? [];
-  const defaultProjectRole = roles?.find((role) => role.name === 'Editor')?.name || roles?.[0]?.name;
+  const defaultProjectRole =
+    roles?.find((role) => role.name === 'Editor')?.name || roles?.[0]?.name;
 
   const form = useForm<FormSchema>({
     resolver: typeboxResolver(FormSchema),
@@ -228,21 +229,25 @@ export const InviteUserDialog = ({
                 {invitationLink ? t('Invitation Link') : t('Invite User')}
               </DialogTitle>
               <DialogDescription>
-                {invitationLink
-                  ? t(
-                      'Please copy the link below and share it with the user you want to invite, the invitation expires in 7 days.',
-                    )
-                  : isPlatformPage
-                  ? t(
-                      'Type email addresses separated by commas to invite multiple users to the entire platform. Invitations expire in 7 days.',
-                    )
-                  : (
-                      <>
-                        {t('Type email addresses separated by commas to add members to')}{' '}
-                        <span className="text-foreground font-semibold">{project.displayName}</span>.{' '}
-                        {t('Invitations expire in 7 days')}.
-                      </>
-                    )}
+                {invitationLink ? (
+                  t(
+                    'Please copy the link below and share it with the user you want to invite, the invitation expires in 7 days.',
+                  )
+                ) : isPlatformPage ? (
+                  t(
+                    'Type email addresses separated by commas to invite multiple users to the entire platform. Invitations expire in 7 days.',
+                  )
+                ) : (
+                  <>
+                    {t(
+                      'Type email addresses separated by commas to add members to',
+                    )}{' '}
+                    <span className="text-foreground font-semibold">
+                      {project.displayName}
+                    </span>
+                    . {t('Invitations expire in 7 days')}.
+                  </>
+                )}
               </DialogDescription>
             </DialogHeader>
 


### PR DESCRIPTION
## What does this PR do?

Change email separation from spaces to commas, and fix the email validation issue when clicking “Invite” without separating the email, which causes it not to be converted into a tag.
