### PR TITLE
fix(ui): support property names with brackets in UI

### DIFF
--- a/packages/react-ui/src/app/builder/piece-properties/generic-properties-form.tsx
+++ b/packages/react-ui/src/app/builder/piece-properties/generic-properties-form.tsx
@@ -19,6 +19,19 @@ import {
   SelectGenericFormComponentForPropertyParams,
 } from './properties-utils';
 
+// Helper function to construct property path with proper quoting for special characters
+const constructPropertyPath = (prefix: string, propertyName: string): string => {
+  if (prefix.length === 0) {
+    return propertyName;
+  }
+  // If property name contains brackets, dots, or other special chars, use bracket notation with quotes
+  if (/[\[\]\.]/.test(propertyName)) {
+    return `${prefix}['${propertyName}']`;
+  }
+  // Otherwise use dot notation
+  return `${prefix}.${propertyName}`;
+};
+
 export const GenericPropertiesForm = React.memo(
   ({
     markdownVariables,
@@ -41,11 +54,7 @@ export const GenericPropertiesForm = React.memo(
             return (
               <FormField
                 key={propertyName}
-                name={
-                  prefixValue.length > 0
-                    ? `${prefixValue}.${propertyName}`
-                    : propertyName
-                }
+                name={constructPropertyPath(prefixValue, propertyName)}
                 control={form.control}
                 render={({ field }) =>
                   selectGenericFormComponentForProperty({
@@ -60,10 +69,7 @@ export const GenericPropertiesForm = React.memo(
                       },
                     },
                     propertyName,
-                    inputName:
-                      prefixValue.length > 0
-                        ? `${prefixValue}.${propertyName}`
-                        : propertyName,
+                    inputName: constructPropertyPath(prefixValue, propertyName),
                     property: props[propertyName],
                     allowDynamicValues: !isNil(propertySettings),
                     markdownVariables: markdownVariables ?? {},

--- a/packages/react-ui/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
+++ b/packages/react-ui/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
@@ -27,11 +27,22 @@ const incrementArrayIndexes = (text: string) => {
 };
 
 const keysWithinPath = (path: string) => {
-  return path
-    .split(/\.|\[|\]/)
-    .filter((key) => key && key.trim().length > 0)
-    .map(incrementArrayIndexes)
-    .map(removeQuotes);
+  // Match either:
+  // - Quoted strings (single or double quotes): ['key'] or ["key"]
+  // - Unquoted segments between dots or brackets
+  const regex = /\[?['"]([^'"]+)['"]\]?|([^\.\[\]]+)/g;
+  const keys: string[] = [];
+  let match;
+
+  while ((match = regex.exec(path)) !== null) {
+    // match[1] is quoted content, match[2] is unquoted content
+    const key = (match[1] || match[2]).trim();
+    if (key.length > 0) {
+      keys.push(key);
+    }
+  }
+
+  return keys.map(incrementArrayIndexes);
 };
 
 type ApMentionNodeAttrs = {


### PR DESCRIPTION
## Summary
Fixes the bug where property names containing brackets `[]` don't work in the UI. Properties like `[multi_select_dropdown]` can now be used without issues.

## Problem
When a piece defines a property with brackets in its name:
```typescript
props: {
  '[multi_select_dropdown]': Property.StaticMultiSelectDropdown({
    displayName: 'Multi Select Dropdown',
    required: true,
    options: { ... }
  })
}
```

The UI would fail to properly handle this property because:
1. The path construction would create: `input.[multi_select_dropdown]`
2. The path parser would split on `[` and `]`, treating them as array indexing delimiters
3. This resulted in the property name being incorrectly parsed as `multi_select_dropdown` instead of `[multi_select_dropdown]`

## Solution

### 1. Enhanced Path Construction (`generic-properties-form.tsx`)
Added `constructPropertyPath()` helper function that:
- Detects property names with special characters (brackets, dots)
- Uses quoted bracket notation for these: `prefix['[property]']`
- Maintains dot notation for normal properties: `prefix.property`

```typescript
// Before:
name: `${prefixValue}.${propertyName}`
// Result: input.[multi_select_dropdown] ❌

// After:
name: constructPropertyPath(prefixValue, propertyName)
// Result: input['[multi_select_dropdown]'] ✅
```

### 2. Enhanced Path Parser (`text-input-utils.ts`)
Updated `keysWithinPath()` function with improved regex that:
- Correctly parses quoted property names: `['property']` or `["property"]`
- Maintains support for array indexing: `[0]`, `[1]`
- Handles unquoted segments properly

```typescript
// New regex matches:
// - ['key'] or ["key"] → extracts 'key'
// - unquoted.segments → extracts 'unquoted' and 'segments'
const regex = /\[?['"]([^'"]+)['"]\]?|([^\.\[\]]+)/g;
```

## Examples

| Property Name | Old Path | New Path |
|--------------|----------|----------|
| `normalProp` | `input.normalProp` | `input.normalProp` |
| `[multi_select]` | `input.[multi_select]` ❌ | `input['[multi_select]']` ✅ |
| `prop.with.dots` | `input.prop.with.dots` ❌ | `input['prop.with.dots']` ✅ |

## Testing
- ✅ Property names with brackets work correctly
- ✅ Normal property names continue working with dot notation
- ✅ Array indexing still functions properly
- ✅ Backward compatible with existing flows

Fixes #11351

🤖 Generated with [Claude Code](https://claude.com/claude-code)