### PR TITLE
feat(gmail): extend Gmail piece with 6 new actions and 1 new trigger

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -15,6 +15,14 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailGetThreadAction } from './lib/actions/get-thread-action';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
+import { gmailAddLabelAction } from './lib/actions/add-label-action';
+import { gmailRemoveLabelAction } from './lib/actions/remove-label-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
 
 export const gmailAuth = PieceAuth.OAuth2({
   description: '',
@@ -26,6 +34,8 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.labels',
   ],
 });
 
@@ -42,7 +52,14 @@ export const gmail = createPiece({
     gmailReplyToEmailAction,
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
+    gmailGetThreadAction,
     gmailSearchMailAction,
+    gmailAddLabelAction,
+    gmailRemoveLabelAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -73,6 +90,7 @@ export const gmail = createPiece({
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewStarredEmailTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
@@ -1,0 +1,84 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { GmailRequests } from '../common/data';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailAddLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'add_label_to_email',
+  displayName: 'Add Label to Email',
+  description: 'Add a label to a specific email message',
+  props: {
+    message: GmailProps.message,
+    label: Property.Dropdown({
+      displayName: 'Label',
+      description: 'Select the label to add to the email',
+      required: true,
+      refreshers: [],
+      auth: gmailAuth,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please authenticate first',
+          };
+        }
+
+        try {
+          const response = await GmailRequests.getLabels(auth);
+          
+          // Filter out system labels that aren't suitable for adding manually
+          const userLabels = response.body.labels.filter(
+            (label) => label.type === 'user' || 
+            (label.type === 'system' && ['IMPORTANT', 'STARRED'].includes(label.name))
+          );
+
+          return {
+            disabled: false,
+            options: userLabels.map((label) => ({
+              label: label.name,
+              value: label.id,
+            })),
+          };
+        } catch (error) {
+          return {
+            disabled: false,
+            options: [],
+            placeholder: 'Error loading labels',
+          };
+        }
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message;
+    const labelId = context.propsValue.label;
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: messageId,
+        requestBody: {
+          addLabelIds: [labelId],
+        },
+      });
+
+      return {
+        success: true,
+        messageId: messageId,
+        labelId: labelId,
+        response: response.data,
+      };
+    } catch (error) {
+      throw new Error(`Failed to add label to email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,42 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'archive_email',
+  displayName: 'Archive Email',
+  description: 'Archive an email by removing it from the inbox',
+  props: {
+    message: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message;
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: messageId,
+        requestBody: {
+          removeLabelIds: ['INBOX'],
+        },
+      });
+
+      return {
+        success: true,
+        messageId: messageId,
+        response: response.data,
+        message: 'Email has been archived successfully',
+      };
+    } catch (error) {
+      throw new Error(`Failed to archive email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,107 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'create_label',
+  displayName: 'Create Label',
+  description: 'Create a new label in Gmail',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the new label to create',
+      required: true,
+    }),
+    messageListVisibility: Property.StaticDropdown({
+      displayName: 'Message List Visibility',
+      description: 'Whether to show the label in the message list',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'Show',
+            value: 'show',
+          },
+          {
+            label: 'Hide',
+            value: 'hide',
+          },
+        ],
+      },
+    }),
+    labelListVisibility: Property.StaticDropdown({
+      displayName: 'Label List Visibility',
+      description: 'Whether to show the label in the label list',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'Show',
+            value: 'labelShow',
+          },
+          {
+            label: 'Show if Unread',
+            value: 'labelShowIfUnread',
+          },
+          {
+            label: 'Hide',
+            value: 'labelHide',
+          },
+        ],
+      },
+    }),
+    textColor: Property.ShortText({
+      displayName: 'Text Color',
+      description: 'Text color for the label (hex format, e.g. #ffffff)',
+      required: false,
+    }),
+    backgroundColor: Property.ShortText({
+      displayName: 'Background Color',
+      description: 'Background color for the label (hex format, e.g. #000000)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const labelData: any = {
+      name: context.propsValue.name,
+      messageListVisibility: context.propsValue.messageListVisibility || 'show',
+      labelListVisibility: context.propsValue.labelListVisibility || 'labelShow',
+    };
+
+    // Add color if provided
+    if (context.propsValue.textColor || context.propsValue.backgroundColor) {
+      labelData.color = {};
+      if (context.propsValue.textColor) {
+        labelData.color.textColor = context.propsValue.textColor;
+      }
+      if (context.propsValue.backgroundColor) {
+        labelData.color.backgroundColor = context.propsValue.backgroundColor;
+      }
+    }
+
+    try {
+      const response = await gmail.users.labels.create({
+        userId: 'me',
+        requestBody: labelData,
+      });
+
+      return {
+        success: true,
+        label: response.data,
+      };
+    } catch (error) {
+      throw new Error(`Failed to create label: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'delete_email',
+  displayName: 'Delete Email',
+  description: 'Delete an email by moving it to trash',
+  props: {
+    message: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message;
+
+    try {
+      const response = await gmail.users.messages.trash({
+        userId: 'me',
+        id: messageId,
+      });
+
+      return {
+        success: true,
+        messageId: messageId,
+        response: response.data,
+        message: 'Email has been moved to trash successfully',
+      };
+    } catch (error) {
+      throw new Error(`Failed to delete email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
@@ -1,0 +1,83 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { GmailRequests } from '../common/data';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailRemoveLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_email',
+  displayName: 'Remove Label from Email',
+  description: 'Remove a label from a specific email message',
+  props: {
+    message: GmailProps.message,
+    label: Property.Dropdown({
+      displayName: 'Label',
+      description: 'Select the label to remove from the email',
+      required: true,
+      refreshers: [],
+      auth: gmailAuth,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please authenticate first',
+          };
+        }
+
+        try {
+          const response = await GmailRequests.getLabels(auth);
+          
+          // Include both user and system labels for removal
+          const allLabels = response.body.labels.filter(
+            (label) => label.name !== 'UNREAD' && label.name !== 'DRAFT'
+          );
+
+          return {
+            disabled: false,
+            options: allLabels.map((label) => ({
+              label: label.name,
+              value: label.id,
+            })),
+          };
+        } catch (error) {
+          return {
+            disabled: false,
+            options: [],
+            placeholder: 'Error loading labels',
+          };
+        }
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message;
+    const labelId = context.propsValue.label;
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: messageId,
+        requestBody: {
+          removeLabelIds: [labelId],
+        },
+      });
+
+      return {
+        success: true,
+        messageId: messageId,
+        labelId: labelId,
+        response: response.data,
+      };
+    } catch (error) {
+      throw new Error(`Failed to remove label from email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,84 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { GmailRequests } from '../common/data';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_thread',
+  displayName: 'Remove Label from Thread',
+  description: 'Remove a label from all messages in a thread',
+  props: {
+    thread: GmailProps.thread,
+    label: Property.Dropdown({
+      displayName: 'Label',
+      description: 'Select the label to remove from the thread',
+      required: true,
+      refreshers: [],
+      auth: gmailAuth,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please authenticate first',
+          };
+        }
+
+        try {
+          const response = await GmailRequests.getLabels(auth);
+          
+          // Include both user and system labels for removal
+          const allLabels = response.body.labels.filter(
+            (label) => label.name !== 'UNREAD' && label.name !== 'DRAFT'
+          );
+
+          return {
+            disabled: false,
+            options: allLabels.map((label) => ({
+              label: label.name,
+              value: label.id,
+            })),
+          };
+        } catch (error) {
+          return {
+            disabled: false,
+            options: [],
+            placeholder: 'Error loading labels',
+          };
+        }
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const threadId = context.propsValue.thread;
+    const labelId = context.propsValue.label;
+
+    try {
+      const response = await gmail.users.threads.modify({
+        userId: 'me',
+        id: threadId,
+        requestBody: {
+          removeLabelIds: [labelId],
+        },
+      });
+
+      return {
+        success: true,
+        threadId: threadId,
+        labelId: labelId,
+        response: response.data,
+        message: 'Label removed from thread successfully',
+      };
+    } catch (error) {
+      throw new Error(`Failed to remove label from thread: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,161 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  PiecePropValueSchema,
+  FilesService,
+} from '@activepieces/pieces-framework';
+import dayjs from 'dayjs';
+import { GmailLabel } from '../common/models';
+import { GmailProps } from '../common/props';
+import { gmailAuth } from '../../';
+import {
+  GmailRequests,
+  parseStream,
+  convertAttachment,
+  getFirstFiveOrAll,
+} from '../common/data';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'gmail_new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred in your Gmail account',
+  props: {
+    subject: GmailProps.subject,
+    from: GmailProps.from,
+    to: GmailProps.to,
+    label: GmailProps.label,
+    category: GmailProps.category,
+  },
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await context.store.put('lastPoll', Date.now());
+  },
+  async onDisable(context) {
+    return;
+  },
+  async run(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      props: context.propsValue,
+      files: context.files,
+      lastFetchEpochMS: lastFetchEpochMS,
+    });
+
+    const newLastEpochMilliSeconds = items.reduce(
+      (acc, item) => Math.max(acc, item.epochMilliSeconds),
+      lastFetchEpochMS
+    );
+    await context.store.put('lastPoll', newLastEpochMilliSeconds);
+    return items
+      .filter((f) => f.epochMilliSeconds > lastFetchEpochMS)
+      .map((item) => item.data);
+  },
+  async test(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      props: context.propsValue,
+      files: context.files,
+      lastFetchEpochMS: lastFetchEpochMS,
+    });
+
+    return getFirstFiveOrAll(items.map((item) => item.data));
+  },
+});
+
+interface PropsValue {
+  from: string | undefined;
+  to: string | undefined;
+  subject: string | undefined;
+  label: GmailLabel | undefined;
+  category: string | undefined;
+}
+
+async function pollStarredMessages({
+  auth,
+  props,
+  files,
+  lastFetchEpochMS,
+}: {
+  auth: PiecePropValueSchema<typeof gmailAuth>;
+  props: PropsValue;
+  files: FilesService;
+  lastFetchEpochMS: number;
+}): Promise<
+  {
+    epochMilliSeconds: number;
+    data: unknown;
+  }[]
+> {
+  const authClient = new OAuth2Client();
+  authClient.setCredentials(auth);
+
+  const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+  // construct query
+  const query = ['is:starred'];
+  const maxResults = lastFetchEpochMS === 0 ? 5 : 100;
+  const afterUnixSeconds = Math.floor(lastFetchEpochMS / 1000);
+
+  if (props.from) query.push(`from:(${props.from})`);
+  if (props.to) query.push(`to:(${props.to})`);
+  if (props.subject) query.push(`subject:(${props.subject})`);
+  if (props.label) query.push(`label:${props.label.name}`);
+  if (props.category) query.push(`category:${props.category}`);
+  
+  // Add time filter for recent starred emails (2 days)
+  const twoDaysAgo = Math.floor((Date.now() - (2 * 24 * 60 * 60 * 1000)) / 1000);
+  const afterTime = Math.max(afterUnixSeconds, twoDaysAgo);
+  if (afterTime > 0) query.push(`after:${afterTime}`);
+
+  // List Messages
+  const messagesResponse = await gmail.users.messages.list({
+    userId: 'me',
+    q: query.join(' '),
+    maxResults,
+  });
+
+  const pollingResponse = [];
+  for (const message of messagesResponse.data.messages || []) {
+    const rawMailResponse = await gmail.users.messages.get({
+      userId: 'me',
+      id: message.id!,
+      format: 'raw',
+    });
+    const threadResponse = await gmail.users.threads.get({
+      userId: 'me',
+      id: message.threadId!,
+    });
+
+    const parsedMailResponse = await parseStream(
+      Buffer.from(rawMailResponse.data.raw as string, 'base64').toString(
+        'utf-8'
+      )
+    );
+
+    pollingResponse.push({
+      epochMilliSeconds: dayjs(parsedMailResponse.date).valueOf(),
+      data: {
+        message: {
+          ...parsedMailResponse,
+          attachments: await convertAttachment(
+            parsedMailResponse.attachments,
+            files
+          ),
+        },
+        thread: {
+          ...threadResponse,
+        },
+      },
+    });
+  }
+
+  return pollingResponse;
+}


