### PR TITLE
feat(linear): add OAuth2 authentication support

### DIFF
--- a/packages/pieces/community/linear/src/index.ts
+++ b/packages/pieces/community/linear/src/index.ts
@@ -10,7 +10,7 @@ import { linearNewIssue } from './lib/triggers/new-issue';
 import { linearUpdatedIssue } from './lib/triggers/updated-issue';
 import { linearRemovedIssue } from './lib/triggers/removed-issue';
 
-const markdown = `
+const apiKeyMarkdown = `
 To obtain your API key, follow these steps:
 
 1. Go to settings by clicking your profile-pic (top-left)
@@ -20,7 +20,7 @@ To obtain your API key, follow these steps:
 export const linearAuth = PieceAuth.SecretText({
   displayName: 'API Key',
   required: true,
-  description: markdown,
+  description: apiKeyMarkdown,
   validate: async ({ auth }) => {
     if (auth.startsWith('lin_api_')) {
       return {
@@ -33,11 +33,19 @@ export const linearAuth = PieceAuth.SecretText({
     };
   },
 });
+
+export const linearOAuth2Auth = PieceAuth.OAuth2({
+  displayName: 'OAuth2',
+  required: true,
+  authUrl: 'https://linear.app/oauth/authorize',
+  tokenUrl: 'https://api.linear.app/oauth/token',
+  scope: ['read', 'write', 'issues:create', 'comments:create'],
+});
+
 export const linear = createPiece({
   displayName: 'Linear',
   description: 'Issue tracking for modern software teams',
-
-  auth: linearAuth,
+  auth: [linearOAuth2Auth, linearAuth],
   minimumSupportedRelease: '0.30.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/linear.png',
   authors: ['lldiegon', 'kishanprmr', 'abuaboud'],

--- a/packages/pieces/community/linear/src/lib/common/client.ts
+++ b/packages/pieces/community/linear/src/lib/common/client.ts
@@ -1,11 +1,15 @@
-import { AppConnectionValueForAuthProperty } from '@activepieces/pieces-framework';
 import { LinearClient, LinearDocument } from '@linear/sdk';
-import { linearAuth } from '../..';
 
 export class LinearClientWrapper {
   private client: LinearClient;
-  constructor(apiKey: string) {
-    this.client = new LinearClient({ apiKey: apiKey });
+  constructor(config: { apiKey?: string; accessToken?: string }) {
+    if (config.accessToken) {
+      this.client = new LinearClient({ accessToken: config.accessToken });
+    } else if (config.apiKey) {
+      this.client = new LinearClient({ apiKey: config.apiKey });
+    } else {
+      throw new Error('Either apiKey or accessToken must be provided');
+    }
   }
   async createIssue(input: LinearDocument.IssueCreateInput) {
     return this.client.createIssue(input);
@@ -69,6 +73,11 @@ export class LinearClientWrapper {
   }
 }
 
-export function makeClient(auth: AppConnectionValueForAuthProperty<typeof linearAuth>): LinearClientWrapper {
-  return new LinearClientWrapper(auth.secret_text);
+export function makeClient(
+  auth: { access_token: string } | { secret_text: string }
+): LinearClientWrapper {
+  if ('access_token' in auth) {
+    return new LinearClientWrapper({ accessToken: auth.access_token });
+  }
+  return new LinearClientWrapper({ apiKey: auth.secret_text });
 }


### PR DESCRIPTION
## Summary

- Adds OAuth2 as an authentication option for the Linear piece alongside the existing API key auth
- Users can now connect via Linear's OAuth2 flow (`https://linear.app/oauth/authorize`) or continue using personal API keys (`lin_api_*`)
- Uses the framework's dual auth array pattern (`auth: [OAuth2, SecretText]`) so both connection types work transparently

## Changes

**`packages/pieces/community/linear/src/index.ts`**
- Added `linearOAuth2Auth` using `PieceAuth.OAuth2` with Linear's OAuth2 endpoints and scopes (`read`, `write`, `issues:create`, `comments:create`)
- Changed piece `auth` from single `linearAuth` to dual auth array `[linearOAuth2Auth, linearAuth]`

**`packages/pieces/community/linear/src/lib/common/client.ts`**
- Updated `LinearClientWrapper` constructor to accept `{ apiKey }` or `{ accessToken }` config object
- Updated `makeClient()` to detect auth type at runtime — uses `accessToken` for OAuth2 connections and `apiKey` for API key connections
- Removed unused `AppConnectionValueForAuthProperty` import

## Context

Linear natively supports OAuth2 (Authorization Code flow with PKCE, refresh tokens). The `@linear/sdk` `LinearClient` already accepts both `apiKey` and `accessToken` constructor options. This change leverages both capabilities.

No changes were needed to actions, triggers, or dropdown properties — they all call `makeClient(auth)` which now handles both auth types transparently.

## Test plan

- [ ] Verify OAuth2 connection flow works with Linear's authorize/token endpoints
- [ ] Verify existing API key connections continue to work
- [ ] Verify all 6 actions work with both auth types
- [ ] Verify all 3 webhook triggers work with both auth types
- [ ] Verify dropdown property options load correctly with both auth types