### PR TITLE
fix(docs): update broken building pieces documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ src="https://github.com/activepieces/activepieces/assets/1812998/76c97441-c285-4
     target="_blank"
   ><b>Documentation</b></a>&nbsp;&nbsp;&nbsp;🌪️&nbsp;&nbsp;&nbsp;
    <a
-    href="https://www.activepieces.com/docs/developers/building-pieces/overview"
+    href="https://www.activepieces.com/docs/build-pieces/building-pieces/overview"
     target="_blank"
   ><b>Create a Piece</b></a>&nbsp;&nbsp;&nbsp;🖉&nbsp;&nbsp;&nbsp;
   <a

--- a/packages/web/src/features/pieces/components/install-piece-dialog.tsx
+++ b/packages/web/src/features/pieces/components/install-piece-dialog.tsx
@@ -174,7 +174,7 @@ const InstallPieceDialog = ({
           <DialogDescription>
             <ApMarkdown
               markdown={
-                'Use this to install a [custom piece]("https://www.activepieces.com/docs/developers/building-pieces/create-action") that you (or someone else) created. Once the piece is installed, you can use it in the flow builder.\n\nWarning: Make sure you trust the author as the piece will have access to your flow data and it might not be compatible with the current version of Activepieces.'
+                'Use this to install a [custom piece]("https://www.activepieces.com/docs/build-pieces/building-pieces/create-action") that you (or someone else) created. Once the piece is installed, you can use it in the flow builder.\n\nWarning: Make sure you trust the author as the piece will have access to your flow data and it might not be compatible with the current version of Activepieces.'
               }
             />
           </DialogDescription>


### PR DESCRIPTION
## Summary
Fixes broken documentation links that were returning 404 errors when users clicked on "Contribute" buttons and tried to learn about building custom pieces.

## Changes
Updated the documentation URL structure from the old path to the new path:
- **Old**: `docs/developers/building-pieces/...`
- **New**: `docs/build-pieces/building-pieces/...`

### Files Updated:
1. **README.md** (line 31) - "Create a Piece" button link
   - Old: `https://www.activepieces.com/docs/developers/building-pieces/overview`
   - New: `https://www.activepieces.com/docs/build-pieces/building-pieces/overview`

2. **install-piece-dialog.tsx** (line 184) - Custom piece documentation link
   - Old: `https://www.activepieces.com/docs/developers/building-pieces/create-action`
   - New: `https://www.activepieces.com/docs/build-pieces/building-pieces/create-action`

## Verification
- ✅ Both new URLs return HTTP 200
- ✅ URLs display correct documentation pages
- ✅ Matches the URL structure used elsewhere in the codebase (as per previous fix in commit b9585392a3)

## Related Issues
Fixes #11207 - 404 error on Contribute button
Fixes #11099 - 404 Page Not Found when clicked on Contribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)