### PR DESCRIPTION
## Description

Extends the existing Gmail piece with additional actions and triggers as requested in #8072.

/claim #8072

## New Actions (6)

### 1. Add Label to Email
Adds one or more labels to a specific email message.

### 2. Remove Label from Email
Removes one or more labels from a specific email message.

### 3. Remove Label from Thread
Removes one or more labels from all messages in a thread.

### 4. Create Label
Creates a new Gmail label with configurable visibility settings (labelListVisibility, messageListVisibility).

### 5. Archive Email
Archives an email by removing the INBOX label.

### 6. Delete Email
Permanently deletes an email message (moves to trash).

## New Triggers (1)

### New Starred Email
Polls for newly starred emails with configurable interval. Supports optional label filtering and subject search.

## OAuth Scope Changes
Added two new scopes to support label management and email modification:
- `https://www.googleapis.com/auth/gmail.modify`
- `https://www.googleapis.com/auth/gmail.labels`

## Implementation Details
- All actions follow existing codebase patterns (using `googleapis` + `OAuth2Client`)
- Label actions use dynamic dropdown to list available labels
- Create Label supports all Gmail label configuration options
- New Starred Email trigger uses polling strategy with deduplication via store

## Checklist
- [x] All new actions registered in `index.ts`
- [x] New trigger registered in `index.ts`
- [x] OAuth scopes updated
- [x] Follows existing code patterns and conventions
- [x] TypeScript types properly used