### PR TITLE
feat(pieces-pcloud): add pCloud storage integration with MCP support

### DIFF
--- a/packages/pieces/community/pcloud/.babelrc
+++ b/packages/pieces/community/pcloud/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nx/js/babel", { "useBuiltIns": "usage" }]]
+}

--- a/packages/pieces/community/pcloud/.eslintrc.json
+++ b/packages/pieces/community/pcloud/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {},
+        "extends": [
+        "plugin:prettier/recommended"
+        ],
+      "plugins": ["prettier"]
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/pcloud/README.md
+++ b/packages/pieces/community/pcloud/README.md
@@ -1,0 +1,3 @@
+# pCloud
+
+pCloud is a secure cloud storage platform that allows users to store, share, and manage files easily across devices.

--- a/packages/pieces/community/pcloud/package.json
+++ b/packages/pieces/community/pcloud/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@activepieces/piece-pcloud",
+  "version": "0.1.0",
+  "dependencies": {
+    "form-data": "^4.0.0"
+  }
+}

--- a/packages/pieces/community/pcloud/project.json
+++ b/packages/pieces/community/pcloud/project.json
@@ -1,0 +1,47 @@
+{
+  "name": "pieces-pcloud",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/pcloud/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/pcloud",
+        "tsConfig": "packages/pieces/community/pcloud/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/pcloud/package.json",
+        "main": "packages/pieces/community/pcloud/src/index.ts",
+        "assets": [
+          "packages/pieces/community/pcloud/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true,
+        "clean": false
+      },
+      "dependsOn": [
+        "^build",
+        "prebuild"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    },
+    "prebuild": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/pieces/community/pcloud",
+        "command": "bun install --no-save --silent"
+      },
+      "dependsOn": [
+        "^build"
+      ]
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/pcloud/src/index.ts
+++ b/packages/pieces/community/pcloud/src/index.ts
@@ -1,0 +1,43 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/shared';
+import { pcloudUploadFile } from './lib/actions/upload-file';
+import { pcloudCreateFolder } from './lib/actions/create-folder';
+import { pcloudGetFileLink } from './lib/actions/get-file-link';
+import { pcloudListFolder } from './lib/actions/list-folder';
+import { pcloudCopyFile } from './lib/actions/copy-file';
+import { pcloudNewFile } from './lib/triggers/new-file';
+import { pcloudNewFolder } from './lib/triggers/new-folder';
+
+export const pcloudAuth = PieceAuth.OAuth2({
+  description: 'Authenticate with your pCloud account',
+  authUrl: 'https://my.pcloud.com/oauth2/authorize',
+  tokenUrl: 'https://api.pcloud.com/oauth2_token',
+  required: true,
+  scope: [],
+});
+
+export const pcloud = createPiece({
+  displayName: 'pCloud',
+  description: 'Secure cloud storage for files and folders',
+  auth: pcloudAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/pcloud.png',
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  authors: ['your-username'],
+  actions: [
+    pcloudUploadFile,
+    pcloudCreateFolder,
+    pcloudGetFileLink,
+    pcloudListFolder,
+    pcloudCopyFile,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.pcloud.com',
+      auth: pcloudAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${auth.access_token}`,
+      }),
+    }),
+  ],
+  triggers: [pcloudNewFile, pcloudNewFolder],
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/copy-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/copy-file.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../../index';
+import { PCloudClient } from '../common';
+
+export const pcloudCopyFile = createAction({
+  auth: pcloudAuth,
+  name: 'copy_file',
+  displayName: 'Copy File',
+  description: 'Copy a file to another folder in pCloud',
+  props: {
+    fileId: Property.Number({
+      displayName: 'File ID',
+      description: 'ID of the file to copy',
+      required: true,
+    }),
+    targetFolderId: Property.Number({
+      displayName: 'Target Folder ID',
+      description: 'ID of the destination folder',
+      required: true,
+    }),
+    overwrite: Property.Checkbox({
+      displayName: 'Overwrite',
+      description: 'Overwrite file if it exists in target folder',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const client = new PCloudClient(context.auth);
+    const { fileId, targetFolderId, overwrite } = context.propsValue;
+
+    const result = await client.copyFile(
+      fileId,
+      targetFolderId,
+      overwrite ?? false
+    );
+
+    if (result.result !== 0) {
+      throw new Error(result.error || 'Failed to copy file');
+    }
+
+    return result.metadata;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/create-folder.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/create-folder.ts
@@ -1,0 +1,38 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../../index';
+import { PCloudClient } from '../common';
+
+export const pcloudCreateFolder = createAction({
+  auth: pcloudAuth,
+  name: 'create_folder',
+  displayName: 'Create Folder',
+  description: 'Create a new folder in pCloud',
+  props: {
+    folderName: Property.ShortText({
+      displayName: 'Folder Name',
+      description: 'Name of the new folder',
+      required: true,
+    }),
+    parentFolderId: Property.Number({
+      displayName: 'Parent Folder ID',
+      description: 'ID of the parent folder (0 for root)',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  async run(context) {
+    const client = new PCloudClient(context.auth);
+    const { folderName, parentFolderId } = context.propsValue;
+
+    const result = await client.createFolder(
+      folderName,
+      parentFolderId ?? 0
+    );
+
+    if (result.result !== 0) {
+      throw new Error(result.error || 'Failed to create folder');
+    }
+
+    return result.metadata;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/get-file-link.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/get-file-link.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../../index';
+import { PCloudClient } from '../common';
+
+export const pcloudGetFileLink = createAction({
+  auth: pcloudAuth,
+  name: 'get_file_link',
+  displayName: 'Get File Download Link',
+  description: 'Get a download link for a file in pCloud',
+  props: {
+    fileId: Property.Number({
+      displayName: 'File ID',
+      description: 'ID of the file to get download link for',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const client = new PCloudClient(context.auth);
+    const { fileId } = context.propsValue;
+
+    const result = await client.getFileLink(fileId);
+
+    if (result.result !== 0) {
+      throw new Error(result.error || 'Failed to get file link');
+    }
+
+    return {
+      fileId,
+      downloadLink: result.link || null,
+      metadata: result.metadata,
+    };
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/list-folder.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/list-folder.ts
@@ -1,0 +1,30 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../../index';
+import { PCloudClient } from '../common';
+
+export const pcloudListFolder = createAction({
+  auth: pcloudAuth,
+  name: 'list_folder',
+  displayName: 'List Folder Contents',
+  description: 'List files and folders in a pCloud folder',
+  props: {
+    folderId: Property.Number({
+      displayName: 'Folder ID',
+      description: 'ID of the folder to list (0 for root)',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  async run(context) {
+    const client = new PCloudClient(context.auth);
+    const { folderId } = context.propsValue;
+
+    const result = await client.listFolder(folderId ?? 0);
+
+    if (result.result !== 0) {
+      throw new Error(result.error || 'Failed to list folder');
+    }
+
+    return result.metadata;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/upload-file.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../../index';
+import { PCloudClient } from '../common';
+
+export const pcloudUploadFile = createAction({
+  auth: pcloudAuth,
+  name: 'upload_file',
+  displayName: 'Upload File',
+  description: 'Upload a file to pCloud',
+  props: {
+    file: Property.File({
+      displayName: 'File',
+      description: 'The file to upload',
+      required: true,
+    }),
+    fileName: Property.ShortText({
+      displayName: 'File Name',
+      description: 'Name for the uploaded file',
+      required: true,
+    }),
+    folderId: Property.Number({
+      displayName: 'Folder ID',
+      description: 'ID of the folder to upload to (0 for root)',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  async run(context) {
+    const client = new PCloudClient(context.auth);
+    const { file, fileName, folderId } = context.propsValue;
+
+    const result = await client.uploadFile(
+      fileName,
+      file.base64,
+      folderId ?? 0
+    );
+
+    if (result.result !== 0) {
+      throw new Error(result.error || 'Failed to upload file');
+    }
+
+    return result.metadata;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/common/index.ts
+++ b/packages/pieces/community/pcloud/src/lib/common/index.ts
@@ -1,0 +1,130 @@
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+import { OAuth2PropertyValue } from '@activepieces/pieces-framework';
+
+export interface PCloudFile {
+  fileid: number;
+  name: string;
+  size: number;
+  contenttype: string;
+  created: string;
+  modified: string;
+  isfolder: boolean;
+  parentfolderid: number;
+}
+
+export interface PCloudFolder {
+  folderid: number;
+  name: string;
+  created: string;
+  modified: string;
+  contents?: (PCloudFile | PCloudFolder)[];
+}
+
+export interface PCloudApiResponse {
+  result: number;
+  error?: string;
+  metadata?: PCloudFile | PCloudFolder;
+  fileids?: number[];
+}
+
+export class PCloudClient {
+  constructor(private auth: OAuth2PropertyValue) {}
+
+  private getApiUrl(): string {
+    return 'https://api.pcloud.com';
+  }
+
+  async makeRequest<T = unknown>(
+    method: string,
+    params: Record<string, string | number> = {}
+  ): Promise<T> {
+    const url = `${this.getApiUrl()}/${method}`;
+    const queryParams: Record<string, string> = {};
+    Object.entries(params).forEach(([key, value]) => {
+      queryParams[key] = String(value);
+    });
+
+    const request: HttpRequest = {
+      method: HttpMethod.GET,
+      url,
+      queryParams,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: this.auth.access_token,
+      },
+    };
+
+    const response = await httpClient.sendRequest<T>(request);
+    return response.body;
+  }
+
+  async uploadFile(
+    fileName: string,
+    fileData: string,
+    folderId: number = 0
+  ): Promise<PCloudApiResponse> {
+    const buffer = Buffer.from(fileData, 'base64');
+    const url = `${this.getApiUrl()}/uploadfile`;
+
+    const FormData = (await import('form-data')).default;
+    const form = new FormData();
+    form.append('folderid', folderId.toString());
+    form.append('filename', fileName);
+    form.append('file', buffer, fileName);
+
+    const response = await httpClient.sendRequest<PCloudApiResponse>({
+      method: HttpMethod.POST,
+      url,
+      body: form,
+      headers: {
+        ...form.getHeaders(),
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: this.auth.access_token,
+      },
+    });
+
+    return response.body;
+  }
+
+  async createFolder(
+    name: string,
+    parentFolderId: number = 0
+  ): Promise<PCloudApiResponse> {
+    return this.makeRequest<PCloudApiResponse>('createfolder', {
+      folderid: parentFolderId,
+      name,
+    });
+  }
+
+  async listFolder(folderId: number = 0): Promise<PCloudApiResponse> {
+    return this.makeRequest<PCloudApiResponse>('listfolder', {
+      folderid: folderId,
+      recursive: 0,
+    });
+  }
+
+  async getFileLink(fileId: number): Promise<PCloudApiResponse & { link?: string }> {
+    return this.makeRequest<PCloudApiResponse & { link?: string }>('getfilelink', {
+      fileid: fileId,
+    });
+  }
+
+  async copyFile(
+    fileId: number,
+    toFolderId: number,
+    overwrite: boolean = false
+  ): Promise<PCloudApiResponse> {
+    return this.makeRequest<PCloudApiResponse>('copyfile', {
+      fileid: fileId,
+      tofolderid: toFolderId,
+      overwrite: overwrite ? 1 : 0,
+    });
+  }
+}

--- a/packages/pieces/community/pcloud/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/triggers/new-file.ts
@@ -1,0 +1,80 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../../index';
+import { PCloudClient } from '../common';
+
+export const pcloudNewFile = createTrigger({
+  auth: pcloudAuth,
+  name: 'new_file',
+  displayName: 'New File Uploaded',
+  description: 'Triggers when a new file is uploaded to pCloud',
+  type: TriggerStrategy.POLLING,
+  props: {
+    folderId: Property.Number({
+      displayName: 'Folder ID',
+      description: 'ID of folder to monitor (0 for root)',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  sampleData: {
+    fileid: 123456,
+    name: 'example.txt',
+    size: 1024,
+    contenttype: 'text/plain',
+    created: '2025-01-01T00:00:00Z',
+    modified: '2025-01-01T00:00:00Z',
+    isfolder: false,
+    parentfolderid: 0,
+  },
+  async onEnable(context) {
+    await context.store.put('lastPollTime', Date.now());
+  },
+  async onDisable() {
+    return;
+  },
+  async run(context) {
+    const client = new PCloudClient(context.auth);
+    const folderId = context.propsValue.folderId ?? 0;
+    const storedTime = await context.store.get<number>('lastPollTime');
+    const lastPollTime = typeof storedTime === 'number' ? storedTime : 0;
+
+    const result = await client.listFolder(folderId);
+    
+    if (result.result !== 0) {
+      return [];
+    }
+
+    const metadata = result.metadata as any;
+    const contents = metadata?.contents || [];
+    
+    const newFiles = contents.filter((item: any) => {
+      if (item.isfolder) return false;
+      const createdTime = new Date(item.created).getTime();
+      return createdTime > lastPollTime;
+    });
+
+    await context.store.put('lastPollTime', Date.now());
+    
+    return newFiles;
+  },
+  async test(context) {
+    const client = new PCloudClient(context.auth);
+    const folderId = context.propsValue.folderId ?? 0;
+
+    const result = await client.listFolder(folderId);
+    
+    if (result.result !== 0) {
+      return [];
+    }
+
+    const metadata = result.metadata as any;
+    const contents = metadata?.contents || [];
+    const files = contents.filter((item: any) => !item.isfolder);
+    
+    return files.slice(0, 5);
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/triggers/new-folder.ts
+++ b/packages/pieces/community/pcloud/src/lib/triggers/new-folder.ts
@@ -1,0 +1,76 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../../index';
+import { PCloudClient } from '../common';
+
+export const pcloudNewFolder = createTrigger({
+  auth: pcloudAuth,
+  name: 'new_folder',
+  displayName: 'Folder Created',
+  description: 'Triggers when a new folder is created in pCloud',
+  type: TriggerStrategy.POLLING,
+  props: {
+    parentFolderId: Property.Number({
+      displayName: 'Parent Folder ID',
+      description: 'ID of parent folder to monitor (0 for root)',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  sampleData: {
+    folderid: 123456,
+    name: 'New Folder',
+    created: '2025-01-01T00:00:00Z',
+    modified: '2025-01-01T00:00:00Z',
+  },
+  async onEnable(context) {
+    await context.store.put('lastPollTime', Date.now());
+  },
+  async onDisable() {
+    return;
+  },
+  async run(context) {
+    const client = new PCloudClient(context.auth);
+    const parentFolderId = context.propsValue.parentFolderId ?? 0;
+    const storedTime = await context.store.get<number>('lastPollTime');
+    const lastPollTime = typeof storedTime === 'number' ? storedTime : 0;
+
+    const result = await client.listFolder(parentFolderId);
+    
+    if (result.result !== 0) {
+      return [];
+    }
+
+    const metadata = result.metadata as any;
+    const contents = metadata?.contents || [];
+    
+    const newFolders = contents.filter((item: any) => {
+      if (!item.isfolder) return false;
+      const createdTime = new Date(item.created).getTime();
+      return createdTime > lastPollTime;
+    });
+
+    await context.store.put('lastPollTime', Date.now());
+    
+    return newFolders;
+  },
+  async test(context) {
+    const client = new PCloudClient(context.auth);
+    const parentFolderId = context.propsValue.parentFolderId ?? 0;
+
+    const result = await client.listFolder(parentFolderId);
+    
+    if (result.result !== 0) {
+      return [];
+    }
+
+    const metadata = result.metadata as any;
+    const contents = metadata?.contents || [];
+    const folders = contents.filter((item: any) => item.isfolder);
+    
+    return folders.slice(0, 5);
+  },
+});

--- a/packages/pieces/community/pcloud/tsconfig.json
+++ b/packages/pieces/community/pcloud/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/pcloud/tsconfig.lib.json
+++ b/packages/pieces/community/pcloud/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

Adds a comprehensive pCloud cloud storage integration for Activepieces with OAuth2 authentication, file operations, and folder management capabilities.

### Features Implemented

**Actions:**
- Upload File - Binary file upload with folder targeting
- Create Folder - Directory creation with parent folder support
- Get File Download Link - Generates download URLs for files
- List Folder Contents - Browse files and folders
- Copy File - Duplicate files across folders with overwrite option
- Custom API Call - Generic pCloud API endpoint access

**Triggers:**
- New File Uploaded - Polling-based file detection
- Folder Created - Polling-based folder creation monitoring

### Technical Details

- **Authentication:** OAuth2 with pCloud API (`https://my.pcloud.com/oauth2/authorize`)
- **API Integration:** RESTful HTTP client with Bearer token authentication
- **Architecture:** Follows Activepieces piece framework patterns (modeled after Google Drive/Dropbox pieces)
- **Type Safety:** Full TypeScript implementation with proper error handling
- **MCP Compatible:** Works as both piece and MCP tool

### Test Account Access

Developers can test using free pCloud accounts at https://www.pcloud.com

Fixes #7670
/claim #7670