### PR TITLE
feat: add Alai piece

### DIFF
--- a/packages/pieces/community/alai/.eslintrc.json
+++ b/packages/pieces/community/alai/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/alai/README.md
+++ b/packages/pieces/community/alai/README.md
@@ -1,0 +1,7 @@
+# pieces-alai
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-alai` to build the library.

--- a/packages/pieces/community/alai/package.json
+++ b/packages/pieces/community/alai/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@activepieces/piece-alai",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/pieces/community/alai/project.json
+++ b/packages/pieces/community/alai/project.json
@@ -1,0 +1,50 @@
+{
+  "name": "pieces-alai",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/alai/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/alai",
+        "tsConfig": "packages/pieces/community/alai/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/alai/package.json",
+        "main": "packages/pieces/community/alai/src/index.ts",
+        "assets": [
+          "packages/pieces/community/alai/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "clean": false
+      },
+      "dependsOn": [
+        "^build"
+      ]
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/alai/src/index.ts
+++ b/packages/pieces/community/alai/src/index.ts
@@ -1,0 +1,30 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { alaiAuth } from './lib/common/auth';
+import { generatePresentation } from './lib/actions/generate-presentation';
+import { getGeneration } from './lib/actions/get-generation';
+import { exportPresentation } from './lib/actions/export-presentation';
+import { addSlide } from './lib/actions/add-slide';
+import { deletePresentation } from './lib/actions/delete-presentation';
+
+export const alai = createPiece({
+  displayName: 'Alai',
+  auth: alaiAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/alai.png',
+  authors: ['getalai'],
+  description:
+    'AI-powered presentation generation API. Create, export, and manage professional presentations from text.',
+  categories: [
+    PieceCategory.CONTENT_AND_FILES,
+    PieceCategory.ARTIFICIAL_INTELLIGENCE,
+  ],
+  actions: [
+    generatePresentation,
+    getGeneration,
+    exportPresentation,
+    addSlide,
+    deletePresentation,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/alai/src/lib/actions/add-slide.ts
+++ b/packages/pieces/community/alai/src/lib/actions/add-slide.ts
@@ -1,0 +1,64 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { alaiAuth } from '../common/auth';
+
+export const addSlide = createAction({
+  auth: alaiAuth,
+  name: 'addSlide',
+  displayName: 'Add Slide',
+  description: 'Add a new slide to an existing presentation.',
+  props: {
+    presentationId: Property.ShortText({
+      displayName: 'Presentation ID',
+      description: 'The ID of the presentation to add a slide to.',
+      required: true,
+    }),
+    inputText: Property.LongText({
+      displayName: 'Input Text',
+      description: 'The text content for the new slide.',
+      required: true,
+    }),
+    additionalInstructions: Property.LongText({
+      displayName: 'Additional Instructions',
+      description: 'Extra instructions for how the slide should be generated.',
+      required: false,
+    }),
+    includeAiImages: Property.Checkbox({
+      displayName: 'Include AI Images',
+      description: 'Whether to include AI-generated images in the slide.',
+      required: false,
+      defaultValue: true,
+    }),
+    imageStyle: Property.ShortText({
+      displayName: 'Image Style',
+      description: 'The style for AI-generated images.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { presentationId, inputText, additionalInstructions, includeAiImages, imageStyle } =
+      context.propsValue;
+    const body: Record<string, unknown> = {
+      input_text: inputText,
+    };
+    if (additionalInstructions) body['additional_instructions'] = additionalInstructions;
+    const imageOptions: Record<string, unknown> = {};
+    if (includeAiImages !== undefined && includeAiImages !== null) {
+      imageOptions['include_ai_images'] = includeAiImages;
+    }
+    if (imageStyle) imageOptions['image_style'] = imageStyle;
+    if (Object.keys(imageOptions).length > 0) {
+      body['image_options'] = imageOptions;
+    }
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `https://slides-api.getalai.com/api/v1/presentations/${presentationId}/slides`,
+      headers: {
+        Authorization: `Bearer ${context.auth.props.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/alai/src/lib/actions/delete-presentation.ts
+++ b/packages/pieces/community/alai/src/lib/actions/delete-presentation.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { alaiAuth } from '../common/auth';
+
+export const deletePresentation = createAction({
+  auth: alaiAuth,
+  name: 'deletePresentation',
+  displayName: 'Delete Presentation',
+  description: 'Delete a presentation by its ID.',
+  props: {
+    presentationId: Property.ShortText({
+      displayName: 'Presentation ID',
+      description: 'The ID of the presentation to delete.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { presentationId } = context.propsValue;
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.DELETE,
+      url: `https://slides-api.getalai.com/api/v1/presentations/${presentationId}`,
+      headers: {
+        Authorization: `Bearer ${context.auth.props.apiKey}`,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/alai/src/lib/actions/export-presentation.ts
+++ b/packages/pieces/community/alai/src/lib/actions/export-presentation.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { alaiAuth } from '../common/auth';
+
+export const exportPresentation = createAction({
+  auth: alaiAuth,
+  name: 'exportPresentation',
+  displayName: 'Export Presentation',
+  description: 'Export a presentation in the specified formats.',
+  props: {
+    presentationId: Property.ShortText({
+      displayName: 'Presentation ID',
+      description: 'The ID of the presentation to export.',
+      required: true,
+    }),
+    exportFormats: Property.StaticMultiSelectDropdown({
+      displayName: 'Export Formats',
+      description: 'Formats to export the presentation in.',
+      required: true,
+      options: {
+        options: [
+          { label: 'Link', value: 'link' },
+          { label: 'PDF', value: 'pdf' },
+          { label: 'PowerPoint (PPTX)', value: 'ppt' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { presentationId, exportFormats } = context.propsValue;
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `https://slides-api.getalai.com/api/v1/presentations/${presentationId}/exports`,
+      headers: {
+        Authorization: `Bearer ${context.auth.props.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        export_formats: exportFormats,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/alai/src/lib/actions/generate-presentation.ts
+++ b/packages/pieces/community/alai/src/lib/actions/generate-presentation.ts
@@ -1,0 +1,158 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { alaiAuth } from '../common/auth';
+
+export const generatePresentation = createAction({
+  auth: alaiAuth,
+  name: 'generatePresentation',
+  displayName: 'Generate Presentation',
+  description: 'Create a new AI-generated presentation from text.',
+  props: {
+    inputText: Property.LongText({
+      displayName: 'Input Text',
+      description: 'The text content to generate a presentation from.',
+      required: true,
+    }),
+    additionalInstructions: Property.LongText({
+      displayName: 'Additional Instructions',
+      description: 'Extra instructions for how the presentation should be generated.',
+      required: false,
+    }),
+    exportFormats: Property.StaticMultiSelectDropdown({
+      displayName: 'Export Formats',
+      description: 'Formats to export the presentation in after generation.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Link', value: 'link' },
+          { label: 'PDF', value: 'pdf' },
+          { label: 'PowerPoint (PPTX)', value: 'ppt' },
+        ],
+      },
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'A title for the presentation. If not provided, one will be generated.',
+      required: false,
+    }),
+    themeId: Property.StaticDropdown({
+      displayName: 'Theme',
+      description: 'The visual theme for the presentation.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Default', value: 'default' },
+          { label: 'Starter', value: 'starter' },
+          { label: 'Modern', value: 'modern' },
+          { label: 'Corporate', value: 'corporate' },
+          { label: 'Creative', value: 'creative' },
+          { label: 'Elegant', value: 'elegant' },
+          { label: 'Playful', value: 'playful' },
+          { label: 'Bold', value: 'bold' },
+          { label: 'Minimal', value: 'minimal' },
+          { label: 'Academic', value: 'academic' },
+          { label: 'Tech', value: 'tech' },
+          { label: 'Nature', value: 'nature' },
+        ],
+      },
+    }),
+    slideRange: Property.ShortText({
+      displayName: 'Slide Range',
+      description: 'Number of slides to generate (e.g., "8-12").',
+      required: false,
+    }),
+    tone: Property.StaticDropdown({
+      displayName: 'Tone',
+      description: 'The tone of voice for the presentation content.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Professional', value: 'professional' },
+          { label: 'Casual', value: 'casual' },
+          { label: 'Enthusiastic', value: 'enthusiastic' },
+          { label: 'Informative', value: 'informative' },
+          { label: 'Persuasive', value: 'persuasive' },
+          { label: 'Inspirational', value: 'inspirational' },
+          { label: 'Educational', value: 'educational' },
+          { label: 'Storytelling', value: 'storytelling' },
+          { label: 'Technical', value: 'technical' },
+          { label: 'Humorous', value: 'humorous' },
+          { label: 'Formal', value: 'formal' },
+        ],
+      },
+    }),
+    contentMode: Property.StaticDropdown({
+      displayName: 'Content Mode',
+      description: 'How the input text should be used.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Auto', value: 'auto' },
+          { label: 'Document', value: 'document' },
+          { label: 'Topic', value: 'topic' },
+        ],
+      },
+    }),
+    includeAiImages: Property.Checkbox({
+      displayName: 'Include AI Images',
+      description: 'Whether to include AI-generated images in the presentation.',
+      required: false,
+      defaultValue: true,
+    }),
+    imageStyle: Property.ShortText({
+      displayName: 'Image Style',
+      description: 'The style for AI-generated images (e.g., "photorealistic", "illustration").',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const {
+      inputText,
+      additionalInstructions,
+      exportFormats,
+      title,
+      themeId,
+      slideRange,
+      tone,
+      contentMode,
+      includeAiImages,
+      imageStyle,
+    } = context.propsValue;
+    const body: Record<string, unknown> = {
+      input_text: inputText,
+    };
+    if (additionalInstructions) body['additional_instructions'] = additionalInstructions;
+    if (exportFormats && exportFormats.length > 0) body['export_formats'] = exportFormats;
+    if (title) body['title'] = title;
+    const presentationOptions: Record<string, unknown> = {};
+    if (themeId) presentationOptions['theme_id'] = themeId;
+    if (slideRange) presentationOptions['slide_range'] = slideRange;
+    if (Object.keys(presentationOptions).length > 0) {
+      body['presentation_options'] = presentationOptions;
+    }
+    const textOptions: Record<string, unknown> = {};
+    if (tone) textOptions['tone'] = tone;
+    if (contentMode) textOptions['content_mode'] = contentMode;
+    if (Object.keys(textOptions).length > 0) {
+      body['text_options'] = textOptions;
+    }
+    const imageOptions: Record<string, unknown> = {};
+    if (includeAiImages !== undefined && includeAiImages !== null) {
+      imageOptions['include_ai_images'] = includeAiImages;
+    }
+    if (imageStyle) imageOptions['image_style'] = imageStyle;
+    if (Object.keys(imageOptions).length > 0) {
+      body['image_options'] = imageOptions;
+    }
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://slides-api.getalai.com/api/v1/generations',
+      headers: {
+        Authorization: `Bearer ${context.auth.props.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/alai/src/lib/actions/get-generation.ts
+++ b/packages/pieces/community/alai/src/lib/actions/get-generation.ts
@@ -1,0 +1,29 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { alaiAuth } from '../common/auth';
+
+export const getGeneration = createAction({
+  auth: alaiAuth,
+  name: 'getGeneration',
+  displayName: 'Get Generation',
+  description: 'Fetch the status and result of a generation job.',
+  props: {
+    generationId: Property.ShortText({
+      displayName: 'Generation ID',
+      description: 'The ID of the generation job (from the "Generate Presentation" action).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { generationId } = context.propsValue;
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://slides-api.getalai.com/api/v1/generations/${generationId}`,
+      headers: {
+        Authorization: `Bearer ${context.auth.props.apiKey}`,
+        Accept: 'application/json',
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/alai/src/lib/common/auth.ts
+++ b/packages/pieces/community/alai/src/lib/common/auth.ts
@@ -1,0 +1,43 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { HttpError, HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+const markdownDescription = `
+Follow these steps to get your Alai API Key:
+
+1. Go to [**https://getalai.com/api**](https://getalai.com/api) and sign up or log in.
+2. Navigate to the **API Keys** section.
+3. Click **Create API Key** and give it a name (e.g., "Activepieces").
+4. Copy the key and paste it below.
+`;
+
+export const alaiAuth = PieceAuth.CustomAuth({
+  description: markdownDescription,
+  required: true,
+  props: {
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API Key',
+      description: 'Paste your API key here.',
+      required: true,
+    }),
+  },
+  async validate(auth) {
+    const apiKey = auth.auth.apiKey;
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://slides-api.getalai.com/api/v1/ping',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+      });
+      return { valid: true };
+    } catch (e) {
+      if (e instanceof HttpError) {
+        if (e.response.status === 401) {
+          return { valid: false, error: 'Invalid API Key' };
+        }
+      }
+      return { valid: false, error: 'Failed to connect to Alai API' };
+    }
+  },
+});

--- a/packages/pieces/community/alai/tsconfig.json
+++ b/packages/pieces/community/alai/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/alai/tsconfig.lib.json
+++ b/packages/pieces/community/alai/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a community piece for [Alai](https://getalai.com) — an AI-powered presentation generation API.

### Actions

- **Generate Presentation** — Create AI-generated presentations from text with options for theme, tone, slide range, content mode, and AI images
- **Get Generation** — Check the status and result of a generation job
- **Export Presentation** — Export presentations to link, PDF, or PPTX
- **Add Slide** — Add new slides to an existing presentation
- **Delete Presentation** — Remove a presentation by ID

### Auth

Custom auth with Bearer token, validated via `GET /ping`.

### Categories

`CONTENT_AND_FILES`, `ARTIFICIAL_INTELLIGENCE`

## Test plan

- [ ] Verify auth validation with valid/invalid API keys
- [ ] Test generate presentation action with various options
- [ ] Test get generation with a valid generation ID
- [ ] Test export in each format (link, pdf, ppt)
- [ ] Test add slide to existing presentation
- [ ] Test delete presentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)