### PR TITLE
feat: add Klaviyo piece

### DIFF
--- a/packages/pieces/community/klaviyo/.babelrc
+++ b/packages/pieces/community/klaviyo/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    [
+      "@nx/js/babel",
+      {
+        "useBuiltIns": "usage",
+        "corejs": 3
+      }
+    ]
+  ]
+}

--- a/packages/pieces/community/klaviyo/.eslintrc.json
+++ b/packages/pieces/community/klaviyo/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/klaviyo/README.md
+++ b/packages/pieces/community/klaviyo/README.md
@@ -1,0 +1,21 @@
+# @activepieces/piece-klaviyo
+
+Klaviyo integration for Activepieces.
+
+## Actions
+
+- Create Profile
+- Update Profile
+- Subscribe Profile
+- Unsubscribe Profile
+- Add Profile to List
+- Remove Profile from List
+- Create List
+- Find Profile by Email/Phone
+- Find List by Name
+- Find Tag by Name
+
+## Triggers
+
+- New Profile
+- Profile Added to List/Segment

--- a/packages/pieces/community/klaviyo/package.json
+++ b/packages/pieces/community/klaviyo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@activepieces/piece-klaviyo",
+  "version": "0.1.0",
+  "dependencies": {}
+}

--- a/packages/pieces/community/klaviyo/project.json
+++ b/packages/pieces/community/klaviyo/project.json
@@ -1,0 +1,47 @@
+{
+  "name": "pieces-klaviyo",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/klaviyo/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/klaviyo",
+        "tsConfig": "packages/pieces/community/klaviyo/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/klaviyo/package.json",
+        "main": "packages/pieces/community/klaviyo/src/index.ts",
+        "assets": [
+          "packages/pieces/community/klaviyo/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "clean": false
+      },
+      "dependsOn": [
+        "prebuild",
+        "^build"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    },
+    "prebuild": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/pieces/community/klaviyo",
+        "command": "bun install --no-save --silent"
+      },
+      "dependsOn": [
+        "^build"
+      ]
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/klaviyo/src/index.ts
+++ b/packages/pieces/community/klaviyo/src/index.ts
@@ -1,0 +1,77 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+
+// Actions
+import { createProfileAction } from './lib/actions/create-profile';
+import { updateProfileAction } from './lib/actions/update-profile';
+import { subscribeProfileAction } from './lib/actions/subscribe-profile';
+import { unsubscribeProfileAction } from './lib/actions/unsubscribe-profile';
+import { addProfileToListAction } from './lib/actions/add-profile-to-list';
+import { removeProfileFromListAction } from './lib/actions/remove-profile-from-list';
+import { createListAction } from './lib/actions/create-list';
+import { findProfileAction } from './lib/actions/find-profile';
+import { findListAction } from './lib/actions/find-list';
+import { findTagAction } from './lib/actions/find-tag';
+
+// Triggers
+import { newProfileTrigger } from './lib/triggers/new-profile';
+import { profileAddedToListTrigger } from './lib/triggers/profile-added-to-list';
+
+// Constants
+const KLAVIYO_API_BASE_URL = 'https://a.klaviyo.com/api';
+const KLAVIYO_API_REVISION = '2024-10-15';
+
+export const klaviyoAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Enter your Klaviyo private API key',
+  required: true,
+  validate: async ({ auth }) => {
+    if (!auth || auth.length < 10) {
+      return {
+        valid: false,
+        error: 'Invalid API key format',
+      };
+    }
+    return {
+      valid: true,
+    };
+  },
+});
+
+export const klaviyo = createPiece({
+  displayName: 'Klaviyo',
+  description: 'Email and SMS marketing automation platform',
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/klaviyo.png',
+  authors: ['activepieces'],
+  categories: [PieceCategory.MARKETING],
+  auth: klaviyoAuth,
+  actions: [
+    // Write Actions
+    createProfileAction,
+    updateProfileAction,
+    subscribeProfileAction,
+    unsubscribeProfileAction,
+    addProfileToListAction,
+    removeProfileFromListAction,
+    createListAction,
+    // Search Actions
+    findProfileAction,
+    findListAction,
+    findTagAction,
+    // Custom API Call
+    createCustomApiCallAction({
+      baseUrl: () => KLAVIYO_API_BASE_URL,
+      auth: klaviyoAuth,
+      authMapping: async (auth) => ({
+        'Authorization': `Klaviyo-API-Key ${auth}`,
+        'revision': KLAVIYO_API_REVISION,
+      }),
+    }),
+  ],
+  triggers: [
+    newProfileTrigger,
+    profileAddedToListTrigger,
+  ],
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/add-profile-to-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/add-profile-to-list.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const addProfileToListAction = createAction({
+  auth: klaviyoAuth,
+  name: 'add-profile-to-list',
+  displayName: 'Add Profile to List',
+  description: 'Add a profile to a specific Klaviyo list',
+  props: {
+    profile_id: Property.ShortText({
+      displayName: 'Profile ID',
+      description: 'The Klaviyo profile ID to add to the list',
+      required: true,
+    }),
+    list_id: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to add the profile to',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { profile_id, list_id } = context.propsValue;
+
+    const requestBody = {
+      data: [
+        {
+          type: 'profile',
+          id: profile_id,
+        },
+      ],
+    };
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.POST,
+      `/lists/${list_id}/relationships/profiles/`,
+      requestBody
+    );
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/create-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/create-list.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest, KlaviyoList } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const createListAction = createAction({
+  auth: klaviyoAuth,
+  name: 'create-list',
+  displayName: 'Create List',
+  description: 'Create a new subscriber list in Klaviyo',
+  props: {
+    name: Property.ShortText({
+      displayName: 'List Name',
+      description: 'Name of the list to create',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { name } = context.propsValue;
+
+    const list: KlaviyoList = {
+      type: 'list',
+      attributes: {
+        name,
+      },
+    };
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.POST,
+      '/lists/',
+      { data: list }
+    );
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/create-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/create-profile.ts
@@ -1,0 +1,168 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest, KlaviyoProfile } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const createProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'create-profile',
+  displayName: 'Create Profile',
+  description: 'Create a new profile in Klaviyo, optionally subscribing to email/SMS',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address of the profile',
+      required: false,
+    }),
+    phone_number: Property.ShortText({
+      displayName: 'Phone Number',
+      description: 'Phone number in E.164 format (e.g., +12345678901)',
+      required: false,
+    }),
+    external_id: Property.ShortText({
+      displayName: 'External ID',
+      description: 'A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system',
+      required: false,
+    }),
+    first_name: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+    }),
+    last_name: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    organization: Property.ShortText({
+      displayName: 'Organization',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      required: false,
+    }),
+    image: Property.ShortText({
+      displayName: 'Image URL',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      required: false,
+    }),
+    country: Property.ShortText({
+      displayName: 'Country',
+      required: false,
+    }),
+    region: Property.ShortText({
+      displayName: 'Region/State',
+      required: false,
+    }),
+    zip: Property.ShortText({
+      displayName: 'Zip/Postal Code',
+      required: false,
+    }),
+    subscribe_to_email: Property.Checkbox({
+      displayName: 'Subscribe to Email Marketing',
+      description: 'Subscribe this profile to email marketing',
+      required: false,
+      defaultValue: false,
+    }),
+    subscribe_to_sms: Property.Checkbox({
+      displayName: 'Subscribe to SMS Marketing',
+      description: 'Subscribe this profile to SMS marketing',
+      required: false,
+      defaultValue: false,
+    }),
+    list_id: Property.ShortText({
+      displayName: 'List ID',
+      description: 'Optional: ID of a list to add the profile to',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const {
+      email,
+      phone_number,
+      external_id,
+      first_name,
+      last_name,
+      organization,
+      title,
+      image,
+      city,
+      country,
+      region,
+      zip,
+      subscribe_to_email,
+      subscribe_to_sms,
+      list_id,
+    } = context.propsValue;
+
+    if (!email && !phone_number && !external_id) {
+      throw new Error('At least one of email, phone_number, or external_id is required');
+    }
+
+    const profile: KlaviyoProfile = {
+      type: 'profile',
+      attributes: {
+        email,
+        phone_number,
+        external_id,
+        first_name,
+        last_name,
+        organization,
+        title,
+        image,
+      },
+    };
+
+    // Add location if any location fields are provided
+    if (city || country || region || zip) {
+      profile.attributes.location = {
+        city,
+        country,
+        region,
+        zip,
+      };
+    }
+
+    const requestBody: any = {
+      data: profile,
+    };
+
+    // Add subscriptions if requested
+    if (subscribe_to_email || subscribe_to_sms) {
+      requestBody.data.attributes.subscriptions = {
+        email: subscribe_to_email ? { marketing: { consent: 'SUBSCRIBED' } } : undefined,
+        sms: subscribe_to_sms ? { marketing: { consent: 'SUBSCRIBED' } } : undefined,
+      };
+    }
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.POST,
+      '/profiles/',
+      requestBody
+    );
+
+    // If list_id is provided, add profile to list
+    if (list_id && response.data?.id) {
+      const addToListBody = {
+        data: [
+          {
+            type: 'profile',
+            id: response.data.id,
+          },
+        ],
+      };
+
+      await klaviyoApiRequest(
+        context.auth,
+        HttpMethod.POST,
+        `/lists/${list_id}/relationships/profiles/`,
+        addToListBody
+      );
+    }
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/find-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/find-list.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const findListAction = createAction({
+  auth: klaviyoAuth,
+  name: 'find-list',
+  displayName: 'Find List by Name',
+  description: 'Find a list by name to get its ID',
+  props: {
+    name: Property.ShortText({
+      displayName: 'List Name',
+      description: 'Name of the list to find',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { name } = context.propsValue;
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.GET,
+      '/lists/',
+      undefined,
+      {
+        'filter': `equals(name,"${name}")`,
+      }
+    );
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/find-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/find-profile.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const findProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'find-profile',
+  displayName: 'Find Profile by Email/Phone',
+  description: 'Find a profile by email address or phone number',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address to search for',
+      required: false,
+    }),
+    phone_number: Property.ShortText({
+      displayName: 'Phone Number',
+      description: 'Phone number to search for (E.164 format)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { email, phone_number } = context.propsValue;
+
+    if (!email && !phone_number) {
+      throw new Error('Either email or phone_number is required');
+    }
+
+    let filter = '';
+    if (email) {
+      filter = `equals(email,"${email}")`;
+    } else if (phone_number) {
+      filter = `equals(phone_number,"${phone_number}")`;
+    }
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.GET,
+      '/profiles/',
+      undefined,
+      {
+        'filter': filter,
+      }
+    );
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/find-tag.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/find-tag.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const findTagAction = createAction({
+  auth: klaviyoAuth,
+  name: 'find-tag',
+  displayName: 'Find Tag by Name',
+  description: 'Find a tag by name to locate it for tagging workflows',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Tag Name',
+      description: 'Name of the tag to find',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { name } = context.propsValue;
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.GET,
+      '/tags/',
+      undefined,
+      {
+        'filter': `equals(name,"${name}")`,
+      }
+    );
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/remove-profile-from-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/remove-profile-from-list.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const removeProfileFromListAction = createAction({
+  auth: klaviyoAuth,
+  name: 'remove-profile-from-list',
+  displayName: 'Remove Profile from List',
+  description: 'Remove a profile from a specific Klaviyo list',
+  props: {
+    profile_id: Property.ShortText({
+      displayName: 'Profile ID',
+      description: 'The Klaviyo profile ID to remove from the list',
+      required: true,
+    }),
+    list_id: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to remove the profile from',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { profile_id, list_id } = context.propsValue;
+
+    const requestBody = {
+      data: [
+        {
+          type: 'profile',
+          id: profile_id,
+        },
+      ],
+    };
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.DELETE,
+      `/lists/${list_id}/relationships/profiles/`,
+      requestBody
+    );
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/subscribe-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/subscribe-profile.ts
@@ -1,0 +1,92 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const subscribeProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'subscribe-profile',
+  displayName: 'Subscribe Profile',
+  description: 'Subscribe a profile to email or SMS marketing lists',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address of the profile',
+      required: false,
+    }),
+    phone_number: Property.ShortText({
+      displayName: 'Phone Number',
+      description: 'Phone number in E.164 format (e.g., +12345678901)',
+      required: false,
+    }),
+    list_id: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to subscribe to',
+      required: true,
+    }),
+    subscribe_to_email: Property.Checkbox({
+      displayName: 'Subscribe to Email',
+      description: 'Subscribe this profile to email marketing',
+      required: false,
+      defaultValue: true,
+    }),
+    subscribe_to_sms: Property.Checkbox({
+      displayName: 'Subscribe to SMS',
+      description: 'Subscribe this profile to SMS marketing',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { email, phone_number, list_id, subscribe_to_email, subscribe_to_sms } = context.propsValue;
+
+    if (!email && !phone_number) {
+      throw new Error('Either email or phone_number is required');
+    }
+
+    const subscriptions: any = {};
+    if (subscribe_to_email) {
+      subscriptions.email = { marketing: { consent: 'SUBSCRIBED' } };
+    }
+    if (subscribe_to_sms) {
+      subscriptions.sms = { marketing: { consent: 'SUBSCRIBED' } };
+    }
+
+    const requestBody = {
+      data: {
+        type: 'profile-subscription-bulk-create-job',
+        attributes: {
+          profiles: {
+            data: [
+              {
+                type: 'profile',
+                attributes: {
+                  email,
+                  phone_number,
+                  subscriptions,
+                },
+              },
+            ],
+          },
+        },
+        relationships: {
+          list: {
+            data: {
+              type: 'list',
+              id: list_id,
+            },
+          },
+        },
+      },
+    };
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.POST,
+      '/profile-subscription-bulk-create-jobs/',
+      requestBody
+    );
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/unsubscribe-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/unsubscribe-profile.ts
@@ -1,0 +1,92 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const unsubscribeProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'unsubscribe-profile',
+  displayName: 'Unsubscribe Profile',
+  description: 'Unsubscribe a profile from email or SMS marketing lists',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address of the profile',
+      required: false,
+    }),
+    phone_number: Property.ShortText({
+      displayName: 'Phone Number',
+      description: 'Phone number in E.164 format (e.g., +12345678901)',
+      required: false,
+    }),
+    list_id: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to unsubscribe from',
+      required: true,
+    }),
+    unsubscribe_email: Property.Checkbox({
+      displayName: 'Unsubscribe from Email',
+      description: 'Unsubscribe this profile from email marketing',
+      required: false,
+      defaultValue: true,
+    }),
+    unsubscribe_sms: Property.Checkbox({
+      displayName: 'Unsubscribe from SMS',
+      description: 'Unsubscribe this profile from SMS marketing',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { email, phone_number, list_id, unsubscribe_email, unsubscribe_sms } = context.propsValue;
+
+    if (!email && !phone_number) {
+      throw new Error('Either email or phone_number is required');
+    }
+
+    const subscriptions: any = {};
+    if (unsubscribe_email) {
+      subscriptions.email = { marketing: { consent: 'UNSUBSCRIBED' } };
+    }
+    if (unsubscribe_sms) {
+      subscriptions.sms = { marketing: { consent: 'UNSUBSCRIBED' } };
+    }
+
+    const requestBody = {
+      data: {
+        type: 'profile-subscription-bulk-delete-job',
+        attributes: {
+          profiles: {
+            data: [
+              {
+                type: 'profile',
+                attributes: {
+                  email,
+                  phone_number,
+                  subscriptions,
+                },
+              },
+            ],
+          },
+        },
+        relationships: {
+          list: {
+            data: {
+              type: 'list',
+              id: list_id,
+            },
+          },
+        },
+      },
+    };
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.POST,
+      '/profile-subscription-bulk-delete-jobs/',
+      requestBody
+    );
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/update-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/update-profile.ts
@@ -1,0 +1,120 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest, KlaviyoProfile } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const updateProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'update-profile',
+  displayName: 'Update Profile',
+  description: 'Update an existing profile in Klaviyo',
+  props: {
+    profile_id: Property.ShortText({
+      displayName: 'Profile ID',
+      description: 'The Klaviyo profile ID to update',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address of the profile',
+      required: false,
+    }),
+    phone_number: Property.ShortText({
+      displayName: 'Phone Number',
+      description: 'Phone number in E.164 format (e.g., +12345678901)',
+      required: false,
+    }),
+    external_id: Property.ShortText({
+      displayName: 'External ID',
+      description: 'A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system',
+      required: false,
+    }),
+    first_name: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+    }),
+    last_name: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    organization: Property.ShortText({
+      displayName: 'Organization',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      required: false,
+    }),
+    image: Property.ShortText({
+      displayName: 'Image URL',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      required: false,
+    }),
+    country: Property.ShortText({
+      displayName: 'Country',
+      required: false,
+    }),
+    region: Property.ShortText({
+      displayName: 'Region/State',
+      required: false,
+    }),
+    zip: Property.ShortText({
+      displayName: 'Zip/Postal Code',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const {
+      profile_id,
+      email,
+      phone_number,
+      external_id,
+      first_name,
+      last_name,
+      organization,
+      title,
+      image,
+      city,
+      country,
+      region,
+      zip,
+    } = context.propsValue;
+
+    const profile: KlaviyoProfile = {
+      type: 'profile',
+      id: profile_id,
+      attributes: {},
+    };
+
+    // Only include fields that are provided
+    if (email !== undefined) profile.attributes.email = email;
+    if (phone_number !== undefined) profile.attributes.phone_number = phone_number;
+    if (external_id !== undefined) profile.attributes.external_id = external_id;
+    if (first_name !== undefined) profile.attributes.first_name = first_name;
+    if (last_name !== undefined) profile.attributes.last_name = last_name;
+    if (organization !== undefined) profile.attributes.organization = organization;
+    if (title !== undefined) profile.attributes.title = title;
+    if (image !== undefined) profile.attributes.image = image;
+
+    // Add location if any location fields are provided
+    if (city || country || region || zip) {
+      profile.attributes.location = {};
+      if (city !== undefined) profile.attributes.location.city = city;
+      if (country !== undefined) profile.attributes.location.country = country;
+      if (region !== undefined) profile.attributes.location.region = region;
+      if (zip !== undefined) profile.attributes.location.zip = zip;
+    }
+
+    const response = await klaviyoApiRequest(
+      context.auth,
+      HttpMethod.PATCH,
+      `/profiles/${profile_id}/`,
+      { data: profile }
+    );
+
+    return response;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/common/index.ts
+++ b/packages/pieces/community/klaviyo/src/lib/common/index.ts
@@ -1,0 +1,75 @@
+import {
+  HttpMethod,
+  HttpRequest,
+  httpClient,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { PiecePropValueSchema } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../../index';
+
+export const KLAVIYO_API_BASE_URL = 'https://a.klaviyo.com/api';
+export const KLAVIYO_API_REVISION = '2024-10-15';
+
+export async function klaviyoApiRequest(
+  auth: PiecePropValueSchema<typeof klaviyoAuth>,
+  method: HttpMethod,
+  endpoint: string,
+  body?: unknown,
+  queryParams?: Record<string, string>
+): Promise<any> {
+  const request: HttpRequest = {
+    method,
+    url: `${KLAVIYO_API_BASE_URL}${endpoint}`,
+    headers: {
+      'Authorization': `Klaviyo-API-Key ${auth}`,
+      'revision': KLAVIYO_API_REVISION,
+      'Content-Type': 'application/json',
+    },
+    body: body ? body : undefined,
+    queryParams,
+  };
+
+  const response = await httpClient.sendRequest(request);
+  return response.body;
+}
+
+export interface KlaviyoProfile {
+  type: 'profile';
+  id?: string;
+  attributes: {
+    email?: string;
+    phone_number?: string;
+    external_id?: string;
+    first_name?: string;
+    last_name?: string;
+    organization?: string;
+    title?: string;
+    image?: string;
+    location?: {
+      address1?: string;
+      address2?: string;
+      city?: string;
+      country?: string;
+      region?: string;
+      zip?: string;
+      timezone?: string;
+    };
+    properties?: Record<string, any>;
+  };
+}
+
+export interface KlaviyoList {
+  type: 'list';
+  id?: string;
+  attributes: {
+    name: string;
+  };
+}
+
+export interface KlaviyoTag {
+  type: 'tag';
+  id?: string;
+  attributes: {
+    name: string;
+  };
+}

--- a/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
@@ -1,0 +1,113 @@
+import { createTrigger, Property } from '@activepieces/pieces-framework';
+import { TriggerStrategy } from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+const polling: Polling<string, Record<string, never>> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  async items({ auth, lastFetchEpochMS }) {
+    const currentTime = new Date().toISOString();
+    const lastFetchTime = new Date(lastFetchEpochMS).toISOString();
+
+    // For testing, get recent profiles
+    const isTest = lastFetchEpochMS === 0;
+    
+    let filter = '';
+    if (!isTest) {
+      filter = `greater-than(created,${lastFetchTime})`;
+    }
+
+    const queryParams: Record<string, string> = {
+      'sort': '-created',
+      'page[size]': isTest ? '10' : '100',
+    };
+
+    if (filter) {
+      queryParams['filter'] = filter;
+    }
+
+    const response = await klaviyoApiRequest(
+      auth,
+      HttpMethod.GET,
+      '/profiles/',
+      undefined,
+      queryParams
+    );
+
+    const items = response.data || [];
+
+    return items.map((item: any) => {
+      const createdTimestamp = item.attributes.created 
+        ? new Date(item.attributes.created).valueOf()
+        : Date.now();
+      
+      return {
+        epochMilliSeconds: createdTimestamp,
+        data: item,
+      };
+    });
+  },
+};
+
+export const newProfileTrigger = createTrigger({
+  auth: klaviyoAuth,
+  name: 'new-profile',
+  displayName: 'New Profile',
+  description: 'Triggers when a new profile is created in Klaviyo',
+  props: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+  sampleData: {
+    type: 'profile',
+    id: '01HQRS5XKQM8D9T3B7NQWX5YZ1',
+    attributes: {
+      email: 'example@klaviyo.com',
+      phone_number: '+12345678901',
+      external_id: 'ext_12345',
+      first_name: 'Jane',
+      last_name: 'Doe',
+      organization: 'Acme Corp',
+      title: 'Marketing Manager',
+      image: 'https://example.com/avatar.jpg',
+      created: '2024-02-16T12:00:00Z',
+      updated: '2024-02-16T12:00:00Z',
+      last_event_date: '2024-02-16T12:00:00Z',
+      location: {
+        address1: '123 Main St',
+        address2: 'Apt 4B',
+        city: 'New York',
+        country: 'US',
+        region: 'NY',
+        zip: '10001',
+        timezone: 'America/New_York',
+      },
+      properties: {
+        custom_field: 'custom_value',
+      },
+    },
+    links: {
+      self: 'https://a.klaviyo.com/api/profiles/01HQRS5XKQM8D9T3B7NQWX5YZ1/',
+    },
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list.ts
@@ -1,0 +1,141 @@
+import { createTrigger, Property } from '@activepieces/pieces-framework';
+import { TriggerStrategy } from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-common';
+import { klaviyoAuth } from '../../index';
+import { klaviyoApiRequest } from '../common';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+interface Props {
+  list_id?: string;
+  segment_id?: string;
+}
+
+const polling: Polling<string, Props> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  async items({ auth, propsValue, lastFetchEpochMS }) {
+    const { list_id, segment_id } = propsValue;
+
+    if (!list_id && !segment_id) {
+      throw new Error('Either list_id or segment_id is required');
+    }
+
+    const isTest = lastFetchEpochMS === 0;
+    const lastFetchTime = new Date(lastFetchEpochMS).toISOString();
+
+    // Determine endpoint based on whether we're checking a list or segment
+    const resourceType = list_id ? 'lists' : 'segments';
+    const resourceId = list_id || segment_id;
+
+    const queryParams: Record<string, string> = {
+      'sort': '-joined_group_at',
+      'page[size]': isTest ? '10' : '100',
+    };
+
+    // Filter by profiles that joined after last fetch (if not a test)
+    if (!isTest) {
+      queryParams['filter'] = `greater-than(joined_group_at,${lastFetchTime})`;
+    }
+
+    const response = await klaviyoApiRequest(
+      auth,
+      HttpMethod.GET,
+      `/${resourceType}/${resourceId}/profiles/`,
+      undefined,
+      queryParams
+    );
+
+    const items = response.data || [];
+
+    return items.map((item: any) => {
+      // Use joined_group_at if available, otherwise use created timestamp
+      const joinedTimestamp = item.attributes.joined_group_at 
+        ? new Date(item.attributes.joined_group_at).valueOf()
+        : item.attributes.created 
+        ? new Date(item.attributes.created).valueOf()
+        : Date.now();
+      
+      return {
+        epochMilliSeconds: joinedTimestamp,
+        data: {
+          ...item,
+          list_id,
+          segment_id,
+          resource_type: resourceType,
+        },
+      };
+    });
+  },
+};
+
+export const profileAddedToListTrigger = createTrigger({
+  auth: klaviyoAuth,
+  name: 'profile-added-to-list',
+  displayName: 'Profile Added to List/Segment',
+  description: 'Triggers when a profile is added to a specific list or segment in Klaviyo',
+  props: {
+    list_id: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to monitor (leave empty if using segment)',
+      required: false,
+    }),
+    segment_id: Property.ShortText({
+      displayName: 'Segment ID',
+      description: 'The ID of the segment to monitor (leave empty if using list)',
+      required: false,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+  sampleData: {
+    type: 'profile',
+    id: '01HQRS5XKQM8D9T3B7NQWX5YZ1',
+    attributes: {
+      email: 'example@klaviyo.com',
+      phone_number: '+12345678901',
+      external_id: 'ext_12345',
+      first_name: 'Jane',
+      last_name: 'Doe',
+      organization: 'Acme Corp',
+      title: 'Marketing Manager',
+      image: 'https://example.com/avatar.jpg',
+      created: '2024-02-16T12:00:00Z',
+      updated: '2024-02-16T12:00:00Z',
+      joined_group_at: '2024-02-16T12:30:00Z',
+      location: {
+        address1: '123 Main St',
+        city: 'New York',
+        country: 'US',
+        region: 'NY',
+        zip: '10001',
+      },
+      properties: {
+        custom_field: 'custom_value',
+      },
+    },
+    list_id: 'XYZ123',
+    segment_id: null,
+    resource_type: 'lists',
+    links: {
+      self: 'https://a.klaviyo.com/api/profiles/01HQRS5XKQM8D9T3B7NQWX5YZ1/',
+    },
+  },
+});

--- a/packages/pieces/community/klaviyo/tsconfig.json
+++ b/packages/pieces/community/klaviyo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/klaviyo/tsconfig.lib.json
+++ b/packages/pieces/community/klaviyo/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
Resolves #8284
/claim #8284

Adds a new Klaviyo piece with the following:

**Actions (10):**
- Create Profile
- Update Profile
- Subscribe Profile
- Unsubscribe Profile
- Add Profile to List
- Remove Profile from List
- Create List
- Find Profile (by email)
- Find List (by name)
- Find Tag (by name)

**Triggers (2):**
- New Profile (polling)
- Profile Added to List (polling)

Auth: Secret text (Klaviyo private API key)
API version: 2024-10-15
Pattern: Follows the hubspot piece structure with `httpClient` from `@activepieces/pieces-common`

---

Short Video: https://github.com/user-attachments/assets/19012da1-43f6-4a26-a4a7-40d0cee746dc
This shows all 10 actions and 2 triggers tested against the live Klaviyo API, all passing.