### PR TITLE
feat(gmail): extend Gmail piece with label management, archive, delete, and starred trigger

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -15,6 +15,13 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailAddLabelToEmailAction } from './lib/actions/add-label-to-email-action';
+import { gmailRemoveLabelFromEmailAction } from './lib/actions/remove-label-from-email-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
 
 export const gmailAuth = PieceAuth.OAuth2({
   description: '',
@@ -26,6 +33,8 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.labels',
   ],
 });
 
@@ -43,6 +52,12 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailAddLabelToEmailAction,
+    gmailRemoveLabelFromEmailAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -67,12 +82,14 @@ export const gmail = createPiece({
     'AdamSelene',
     'sanket-a11y',
     'onyedikachi-david',
+    'Crazy-D1359',
   ],
   triggers: [
     gmailNewEmailTrigger,
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewStarredEmailTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
@@ -1,0 +1,34 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailAddLabelToEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_add_label_to_email',
+  description: 'Add a label to a specific email message.',
+  displayName: 'Add Label to Email',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        addLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,30 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_archive_email',
+  description: 'Archive an email by removing it from the inbox.',
+  displayName: 'Archive Email',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,59 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_create_label',
+  description: 'Create a new label in Gmail.',
+  displayName: 'Create Label',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the new label to create.',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Label List',
+      description: 'Whether the label is shown in the label list.',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Show if Unread', value: 'labelShowIfUnread' },
+          { label: 'Hide', value: 'labelHide' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Message List',
+      description: 'Whether the label is shown in the message list.',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.labels.create({
+      userId: 'me',
+      requestBody: {
+        name: context.propsValue.name,
+        labelListVisibility: context.propsValue.label_list_visibility ?? 'labelShow',
+        messageListVisibility: context.propsValue.message_list_visibility ?? 'show',
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,27 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_delete_email',
+  description: 'Move an email to the Trash folder.',
+  displayName: 'Delete Email',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.trash({
+      userId: 'me',
+      id: context.propsValue.message_id,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
@@ -1,0 +1,34 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailRemoveLabelFromEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_email',
+  description: 'Remove a label from a specific email message.',
+  displayName: 'Remove Label from Email',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,34 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_thread',
+  description: 'Remove a label from all emails in a thread.',
+  displayName: 'Remove Label from Thread',
+  props: {
+    thread_id: GmailProps.thread,
+    label: {
+      ...GmailProps.label,
+      required: true,
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.threads.modify({
+      userId: 'me',
+      id: context.propsValue.thread_id,
+      requestBody: {
+        removeLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,139 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  FilesService,
+} from '@activepieces/pieces-framework';
+import { GmailProps } from '../common/props';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { parseStream, convertAttachment, getFirstFiveOrAll } from '../common/data';
+
+async function enrichStarredMessage({
+  gmail,
+  messageId,
+  files,
+}: {
+  gmail: any;
+  messageId: string;
+  files: FilesService;
+}) {
+  const rawMailResponse = await gmail.users.messages.get({
+    userId: 'me',
+    id: messageId,
+    format: 'raw',
+  });
+
+  const parsedMailResponse = await parseStream(
+    Buffer.from(rawMailResponse.data.raw as string, 'base64').toString('utf-8')
+  );
+
+  return {
+    message: {
+      id: messageId,
+      threadId: rawMailResponse.data.threadId,
+      labelIds: rawMailResponse.data.labelIds,
+      ...parsedMailResponse,
+      attachments: await convertAttachment(
+        parsedMailResponse.attachments,
+        files
+      ),
+    },
+    starredAt: Date.now(),
+  };
+}
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'gmail_new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred.',
+  props: {},
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  onEnable: async (context) => {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const profile = await gmail.users.getProfile({ userId: 'me' });
+    await context.store.put('lastHistoryId', profile.data.historyId);
+  },
+  onDisable: async (context) => {
+    await context.store.delete('lastHistoryId');
+  },
+  run: async (context) => {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const lastHistoryId = await context.store.get('lastHistoryId');
+
+    const historyResponse = await gmail.users.history.list({
+      userId: 'me',
+      startHistoryId: lastHistoryId as string,
+      labelId: 'STARRED',
+      historyTypes: ['labelAdded'],
+    });
+
+    const starredMessageIds = new Set<string>();
+    const results = [];
+
+    if (historyResponse.data.history) {
+      for (const history of historyResponse.data.history) {
+        if (history.labelsAdded) {
+          for (const labelAdded of history.labelsAdded) {
+            if (
+              labelAdded.labelIds?.includes('STARRED') &&
+              labelAdded.message?.id
+            ) {
+              starredMessageIds.add(labelAdded.message.id);
+            }
+          }
+        }
+      }
+    }
+
+    for (const messageId of starredMessageIds) {
+      const enrichedMessage = await enrichStarredMessage({
+        gmail,
+        messageId,
+        files: context.files,
+      });
+      results.push(enrichedMessage);
+    }
+
+    if (historyResponse.data.historyId) {
+      await context.store.put('lastHistoryId', historyResponse.data.historyId);
+    }
+
+    return results;
+  },
+  test: async (context) => {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messagesResponse = await gmail.users.messages.list({
+      userId: 'me',
+      labelIds: ['STARRED'],
+      maxResults: 5,
+    });
+
+    const results = [];
+
+    if (messagesResponse.data.messages) {
+      for (const message of messagesResponse.data.messages) {
+        if (!message.id) continue;
+        const enrichedMessage = await enrichStarredMessage({
+          gmail,
+          messageId: message.id,
+          files: context.files,
+        });
+        results.push(enrichedMessage);
+      }
+    }
+
+    return getFirstFiveOrAll(results);
+  },
+});


### PR DESCRIPTION
## Summary

Extends the existing Gmail piece with all missing actions and triggers requested in #8072.

### New Actions (6)
| Action | Description |
|--------|-------------|
| **Add Label to Email** | Attach a label to an individual email |
| **Remove Label from Email** | Remove a specific label from an email |
| **Create Label** | Create a new user label in Gmail |
| **Archive Email** | Archive (remove from Inbox) rather than deleting |
| **Delete Email** | Move an email to Trash |
| **Remove Label from Thread** | Strip a label from all emails in a thread |

### New Triggers (1)
| Trigger | Description |
|---------|-------------|
| **New Starred Email** | Fires when an email is starred, using Gmail History API for efficient polling |

### Changes
- Added 6 new action files in `src/lib/actions/`
- Added 1 new trigger file in `src/lib/triggers/new-starred-email.ts`
- Updated `src/index.ts` to register all new actions and triggers
- Added required OAuth2 scopes: `gmail.modify`, `gmail.labels`

### Implementation Notes
- All new actions follow existing piece patterns (OAuth2Client + googleapis)
- New Starred Email trigger uses History API with `labelAdded` history type for STARRED label — same efficient approach as the existing New Labeled Email trigger
- Label dropdowns reuse existing `GmailProps.label` for consistency
- Message/Thread selectors reuse existing `GmailProps.message` and `GmailProps.thread`

Resolves #8072

/attempt #8072

/claim #8072