### PR TITLE
feat(google-docs): add service account auth

### DIFF
--- a/packages/pieces/community/google-docs/package.json
+++ b/packages/pieces/community/google-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-docs",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "dependencies": {
     "googleapis": "129.0.0"
   }

--- a/packages/pieces/community/google-docs/src/index.ts
+++ b/packages/pieces/community/google-docs/src/index.ts
@@ -1,4 +1,4 @@
-import { OAuth2PropertyValue, PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { createPiece } from '@activepieces/pieces-framework';
 
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
 import { PieceCategory } from '@activepieces/shared';
@@ -8,17 +8,9 @@ import { readDocument } from './lib/actions/read-document.action';
 import { appendText } from './lib/actions/append-text';
 import { findDocumentAction } from './lib/actions/find-document';
 import { newDocumentTrigger } from './lib/triggers/new-document';
+import { googleDocsAuth, getAccessToken } from './lib/common';
 
-export const googleDocsAuth = PieceAuth.OAuth2({
-	authUrl: 'https://accounts.google.com/o/oauth2/auth',
-	tokenUrl: 'https://oauth2.googleapis.com/token',
-	required: true,
-	scope: [
-		'https://www.googleapis.com/auth/documents',
-		'https://www.googleapis.com/auth/drive.readonly',
-		'https://www.googleapis.com/auth/drive',
-	],
-});
+export { googleDocsAuth, getAccessToken, GoogleDocsAuthValue } from './lib/common';
 
 export const googleDocs = createPiece({
 	displayName: 'Google Docs',
@@ -45,7 +37,7 @@ export const googleDocs = createPiece({
 			baseUrl: () => 'https://docs.googleapis.com/v1',
 			auth: googleDocsAuth,
 			authMapping: async (auth) => ({
-				Authorization: `Bearer ${(auth).access_token}`,
+				Authorization: `Bearer ${await getAccessToken(auth as any)}`,
 			}),
 		}),
 		appendText,

--- a/packages/pieces/community/google-docs/src/lib/actions/append-text.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/append-text.ts
@@ -1,5 +1,4 @@
-import { docsCommon } from '../common';
-import { googleDocsAuth } from '../..';
+import { docsCommon, googleDocsAuth, getAccessToken } from '../common';
 import { Property, createAction } from "@activepieces/pieces-framework";
 
 export const appendText = createAction({
@@ -23,7 +22,7 @@ export const appendText = createAction({
       return await docsCommon.writeToDocument(
         context.propsValue.documentId,
         context.propsValue.text,
-        context.auth.access_token
+        await getAccessToken(context.auth)
       );
     },
   });

--- a/packages/pieces/community/google-docs/src/lib/actions/create-document-based-on-template.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-document-based-on-template.action.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { googleDocsAuth } from '../../index';
+import { googleDocsAuth, createGoogleClient } from '../common';
 import { Property, createAction } from '@activepieces/pieces-framework';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 
 export const createDocumentBasedOnTemplate = createAction({
   auth: googleDocsAuth,
@@ -48,8 +47,7 @@ export const createDocumentBasedOnTemplate = createAction({
     const values = context.propsValue.values;
     const placeholder_format = context.propsValue.placeholder_format;
 
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
     const docs = google.docs('v1');
 
     const requests = [];

--- a/packages/pieces/community/google-docs/src/lib/actions/create-document.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-document.ts
@@ -1,6 +1,5 @@
 import { createAction } from '@activepieces/pieces-framework';
-import { docsCommon } from '../common';
-import { googleDocsAuth } from '../..';
+import { docsCommon, googleDocsAuth, getAccessToken } from '../common';
 
 export const createDocument = createAction({
   auth: googleDocsAuth,
@@ -12,14 +11,15 @@ export const createDocument = createAction({
     body: docsCommon.body,
   },
   async run(context) {
+    const accessToken = await getAccessToken(context.auth);
     const document = await docsCommon.createDocument(
       context.propsValue.title,
-      context.auth.access_token
+      accessToken
     );
     const response = await docsCommon.writeToDocument(
       document.documentId,
       context.propsValue.body,
-      context.auth.access_token
+      accessToken
     );
 
     return response;

--- a/packages/pieces/community/google-docs/src/lib/actions/find-document.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/find-document.ts
@@ -1,11 +1,10 @@
-import { googleDocsAuth } from '../..';
+import { googleDocsAuth, createGoogleClient } from '../common';
 import {
 	createAction,
 	DynamicPropsValue,
 	Property,
 } from '@activepieces/pieces-framework';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 import { folderIdProp } from '../common/props';
 
 export const findDocumentAction = createAction({
@@ -50,8 +49,7 @@ export const findDocumentAction = createAction({
 		const { name: documentName, folderId, createIfNotFound, newDocumentProps } = context.propsValue;
 		const newDocumentContent = newDocumentProps?.['content'] as string;
 
-		const authClient = new OAuth2Client();
-		authClient.setCredentials(context.auth);
+		const authClient = await createGoogleClient(context.auth);
 
 		const drive = google.drive({ version: 'v3', auth: authClient });
 		const docs = google.docs({ version: 'v1', auth: authClient });

--- a/packages/pieces/community/google-docs/src/lib/actions/read-document.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/read-document.action.ts
@@ -1,7 +1,6 @@
-import { googleDocsAuth } from '../../index';
+import { googleDocsAuth, createGoogleClient } from '../common';
 import { Property, createAction } from '@activepieces/pieces-framework';
 import { google } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 
 export const readDocument = createAction({
   displayName: 'Read Document',
@@ -16,8 +15,7 @@ export const readDocument = createAction({
     }),
   },
   async run(context) {
-    const authClient = new OAuth2Client();
-    authClient.setCredentials(context.auth);
+    const authClient = await createGoogleClient(context.auth);
 
     const docs = google.docs({ version: 'v1', auth: authClient });
     const response = await docs.documents.get({

--- a/packages/pieces/community/google-docs/src/lib/common/index.ts
+++ b/packages/pieces/community/google-docs/src/lib/common/index.ts
@@ -1,6 +1,84 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Property } from '@activepieces/pieces-framework';
+import { AppConnectionValueForAuthProperty, PieceAuth, Property } from '@activepieces/pieces-framework';
 import { HttpMethod, httpClient, AuthenticationType } from '@activepieces/pieces-common';
+import { AppConnectionType } from '@activepieces/shared';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const googleDocsScopes = [
+	'https://www.googleapis.com/auth/documents',
+	'https://www.googleapis.com/auth/drive.readonly',
+	'https://www.googleapis.com/auth/drive',
+];
+
+export const googleDocsAuth = [PieceAuth.OAuth2({
+	description: '',
+	authUrl: 'https://accounts.google.com/o/oauth2/auth',
+	tokenUrl: 'https://oauth2.googleapis.com/token',
+	required: true,
+	scope: googleDocsScopes,
+}), PieceAuth.CustomAuth({
+	displayName: 'Service Account (Advanced)',
+	description: 'Authenticate via service account from https://console.cloud.google.com/ > IAM & Admin > Service Accounts > Create Service Account > Keys > Add key.  <br> <br> You can optionally use domain-wide delegation (https://support.google.com/a/answer/162106?hl=en#zippy=%2Cset-up-domain-wide-delegation-for-a-client) to access documents without adding the service account to each one. <br> <br> **Note:** Without a user email, the service account only has access to files/folders you explicitly share with it.',
+	required: true,
+	props: {
+		serviceAccount: Property.ShortText({
+			displayName: 'Service Account JSON Key',
+			required: true,
+		}),
+		userEmail: Property.ShortText({
+			displayName: 'User Email',
+			required: false,
+			description: 'Email address of the user to impersonate for domain-wide delegation.',
+		}),
+	},
+	validate: async ({ auth }) => {
+		try {
+			await getAccessToken({
+				type: AppConnectionType.CUSTOM_AUTH,
+				props: { ...auth },
+			});
+		} catch (e) {
+			return {
+				valid: false,
+				error: (e as Error).message,
+			};
+		}
+		return {
+			valid: true,
+		};
+	},
+})];
+
+export type GoogleDocsAuthValue = AppConnectionValueForAuthProperty<typeof googleDocsAuth>;
+
+export async function createGoogleClient(auth: GoogleDocsAuthValue): Promise<OAuth2Client> {
+	if (auth.type === AppConnectionType.CUSTOM_AUTH) {
+		const serviceAccount = JSON.parse(auth.props.serviceAccount);
+		return new google.auth.JWT({
+			email: serviceAccount.client_email,
+			key: serviceAccount.private_key,
+			scopes: googleDocsScopes,
+			subject: auth.props.userEmail,
+		});
+	}
+	const authClient = new OAuth2Client();
+	authClient.setCredentials(auth);
+	return authClient;
+}
+
+export const getAccessToken = async (auth: GoogleDocsAuthValue): Promise<string> => {
+	if (auth.type === AppConnectionType.CUSTOM_AUTH) {
+		const googleClient = await createGoogleClient(auth);
+		const response = await googleClient.getAccessToken();
+		if (response.token) {
+			return response.token;
+		} else {
+			throw new Error('Could not retrieve access token from service account json');
+		}
+	}
+	return auth.access_token;
+};
 
 export const docsCommon = {
 	baseUrl: 'https://docs.googleapis.com/v1',

--- a/packages/pieces/community/google-docs/src/lib/common/props.ts
+++ b/packages/pieces/community/google-docs/src/lib/common/props.ts
@@ -1,7 +1,6 @@
-import { googleDocsAuth } from '../../index';
-import { DropdownOption, PiecePropValueSchema, Property } from '@activepieces/pieces-framework';
-import { google, drive_v3 } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
+import { googleDocsAuth, createGoogleClient, GoogleDocsAuthValue } from '.';
+import { DropdownOption, Property } from '@activepieces/pieces-framework';
+import { drive_v3 } from 'googleapis';
 
 export const folderIdProp = Property.Dropdown({
 	displayName: 'Folder',
@@ -16,11 +15,11 @@ export const folderIdProp = Property.Dropdown({
 				options: [],
 			};
 		}
-		const authValue = auth as PiecePropValueSchema<typeof googleDocsAuth>;
+		const authValue = auth as GoogleDocsAuthValue;
 
-		const authClient = new OAuth2Client();
-		authClient.setCredentials(authValue);
+		const authClient = await createGoogleClient(authValue);
 
+		const { google } = await import('googleapis');
 		const drive = google.drive({ version: 'v3', auth: authClient });
 
 		const options: DropdownOption<string>[] = [];

--- a/packages/pieces/community/google-docs/src/lib/triggers/new-document.ts
+++ b/packages/pieces/community/google-docs/src/lib/triggers/new-document.ts
@@ -1,15 +1,13 @@
-import { googleDocsAuth } from '../../index';
+import { googleDocsAuth, createGoogleClient } from '../common';
 import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
 import {
 	AppConnectionValueForAuthProperty,
 	createTrigger,
-	PiecePropValueSchema,
 	TriggerStrategy,
 } from '@activepieces/pieces-framework';
 import { folderIdProp } from '../common/props';
 import dayjs from 'dayjs';
 import { google, drive_v3 } from 'googleapis';
-import { OAuth2Client } from 'googleapis-common';
 
 type Props = {
 	folderId?: string;
@@ -18,7 +16,6 @@ type Props = {
 const polling: Polling<AppConnectionValueForAuthProperty<typeof googleDocsAuth>, Props> = {
 	strategy: DedupeStrategy.TIMEBASED,
 	async items({ auth, propsValue, lastFetchEpochMS }) {
-		const authValue = auth;
 		const folderId = propsValue.folderId;
 
 		const q = ["mimeType='application/vnd.google-apps.document'", 'trashed = false'];
@@ -29,8 +26,7 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof googleDocsAuth>,
 			q.push(`'${folderId}' in parents`);
 		}
 
-		const authClient = new OAuth2Client();
-		authClient.setCredentials(authValue);
+		const authClient = await createGoogleClient(auth);
 
 		const drive = google.drive({ version: 'v3', auth: authClient });
 


### PR DESCRIPTION
## What does this PR do?

Add service account auth (like `google-sheet`)

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
