### PR TITLE
feat(gmail): extend piece with 6 new actions + new starred email trigger (#8072)

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -13,8 +13,16 @@ import { gmailNewLabeledEmailTrigger } from './lib/triggers/new-labeled-email';
 import { requestApprovalInEmail } from './lib/actions/request-approval-in-email';
 import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
+import { gmailNewConversationTrigger } from './lib/triggers/new-conversation';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailAddLabelToEmailAction } from './lib/actions/add-label-to-email-action';
+import { gmailRemoveLabelFromEmailAction } from './lib/actions/remove-label-from-email-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
 
 export const gmailAuth = PieceAuth.OAuth2({
   description: '',
@@ -26,6 +34,8 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.labels',
   ],
 });
 
@@ -43,6 +53,12 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailAddLabelToEmailAction,
+    gmailRemoveLabelFromEmailAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -67,12 +83,15 @@ export const gmail = createPiece({
     'AdamSelene',
     'sanket-a11y',
     'onyedikachi-david',
+    'Harmatta',
   ],
   triggers: [
     gmailNewEmailTrigger,
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewConversationTrigger,
+    gmailNewStarredEmailTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
@@ -1,0 +1,38 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailAddLabelToEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_add_label_to_email',
+  displayName: 'Add Label to Email',
+  description: 'Attach a label to an individual email.',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+      description: 'The label to add to the email.',
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const label = context.propsValue.label as { id: string; name: string };
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        addLabelIds: [label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,31 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_archive_email',
+  displayName: 'Archive Email',
+  description: 'Archive an email by removing it from the Inbox (moves to "All Mail").',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,81 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_create_label',
+  displayName: 'Create Label',
+  description: 'Create a new user label in Gmail.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the new label.',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Label List',
+      description: 'Whether the label is shown in the label list.',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Hide', value: 'labelHide' },
+          { label: 'Show if Unread', value: 'labelShowIfUnread' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Message List',
+      description: 'Whether the label is shown in the message list.',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+    background_color: Property.ShortText({
+      displayName: 'Background Color',
+      description: 'Background color hex code (e.g., #16a765).',
+      required: false,
+    }),
+    text_color: Property.ShortText({
+      displayName: 'Text Color',
+      description: 'Text color hex code (e.g., #ffffff).',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const requestBody: any = {
+      name: context.propsValue.name,
+      labelListVisibility: context.propsValue.label_list_visibility || 'labelShow',
+      messageListVisibility: context.propsValue.message_list_visibility || 'show',
+    };
+
+    if (context.propsValue.background_color && context.propsValue.text_color) {
+      requestBody.color = {
+        backgroundColor: context.propsValue.background_color,
+        textColor: context.propsValue.text_color,
+      };
+    }
+
+    const response = await gmail.users.labels.create({
+      userId: 'me',
+      requestBody,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_delete_email',
+  displayName: 'Delete Email',
+  description: 'Move an email to the Trash folder.',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.trash({
+      userId: 'me',
+      id: context.propsValue.message_id,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
@@ -1,0 +1,38 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveLabelFromEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_email',
+  displayName: 'Remove Label from Email',
+  description: 'Remove a specific label from an email.',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+      description: 'The label to remove from the email.',
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const label = context.propsValue.label as { id: string; name: string };
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: [label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,38 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_thread',
+  displayName: 'Remove Label from Thread',
+  description: 'Remove a label from all emails in a thread.',
+  props: {
+    thread_id: GmailProps.thread,
+    label: {
+      ...GmailProps.label,
+      required: true,
+      description: 'The label to remove from the thread.',
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const label = context.propsValue.label as { id: string; name: string };
+
+    const response = await gmail.users.threads.modify({
+      userId: 'me',
+      id: context.propsValue.thread_id,
+      requestBody: {
+        removeLabelIds: [label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,156 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  PiecePropValueSchema,
+  FilesService,
+  Property,
+} from '@activepieces/pieces-framework';
+import { GmailProps } from '../common/props';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { parseStream, convertAttachment, getFirstFiveOrAll } from '../common/data';
+import dayjs from 'dayjs';
+
+type Props = {
+  from?: string;
+  to?: string;
+  subject?: string;
+};
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred (within 2 days).',
+  props: {
+    from: {
+      ...GmailProps.from,
+      description: 'Filter by sender email (optional).',
+      displayName: 'From',
+      required: false,
+    },
+    to: {
+      ...GmailProps.to,
+      description: 'Filter by recipient email (optional).',
+      displayName: 'To',
+      required: false,
+    },
+    subject: Property.ShortText({
+      displayName: 'Subject Contains',
+      description:
+        'Only trigger for emails containing this text in the subject (optional).',
+      required: false,
+    }),
+  },
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await context.store.put('lastPoll', Date.now());
+  },
+  async onDisable(context) {
+    return;
+  },
+  async run(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      props: context.propsValue,
+      files: context.files,
+      lastFetchEpochMS,
+    });
+
+    const newLastEpochMilliSeconds = items.reduce(
+      (acc, item) => Math.max(acc, item.epochMilliSeconds),
+      lastFetchEpochMS
+    );
+    await context.store.put('lastPoll', newLastEpochMilliSeconds);
+
+    return items
+      .filter((f) => f.epochMilliSeconds > lastFetchEpochMS)
+      .map((item) => item.data);
+  },
+  async test(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      props: context.propsValue,
+      files: context.files,
+      lastFetchEpochMS,
+    });
+
+    return getFirstFiveOrAll(items.map((item) => item.data));
+  },
+});
+
+async function pollStarredMessages({
+  auth,
+  props,
+  files,
+  lastFetchEpochMS,
+}: {
+  auth: PiecePropValueSchema<typeof gmailAuth>;
+  props: Props;
+  files: FilesService;
+  lastFetchEpochMS: number;
+}): Promise<
+  {
+    epochMilliSeconds: number;
+    data: unknown;
+  }[]
+> {
+  const authClient = new OAuth2Client();
+  authClient.setCredentials(auth);
+
+  const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+  const query = ['is:starred'];
+  const maxResults = lastFetchEpochMS === 0 ? 5 : 100;
+
+  // Look back 2 days max
+  const twoDaysAgo = Math.floor((Date.now() - 2 * 24 * 60 * 60 * 1000) / 1000);
+  const afterUnixSeconds = Math.max(
+    Math.floor(lastFetchEpochMS / 1000),
+    twoDaysAgo
+  );
+
+  if (props.from) query.push(`from:(${props.from})`);
+  if (props.to) query.push(`to:(${props.to})`);
+  if (props.subject) query.push(`subject:(${props.subject})`);
+  if (afterUnixSeconds > 0) query.push(`after:${afterUnixSeconds}`);
+
+  const messagesResponse = await gmail.users.messages.list({
+    userId: 'me',
+    q: query.join(' '),
+    maxResults,
+  });
+
+  const pollingResponse = [];
+  for (const message of messagesResponse.data.messages || []) {
+    const rawMailResponse = await gmail.users.messages.get({
+      userId: 'me',
+      id: message.id!,
+      format: 'raw',
+    });
+
+    const parsedMailResponse = await parseStream(
+      Buffer.from(rawMailResponse.data.raw as string, 'base64').toString('utf-8')
+    );
+
+    pollingResponse.push({
+      epochMilliSeconds: dayjs(parsedMailResponse.date).valueOf(),
+      data: {
+        id: message.id,
+        ...parsedMailResponse,
+        attachments: await convertAttachment(
+          parsedMailResponse.attachments,
+          files
+        ),
+      },
+    });
+  }
+
+  return pollingResponse;
+}


### PR DESCRIPTION
## Summary

Extends the existing Gmail piece with the missing actions and triggers requested in #8072.

### New Actions (6)
| Action | Description |
|--------|-------------|
| **Add Label to Email** | Attach a label to an individual email |
| **Remove Label from Email** | Remove a specific label from an email |
| **Create Label** | Create a new user label with optional color and visibility settings |
| **Archive Email** | Move email to "All Mail" by removing the INBOX label |
| **Delete Email** | Move an email to Trash |
| **Remove Label from Thread** | Strip a label from all emails in a thread |

### New Triggers (1)
| Trigger | Description |
|---------|-------------|
| **New Starred Email** | Fires when an email is starred (polls within 2-day window, with optional from/to/subject filters) |

### Bug Fix
- Registered the **New Conversation** trigger which existed as a file but was never imported in `index.ts`

### OAuth Scope Updates
- Added `gmail.modify` and `gmail.labels` scopes to support label management and email modification operations

### Implementation Notes
- All actions follow existing piece patterns (OAuth2Client, googleapis, shared GmailProps)
- Reuses existing `GmailProps.message`, `GmailProps.thread`, and `GmailProps.label` from `common/props.ts`
- New Starred Email trigger uses polling strategy consistent with other Gmail triggers
- No changes to existing actions or triggers

Resolves #8072