### PR TITLE
feat(gmail): add label management, archive, delete actions and starred email trigger

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -15,6 +15,12 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
+import { gmailAddLabelAction } from './lib/actions/add-label-action';
+import { gmailRemoveLabelAction } from './lib/actions/remove-label-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
 
 export const gmailAuth = PieceAuth.OAuth2({
   description: '',
@@ -26,6 +32,7 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.modify',
   ],
 });
 
@@ -43,6 +50,11 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailAddLabelAction,
+    gmailRemoveLabelAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -67,12 +79,14 @@ export const gmail = createPiece({
     'AdamSelene',
     'sanket-a11y',
     'onyedikachi-david',
+    'St34lthcole',
   ],
   triggers: [
     gmailNewEmailTrigger,
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewStarredEmailTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
@@ -1,0 +1,68 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailAddLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'add_label',
+  description: 'Add a label to an email',
+  displayName: 'Add Label to Email',
+  props: {
+    message: GmailProps.message,
+    label: Property.Dropdown({
+      displayName: 'Label',
+      description: 'Select the label to add to the email',
+      required: true,
+      refreshers: [],
+      auth: gmailAuth,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please authenticate first',
+          };
+        }
+
+        const authClient = new OAuth2Client();
+        authClient.setCredentials(auth);
+        const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+        const response = await gmail.users.labels.list({
+          userId: 'me',
+        });
+
+        const labels = response.data.labels || [];
+
+        return {
+          disabled: false,
+          options: labels.map((label) => ({
+            label: label.name || '',
+            value: label.id || '',
+          })),
+        };
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message;
+    const labelId = context.propsValue.label;
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: messageId,
+      requestBody: {
+        addLabelIds: [labelId],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,34 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'archive_email',
+  description: 'Archive an email by removing it from the inbox',
+  displayName: 'Archive Email',
+  props: {
+    message: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message;
+
+    // Archive by removing INBOX label
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: messageId,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,77 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'create_label',
+  description: 'Create a new label in Gmail',
+  displayName: 'Create Label',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the label to create',
+      required: true,
+    }),
+    labelListVisibility: Property.StaticDropdown({
+      displayName: 'Label List Visibility',
+      description: 'The visibility of the label in the label list in the Gmail web interface',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'Show',
+            value: 'labelShow',
+          },
+          {
+            label: 'Show if unread',
+            value: 'labelShowIfUnread',
+          },
+          {
+            label: 'Hide',
+            value: 'labelHide',
+          },
+        ],
+      },
+    }),
+    messageListVisibility: Property.StaticDropdown({
+      displayName: 'Message List Visibility',
+      description: 'The visibility of messages with this label in the message list in the Gmail web interface',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'Show',
+            value: 'show',
+          },
+          {
+            label: 'Hide',
+            value: 'hide',
+          },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.labels.create({
+      userId: 'me',
+      requestBody: {
+        name: context.propsValue.name,
+        labelListVisibility: context.propsValue.labelListVisibility,
+        messageListVisibility: context.propsValue.messageListVisibility,
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,31 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'delete_email',
+  description: 'Move an email to trash',
+  displayName: 'Delete Email',
+  props: {
+    message: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message;
+
+    // Move to trash using trash method
+    const response = await gmail.users.messages.trash({
+      userId: 'me',
+      id: messageId,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
@@ -1,0 +1,68 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailRemoveLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label',
+  description: 'Remove a label from an email',
+  displayName: 'Remove Label from Email',
+  props: {
+    message: GmailProps.message,
+    label: Property.Dropdown({
+      displayName: 'Label',
+      description: 'Select the label to remove from the email',
+      required: true,
+      refreshers: [],
+      auth: gmailAuth,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please authenticate first',
+          };
+        }
+
+        const authClient = new OAuth2Client();
+        authClient.setCredentials(auth);
+        const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+        const response = await gmail.users.labels.list({
+          userId: 'me',
+        });
+
+        const labels = response.data.labels || [];
+
+        return {
+          disabled: false,
+          options: labels.map((label) => ({
+            label: label.name || '',
+            value: label.id || '',
+          })),
+        };
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messageId = context.propsValue.message;
+    const labelId = context.propsValue.label;
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: messageId,
+      requestBody: {
+        removeLabelIds: [labelId],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,133 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  PiecePropValueSchema,
+  FilesService,
+} from '@activepieces/pieces-framework';
+import dayjs from 'dayjs';
+import { gmailAuth } from '../../';
+import {
+  parseStream,
+  convertAttachment,
+  getFirstFiveOrAll,
+} from '../common/data';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred',
+  props: {},
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await context.store.put('lastPoll', Date.now());
+  },
+  async onDisable(context) {
+    return;
+  },
+  async run(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      files: context.files,
+      lastFetchEpochMS: lastFetchEpochMS,
+    });
+
+    const newLastEpochMilliSeconds = items.reduce(
+      (acc, item) => Math.max(acc, item.epochMilliSeconds),
+      lastFetchEpochMS
+    );
+    await context.store.put('lastPoll', newLastEpochMilliSeconds);
+    return items
+      .filter((f) => f.epochMilliSeconds > lastFetchEpochMS)
+      .map((item) => item.data);
+  },
+  async test(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      files: context.files,
+      lastFetchEpochMS: lastFetchEpochMS,
+    });
+
+    return getFirstFiveOrAll(items.map((item) => item.data));
+  },
+});
+
+async function pollStarredMessages({
+  auth,
+  files,
+  lastFetchEpochMS,
+}: {
+  auth: PiecePropValueSchema<typeof gmailAuth>;
+  files: FilesService;
+  lastFetchEpochMS: number;
+}): Promise<
+  {
+    epochMilliSeconds: number;
+    data: unknown;
+  }[]
+> {
+  const authClient = new OAuth2Client();
+  authClient.setCredentials(auth);
+
+  const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+  // construct query for starred emails within last 2 days
+  const query = ['is:starred'];
+  const maxResults = lastFetchEpochMS === 0 ? 5 : 100;
+  const afterUnixSeconds = Math.floor(lastFetchEpochMS / 1000);
+
+  if (afterUnixSeconds != null && afterUnixSeconds > 0) {
+    query.push(`after:${afterUnixSeconds}`);
+  }
+
+  // List starred messages
+  const messagesResponse = await gmail.users.messages.list({
+    userId: 'me',
+    q: query.join(' '),
+    maxResults,
+  });
+
+  const pollingResponse = [];
+  for (const message of messagesResponse.data.messages || []) {
+    const rawMailResponse = await gmail.users.messages.get({
+      userId: 'me',
+      id: message.id!,
+      format: 'raw',
+    });
+    const threadResponse = await gmail.users.threads.get({
+      userId: 'me',
+      id: message.threadId!,
+    });
+
+    const parsedMailResponse = await parseStream(
+      Buffer.from(rawMailResponse.data.raw as string, 'base64').toString(
+        'utf-8'
+      )
+    );
+
+    pollingResponse.push({
+      epochMilliSeconds: dayjs(parsedMailResponse.date).valueOf(),
+      data: {
+        message: {
+          ...parsedMailResponse,
+          attachments: await convertAttachment(
+            parsedMailResponse.attachments,
+            files
+          ),
+        },
+        thread: {
+          ...threadResponse,
+        },
+      },
+    });
+  }
+
+  return pollingResponse;
+}


### PR DESCRIPTION
## Description

Extends the Gmail piece with label management, email organization, and a new trigger, as requested in #8072.

### New Actions (5):
- **Add Label to Email** - Apply any label to a message (dynamic label dropdown)
- **Remove Label from Email** - Remove a label from a message
- **Create Label** - Create new labels with visibility settings
- **Archive Email** - Archive by removing INBOX label
- **Delete Email** - Move email to trash

### New Trigger (1):
- **New Starred Email** - Triggers when an email is starred (polling strategy)

### Changes to Existing:
- Added `gmail.modify` scope (required for label/archive/delete operations)
- All new code follows existing Gmail piece patterns (googleapis, OAuth2Client)

/claim #8072

?? Built with AI assistance (Claude)
Co-Authored-By: Claude <noreply@anthropic.com>