### PR TITLE
feat(gmail): add create label action

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -15,6 +15,7 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
 
 export const gmailAuth = PieceAuth.OAuth2({
   description: '',
@@ -26,6 +27,7 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.labels',
   ],
 });
 
@@ -43,6 +45,7 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailCreateLabelAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,94 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../../';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'create_label',
+  description: 'Create a new label in Gmail',
+  displayName: 'Create Label',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The display name of the label',
+      required: true,
+    }),
+    labelListVisibility: Property.StaticDropdown({
+      displayName: 'Label List Visibility',
+      description: 'The visibility of the label in the label list in the Gmail web interface',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'Show',
+            value: 'labelShow',
+          },
+          {
+            label: 'Show if unread',
+            value: 'labelShowIfUnread',
+          },
+          {
+            label: 'Hide',
+            value: 'labelHide',
+          },
+        ],
+      },
+    }),
+    messageListVisibility: Property.StaticDropdown({
+      displayName: 'Message List Visibility',
+      description: 'The visibility of messages with this label in the message list in the Gmail web interface',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'Show',
+            value: 'show',
+          },
+          {
+            label: 'Hide',
+            value: 'hide',
+          },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { name, labelListVisibility, messageListVisibility } = context.propsValue;
+
+    const authClient = new OAuth2Client();
+    authClient.setCredentials({
+      access_token: context.auth.access_token,
+    });
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.labels.create({
+        userId: 'me',
+        requestBody: {
+          name: name,
+          labelListVisibility: labelListVisibility || 'labelShow',
+          messageListVisibility: messageListVisibility || 'show',
+        },
+      });
+
+      return {
+        success: true,
+        label: {
+          id: response.data.id,
+          name: response.data.name,
+          type: response.data.type,
+          labelListVisibility: response.data.labelListVisibility,
+          messageListVisibility: response.data.messageListVisibility,
+        },
+      };
+    } catch (error: any) {
+      throw new Error(`Failed to create label: ${error.message}`);
+    }
+  },
+});


### PR DESCRIPTION
## Description
Adds a new Gmail action that allows users to create labels programmatically.

## Changes
- Added `create-label-action.ts` implementing the Gmail Labels.create API
- Updated Gmail piece to include the new action
- Added `gmail.labels` OAuth2 scope for label management

## Features
- Create labels with custom names
- Configure label visibility (show, show if unread, hide)
- Configure message list visibility (show, hide)
- Full error handling

## Testing
Tested against Gmail API v1 with OAuth2 authentication.

## Related Issue
Closes MCP bounty for Gmail label management.