### PR TITLE
fix: don't show flow-in-use toaster when saving sample data

### DIFF
--- a/packages/server/api/src/app/flows/flow/flow.controller.ts
+++ b/packages/server/api/src/app/flows/flow/flow.controller.ts
@@ -114,7 +114,9 @@ export const flowController: FastifyPluginAsyncTypebox = async (app) => {
                 PlatformUsageMetric.ACTIVE_FLOWS,
             )
         }
-        await assertThatFlowIsNotBeingUsed(flow, userId)
+        if (request.body.type !== FlowOperationType.SAVE_SAMPLE_DATA) {
+            await assertThatFlowIsNotBeingUsed(flow, userId)
+        }
         const updatedFlow = await flowService(request.log).update({
             id: request.params.id,
             userId: request.principal.type === PrincipalType.SERVICE ? null : userId,


### PR DESCRIPTION
## What does this PR do?
Sometimes the "flow already in use" toaster appears after clicking on "test step" then loading a different step

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
