### PR TITLE
feat(gmail): add new actions and triggers

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -15,6 +15,14 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailAddLabelAction } from './lib/actions/add-label-action';
+import { gmailRemoveLabelAction } from './lib/actions/remove-label-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
+import { gmailNewConversationTrigger } from './lib/triggers/new-conversation';
 
 export const gmailAuth = PieceAuth.OAuth2({
   description: '',
@@ -26,6 +34,7 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.modify',
   ],
 });
 
@@ -43,6 +52,12 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailAddLabelAction,
+    gmailRemoveLabelAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -67,12 +82,15 @@ export const gmail = createPiece({
     'AdamSelene',
     'sanket-a11y',
     'onyedikachi-david',
+    'xiajohn',
   ],
   triggers: [
     gmailNewEmailTrigger,
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewStarredEmailTrigger,
+    gmailNewConversationTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+import { GmailLabel } from '../common/models';
+
+export const gmailAddLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'add_label_to_email',
+  description: 'Add a label to an email message.',
+  displayName: 'Add Label to Email',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message_id as string;
+    const label = context.propsValue.label as GmailLabel;
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: messageId,
+      requestBody: {
+        addLabelIds: [label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,31 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'archive_email',
+  description: 'Archive an email by removing it from the inbox',
+  displayName: 'Archive Email',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id!,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,61 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'create_label',
+  description: 'Create a new label in Gmail.',
+  displayName: 'Create Label',
+  props: {
+    label_name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the label to create.',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Label List Visibility',
+      description: 'The visibility of the label in the label list.',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Hide', value: 'labelHide' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Message List Visibility',
+      description: 'The visibility of messages with this label in the message list.',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.labels.create({
+      userId: 'me',
+      requestBody: {
+        name: context.propsValue.label_name,
+        labelListVisibility: context.propsValue.label_list_visibility ?? 'labelShow',
+        messageListVisibility: context.propsValue.message_list_visibility ?? 'show',
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'delete_email',
+  description: 'Move an email to the trash',
+  displayName: 'Delete Email',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.trash({
+      userId: 'me',
+      id: context.propsValue.message_id!,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+import { GmailLabel } from '../common/models';
+
+export const gmailRemoveLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_email',
+  description: 'Remove a label from an email message.',
+  displayName: 'Remove Label from Email',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message_id as string;
+    const label = context.propsValue.label as GmailLabel;
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: messageId,
+      requestBody: {
+        removeLabelIds: [label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+import { GmailLabel } from '../common/models';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_thread',
+  description: 'Remove a label from an email thread.',
+  displayName: 'Remove Label from Thread',
+  props: {
+    thread_id: GmailProps.thread,
+    label: {
+      ...GmailProps.label,
+      required: true,
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const threadId = context.propsValue.thread_id as string;
+    const label = context.propsValue.label as GmailLabel;
+
+    const response = await gmail.users.threads.modify({
+      userId: 'me',
+      id: threadId,
+      requestBody: {
+        removeLabelIds: [label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,130 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  PiecePropValueSchema,
+  FilesService,
+} from '@activepieces/pieces-framework';
+import dayjs from 'dayjs';
+import { gmailAuth } from '../../';
+import {
+  parseStream,
+  convertAttachment,
+  getFirstFiveOrAll,
+} from '../common/data';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'gmail_new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred in your Gmail account',
+  props: {},
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await context.store.put('lastPoll', Date.now());
+  },
+  async onDisable(context) {
+    return;
+  },
+  async run(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      files: context.files,
+      lastFetchEpochMS,
+    });
+
+    const newLastEpochMilliSeconds = items.reduce(
+      (acc, item) => Math.max(acc, item.epochMilliSeconds),
+      lastFetchEpochMS
+    );
+    await context.store.put('lastPoll', newLastEpochMilliSeconds);
+    return items
+      .filter((f) => f.epochMilliSeconds > lastFetchEpochMS)
+      .map((item) => item.data);
+  },
+  async test(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      files: context.files,
+      lastFetchEpochMS,
+    });
+
+    return getFirstFiveOrAll(items.map((item) => item.data));
+  },
+});
+
+async function pollStarredMessages({
+  auth,
+  files,
+  lastFetchEpochMS,
+}: {
+  auth: PiecePropValueSchema<typeof gmailAuth>;
+  files: FilesService;
+  lastFetchEpochMS: number;
+}): Promise<
+  {
+    epochMilliSeconds: number;
+    data: unknown;
+  }[]
+> {
+  const authClient = new OAuth2Client();
+  authClient.setCredentials(auth);
+
+  const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+  const query = ['is:starred'];
+  const maxResults = lastFetchEpochMS === 0 ? 5 : 100;
+  const afterUnixSeconds = Math.floor(lastFetchEpochMS / 1000);
+
+  if (afterUnixSeconds != null && afterUnixSeconds > 0)
+    query.push(`after:${afterUnixSeconds}`);
+
+  const messagesResponse = await gmail.users.messages.list({
+    userId: 'me',
+    q: query.join(' '),
+    maxResults,
+  });
+
+  const pollingResponse = [];
+  for (const message of messagesResponse.data.messages || []) {
+    const rawMailResponse = await gmail.users.messages.get({
+      userId: 'me',
+      id: message.id!,
+      format: 'raw',
+    });
+    const threadResponse = await gmail.users.threads.get({
+      userId: 'me',
+      id: message.threadId!,
+    });
+
+    const parsedMailResponse = await parseStream(
+      Buffer.from(rawMailResponse.data.raw as string, 'base64').toString(
+        'utf-8'
+      )
+    );
+
+    pollingResponse.push({
+      epochMilliSeconds: dayjs(parsedMailResponse.date).valueOf(),
+      data: {
+        message: {
+          ...parsedMailResponse,
+          attachments: await convertAttachment(
+            parsedMailResponse.attachments,
+            files
+          ),
+        },
+        thread: {
+          ...threadResponse,
+        },
+      },
+    });
+  }
+
+  return pollingResponse;
+}


### PR DESCRIPTION
/claim #8072

## Summary

Extends the existing Gmail piece with the remaining actions and triggers from #8072.

### New Actions (6)
| Action | Description |
|--------|-------------|
| **Add Label to Email** | Attach a label to an individual email |
| **Remove Label from Email** | Remove a specific label from an email |
| **Create Label** | Create a new user label in Gmail |
| **Archive Email** | Archive (remove from Inbox) rather than deleting |
| **Delete Email** | Move an email to Trash |
| **Remove Label from Thread** | Strip a label from all emails in a thread |

### New Trigger (1)
| Trigger | Description |
|---------|-------------|
| **New Starred Email** | Fires when an email is starred (polling-based) |

### Other Changes
- Registered existing `New Conversation` trigger (file existed but wasn't wired up)
- Added `gmail.modify` OAuth scope for label/archive/delete operations

All new actions reuse `GmailProps.message`, `GmailProps.label`, and `GmailProps.thread` dropdowns. The starred email trigger follows the same polling pattern as the existing `New Email` trigger.

## Test plan
- [ ] Each new action works with a connected Gmail account
- [ ] New Starred Email trigger fires correctly
- [ ] New Conversation trigger works (was already implemented, just registered)
- [ ] `gmail.modify` scope is requested during OAuth flow

Closes #8072