### PR TITLE
feat(notion): add support for simple access token auth

### DIFF
--- a/packages/pieces/community/notion/package.json
+++ b/packages/pieces/community/notion/package.json
@@ -1,12 +1,9 @@
 {
   "name": "@activepieces/piece-notion",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {
-    "@activepieces/pieces-common": "workspace:*",
-    "@activepieces/pieces-framework": "workspace:*",
-    "@activepieces/shared": "workspace:*",
     "@notionhq/client": "2.2.14",
     "@tryfabric/martian": "1.2.4",
     "dayjs": "1.11.9",

--- a/packages/pieces/community/notion/src/index.ts
+++ b/packages/pieces/community/notion/src/index.ts
@@ -1,11 +1,12 @@
-import { createCustomApiCallAction } from '@activepieces/pieces-common';
 import {
-  OAuth2AuthorizationMethod,
-  OAuth2PropertyValue,
-  PieceAuth,
+  createCustomApiCallAction,
+} from '@activepieces/pieces-common';
+import {
   createPiece,
 } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
+import { notionAuth } from './lib/auth';
+import { getNotionToken, NotionAuthValue } from './lib/common';
 import { appendToPage } from './lib/actions/append-to-page';
 import { createDatabaseItem } from './lib/actions/create-database-item';
 import { createPage } from './lib/actions/create-page';
@@ -22,7 +23,6 @@ import { addComment } from './lib/actions/add-comment';
 import { retrieveDatabase } from './lib/actions/retrieve-database';
 import { getPageComments } from './lib/actions/get-page-comments';
 import { findPage } from './lib/actions/find-page';
-import { notionAuth } from './lib/auth';
 
 export const notion = createPiece({
   displayName: 'Notion',
@@ -58,7 +58,7 @@ export const notion = createPiece({
       baseUrl: () => 'https://api.notion.com/v1',
       auth: notionAuth,
       authMapping: async (auth) => ({
-        Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
+        Authorization: `Bearer ${getNotionToken(auth as NotionAuthValue)}`,
       }),
     }),
   ],

--- a/packages/pieces/community/notion/src/lib/actions/add-comment.ts
+++ b/packages/pieces/community/notion/src/lib/actions/add-comment.ts
@@ -1,11 +1,10 @@
 import {
   createAction,
-  OAuth2PropertyValue,
   Property,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 
 export const addComment = createAction({
   auth: notionAuth,
@@ -30,7 +29,7 @@ export const addComment = createAction({
     }
 
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/append-to-page.ts
+++ b/packages/pieces/community/notion/src/lib/actions/append-to-page.ts
@@ -1,12 +1,11 @@
 import {
   createAction,
-  OAuth2PropertyValue,
   Property,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 
 import { notionAuth } from '../auth';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 import { markdownToBlocks } from '@tryfabric/martian';
 import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
 
@@ -28,7 +27,7 @@ export const appendToPage = createAction({
     const { pageId, content } = context.propsValue;
 
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/archive-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/actions/archive-database-item.ts
@@ -1,10 +1,9 @@
 import {
   createAction,
-  OAuth2PropertyValue,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 
 export const archiveDatabaseItem = createAction({
   auth: notionAuth,
@@ -28,7 +27,7 @@ export const archiveDatabaseItem = createAction({
     }
 
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/create-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/actions/create-database-item.ts
@@ -1,13 +1,12 @@
 import {
   createAction,
   DynamicPropsValue,
-  OAuth2PropertyValue,
   Property,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 import { NotionFieldMapping } from '../common/models';
 import { notionAuth } from '../auth';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 
 export const createDatabaseItem = createAction({
   auth: notionAuth,
@@ -30,7 +29,7 @@ export const createDatabaseItem = createAction({
     const content = context.propsValue.content;
     const notionFields: DynamicPropsValue = {};
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
     const { properties } = await notion.databases.retrieve({

--- a/packages/pieces/community/notion/src/lib/actions/create-page.ts
+++ b/packages/pieces/community/notion/src/lib/actions/create-page.ts
@@ -1,12 +1,11 @@
 import {
   createAction,
-  OAuth2PropertyValue,
   Property,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 
 import { notionAuth } from '../auth';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 
 export const createPage = createAction({
   auth: notionAuth,
@@ -32,7 +31,7 @@ export const createPage = createAction({
     const { pageId, title, content } = context.propsValue;
 
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/find-item.ts
+++ b/packages/pieces/community/notion/src/lib/actions/find-item.ts
@@ -1,6 +1,6 @@
 import { notionAuth } from '../auth';
 import { createAction } from '@activepieces/pieces-framework';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 import { Client } from '@notionhq/client';
 
 export const findDatabaseItem = createAction({
@@ -17,7 +17,7 @@ export const findDatabaseItem = createAction({
     const filterFields = context.propsValue.filterDatabaseFields;
 
     const notion = new Client({
-      auth: context.auth.access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/find-page.ts
+++ b/packages/pieces/community/notion/src/lib/actions/find-page.ts
@@ -1,10 +1,10 @@
 import {
   createAction,
-  OAuth2PropertyValue,
   Property,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
+import { getNotionToken } from '../common';
 
 export const findPage = createAction({
   auth: notionAuth,
@@ -43,7 +43,7 @@ export const findPage = createAction({
     const searchLimit = Math.min(Math.max(limit || 10, 1), 100);
 
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/get-page-comments.ts
+++ b/packages/pieces/community/notion/src/lib/actions/get-page-comments.ts
@@ -1,10 +1,9 @@
 import {
   createAction,
-  OAuth2PropertyValue,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 
 export const getPageComments = createAction({
   auth: notionAuth,
@@ -23,7 +22,7 @@ export const getPageComments = createAction({
     }
 
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/get-page-or-block-children.ts
+++ b/packages/pieces/community/notion/src/lib/actions/get-page-or-block-children.ts
@@ -1,11 +1,11 @@
 import {
   createAction,
   DynamicPropsValue,
-  OAuth2PropertyValue,
   Property,
 } from '@activepieces/pieces-framework';
 import { NotionToMarkdown } from 'notion-to-md';
 import { notionAuth } from '../auth';
+import { getNotionToken } from '../common';
 import { Client, collectPaginatedAPI, isFullBlock } from '@notionhq/client';
 import { PartialBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
@@ -48,7 +48,7 @@ export const getPageOrBlockChildren = createAction({
   },
   async run(context) {
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/restore-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/actions/restore-database-item.ts
@@ -1,10 +1,9 @@
 import {
   createAction,
-  OAuth2PropertyValue,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 
 export const restoreDatabaseItem = createAction({
   auth: notionAuth,
@@ -28,7 +27,7 @@ export const restoreDatabaseItem = createAction({
     }
 
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/retrieve-database.ts
+++ b/packages/pieces/community/notion/src/lib/actions/retrieve-database.ts
@@ -1,10 +1,9 @@
 import {
   createAction,
-  OAuth2PropertyValue,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 import {
   FormStructure,
   NotionDatabase,
@@ -28,7 +27,7 @@ export const retrieveDatabase = createAction({
     }
 
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
 

--- a/packages/pieces/community/notion/src/lib/actions/update-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/actions/update-database-item.ts
@@ -1,13 +1,12 @@
 import {
   createAction,
   DynamicPropsValue,
-  OAuth2PropertyValue,
 } from '@activepieces/pieces-framework';
 import { Client } from '@notionhq/client';
 import { NotionFieldMapping } from '../common/models';
 
 import { notionAuth } from '../auth';
-import { notionCommon } from '../common';
+import { getNotionToken, notionCommon } from '../common';
 export const updateDatabaseItem = createAction({
   auth: notionAuth,
   name: 'update_database_item',
@@ -28,7 +27,7 @@ export const updateDatabaseItem = createAction({
     const notionFields: DynamicPropsValue = {};
 
     const notion = new Client({
-      auth: (context.auth as OAuth2PropertyValue).access_token,
+      auth: getNotionToken(context.auth),
       notionVersion: '2022-02-22',
     });
     const { properties } = await notion.databases.retrieve({

--- a/packages/pieces/community/notion/src/lib/auth.ts
+++ b/packages/pieces/community/notion/src/lib/auth.ts
@@ -1,9 +1,14 @@
 import {
-  PieceAuth,
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import {
   OAuth2AuthorizationMethod,
+  PieceAuth,
 } from '@activepieces/pieces-framework';
 
-export const notionAuth = PieceAuth.OAuth2({
+export const notionOAuth2Auth = PieceAuth.OAuth2({
   authUrl: 'https://api.notion.com/v1/oauth/authorize',
   tokenUrl: 'https://api.notion.com/v1/oauth/token',
   scope: [],
@@ -13,3 +18,36 @@ export const notionAuth = PieceAuth.OAuth2({
   authorizationMethod: OAuth2AuthorizationMethod.HEADER,
   required: true,
 });
+
+const notionCustomAuth = PieceAuth.CustomAuth({
+  displayName: 'Access Token',
+  description:
+    'Connect using a Notion Internal Integration Token. Create one at https://www.notion.so/my-integrations.',
+  required: true,
+  props: {
+    accessToken: PieceAuth.SecretText({
+      displayName: 'Internal Integration Token',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://api.notion.com/v1/users/me',
+        headers: {
+          'Notion-Version': '2022-02-22',
+        },
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: auth.accessToken,
+        },
+      });
+      return { valid: true };
+    } catch (e) {
+      return { valid: false, error: (e as Error).message };
+    }
+  },
+});
+
+export const notionAuth = [notionOAuth2Auth, notionCustomAuth];

--- a/packages/pieces/community/notion/src/lib/common/index.ts
+++ b/packages/pieces/community/notion/src/lib/common/index.ts
@@ -1,11 +1,24 @@
+import { getAccessTokenOrThrow } from '@activepieces/pieces-common';
 import {
-  OAuth2PropertyValue,
+  AppConnectionValueForAuthProperty,
   Property,
   DynamicPropsValue,
 } from '@activepieces/pieces-framework';
+import { AppConnectionType } from '@activepieces/shared';
 import { Client } from '@notionhq/client';
 import { NotionFieldMapping } from './models';
 import { notionAuth } from '../auth';
+
+export type NotionAuthValue = AppConnectionValueForAuthProperty<
+  typeof notionAuth
+>;
+
+export function getNotionToken(auth: NotionAuthValue): string {
+  if (auth.type === AppConnectionType.CUSTOM_AUTH) {
+    return auth.props.accessToken;
+  }
+  return getAccessTokenOrThrow(auth);
+}
 
 export const notionCommon = {
   baseUrl: 'https://api.notion.com/v1',
@@ -25,7 +38,7 @@ export const notionCommon = {
         };
       }
       const notion = new Client({
-        auth: (auth as OAuth2PropertyValue).access_token,
+        auth: getNotionToken(auth as NotionAuthValue),
         notionVersion: '2022-02-22',
       });
       const databases = await notion.search({
@@ -61,7 +74,7 @@ export const notionCommon = {
         };
       }
       const notion = new Client({
-        auth: (auth as OAuth2PropertyValue).access_token,
+        auth: getNotionToken(auth as NotionAuthValue),
         notionVersion: '2022-02-22',
       });
       const { results } = await notion.databases.query({
@@ -99,7 +112,7 @@ export const notionCommon = {
 
       try {
         const notion = new Client({
-          auth: (auth as OAuth2PropertyValue).access_token,
+          auth: getNotionToken(auth as NotionAuthValue),
           notionVersion: '2022-02-22',
         });
 
@@ -156,7 +169,7 @@ export const notionCommon = {
       const fields: DynamicPropsValue = {};
       try {
         const notion = new Client({
-          auth: (auth as OAuth2PropertyValue).access_token,
+          auth: getNotionToken(auth as NotionAuthValue),
           notionVersion: '2022-02-22',
         });
         const { properties } = await notion.databases.retrieve({
@@ -237,7 +250,7 @@ export const notionCommon = {
       const fields: DynamicPropsValue = {};
       try {
         const notion = new Client({
-          auth: (auth as OAuth2PropertyValue).access_token,
+          auth: getNotionToken(auth as NotionAuthValue),
           notionVersion: '2022-02-22',
         });
         const { properties } = await notion.databases.retrieve({
@@ -291,7 +304,7 @@ export const notionCommon = {
           options: [],
         };
       }
-      const pages = await getPages(auth as OAuth2PropertyValue);
+      const pages = await getPages(auth as NotionAuthValue);
 
       return {
         placeholder: 'Select a page',
@@ -308,7 +321,7 @@ export const notionCommon = {
 };
 
 export async function getPages(
-  auth: OAuth2PropertyValue,
+  auth: NotionAuthValue,
   search?: {
     editedAfter?: Date;
     createdAfter?: Date;
@@ -319,7 +332,7 @@ export async function getPages(
   }
 ): Promise<any[]> {
   const notion = new Client({
-    auth: auth.access_token,
+    auth: getNotionToken(auth),
     notionVersion: '2022-02-22',
   });
 

--- a/packages/pieces/community/notion/src/lib/triggers/new-comment.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/new-comment.ts
@@ -6,11 +6,10 @@ import {
 import {
   createTrigger,
   TriggerStrategy,
-  OAuth2PropertyValue,
   AppConnectionValueForAuthProperty,
 } from '@activepieces/pieces-framework';
 import dayjs from 'dayjs';
-import { notionCommon } from '../common';
+import { getNotionToken, NotionAuthValue, notionCommon } from '../common';
 import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
 
@@ -126,12 +125,12 @@ const polling: Polling<
 };
 
 const getComments = async (
-  authentication: OAuth2PropertyValue,
+  authentication: NotionAuthValue,
   page_id: string,
   startDate: string | null
 ) => {
   const notion = new Client({
-    auth: authentication.access_token,
+    auth: getNotionToken(authentication),
     notionVersion: '2022-02-22',
   });
 

--- a/packages/pieces/community/notion/src/lib/triggers/new-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/new-database-item.ts
@@ -6,11 +6,10 @@ import {
 import {
   createTrigger,
   TriggerStrategy,
-  OAuth2PropertyValue,
   AppConnectionValueForAuthProperty,
 } from '@activepieces/pieces-framework';
 import dayjs from 'dayjs';
-import { notionCommon } from '../common';
+import { getNotionToken, NotionAuthValue, notionCommon } from '../common';
 import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
 import { isNil } from '@activepieces/shared';
@@ -152,12 +151,12 @@ const polling: Polling<
 };
 
 const getResponse = async (
-  authentication: OAuth2PropertyValue,
+  authentication: NotionAuthValue,
   database_id: string,
   startDate: string | null
 ) => {
   const notion = new Client({
-    auth: authentication.access_token,
+    auth: getNotionToken(authentication),
     notionVersion: '2022-02-22',
   });
   let cursor;

--- a/packages/pieces/community/notion/src/lib/triggers/updated-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/updated-database-item.ts
@@ -6,11 +6,10 @@ import {
 import {
   createTrigger,
   TriggerStrategy,
-  OAuth2PropertyValue,
   AppConnectionValueForAuthProperty,
 } from '@activepieces/pieces-framework';
 import dayjs from 'dayjs';
-import { notionCommon } from '../common';
+import { getNotionToken, NotionAuthValue, notionCommon } from '../common';
 import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
 import { isNil } from '@activepieces/shared';
@@ -153,12 +152,12 @@ const polling: Polling<
 };
 
 const getResponse = async (
-  authentication: OAuth2PropertyValue,
+  authentication: NotionAuthValue,
   database_id: string,
   startDate: string | null
 ) => {
   const notion = new Client({
-    auth: authentication.access_token,
+    auth: getNotionToken(authentication),
     notionVersion: '2022-02-22',
   });
 

--- a/packages/pieces/community/notion/src/lib/triggers/updated-page.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/updated-page.ts
@@ -6,11 +6,10 @@ import {
 import {
   createTrigger,
   TriggerStrategy,
-  OAuth2PropertyValue,
   AppConnectionValueForAuthProperty,
 } from '@activepieces/pieces-framework';
 import dayjs from 'dayjs';
-import { getPages } from '../common';
+import { getPages, NotionAuthValue } from '../common';
 import { notionAuth } from '../auth';
 
 export const updatedPage = createTrigger({
@@ -131,7 +130,7 @@ const polling: Polling<
 };
 
 const getUpdatedPages = async (
-  authentication: OAuth2PropertyValue,
+  authentication: NotionAuthValue,
   startDate?: Date
 ) => {
   const searchOptions = startDate ? { editedAfter: startDate } : undefined;


### PR DESCRIPTION
## What does this PR do?

We want to be able to use simple integration tokens instead of OAuth

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
