### PR TITLE
fix(piece-dev): loading dev pieces metadata in rebuild

### DIFF
--- a/packages/server/worker/src/lib/cache/pieces/development/dev-pieces-builder.ts
+++ b/packages/server/worker/src/lib/cache/pieces/development/dev-pieces-builder.ts
@@ -74,7 +74,7 @@ export async function devPiecesBuilder(app: FastifyInstance, io: Server, package
         await devPiecesInstaller(app.log).linkSharedActivepiecesPackagesToPiece(packageJsonName)
     }
 
-    for (const { packageName, pieceDirectory, packageJsonName } of pieceInfos) {
+    for (const { packageName, pieceDirectory } of pieceInfos) {
         app.log.info(chalk.blue(`Starting watch for package: ${packageName}`))
         app.log.info(chalk.yellow(`Found piece directory: ${pieceDirectory}`))
 
@@ -83,7 +83,6 @@ export async function devPiecesBuilder(app: FastifyInstance, io: Server, package
                 try {
                     await buildPieces([packageName], io, app.log)
                     await devPiecesInstaller(app.log).linkSharedActivepiecesPackagesToEachOther()
-                    await devPiecesInstaller(app.log).linkSharedActivepiecesPackagesToPiece(packageJsonName)
                 }
                 catch (error) {
                     app.log.error(error)


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->
To fix the error:
[API] [09:43:11 UTC] WARN (FilePieceMetadataService#loadPiecesFromFolder):
[API]     reqId: "req_XTGhY2zKbw6XlL0qiDRKt"
[API]     message: "ENOENT: no such file or directory, open 'activepieces/activepieces/dist/packages/pieces/community/framework/node_modules/semver/index.js'"

Using bun link --save ensures node_modules is always in dist.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
