### PR TITLE
fix: replacing trigger with the same name of another piece was not taking effect in canvas

### DIFF
--- a/packages/react-ui/src/app/builder/flow-canvas/index.tsx
+++ b/packages/react-ui/src/app/builder/flow-canvas/index.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   FlowActionType,
   flowStructureUtil,
+  FlowTriggerType,
   FlowVersion,
   isNil,
   Note,
@@ -277,7 +278,10 @@ const createGraphKey = (flowVersion: FlowVersion, notes: Note[]) => {
       return `${acc}-${step.displayName}-${step.type}-${
         step.nextAction ? step.nextAction.name : ''
       }-${
-        step.type === FlowActionType.PIECE ? step.settings.pieceName : ''
+        step.type === FlowActionType.PIECE ||
+        step.type === FlowTriggerType.PIECE
+          ? step.settings.pieceName
+          : ''
       }-${branchesNames}-${childrenKey}}`;
     }, '');
   const notesGraphKey = notes


### PR DESCRIPTION
closes #11045