### PR TITLE
fix: [BUG] fixed form values not getting clear after form submission and same fieldName problem

### DIFF
--- a/packages/pieces/community/forms/src/lib/triggers/form-trigger.ts
+++ b/packages/pieces/community/forms/src/lib/triggers/form-trigger.ts
@@ -9,7 +9,6 @@ import {
   USE_DRAFT_QUERY_PARAM_NAME,
 } from '@activepieces/shared';
 
-
 const markdown = `**Published Form URL:**
 \`\`\`text
 {{formUrl}}
@@ -44,7 +43,9 @@ const parseBoolean = (value: unknown, fieldName: string): boolean => {
       return lowerValue === 'true';
     }
   }
-  throw new Error(`Field ${fieldName} must be a boolean or 'true'/'false' string`);
+  throw new Error(
+    `Field ${fieldName} must be a boolean or 'true'/'false' string`
+  );
 };
 
 export const onFormSubmission = createTrigger({
@@ -64,6 +65,11 @@ export const onFormSubmission = createTrigger({
       displayName: 'Wait for Response',
       defaultValue: false,
       required: true,
+    }),
+    note: Property.MarkDown({
+      value:
+        'Note: The Filed Name must be unique. if same field name is used multiple times, then rest filed name will be like fieldName_1, fieldName_2 etc.',
+      variant: MarkdownVariant.WARNING,
     }),
     inputs: Property.Array({
       displayName: 'Inputs',
@@ -109,8 +115,19 @@ export const onFormSubmission = createTrigger({
     const inputs = context.propsValue.inputs as FormInput[];
 
     const processedPayload: Record<string, unknown> = {};
+    const keyCounts: Record<string, number> = {};
+
     for (const input of inputs) {
-      const key = createKeyForFormInput(input.displayName);
+      const baseKey = createKeyForFormInput(input.displayName);
+      if (keyCounts[baseKey] === undefined) {
+        keyCounts[baseKey] = 0;
+      } else {
+        keyCounts[baseKey]++;
+      }
+
+      const keyCountForThisKey = keyCounts[baseKey];
+      const key =
+        keyCountForThisKey === 0 ? baseKey : `${baseKey}_${keyCountForThisKey}`;
       const value = payload[key];
 
       switch (input.type) {


### PR DESCRIPTION
### What does this PR do?
 #### The Problems :- 
  1. Form values wasn't resetting after form submission
  2. if we give a form two fields with same name "address" and "address" then if we fill out first address field in form then it used to fill out second input automatically.
  3. when we give a form same "fieldName" and if we run test , then second fieldName used to override the first fieldName value in the test result.

#### Fixes :-  
 1. Now form's all values ( text, textArea, file, dropdown,checkbox) gets resetted after form submission.
 2. now even if user set two fields with same name , filling out first input doesn't fill out second input.
 3. This is a little long how i fixed this - earlier the field name used to override same values which made the bug in our web from , so fix was that i used a diffrent technique for that.
 first i wll get the fieldName and then increment the counter = 0 for that fieldName , and then if i again get the same fieldName then i increment the counter++ and while setting the object for payload i use fieldname+counter index to make same field name unique and then i send to backend , and in backend the same logic applies for parsing the payload and it solves our this problem.
you can find comments added in code where i explain these things.


#### TEST :- 
 1. Check if the form values are resetting or not after the form submission
 2. check if same fieldName inputs doesn't fill other inputs with same name
 3. check if you create a form with same name and then run the test , you should see all your fields and values even with same name , make sure last same name field doesn't override earlier same name field.

#### Video Before fix

https://github.com/user-attachments/assets/47ae10ab-3518-47b1-81ec-c8c6122da3c4



#### After fix

https://github.com/user-attachments/assets/a0293479-7686-47bc-b610-629c45c55ccc




