### PR TITLE
feat(pieces): add Klaviyo piece with profiles, lists, and marketing automation

### DIFF
--- a/packages/pieces/community/klaviyo/.eslintrc.json
+++ b/packages/pieces/community/klaviyo/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/klaviyo/README.md
+++ b/packages/pieces/community/klaviyo/README.md
@@ -1,0 +1,58 @@
+# Klaviyo Piece for Activepieces
+
+This piece provides integration with Klaviyo's API for marketing automation and customer data management.
+
+## Features
+
+### Authentication
+- API Key authentication using Klaviyo Private API Key
+- Automatic validation of credentials
+
+### Actions
+
+#### Profile Management
+1. **Create Profile** - Create a new profile with email, phone, and custom properties
+2. **Update Profile** - Update an existing profile's information
+3. **Find Profile** - Search for profiles by email or phone number
+
+#### List Management
+4. **Subscribe Profile to List** - Subscribe one or more profiles to a list
+5. **Unsubscribe Profile from List** - Unsubscribe profiles from a list
+6. **Add Profile to List** - Add profiles to a list by profile ID
+7. **Remove Profile from List** - Remove profiles from a list by profile ID
+8. **Create List** - Create a new list in Klaviyo
+9. **Find List by Name** - Search for lists by name
+
+#### Tags
+10. **Find Tag by Name** - Search for tags by name
+
+### Triggers
+
+1. **New Profile** - Triggers when a new profile is created (polling)
+2. **Profile Added to List** - Triggers when a profile is added to a specific list (polling)
+
+## API Details
+
+- **Base URL**: `https://a.klaviyo.com/api`
+- **API Revision**: `2025-01-15`
+- **Content Type**: `application/vnd.api+json`
+- All requests follow JSON:API specification
+
+## Setup
+
+1. Get your Klaviyo Private API Key from your Klaviyo account settings
+2. Add the API key to your Activepieces connection
+3. Start using the actions and triggers
+
+## Notes
+
+- All API requests include the required `revision` header
+- Requests and responses follow JSON:API format
+- Phone numbers should be in E.164 format for best results
+- Profile creation requires either email or phone number
+- Bulk operations (subscribe/unsubscribe) support multiple profiles at once
+- Triggers use polling strategy with cursor-based pagination for efficiency
+
+## Author
+
+Built by St34lthcole for Activepieces bounty #8284

