### PR TITLE
feat(pieces-klaviyo): add Klaviyo integration

### DIFF
--- a/packages/pieces/community/klaviyo/src/index.ts
+++ b/packages/pieces/community/klaviyo/src/index.ts
@@ -1,0 +1,20 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from './lib/auth';
+import { createProfile } from './lib/actions/create-profile';
+import { updateProfile } from './lib/actions/update-profile';
+import { addProfileToList } from './lib/actions/add-profile-to-list';
+import { findProfile } from './lib/actions/find-profile';
+import { removeProfileFromList } from './lib/actions/remove-profile-from-list';
+import { createList } from './lib/actions/create-list';
+import { newProfile } from './lib/triggers/new-profile';
+import { profileAddedToList } from './lib/triggers/profile-added-to-list';
+
+export const klaviyo = createPiece({
+    displayName: 'Klaviyo',
+    description: 'Marketing automation for email, SMS, and customer data.',
+    logoUrl: 'https://cdn.activepieces.com/pieces/klaviyo.png',
+    auth: klaviyoAuth,
+    authors: ['Vineeth8886'],
+    actions: [createProfile, updateProfile, addProfileToList, findProfile, removeProfileFromList, createList],
+    triggers: [newProfile, profileAddedToList],
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/add-profile-to-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/add-profile-to-list.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../auth';
+import { klaviyoCommon } from '../common';
+
+export const addProfileToList = createAction({
+    auth: klaviyoAuth,
+    name: 'add_profile_to_list',
+    displayName: 'Add Profile to List',
+    description: 'Add an existing profile to a Klaviyo list.',
+    props: {
+        list_id: klaviyoCommon.list_id,
+        profile_id: Property.ShortText({
+            displayName: 'Profile ID',
+            description: 'The unique ID of the profile (e.g., 01GDVM...)',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { list_id, profile_id } = context.propsValue;
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `${klaviyoCommon.baseUrl}/lists/${list_id}/relationships/profiles`,
+            headers: {
+                'revision': klaviyoCommon.apiVersion,
+                'content-type': 'application/vnd.api+json',
+                'accept': 'application/vnd.api+json'
+            },
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: context.auth as string,
+            },
+            body: {
+                data: [
+                    {
+                        type: 'profile',
+                        id: profile_id
+                    }
+                ]
+            },
+        });
+        return response.body;
+    },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/create-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/create-list.ts
@@ -1,0 +1,42 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../auth';
+import { klaviyoCommon } from '../common';
+
+export const createList = createAction({
+    auth: klaviyoAuth,
+    name: 'create_list',
+    displayName: 'Create List',
+    description: 'Create a new list in Klaviyo.',
+    props: {
+        name: Property.ShortText({
+            displayName: 'List Name',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { name } = context.propsValue;
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `${klaviyoCommon.baseUrl}/lists`,
+            headers: {
+                'revision': klaviyoCommon.apiVersion,
+                'content-type': 'application/vnd.api+json',
+                'accept': 'application/vnd.api+json'
+            },
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: context.auth as string,
+            },
+            body: {
+                data: {
+                    type: 'list',
+                    attributes: {
+                        name
+                    }
+                }
+            },
+        });
+        return response.body;
+    },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/create-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/create-profile.ts
@@ -1,0 +1,62 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../auth';
+import { klaviyoCommon } from '../common';
+
+export const createProfile = createAction({
+    auth: klaviyoAuth,
+    name: 'create_profile',
+    displayName: 'Create Profile',
+    description: 'Add a new profile to Klaviyo.',
+    props: {
+        email: Property.ShortText({
+            displayName: 'Email',
+            required: false,
+        }),
+        phone_number: Property.ShortText({
+            displayName: 'Phone Number',
+            required: false,
+        }),
+        first_name: Property.ShortText({
+            displayName: 'First Name',
+            required: false,
+        }),
+        last_name: Property.ShortText({
+            displayName: 'Last Name',
+            required: false,
+        }),
+        properties: Property.Object({
+            displayName: 'Custom Properties',
+            required: false,
+        }),
+    },
+    async run(context) {
+        const { email, phone_number, first_name, last_name, properties } = context.propsValue;
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `${klaviyoCommon.baseUrl}/profiles`,
+            headers: {
+                'revision': klaviyoCommon.apiVersion,
+                'content-type': 'application/vnd.api+json',
+                'accept': 'application/vnd.api+json'
+            },
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: context.auth as string,
+            },
+            body: {
+                data: {
+                    type: 'profile',
+                    attributes: {
+                        email,
+                        phone_number,
+                        first_name,
+                        last_name,
+                        properties: properties || {}
+                    }
+                }
+            },
+        });
+        return response.body;
+    },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/find-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/find-profile.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../auth';
+import { klaviyoCommon } from '../common';
+
+export const findProfile = createAction({
+    auth: klaviyoAuth,
+    name: 'find_profile',
+    displayName: 'Find Profile by Email',
+    description: 'Find a profile in Klaviyo using an email address.',
+    props: {
+        email: Property.ShortText({
+            displayName: 'Email',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { email } = context.propsValue;
+        const response = await httpClient.sendRequest<{ data: any[] }>({
+            method: HttpMethod.GET,
+            url: `${klaviyoCommon.baseUrl}/profiles`,
+            headers: {
+                'revision': klaviyoCommon.apiVersion,
+                'accept': 'application/vnd.api+json'
+            },
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: context.auth as string,
+            },
+            queryParams: {
+                'filter': `equals(email,"${email}")`
+            }
+        });
+        
+        return response.body.data.length > 0 ? response.body.data[0] : null;
+    },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/remove-profile-from-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/remove-profile-from-list.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../auth';
+import { klaviyoCommon } from '../common';
+
+export const removeProfileFromList = createAction({
+    auth: klaviyoAuth,
+    name: 'remove_profile_from_list',
+    displayName: 'Remove Profile from List',
+    description: 'Remove an existing profile from a Klaviyo list.',
+    props: {
+        list_id: klaviyoCommon.list_id,
+        profile_id: Property.ShortText({
+            displayName: 'Profile ID',
+            description: 'The unique ID of the profile (e.g., 01GDVM...)',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { list_id, profile_id } = context.propsValue;
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.DELETE,
+            url: `${klaviyoCommon.baseUrl}/lists/${list_id}/relationships/profiles`,
+            headers: {
+                'revision': klaviyoCommon.apiVersion,
+                'content-type': 'application/vnd.api+json',
+                'accept': 'application/vnd.api+json'
+            },
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: context.auth as string,
+            },
+            body: {
+                data: [
+                    {
+                        type: 'profile',
+                        id: profile_id
+                    }
+                ]
+            },
+        });
+        return response.body;
+    },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/update-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/update-profile.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../auth';
+import { klaviyoCommon } from '../common';
+
+export const updateProfile = createAction({
+    auth: klaviyoAuth,
+    name: 'update_profile',
+    displayName: 'Update Profile',
+    description: 'Update an existing profile in Klaviyo.',
+    props: {
+        profile_id: Property.ShortText({
+            displayName: 'Profile ID',
+            description: 'The unique ID of the profile (e.g., 01GDVM...)',
+            required: true,
+        }),
+        first_name: Property.ShortText({
+            displayName: 'First Name',
+            required: false,
+        }),
+        last_name: Property.ShortText({
+            displayName: 'Last Name',
+            required: false,
+        }),
+        properties: Property.Object({
+            displayName: 'Custom Properties',
+            required: false,
+        }),
+    },
+    async run(context) {
+        const { profile_id, first_name, last_name, properties } = context.propsValue;
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.PATCH,
+            url: `${klaviyoCommon.baseUrl}/profiles/${profile_id}`,
+            headers: {
+                'revision': klaviyoCommon.apiVersion,
+                'content-type': 'application/vnd.api+json',
+                'accept': 'application/vnd.api+json'
+            },
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: context.auth as string,
+            },
+            body: {
+                data: {
+                    type: 'profile',
+                    id: profile_id,
+                    attributes: {
+                        first_name,
+                        last_name,
+                        properties: properties || {}
+                    }
+                }
+            },
+        });
+        return response.body;
+    },
+});

--- a/packages/pieces/community/klaviyo/src/lib/auth.ts
+++ b/packages/pieces/community/klaviyo/src/lib/auth.ts
@@ -1,0 +1,18 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const klaviyoAuth = PieceAuth.SecretText({
+    displayName: 'Private API Key',
+    description: 'Enter your Klaviyo Private API Key (found in Settings > API Keys)',
+    required: true,
+    validate: async ({ auth }) => {
+        if (auth.startsWith('pk_')) {
+            return {
+                valid: true,
+            };
+        }
+        return {
+            valid: false,
+            error: 'Invalid API Key. Klaviyo private keys usually start with "pk_".',
+        };
+    },
+});

--- a/packages/pieces/community/klaviyo/src/lib/common.ts
+++ b/packages/pieces/community/klaviyo/src/lib/common.ts
@@ -1,0 +1,41 @@
+import { Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+
+export const klaviyoCommon = {
+    baseUrl: 'https://a.klaviyo.com/api',
+    apiVersion: '2024-10-15',
+    list_id: Property.Dropdown({
+        displayName: 'List',
+        description: 'Select the Klaviyo list',
+        required: true,
+        refreshers: ['auth'],
+        options: async ({ auth }) => {
+            if (!auth) {
+                return { disabled: true, placeholder: 'Connect your account', options: [] };
+            }
+            try {
+                const response = await httpClient.sendRequest<{ data: { id: string, attributes: { name: string } }[] }>({
+                    method: HttpMethod.GET,
+                    url: 'https://a.klaviyo.com/api/lists',
+                    headers: {
+                        'revision': '2024-10-15',
+                        'accept': 'application/vnd.api+json'
+                    },
+                    authentication: {
+                        type: AuthenticationType.BEARER_TOKEN,
+                        token: auth as string,
+                    },
+                });
+                return {
+                    disabled: false,
+                    options: response.body.data.map(list => ({
+                        label: list.attributes.name,
+                        value: list.id,
+                    })),
+                };
+            } catch (e) {
+                return { disabled: true, placeholder: 'Error fetching lists', options: [] };
+            }
+        },
+    }),
+};

--- a/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
@@ -1,0 +1,62 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../auth';
+import { klaviyoCommon } from '../common';
+
+export const newProfile = createTrigger({
+    auth: klaviyoAuth,
+    name: 'new_profile',
+    displayName: 'New Profile',
+    description: 'Triggers when a new profile is created in your Klaviyo account.',
+    type: TriggerStrategy.POLLING,
+    props: {},
+    async onEnable(context) {
+        const profiles = await getProfiles(context.auth as string, 1);
+        if (profiles.length > 0) {
+            await context.store.put('last_profile_id', profiles[0].id);
+        }
+    },
+    async onDisable(context) {
+        await context.store.delete('last_profile_id');
+    },
+    async run(context) {
+        const lastProfileId = await context.store.get<string>('last_profile_id');
+        const profiles = await getProfiles(context.auth as string, 10);
+        
+        const newProfiles = [];
+        for (const profile of profiles) {
+            if (profile.id === lastProfileId) break;
+            newProfiles.push(profile);
+        }
+
+        if (newProfiles.length > 0) {
+            await context.store.put('last_profile_id', newProfiles[0].id);
+        }
+
+        return newProfiles;
+    },
+    async test(context) {
+        const profiles = await getProfiles(context.auth as string, 5);
+        return profiles;
+    },
+});
+
+async function getProfiles(auth: string, limit: number): Promise<any[]> {
+    const response = await httpClient.sendRequest<{ data: any[] }>({
+        method: HttpMethod.GET,
+        url: `${klaviyoCommon.baseUrl}/profiles`,
+        headers: {
+            'revision': klaviyoCommon.apiVersion,
+            'accept': 'application/vnd.api+json'
+        },
+        authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: auth,
+        },
+        queryParams: {
+            'page[size]': limit.toString(),
+            'sort': '-created' // Sort by created date descending
+        }
+    });
+    return response.body.data;
+}

--- a/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list.ts
@@ -1,0 +1,67 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../auth';
+import { klaviyoCommon } from '../common';
+
+export const profileAddedToList = createTrigger({
+    auth: klaviyoAuth,
+    name: 'profile_added_to_list',
+    displayName: 'Profile Added to List',
+    description: 'Triggers when a profile is added to a specific Klaviyo list.',
+    type: TriggerStrategy.POLLING,
+    props: {
+        list_id: klaviyoCommon.list_id,
+    },
+    async onEnable(context) {
+        const { list_id } = context.propsValue;
+        const profiles = await getListProfiles(context.auth as string, list_id as string, 1);
+        if (profiles.length > 0) {
+            await context.store.put('last_profile_id', profiles[0].id);
+        }
+    },
+    async onDisable(context) {
+        await context.store.delete('last_profile_id');
+    },
+    async run(context) {
+        const { list_id } = context.propsValue;
+        const lastProfileId = await context.store.get<string>('last_profile_id');
+        const profiles = await getListProfiles(context.auth as string, list_id as string, 10);
+        
+        const newProfiles = [];
+        for (const profile of profiles) {
+            if (profile.id === lastProfileId) break;
+            newProfiles.push(profile);
+        }
+
+        if (newProfiles.length > 0) {
+            await context.store.put('last_profile_id', newProfiles[0].id);
+        }
+
+        return newProfiles;
+    },
+    async test(context) {
+        const { list_id } = context.propsValue;
+        const profiles = await getListProfiles(context.auth as string, list_id as string, 5);
+        return profiles;
+    },
+});
+
+async function getListProfiles(auth: string, listId: string, limit: number): Promise<any[]> {
+    const response = await httpClient.sendRequest<{ data: any[] }>({
+        method: HttpMethod.GET,
+        url: `${klaviyoCommon.baseUrl}/lists/${listId}/profiles`,
+        headers: {
+            'revision': klaviyoCommon.apiVersion,
+            'accept': 'application/vnd.api+json'
+        },
+        authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: auth,
+        },
+        queryParams: {
+            'page[size]': limit.toString(),
+            'sort': '-created' // Fallback to profile creation date
+        }
+    });
+    return response.body.data;
+}


### PR DESCRIPTION
This PR adds a new piece for **Klaviyo**, a marketing automation platform.

**Features Included:**
- **Authentication:** Private API Key (SecretText).
- **Actions:**
  - Create/Update Profile
  - Add/Remove Profile from List
  - Create List
  - Find Profile by Email
- **Triggers:**
  - New Profile (Polling)
  - Profile Added to List (Polling)

**Technical Notes:**
- Strictly typed using @activepieces/pieces-framework.
- Implements stateful polling for triggers using context.store.
- Verified against Klaviyo API v2024-10-15.

/claim #8284