### PR TITLE
feat(gmail): extend Gmail piece with label management, archive, delete, and starred trigger

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -8,13 +8,22 @@ import { PieceCategory } from '@activepieces/shared';
 import { gmailSendEmailAction } from './lib/actions/send-email-action';
 import { gmailReplyToEmailAction } from './lib/actions/reply-to-email-action';
 import { gmailCreateDraftReplyAction } from './lib/actions/create-draft-reply-action';
+import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailGetThread } from './lib/actions/get-thread-action';
+import { gmailSearchMailAction } from './lib/actions/search-email-action';
+import { requestApprovalInEmail } from './lib/actions/request-approval-in-email';
+import { gmailAddLabelToEmailAction } from './lib/actions/add-label-to-email-action';
+import { gmailRemoveLabelFromEmailAction } from './lib/actions/remove-label-from-email-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
 import { gmailNewEmailTrigger } from './lib/triggers/new-email';
 import { gmailNewLabeledEmailTrigger } from './lib/triggers/new-labeled-email';
-import { requestApprovalInEmail } from './lib/actions/request-approval-in-email';
 import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
-import { gmailSearchMailAction } from './lib/actions/search-email-action';
-import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailNewConversationTrigger } from './lib/triggers/new-conversation';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
 
 export const gmailAuth = PieceAuth.OAuth2({
   description: '',
@@ -26,6 +35,8 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.labels',
   ],
 });
 
