### PR TITLE
feat(pieces): add Canva community piece

### DIFF
--- a/packages/pieces/community/canva/.eslintrc.json
+++ b/packages/pieces/community/canva/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/canva/README.md
+++ b/packages/pieces/community/canva/README.md
@@ -1,0 +1,7 @@
+# pieces-canva
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-canva` to build the library.

--- a/packages/pieces/community/canva/package.json
+++ b/packages/pieces/community/canva/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-canva",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/canva/project.json
+++ b/packages/pieces/community/canva/project.json
@@ -1,0 +1,50 @@
+{
+  "name": "pieces-canva",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/canva/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/canva",
+        "tsConfig": "packages/pieces/community/canva/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/canva/package.json",
+        "main": "packages/pieces/community/canva/src/index.ts",
+        "assets": [
+          "packages/pieces/community/canva/*.md",
+          {
+            "input": "packages/pieces/community/canva/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/canva/src/index.ts
+++ b/packages/pieces/community/canva/src/index.ts
@@ -1,0 +1,101 @@
+import {
+  OAuth2PropertyValue,
+  PieceAuth,
+  createPiece,
+} from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createCustomApiCallAction, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { canvaCommon } from './lib/common';
+import { createDesign } from './lib/actions/create-design';
+import { uploadAsset } from './lib/actions/upload-asset';
+import { importDesign } from './lib/actions/import-design';
+import { exportDesign } from './lib/actions/export-design';
+import { moveFolderItem } from './lib/actions/move-folder-item';
+import { findDesign } from './lib/actions/find-design';
+import { getFolder } from './lib/actions/get-folder';
+import { getImage } from './lib/actions/get-image';
+
+export const canvaAuth = PieceAuth.OAuth2({
+  description: `Authentication for Canva API
+
+📋 **Required Scopes** (enable these in your Canva integration settings):
+✅ **design:content** - Read & Write (for creating, editing, importing, and exporting designs)
+✅ **design:meta** - Read (for finding and listing designs)  
+✅ **asset** - Read & Write (for uploading and managing assets)
+✅ **folder** - Read & Write (for organizing designs and moving items)
+
+🔗 Configure scopes at: https://canva.com/developers/integrations → Your Integration → Configuration → Scopes`,
+  authUrl: 'https://www.canva.com/api/oauth/authorize',
+  tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+  required: true,
+  pkce: true,
+  pkceMethod: 'S256',
+  scope: [
+    'design:content:read',
+    'design:content:write',
+    'design:meta:read',
+    'asset:read',
+    'asset:write',
+    'folder:read',
+    'folder:write',
+  ],
+  validate: async ({ auth }) => {
+    try {
+      const authValue = auth as OAuth2PropertyValue;
+      if (!authValue.access_token) {
+        return { valid: false, error: 'No access token found' };
+      }
+
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${canvaCommon.baseUrl}/users/me`,
+        headers: {
+          Authorization: `Bearer ${authValue.access_token}`,
+        },
+      });
+
+      if (response.status === 200) {
+        return { valid: true };
+      }
+      
+      return { valid: false, error: 'Invalid or expired access token' };
+    } catch (error: any) {
+      if (error.response?.status === 401) {
+        return { valid: false, error: 'Access token is invalid or expired' };
+      }
+      return { valid: false, error: 'Failed to validate authentication credentials' };
+    }
+  },
+});
+
+export const canva = createPiece({
+  displayName: 'Canva',
+  description: 'Create stunning designs with Canva\'s powerful design automation tools',
+  auth: canvaAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/canva.png',
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  authors: ['Harmatta'],
+  actions: [
+    createDesign,
+    uploadAsset,
+    importDesign,
+    exportDesign,
+    moveFolderItem,
+    findDesign,
+    getFolder,
+    getImage,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.canva.com/rest/v1',
+      auth: canvaAuth,
+      authMapping: async (auth) => {
+        const authValue = auth as OAuth2PropertyValue;
+        return {
+          Authorization: `Bearer ${authValue.access_token}`,
+        };
+      },
+    }),
+  ],
+  triggers: [],
+});
+    

--- a/packages/pieces/community/canva/src/lib/actions/create-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/create-design.ts
@@ -1,0 +1,172 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { canvaCommon, CanvaDesignCreateRequest, CanvaDesignResponse, fetchUserAssets } from '../common';
+
+export const createDesign = createAction({
+  auth: canvaAuth,
+  name: 'create_design',
+  displayName: 'Create Design',
+  description: 'Create a new Canva design using preset design types or custom dimensions. Blank designs are automatically deleted if not edited within 7 days.',
+  props: {
+    designTypeOption: Property.StaticDropdown({
+      displayName: '🎨 Design Type',
+      description: 'Choose how to create your design - preset templates or custom dimensions',
+      required: true,
+      defaultValue: 'preset',
+      options: {
+        options: [
+          { label: '📋 Preset Design Type (Document, Whiteboard, Presentation)', value: 'preset' },
+          { label: '📐 Custom Dimensions (Specify width & height)', value: 'custom' },
+        ],
+      },
+    }),
+    presetName: Property.StaticDropdown({
+      displayName: 'Preset Design Type',
+      description: '⚠️ Only fill this if you selected "Preset Design Type" above',
+      required: false,
+      options: {
+        options: [
+          { label: 'Document (Canva Docs)', value: 'doc' },
+          { label: 'Whiteboard', value: 'whiteboard' },
+          { label: 'Presentation', value: 'presentation' },
+        ],
+      },
+    }),
+    customWidth: Property.Number({
+      displayName: 'Custom Width (pixels)',
+      description: '⚠️ Only fill this if you selected "Custom Dimensions" above. Min: 40, Max: 8000',
+      required: false,
+    }),
+    customHeight: Property.Number({
+      displayName: 'Custom Height (pixels)',
+      description: '⚠️ Only fill this if you selected "Custom Dimensions" above. Min: 40, Max: 8000',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: '🏷️ Design Title',
+      description: 'Optional: Name for your design (1-255 characters). If empty, Canva will auto-generate a title.',
+      required: false,
+    }),
+    assetId: Property.Dropdown({
+      displayName: 'Asset',
+      description: 'Optional: Select an existing image asset to add to the design',
+      required: false,
+      auth: canvaAuth,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate with Canva first',
+            options: [],
+          };
+        }
+        
+        try {
+          const assets = await fetchUserAssets(auth, 'image');
+          return {
+            disabled: false,
+            options: assets,
+          };
+        } catch (error) {
+          console.error('Error fetching assets:', error);
+          return {
+            disabled: true,
+            placeholder: 'Error loading assets',
+            options: [],
+          };
+        }
+      },
+    }),
+  },
+  async run(context) {
+    const { designTypeOption, presetName, customWidth, customHeight, title, assetId } = context.propsValue;
+    
+    if (designTypeOption === 'preset' && !presetName) {
+      throw new Error('Preset design type is required when using preset option');
+    }
+    
+    if (designTypeOption === 'custom') {
+      if (!customWidth || !customHeight) {
+        throw new Error('Both custom width and height are required when using custom dimensions');
+      }
+      if (customWidth < 40 || customWidth > 8000) {
+        throw new Error('Custom width must be between 40 and 8000 pixels');
+      }
+      if (customHeight < 40 || customHeight > 8000) {
+        throw new Error('Custom height must be between 40 and 8000 pixels');
+      }
+    }
+    
+    if (title && (title.length < 1 || title.length > 255)) {
+      throw new Error('Title must be between 1 and 255 characters');
+    }
+
+    const requestBody: CanvaDesignCreateRequest = {};
+    
+    if (designTypeOption === 'preset') {
+      requestBody.design_type = {
+        type: 'preset',
+        name: presetName as 'doc' | 'whiteboard' | 'presentation',
+      };
+    } else if (designTypeOption === 'custom') {
+      requestBody.design_type = {
+        type: 'custom',
+        width: customWidth!,
+        height: customHeight!,
+      };
+    }
+    
+    if (title) {
+      requestBody.title = title;
+    }
+    
+    if (assetId) {
+      requestBody.asset_id = assetId;
+    }
+
+    try {
+      const response = await httpClient.sendRequest<CanvaDesignResponse>({
+        method: HttpMethod.POST,
+        url: `${canvaCommon.baseUrl}/designs`,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: context.auth.access_token,
+        },
+        body: requestBody,
+      });
+
+      return {
+        success: true,
+        design: response.body.design,
+        message: `Design "${response.body.design.title || response.body.design.id}" created successfully`,
+      };
+    } catch (error: any) {
+      if (error.response?.status === 429) {
+        throw new Error('Rate limit exceeded. Please wait before making another request (20 requests per minute limit).');
+      }
+      
+      if (error.response?.status === 401) {
+        throw new Error('Authentication failed. Please check your Canva connection.');
+      }
+      
+      if (error.response?.status === 403) {
+        throw new Error('Access forbidden. Make sure your integration has the required scope: design:content:write');
+      }
+      
+      if (error.response?.data?.message) {
+        throw new Error(`Canva API error: ${error.response.data.message}`);
+      }
+      
+      throw new Error(`Failed to create design: ${error.message || 'Unknown error'}`);
+    }
+  },
+}); 

--- a/packages/pieces/community/canva/src/lib/actions/export-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/export-design.ts
@@ -1,0 +1,279 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { 
+  canvaCommon, 
+  ExportResponse,
+  ExportRequest,
+  ExportFormat,
+  EXPORT_FORMATS,
+  PDF_SIZES,
+  MP4_QUALITIES,
+  MIN_EXPORT_DIMENSION,
+  MAX_EXPORT_DIMENSION,
+  fetchUserDesigns
+} from '../common';
+
+export const exportDesign = createAction({
+  auth: canvaAuth,
+  name: 'export_design',
+  displayName: 'Export Design',
+  description: 'Export a Canva design to various formats (PDF, JPG, PNG, GIF, PPTX, MP4). This creates an asynchronous job with download URLs valid for 24 hours.',
+  props: {
+    designId: Property.Dropdown({
+      displayName: 'Design',
+      description: 'Select the design to export',
+      required: true,
+      auth: canvaAuth,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate with Canva first',
+            options: [],
+          };
+        }
+        
+        try {
+          const designs = await fetchUserDesigns(auth);
+          return {
+            disabled: false,
+            options: designs,
+          };
+        } catch (error) {
+          console.error('Error fetching designs:', error);
+          return {
+            disabled: true,
+            placeholder: 'Error loading designs',
+            options: [],
+          };
+        }
+      },
+    }),
+    exportFormat: Property.StaticDropdown({
+      displayName: 'Export Format',
+      description: 'The format to export the design to',
+      required: true,
+      options: {
+        options: EXPORT_FORMATS,
+      },
+    }),
+    exportQuality: Property.StaticDropdown({
+      displayName: 'Export Quality',
+      description: 'Export quality level (Pro quality may require premium elements license)',
+      required: false,
+      defaultValue: 'regular',
+      options: {
+        options: [
+          { label: 'Regular Quality', value: 'regular' },
+          { label: 'Pro Quality (Premium)', value: 'pro' },
+        ],
+      },
+    }),
+    pages: Property.Array({
+      displayName: 'Specific Pages',
+      description: 'Page numbers to export (leave empty to export all pages). First page is 1.',
+      required: false,
+    }),
+    jpegQuality: Property.Number({
+      displayName: '📸 JPEG Quality',
+      description: '🎯 JPEG ONLY: Compression quality (1-100, higher = better quality, larger file)',
+      required: false,
+      defaultValue: 80,
+    }),
+    pdfSize: Property.StaticDropdown({
+      displayName: '📄 PDF Paper Size',
+      description: '🎯 PDF ONLY: Paper size for PDF export (only for Canva Docs)',
+      required: false,
+      defaultValue: 'a4',
+      options: {
+        options: PDF_SIZES,
+      },
+    }),
+    mp4Quality: Property.StaticDropdown({
+      displayName: '🎬 MP4 Quality',
+      description: '🎯 MP4 ONLY: Video orientation and resolution for MP4 export',
+      required: false,
+      defaultValue: 'horizontal_1080p',
+      options: {
+        options: MP4_QUALITIES,
+      },
+    }),
+    customWidth: Property.Number({
+      displayName: '📐 Custom Width (pixels)',
+      description: `🎯 IMAGES ONLY (JPG/PNG/GIF): Custom width (${MIN_EXPORT_DIMENSION}-${MAX_EXPORT_DIMENSION}px). Leave empty for original size.`,
+      required: false,
+    }),
+    customHeight: Property.Number({
+      displayName: '📐 Custom Height (pixels)',
+      description: `🎯 IMAGES ONLY (JPG/PNG/GIF): Custom height (${MIN_EXPORT_DIMENSION}-${MAX_EXPORT_DIMENSION}px). Leave empty for original size.`,
+      required: false,
+    }),
+    pngLossless: Property.Checkbox({
+      displayName: '🔧 PNG Lossless Compression',
+      description: '🎯 PNG ONLY: Export PNG without compression (default: true). Lossy compression requires Pro plan.',
+      required: false,
+      defaultValue: true,
+    }),
+    pngTransparentBackground: Property.Checkbox({
+      displayName: '🫥 PNG Transparent Background',
+      description: '🎯 PNG ONLY: Export PNG with transparent background (Pro feature)',
+      required: false,
+      defaultValue: false,
+    }),
+    pngSingleImage: Property.Checkbox({
+      displayName: '📑 PNG Merge Multi-page',
+      description: '🎯 PNG ONLY: Merge multi-page designs into a single image (default: separate images per page)',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { 
+      designId, 
+      exportFormat, 
+      exportQuality, 
+      pages,
+      jpegQuality,
+      pdfSize,
+      mp4Quality,
+      customWidth,
+      customHeight,
+      pngLossless,
+      pngTransparentBackground,
+      pngSingleImage
+    } = context.propsValue;
+    
+    if (!designId || designId.trim().length === 0) {
+      throw new Error('Design ID is required');
+    }
+    
+    if (customWidth && (customWidth < MIN_EXPORT_DIMENSION || customWidth > MAX_EXPORT_DIMENSION)) {
+      throw new Error(`Custom width must be between ${MIN_EXPORT_DIMENSION} and ${MAX_EXPORT_DIMENSION} pixels`);
+    }
+    
+    if (customHeight && (customHeight < MIN_EXPORT_DIMENSION || customHeight > MAX_EXPORT_DIMENSION)) {
+      throw new Error(`Custom height must be between ${MIN_EXPORT_DIMENSION} and ${MAX_EXPORT_DIMENSION} pixels`);
+    }
+    
+    if (exportFormat === 'jpg' && (!jpegQuality || jpegQuality < 1 || jpegQuality > 100)) {
+      throw new Error('JPEG quality must be between 1 and 100');
+    }
+    
+    if (exportFormat === 'mp4' && !mp4Quality) {
+      throw new Error('MP4 quality is required when exporting as MP4');
+    }
+    
+    const format: ExportFormat = {
+      type: exportFormat as 'pdf' | 'jpg' | 'png' | 'gif' | 'pptx' | 'mp4',
+    };
+    
+    if (exportQuality) {
+      format.export_quality = exportQuality as 'regular' | 'pro';
+    }
+    
+    if (pages && Array.isArray(pages) && pages.length > 0) {
+      format.pages = pages.map(p => Number(p)).filter(p => p > 0);
+    }
+    
+    switch (exportFormat) {
+      case 'jpg':
+        if (jpegQuality) format.quality = jpegQuality;
+        if (customWidth) format.width = customWidth;
+        if (customHeight) format.height = customHeight;
+        break;
+        
+      case 'png':
+        if (customWidth) format.width = customWidth;
+        if (customHeight) format.height = customHeight;
+        if (typeof pngLossless === 'boolean') format.lossless = pngLossless;
+        if (typeof pngTransparentBackground === 'boolean') format.transparent_background = pngTransparentBackground;
+        if (typeof pngSingleImage === 'boolean') format.as_single_image = pngSingleImage;
+        break;
+        
+      case 'gif':
+        if (customWidth) format.width = customWidth;
+        if (customHeight) format.height = customHeight;
+        break;
+        
+      case 'pdf':
+        if (pdfSize) format.size = pdfSize as 'a4' | 'a3' | 'letter' | 'legal';
+        break;
+        
+      case 'mp4':
+        if (mp4Quality) format.quality = mp4Quality;
+        break;
+        
+      case 'pptx':
+        break;
+    }
+    
+    const requestBody: ExportRequest = {
+      design_id: designId.trim(),
+      format,
+    };
+
+    try {
+      const response = await httpClient.sendRequest<ExportResponse>({
+        method: HttpMethod.POST,
+        url: `${canvaCommon.baseUrl}/exports`,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: context.auth.access_token,
+        },
+        body: requestBody,
+      });
+
+      return {
+        success: true,
+        job: response.body.job,
+        export_info: {
+          design_id: designId.trim(),
+          format: exportFormat.toUpperCase(),
+          quality: exportQuality || 'regular',
+          pages: format.pages ? `Pages: ${format.pages.join(', ')}` : 'All pages',
+          dimensions: customWidth || customHeight 
+            ? `${customWidth || 'auto'}x${customHeight || 'auto'} pixels`
+            : 'Original size',
+        },
+        message: `Export job created successfully. Job ID: ${response.body.job.id}. Status: ${response.body.job.status}`,
+        next_steps: response.body.job.status === 'in_progress' 
+          ? `Poll /exports/${response.body.job.id} via custom API call to retrieve download URLs.`
+          : response.body.job.status === 'success' && response.body.job.urls
+          ? `Export completed! ${response.body.job.urls.length} file(s) ready for download.`
+          : undefined,
+        download_urls: response.body.job.urls || undefined,
+      };
+    } catch (error: any) {
+      if (error.response?.status === 429) {
+        throw new Error('Rate limit exceeded. Please wait before making another request (20 requests per minute limit).');
+      }
+      
+      if (error.response?.status === 401) {
+        throw new Error('Authentication failed. Please check your Canva connection.');
+      }
+      
+      if (error.response?.status === 403) {
+        throw new Error('Access forbidden. Make sure your integration has the required scope: design:content:read');
+      }
+      
+      if (error.response?.status === 404) {
+        throw new Error(`Design with ID "${designId}" was not found or you don't have access to it.`);
+      }
+      
+      if (error.response?.data?.message) {
+        throw new Error(`Canva API error: ${error.response.data.message}`);
+      }
+      
+      throw new Error(`Failed to export design: ${error.message || 'Unknown error'}`);
+    }
+  },
+}); 

