### PR TITLE
feat(gmail): add label management, archive, delete and starred trigger

### DIFF
--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "dependencies": {
     "googleapis": "129.0.0",
     "mailparser": "3.7.5"

--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -15,6 +15,15 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailGetThread } from './lib/actions/get-thread-action';
+import { gmailAddLabelToEmailAction } from './lib/actions/add-label-to-email-action';
+import { gmailRemoveLabelFromEmailAction } from './lib/actions/remove-label-from-email-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
+import { gmailNewConversationTrigger } from './lib/triggers/new-conversation';
 
 export const gmailAuth = PieceAuth.OAuth2({
   description: '',
@@ -26,6 +35,7 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.modify',
   ],
 });
 
@@ -42,7 +52,14 @@ export const gmail = createPiece({
     gmailReplyToEmailAction,
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
+    gmailGetThread,
     gmailSearchMailAction,
+    gmailAddLabelToEmailAction,
+    gmailRemoveLabelFromEmailAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -67,12 +84,15 @@ export const gmail = createPiece({
     'AdamSelene',
     'sanket-a11y',
     'onyedikachi-david',
+    'edow',
   ],
   triggers: [
     gmailNewEmailTrigger,
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewStarredEmailTrigger,
+    gmailNewConversationTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
@@ -1,0 +1,36 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailAddLabelToEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_add_label_to_email',
+  displayName: 'Add Label to Email',
+  description: 'Add a label to a specific email message.',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+      description: 'The label to add to the email.',
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        addLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,31 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_archive_email',
+  displayName: 'Archive Email',
+  description: 'Archive an email by removing the INBOX label (moves to All Mail).',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,62 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_create_label',
+  displayName: 'Create Label',
+  description: 'Create a new user label in Gmail.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the label to create.',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Label List',
+      description: 'Whether this label should appear in the label list.',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Hide', value: 'labelHide' },
+          { label: 'Show if Unread', value: 'labelShowIfUnread' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Message List',
+      description: 'Whether messages with this label show in the message list.',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.labels.create({
+      userId: 'me',
+      requestBody: {
+        name: context.propsValue.name,
+        labelListVisibility: context.propsValue.label_list_visibility || 'labelShow',
+        messageListVisibility: context.propsValue.message_list_visibility || 'show',
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_delete_email',
+  displayName: 'Delete Email',
+  description: 'Move an email to the Trash folder.',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.trash({
+      userId: 'me',
+      id: context.propsValue.message_id,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
@@ -1,0 +1,36 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveLabelFromEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_email',
+  displayName: 'Remove Label from Email',
+  description: 'Remove a specific label from an email message.',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+      description: 'The label to remove from the email.',
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,36 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_thread',
+  displayName: 'Remove Label from Thread',
+  description: 'Remove a label from all emails in a thread.',
+  props: {
+    thread_id: GmailProps.thread,
+    label: {
+      ...GmailProps.label,
+      required: true,
+      description: 'The label to remove from the thread.',
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.threads.modify({
+      userId: 'me',
+      id: context.propsValue.thread_id,
+      requestBody: {
+        removeLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,160 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  PiecePropValueSchema,
+  FilesService,
+} from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import {
+  parseStream,
+  convertAttachment,
+  getFirstFiveOrAll,
+} from '../common/data';
+import dayjs from 'dayjs';
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred (checks emails within the last 2 days).',
+  props: {},
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const profile = await gmail.users.getProfile({ userId: 'me' });
+    await context.store.put('lastHistoryId', profile.data.historyId);
+  },
+  async onDisable(context) {
+    await context.store.delete('lastHistoryId');
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const lastHistoryId = await context.store.get<string>('lastHistoryId');
+    if (!lastHistoryId) {
+      return [];
+    }
+
+    try {
+      const historyResponse = await gmail.users.history.list({
+        userId: 'me',
+        startHistoryId: lastHistoryId,
+        historyTypes: ['labelAdded'],
+      });
+
+      const starredMessageIds = new Set<string>();
+
+      if (historyResponse.data.history) {
+        for (const history of historyResponse.data.history) {
+          if (history.labelsAdded) {
+            for (const labelAdded of history.labelsAdded) {
+              if (
+                labelAdded.labelIds?.includes('STARRED') &&
+                labelAdded.message?.id
+              ) {
+                starredMessageIds.add(labelAdded.message.id);
+              }
+            }
+          }
+        }
+      }
+
+      const results = [];
+      // Only consider emails within the last 2 days
+      const twoDaysAgo = dayjs().subtract(2, 'day').valueOf();
+
+      for (const messageId of starredMessageIds) {
+        const rawMailResponse = await gmail.users.messages.get({
+          userId: 'me',
+          id: messageId,
+          format: 'raw',
+        });
+
+        const internalDate = parseInt(rawMailResponse.data.internalDate || '0');
+        if (internalDate < twoDaysAgo) {
+          continue;
+        }
+
+        const parsedMailResponse = await parseStream(
+          Buffer.from(rawMailResponse.data.raw as string, 'base64').toString('utf-8')
+        );
+
+        results.push({
+          message: {
+            id: messageId,
+            threadId: rawMailResponse.data.threadId,
+            ...parsedMailResponse,
+            attachments: await convertAttachment(
+              parsedMailResponse.attachments,
+              context.files
+            ),
+          },
+        });
+      }
+
+      if (historyResponse.data.historyId) {
+        await context.store.put('lastHistoryId', historyResponse.data.historyId);
+      }
+
+      return results;
+    } catch (error: any) {
+      if (error.code === 404) {
+        // History ID expired, reset
+        const profile = await gmail.users.getProfile({ userId: 'me' });
+        await context.store.put('lastHistoryId', profile.data.historyId);
+        return [];
+      }
+      throw error;
+    }
+  },
+  async test(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    // Get recent starred emails
+    const messagesResponse = await gmail.users.messages.list({
+      userId: 'me',
+      q: 'is:starred',
+      maxResults: 5,
+    });
+
+    const results = [];
+
+    if (messagesResponse.data.messages) {
+      for (const message of messagesResponse.data.messages) {
+        const rawMailResponse = await gmail.users.messages.get({
+          userId: 'me',
+          id: message.id!,
+          format: 'raw',
+        });
+
+        const parsedMailResponse = await parseStream(
+          Buffer.from(rawMailResponse.data.raw as string, 'base64').toString('utf-8')
+        );
+
+        results.push({
+          message: {
+            id: message.id,
+            threadId: message.threadId,
+            ...parsedMailResponse,
+            attachments: await convertAttachment(
+              parsedMailResponse.attachments,
+              context.files
+            ),
+          },
+        });
+      }
+    }
+
+    return getFirstFiveOrAll(results);
+  },
+});


### PR DESCRIPTION
Extends the Gmail piece with the missing actions and triggers from #8072.

**New actions:**
- Add Label to Email — attach a label to an email
- Remove Label from Email — strip a label from an email  
- Create Label — create a new user label
- Archive Email — remove INBOX label (move to All Mail)
- Delete Email — move email to Trash
- Remove Label from Thread — remove a label from all messages in a thread

**New trigger:**
- New Starred Email — fires when an email gets starred (checks within last 2 days, uses History API)

**Other changes:**
- Registered the existing but unregistered `Get Thread` action
- Registered the existing but unregistered `New Conversation` trigger
- Added `gmail.modify` scope needed for label/archive/delete operations
- Bumped piece version to 0.12.0

All new code follows the existing patterns — uses googleapis client, OAuth2Client, and the shared props/helpers.

/claim #8072