### PR TITLE
feat(gmail): add service account auth

### DIFF
--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "dependencies": {
     "googleapis": "129.0.0",
     "mailparser": "3.7.5"

--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -1,7 +1,5 @@
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
 import {
-  OAuth2PropertyValue,
-  PieceAuth,
   createPiece,
 } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
@@ -15,19 +13,9 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailAuth, getAccessToken } from './lib/common/data';
 
-export const gmailAuth = PieceAuth.OAuth2({
-  description: '',
-  authUrl: 'https://accounts.google.com/o/oauth2/auth',
-  tokenUrl: 'https://oauth2.googleapis.com/token',
-  required: true,
-  scope: [
-    'https://www.googleapis.com/auth/gmail.send',
-    'email',
-    'https://www.googleapis.com/auth/gmail.readonly',
-    'https://www.googleapis.com/auth/gmail.compose',
-  ],
-});
+export { gmailAuth, getAccessToken, GmailAuthValue, createGoogleClient } from './lib/common/data';
 
 export const gmail = createPiece({
   minimumSupportedRelease: '0.30.0',
@@ -47,7 +35,7 @@ export const gmail = createPiece({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
       authMapping: async (auth) => ({
-        Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
+        Authorization: `Bearer ${await getAccessToken(auth as any)}`,
       }),
     }),
   ],

--- a/packages/pieces/community/gmail/src/lib/actions/create-draft-reply-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-draft-reply-action.ts
@@ -2,9 +2,8 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import mime from 'mime-types';
 import MailComposer from 'nodemailer/lib/mail-composer';
 import Mail, { Attachment } from 'nodemailer/lib/mailer';
-import { gmailAuth } from '../../';
+import { gmailAuth, createGoogleClient } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 import { GmailProps } from '../common/props';
 
 export const gmailCreateDraftReplyAction = createAction({
@@ -80,8 +79,7 @@ export const gmailCreateDraftReplyAction = createAction({
     }),
   },
   async run(context) {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
 
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 

--- a/packages/pieces/community/gmail/src/lib/actions/get-mail-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-mail-action.ts
@@ -1,8 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { gmailAuth } from '../../';
+import { gmailAuth, createGoogleClient, convertAttachment, parseStream } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
-import { convertAttachment, parseStream } from '../common/data';
 
 export const gmailGetEmailAction = createAction({
   auth: gmailAuth,
@@ -17,8 +15,7 @@ export const gmailGetEmailAction = createAction({
     }),
   },
   async run(context) {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
 
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 

--- a/packages/pieces/community/gmail/src/lib/actions/get-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-thread-action.ts
@@ -1,7 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { GmailRequests } from '../common/data';
+import { GmailRequests, gmailAuth, getAccessToken } from '../common/data';
 import { GmailMessageFormat } from '../common/models';
-import { gmailAuth } from '../../';
 
 export const gmailGetThread = createAction({
   auth: gmailAuth,
@@ -32,7 +31,7 @@ export const gmailGetThread = createAction({
   },
   run: async ({ auth, propsValue: { format, thread_id } }) =>
     await GmailRequests.getThread({
-      access_token: auth.access_token,
+      access_token: await getAccessToken(auth),
       thread_id,
       format: format ?? GmailMessageFormat.FULL,
     }),

--- a/packages/pieces/community/gmail/src/lib/actions/reply-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/reply-to-email-action.ts
@@ -2,9 +2,8 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import mime from 'mime-types';
 import MailComposer from 'nodemailer/lib/mail-composer';
 import Mail, { Attachment } from 'nodemailer/lib/mailer';
-import { gmailAuth } from '../../';
+import { gmailAuth, createGoogleClient } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 import { GmailProps } from '../common/props';
 
 export const gmailReplyToEmailAction = createAction({
@@ -74,8 +73,7 @@ export const gmailReplyToEmailAction = createAction({
     }),
   },
   async run(context) {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
 
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 

--- a/packages/pieces/community/gmail/src/lib/actions/request-approval-in-email.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/request-approval-in-email.ts
@@ -1,7 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { gmailAuth } from '../..';
+import { gmailAuth, createGoogleClient, getAccessToken } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 import MailComposer from 'nodemailer/lib/mail-composer';
 import Mail from 'nodemailer/lib/mailer';
 import {
@@ -70,7 +69,7 @@ export const requestApprovalInEmail = createAction({
   async run(context) {
     if (context.executionType === ExecutionType.BEGIN) {
       try {
-        const token = context.auth.access_token;
+        const token = await getAccessToken(context.auth);
 
         const { subject, body } = context.propsValue;
 
@@ -97,8 +96,7 @@ export const requestApprovalInEmail = createAction({
         </div>
       `;
 
-        const authClient = new OAuth2Client();
-        authClient.setCredentials(context.auth);
+        const authClient = await createGoogleClient(context.auth);
 
         const gmail = google.gmail({ version: 'v1', auth: authClient });
 

--- a/packages/pieces/community/gmail/src/lib/actions/search-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/search-email-action.ts
@@ -1,8 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { gmailAuth } from '../../';
+import { gmailAuth, createGoogleClient, convertAttachment, parseStream } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
-import { convertAttachment, parseStream } from '../common/data';
 import { GmailProps } from '../common/props';
 import { GmailLabel } from '../common/models';
 
@@ -59,8 +57,7 @@ export const gmailSearchMailAction = createAction({
     }),
   },
   async run(context) {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
 
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 

--- a/packages/pieces/community/gmail/src/lib/actions/send-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/send-email-action.ts
@@ -2,9 +2,8 @@ import { ApFile, createAction, Property } from '@activepieces/pieces-framework';
 import mime from 'mime-types';
 import MailComposer from 'nodemailer/lib/mail-composer';
 import Mail, { Attachment } from 'nodemailer/lib/mailer';
-import { gmailAuth } from '../../';
+import { gmailAuth, createGoogleClient } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 
 export const gmailSendEmailAction = createAction({
   auth: gmailAuth,
@@ -99,8 +98,7 @@ export const gmailSendEmailAction = createAction({
     }),
   },
   async run(context) {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
 
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 

--- a/packages/pieces/community/gmail/src/lib/common/props.ts
+++ b/packages/pieces/community/gmail/src/lib/common/props.ts
@@ -1,9 +1,7 @@
-import { Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
-import { GmailRequests } from './data';
+import { Property } from '@activepieces/pieces-framework';
+import { GmailRequests, gmailAuth, createGoogleClient, GmailAuthValue } from './data';
 import { GmailLabel } from './models';
-import { gmailAuth } from '../..';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 
 export const GmailProps = {
   from: Property.ShortText({
@@ -96,14 +94,13 @@ export const GmailProps = {
       }
 
       try {
-        const authValue = auth as OAuth2PropertyValue;
-        const authClient = new OAuth2Client();
-        authClient.setCredentials(authValue);
+        const authValue = auth as GmailAuthValue;
+        const authClient = await createGoogleClient(authValue);
 
         const gmail = google.gmail({ version: 'v1', auth: authClient });
 
         const response = await GmailRequests.getRecentMessages(
-          auth as OAuth2PropertyValue,
+          authValue,
           20 // Get last 20 messages
         );
 
@@ -184,14 +181,13 @@ export const GmailProps = {
       }
 
       try {
-        const authValue = auth as OAuth2PropertyValue;
-        const authClient = new OAuth2Client();
-        authClient.setCredentials(authValue);
+        const authValue = auth as GmailAuthValue;
+        const authClient = await createGoogleClient(authValue);
 
         const gmail = google.gmail({ version: 'v1', auth: authClient });
 
         const response = await GmailRequests.getRecentThreads(
-          auth as OAuth2PropertyValue,
+          authValue,
           15 // Get last 15 threads
         );
 

--- a/packages/pieces/community/gmail/src/lib/triggers/new-attachment.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-attachment.ts
@@ -2,18 +2,18 @@ import {
   createTrigger,
   TriggerStrategy,
   Property,
-  PiecePropValueSchema,
   FilesService,
 } from '@activepieces/pieces-framework';
 import { GmailProps } from '../common/props';
-import { gmailAuth } from '../../';
-import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 import {
+  gmailAuth,
+  createGoogleClient,
+  GmailAuthValue,
   parseStream,
   convertAttachment,
   getFirstFiveOrAll,
 } from '../common/data';
+import { google } from 'googleapis';
 import { GmailLabel } from '../common/models';
 import dayjs from 'dayjs';
 
@@ -116,7 +116,7 @@ async function pollRecentMessages({
   files,
   lastFetchEpochMS,
 }: {
-  auth: PiecePropValueSchema<typeof gmailAuth>;
+  auth: GmailAuthValue;
   props: Props;
   files: FilesService;
   lastFetchEpochMS: number;
@@ -126,8 +126,7 @@ async function pollRecentMessages({
     data: unknown;
   }[]
 > {
-  const authClient = new OAuth2Client();
-  authClient.setCredentials(auth);
+  const authClient = await createGoogleClient(auth);
 
   const gmail = google.gmail({ version: 'v1', auth: authClient });
 

--- a/packages/pieces/community/gmail/src/lib/triggers/new-conversation.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-conversation.ts
@@ -5,10 +5,8 @@ import {
   Property,
 } from '@activepieces/pieces-framework';
 import { GmailProps } from '../common/props';
-import { gmailAuth } from '../../';
+import { gmailAuth, createGoogleClient, parseStream, convertAttachment } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
-import { parseStream, convertAttachment } from '../common/data';
 
 async function enrichNewConversation({
   gmail,
@@ -162,8 +160,7 @@ export const gmailNewConversationTrigger = createTrigger({
   sampleData: {},
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
     const profile = await gmail.users.getProfile({ userId: 'me' });
@@ -175,8 +172,7 @@ export const gmailNewConversationTrigger = createTrigger({
     await context.store.delete('processedThreads');
   },
   run: async (context) => {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
     const lastHistoryId = await context.store.get('lastHistoryId');
@@ -324,8 +320,7 @@ export const gmailNewConversationTrigger = createTrigger({
     }
   },
   test: async (context) => {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
     const maxAge = (context.propsValue.maxAgeHours || 24) * 60 * 60 * 1000;

--- a/packages/pieces/community/gmail/src/lib/triggers/new-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-email.ts
@@ -1,21 +1,21 @@
 import {
   createTrigger,
   TriggerStrategy,
-  PiecePropValueSchema,
   FilesService,
 } from '@activepieces/pieces-framework';
 import dayjs from 'dayjs';
 import { GmailLabel } from '../common/models';
 import { GmailProps } from '../common/props';
-import { gmailAuth } from '../../';
 import {
+  gmailAuth,
+  createGoogleClient,
+  GmailAuthValue,
   GmailRequests,
   parseStream,
   convertAttachment,
   getFirstFiveOrAll,
 } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 
 export const gmailNewEmailTrigger = createTrigger({
   auth: gmailAuth,
@@ -84,7 +84,7 @@ async function pollRecentMessages({
   files,
   lastFetchEpochMS,
 }: {
-  auth: PiecePropValueSchema<typeof gmailAuth>;
+  auth: GmailAuthValue;
   props: PropsValue;
   files: FilesService;
   lastFetchEpochMS: number;
@@ -94,8 +94,7 @@ async function pollRecentMessages({
     data: unknown;
   }[]
 > {
-  const authClient = new OAuth2Client();
-  authClient.setCredentials(auth);
+  const authClient = await createGoogleClient(auth);
 
   const gmail = google.gmail({ version: 'v1', auth: authClient });
 

--- a/packages/pieces/community/gmail/src/lib/triggers/new-label.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-label.ts
@@ -1,8 +1,6 @@
 import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
-import { gmailAuth } from '../../';
+import { gmailAuth, createGoogleClient, getFirstFiveOrAll } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
-import { getFirstFiveOrAll } from '../common/data';
 import { isNil } from '@activepieces/shared';
 
 const TRIGGER_KEY = 'labels';
@@ -16,8 +14,7 @@ export const gmailNewLabelTrigger = createTrigger({
   sampleData: {},
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
     const response = await gmail.users.labels.list({
@@ -33,8 +30,7 @@ export const gmailNewLabelTrigger = createTrigger({
     await context.store.delete(TRIGGER_KEY);
   },
   async test(context) {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
     const response = await gmail.users.labels.list({
@@ -49,8 +45,7 @@ export const gmailNewLabelTrigger = createTrigger({
     const existingIds = (await context.store.get<string>(TRIGGER_KEY)) ?? '[]';
     const parsedExistingIds = JSON.parse(existingIds) as string[];
 
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
 
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 

--- a/packages/pieces/community/gmail/src/lib/triggers/new-labeled-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-labeled-email.ts
@@ -4,10 +4,8 @@ import {
   FilesService,
 } from '@activepieces/pieces-framework';
 import { GmailProps } from '../common/props';
-import { gmailAuth } from '../../';
+import { gmailAuth, createGoogleClient, parseStream, convertAttachment } from '../common/data';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
-import { parseStream, convertAttachment } from '../common/data';
 
 async function enrichGmailMessage({
   gmail,
@@ -68,8 +66,7 @@ export const gmailNewLabeledEmailTrigger = createTrigger({
   sampleData: {},
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
     const profile = await gmail.users.getProfile({
@@ -82,8 +79,7 @@ export const gmailNewLabeledEmailTrigger = createTrigger({
     await context.store.delete('lastHistoryId');
   },
   run: async (context) => {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
     const lastHistoryId = await context.store.get('lastHistoryId');
@@ -156,8 +152,7 @@ export const gmailNewLabeledEmailTrigger = createTrigger({
     return results;
   },
   test: async (context) => {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
     const gmail = google.gmail({ version: 'v1', auth: authClient });
 
     const messagesResponse = await gmail.users.messages.list({


### PR DESCRIPTION
## What does this PR do?
We want to be able to use service accounts (like for `google-sheets`)
<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