--- a/packages/pieces/community/canva/src/lib/actions/find-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/find-design.ts
@@ -1,0 +1,161 @@
+import {
+  Property,
+  createAction,
+  OAuth2PropertyValue,
+} from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { canvaCommon, Design } from '../common';
+
+interface ListDesignsResponse {
+  items: Design[];
+  continuation?: string;
+}
+
+export const findDesign = createAction({
+  auth: canvaAuth,
+  name: 'find_design',
+  displayName: 'Find Design',
+  description: 'Search and list designs from your Canva library. Use this to find existing designs before creating new ones.',
+  props: {
+    query: Property.ShortText({
+      displayName: '🔍 Search Query',
+      description: 'Enter keywords to search designs by title or content (leave empty to get all designs)',
+      required: false,
+    }),
+    ownership: Property.StaticDropdown({
+      displayName: '👥 Ownership Filter',
+      description: 'Filter designs by who owns them',
+      required: false,
+      defaultValue: 'any',
+      options: {
+        options: [
+          { label: 'Any (owned + shared)', value: 'any' },
+          { label: 'Owned by me', value: 'owned' },
+          { label: 'Shared with me', value: 'shared' },
+        ],
+      },
+    }),
+    sort_by: Property.StaticDropdown({
+      displayName: '📊 Sort By',
+      description: 'How to order the search results',
+      required: false,
+      defaultValue: 'modified_descending',
+      options: {
+        options: [
+          { label: '📅 Recently Modified (Recommended)', value: 'modified_descending' },
+          { label: '🔍 Relevance', value: 'relevance' },
+          { label: '📅 Oldest Modified', value: 'modified_ascending' },
+          { label: '🔤 Title A-Z', value: 'title_ascending' },
+          { label: '🔤 Title Z-A', value: 'title_descending' },
+        ],
+      },
+    }),
+    limit: Property.Number({
+      displayName: '⚙️ Result Limit (Advanced)',
+      description: 'Max designs to return (default: 20, max: 100). Higher numbers may be slower.',
+      required: false,
+      defaultValue: 20,
+    }),
+    continuation: Property.ShortText({
+      displayName: '⚙️ Continuation Token (Advanced)',
+      description: 'For pagination: token from previous search to get next page of results',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { query, ownership, sort_by, limit, continuation } = context.propsValue;
+    const authValue = context.auth as OAuth2PropertyValue;
+
+    try {
+      const params = new URLSearchParams();
+      
+      if (query && query.trim()) {
+        params.append('query', query.trim());
+      }
+      
+      if (ownership && ownership !== 'any') {
+        params.append('ownership', ownership);
+      }
+      
+      if (sort_by && sort_by !== 'relevance') {
+        params.append('sort_by', sort_by);
+      }
+      
+      if (continuation && continuation.trim()) {
+        params.append('continuation', continuation.trim());
+      }
+
+      const queryString = params.toString();
+      const url = `${canvaCommon.baseUrl}/designs${queryString ? `?${queryString}` : ''}`;
+
+      const response = await httpClient.sendRequest<ListDesignsResponse>({
+        method: HttpMethod.GET,
+        url,
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: authValue.access_token,
+        },
+      });
+
+      const data = response.body;
+
+      let designs = data.items || [];
+      if (limit && limit > 0) {
+        designs = designs.slice(0, Math.min(limit, 100));
+      }
+
+      return {
+        designs,
+        total_found: designs.length,
+        has_more: !!data.continuation,
+        continuation_token: data.continuation,
+        search_query: query || null,
+        ownership_filter: ownership || 'any',
+        sort_order: sort_by || 'relevance',
+        design_ids: designs.map(d => d.id),
+        design_titles: designs.map(d => d.title).filter(Boolean),
+      };
+    } catch (error: unknown) {
+      const errorResponse = error as {
+        response?: {
+          status?: number;
+          data?: { message?: string };
+        };
+      };
+      const status = errorResponse.response?.status;
+
+      if (status === 400) {
+        throw new Error('Bad Request: Invalid search parameters');
+      }
+
+      if (status === 401) {
+        throw new Error('Unauthorized: Please check your authentication credentials');
+      }
+
+      if (status === 403) {
+        throw new Error('Forbidden: Insufficient permissions to access designs');
+      }
+
+      if (status === 429) {
+        throw new Error('Rate limit exceeded: Too many requests (limit: 100 per minute)');
+      }
+
+      if (errorResponse.response?.data?.message) {
+        throw new Error(
+          `HTTP ${status || 'unknown'}: ${errorResponse.response.data.message}`,
+        );
+      }
+
+      if (error instanceof Error) {
+        throw new Error(`Failed to find designs: ${error.message}`);
+      }
+
+      throw new Error(`Failed to find designs: ${String(error)}`);
+    }
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-folder.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-folder.ts
@@ -1,0 +1,116 @@
+import {
+  Property,
+  createAction,
+  OAuth2PropertyValue,
+} from '@activepieces/pieces-framework';
+import { canvaAuth } from '../../index';
+import { canvaCommon, FolderResponse, fetchUserFolders } from '../common';
+
+export const getFolder = createAction({
+  auth: canvaAuth,
+  name: 'get_folder',
+  displayName: 'Get Folder',
+  description: 'Retrieve metadata for a specific folder, including name, creation date, and thumbnail.',
+  props: {
+    folder_id: Property.Dropdown({
+      displayName: 'Folder',
+      description: 'Select the folder to retrieve metadata for',
+      required: true,
+      auth: canvaAuth,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate with Canva first',
+            options: [],
+          };
+        }
+        
+        try {
+          const folders = await fetchUserFolders(auth);
+          return {
+            disabled: false,
+            options: folders,
+          };
+        } catch (error) {
+          console.error('Error fetching folders:', error);
+          return {
+            disabled: true,
+            placeholder: 'Error loading folders',
+            options: [],
+          };
+        }
+      },
+    }),
+  },
+  async run(context) {
+    const { folder_id } = context.propsValue;
+    const authValue = context.auth as OAuth2PropertyValue;
+
+    if (!folder_id || !folder_id.trim()) {
+      throw new Error('Folder ID is required');
+    }
+
+    const cleanFolderId = folder_id.trim();
+
+    try {
+      const response = await fetch(`${canvaCommon.baseUrl}/folders/${cleanFolderId}`, {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${authValue.access_token}`,
+        },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        
+        if (response.status === 400) {
+          throw new Error(`Bad Request: ${errorData.message || 'Invalid folder ID format'}`);
+        }
+        
+        if (response.status === 401) {
+          throw new Error('Unauthorized: Please check your authentication credentials');
+        }
+        
+        if (response.status === 403) {
+          throw new Error('Forbidden: You do not have permission to access this folder');
+        }
+        
+        if (response.status === 404) {
+          throw new Error(`Folder not found: The folder with ID "${cleanFolderId}" does not exist or you do not have access to it`);
+        }
+        
+        if (response.status === 429) {
+          throw new Error('Rate limit exceeded: Too many requests (limit: 100 per minute)');
+        }
+        
+        throw new Error(`HTTP ${response.status}: ${errorData.message || 'Request failed'}`);
+      }
+
+      const data: FolderResponse = await response.json();
+      const folder = data.folder;
+
+      return {
+        folder: {
+          id: folder.id,
+          name: folder.name,
+          created_at: folder.created_at,
+          updated_at: folder.updated_at,
+          thumbnail: folder.thumbnail || null,
+        },
+        folder_id: folder.id,
+        folder_name: folder.name,
+        created_date: new Date(folder.created_at * 1000).toISOString(),
+        updated_date: new Date(folder.updated_at * 1000).toISOString(),
+        has_thumbnail: !!folder.thumbnail,
+        thumbnail_url: folder.thumbnail?.url || null,
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(`Failed to get folder: ${String(error)}`);
+    }
+  },
+}); 

--- a/packages/pieces/community/canva/src/lib/actions/get-image.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-image.ts
@@ -1,0 +1,132 @@
+import {
+  Property,
+  createAction,
+  OAuth2PropertyValue,
+} from '@activepieces/pieces-framework';
+import { canvaAuth } from '../../index';
+import { canvaCommon, AssetResponse, fetchUserAssets } from '../common';
+
+export const getImage = createAction({
+  auth: canvaAuth,
+  name: 'get_image',
+  displayName: 'Get Image',
+  description:
+    'Retrieve metadata for an image in your Canva library, including name, tags, creation date, and thumbnail.',
+  props: {
+    image_id: Property.Dropdown({
+      displayName: 'Image',
+      description: 'Select the image to retrieve metadata for',
+      required: true,
+      auth: canvaAuth,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate with Canva first',
+            options: [],
+          };
+        }
+        
+        try {
+          const assets = await fetchUserAssets(auth);
+          return {
+            disabled: false,
+            options: assets,
+          };
+        } catch (error) {
+          console.error('Error fetching assets:', error);
+          return {
+            disabled: true,
+            placeholder: 'Error loading assets',
+            options: [],
+          };
+        }
+      },
+    }),
+  },
+  async run(context) {
+    const { image_id } = context.propsValue;
+    const authValue = context.auth as OAuth2PropertyValue;
+
+    if (!image_id || !image_id.trim()) {
+      throw new Error('Image ID is required');
+    }
+
+    const cleanImageId = image_id.trim();
+
+    try {
+      const response = await fetch(`${canvaCommon.baseUrl}/assets/${cleanImageId}`, {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${authValue.access_token}`,
+        },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        
+        if (response.status === 400) {
+          throw new Error(`Bad Request: ${errorData.message || 'Invalid asset ID format'}`);
+        }
+        
+        if (response.status === 401) {
+          throw new Error('Unauthorized: Please check your authentication credentials');
+        }
+        
+        if (response.status === 403) {
+          throw new Error('Forbidden: You do not have permission to access this asset');
+        }
+        
+        if (response.status === 404) {
+          throw new Error(
+            `Image not found: The image with ID "${cleanImageId}" does not exist or you do not have access to it`
+          );
+        }
+        
+        if (response.status === 429) {
+          throw new Error('Rate limit exceeded: Too many requests (limit: 100 per minute)');
+        }
+        
+        throw new Error(`HTTP ${response.status}: ${errorData.message || 'Request failed'}`);
+      }
+
+      const data: AssetResponse = await response.json();
+      const image = data.asset;
+
+      return {
+        image: {
+          type: image.type,
+          id: image.id,
+          name: image.name,
+          tags: image.tags,
+          created_at: image.created_at,
+          updated_at: image.updated_at,
+          thumbnail: image.thumbnail || null,
+          import_status: image.import_status || null,
+        },
+        image_id: image.id,
+        image_name: image.name,
+        image_type: image.type,
+        tags_count: image.tags.length,
+        tags_list: image.tags.join(', '),
+        created_date: new Date(image.created_at * 1000).toISOString(),
+        updated_date: new Date(image.updated_at * 1000).toISOString(),
+        has_thumbnail: !!image.thumbnail,
+        thumbnail_url: image.thumbnail?.url || null,
+        thumbnail_dimensions: image.thumbnail 
+          ? `${image.thumbnail.width}x${image.thumbnail.height}` 
+          : null,
+        is_imported_successfully:
+          !image.import_status || image.import_status.state === 'success',
+        import_status_state: image.import_status?.state || 'success',
+        import_error_message: image.import_status?.error?.message || null,
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(`Failed to get asset: ${String(error)}`);
+    }
+  },
+}); 

--- a/packages/pieces/community/canva/src/lib/actions/import-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/import-design.ts
@@ -1,0 +1,142 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { 
+  canvaCommon, 
+  DesignImportResponse,
+  DesignImportMetadata,
+  SUPPORTED_IMPORT_FORMATS,
+  MAX_DESIGN_TITLE_LENGTH
+} from '../common';
+
+export const importDesign = createAction({
+  auth: canvaAuth,
+  name: 'import_design',
+  displayName: 'Import Design',
+  description: 'Import an external file (PDF, PSD, DOCX, PPTX, etc.) into Canva as a new design. This creates an asynchronous job that you can monitor for completion.',
+  props: {
+    file: Property.File({
+      displayName: 'Design File',
+      description: `📄 Supported formats:
+      📋 Documents: PDF, DOC, DOCX, ODT, Pages
+      📊 Presentations: PPT, PPTX, ODP, Keynote  
+      📈 Spreadsheets: XLS, XLSX, ODS, Numbers
+      🎨 Design Files: AI (Illustrator), PSD (Photoshop), ODG`,
+      required: true,
+    }),
+    designTitle: Property.ShortText({
+      displayName: 'Design Title',
+      description: '🏷️ Title for the imported design (max 50 characters, supports emojis and special characters)',
+      required: true,
+    }),
+    autoDetectMimeType: Property.Checkbox({
+      displayName: '🔍 Auto-detect File Type',
+      description: '✅ Recommended: Let Canva automatically detect the file type. Uncheck to manually specify MIME type from file extension.',
+      required: false,
+      defaultValue: true,
+    }),
+  },
+  async run(context) {
+    const { file, designTitle, autoDetectMimeType } = context.propsValue;
+    
+    if (!designTitle || designTitle.trim().length === 0) {
+      throw new Error('Design title is required');
+    }
+    
+    if (designTitle.length > MAX_DESIGN_TITLE_LENGTH) {
+      throw new Error(`Design title must be ${MAX_DESIGN_TITLE_LENGTH} characters or less`);
+    }
+    
+    if (!file) {
+      throw new Error('File is required');
+    }
+    
+    const fileExtension = file.filename?.split('.').pop()?.toLowerCase();
+    if (!fileExtension) {
+      throw new Error('Unable to determine file type from filename');
+    }
+    
+    const supportedFormat = SUPPORTED_IMPORT_FORMATS.find(format => format.ext === fileExtension);
+    if (!supportedFormat) {
+      const supportedExts = SUPPORTED_IMPORT_FORMATS.map(f => f.ext.toUpperCase()).join(', ');
+      throw new Error(`Unsupported file format: ${fileExtension.toUpperCase()}. Supported formats: ${supportedExts}`);
+    }
+    
+    const fileBuffer = Buffer.from(file.base64, 'base64');
+    const fileSizeMB = fileBuffer.length / (1024 * 1024);
+    
+    const titleBase64 = Buffer.from(designTitle.trim()).toString('base64');
+    
+    const importMetadata: DesignImportMetadata = {
+      title_base64: titleBase64,
+    };
+    
+    if (!autoDetectMimeType) {
+      importMetadata.mime_type = supportedFormat.mime;
+    }
+
+    try {
+      const response = await httpClient.sendRequest<DesignImportResponse>({
+        method: HttpMethod.POST,
+        url: `${canvaCommon.baseUrl}/imports`,
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Import-Metadata': JSON.stringify(importMetadata),
+        },
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: context.auth.access_token,
+        },
+        body: fileBuffer,
+      });
+
+      return {
+        success: true,
+        job: response.body.job,
+        file_info: {
+          title: designTitle.trim(),
+          size_mb: Math.round(fileSizeMB * 100) / 100,
+          format: supportedFormat.name,
+          extension: fileExtension.toUpperCase(),
+          mime_type: autoDetectMimeType ? 'auto-detected' : supportedFormat.mime,
+        },
+        message: `Design import job created successfully. Job ID: ${response.body.job.id}. Status: ${response.body.job.status}`,
+        next_steps: response.body.job.status === 'in_progress' 
+          ? `Poll /imports/${response.body.job.id} via custom API call until the job status is success.`
+          : response.body.job.status === 'success' && response.body.job.result
+          ? `Import completed! ${response.body.job.result.designs.length} design(s) created.`
+          : undefined,
+      };
+    } catch (error: any) {
+      if (error.response?.status === 429) {
+        throw new Error('Rate limit exceeded. Please wait before making another request (20 requests per minute limit).');
+      }
+      
+      if (error.response?.status === 401) {
+        throw new Error('Authentication failed. Please check your Canva connection.');
+      }
+      
+      if (error.response?.status === 403) {
+        throw new Error('Access forbidden. Make sure your integration has the required scope: design:content:write');
+      }
+      
+      if (error.response?.status === 413) {
+        throw new Error('File too large. Check the upload requirements for your file type.');
+      }
+      
+      if (error.response?.status === 415) {
+        throw new Error(`Unsupported media type. File format ${fileExtension.toUpperCase()} may not be supported or the file may be corrupted.`);
+      }
+      
+      if (error.response?.data?.message) {
+        throw new Error(`Canva API error: ${error.response.data.message}`);
+      }
+      
+      throw new Error(`Failed to import design: ${error.message || 'Unknown error'}`);
+    }
+  },
+}); 

