### PR TITLE
feat(slack): allow reaction trigger to work on multiple or all channels

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "dependencies": {
     "@slack/web-api": "7.9.0",
     "slackify-markdown": "4.4.0"

--- a/packages/pieces/community/slack/src/lib/triggers/new-reaction-added.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-reaction-added.ts
@@ -1,11 +1,11 @@
 import {
+  OAuth2PropertyValue,
   Property,
   TriggerStrategy,
   createTrigger,
 } from '@activepieces/pieces-framework';
 import { slackAuth } from '../../';
-import { slackChannel } from '../common/props';
-import { WebClient } from '@slack/web-api';
+import { getChannels, multiSelectChannelInfo } from '../common/props';
 
 
 export const newReactionAdded = createTrigger({
@@ -14,12 +14,37 @@ export const newReactionAdded = createTrigger({
   displayName: 'New Reaction',
   description: 'Triggers when a new reaction is added to a message',
   props: {
+    info: multiSelectChannelInfo,
     emojis: Property.Array({
       displayName: 'Emojis (E.g fire, smile)',
       description: 'Select emojis to trigger on',
       required: false,
     }),
-    channel: slackChannel(false),
+    channels: Property.MultiSelectDropdown({
+      auth: slackAuth,
+      displayName: 'Channels',
+      description:
+        'If no channel is selected, the flow will be triggered for reactions in all channels the app has access to',
+      required: false,
+      refreshers: [],
+      async options({ auth }) {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'connect slack account',
+            options: [],
+          };
+        }
+        const authentication = auth as OAuth2PropertyValue;
+        const accessToken = authentication['access_token'];
+        const channels = await getChannels(accessToken);
+        return {
+          disabled: false,
+          placeholder: 'Select channels',
+          options: channels,
+        };
+      },
+    }),
   },
   type: TriggerStrategy.APP_WEBHOOK,
   sampleData: undefined,
@@ -40,16 +65,20 @@ export const newReactionAdded = createTrigger({
 
   run: async (context) => {
     const payloadBody = context.payload.body as PayloadBody;
+    const channels = (context.propsValue.channels as string[]) ?? [];
+
+    // Filter by emoji if specified
     if (context.propsValue.emojis) {
       if (!context.propsValue.emojis.includes(payloadBody.event.reaction)) {
         return [];
       }
     }
-    if (context.propsValue.channel) {
-      if (payloadBody.event.item['channel'] !== context.propsValue.channel) {
-        return [];
-      }
+
+    // Filter by channels - if no channels selected, trigger for all
+    if (channels.length > 0 && !channels.includes(payloadBody.event.item.channel)) {
+      return [];
     }
+
     return [payloadBody.event];
   },
 });
@@ -62,3 +91,4 @@ type PayloadBody = {
     };
   };
 };
+


### PR DESCRIPTION
## What does this PR do?

"New reaction" trigger now allows selecting 0, 1, or multiple channels.
If no channel is selected, it is triggered on all channels the Slack app has access to.

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
