### PR TITLE
fix(docs): update broken editions link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can easily create your own integration using our TypeScript framework. For d
 Activepieces' Community Edition is released as open source under the [MIT license](https://github.com/activepieces/activepieces/blob/main/LICENSE) and enterprise features are released under [Commercial License](https://github.com/activepieces/activepieces/blob/main/packages/ee/LICENSE)
 
 
-Read more about the feature comparison here https://www.activepieces.com/docs/about/editions
+Read more about the feature comparison here https://www.activepieces.com/pricing
 <br>
 <br>
 


### PR DESCRIPTION
## Summary
Fixes the broken documentation link in README.md that was returning 404.

## Changes
- Updated URL from `https://www.activepieces.com/docs/about/editions` (404) to `https://www.activepieces.com/pricing`
- The new URL correctly displays the feature comparison between MIT and Enterprise editions

## Verification
- ✅ New URL returns HTTP 200
- ✅ Matches documentation references found in `/docs/install/overview.mdx` and `/docs/install/configuration/overview.mdx`

Fixes #11219

🤖 Generated with [Claude Code](https://claude.com/claude-code)