--- a/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
+++ b/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
@@ -1,0 +1,166 @@
+import {
+  Property,
+  createAction,
+  OAuth2PropertyValue,
+} from '@activepieces/pieces-framework';
+import { canvaAuth } from '../../index';
+import { canvaCommon, fetchUserFolders, fetchUserDesigns, fetchUserAssets } from '../common';
+
+export const moveFolderItem = createAction({
+  auth: canvaAuth,
+  name: 'move_folder_item',
+  displayName: 'Move Folder Item',
+  description: 'Move an item from one folder to another in Canva',
+  props: {
+    to_folder_id: Property.Dropdown({
+      displayName: 'Destination Folder',
+      description: 'Select the folder to move the item to',
+      required: true,
+      auth: canvaAuth,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate with Canva first',
+            options: [],
+          };
+        }
+        
+        try {
+          const folders = await fetchUserFolders(auth);
+          return {
+            disabled: false,
+            options: folders,
+          };
+        } catch (error) {
+          console.error('Error fetching folders:', error);
+          return {
+            disabled: true,
+            placeholder: 'Error loading folders',
+            options: [],
+          };
+        }
+      },
+    }),
+    item_type: Property.StaticDropdown({
+      displayName: 'Item Type',
+      description: 'Select the type of item you want to move',
+      required: true,
+      defaultValue: 'design',
+      options: {
+        options: [
+          { label: 'Design', value: 'design' },
+          { label: 'Image Asset', value: 'image' },
+        ],
+      },
+    }),
+    item_id: Property.Dropdown({
+      displayName: 'Item to Move',
+      description: 'Select the item you want to move',
+      required: true,
+      auth: canvaAuth,
+      refreshers: ['item_type'],
+      options: async ({ auth, item_type }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please authenticate with Canva first',
+            options: [],
+          };
+        }
+        
+        if (!item_type) {
+          return {
+            disabled: true,
+            placeholder: 'Please select an item type first',
+            options: [],
+          };
+        }
+        
+        try {
+          let items: Array<{ label: string; value: string }> = [];
+          
+          if (item_type === 'design') {
+            items = await fetchUserDesigns(auth);
+          } else if (item_type === 'image') {
+            items = await fetchUserAssets(auth, 'image');
+          }
+          
+          return {
+            disabled: false,
+            options: items,
+          };
+        } catch (error) {
+          console.error('Error fetching items:', error);
+          return {
+            disabled: true,
+            placeholder: 'Error loading items',
+            options: [],
+          };
+        }
+      },
+    }),
+  },
+  async run(context) {
+    const { to_folder_id, item_id } = context.propsValue;
+    const authValue = context.auth as OAuth2PropertyValue;
+
+    try {
+      const response = await fetch(`${canvaCommon.baseUrl}/folders/move`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${authValue.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          to_folder_id,
+          item_id,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        
+        if (response.status === 400) {
+          if (errorData.type === 'item_in_multiple_folders') {
+            throw new Error(
+              'This item exists in multiple folders. Please use the Canva UI to move the item to another folder.'
+            );
+          }
+          throw new Error(`Bad Request: ${errorData.message || 'Invalid request parameters'}`);
+        }
+        
+        if (response.status === 401) {
+          throw new Error('Unauthorized: Please check your authentication credentials');
+        }
+        
+        if (response.status === 403) {
+          throw new Error('Forbidden: Insufficient permissions or invalid folder/item access');
+        }
+        
+        if (response.status === 404) {
+          throw new Error('Not Found: The specified folder or item does not exist');
+        }
+        
+        if (response.status === 429) {
+          throw new Error('Rate limit exceeded: Too many requests (limit: 100 per minute)');
+        }
+        
+        throw new Error(`HTTP ${response.status}: ${errorData.message || 'Request failed'}`);
+      }
+
+      return {
+        success: true,
+        message: `Item ${item_id} successfully moved to folder ${to_folder_id}`,
+        moved_item_id: item_id,
+        destination_folder_id: to_folder_id,
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(`Failed to move folder item: ${String(error)}`);
+    }
+  },
+}); 

