### PR TITLE
fix(mysql): use backticks for column names in UPDATE WHERE clause

### DIFF
--- a/packages/pieces/community/mysql/src/lib/actions/update-row.ts
+++ b/packages/pieces/community/mysql/src/lib/actions/update-row.ts
@@ -1,7 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { mysqlCommon, mysqlConnect, sanitizeColumnName } from '../common';
 import { mysqlAuth } from '../..';
-import sqlstring from 'sqlstring';
 
 export default createAction({
   auth: mysqlAuth,
@@ -27,7 +26,7 @@ export default createAction({
   async run(context) {
     const fields = Object.keys(context.propsValue.values);
     const qsValues = fields.map((f) => sanitizeColumnName(f) + '=?').join(',');
-    const qs = `UPDATE ${sanitizeColumnName(context.propsValue.table)} SET ${qsValues} WHERE ${sqlstring.escape(context.propsValue.search_column)}=?;`;
+    const qs = `UPDATE ${sanitizeColumnName(context.propsValue.table)} SET ${qsValues} WHERE ${sanitizeColumnName(context.propsValue.search_column)}=?;`;
     const conn = await mysqlConnect(context.auth, context.propsValue);
     try {
     const values = fields.map((f) => context.propsValue.values[f]);


### PR DESCRIPTION
## Summary
Fixes the MySQL UPDATE query generation bug where column names in the WHERE clause were incorrectly quoted with single quotes instead of backticks.

## Problem
The `update_row` action was generating incorrect SQL queries:
```sql
-- Before (incorrect):
UPDATE `DocumentTasks` SET `TaskStatus`='Done' WHERE 'TaskId'='15598b97-c398-4a56-b518-41c8f06d6efa'

-- After (correct):
UPDATE `DocumentTasks` SET `TaskStatus`='Done' WHERE `TaskId`='15598b97-c398-4a56-b518-41c8f06d6efa'
```

In MySQL:
- **Single quotes `'...'`** are for string values
- **Backticks `` `...` ``** are for identifiers (table names, column names)

## Root Cause
Line 30 in `update-row.ts` was using `sqlstring.escape()` for the search column name, which escapes values (adds single quotes), not identifiers.

## Changes
1. **Replaced** `sqlstring.escape(context.propsValue.search_column)` with `sanitizeColumnName(context.propsValue.search_column)`
2. **Removed** unused `sqlstring` import

## Code Change
```diff
- const qs = `UPDATE ${sanitizeColumnName(context.propsValue.table)} SET ${qsValues} WHERE ${sqlstring.escape(context.propsValue.search_column)}=?;`;
+ const qs = `UPDATE ${sanitizeColumnName(context.propsValue.table)} SET ${qsValues} WHERE ${sanitizeColumnName(context.propsValue.search_column)}=?;`;
```

The `sanitizeColumnName()` function uses `sqlstring.escapeId()` internally, which correctly adds backticks for identifiers.

## Testing
The fix ensures:
- ✅ Column names in WHERE clause are properly escaped with backticks
- ✅ Consistent with how table names and SET clause columns are handled
- ✅ Prevents SQL syntax errors when updating rows

Fixes #11301

🤖 Generated with [Claude Code](https://claude.com/claude-code)