### PR TITLE
chore: bump Microsoft pieces patch versions

### DIFF
--- a/packages/pieces/community/microsoft-365-people/package.json
+++ b/packages/pieces/community/microsoft-365-people/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-365-people",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/packages/pieces/community/microsoft-365-planner/package.json
+++ b/packages/pieces/community/microsoft-365-planner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-365-planner",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/packages/pieces/community/microsoft-excel-365/package.json
+++ b/packages/pieces/community/microsoft-excel-365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-excel-365",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-onedrive/package.json
+++ b/packages/pieces/community/microsoft-onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-onedrive",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-onenote/package.json
+++ b/packages/pieces/community/microsoft-onenote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-onenote",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/packages/pieces/community/microsoft-outlook/package.json
+++ b/packages/pieces/community/microsoft-outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-outlook",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-sharepoint/package.json
+++ b/packages/pieces/community/microsoft-sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-sharepoint",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-teams/package.json
+++ b/packages/pieces/community/microsoft-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-teams",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-todo/package.json
+++ b/packages/pieces/community/microsoft-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-todo",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",


### PR DESCRIPTION
## Summary
- Bump patch versions for 8 Microsoft pieces to trigger re-publish
- **Excluded**: `@activepieces/piece-ai` (not bumped per request)

### Version changes:
| Piece | Old | New |
|-------|-----|-----|
| microsoft-365-people | 0.1.5 | 0.1.6 |
| microsoft-365-planner | 0.1.5 | 0.1.6 |
| microsoft-excel-365 | 0.4.8 | 0.4.9 |
| microsoft-onedrive | 0.1.5 | 0.1.6 |
| microsoft-onenote | 0.1.4 | 0.1.5 |
| microsoft-outlook | 0.2.8 | 0.2.9 |
| microsoft-sharepoint | 0.2.7 | 0.2.8 |
| microsoft-teams | 0.3.7 | 0.3.8 |
| microsoft-todo | 0.2.5 | 0.2.6 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)