--- a/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
@@ -1,0 +1,135 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { 
+  canvaCommon, 
+  AssetUploadResponse,
+  AssetUploadMetadata,
+  SUPPORTED_IMAGE_FORMATS,
+  SUPPORTED_VIDEO_FORMATS,
+  MAX_IMAGE_SIZE_MB,
+  MAX_VIDEO_SIZE_MB,
+  MAX_ASSET_NAME_LENGTH
+} from '../common';
+
+export const uploadAsset = createAction({
+  auth: canvaAuth,
+  name: 'upload_asset',
+  displayName: 'Upload Asset',
+  description: 'Upload an image or video asset to your Canva library. This creates an asynchronous job that you can monitor for completion.',
+  props: {
+    file: Property.File({
+      displayName: 'Asset File',
+      description: `📁 Supported formats:
+      🖼️ Images (max 50MB): ${SUPPORTED_IMAGE_FORMATS.map(f => f.toUpperCase()).join(', ')}
+      🎬 Videos (max 500MB): ${SUPPORTED_VIDEO_FORMATS.map(f => f.toUpperCase()).join(', ')}`,
+      required: true,
+    }),
+    assetName: Property.ShortText({
+      displayName: 'Asset Name',
+      description: '🏷️ Name for the asset (max 50 characters, supports emojis and special characters)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { file, assetName } = context.propsValue;
+    
+    if (!assetName || assetName.trim().length === 0) {
+      throw new Error('Asset name is required');
+    }
+    
+    if (assetName.length > MAX_ASSET_NAME_LENGTH) {
+      throw new Error(`Asset name must be ${MAX_ASSET_NAME_LENGTH} characters or less`);
+    }
+    
+    if (!file) {
+      throw new Error('File is required');
+    }
+    
+    const fileExtension = file.filename?.split('.').pop()?.toLowerCase();
+    if (!fileExtension) {
+      throw new Error('Unable to determine file type from filename');
+    }
+    
+    const isImage = SUPPORTED_IMAGE_FORMATS.includes(fileExtension);
+    const isVideo = SUPPORTED_VIDEO_FORMATS.includes(fileExtension);
+    
+    if (!isImage && !isVideo) {
+      throw new Error(`Unsupported file format: ${fileExtension}. Supported formats - Images: ${SUPPORTED_IMAGE_FORMATS.join(', ')}. Videos: ${SUPPORTED_VIDEO_FORMATS.join(', ')}`);
+    }
+    
+    const fileBuffer = Buffer.from(file.base64, 'base64');
+    const fileSizeMB = fileBuffer.length / (1024 * 1024);
+    
+    if (isImage && fileSizeMB > MAX_IMAGE_SIZE_MB) {
+      throw new Error(`Image file size (${fileSizeMB.toFixed(2)}MB) exceeds maximum limit of ${MAX_IMAGE_SIZE_MB}MB`);
+    }
+    
+    if (isVideo && fileSizeMB > MAX_VIDEO_SIZE_MB) {
+      throw new Error(`Video file size (${fileSizeMB.toFixed(2)}MB) exceeds maximum limit of ${MAX_VIDEO_SIZE_MB}MB`);
+    }
+    
+    const nameBase64 = Buffer.from(assetName.trim()).toString('base64');
+    
+    const uploadMetadata: AssetUploadMetadata = {
+      name_base64: nameBase64,
+    };
+
+    try {
+      const response = await httpClient.sendRequest<AssetUploadResponse>({
+        method: HttpMethod.POST,
+        url: `${canvaCommon.baseUrl}/asset-uploads`,
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Asset-Upload-Metadata': JSON.stringify(uploadMetadata),
+        },
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: context.auth.access_token,
+        },
+        body: fileBuffer,
+      });
+
+      return {
+        success: true,
+        job: response.body.job,
+        file_info: {
+          name: assetName.trim(),
+          size_mb: Math.round(fileSizeMB * 100) / 100,
+          type: isImage ? 'image' : 'video',
+          format: fileExtension.toUpperCase(),
+        },
+        message: `Asset upload job created successfully. Job ID: ${response.body.job.id}. Status: ${response.body.job.status}`,
+        next_steps: response.body.job.status === 'in_progress' 
+          ? `Poll /asset-uploads/${response.body.job.id} via custom API call until the job status is success.`
+          : undefined,
+      };
+    } catch (error: any) {
+      if (error.response?.status === 429) {
+        throw new Error('Rate limit exceeded. Please wait before making another request (30 requests per minute limit).');
+      }
+      
+      if (error.response?.status === 401) {
+        throw new Error('Authentication failed. Please check your Canva connection.');
+      }
+      
+      if (error.response?.status === 403) {
+        throw new Error('Access forbidden. Make sure your integration has the required scope: asset:write');
+      }
+      
+      if (error.response?.status === 413) {
+        throw new Error('File too large. Check file size limits: Images max 50MB, Videos max 500MB.');
+      }
+      
+      if (error.response?.data?.message) {
+        throw new Error(`Canva API error: ${error.response.data.message}`);
+      }
+      
+      throw new Error(`Failed to upload asset: ${error.message || 'Unknown error'}`);
+    }
+  },
+}); 

