### PR TITLE
fix: pass password as passphrase for SFTP private key authentication

### DIFF
--- a/packages/pieces/community/sftp/src/index.ts
+++ b/packages/pieces/community/sftp/src/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@activepieces/pieces-framework';
 import { isNil, PieceCategory } from '@activepieces/shared';
 import Client from 'ssh2-sftp-client';
+import { ServerHostKeyAlgorithm } from 'ssh2';
 import { Client as FTPClient } from 'basic-ftp';
 import { createFile } from './lib/actions/create-file';
 import { uploadFileAction } from './lib/actions/upload-file';
@@ -22,33 +23,76 @@ export async function getProtocolBackwardCompatibility(protocol: string | undefi
   }
   return protocol;
 }
-export async function getClient<T extends Client | FTPClient>(auth: { protocol: string | undefined, host: string, port: number, allow_unauthorized_certificates: boolean | undefined, allow_anonymous_login: boolean | undefined, username: string, password: string | undefined, privateKey: string | undefined, algorithm: string[] | undefined }): Promise<T> {
+export async function getClient<T extends Client | FTPClient>(auth: { protocol: string | undefined, host: string, port: number, allow_unauthorized_certificates: boolean | undefined, allow_anonymous_login: boolean | undefined, username: string, password: string | undefined, privateKey: string | undefined, algorithm: ServerHostKeyAlgorithm[] | string[] | undefined }): Promise<T> {
   const { protocol, host, port, allow_unauthorized_certificates, allow_anonymous_login, username, password, privateKey, algorithm } = auth;
   const protocolBackwardCompatibility = await getProtocolBackwardCompatibility(protocol);
   if (protocolBackwardCompatibility === 'sftp') {
     const sftp = new Client();
 
-    if (password) {
+    if (privateKey) {
+      // Handle literal \\n strings (from users who manually escaped newlines)
+      let processedKey = privateKey
+        .replace(/\\r\\n/g, '\n')
+        .replace(/\\n/g, '\n')
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .trim();
+      
+      // Handle case where browser input converts newlines to spaces
+      // Detect if key is on a single line (no newlines) but has PEM markers
+      if (!processedKey.includes('\n') && processedKey.match(/-----BEGIN [A-Z0-9 ]+ KEY-----.*-----END [A-Z0-9 ]+ KEY-----/)) {
+        // Split on spaces that appear after key markers or base64 content
+        // PEM format: header, optional encryption info, blank line, base64 (64 chars/line), footer
+        processedKey = processedKey
+          // Add newline after BEGIN header
+          .replace(/(-----BEGIN [A-Z0-9 ]+ KEY-----)\s+/, '$1\n')
+          // Add newline after Proc-Type header
+          .replace(/(Proc-Type:\s*\S+)\s+/, '$1\n')
+          // Add newline after DEK-Info header (followed by blank line)
+          .replace(/(DEK-Info:\s*\S+)\s+/, '$1\n\n')
+          // Add newline before END footer
+          .replace(/\s+(-----END [A-Z0-9 ]+ KEY-----)/, '\n$1');
+        
+        // Now handle the base64 content - split into 64-char lines
+        const beginMatch = processedKey.match(/(-----BEGIN [A-Z0-9 ]+ KEY-----\n(?:Proc-Type:[^\n]+\n)?(?:DEK-Info:[^\n]+\n\n)?)/);
+        const endMatch = processedKey.match(/(\n-----END [A-Z0-9 ]+ KEY-----)/);
+        if (beginMatch && endMatch) {
+          const header = beginMatch[1];
+          const footer = endMatch[1];
+          const base64Content = processedKey
+            .replace(header, '')
+            .replace(footer, '')
+            .replace(/\s+/g, ''); // Remove all whitespace from base64
+          
+          // Split base64 into 64-character lines
+          const lines = base64Content.match(/.{1,64}/g) || [];
+          processedKey = header + lines.join('\n') + footer;
+        }
+      }
+      
+      const connectOptions: Client.ConnectOptions = {
+        host,
+        port,
+        username,
+        privateKey: processedKey,
+        timeout: 10000,
+      };
+      if (password) {
+        connectOptions.passphrase = password;
+      }
+      if (algorithm && algorithm.length > 0) {
+        connectOptions.algorithms = {
+          serverHostKey: algorithm as ServerHostKeyAlgorithm[]
+        };
+      }
+      await sftp.connect(connectOptions);
+    }
+    else if (password) {
       await sftp.connect({
         host,
         port,
         username,
         password,
-        timeout: 10000,
-      });
-    }
-    else if (privateKey) {
-      if (!algorithm || algorithm.length === 0) {
-        throw new Error('At least one algorithm must be selected for SFTP Private Key authentication.');
-      }
-      await sftp.connect({
-        host,
-        port,
-        username,
-        privateKey: privateKey.replace(/\\n/g, '\n').trim(),
-        algorithms: {
-          serverHostKey: algorithm 
-        }  as Client.ConnectOptions['algorithms'],
         timeout: 10000,
       });
     }
@@ -125,17 +169,17 @@ export const sftpAuth = PieceAuth.CustomAuth({
     }),
     password: PieceAuth.SecretText({
       displayName: 'Password',
-      description: 'The password to authenticate with. Either this or private key is required',
+      description: 'The password to authenticate with. Either this or private key is required. When using a private key, this field is used as the passphrase to decrypt the key.',
       required: false,
     }),
     privateKey: PieceAuth.SecretText({
       displayName: 'Private Key',
-      description: 'The private key to authenticate with. Either this or password is required',
+      description: 'The private key to authenticate with. Either this or password is required.',
       required: false,
     }),
     algorithm: Property.StaticMultiSelectDropdown({
       displayName: 'Host Key Algorithm',
-      description: 'The host key algorithm to use for SFTP Private Key authentication',
+      description: 'The host key algorithm to use for SFTP connection. Only needed if you want to override the default algorithms (e.g., to support ssh-dss).',
       required: false,
       options: {
         options: [


### PR DESCRIPTION
When using private key auth with SFTP, the password field should be passed as the passphrase to decrypt the private key, not as the SSH password.