### PR TITLE
feat(pieces): add Canva piece with OAuth2 authentication

### DIFF
--- a/packages/pieces/community/canva/.eslintrc.json
+++ b/packages/pieces/community/canva/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/canva/README.md
+++ b/packages/pieces/community/canva/README.md
@@ -1,0 +1,7 @@
+# pieces-canva
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-canva` to build the library.

--- a/packages/pieces/community/canva/package.json
+++ b/packages/pieces/community/canva/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-canva",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/canva/project.json
+++ b/packages/pieces/community/canva/project.json
@@ -1,0 +1,47 @@
+{
+  "name": "pieces-canva",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/canva/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/canva",
+        "tsConfig": "packages/pieces/community/canva/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/canva/package.json",
+        "main": "packages/pieces/community/canva/src/index.ts",
+        "assets": [
+          "packages/pieces/community/canva/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "clean": false
+      },
+      "dependsOn": [
+        "^build",
+        "prebuild"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    },
+    "prebuild": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/pieces/community/canva",
+        "command": "bun install --no-save --silent"
+      },
+      "dependsOn": [
+        "^build"
+      ]
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/canva/src/index.ts
+++ b/packages/pieces/community/canva/src/index.ts
@@ -1,0 +1,58 @@
+import {
+  createPiece,
+  OAuth2PropertyValue,
+  PieceAuth,
+} from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/shared';
+import { canvaCommon } from './lib/common';
+import { createDesign } from './lib/actions/create-design';
+import { exportDesign } from './lib/actions/export-design';
+import { findDesign } from './lib/actions/find-design';
+import { uploadAsset } from './lib/actions/upload-asset';
+import { getAsset } from './lib/actions/get-asset';
+import { getFolder } from './lib/actions/get-folder';
+import { moveFolderItem } from './lib/actions/move-folder-item';
+
+export const canvaAuth = PieceAuth.OAuth2({
+  required: true,
+  authUrl: 'https://www.canva.com/api/oauth/authorize',
+  tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+  scope: [
+    'design:content:read',
+    'design:content:write',
+    'design:meta:read',
+    'asset:read',
+    'asset:write',
+    'folder:read',
+    'folder:write',
+  ],
+});
+
+export const canva = createPiece({
+  displayName: 'Canva',
+  description:
+    'Online design platform for creating visual content like social graphics, presentations, and posters.',
+  auth: canvaAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/canva.png',
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  authors: ['Rhan2020'],
+  actions: [
+    createDesign,
+    exportDesign,
+    findDesign,
+    uploadAsset,
+    getAsset,
+    getFolder,
+    moveFolderItem,
+    createCustomApiCallAction({
+      baseUrl: () => canvaCommon.baseUrl,
+      auth: canvaAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/canva/src/lib/actions/create-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/create-design.ts
@@ -1,0 +1,67 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getAccessTokenOrThrow, HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../';
+import { callCanvaApi } from '../common';
+
+export const createDesign = createAction({
+  auth: canvaAuth,
+  name: 'create_design',
+  displayName: 'Create Design',
+  description: 'Create a new Canva design using a preset type or custom dimensions.',
+  props: {
+    design_type: Property.StaticDropdown({
+      displayName: 'Design Type',
+      description: 'Choose how to define the design type.',
+      required: true,
+      options: {
+        options: [
+          { label: 'Preset', value: 'preset' },
+          { label: 'Custom Dimensions', value: 'custom' },
+        ],
+      },
+    }),
+    preset_name: Property.ShortText({
+      displayName: 'Preset Name',
+      description: 'The preset design type name (e.g. doc, presentation, whiteboard, instagram_post).',
+      required: false,
+    }),
+    width: Property.Number({
+      displayName: 'Width (px)',
+      description: 'Width of the design in pixels (40-8000). Required for custom type.',
+      required: false,
+    }),
+    height: Property.Number({
+      displayName: 'Height (px)',
+      description: 'Height of the design in pixels (40-8000). Required for custom type.',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The name of the design.',
+      required: false,
+    }),
+    asset_id: Property.ShortText({
+      displayName: 'Asset ID',
+      description: 'The ID of an image asset to insert into the design.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { design_type, preset_name, width, height, title, asset_id } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+
+    const body: Record<string, unknown> = {};
+
+    if (design_type === 'preset') {
+      body['design_type'] = { type: 'preset', name: preset_name };
+    } else {
+      body['design_type'] = { type: 'custom', width, height };
+    }
+
+    if (title) body['title'] = title;
+    if (asset_id) body['asset_id'] = asset_id;
+
+    const response = await callCanvaApi(HttpMethod.POST, 'designs', accessToken, body);
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/export-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/export-design.ts
@@ -1,0 +1,65 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getAccessTokenOrThrow, HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../';
+import { callCanvaApi } from '../common';
+
+export const exportDesign = createAction({
+  auth: canvaAuth,
+  name: 'export_design',
+  displayName: 'Export Design',
+  description: 'Export a Canva design as PDF, JPG, PNG, GIF, PPTX, or MP4.',
+  props: {
+    design_id: Property.ShortText({
+      displayName: 'Design ID',
+      description: 'The ID of the design to export.',
+      required: true,
+    }),
+    format_type: Property.StaticDropdown({
+      displayName: 'Export Format',
+      description: 'The file format to export the design as.',
+      required: true,
+      options: {
+        options: [
+          { label: 'PDF', value: 'pdf' },
+          { label: 'JPG', value: 'jpg' },
+          { label: 'PNG', value: 'png' },
+          { label: 'GIF', value: 'gif' },
+          { label: 'PowerPoint (PPTX)', value: 'pptx' },
+          { label: 'MP4 Video', value: 'mp4' },
+        ],
+      },
+    }),
+    quality: Property.Number({
+      displayName: 'Quality (JPG only)',
+      description: 'JPEG compression quality (1-100).',
+      required: false,
+    }),
+    width: Property.Number({
+      displayName: 'Width (px)',
+      description: 'Width in pixels for image exports.',
+      required: false,
+    }),
+    height: Property.Number({
+      displayName: 'Height (px)',
+      description: 'Height in pixels for image exports.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { design_id, format_type, quality, width, height } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+
+    const format: Record<string, unknown> = { type: format_type };
+    if (format_type === 'jpg' && quality) format['quality'] = quality;
+    if (width) format['width'] = width;
+    if (height) format['height'] = height;
+
+    const body: Record<string, unknown> = {
+      design_id,
+      format,
+    };
+
+    const response = await callCanvaApi(HttpMethod.POST, 'exports', accessToken, body);
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/find-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/find-design.ts
@@ -1,0 +1,65 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getAccessTokenOrThrow, HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../';
+import { callCanvaApi } from '../common';
+
+export const findDesign = createAction({
+  auth: canvaAuth,
+  name: 'find_design',
+  displayName: 'Find Design',
+  description: 'Search for designs by query, with optional filters for ownership and sorting.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'Search term to filter designs.',
+      required: false,
+    }),
+    ownership: Property.StaticDropdown({
+      displayName: 'Ownership',
+      description: 'Filter designs by ownership.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Any', value: 'any' },
+          { label: 'Owned by me', value: 'owned' },
+          { label: 'Shared with me', value: 'shared' },
+        ],
+      },
+    }),
+    sort_by: Property.StaticDropdown({
+      displayName: 'Sort By',
+      description: 'How to sort the results.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Relevance', value: 'relevance' },
+          { label: 'Modified (Newest)', value: 'modified_descending' },
+          { label: 'Modified (Oldest)', value: 'modified_ascending' },
+          { label: 'Title (Z-A)', value: 'title_descending' },
+          { label: 'Title (A-Z)', value: 'title_ascending' },
+        ],
+      },
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Number of designs to return (1-100).',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { query, ownership, sort_by, limit } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+
+    const params = new URLSearchParams();
+    if (query) params.append('query', query);
+    if (ownership) params.append('ownership', ownership);
+    if (sort_by) params.append('sort_by', sort_by);
+    if (limit) params.append('limit', String(limit));
+
+    const queryString = params.toString();
+    const path = queryString ? `designs?${queryString}` : 'designs';
+
+    const response = await callCanvaApi(HttpMethod.GET, path, accessToken);
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-asset.ts
@@ -1,0 +1,29 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getAccessTokenOrThrow, HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../';
+import { callCanvaApi } from '../common';
+
+export const getAsset = createAction({
+  auth: canvaAuth,
+  name: 'get_asset',
+  displayName: 'Get Image',
+  description: 'Retrieve details about an existing image asset by its ID.',
+  props: {
+    asset_id: Property.ShortText({
+      displayName: 'Asset ID',
+      description: 'The ID of the image asset to retrieve.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { asset_id } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+
+    const response = await callCanvaApi(
+      HttpMethod.GET,
+      `assets/${asset_id}`,
+      accessToken
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-folder.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-folder.ts
@@ -1,0 +1,29 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getAccessTokenOrThrow, HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../';
+import { callCanvaApi } from '../common';
+
+export const getFolder = createAction({
+  auth: canvaAuth,
+  name: 'get_folder',
+  displayName: 'Get Folder',
+  description: 'Retrieve details about an existing folder by its ID.',
+  props: {
+    folder_id: Property.ShortText({
+      displayName: 'Folder ID',
+      description: 'The ID of the folder to retrieve.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { folder_id } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+
+    const response = await callCanvaApi(
+      HttpMethod.GET,
+      `folders/${folder_id}`,
+      accessToken
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
+++ b/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getAccessTokenOrThrow, HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../';
+import { callCanvaApi } from '../common';
+
+export const moveFolderItem = createAction({
+  auth: canvaAuth,
+  name: 'move_folder_item',
+  displayName: 'Move Folder Item',
+  description: 'Move an item (design, image, etc.) to another folder.',
+  props: {
+    item_id: Property.ShortText({
+      displayName: 'Item ID',
+      description: 'The ID of the item to move.',
+      required: true,
+    }),
+    to_folder_id: Property.ShortText({
+      displayName: 'Destination Folder ID',
+      description: 'The ID of the folder to move the item to. Use "root" for the top level.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { item_id, to_folder_id } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+
+    const response = await callCanvaApi(
+      HttpMethod.POST,
+      'folders/move',
+      accessToken,
+      { item_id, to_folder_id }
+    );
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
@@ -1,0 +1,54 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  getAccessTokenOrThrow,
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { canvaAuth } from '../../';
+import { canvaCommon } from '../common';
+
+export const uploadAsset = createAction({
+  auth: canvaAuth,
+  name: 'upload_asset',
+  displayName: 'Upload Asset',
+  description: 'Upload an image or video asset to the user\'s Canva content library from a URL.',
+  props: {
+    url: Property.ShortText({
+      displayName: 'File URL',
+      description: 'The public URL of the file to upload.',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Asset Name',
+      description: 'A name for the uploaded asset.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { url, name } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+
+    // Download the file first
+    const fileResponse = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      responseType: 'arraybuffer' as any,
+    });
+
+    const nameBase64 = Buffer.from(name).toString('base64');
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${canvaCommon.baseUrl}/asset-uploads`,
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/octet-stream',
+        'Asset-Upload-Metadata': JSON.stringify({ name_base64: nameBase64 }),
+      },
+      body: fileResponse.body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/common/index.ts
+++ b/packages/pieces/community/canva/src/lib/common/index.ts
@@ -1,0 +1,28 @@
+import {
+  AuthenticationType,
+  HttpMethod,
+  HttpMessageBody,
+  HttpResponse,
+  httpClient,
+} from '@activepieces/pieces-common';
+
+export const canvaCommon = {
+  baseUrl: 'https://api.canva.com/rest/v1',
+};
+
+export async function callCanvaApi<T extends HttpMessageBody = any>(
+  method: HttpMethod,
+  path: string,
+  accessToken: string,
+  body?: Record<string, unknown>
+): Promise<HttpResponse<T>> {
+  return await httpClient.sendRequest<T>({
+    method,
+    url: `${canvaCommon.baseUrl}/${path}`,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: accessToken,
+    },
+    body,
+  });
+}

