### PR TITLE
feat: add Slack MCP actions

### DIFF
--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -48,6 +48,9 @@ import { newSavedMessageTrigger } from './lib/triggers/new-saved-message';
 import { newTeamCustomEmojiTrigger } from './lib/triggers/new-team-custom-emoji';
 import { inviteUserToChannelAction } from './lib/actions/invite-user-to-channel';
 import { listUsers } from './lib/actions/list-users';
+import { slackSendMessageMcpAction } from './lib/actions/send-message-mcp-action';
+import { slackCreateChannelMcpAction } from './lib/actions/create-channel-mcp-action';
+import { slackListThreadsMcpAction } from './lib/actions/list-threads-mcp-action';
 import { deleteMessageAction } from './lib/actions/delete-message';
 
 export const slackAuth = PieceAuth.OAuth2({
@@ -193,6 +196,9 @@ export const slack = createPiece({
     setChannelTopicAction,
     getMessageAction,
     inviteUserToChannelAction,
+    slackSendMessageMcpAction,
+    slackCreateChannelMcpAction,
+    slackListThreadsMcpAction,
     createCustomApiCallAction({
       baseUrl: () => {
         return 'https://slack.com/api';

--- a/packages/pieces/community/slack/src/lib/actions/create-channel-mcp-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/create-channel-mcp-action.ts
@@ -1,0 +1,30 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { slackAuth } from '../../';
+import { WebClient } from '@slack/web-api';
+
+export const slackCreateChannelMcpAction = createAction({
+    auth: slackAuth,
+    name: 'create_channel_mcp',
+    displayName: 'Create Channel (MCP)',
+    description: 'Create a new Slack channel (Optimized for AI/MCP)',
+    props: {
+        name: Property.ShortText({
+            displayName: 'Channel Name',
+            description: 'The name of the channel to create',
+            required: true,
+        }),
+        isPrivate: Property.Checkbox({
+            displayName: 'Is Private?',
+            description: 'Whether the channel should be private',
+            required: false,
+            defaultValue: false,
+        }),
+    },
+    async run(context) {
+        const client = new WebClient(context.auth.access_token);
+        return await client.conversations.create({
+            name: context.propsValue.name,
+            is_private: context.propsValue.isPrivate,
+        });
+    },
+});

--- a/packages/pieces/community/slack/src/lib/actions/list-threads-mcp-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/list-threads-mcp-action.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { slackAuth } from '../../';
+import { slackChannel } from '../common/props';
+import { WebClient } from '@slack/web-api';
+
+export const slackListThreadsMcpAction = createAction({
+    auth: slackAuth,
+    name: 'list_threads_mcp',
+    displayName: 'List Thread Messages (MCP)',
+    description: 'Retrieve messages from a specific thread (Optimized for AI/MCP)',
+    props: {
+        channel: slackChannel(true),
+        threadTs: Property.ShortText({
+            displayName: 'Thread Timestamp',
+            description: 'The timestamp of the thread to retrieve messages from',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const client = new WebClient(context.auth.access_token);
+        return await client.conversations.replies({
+            channel: context.propsValue.channel,
+            ts: context.propsValue.threadTs,
+        });
+    },
+});

--- a/packages/pieces/community/slack/src/lib/actions/send-message-mcp-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-message-mcp-action.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { slackAuth } from '../../';
+import { slackChannel } from '../common/props';
+import { slackSendMessage } from '../common/utils';
+
+export const slackSendMessageMcpAction = createAction({
+    auth: slackAuth,
+    name: 'send_message_mcp',
+    displayName: 'Send Message (MCP)',
+    description: 'Send a message to a Slack channel (Optimized for AI/MCP)',
+    props: {
+        channel: slackChannel(true),
+        text: Property.LongText({
+            displayName: 'Message',
+            description: 'The text of your message',
+            required: true,
+        }),
+        threadTs: Property.ShortText({
+            displayName: 'Thread Timestamp',
+            description: 'The timestamp of the thread to reply to',
+            required: false,
+        }),
+    },
+    async run(context) {
+        const { channel, text, threadTs } = context.propsValue;
+        return slackSendMessage({
+            token: context.auth.access_token,
+            text,
+            conversationId: channel,
+            threadTs: threadTs || undefined,
+        });
+    },
+});


### PR DESCRIPTION
This PR adds Slack MCP-optimized actions for the Activepieces MCP Challenge. \n\nActions included:\n- Send Message (MCP)\n- Create Channel (MCP)\n- List Thread Messages (MCP)