### PR TITLE
fix: remove doubled memory allocation for V8

### DIFF
--- a/packages/server/worker/src/lib/compute/sandbox/process/simple-process.ts
+++ b/packages/server/worker/src/lib/compute/sandbox/process/simple-process.ts
@@ -11,7 +11,6 @@ export const simpleProcess = (_log: FastifyBaseLogger): ProcessMaker => ({
                 // IMPORTANT DO NOT REMOVE THIS ARGUMENT: https://github.com/laverdet/isolated-vm/issues/424
                 '--no-node-snapshot',
                 `--max-old-space-size=${memoryLimitMb}`,
-                '--max-semi-space-size=64',
             ],
             env: {
                 ...env,


### PR DESCRIPTION
## What does this PR do?

`memoryLimitMb` references `AP_SANDBOX_MEMORY_LIMIT`. This makes sense to pass to `--max-old-space-size`  as the max V8 heap for long-lived objects, but this probably doesn't make sense to pass to `--max-semi-space-size`.

`--max-semi-space-size` default [is usually <= 16 MiB](https://nodejs.org/api/cli.html#--max-semi-space-sizesize-in-megabytes). Per Activepieces' [recommendations](https://www.activepieces.com/docs/flows/known-limits), this is probably 1GB / 1024MiB in actuality.

This means the actual V8 allocation is using 1GB for old heap AND 1GB for new heap (when normally V8 thinks you should use <16MiB even for a 2GB old heap). AFAIK, this means you are essentially wasting 1GB of allocation for each process (depends on your AP_SANDBOX_MEMORY_LIMIT setting, but essentially 50% wastage).

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