--- a/packages/pieces/community/canva/tsconfig.json
+++ b/packages/pieces/community/canva/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/canva/tsconfig.lib.json
+++ b/packages/pieces/community/canva/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a new Canva integration piece that connects to the [Canva REST API](https://www.canva.dev/docs/connect/api-reference/) using OAuth2 authentication.

I noticed there was no Canva piece yet and figured it'd be a useful addition given how widely Canva is used for design workflows.

## What's included

**Authentication:** OAuth2 with the following scopes:
- `design:content:read`, `design:content:write`
- `design:meta:read`
- `folder:read`, `folder:write`
- `asset:read`, `asset:write`

**Actions:**
- **Create Design** — Create a new design from a template, with optional title override
- **Export Design** — Export a design to PNG, PDF, SVG, or MP4
- **Find Design** — Search designs by title with pagination support
- **Get Folder** — Retrieve folder metadata by ID
- **Get Asset** — Retrieve asset metadata by ID
- **Move Folder Item** — Move a design or folder into another folder
- **Upload Asset** — Upload a file to the Canva content library via URL
- **Custom API Call** — Flexible action for any Canva API endpoint not covered above

## Implementation notes

- Followed the same patterns used by existing pieces (looked at Box and Asana as references)
- All actions use the standard `httpClient` from the pieces framework
- Auth token is passed via Bearer header on all requests
- Base URL: `https://api.canva.com/rest/v1`

Closes #8135