### PR TITLE
feat(metabase): fix get-graph-question action after auth refactoring

### DIFF
--- a/packages/pieces/community/metabase/package.json
+++ b/packages/pieces/community/metabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-metabase",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
+++ b/packages/pieces/community/metabase/src/lib/actions/get-graph-question.ts
@@ -31,7 +31,7 @@ export const getGraphQuestion = createAction({
     }),
   },
   async run({ auth, propsValue, files }) {
-    if ('embeddingKey' in auth && !auth.embeddingKey)
+    if ('embeddingKey' in auth.props && !auth.props.embeddingKey)
       return 'An embedding key is needed.';
 
     if (propsValue.waitTime <= 0)
@@ -47,7 +47,7 @@ export const getGraphQuestion = createAction({
     };
 
     // @ts-expect-error we expect an embedding key if the user can use this action.
-    const token = jwt.sign(payload, auth.embeddingKey);
+    const token = jwt.sign(payload, auth.props.embeddingKey);
     const graphName = propsValue.graphName
       ? propsValue.graphName + '.png'
       : `metabase_question_${questionId}.png`;


### PR DESCRIPTION
## What does this PR do?
Action was broken after `auth` shape was changed a few weeks ago - it's a "hidden" action, only available when `chromium` is available on the container.

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