--- a/packages/pieces/community/canva/src/lib/common/index.ts
+++ b/packages/pieces/community/canva/src/lib/common/index.ts
@@ -1,0 +1,366 @@
+export const canvaCommon = {
+  baseUrl: 'https://api.canva.com/rest/v1',
+};
+
+export interface DesignTypeInput {
+  type: 'preset' | 'custom';
+  name?: 'doc' | 'whiteboard' | 'presentation'; // Required if type is 'preset'
+  width?: number; // Required if type is 'custom', min: 40, max: 8000
+  height?: number; // Required if type is 'custom', min: 40, max: 8000
+}
+
+// Request body for create design API
+export interface CanvaDesignCreateRequest {
+  design_type?: DesignTypeInput;
+  asset_id?: string;
+  title?: string; // Min length: 1, Max length: 255
+}
+
+// Owner information
+export interface TeamUserSummary {
+  user_id: string;
+  team_id: string;
+}
+
+// Design URLs
+export interface DesignLinks {
+  edit_url: string;
+  view_url: string;
+}
+
+// Thumbnail information
+export interface Thumbnail {
+  width: number;
+  height: number;
+  url: string;
+}
+
+// Design response structure
+export interface Design {
+  id: string;
+  title?: string;
+  owner: TeamUserSummary;
+  urls: DesignLinks;
+  created_at: number; // Unix timestamp
+  updated_at: number; // Unix timestamp
+  thumbnail?: Thumbnail;
+  page_count?: number;
+}
+
+// API response wrapper
+export interface CanvaDesignResponse {
+  design: Design;
+}
+
+// Folder information
+export interface Folder {
+  id: string;
+  name: string;
+  created_at: number; // Unix timestamp
+  updated_at: number; // Unix timestamp
+  thumbnail?: Thumbnail;
+}
+
+// Folder response wrapper
+export interface FolderResponse {
+  folder: Folder;
+}
+
+// Asset summary for folder items
+export interface AssetSummary {
+  type: 'image' | 'video';
+  id: string;
+  name: string;
+  tags: string[];
+  created_at: number; // Unix timestamp
+  updated_at: number; // Unix timestamp
+  thumbnail?: Thumbnail;
+}
+
+// Folder item summary - polymorphic structure
+export interface FolderItemSummary {
+  type: 'folder' | 'design' | 'image';
+  folder?: Folder; // Present when type is 'folder'
+  design?: DesignSummary; // Present when type is 'design'
+  image?: AssetSummary; // Present when type is 'image'
+}
+
+// List folder items response
+export interface ListFolderItemsResponse {
+  items: FolderItemSummary[];
+  continuation?: string;
+}
+
+// Asset upload metadata for header
+export interface AssetUploadMetadata {
+  name_base64: string; // Asset name encoded in Base64, max 50 chars unencoded
+}
+
+// Asset upload error
+export interface AssetUploadError {
+  code: 'file_too_big' | 'import_failed' | 'fetch_failed';
+  message: string;
+}
+
+export interface ImportError {
+  code: 'file_too_big' | 'import_failed';
+  message: string;
+}
+
+export interface ImportStatus {
+  state: 'failed' | 'in_progress' | 'success';
+  error?: ImportError;
+}
+
+// Asset information
+export interface Asset {
+  type: 'image' | 'video';
+  id: string;
+  name: string;
+  tags: string[];
+  created_at: number; // Unix timestamp
+  updated_at: number; // Unix timestamp
+  thumbnail?: Thumbnail;
+  import_status?: ImportStatus; // deprecated
+}
+
+// Asset upload job
+export interface AssetUploadJob {
+  id: string;
+  status: 'failed' | 'in_progress' | 'success';
+  error?: AssetUploadError;
+  asset?: Asset;
+}
+
+// Asset upload response
+export interface AssetUploadResponse {
+  job: AssetUploadJob;
+}
+
+// Asset response wrapper
+export interface AssetResponse {
+  asset: Asset;
+}
+
+// Design import metadata for header
+export interface DesignImportMetadata {
+  title_base64: string; // Design title encoded in Base64, max 50 chars unencoded
+  mime_type?: string; // Optional MIME type
+}
+
+// Design summary for import results
+export interface DesignSummary {
+  id: string;
+  title?: string;
+  url?: string;
+  urls: DesignLinks;
+  created_at: number; // Unix timestamp
+  updated_at: number; // Unix timestamp
+  thumbnail?: Thumbnail;
+  page_count?: number;
+}
+
+// Design import job result
+export interface DesignImportJobResult {
+  designs: DesignSummary[]; // Usually contains one item, may be split for large files
+}
+
+// Design import error
+export interface DesignImportError {
+  code: 'design_creation_throttled' | 'design_import_throttled' | 'duplicate_import' | 'internal_error' | 'invalid_file' | 'fetch_failed';
+  message: string;
+}
+
+// Design import job
+export interface DesignImportJob {
+  id: string;
+  status: 'failed' | 'in_progress' | 'success';
+  result?: DesignImportJobResult;
+  error?: DesignImportError;
+}
+
+// Design import response
+export interface DesignImportResponse {
+  job: DesignImportJob;
+}
+
+// Export format structure
+export interface ExportFormat {
+  type: 'pdf' | 'jpg' | 'png' | 'gif' | 'pptx' | 'mp4';
+  quality?: number | string; // Required for jpg (1-100) and mp4 (e.g., 'horizontal_1080p')
+  pages?: number[]; // Specific pages to export
+  export_quality?: 'regular' | 'pro'; // Export quality level
+  size?: 'a4' | 'a3' | 'letter' | 'legal'; // PDF paper size (for Canva Docs)
+  height?: number; // For jpg, png, gif (40-25000)
+  width?: number; // For jpg, png, gif (40-25000)
+  lossless?: boolean; // PNG compression (default true)
+  transparent_background?: boolean; // PNG transparent background (Pro feature)
+  as_single_image?: boolean; // PNG multi-page merge (default false)
+}
+
+// Export error
+export interface ExportError {
+  code: 'license_required' | 'approval_required' | 'internal_failure';
+  message: string;
+}
+
+// Export job
+export interface ExportJob {
+  id: string;
+  status: 'failed' | 'in_progress' | 'success';
+  urls?: string[]; // Download URLs, expire after 24 hours
+  error?: ExportError;
+}
+
+// Export request
+export interface ExportRequest {
+  design_id: string;
+  format: ExportFormat;
+}
+
+// Export response
+export interface ExportResponse {
+  job: ExportJob;
+}
+
+// File format validation
+export const SUPPORTED_IMAGE_FORMATS = ['jpg', 'jpeg', 'png', 'heic', 'gif', 'tiff', 'webp'];
+export const SUPPORTED_VIDEO_FORMATS = ['m4v', 'mkv', 'mp4', 'mpeg', 'mov', 'webm'];
+
+// Supported import file formats with MIME types
+export const SUPPORTED_IMPORT_FORMATS = [
+  { ext: 'ai', mime: 'application/illustrator', name: 'Adobe Illustrator' },
+  { ext: 'psd', mime: 'image/vnd.adobe.photoshop', name: 'Adobe Photoshop' },
+  { ext: 'key', mime: 'application/vnd.apple.keynote', name: 'Apple Keynote' },
+  { ext: 'numbers', mime: 'application/vnd.apple.numbers', name: 'Apple Numbers' },
+  { ext: 'pages', mime: 'application/vnd.apple.pages', name: 'Apple Pages' },
+  { ext: 'xls', mime: 'application/vnd.ms-excel', name: 'Microsoft Excel (pre 2007)' },
+  { ext: 'xlsx', mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', name: 'Microsoft Excel' },
+  { ext: 'ppt', mime: 'application/vnd.ms-powerpoint', name: 'Microsoft PowerPoint (pre 2007)' },
+  { ext: 'pptx', mime: 'application/vnd.openxmlformats-officedocument.presentationml.presentation', name: 'Microsoft PowerPoint' },
+  { ext: 'doc', mime: 'application/msword', name: 'Microsoft Word (pre 2007)' },
+  { ext: 'docx', mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', name: 'Microsoft Word' },
+  { ext: 'odg', mime: 'application/vnd.oasis.opendocument.graphics', name: 'OpenOffice Draw' },
+  { ext: 'odp', mime: 'application/vnd.oasis.opendocument.presentation', name: 'OpenOffice Presentation' },
+  { ext: 'ods', mime: 'application/vnd.oasis.opendocument.spreadsheet', name: 'OpenOffice Sheets' },
+  { ext: 'odt', mime: 'application/vnd.oasis.opendocument.text', name: 'OpenOffice Text' },
+  { ext: 'pdf', mime: 'application/pdf', name: 'PDF' },
+];
+
+// Export format constants
+export const EXPORT_FORMATS = [
+  { value: 'pdf', label: 'PDF' },
+  { value: 'jpg', label: 'JPEG' },
+  { value: 'png', label: 'PNG' },
+  { value: 'gif', label: 'GIF' },
+  { value: 'pptx', label: 'PowerPoint (PPTX)' },
+  { value: 'mp4', label: 'MP4 Video' },
+];
+
+export const PDF_SIZES = [
+  { value: 'a4', label: 'A4' },
+  { value: 'a3', label: 'A3' },
+  { value: 'letter', label: 'Letter' },
+  { value: 'legal', label: 'Legal' },
+];
+
+export const MP4_QUALITIES = [
+  { value: 'horizontal_480p', label: 'Horizontal 480p' },
+  { value: 'horizontal_720p', label: 'Horizontal 720p' },
+  { value: 'horizontal_1080p', label: 'Horizontal 1080p' },
+  { value: 'horizontal_4k', label: 'Horizontal 4K' },
+  { value: 'vertical_480p', label: 'Vertical 480p' },
+  { value: 'vertical_720p', label: 'Vertical 720p' },
+  { value: 'vertical_1080p', label: 'Vertical 1080p' },
+  { value: 'vertical_4k', label: 'Vertical 4K' },
+];
+
+// File size limits
+export const MAX_IMAGE_SIZE_MB = 50;
+export const MAX_VIDEO_SIZE_MB = 500;
+export const MAX_ASSET_NAME_LENGTH = 50;
+export const MAX_DESIGN_TITLE_LENGTH = 50;
+
+// Export dimension limits
+export const MIN_EXPORT_DIMENSION = 40;
+export const MAX_EXPORT_DIMENSION = 25000;
+
+// Dynamic field helpers
+export async function fetchUserDesigns(auth: any, query?: string): Promise<Array<{ label: string; value: string }>> {
+  try {
+    const params = new URLSearchParams();
+    if (query && query.trim()) {
+      params.append('query', query.trim());
+    }
+    params.append('sort_by', 'modified_descending');
+
+    const response = await fetch(`${canvaCommon.baseUrl}/designs?${params.toString()}`, {
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+      },
+    });
+
+    if (!response.ok) return [];
+
+    const data = await response.json();
+    return (data.items || []).map((design: any) => ({
+      label: design.title || `Design ${design.id}`,
+      value: design.id,
+    }));
+  } catch (error) {
+    console.error('Failed to fetch designs:', error);
+    return [];
+  }
+}
+
+export async function fetchUserAssets(auth: any, assetType?: 'image' | 'video'): Promise<Array<{ label: string; value: string }>> {
+  try {
+    const response = await fetch(`${canvaCommon.baseUrl}/folders/root/items?item_types=image`, {
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+      },
+    });
+
+    if (!response.ok) return [];
+
+    const data = await response.json();
+    return (data.items || [])
+      .filter((item: any) => item.type === 'image' && (!assetType || item.image?.type === assetType))
+      .map((item: any) => ({
+        label: item.image?.name || `Asset ${item.image?.id}`,
+        value: item.image?.id || '',
+      }))
+      .filter((item: any) => item.value);
+  } catch (error) {
+    console.error('Failed to fetch assets:', error);
+    return [];
+  }
+}
+
+export async function fetchUserFolders(auth: any): Promise<Array<{ label: string; value: string }>> {
+  try {
+    const folders = [{ label: 'Root (Top Level)', value: 'root' }];
+    
+    const response = await fetch(`${canvaCommon.baseUrl}/folders/root/items?item_types=folder`, {
+      headers: {
+        'Authorization': `Bearer ${auth.access_token}`,
+      },
+    });
+
+    if (!response.ok) return folders;
+
+    const data = await response.json();
+    const subfolders = (data.items || [])
+      .filter((item: any) => item.type === 'folder')
+      .map((item: any) => ({
+        label: item.folder?.name || `Folder ${item.folder?.id}`,
+        value: item.folder?.id || '',
+      }))
+      .filter((item: any) => item.value);
+
+    return [...folders, ...subfolders];
+  } catch (error) {
+    console.error('Failed to fetch folders:', error);
+    return [{ label: 'Root (Top Level)', value: 'root' }];
+  }
+} 

