### PR TITLE
fix(worker): prevent crashes from post-response engine messages

### DIFF
--- a/packages/server/worker/src/lib/compute/sandbox/sandbox.ts
+++ b/packages/server/worker/src/lib/compute/sandbox/sandbox.ts
@@ -144,10 +144,8 @@ export const createSandbox = (log: FastifyBaseLogger, sandboxId: string, options
                 if (!isNil(timeout)) {
                     clearTimeout(timeout)
                 }
-                void sandboxWebsocketServer.removeListener(sandboxId)
                 process?.removeAllListeners('exit')
                 process?.removeAllListeners('error')
-                process?.removeAllListeners('command')
             }
         },
         shutdown: async () => {


### PR DESCRIPTION
Fixes worker instance terminations caused by engine messages arriving after execution completes.

The issue occurred when the 15-second backup interval raced with flow completion. The websocket listener was immediately removed after ENGINE_RESPONSE, but the engine's backup() could still be in-flight and would send UPLOAD_RUN_LOG afterward, causing "listeners[sandboxId] is not a function" crashes.

Changes:
- Remove premature removeListener() from execute() finally block
- Listener lifecycle now properly managed by socket disconnect events and attachListener overwrites

This ensures UPLOAD_RUN_LOG are processed correctly.