@@ -42,7 +53,14 @@ export const gmail = createPiece({
     gmailReplyToEmailAction,
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
+    gmailGetThread,
     gmailSearchMailAction,
+    gmailAddLabelToEmailAction,
+    gmailRemoveLabelFromEmailAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -53,7 +71,6 @@ export const gmail = createPiece({
   ],
   displayName: 'Gmail',
   description: 'Email service by Google',
-
   authors: [
     'kanarelo',
     'abdullahranginwala',
@@ -67,12 +84,15 @@ export const gmail = createPiece({
     'AdamSelene',
     'sanket-a11y',
     'onyedikachi-david',
+    'a827681306',
   ],
   triggers: [
     gmailNewEmailTrigger,
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewConversationTrigger,
+    gmailNewStarredEmailTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
@@ -1,0 +1,48 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+import { GmailLabel } from '../common/models';
+
+export const gmailAddLabelToEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_add_label_to_email',
+  displayName: 'Add Label to Email',
+  description: 'Attach one or more labels to an individual email message.',
+  props: {
+    message: GmailProps.message,
+    labels: GmailProps.labels,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+    const selectedLabels = context.propsValue.labels as GmailLabel[];
+    const labelIds = selectedLabels.map((label) => label.id);
+
+    if (labelIds.length === 0) {
+      throw new Error('At least one label must be selected.');
+    }
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message as string,
+        requestBody: {
+          addLabelIds: labelIds,
+        },
+      });
+
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 404) {
+        throw new Error(
+          `Message with ID ${context.propsValue.message} not found.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,41 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_archive_email',
+  displayName: 'Archive Email',
+  description:
+    'Archive an email by removing the INBOX label (moves to All Mail).',
+  props: {
+    message: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message as string,
+        requestBody: {
+          removeLabelIds: ['INBOX'],
+        },
+      });
+
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 404) {
+        throw new Error(
+          `Message with ID ${context.propsValue.message} not found.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,98 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_create_label',
+  displayName: 'Create Label',
+  description: 'Create a new user label in Gmail.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the label to create.',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Label List',
+      description: 'Whether the label is shown in the label list.',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Hide', value: 'labelHide' },
+          { label: 'Show if Unread', value: 'labelShowIfUnread' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Message List',
+      description:
+        'Whether messages with this label are shown in the message list.',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+    background_color: Property.ShortText({
+      displayName: 'Background Color',
+      description: 'Hex color code for the label background (e.g. #16a765).',
+      required: false,
+    }),
+    text_color: Property.ShortText({
+      displayName: 'Text Color',
+      description: 'Hex color code for the label text (e.g. #ffffff).',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const requestBody: {
+      name: string;
+      labelListVisibility: string;
+      messageListVisibility: string;
+      color?: { textColor: string; backgroundColor: string };
+    } = {
+      name: context.propsValue.name,
+      labelListVisibility:
+        context.propsValue.label_list_visibility ?? 'labelShow',
+      messageListVisibility:
+        context.propsValue.message_list_visibility ?? 'show',
+    };
+
+    if (context.propsValue.background_color && context.propsValue.text_color) {
+      requestBody.color = {
+        backgroundColor: context.propsValue.background_color,
+        textColor: context.propsValue.text_color,
+      };
+    }
+
+    try {
+      const response = await gmail.users.labels.create({
+        userId: 'me',
+        requestBody,
+      });
+
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 409) {
+        throw new Error(
+          `A label with the name "${context.propsValue.name}" already exists.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,37 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_delete_email',
+  displayName: 'Delete Email',
+  description: 'Move an email to the Trash folder.',
+  props: {
+    message: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.trash({
+        userId: 'me',
+        id: context.propsValue.message as string,
+      });
+
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 404) {
+        throw new Error(
+          `Message with ID ${context.propsValue.message} not found.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
@@ -1,0 +1,48 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+import { GmailLabel } from '../common/models';
+
+export const gmailRemoveLabelFromEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_email',
+  displayName: 'Remove Label from Email',
+  description: 'Remove one or more labels from an email message.',
+  props: {
+    message: GmailProps.message,
+    labels: GmailProps.labels,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+    const selectedLabels = context.propsValue.labels as GmailLabel[];
+    const labelIds = selectedLabels.map((label) => label.id);
+
+    if (labelIds.length === 0) {
+      throw new Error('At least one label must be selected.');
+    }
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message as string,
+        requestBody: {
+          removeLabelIds: labelIds,
+        },
+      });
+
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 404) {
+        throw new Error(
+          `Message with ID ${context.propsValue.message} not found.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,48 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+import { GmailLabel } from '../common/models';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_thread',
+  displayName: 'Remove Label from Thread',
+  description: 'Remove one or more labels from all emails in a thread.',
+  props: {
+    thread: GmailProps.thread,
+    labels: GmailProps.labels,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+    const selectedLabels = context.propsValue.labels as GmailLabel[];
+    const labelIds = selectedLabels.map((label) => label.id);
+
+    if (labelIds.length === 0) {
+      throw new Error('At least one label must be selected.');
+    }
+
+    try {
+      const response = await gmail.users.threads.modify({
+        userId: 'me',
+        id: context.propsValue.thread as string,
+        requestBody: {
+          removeLabelIds: labelIds,
+        },
+      });
+
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 404) {
+        throw new Error(
+          `Thread with ID ${context.propsValue.thread} not found.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/common/props.ts
+++ b/packages/pieces/community/gmail/src/lib/common/props.ts
@@ -72,6 +72,40 @@ export const GmailProps = {
       };
     },
   }),
+  labels: Property.MultiSelectDropdown<GmailLabel, true, typeof gmailAuth>({
+    displayName: 'Labels',
+    description: 'Select one or more labels.',
+    required: true,
+    auth: gmailAuth,
+    refreshers: [],
+    options: async ({ auth }) => {
+      if (!auth) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Please authenticate first',
+        };
+      }
+
+      const response = await GmailRequests.getLabels(
+        auth as OAuth2PropertyValue
+      );
+
+      const selectableLabels = response.body.labels.filter(
+        (label) =>
+          label.type === 'user' ||
+          ['INBOX', 'STARRED', 'IMPORTANT', 'SENT', 'DRAFT'].includes(label.id)
+      );
+
+      return {
+        disabled: false,
+        options: selectableLabels.map((label) => ({
+          label: `${label.name}${label.type === 'system' ? ' (System)' : ''}`,
+          value: label,
+        })),
+      };
+    },
+  }),
   unread: (required = false) =>
     Property.Checkbox({
       displayName: 'Is unread?',

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,113 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { getFirstFiveOrAll } from '../common/data';
+
+const TRIGGER_KEY = 'starred_message_ids';
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred (checks within the last 2 days).',
+  props: {},
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.list({
+      userId: 'me',
+      labelIds: ['STARRED'],
+      maxResults: 100,
+    });
+
+    const messageIds = (response.data.messages || []).map((m) => m.id);
+    await context.store.put(TRIGGER_KEY, JSON.stringify(messageIds));
+  },
+  async onDisable(context) {
+    await context.store.delete(TRIGGER_KEY);
+  },
+  async test(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.list({
+      userId: 'me',
+      labelIds: ['STARRED'],
+      maxResults: 5,
+    });
+
+    if (!response.data.messages || response.data.messages.length === 0) {
+      return [];
+    }
+
+    const messages = await Promise.all(
+      response.data.messages.map(async (m) => {
+        const detail = await gmail.users.messages.get({
+          userId: 'me',
+          id: m.id!,
+          format: 'metadata',
+          metadataHeaders: ['Subject', 'From', 'Date'],
+        });
+        return detail.data;
+      })
+    );
+
+    return getFirstFiveOrAll(messages);
+  },
+  async run(context) {
+    const existingIds = (await context.store.get<string>(TRIGGER_KEY)) ?? '[]';
+    const parsedExistingIds = JSON.parse(existingIds) as string[];
+
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    // Get starred messages from the last 2 days
+    const twoDaysAgo = new Date();
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+    const afterDate = twoDaysAgo.toISOString().split('T')[0].replace(/-/g, '/');
+
+    const response = await gmail.users.messages.list({
+      userId: 'me',
+      labelIds: ['STARRED'],
+      q: `after:${afterDate}`,
+      maxResults: 100,
+    });
+
+    const currentMessages = response.data.messages || [];
+    const allCurrentIds = currentMessages.map((m) => m.id);
+
+    // Find newly starred messages
+    const newMessages = currentMessages.filter(
+      (m) => m.id && !parsedExistingIds.includes(m.id)
+    );
+
+    // Update stored IDs
+    await context.store.put(TRIGGER_KEY, JSON.stringify(allCurrentIds));
+
+    if (newMessages.length === 0) {
+      return [];
+    }
+
+    // Fetch details for new starred messages
+    const detailedMessages = await Promise.all(
+      newMessages.map(async (m) => {
+        const detail = await gmail.users.messages.get({
+          userId: 'me',
+          id: m.id!,
+          format: 'metadata',
+          metadataHeaders: ['Subject', 'From', 'To', 'Date'],
+        });
+        return detail.data;
+      })
+    );
+
+    return detailedMessages;
+  },
+});


### PR DESCRIPTION
## Summary

Extends the existing Gmail piece with 6 new actions and 1 new trigger as requested in #8072.

/claim #8072

## New Actions

| Action | Description |
|--------|-------------|
| Add Label to Email | Multi-select labels to attach to an email |
| Remove Label from Email | Multi-select labels to remove |
| Create Label | Create with visibility + color options |
| Archive Email | Remove INBOX label (move to All Mail) |
| Delete Email | Move to Trash (recoverable) |
| Remove Label from Thread | Strip labels from entire thread |

## New Trigger

| Trigger | Description |
|---------|-------------|
| New Starred Email | Polling trigger, fires when email is starred (2-day window) |

## Bug Fixes

- Registered existing but unregistered `Get Thread` action and `New Conversation` trigger in index.ts

## Implementation

- All code uses `googleapis` + `OAuth2Client` (consistent with existing patterns)
- Added `labels` multi-select dropdown prop for batch operations
- Added `gmail.modify` and `gmail.labels` OAuth scopes
- Proper error handling with user-friendly messages
- No new dependencies added

Note: PR #8083 has been open since June 2025 (8+ months) pending App Review. This PR provides a more complete implementation including the New Starred Email trigger and bug fixes for unregistered existing components.