### PR TITLE
feat(slack): add support for bot/user token authentication

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",
@@ -5742,7 +5743,7 @@
     },
     "packages/pieces/community/slack": {
       "name": "@activepieces/piece-slack",
-      "version": "0.12.5",
+      "version": "0.14.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.12.5",
+  "version": "0.14.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -1,9 +1,7 @@
 import { createCustomApiCallAction, httpClient, HttpMethod } from '@activepieces/pieces-common';
 import {
-    createPiece,
-    OAuth2PropertyValue,
-    PieceAuth,
-    Property,
+  createPiece,
+  Property,
 } from '@activepieces/pieces-framework';
 
 import { PieceCategory } from '@activepieces/shared';
@@ -45,184 +43,189 @@ import { newTeamCustomEmojiTrigger } from './lib/triggers/new-team-custom-emoji'
 import { inviteUserToChannelAction } from './lib/actions/invite-user-to-channel';
 import { listUsers } from './lib/actions/list-users';
 import { deleteMessageAction } from './lib/actions/delete-message';
-import { slackAuth } from './lib/auth';
 import { newModalInteractionTrigger } from './lib/triggers/new-modal-interaction';
+import { slackAuth, slackOAuth2Auth } from './lib/auth';
+import { getBotToken, getUserToken } from './lib/common/auth-helpers';
+import type { SlackAuthValue } from './lib/common/auth-helpers';
+
+export { slackAuth, slackOAuth2Auth } from './lib/auth';
 
 export const slack = createPiece({
-    displayName: 'Slack',
-    description: 'Channel-based messaging platform',
-    minimumSupportedRelease: '0.66.7',
-    logoUrl: 'https://cdn.activepieces.com/pieces/slack.png',
-    categories: [PieceCategory.COMMUNICATION],
-    auth: slackAuth,
-    events: {
-        parseAndReply: ({ payload, server }) => {
-            if (payload.headers['content-type'] === 'application/x-www-form-urlencoded') {
-                if (payload.body && typeof payload.body == 'object' && 'payload' in payload.body) {
-                    const interactionPayloadBody = JSON.parse(
-                        (payload.body as { payload: string }).payload,
-                    ) as InteractionPayloadBody;
-                    if (interactionPayloadBody.type === 'block_actions') {
-                        const action = interactionPayloadBody.actions?.[0];
-                        if (
-                            action &&
-                            action.type === 'button' &&
-                            action.value?.startsWith(server.publicUrl)
-                        ) {
-                            // We don't await the promise as we don't handle the response anyway
-                            httpClient.sendRequest({
-                                url: action.value,
-                                method: HttpMethod.POST,
-                                body: interactionPayloadBody,
-                            });
-                        }
-                    } else if (
-                        interactionPayloadBody.type === 'view_submission' ||
-                        interactionPayloadBody.type === 'view_closed'
-                    ) {
-                        const viewModalPayload = interactionPayloadBody as unknown as {
-                            type: string;
-                            team: {
-                                id: string;
-                                token: string;
-                                api_app_id: string;
-                            };
-                        };
-
-                        return {
-                            event: viewModalPayload.type,
-                            identifierValue: viewModalPayload.team.id,
-                        };
-                    }
-                }
-                return {
-                    reply: {
-                        headers: {},
-                        body: {},
-                    },
-                };
-            } else {
-                const eventPayloadBody = payload.body as EventPayloadBody;
-                if (eventPayloadBody.challenge) {
-                    return {
-                        reply: {
-                            body: eventPayloadBody['challenge'],
-                            headers: {},
-                        },
-                    };
-                }
-
-                return {
-                    event: eventPayloadBody?.event?.type,
-                    identifierValue: eventPayloadBody.team_id,
-                };
+  displayName: 'Slack',
+  description: 'Channel-based messaging platform',
+  minimumSupportedRelease: '0.79.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/slack.png',
+  categories: [PieceCategory.COMMUNICATION],
+  auth: slackAuth,
+  events: {
+    parseAndReply: ({ payload, server }) => {
+      if (payload.headers['content-type'] === 'application/x-www-form-urlencoded') {
+        if (payload.body && typeof payload.body == 'object' && 'payload' in payload.body) {
+          const interactionPayloadBody = JSON.parse(
+            (payload.body as { payload: string }).payload,
+          ) as InteractionPayloadBody;
+          if (interactionPayloadBody.type === 'block_actions') {
+            const action = interactionPayloadBody.actions?.[0];
+            if (
+              action &&
+              action.type === 'button' &&
+              action.value?.startsWith(server.publicUrl)
+            ) {
+              // We don't await the promise as we don't handle the response anyway
+              httpClient.sendRequest({
+                url: action.value,
+                method: HttpMethod.POST,
+                body: interactionPayloadBody,
+              });
             }
-        },
-        verify: ({ webhookSecret, payload }) => {
-            // Construct the signature base string
-            const timestamp = payload.headers['x-slack-request-timestamp'];
-            const signature = payload.headers['x-slack-signature'];
-            const signatureBaseString = `v0:${timestamp}:${payload.rawBody}`;
-            const hmac = crypto.createHmac('sha256', webhookSecret as string);
-            hmac.update(signatureBaseString);
-            const computedSignature = `v0=${hmac.digest('hex')}`;
-            return signature === computedSignature;
-        },
+          } else if (
+            interactionPayloadBody.type === 'view_submission' ||
+            interactionPayloadBody.type === 'view_closed'
+          ) {
+            const viewModalPayload = interactionPayloadBody as unknown as {
+              type: string;
+              team: {
+                id: string;
+                token: string;
+                api_app_id: string;
+              };
+            };
+
+            return {
+              event: viewModalPayload.type,
+              identifierValue: viewModalPayload.team.id,
+            };
+          }
+        }
+        return {
+          reply: {
+            headers: {},
+            body: {},
+          },
+        };
+      } else {
+        const eventPayloadBody = payload.body as EventPayloadBody;
+        if (eventPayloadBody.challenge) {
+          return {
+            reply: {
+              body: eventPayloadBody['challenge'],
+              headers: {},
+            },
+          };
+        }
+
+        return {
+          event: eventPayloadBody?.event?.type,
+          identifierValue: eventPayloadBody.team_id,
+        };
+      }
     },
-    authors: [
-        'rita-gorokhod',
-        'AdamSelene',
-        'Abdallah-Alwarawreh',
-        'kishanprmr',
-        'MoShizzle',
-        'AbdulTheActivePiecer',
-        'khaledmashaly',
-        'abuaboud',
-    ],
-    actions: [
-        addRectionToMessageAction,
-        slackSendDirectMessageAction,
-        slackSendMessageAction,
-        requestApprovalDirectMessageAction,
-        requestSendApprovalMessageAction,
-        requestActionDirectMessageAction,
-        requestActionMessageAction,
-        uploadFile,
-        getFileAction,
-        searchMessages,
-        findUserByEmailAction,
-        findUserByHandleAction,
-        findUserByIdAction,
-        listUsers,
-        updateMessage,
-        deleteMessageAction,
-        createChannelAction,
-        updateProfileAction,
-        getChannelHistory,
-        setUserStatusAction,
-        markdownToSlackFormat,
-        retrieveThreadMessages,
-        setChannelTopicAction,
-        getMessageAction,
-        inviteUserToChannelAction,
-        createCustomApiCallAction({
-            baseUrl: () => {
-                return 'https://slack.com/api';
-            },
-            auth: slackAuth,
-            authMapping: async (auth, propsValue) => {
-                if (propsValue.useUserToken) {
-                    return {
-                        Authorization: `Bearer ${
-                            (auth as OAuth2PropertyValue).data['authed_user']?.access_token
-                        }`,
-                    };
-                } else {
-                    return {
-                        Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
-                    };
-                }
-            },
-            extraProps: {
-                useUserToken: Property.Checkbox({
-                    displayName: 'Use user token',
-                    description: 'Use user token instead of bot token',
-                    required: true,
-                    defaultValue: false,
-                }),
-            },
+    verify: ({ webhookSecret, payload }) => {
+      // Construct the signature base string
+      const timestamp = payload.headers['x-slack-request-timestamp'];
+      const signature = payload.headers['x-slack-signature'];
+      const signatureBaseString = `v0:${timestamp}:${payload.rawBody}`;
+      const hmac = crypto.createHmac('sha256', webhookSecret as string);
+      hmac.update(signatureBaseString);
+      const computedSignature = `v0=${hmac.digest('hex')}`;
+      return signature === computedSignature;
+    },
+  },
+  authors: [
+    'rita-gorokhod',
+    'AdamSelene',
+    'Abdallah-Alwarawreh',
+    'kishanprmr',
+    'MoShizzle',
+    'AbdulTheActivePiecer',
+    'khaledmashaly',
+    'abuaboud',
+  ],
+  actions: [
+    addRectionToMessageAction,
+    slackSendDirectMessageAction,
+    slackSendMessageAction,
+    requestApprovalDirectMessageAction,
+    requestSendApprovalMessageAction,
+    requestActionDirectMessageAction,
+    requestActionMessageAction,
+    uploadFile,
+    getFileAction,
+    searchMessages,
+    findUserByEmailAction,
+    findUserByHandleAction,
+    findUserByIdAction,
+    listUsers,
+    updateMessage,
+    deleteMessageAction,
+    createChannelAction,
+    updateProfileAction,
+    getChannelHistory,
+    setUserStatusAction,
+    markdownToSlackFormat,
+    retrieveThreadMessages,
+    setChannelTopicAction,
+    getMessageAction,
+    inviteUserToChannelAction,
+    createCustomApiCallAction({
+      baseUrl: () => {
+        return 'https://slack.com/api';
+      },
+      auth: slackAuth,
+      authMapping: async (auth, propsValue) => {
+        const typedAuth = auth as SlackAuthValue;
+        if (propsValue.useUserToken) {
+          const userToken = getUserToken(typedAuth);
+          if (userToken) {
+            return {
+              Authorization: `Bearer ${userToken}`,
+            };
+          }
+        }
+        return {
+          Authorization: `Bearer ${getBotToken(typedAuth)}`,
+        };
+      },
+      extraProps: {
+        useUserToken: Property.Checkbox({
+          displayName: 'Use user token',
+          description: 'Use user token instead of bot token',
+          required: true,
+          defaultValue: false,
         }),
-    ],
-    triggers: [
-        newMessageTrigger,
-        newMessageInChannelTrigger,
-        newDirectMessageTrigger,
-        newMention,
-        newMentionInDirectMessageTrigger,
-        newReactionAdded,
-        channelCreated,
-        newCommand,
-        newCommandInDirectMessageTrigger,
-        newUserTrigger,
-        newSavedMessageTrigger,
-        newTeamCustomEmojiTrigger,
-        newModalInteractionTrigger,
-    ],
+      },
+    }),
+  ],
+  triggers: [
+    newMessageTrigger,
+    newMessageInChannelTrigger,
+    newDirectMessageTrigger,
+    newMention,
+    newMentionInDirectMessageTrigger,
+    newReactionAdded,
+    channelCreated,
+    newCommand,
+    newCommandInDirectMessageTrigger,
+    newUserTrigger,
+    newSavedMessageTrigger,
+    newTeamCustomEmojiTrigger,
+    newModalInteractionTrigger,
+  ],
 });
 
 type EventPayloadBody = {
-    // Event payload
-    challenge: string;
-    event: {
-        type: string;
-    };
-    team_id: string;
+  // Event payload
+  challenge: string;
+  event: {
+    type: string;
+  };
+  team_id: string;
 };
 type InteractionPayloadBody = {
-    // Interaction payload
-    type?: string;
-    actions?: {
-        type: string;
-        value: string;
-    }[];
+  // Interaction payload
+  type?: string;
+  actions?: {
+    type: string;
+    value: string;
+  }[];
 };

--- a/packages/pieces/community/slack/src/lib/actions/add-reaction-to-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/add-reaction-to-message.ts
@@ -4,6 +4,7 @@ import { singleSelectChannelInfo, slackChannel } from '../common/props';
 
 import { WebClient } from '@slack/web-api';
 import { processMessageTimestamp } from '../common/utils';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const addRectionToMessageAction = createAction({
   auth: slackAuth,
@@ -30,7 +31,7 @@ export const addRectionToMessageAction = createAction({
   async run(context) {
     const { channel, ts, reaction } = context.propsValue;
 
-    const slack = new WebClient(context.auth.access_token);
+    const slack = new WebClient(getBotToken(context.auth as SlackAuthValue));
 
     const messageTimestamp = processMessageTimestamp(ts);
 

--- a/packages/pieces/community/slack/src/lib/actions/create-channel.ts
+++ b/packages/pieces/community/slack/src/lib/actions/create-channel.ts
@@ -1,6 +1,7 @@
 import { slackAuth } from '../auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const createChannelAction = createAction({
   auth: slackAuth,
@@ -19,7 +20,7 @@ export const createChannelAction = createAction({
     }),
   },
   async run({ auth, propsValue }) {
-    const client = new WebClient(auth.access_token);
+    const client = new WebClient(getBotToken(auth as SlackAuthValue));
     return await client.conversations.create({
       name: propsValue.channelName,
       is_private: propsValue.isPrivate,

--- a/packages/pieces/community/slack/src/lib/actions/delete-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/delete-message.ts
@@ -3,6 +3,7 @@ import { slackAuth } from '../auth';
 import { singleSelectChannelInfo, slackChannel } from '../common/props';
 import { processMessageTimestamp } from '../common/utils';
 import { WebClient } from '@slack/web-api';
+import { requireUserToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const deleteMessageAction = createAction({
   name: 'delete-message',
@@ -25,8 +26,7 @@ export const deleteMessageAction = createAction({
       throw new Error('Invalid Timestamp Value.');
     }
 
-        const userAccessToken = auth.data?.authed_user?.access_token;
-
+    const userAccessToken = requireUserToken(auth as SlackAuthValue);
     const client = new WebClient(userAccessToken);
 
     const historyResponse = await client.conversations.history({
@@ -41,13 +41,6 @@ export const deleteMessageAction = createAction({
     if (!message) {
       throw new Error('No message found for the provided timestamp.');
     }
-
-
-    if (!userAccessToken) {
-      throw new Error('User access token is missing.');
-    }
-
-    // const userClient = new WebClient(userAccessToken);
 
     return client.chat.delete({
       channel: propsValue.channel,

--- a/packages/pieces/community/slack/src/lib/actions/find-user-by-email.ts
+++ b/packages/pieces/community/slack/src/lib/actions/find-user-by-email.ts
@@ -1,6 +1,7 @@
 import { slackAuth } from '../auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const findUserByEmailAction = createAction({
   auth: slackAuth,
@@ -15,7 +16,7 @@ export const findUserByEmailAction = createAction({
   },
   async run({ auth, propsValue }) {
     const email = propsValue.email;
-    const client = new WebClient(auth.access_token);
+    const client = new WebClient(getBotToken(auth as SlackAuthValue));
     return await client.users.lookupByEmail({
       email,
     });

--- a/packages/pieces/community/slack/src/lib/actions/find-user-by-handle.ts
+++ b/packages/pieces/community/slack/src/lib/actions/find-user-by-handle.ts
@@ -1,6 +1,7 @@
 import { slackAuth } from '../auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { UsersListResponse, WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const findUserByHandleAction = createAction({
   auth: slackAuth,
@@ -16,7 +17,7 @@ export const findUserByHandleAction = createAction({
   },
   async run({ auth, propsValue }) {
     const handle = propsValue.handle.replace('@', '');
-    const client = new WebClient(auth.access_token);
+    const client = new WebClient(getBotToken(auth as SlackAuthValue));
     for await (const page of client.paginate('users.list', {
       limit: 1000, // Only limits page size, not total number of results
     })) {

--- a/packages/pieces/community/slack/src/lib/actions/find-user-by-id.ts
+++ b/packages/pieces/community/slack/src/lib/actions/find-user-by-id.ts
@@ -1,6 +1,7 @@
 import { slackAuth } from '../auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const findUserByIdAction = createAction({
 	auth: slackAuth,
@@ -14,7 +15,7 @@ export const findUserByIdAction = createAction({
 		}),
 	},
 	async run({ auth, propsValue }) {
-		const client = new WebClient(auth.access_token);
+		const client = new WebClient(getBotToken(auth as SlackAuthValue));
 		return await client.users.profile.get({
 			user: propsValue.id,
 		});

--- a/packages/pieces/community/slack/src/lib/actions/get-channel-history.ts
+++ b/packages/pieces/community/slack/src/lib/actions/get-channel-history.ts
@@ -2,6 +2,7 @@ import { ConversationsHistoryResponse, WebClient } from '@slack/web-api';
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
 import { singleSelectChannelInfo, slackChannel } from '../common/props';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const getChannelHistory = createAction({
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
@@ -40,7 +41,7 @@ export const getChannelHistory = createAction({
     }),
   },
   async run({ auth, propsValue }) {
-    const client = new WebClient(auth.access_token);
+    const client = new WebClient(getBotToken(auth as SlackAuthValue));
     const messages = [];
     await client.conversations.history({ channel: propsValue.channel });
     for await (const page of client.paginate('conversations.history', {

--- a/packages/pieces/community/slack/src/lib/actions/get-file.ts
+++ b/packages/pieces/community/slack/src/lib/actions/get-file.ts
@@ -2,6 +2,7 @@ import { slackAuth } from '../auth';
 import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const getFileAction = createAction({
 	auth: slackAuth,
@@ -16,7 +17,7 @@ export const getFileAction = createAction({
 		}),
 	},
 	async run(context) {
-		const client = new WebClient(context.auth.access_token);
+		const client = new WebClient(getBotToken(context.auth as SlackAuthValue));
 
 		const fileData = await client.files.info({ file: context.propsValue.fileId });
 
@@ -31,7 +32,7 @@ export const getFileAction = createAction({
 			url: fileDownloadUrl,
 			authentication: {
 				type: AuthenticationType.BEARER_TOKEN,
-				token: context.auth.access_token,
+				token: getBotToken(context.auth as SlackAuthValue),
 			},
 			responseType: 'arraybuffer',
 		});

--- a/packages/pieces/community/slack/src/lib/actions/get-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/get-message.ts
@@ -3,6 +3,7 @@ import { slackAuth } from '../auth';
 import { singleSelectChannelInfo, slackChannel } from '../common/props';
 import { processMessageTimestamp } from '../common/utils';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const getMessageAction = createAction({
 	name: 'get-message',
@@ -24,7 +25,7 @@ export const getMessageAction = createAction({
 		if (!messageTimestamp) {
 			throw new Error('Invalid Timestamp Value.');
 		}
-		const client = new WebClient(auth.access_token);
+		const client = new WebClient(getBotToken(auth as SlackAuthValue));
 
 		return await client.conversations.history({
 			channel: propsValue.channel,

--- a/packages/pieces/community/slack/src/lib/actions/invite-user-to-channel.ts
+++ b/packages/pieces/community/slack/src/lib/actions/invite-user-to-channel.ts
@@ -2,6 +2,7 @@ import { slackAuth } from '../auth';
 import { createAction } from '@activepieces/pieces-framework';
 import { singleSelectChannelInfo, slackChannel, userId } from '../common/props';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const inviteUserToChannelAction = createAction({
 	auth: slackAuth,
@@ -14,7 +15,7 @@ export const inviteUserToChannelAction = createAction({
 		userId,
 	},
 	async run(context) {
-		const client = new WebClient(context.auth.access_token);
+		const client = new WebClient(getBotToken(context.auth as SlackAuthValue));
 
 		return await client.conversations.invite({
 			channel: context.propsValue.channel,

--- a/packages/pieces/community/slack/src/lib/actions/list-users.ts
+++ b/packages/pieces/community/slack/src/lib/actions/list-users.ts
@@ -2,6 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { UsersListResponse, WebClient } from '@slack/web-api';
 import { slackAuth } from '../auth';
 import { Member } from '@slack/web-api/dist/types/response/UsersListResponse';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const listUsers = createAction({
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
@@ -22,7 +23,7 @@ export const listUsers = createAction({
   },
   auth: slackAuth,
   async run({ auth, propsValue }) {
-    const client = new WebClient(auth.access_token);
+    const client = new WebClient(getBotToken(auth as SlackAuthValue));
     const results: Member[] = [];
     for await (const page of client.paginate('users.list', {
       limit: 1000, // Only limits page size, not total number of results

--- a/packages/pieces/community/slack/src/lib/actions/request-approval-direct-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/request-approval-direct-message.ts
@@ -8,6 +8,7 @@ import {
 } from '@activepieces/shared';
 import { profilePicture, text, userId, username, mentionOriginFlow } from '../common/props';
 import { ChatPostMessageResponse, WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const requestApprovalDirectMessageAction = createAction({
   auth: slackAuth,
@@ -24,7 +25,7 @@ export const requestApprovalDirectMessageAction = createAction({
   },
   async run(context) {
     if (context.executionType === ExecutionType.BEGIN) {
-      const token = context.auth.access_token;
+      const token = getBotToken(context.auth as SlackAuthValue);
       const { userId, username, profilePicture, mentionOriginFlow } = context.propsValue;
 
       assertNotNullOrUndefined(token, 'token');

--- a/packages/pieces/community/slack/src/lib/actions/request-approval-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/request-approval-message.ts
@@ -15,6 +15,7 @@ import {
   mentionOriginFlow,
 } from '../common/props';
 import { ChatPostMessageResponse, WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const requestSendApprovalMessageAction = createAction({
   auth: slackAuth,
@@ -32,7 +33,7 @@ export const requestSendApprovalMessageAction = createAction({
   },
   async run(context) {
     if (context.executionType === ExecutionType.BEGIN) {
-      const token = context.auth.access_token;
+      const token = getBotToken(context.auth as SlackAuthValue);
       const { channel, username, profilePicture, mentionOriginFlow } = context.propsValue;
 
       assertNotNullOrUndefined(token, 'token');

--- a/packages/pieces/community/slack/src/lib/actions/retrieve-thread-messages.ts
+++ b/packages/pieces/community/slack/src/lib/actions/retrieve-thread-messages.ts
@@ -3,6 +3,7 @@ import { slackAuth } from '../auth';
 import { WebClient } from '@slack/web-api';
 import { slackChannel } from '../common/props';
 import { processMessageTimestamp } from '../common/utils';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const retrieveThreadMessages = createAction({
   name: 'retrieveThreadMessages',
@@ -19,7 +20,7 @@ export const retrieveThreadMessages = createAction({
     }),
   },
   async run({ auth, propsValue }) {
-    const client = new WebClient(auth.access_token);
+    const client = new WebClient(getBotToken(auth as SlackAuthValue));
       const messageTimestamp = processMessageTimestamp(propsValue.threadTs);
         if (!messageTimestamp) {
           throw new Error('Invalid Timestamp Value.');

--- a/packages/pieces/community/slack/src/lib/actions/search-messages.ts
+++ b/packages/pieces/community/slack/src/lib/actions/search-messages.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
 import { WebClient } from '@slack/web-api';
+import { requireUserToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const searchMessages = createAction({
   name: 'searchMessages',
@@ -14,14 +15,7 @@ export const searchMessages = createAction({
     }),
   },
   async run({ auth, propsValue }) {
-    const userToken = auth.data['authed_user']?.access_token;
-    if (userToken === undefined) {
-      throw new Error(JSON.stringify(
-        {
-          message: 'Missing user token, please re-authenticate'
-        }
-      ));
-    }
+    const userToken = requireUserToken(auth as SlackAuthValue);
     const client = new WebClient(userToken);
     const matches = [];
 

--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
@@ -12,6 +12,7 @@ import {
   iconEmoji,
 } from '../common/props';
 import { Block,KnownBlock } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 
 export const slackSendDirectMessageAction = createAction({
@@ -35,7 +36,7 @@ export const slackSendDirectMessageAction = createAction({
     }),
   },
   async run(context) {
-    const token = context.auth.access_token;
+    const token = getBotToken(context.auth as SlackAuthValue);
     const { text, userId, blocks, unfurlLinks, mentionOriginFlow } = context.propsValue;
 
     assertNotNullOrUndefined(token, 'token');

--- a/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
@@ -12,6 +12,7 @@ import {
 import { buildFlowOriginContextBlock, processMessageTimestamp, slackSendMessage, textToSectionBlocks } from '../common/utils';
 import { slackAuth } from '../auth';
 import { Block,KnownBlock } from '@slack/web-api';
+import { getBotToken, requireUserToken, SlackAuthValue } from '../common/auth-helpers';
 
 
 export const slackSendMessageAction = createAction({
@@ -59,7 +60,7 @@ export const slackSendMessageAction = createAction({
     const { text, channel,sendAsBot, username, profilePicture, iconEmoji, threadTs, file, mentionOriginFlow, blocks, replyBroadcast, unfurlLinks } =
       context.propsValue;
 
-    const token = sendAsBot ?context.auth.access_token :context.auth.data?.authed_user?.access_token ;
+    const token = sendAsBot ? getBotToken(context.auth as SlackAuthValue) : requireUserToken(context.auth as SlackAuthValue);
 
     if (!text && (!blocks || !Array.isArray(blocks) || blocks.length === 0)) {
       throw new Error('Either Message or Block Kit blocks must be provided');

--- a/packages/pieces/community/slack/src/lib/actions/set-channel-topic.ts
+++ b/packages/pieces/community/slack/src/lib/actions/set-channel-topic.ts
@@ -2,6 +2,7 @@ import { slackAuth } from '../auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { singleSelectChannelInfo, slackChannel } from '../common/props';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const setChannelTopicAction = createAction({
 	auth: slackAuth,
@@ -18,7 +19,7 @@ export const setChannelTopicAction = createAction({
 	},
 	async run(context) {
 		const { channel, topic } = context.propsValue;
-		const client = new WebClient(context.auth.access_token);
+		const client = new WebClient(getBotToken(context.auth as SlackAuthValue));
 
 		return await client.conversations.setTopic({
 			channel,

--- a/packages/pieces/community/slack/src/lib/actions/set-user-status.ts
+++ b/packages/pieces/community/slack/src/lib/actions/set-user-status.ts
@@ -3,6 +3,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { WebClient } from '@slack/web-api';
 import { z } from 'zod';
 import { propsValidation } from '@activepieces/pieces-common';
+import { requireUserToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const setUserStatusAction = createAction({
   auth: slackAuth,
@@ -31,7 +32,7 @@ export const setUserStatusAction = createAction({
       text: z.string().max(100),
     });
 
-    const client = new WebClient(auth.data['authed_user']?.access_token);
+    const client = new WebClient(requireUserToken(auth as SlackAuthValue));
     return await client.users.profile.set({
       profile: {
         status_text: propsValue.text,

--- a/packages/pieces/community/slack/src/lib/actions/update-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/update-message.ts
@@ -3,6 +3,7 @@ import { slackAuth } from '../auth';
 import { blocks, singleSelectChannelInfo, slackChannel, mentionOriginFlow } from '../common/props';
 import { buildFlowOriginContextBlock, processMessageTimestamp, textToSectionBlocks } from '../common/utils';
 import { Block,KnownBlock, WebClient } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const updateMessage = createAction({
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
@@ -33,7 +34,7 @@ export const updateMessage = createAction({
     if (!messageTimestamp) {
       throw new Error('Invalid Timestamp Value.');
     }
-    const client = new WebClient(auth.access_token);
+    const client = new WebClient(getBotToken(auth as SlackAuthValue));
 
     const blockList: (KnownBlock | Block)[] = [...textToSectionBlocks(propsValue.text)];
 

--- a/packages/pieces/community/slack/src/lib/actions/update-profile.ts
+++ b/packages/pieces/community/slack/src/lib/actions/update-profile.ts
@@ -1,6 +1,7 @@
 import { slackAuth } from '../auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { WebClient } from '@slack/web-api';
+import { requireUserToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const updateProfileAction = createAction({
   auth: slackAuth,
@@ -29,7 +30,7 @@ export const updateProfileAction = createAction({
     }),
   },
   async run({ auth, propsValue }) {
-    const client = new WebClient(auth.data['authed_user']?.access_token);
+    const client = new WebClient(requireUserToken(auth as SlackAuthValue));
     return client.users.profile.set({
       profile: {
         first_name: propsValue.firstName,

--- a/packages/pieces/community/slack/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/slack/src/lib/actions/upload-file.ts
@@ -4,6 +4,7 @@ import { WebClient } from '@slack/web-api';
 import {
   slackChannel,
 } from '../common/props';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 
 export const uploadFile = createAction({
   auth: slackAuth,
@@ -26,7 +27,7 @@ export const uploadFile = createAction({
     channel: slackChannel(false),
   },
   async run(context) {
-    const token = context.auth.access_token;
+    const token = getBotToken(context.auth as SlackAuthValue);
     const { file, title, filename, channel } = context.propsValue;
     const client = new WebClient(token);
     return await client.files.uploadV2({

--- a/packages/pieces/community/slack/src/lib/auth.ts
+++ b/packages/pieces/community/slack/src/lib/auth.ts
@@ -1,7 +1,9 @@
 import { PieceAuth } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 
-export const slackAuth = PieceAuth.OAuth2({
-  description: '',
+export const slackOAuth2Auth = PieceAuth.OAuth2({
+  description:
+    'Authenticate via a Slack OAuth flow.',
   authUrl:
     'https://slack.com/oauth/v2/authorize?user_scope=search:read,users.profile:write,reactions:read,im:history,stars:read,channels:write,groups:write,im:write,mpim:write,channels:write.invites,groups:write.invites,channels:history,groups:history,chat:write,users:read',
   tokenUrl: 'https://slack.com/api/oauth.v2.access',
@@ -36,3 +38,42 @@ export const slackAuth = PieceAuth.OAuth2({
     'groups:write.invites',
   ],
 });
+
+const slackCustomAuth = PieceAuth.CustomAuth({
+  description: 'Authenticate using a Slack bot token (and optional user token).',
+  required: true,
+  props: {
+    botToken: PieceAuth.SecretText({
+      displayName: 'Bot Token',
+      description: 'The bot token for your Slack app (starts with xoxb-)',
+      required: true,
+    }),
+    userToken: PieceAuth.SecretText({
+      displayName: 'User Token',
+      description: 'Optional user token for actions that require user-level access (starts with xoxp-)',
+      required: false,
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      const response = await httpClient.sendRequest<{ ok: boolean; error?: string }>({
+        method: HttpMethod.GET,
+        url: 'https://slack.com/api/auth.test',
+        headers: {
+          Authorization: `Bearer ${auth.botToken}`,
+        },
+      });
+      if (!response.body.ok) {
+        return {
+          valid: false,
+          error: `Slack auth.test failed: ${response.body.error}`,
+        };
+      }
+      return { valid: true };
+    } catch (e) {
+      return { valid: false, error: (e as Error).message };
+    }
+  },
+});
+
+export const slackAuth = [slackOAuth2Auth, slackCustomAuth];

--- a/packages/pieces/community/slack/src/lib/common/auth-helpers.ts
+++ b/packages/pieces/community/slack/src/lib/common/auth-helpers.ts
@@ -1,0 +1,84 @@
+import { AppConnectionType } from '@activepieces/shared';
+import { AppConnectionValueForAuthProperty } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import type { slackAuth } from '../auth';
+
+export type SlackAuthValue = AppConnectionValueForAuthProperty<
+  typeof slackAuth
+>;
+
+type SlackOAuth2Auth = {
+  type:
+    | AppConnectionType.OAUTH2
+    | AppConnectionType.CLOUD_OAUTH2
+    | AppConnectionType.PLATFORM_OAUTH2;
+  access_token: string;
+  data: Record<string, unknown>;
+};
+
+type SlackCustomAuth = {
+  type: AppConnectionType.CUSTOM_AUTH;
+  props: {
+    botToken: string;
+    userToken?: string;
+  };
+};
+
+type SlackAuth = SlackOAuth2Auth | SlackCustomAuth;
+
+function isCustomAuth(auth: SlackAuth): auth is SlackCustomAuth {
+  return auth.type === AppConnectionType.CUSTOM_AUTH;
+}
+
+export function getBotToken(auth: SlackAuthValue): string {
+  const a = auth as SlackAuth;
+  if (isCustomAuth(a)) {
+    return a.props.botToken;
+  }
+  return a.access_token;
+}
+
+export function getUserToken(auth: SlackAuthValue): string | undefined {
+  const a = auth as SlackAuth;
+  if (isCustomAuth(a)) {
+    return a.props.userToken || undefined;
+  }
+  return (a.data?.['authed_user'] as Record<string, string> | undefined)
+    ?.access_token;
+}
+
+export function requireUserToken(auth: SlackAuthValue): string {
+  const token = getUserToken(auth);
+  if (!token) {
+    throw new Error(
+      JSON.stringify({
+        message: 'Missing user token, please re-authenticate',
+      })
+    );
+  }
+  return token;
+}
+
+export async function getTeamId(auth: SlackAuthValue): Promise<string> {
+  const a = auth as SlackAuth;
+  if (!isCustomAuth(a)) {
+    return (
+      (a.data['team_id'] as string) ??
+      (a.data['team'] as Record<string, string>)['id']
+    );
+  }
+  const response = await httpClient.sendRequest<{
+    ok: boolean;
+    team_id: string;
+  }>({
+    method: HttpMethod.GET,
+    url: 'https://slack.com/api/auth.test',
+    headers: {
+      Authorization: `Bearer ${a.props.botToken}`,
+    },
+  });
+  if (!response.body.ok) {
+    throw new Error('Failed to get team ID from Slack auth.test');
+  }
+  return response.body.team_id;
+}

--- a/packages/pieces/community/slack/src/lib/common/props.ts
+++ b/packages/pieces/community/slack/src/lib/common/props.ts
@@ -1,6 +1,7 @@
-import { OAuth2PropertyValue, Property } from '@activepieces/pieces-framework';
+import { Property } from '@activepieces/pieces-framework';
 import { UsersListResponse, WebClient } from '@slack/web-api';
 import { slackAuth } from '../auth';
+import { getBotToken, SlackAuthValue } from '../common/auth-helpers';
 const slackChannelBotInstruction = `
 	Please make sure add the bot to the channel by following these steps:
 	  1. Type /invite in the channel's chat.
@@ -37,8 +38,7 @@ export const slackChannel = <R extends boolean>(required: R) =>
           options: [],
         };
       }
-      const authentication = auth as OAuth2PropertyValue;
-      const accessToken = authentication['access_token'];
+      const accessToken = getBotToken(auth as SlackAuthValue);
 
       const channels = await getChannels(accessToken);
 
@@ -104,7 +104,7 @@ export const userId = Property.Dropdown<string,true,typeof slackAuth>({
       };
     }
 
-    const accessToken = (auth as OAuth2PropertyValue).access_token;
+    const accessToken = getBotToken(auth as SlackAuthValue);
 
     const client = new WebClient(accessToken);
     const users: { label: string; value: string }[] = [];

--- a/packages/pieces/community/slack/src/lib/common/request-action.ts
+++ b/packages/pieces/community/slack/src/lib/common/request-action.ts
@@ -6,6 +6,7 @@ import {
 } from './utils';
 import { assertNotNullOrUndefined, ExecutionType, PauseType } from '@activepieces/shared';
 import { ChatPostMessageResponse } from '@slack/web-api';
+import { getBotToken, SlackAuthValue } from './auth-helpers';
 
 export const requestAction = async (conversationId: string, context: any) => {
     const { actions } = context.propsValue;
@@ -35,7 +36,7 @@ export const requestAction = async (conversationId: string, context: any) => {
             },
         });
 
-        const token = context.auth.access_token;
+        const token = getBotToken(context.auth as SlackAuthValue);
         const { text, username, profilePicture } = context.propsValue;
 
         assertNotNullOrUndefined(token, 'token');

--- a/packages/pieces/community/slack/src/lib/triggers/new-channel.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-channel.ts
@@ -1,6 +1,7 @@
 import { TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 const sampleData = {
   type: 'channel_created',
@@ -21,9 +22,7 @@ export const channelCreated = createTrigger({
   type: TriggerStrategy.APP_WEBHOOK,
   sampleData: sampleData,
   onEnable: async (context) => {
-    // Older OAuth2 has team_id, newer has team.id
-    const teamId =
-      context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+    const teamId = await getTeamId(context.auth as SlackAuthValue);
     context.app.createListeners({
       events: ['channel_created'],
       identifierValue: teamId,
@@ -33,7 +32,7 @@ export const channelCreated = createTrigger({
     // Ignored
   },
   test: async (context) => {
-    const client = new WebClient(context.auth.access_token);
+    const client = new WebClient(getBotToken(context.auth as SlackAuthValue));
     const response = await client.conversations.list({
       exclude_archived: true,
       limit: 10,

--- a/packages/pieces/community/slack/src/lib/triggers/new-command-in-direct-message.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-command-in-direct-message.ts
@@ -4,11 +4,11 @@ import {
   createTrigger,
 } from '@activepieces/pieces-framework';
 import { userId } from '../common/props';
-import { slackAuth } from '../auth';
+import { slackOAuth2Auth } from '../auth';
 import { parseCommand } from '../common/utils';
 
 export const newCommandInDirectMessageTrigger = createTrigger({
-  auth: slackAuth,
+  auth: slackOAuth2Auth,
   name: 'new-command-in-direct-message',
   displayName: 'New Command in Direct Message',
   description:

--- a/packages/pieces/community/slack/src/lib/triggers/new-command.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-command.ts
@@ -1,5 +1,4 @@
 import {
-  OAuth2PropertyValue,
   Property,
   TriggerStrategy,
   createTrigger,
@@ -7,6 +6,7 @@ import {
 import { getChannels, multiSelectChannelInfo, userId } from '../common/props';
 import { slackAuth } from '../auth';
 import { parseCommand } from '../common/utils';
+import { getBotToken, getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 export const newCommand = createTrigger({
   auth: slackAuth,
@@ -39,8 +39,7 @@ export const newCommand = createTrigger({
             options: [],
           };
         }
-        const authentication = auth as OAuth2PropertyValue;
-        const accessToken = authentication['access_token'];
+        const accessToken = getBotToken(auth as SlackAuthValue);
         const channels = await getChannels(accessToken);
         return {
           disabled: false,
@@ -58,9 +57,7 @@ export const newCommand = createTrigger({
   type: TriggerStrategy.APP_WEBHOOK,
   sampleData: undefined,
   onEnable: async (context) => {
-    // Older OAuth2 has team_id, newer has team.id
-    const teamId =
-      context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+    const teamId = await getTeamId(context.auth as SlackAuthValue);
     context.app.createListeners({
       events: ['message'],
       identifierValue: teamId,

--- a/packages/pieces/community/slack/src/lib/triggers/new-direct-message.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-direct-message.ts
@@ -1,10 +1,10 @@
 import { Property, TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
-import { slackAuth } from '../auth';
+import { slackOAuth2Auth } from '../auth';
 
 
 
 export const newDirectMessageTrigger = createTrigger({
-	auth: slackAuth,
+	auth: slackOAuth2Auth,
 	name: 'new-direct-message',
 	displayName: 'New Direct Message',
 	description: 'Triggers when a message was posted in a direct message channel.',

--- a/packages/pieces/community/slack/src/lib/triggers/new-mention-in-direct-message.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-mention-in-direct-message.ts
@@ -3,11 +3,11 @@ import {
   TriggerStrategy,
   createTrigger,
 } from '@activepieces/pieces-framework';
-import { slackAuth } from '../auth';
+import { slackOAuth2Auth } from '../auth';
 import { userId } from '../common/props';
 
 export const newMentionInDirectMessageTrigger = createTrigger({
-  auth: slackAuth,
+  auth: slackOAuth2Auth,
   name: 'new-mention-in-direct-message',
   displayName: 'New Mention in Direct Message',
   description:

--- a/packages/pieces/community/slack/src/lib/triggers/new-mention.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-mention.ts
@@ -1,11 +1,11 @@
 import {
-  OAuth2PropertyValue,
   Property,
   TriggerStrategy,
   createTrigger,
 } from '@activepieces/pieces-framework';
 import { getChannels, multiSelectChannelInfo, userId } from '../common/props';
 import { slackAuth } from '../auth';
+import { getBotToken, getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 export const newMention = createTrigger({
   auth: slackAuth,
@@ -30,8 +30,7 @@ export const newMention = createTrigger({
             options: [],
           };
         }
-        const authentication = auth as OAuth2PropertyValue;
-        const accessToken = authentication['access_token'];
+        const accessToken = getBotToken(auth as SlackAuthValue);
         const channels = await getChannels(accessToken);
         return {
           disabled: false,
@@ -49,9 +48,7 @@ export const newMention = createTrigger({
   type: TriggerStrategy.APP_WEBHOOK,
   sampleData: undefined,
   onEnable: async (context) => {
-    // Older OAuth2 has team_id, newer has team.id
-    const teamId =
-      context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+    const teamId = await getTeamId(context.auth as SlackAuthValue);
     context.app.createListeners({
       events: ['message'],
       identifierValue: teamId,

--- a/packages/pieces/community/slack/src/lib/triggers/new-message-in-channel.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-message-in-channel.ts
@@ -1,9 +1,7 @@
 import { Property, TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 import { singleSelectChannelInfo, slackChannel } from '../common/props';
 import { slackAuth } from '../auth';
-import { WebClient } from '@slack/web-api';
-import { isNil } from '@activepieces/shared';
-import { getFirstFiveOrAll } from '../common/utils';
+import { getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 
 
@@ -24,8 +22,7 @@ export const newMessageInChannelTrigger = createTrigger({
 	type: TriggerStrategy.APP_WEBHOOK,
 	sampleData: undefined,
 	async onEnable(context) {
-		// Older OAuth2 has team_id, newer has team.id
-		const teamId = context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+		const teamId = await getTeamId(context.auth as SlackAuthValue);
 		context.app.createListeners({
 			events: ['message'],
 			identifierValue: teamId,

--- a/packages/pieces/community/slack/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-message.ts
@@ -1,5 +1,6 @@
 import { Property, TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
+import { getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 export const newMessageTrigger = createTrigger({
 	auth: slackAuth,
@@ -16,8 +17,7 @@ export const newMessageTrigger = createTrigger({
 	type: TriggerStrategy.APP_WEBHOOK,
 	sampleData: undefined,
 	onEnable: async (context) => {
-		// Older OAuth2 has team_id, newer has team.id
-		const teamId = context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+		const teamId = await getTeamId(context.auth as SlackAuthValue);
 		context.app.createListeners({
 			events: ['message'],
 			identifierValue: teamId,

--- a/packages/pieces/community/slack/src/lib/triggers/new-modal-interaction.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-modal-interaction.ts
@@ -1,5 +1,6 @@
 import { Property, TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
+import { getTeamId, SlackAuthValue } from '../common/auth-helpers';
 import { ViewSubmissionPayload } from '../common/types';
 
 export const newModalInteractionTrigger = createTrigger({
@@ -25,8 +26,7 @@ export const newModalInteractionTrigger = createTrigger({
     type: TriggerStrategy.APP_WEBHOOK,
     sampleData: undefined,
     onEnable: async (context) => {
-        // Older OAuth2 has team_id, newer has team.id
-        const teamId = context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+        const teamId = await getTeamId(context.auth as SlackAuthValue);
         context.app.createListeners({
             events: [context.propsValue.interactionType as string],
             identifierValue: teamId,

--- a/packages/pieces/community/slack/src/lib/triggers/new-reaction-added.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-reaction-added.ts
@@ -1,11 +1,11 @@
 import {
-  OAuth2PropertyValue,
   Property,
   TriggerStrategy,
   createTrigger,
 } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
 import { getChannels, multiSelectChannelInfo } from '../common/props';
+import { getBotToken, getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 
 export const newReactionAdded = createTrigger({
@@ -35,8 +35,7 @@ export const newReactionAdded = createTrigger({
             options: [],
           };
         }
-        const authentication = auth as OAuth2PropertyValue;
-        const accessToken = authentication['access_token'];
+        const accessToken = getBotToken(auth as SlackAuthValue);
         const channels = await getChannels(accessToken);
         return {
           disabled: false,
@@ -49,9 +48,7 @@ export const newReactionAdded = createTrigger({
   type: TriggerStrategy.APP_WEBHOOK,
   sampleData: undefined,
   onEnable: async (context) => {
-    // Older OAuth2 has team_id, newer has team.id
-    const teamId =
-      context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+    const teamId = await getTeamId(context.auth as SlackAuthValue);
     context.app.createListeners({
       events: ['reaction_added'],
       identifierValue: teamId,

--- a/packages/pieces/community/slack/src/lib/triggers/new-saved-message.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-saved-message.ts
@@ -1,5 +1,6 @@
 import { TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
+import { getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 export const newSavedMessageTrigger = createTrigger({
 	auth: slackAuth,
@@ -10,8 +11,7 @@ export const newSavedMessageTrigger = createTrigger({
 	type: TriggerStrategy.APP_WEBHOOK,
 	sampleData: undefined,
 	onEnable: async (context) => {
-		// Older OAuth2 has team_id, newer has team.id
-		const teamId = context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+		const teamId = await getTeamId(context.auth as SlackAuthValue);
 		context.app.createListeners({
 			events: ['star_added'],
 			identifierValue: teamId,

--- a/packages/pieces/community/slack/src/lib/triggers/new-team-custom-emoji.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-team-custom-emoji.ts
@@ -1,6 +1,7 @@
 import { TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 const sampleData = {
 	id: 'heart',
@@ -16,8 +17,7 @@ export const newTeamCustomEmojiTrigger = createTrigger({
 	type: TriggerStrategy.APP_WEBHOOK,
 	sampleData,
 	onEnable: async (context) => {
-		// Older OAuth2 has team_id, newer has team.id
-		const teamId = context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+		const teamId = await getTeamId(context.auth as SlackAuthValue);
 		context.app.createListeners({
 			events: ['emoji_changed'],
 			identifierValue: teamId,
@@ -28,7 +28,7 @@ export const newTeamCustomEmojiTrigger = createTrigger({
 	},
 
 	test: async (context) => {
-		const client = new WebClient(context.auth.access_token);
+		const client = new WebClient(getBotToken(context.auth as SlackAuthValue));
 
 		const response = await client.emoji.list();
 

--- a/packages/pieces/community/slack/src/lib/triggers/new-user.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-user.ts
@@ -1,6 +1,7 @@
 import { TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
 import { WebClient } from '@slack/web-api';
+import { getBotToken, getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 const sampleData = {
 	id: 'USLACKBOT',
@@ -59,8 +60,7 @@ export const newUserTrigger = createTrigger({
 	type: TriggerStrategy.APP_WEBHOOK,
 	sampleData,
 	onEnable: async (context) => {
-		// Older OAuth2 has team_id, newer has team.id
-		const teamId = context.auth.data['team_id'] ?? context.auth.data['team']['id'];
+		const teamId = await getTeamId(context.auth as SlackAuthValue);
 		context.app.createListeners({
 			events: ['team_join'],
 			identifierValue: teamId,
@@ -71,7 +71,7 @@ export const newUserTrigger = createTrigger({
 	},
 
 	test: async (context) => {
-		const client = new WebClient(context.auth.access_token);
+		const client = new WebClient(getBotToken(context.auth as SlackAuthValue));
 
 		const response = await client.users.list({limit:10});
 

--- a/packages/server/api/src/app/trigger/app-event-routing/app-event-routing.module.ts
+++ b/packages/server/api/src/app/trigger/app-event-routing/app-event-routing.module.ts
@@ -30,7 +30,7 @@ import { JobType } from '../../workers/queue/queue-manager'
 import { triggerSourceService } from '../trigger-source/trigger-source-service'
 import { appEventRoutingService } from './app-event-routing.service'
 
-const appWebhooks: Record<string, Piece<PieceAuthProperty | undefined>> = {
+const appWebhooks: Record<string, Piece<PieceAuthProperty | PieceAuthProperty[] | undefined>> = {
     slack,
     square,
     'facebook-leads': facebookLeads,


### PR DESCRIPTION
## What does this PR do?

Add support for additional auth scheme with bot token (+ optional user token)
Direct message triggers can only be used with the regular OAuth scheme

⚠️ I had to set a minimum engine version because of the (very minor) change to `app-event-routing.module.ts`

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