--- a/packages/pieces/community/klaviyo/package.json
+++ b/packages/pieces/community/klaviyo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-klaviyo",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/klaviyo/project.json
+++ b/packages/pieces/community/klaviyo/project.json
@@ -1,0 +1,66 @@
+{
+  "name": "pieces-klaviyo",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/klaviyo/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": [
+        "dist/{projectRoot}"
+      ],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/klaviyo",
+        "tsConfig": "packages/pieces/community/klaviyo/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/klaviyo/package.json",
+        "main": "packages/pieces/community/klaviyo/src/index.ts",
+        "assets": [
+          "packages/pieces/community/klaviyo/*.md",
+          {
+            "input": "packages/pieces/community/klaviyo/src/i18n",
+            "output": "./src/i18n",
+            "glob": "**/!(i18n.json)"
+          }
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "clean": false
+      },
+      "dependsOn": [
+        "prebuild",
+        "^build"
+      ]
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "prebuild": {
+      "dependsOn": [
+        "^build"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/pieces/community/klaviyo",
+        "command": "bun install --no-save --silent"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/klaviyo/src/index.ts
+++ b/packages/pieces/community/klaviyo/src/index.ts
@@ -1,0 +1,40 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { klaviyoAuth } from './lib/common/auth';
+import { createProfileAction } from './lib/actions/create-profile';
+import { updateProfileAction } from './lib/actions/update-profile';
+import { subscribeProfileAction } from './lib/actions/subscribe-profile';
+import { unsubscribeProfileAction } from './lib/actions/unsubscribe-profile';
+import { addProfileToListAction } from './lib/actions/add-profile-to-list';
+import { removeProfileFromListAction } from './lib/actions/remove-profile-from-list';
+import { createListAction } from './lib/actions/create-list';
+import { findProfileAction } from './lib/actions/find-profile';
+import { findListAction } from './lib/actions/find-list';
+import { findTagAction } from './lib/actions/find-tag';
+import { newProfileTrigger } from './lib/triggers/new-profile';
+import { profileAddedToListTrigger } from './lib/triggers/profile-added-to-list';
+
+export const klaviyo = createPiece({
+  displayName: 'Klaviyo',
+  auth: klaviyoAuth,
+  minimumSupportedRelease: '0.36.1',
+  categories: [PieceCategory.MARKETING],
+  logoUrl: 'https://cdn.activepieces.com/pieces/klaviyo.png',
+  authors: ['St34lthcole'],
+  actions: [
+    createProfileAction,
+    updateProfileAction,
+    subscribeProfileAction,
+    unsubscribeProfileAction,
+    addProfileToListAction,
+    removeProfileFromListAction,
+    createListAction,
+    findProfileAction,
+    findListAction,
+    findTagAction,
+  ],
+  triggers: [
+    newProfileTrigger,
+    profileAddedToListTrigger,
+  ],
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/add-profile-to-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/add-profile-to-list.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const addProfileToListAction = createAction({
+  auth: klaviyoAuth,
+  name: 'add_profile_to_list',
+  displayName: 'Add Profile to List',
+  description: 'Add one or more profiles to a list by profile ID',
+  props: {
+    listId: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to add profiles to',
+      required: true,
+    }),
+    profileIds: Property.Array({
+      displayName: 'Profile IDs',
+      description: 'Array of profile IDs to add to the list',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { listId, profileIds } = context.propsValue;
+
+    if (!profileIds || profileIds.length === 0) {
+      throw new Error('At least one profile ID must be provided');
+    }
+
+    // Convert to string array if needed
+    const ids = profileIds.map(id => String(id));
+
+    await klaviyoClient.addProfilesToList(
+      context.auth,
+      listId,
+      ids
+    );
+
+    return {
+      success: true,
+      message: `Successfully added ${ids.length} profile(s) to list ${listId}`,
+    };
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/create-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/create-list.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const createListAction = createAction({
+  auth: klaviyoAuth,
+  name: 'create_list',
+  displayName: 'Create List',
+  description: 'Create a new list in Klaviyo',
+  props: {
+    name: Property.ShortText({
+      displayName: 'List Name',
+      description: 'The name of the list',
+      required: true,
+    }),
+    optInProcess: Property.StaticDropdown({
+      displayName: 'Opt-in Process',
+      description: 'The opt-in process for the list',
+      required: false,
+      options: {
+        options: [
+          { label: 'Single Opt-in', value: 'single_opt_in' },
+          { label: 'Double Opt-in', value: 'double_opt_in' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { name, optInProcess } = context.propsValue;
+
+    return await klaviyoClient.createList(
+      context.auth,
+      name,
+      optInProcess as string | undefined
+    );
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/create-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/create-profile.ts
@@ -1,0 +1,97 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const createProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'create_profile',
+  displayName: 'Create Profile',
+  description: 'Create a new profile in Klaviyo',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address of the profile',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone Number',
+      description: 'Phone number of the profile (E.164 format recommended)',
+      required: false,
+    }),
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    organization: Property.ShortText({
+      displayName: 'Organization',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      required: false,
+    }),
+    image: Property.ShortText({
+      displayName: 'Image URL',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      required: false,
+    }),
+    country: Property.ShortText({
+      displayName: 'Country',
+      required: false,
+    }),
+    region: Property.ShortText({
+      displayName: 'Region/State',
+      required: false,
+    }),
+    zip: Property.ShortText({
+      displayName: 'Zip Code',
+      required: false,
+    }),
+    customProperties: Property.Object({
+      displayName: 'Custom Properties',
+      description: 'Additional custom properties as key-value pairs',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { email, phone, firstName, lastName, organization, title, image, city, country, region, zip, customProperties } = context.propsValue;
+
+    if (!email && !phone) {
+      throw new Error('Either email or phone number must be provided');
+    }
+
+    const properties: Record<string, unknown> = {};
+    
+    if (firstName) properties.first_name = firstName;
+    if (lastName) properties.last_name = lastName;
+    if (organization) properties.organization = organization;
+    if (title) properties.title = title;
+    if (image) properties.image = image;
+    
+    if (city || country || region || zip) {
+      properties.location = {};
+      if (city) (properties.location as Record<string, unknown>).city = city;
+      if (country) (properties.location as Record<string, unknown>).country = country;
+      if (region) (properties.location as Record<string, unknown>).region = region;
+      if (zip) (properties.location as Record<string, unknown>).zip = zip;
+    }
+
+    if (customProperties) {
+      properties.properties = customProperties;
+    }
+
+    return await klaviyoClient.createProfile(
+      context.auth,
+      email,
+      phone,
+      properties
+    );
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/find-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/find-list.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const findListAction = createAction({
+  auth: klaviyoAuth,
+  name: 'find_list',
+  displayName: 'Find List by Name',
+  description: 'Find a list by its name in Klaviyo',
+  props: {
+    name: Property.ShortText({
+      displayName: 'List Name',
+      description: 'The name of the list to search for',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { name } = context.propsValue;
+
+    return await klaviyoClient.findListByName(
+      context.auth,
+      name
+    );
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/find-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/find-profile.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const findProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'find_profile',
+  displayName: 'Find Profile',
+  description: 'Find a profile by email or phone number',
+  props: {
+    searchBy: Property.StaticDropdown({
+      displayName: 'Search By',
+      description: 'Field to search by',
+      required: true,
+      options: {
+        options: [
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+        ],
+      },
+    }),
+    searchValue: Property.ShortText({
+      displayName: 'Search Value',
+      description: 'The email or phone number to search for',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { searchBy, searchValue } = context.propsValue;
+
+    if (searchBy === 'email') {
+      return await klaviyoClient.findProfileByEmail(
+        context.auth,
+        searchValue
+      );
+    } else {
+      return await klaviyoClient.findProfileByPhone(
+        context.auth,
+        searchValue
+      );
+    }
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/find-tag.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/find-tag.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const findTagAction = createAction({
+  auth: klaviyoAuth,
+  name: 'find_tag',
+  displayName: 'Find Tag by Name',
+  description: 'Find a tag by its name in Klaviyo',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Tag Name',
+      description: 'The name of the tag to search for',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { name } = context.propsValue;
+
+    return await klaviyoClient.findTagByName(
+      context.auth,
+      name
+    );
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/remove-profile-from-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/remove-profile-from-list.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const removeProfileFromListAction = createAction({
+  auth: klaviyoAuth,
+  name: 'remove_profile_from_list',
+  displayName: 'Remove Profile from List',
+  description: 'Remove one or more profiles from a list by profile ID',
+  props: {
+    listId: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to remove profiles from',
+      required: true,
+    }),
+    profileIds: Property.Array({
+      displayName: 'Profile IDs',
+      description: 'Array of profile IDs to remove from the list',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { listId, profileIds } = context.propsValue;
+
+    if (!profileIds || profileIds.length === 0) {
+      throw new Error('At least one profile ID must be provided');
+    }
+
+    // Convert to string array if needed
+    const ids = profileIds.map(id => String(id));
+
+    await klaviyoClient.removeProfilesFromList(
+      context.auth,
+      listId,
+      ids
+    );
+
+    return {
+      success: true,
+      message: `Successfully removed ${ids.length} profile(s) from list ${listId}`,
+    };
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/subscribe-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/subscribe-profile.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const subscribeProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'subscribe_profile',
+  displayName: 'Subscribe Profile to List',
+  description: 'Subscribe one or more profiles to a list in Klaviyo',
+  props: {
+    listId: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to subscribe profiles to',
+      required: true,
+    }),
+    profiles: Property.Array({
+      displayName: 'Profiles',
+      description: 'Profiles to subscribe (provide email or phone)',
+      required: true,
+      properties: {
+        email: Property.ShortText({
+          displayName: 'Email',
+          required: false,
+        }),
+        phone: Property.ShortText({
+          displayName: 'Phone Number',
+          description: 'Phone number (E.164 format recommended)',
+          required: false,
+        }),
+      },
+    }),
+  },
+  async run(context) {
+    const { listId, profiles } = context.propsValue;
+
+    if (!profiles || profiles.length === 0) {
+      throw new Error('At least one profile must be provided');
+    }
+
+    const profileData = profiles.map((profile: { email?: string; phone?: string }) => {
+      const data: Record<string, string> = {};
+      if (profile.email) data.email = profile.email;
+      if (profile.phone) data.phone_number = profile.phone;
+      
+      if (!data.email && !data.phone_number) {
+        throw new Error('Each profile must have either email or phone number');
+      }
+      
+      return data;
+    });
+
+    return await klaviyoClient.subscribeProfiles(
+      context.auth,
+      listId,
+      profileData
+    );
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/unsubscribe-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/unsubscribe-profile.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const unsubscribeProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'unsubscribe_profile',
+  displayName: 'Unsubscribe Profile from List',
+  description: 'Unsubscribe one or more profiles from a list in Klaviyo',
+  props: {
+    listId: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to unsubscribe profiles from',
+      required: true,
+    }),
+    profiles: Property.Array({
+      displayName: 'Profiles',
+      description: 'Profiles to unsubscribe (provide email or phone)',
+      required: true,
+      properties: {
+        email: Property.ShortText({
+          displayName: 'Email',
+          required: false,
+        }),
+        phone: Property.ShortText({
+          displayName: 'Phone Number',
+          description: 'Phone number (E.164 format recommended)',
+          required: false,
+        }),
+      },
+    }),
+  },
+  async run(context) {
+    const { listId, profiles } = context.propsValue;
+
+    if (!profiles || profiles.length === 0) {
+      throw new Error('At least one profile must be provided');
+    }
+
+    const profileData = profiles.map((profile: { email?: string; phone?: string }) => {
+      const data: Record<string, string> = {};
+      if (profile.email) data.email = profile.email;
+      if (profile.phone) data.phone_number = profile.phone;
+      
+      if (!data.email && !data.phone_number) {
+        throw new Error('Each profile must have either email or phone number');
+      }
+      
+      return data;
+    });
+
+    return await klaviyoClient.unsubscribeProfiles(
+      context.auth,
+      listId,
+      profileData
+    );
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/actions/update-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/actions/update-profile.ts
@@ -1,0 +1,98 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+
+export const updateProfileAction = createAction({
+  auth: klaviyoAuth,
+  name: 'update_profile',
+  displayName: 'Update Profile',
+  description: 'Update an existing profile in Klaviyo',
+  props: {
+    profileId: Property.ShortText({
+      displayName: 'Profile ID',
+      description: 'The ID of the profile to update',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone Number',
+      description: 'Phone number (E.164 format recommended)',
+      required: false,
+    }),
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    organization: Property.ShortText({
+      displayName: 'Organization',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      required: false,
+    }),
+    image: Property.ShortText({
+      displayName: 'Image URL',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      required: false,
+    }),
+    country: Property.ShortText({
+      displayName: 'Country',
+      required: false,
+    }),
+    region: Property.ShortText({
+      displayName: 'Region/State',
+      required: false,
+    }),
+    zip: Property.ShortText({
+      displayName: 'Zip Code',
+      required: false,
+    }),
+    customProperties: Property.Object({
+      displayName: 'Custom Properties',
+      description: 'Additional custom properties as key-value pairs',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { profileId, email, phone, firstName, lastName, organization, title, image, city, country, region, zip, customProperties } = context.propsValue;
+
+    const properties: Record<string, unknown> = {};
+    
+    if (email) properties.email = email;
+    if (phone) properties.phone_number = phone;
+    if (firstName) properties.first_name = firstName;
+    if (lastName) properties.last_name = lastName;
+    if (organization) properties.organization = organization;
+    if (title) properties.title = title;
+    if (image) properties.image = image;
+    
+    if (city || country || region || zip) {
+      properties.location = {};
+      if (city) (properties.location as Record<string, unknown>).city = city;
+      if (country) (properties.location as Record<string, unknown>).country = country;
+      if (region) (properties.location as Record<string, unknown>).region = region;
+      if (zip) (properties.location as Record<string, unknown>).zip = zip;
+    }
+
+    if (customProperties) {
+      properties.properties = customProperties;
+    }
+
+    return await klaviyoClient.updateProfile(
+      context.auth,
+      profileId,
+      properties
+    );
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/common/auth.ts
+++ b/packages/pieces/community/klaviyo/src/lib/common/auth.ts
@@ -1,0 +1,31 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const klaviyoAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Enter your Klaviyo Private API Key',
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://a.klaviyo.com/api/accounts',
+        headers: {
+          'Authorization': `Klaviyo-API-Key ${auth}`,
+          'revision': '2025-01-15',
+          'Accept': 'application/vnd.api+json',
+        },
+      });
+      return {
+        valid: true,
+      };
+    } catch (e) {
+      return {
+        valid: false,
+        error: 'Invalid API key. Please check your Klaviyo Private API Key.',
+      };
+    }
+  },
+});
+
+export type KlaviyoAuthType = string;

--- a/packages/pieces/community/klaviyo/src/lib/common/client.ts
+++ b/packages/pieces/community/klaviyo/src/lib/common/client.ts
@@ -1,0 +1,307 @@
+import {
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+import {
+  KlaviyoApiResponse,
+  KlaviyoApiListResponse,
+  KlaviyoProfile,
+  KlaviyoList,
+  KlaviyoTag,
+  KlaviyoBulkJobResponse,
+} from './types';
+
+const KLAVIYO_API_BASE = 'https://a.klaviyo.com/api';
+const KLAVIYO_API_REVISION = '2025-01-15';
+
+export const klaviyoClient = {
+  async makeRequest<T>(
+    apiKey: string,
+    method: HttpMethod,
+    path: string,
+    body?: unknown
+  ): Promise<T> {
+    const request: HttpRequest = {
+      method,
+      url: `${KLAVIYO_API_BASE}${path}`,
+      headers: {
+        'Authorization': `Klaviyo-API-Key ${apiKey}`,
+        'revision': KLAVIYO_API_REVISION,
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+      },
+    };
+
+    if (body) {
+      request.body = body;
+    }
+
+    const response = await httpClient.sendRequest<T>(request);
+    return response.body;
+  },
+
+  async createProfile(
+    apiKey: string,
+    email?: string,
+    phone?: string,
+    properties?: Record<string, unknown>
+  ): Promise<KlaviyoApiResponse<KlaviyoProfile>> {
+    const attributes: Record<string, unknown> = {};
+    
+    if (email) attributes.email = email;
+    if (phone) attributes.phone_number = phone;
+    if (properties) {
+      Object.assign(attributes, properties);
+    }
+
+    return this.makeRequest<KlaviyoApiResponse<KlaviyoProfile>>(
+      apiKey,
+      HttpMethod.POST,
+      '/profiles',
+      {
+        data: {
+          type: 'profile',
+          attributes,
+        },
+      }
+    );
+  },
+
+  async updateProfile(
+    apiKey: string,
+    profileId: string,
+    properties: Record<string, unknown>
+  ): Promise<KlaviyoApiResponse<KlaviyoProfile>> {
+    return this.makeRequest<KlaviyoApiResponse<KlaviyoProfile>>(
+      apiKey,
+      HttpMethod.PATCH,
+      `/profiles/${profileId}`,
+      {
+        data: {
+          type: 'profile',
+          id: profileId,
+          attributes: properties,
+        },
+      }
+    );
+  },
+
+  async getProfiles(
+    apiKey: string,
+    pageCursor?: string,
+    sort?: string
+  ): Promise<KlaviyoApiListResponse<KlaviyoProfile>> {
+    let path = '/profiles';
+    const params: string[] = [];
+    
+    if (pageCursor) params.push(`page[cursor]=${encodeURIComponent(pageCursor)}`);
+    if (sort) params.push(`sort=${sort}`);
+    
+    if (params.length > 0) {
+      path += `?${params.join('&')}`;
+    }
+
+    return this.makeRequest<KlaviyoApiListResponse<KlaviyoProfile>>(
+      apiKey,
+      HttpMethod.GET,
+      path
+    );
+  },
+
+  async findProfileByEmail(
+    apiKey: string,
+    email: string
+  ): Promise<KlaviyoApiListResponse<KlaviyoProfile>> {
+    return this.makeRequest<KlaviyoApiListResponse<KlaviyoProfile>>(
+      apiKey,
+      HttpMethod.GET,
+      `/profiles?filter=equals(email,"${email}")`
+    );
+  },
+
+  async findProfileByPhone(
+    apiKey: string,
+    phone: string
+  ): Promise<KlaviyoApiListResponse<KlaviyoProfile>> {
+    return this.makeRequest<KlaviyoApiListResponse<KlaviyoProfile>>(
+      apiKey,
+      HttpMethod.GET,
+      `/profiles?filter=equals(phone_number,"${phone}")`
+    );
+  },
+
+  async subscribeProfiles(
+    apiKey: string,
+    listId: string,
+    profiles: Array<{ email?: string; phone_number?: string }>
+  ): Promise<KlaviyoBulkJobResponse> {
+    return this.makeRequest<KlaviyoBulkJobResponse>(
+      apiKey,
+      HttpMethod.POST,
+      '/profile-subscription-bulk-create-jobs',
+      {
+        data: {
+          type: 'profile-subscription-bulk-create-job',
+          attributes: {
+            custom_source: 'Activepieces',
+            profiles: profiles,
+          },
+          relationships: {
+            list: {
+              data: {
+                type: 'list',
+                id: listId,
+              },
+            },
+          },
+        },
+      }
+    );
+  },
+
+  async unsubscribeProfiles(
+    apiKey: string,
+    listId: string,
+    profiles: Array<{ email?: string; phone_number?: string }>
+  ): Promise<KlaviyoBulkJobResponse> {
+    return this.makeRequest<KlaviyoBulkJobResponse>(
+      apiKey,
+      HttpMethod.POST,
+      '/profile-subscription-bulk-delete-jobs',
+      {
+        data: {
+          type: 'profile-subscription-bulk-delete-job',
+          attributes: {
+            profiles: profiles,
+          },
+          relationships: {
+            list: {
+              data: {
+                type: 'list',
+                id: listId,
+              },
+            },
+          },
+        },
+      }
+    );
+  },
+
+  async addProfilesToList(
+    apiKey: string,
+    listId: string,
+    profileIds: string[]
+  ): Promise<void> {
+    await this.makeRequest(
+      apiKey,
+      HttpMethod.POST,
+      `/lists/${listId}/relationships/profiles`,
+      {
+        data: profileIds.map(id => ({
+          type: 'profile',
+          id,
+        })),
+      }
+    );
+  },
+
+  async removeProfilesFromList(
+    apiKey: string,
+    listId: string,
+    profileIds: string[]
+  ): Promise<void> {
+    await this.makeRequest(
+      apiKey,
+      HttpMethod.DELETE,
+      `/lists/${listId}/relationships/profiles`,
+      {
+        data: profileIds.map(id => ({
+          type: 'profile',
+          id,
+        })),
+      }
+    );
+  },
+
+  async createList(
+    apiKey: string,
+    name: string,
+    optInProcess?: string
+  ): Promise<KlaviyoApiResponse<KlaviyoList>> {
+    const attributes: Record<string, unknown> = { name };
+    if (optInProcess) attributes.opt_in_process = optInProcess;
+
+    return this.makeRequest<KlaviyoApiResponse<KlaviyoList>>(
+      apiKey,
+      HttpMethod.POST,
+      '/lists',
+      {
+        data: {
+          type: 'list',
+          attributes,
+        },
+      }
+    );
+  },
+
+  async getLists(
+    apiKey: string,
+    filter?: string
+  ): Promise<KlaviyoApiListResponse<KlaviyoList>> {
+    let path = '/lists';
+    if (filter) {
+      path += `?filter=${encodeURIComponent(filter)}`;
+    }
+    return this.makeRequest<KlaviyoApiListResponse<KlaviyoList>>(
+      apiKey,
+      HttpMethod.GET,
+      path
+    );
+  },
+
+  async findListByName(
+    apiKey: string,
+    name: string
+  ): Promise<KlaviyoApiListResponse<KlaviyoList>> {
+    return this.getLists(apiKey, `equals(name,"${name}")`);
+  },
+
+  async getTags(
+    apiKey: string,
+    filter?: string
+  ): Promise<KlaviyoApiListResponse<KlaviyoTag>> {
+    let path = '/tags';
+    if (filter) {
+      path += `?filter=${encodeURIComponent(filter)}`;
+    }
+    return this.makeRequest<KlaviyoApiListResponse<KlaviyoTag>>(
+      apiKey,
+      HttpMethod.GET,
+      path
+    );
+  },
+
+  async findTagByName(
+    apiKey: string,
+    name: string
+  ): Promise<KlaviyoApiListResponse<KlaviyoTag>> {
+    return this.getTags(apiKey, `equals(name,"${name}")`);
+  },
+
+  async getListProfiles(
+    apiKey: string,
+    listId: string,
+    pageCursor?: string
+  ): Promise<KlaviyoApiListResponse<KlaviyoProfile>> {
+    let path = `/lists/${listId}/profiles`;
+    if (pageCursor) {
+      path += `?page[cursor]=${encodeURIComponent(pageCursor)}`;
+    }
+    return this.makeRequest<KlaviyoApiListResponse<KlaviyoProfile>>(
+      apiKey,
+      HttpMethod.GET,
+      path
+    );
+  },
+};

--- a/packages/pieces/community/klaviyo/src/lib/common/types.ts
+++ b/packages/pieces/community/klaviyo/src/lib/common/types.ts
@@ -1,0 +1,125 @@
+export interface KlaviyoProfile {
+  type: 'profile';
+  id: string;
+  attributes: {
+    email?: string;
+    phone_number?: string;
+    external_id?: string;
+    first_name?: string;
+    last_name?: string;
+    organization?: string;
+    title?: string;
+    image?: string;
+    created?: string;
+    updated?: string;
+    last_event_date?: string;
+    location?: {
+      address1?: string;
+      address2?: string;
+      city?: string;
+      country?: string;
+      region?: string;
+      zip?: string;
+      timezone?: string;
+      latitude?: string;
+      longitude?: string;
+    };
+    properties?: Record<string, unknown>;
+    subscriptions?: {
+      email?: {
+        marketing?: {
+          can_receive_email_marketing?: boolean;
+          consent?: string;
+          consent_timestamp?: string;
+        };
+      };
+      sms?: {
+        marketing?: {
+          can_receive_sms_marketing?: boolean;
+          consent?: string;
+          consent_timestamp?: string;
+        };
+      };
+    };
+  };
+  links?: {
+    self?: string;
+  };
+  relationships?: Record<string, unknown>;
+}
+
+export interface KlaviyoList {
+  type: 'list';
+  id: string;
+  attributes: {
+    name: string;
+    created?: string;
+    updated?: string;
+    opt_in_process?: string;
+  };
+  links?: {
+    self?: string;
+  };
+}
+
+export interface KlaviyoTag {
+  type: 'tag';
+  id: string;
+  attributes: {
+    name: string;
+    created?: string;
+    updated?: string;
+  };
+  links?: {
+    self?: string;
+  };
+}
+
+export interface KlaviyoSegment {
+  type: 'segment';
+  id: string;
+  attributes: {
+    name: string;
+    created?: string;
+    updated?: string;
+    definition?: unknown;
+  };
+  links?: {
+    self?: string;
+  };
+}
+
+export interface KlaviyoApiResponse<T> {
+  data: T;
+  links?: {
+    self?: string;
+    next?: string;
+    prev?: string;
+  };
+}
+
+export interface KlaviyoApiListResponse<T> {
+  data: T[];
+  links?: {
+    self?: string;
+    next?: string;
+    prev?: string;
+  };
+}
+
+export interface KlaviyoBulkJobResponse {
+  data: {
+    type: string;
+    id: string;
+    attributes: {
+      status: string;
+      created_at: string;
+      total_count?: number;
+      completed_count?: number;
+      failed_count?: number;
+      completed_at?: string;
+      expires_at?: string;
+      started_at?: string;
+    };
+  };
+}

--- a/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
@@ -1,0 +1,115 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+import { KlaviyoProfile } from '../common/types';
+
+export const newProfileTrigger = createTrigger({
+  auth: klaviyoAuth,
+  name: 'new_profile',
+  displayName: 'New Profile',
+  description: 'Triggers when a new profile is created in Klaviyo',
+  props: {},
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    type: 'profile',
+    id: '01HXYZ123ABC456DEF',
+    attributes: {
+      email: 'john.doe@example.com',
+      phone_number: '+12125551234',
+      first_name: 'John',
+      last_name: 'Doe',
+      organization: 'Acme Corp',
+      title: 'Software Engineer',
+      created: '2025-01-15T12:00:00Z',
+      updated: '2025-01-15T12:00:00Z',
+      properties: {
+        custom_field: 'value',
+      },
+    },
+  },
+  async onEnable(context) {
+    // Initialize cursor by fetching the most recent profile
+    try {
+      const response = await klaviyoClient.getProfiles(
+        context.auth,
+        undefined,
+        '-created'
+      );
+      
+      if (response.data && response.data.length > 0) {
+        const latestProfile = response.data[0];
+        await context.store.put('last_profile_id', latestProfile.id);
+      }
+    } catch (error) {
+      // If first run fails, we'll start fresh on first poll
+      console.error('Failed to initialize trigger:', error);
+    }
+  },
+  async onDisable(context) {
+    await context.store.delete('last_profile_id');
+  },
+  async test(context) {
+    // Return most recent profiles for testing
+    const response = await klaviyoClient.getProfiles(
+      context.auth,
+      undefined,
+      '-created'
+    );
+    
+    return response.data.slice(0, 10);
+  },
+  async run(context) {
+    const lastProfileId = await context.store.get<string>('last_profile_id');
+    const newProfiles: KlaviyoProfile[] = [];
+    
+    let pageCursor: string | undefined = undefined;
+    let foundLastProfile = false;
+
+    // Fetch profiles in descending order by creation date
+    while (!foundLastProfile) {
+      const response = await klaviyoClient.getProfiles(
+        context.auth,
+        pageCursor,
+        '-created'
+      );
+
+      if (!response.data || response.data.length === 0) {
+        break;
+      }
+
+      for (const profile of response.data) {
+        if (lastProfileId && profile.id === lastProfileId) {
+          foundLastProfile = true;
+          break;
+        }
+        newProfiles.push(profile);
+      }
+
+      // Check if there's a next page and we haven't found the last profile yet
+      if (!foundLastProfile && response.links?.next) {
+        // Extract cursor from next URL
+        const nextUrl = response.links.next;
+        const cursorMatch = nextUrl.match(/page\[cursor\]=([^&]+)/);
+        if (cursorMatch) {
+          pageCursor = decodeURIComponent(cursorMatch[1]);
+        } else {
+          break;
+        }
+      } else {
+        break;
+      }
+
+      // Safety limit: don't fetch more than 100 profiles in one run
+      if (newProfiles.length >= 100) {
+        break;
+      }
+    }
+
+    // Update the last seen profile ID
+    if (newProfiles.length > 0) {
+      await context.store.put('last_profile_id', newProfiles[0].id);
+    }
+
+    return newProfiles;
+  },
+});

--- a/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list.ts
@@ -1,0 +1,118 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { klaviyoAuth } from '../common/auth';
+import { klaviyoClient } from '../common/client';
+import { KlaviyoProfile } from '../common/types';
+
+export const profileAddedToListTrigger = createTrigger({
+  auth: klaviyoAuth,
+  name: 'profile_added_to_list',
+  displayName: 'Profile Added to List',
+  description: 'Triggers when a profile is added to a specific list in Klaviyo',
+  props: {
+    listId: Property.ShortText({
+      displayName: 'List ID',
+      description: 'The ID of the list to monitor',
+      required: true,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    type: 'profile',
+    id: '01HXYZ123ABC456DEF',
+    attributes: {
+      email: 'jane.smith@example.com',
+      phone_number: '+12125555678',
+      first_name: 'Jane',
+      last_name: 'Smith',
+      created: '2025-01-15T12:00:00Z',
+      updated: '2025-01-15T12:00:00Z',
+    },
+  },
+  async onEnable(context) {
+    const { listId } = context.propsValue;
+    
+    // Initialize by fetching current profiles in the list
+    try {
+      const response = await klaviyoClient.getListProfiles(
+        context.auth,
+        listId
+      );
+      
+      // Store all current profile IDs
+      if (response.data && response.data.length > 0) {
+        const profileIds = response.data.map(p => p.id);
+        await context.store.put(`list_${listId}_profile_ids`, profileIds);
+      } else {
+        await context.store.put(`list_${listId}_profile_ids`, []);
+      }
+    } catch (error) {
+      console.error('Failed to initialize trigger:', error);
+      await context.store.put(`list_${listId}_profile_ids`, []);
+    }
+  },
+  async onDisable(context) {
+    const { listId } = context.propsValue;
+    await context.store.delete(`list_${listId}_profile_ids`);
+  },
+  async test(context) {
+    const { listId } = context.propsValue;
+    
+    // Return recent profiles from the list for testing
+    const response = await klaviyoClient.getListProfiles(
+      context.auth,
+      listId
+    );
+    
+    return response.data.slice(0, 10);
+  },
+  async run(context) {
+    const { listId } = context.propsValue;
+    const lastProfileIds = await context.store.get<string[]>(`list_${listId}_profile_ids`) || [];
+    
+    const currentProfiles: KlaviyoProfile[] = [];
+    let pageCursor: string | undefined = undefined;
+
+    // Fetch all current profiles in the list
+    while (true) {
+      const response = await klaviyoClient.getListProfiles(
+        context.auth,
+        listId,
+        pageCursor
+      );
+
+      if (!response.data || response.data.length === 0) {
+        break;
+      }
+
+      currentProfiles.push(...response.data);
+
+      // Check if there's a next page
+      if (response.links?.next) {
+        const nextUrl = response.links.next;
+        const cursorMatch = nextUrl.match(/page\[cursor\]=([^&]+)/);
+        if (cursorMatch) {
+          pageCursor = decodeURIComponent(cursorMatch[1]);
+        } else {
+          break;
+        }
+      } else {
+        break;
+      }
+
+      // Safety limit
+      if (currentProfiles.length >= 1000) {
+        break;
+      }
+    }
+
+    // Find new profiles (profiles that are in current list but not in last known list)
+    const currentProfileIds = currentProfiles.map(p => p.id);
+    const newProfileIds = currentProfileIds.filter(id => !lastProfileIds.includes(id));
+    const newProfiles = currentProfiles.filter(p => newProfileIds.includes(p.id));
+
+    // Update stored profile IDs
+    await context.store.put(`list_${listId}_profile_ids`, currentProfileIds);
+
+    return newProfiles;
+  },
+});

--- a/packages/pieces/community/klaviyo/tsconfig.json
+++ b/packages/pieces/community/klaviyo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/klaviyo/tsconfig.lib.json
+++ b/packages/pieces/community/klaviyo/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -597,6 +597,9 @@
       "@activepieces/piece-kimai": [
         "packages/pieces/community/kimai/src/index.ts"
       ],
+      "@activepieces/piece-klaviyo": [
+          "packages/pieces/community/klaviyo/src/index.ts"
+      ],
       "@activepieces/piece-kizeo-forms": [
         "packages/pieces/community/kizeo-forms/src/index.ts"
       ],


### PR DESCRIPTION
## Description

New Klaviyo piece for email/SMS marketing automation, as requested in #8284.

### Actions (10):
- **Create Profile** - Create a new profile with email, phone, and custom properties
- **Update Profile** - Update existing profile properties
- **Find Profile** - Search by email or phone number
- **Subscribe Profile** - Subscribe to email/SMS list
- **Unsubscribe Profile** - Unsubscribe from a list
- **Add Profile to List** - Add existing profile to a list
- **Remove Profile from List** - Remove profile from a list
- **Create List** - Create a new marketing list
- **Find List** - Search lists by name
- **Find Tag** - Search tags by name

### Triggers (2):
- **New Profile** - Triggers when a new profile is created (polling)
- **Profile Added to List** - Triggers when a profile is added to a specific list (polling)

### Technical Details:
- API key authentication with validation
- Full JSON:API format compliance (`application/vnd.api+json`)
- Klaviyo API revision `2025-01-15`
- Reusable client abstraction with proper headers
- Complete TypeScript type definitions

/claim #8284

?? Built with AI assistance (Claude)
Co-Authored-By: Claude <noreply@anthropic.com>