### PR TITLE
fix(sftp): password as passphrase, optional algorithm, handle key new…

### DIFF
--- a/packages/pieces/community/sftp/package.json
+++ b/packages/pieces/community/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-sftp",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "dependencies": {
     "basic-ftp": "5.0.5",
     "ssh2-sftp-client": "9.1.0"

--- a/packages/pieces/community/sftp/src/index.ts
+++ b/packages/pieces/community/sftp/src/index.ts
@@ -172,9 +172,9 @@ export const sftpAuth = PieceAuth.CustomAuth({
       description: 'The password to authenticate with. Either this or private key is required. When using a private key, this field is used as the passphrase to decrypt the key.',
       required: false,
     }),
-    privateKey: Property.LongText({
+    privateKey: PieceAuth.SecretText({
       displayName: 'Private Key',
-      description: 'The private key to authenticate with. Either this or password is required. You can paste the key directly with newlines.',
+      description: 'The private key to authenticate with. Either this or password is required.',
       required: false,
     }),
     algorithm: Property.StaticMultiSelectDropdown({


### PR DESCRIPTION
…lines

Fixes #11100:
1. Pass password as passphrase when private key is provided
2. Make host key algorithm dropdown optional (not required by ssh2)
3. Handle private key newlines - reconstruct PEM format when browser strips newlines

The fix allows users to:
- Use password field as passphrase for encrypted private keys
- Leave algorithm field empty (uses ssh2 defaults)
- Paste private keys with or without newlines (code handles both cases)

Bump version: 0.4.8 → 0.4.9
