### PR TITLE
fix(cli): fix assertPieceExists func in case of missing piece

### DIFF
--- a/packages/cli/src/lib/commands/create-action.ts
+++ b/packages/cli/src/lib/commands/create-action.ts
@@ -35,7 +35,7 @@ const createAction = async (pieceName: string, displayActionName: string, action
   const actionTemplate = createActionTemplate(displayActionName, actionDescription)
   const actionName = displayNameToKebabCase(displayActionName)
   const pieceFolder = await findPiece(pieceName);
-  assertPieceExists(pieceFolder)
+  assertPieceExists(pieceFolder, pieceName)
   console.log(chalk.blue(`Piece path: ${pieceFolder}`))
   const actionsFolder = join(pieceFolder, 'src', 'lib', 'actions')
   const actionPath = join(actionsFolder, `${actionName}.ts`)

--- a/packages/cli/src/lib/commands/create-trigger.ts
+++ b/packages/cli/src/lib/commands/create-trigger.ts
@@ -94,7 +94,7 @@ const createTrigger = async (pieceName: string, displayTriggerName: string, trig
     const triggerTemplate = createTriggerTemplate(displayTriggerName, triggerDescription, triggerTechnique)
     const triggerName = displayNameToKebabCase(displayTriggerName)
     const pieceFolder = await findPiece(pieceName);
-    assertPieceExists(pieceFolder)
+    assertPieceExists(pieceFolder, pieceName)
     console.log(chalk.blue(`Piece path: ${pieceFolder}`))
 
     const triggersFolder = join(pieceFolder, 'src', 'lib', 'triggers')

--- a/packages/cli/src/lib/commands/publish-piece.ts
+++ b/packages/cli/src/lib/commands/publish-piece.ts
@@ -14,7 +14,7 @@ async function publishPiece(
     failOnError: boolean,}
 ) {
     const pieceFolder = await findPiece(pieceName);
-    assertPieceExists(pieceFolder)
+    assertPieceExists(pieceFolder, pieceName)
     await publishPieceFromFolder({
         pieceFolder,
         apiUrl,

--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -163,8 +163,8 @@ export function displayNameToCamelCase(input: string): string {
     return camelCaseWords.join('');
   }
 
-export const assertPieceExists = async (pieceName: string | null) => {
-    if (!pieceName) {
+export const assertPieceExists = (pieceFolder: string | null, pieceName: string) => {
+    if (!pieceFolder) {
       console.error(chalk.red(`🚨 Piece ${pieceName} not found`));
       process.exit(1);
     }


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->

When One tries to create an action with cli command 
`npm run cli actions create` and the piece is not there, error message displays is as follows:

<img width="477" height="83" alt="image" src="https://github.com/user-attachments/assets/f84590e3-bded-4515-9c1f-de9c9ccd54a1" />

The `assertPieceExists` function is modified to handle such case:

<img width="432" height="81" alt="image" src="https://github.com/user-attachments/assets/59fb57e4-8b36-4990-90a9-456a0b30f795" />



### Explain How the Feature Works

It shows the correct error message now, the modified ss is pasted above.


### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