--- a/packages/pieces/community/canva/tsconfig.json
+++ b/packages/pieces/community/canva/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/canva/tsconfig.lib.json
+++ b/packages/pieces/community/canva/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -196,6 +196,9 @@
       "@activepieces/piece-campaign-monitor": [
         "packages/pieces/community/campaign-monitor/src/index.ts"
       ],
+      "@activepieces/piece-canva": [
+        "packages/pieces/community/canva/src/index.ts"
+      ],
       "@activepieces/piece-capsule-crm": [
         "packages/pieces/community/capsule-crm/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Adds the new Canva community piece with OAuth2 authentication, core Canva actions, and custom API call support.
Also updates find_design to use the Activepieces httpClient (instead of raw fetch) and sets the piece author metadata.

### Explain How the Feature Works

- Introduces pieces-canva under packages/pieces/community/canva.
- Adds Canva OAuth2 auth (PKCE + scope validation) in the piece entrypoint.
- Adds actions:
  - Create Design
  - Import Design
  - Export Design
  - Find Design
  - Get Folder
  - Get Image
  - Move Folder Item
  - Upload Asset
- Includes createCustomApiCallAction for direct Canva REST calls.
- find_design sends requests via httpClient.sendRequest with bearer-token authentication and mapped HTTP error handling.

### Relevant User Scenarios

- Users can search their Canva designs before creating or exporting.
- Users can automate design creation/import/export flows in Activepieces.
- Users can retrieve folder/image metadata and move items between folders.
- Users can upload assets and use them in downstream Canva automations.

Fixes #8135