### PR TITLE
fix(google-drive): fix pagination bugs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",
@@ -2709,7 +2710,7 @@
     },
     "packages/pieces/community/google-drive": {
       "name": "@activepieces/piece-google-drive",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
@@ -39,7 +39,7 @@ async function getFilesRecursively(
 
   const params: Record<string, string> = {
     q: q,
-    fields: 'files(id,kind,mimeType,name,trashed,parents)',
+    fields: 'nextPageToken,files(id,kind,mimeType,name,trashed,parents)',
     supportsAllDrives: 'true',
     includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
   };


### PR DESCRIPTION
## What does this PR do?

The list-files action could only retrieve the first page (100 items) because the pagination token was not returned by the API 🤦 
Added pagination to the search action and to both triggers too

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
