### PR TITLE
feat(canva): add Canva integration piece

### DIFF
--- a/packages/pieces/community/canva/.eslintrc.json
+++ b/packages/pieces/community/canva/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/canva/README.md
+++ b/packages/pieces/community/canva/README.md
@@ -1,0 +1,23 @@
+# Canva
+
+Canva is an online design platform for creating visual content. This piece enables automation of design workflows using the Canva Connect API.
+
+## Authentication
+
+OAuth2 via Canva Connect API. Required scopes:
+- `design:content:read` / `design:content:write`
+- `design:meta:read`
+- `asset:read` / `asset:write`
+- `folder:read` / `folder:write`
+
+## Actions
+
+- **Create Design** — Create a new design using a preset type or custom dimensions
+- **Upload Asset** — Upload an image or video to the Canva asset library
+- **Import Design** — Import an external file (PDF, PPTX, DOCX, etc.) as a Canva design
+- **Export Design** — Export a design to PDF, JPG, PNG, GIF, PPTX, or MP4
+- **Get Design** — Retrieve metadata for a design
+- **Find Design** — Search designs by keyword
+- **Move Folder Item** — Move a design or asset to a different folder
+- **Get Folder** — Retrieve folder details
+- **Get Asset** — Retrieve asset details

--- a/packages/pieces/community/canva/package.json
+++ b/packages/pieces/community/canva/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@activepieces/piece-canva",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/canva/src/index.ts
+++ b/packages/pieces/community/canva/src/index.ts
@@ -1,0 +1,58 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { OAuth2PropertyValue, PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createDesign } from './lib/actions/create-design';
+import { uploadAsset } from './lib/actions/upload-asset';
+import { importDesign } from './lib/actions/import-design';
+import { exportDesign } from './lib/actions/export-design';
+import { getDesign } from './lib/actions/get-design';
+import { findDesign } from './lib/actions/find-design';
+import { moveFolderItem } from './lib/actions/move-folder-item';
+import { getFolder } from './lib/actions/get-folder';
+import { getAsset } from './lib/actions/get-asset';
+
+export const canvaAuth = PieceAuth.OAuth2({
+  description: 'Authenticate with your Canva account.',
+  authUrl: 'https://www.canva.com/api/oauth/authorize',
+  tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+  required: true,
+  pkce: true,
+  scope: [
+    'design:content:read',
+    'design:content:write',
+    'design:meta:read',
+    'asset:read',
+    'asset:write',
+    'folder:read',
+    'folder:write',
+  ],
+});
+
+export const canva = createPiece({
+  displayName: 'Canva',
+  description: 'Design automation with Canva — create, import, export, and manage designs.',
+  auth: canvaAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/canva.png',
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  authors: ['GoThundercats'],
+  actions: [
+    createDesign,
+    uploadAsset,
+    importDesign,
+    exportDesign,
+    getDesign,
+    findDesign,
+    moveFolderItem,
+    getFolder,
+    getAsset,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.canva.com/rest/v1',
+      auth: canvaAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${(auth as OAuth2PropertyValue).access_token}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/canva/src/lib/actions/create-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/create-design.ts
@@ -1,0 +1,77 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { canvaApiRequest } from '../common';
+
+export const createDesign = createAction({
+  auth: canvaAuth,
+  name: 'create_design',
+  displayName: 'Create Design',
+  description: 'Create a new Canva design using a preset type or custom dimensions.',
+  props: {
+    designTypeOption: Property.StaticDropdown({
+      displayName: 'Design Type',
+      description: 'Use a preset template or specify custom dimensions.',
+      required: true,
+      defaultValue: 'preset',
+      options: {
+        options: [
+          { label: 'Preset Type', value: 'preset' },
+          { label: 'Custom Dimensions', value: 'custom' },
+        ],
+      },
+    }),
+    presetName: Property.StaticDropdown({
+      displayName: 'Preset Type',
+      description: 'Required when Design Type is set to Preset.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Document (Canva Docs)', value: 'doc' },
+          { label: 'Whiteboard', value: 'whiteboard' },
+          { label: 'Presentation', value: 'presentation' },
+        ],
+      },
+    }),
+    customWidth: Property.Number({
+      displayName: 'Width (pixels)',
+      description: 'Required when Design Type is Custom. Between 40 and 8000.',
+      required: false,
+    }),
+    customHeight: Property.Number({
+      displayName: 'Height (pixels)',
+      description: 'Required when Design Type is Custom. Between 40 and 8000.',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'Name for the design (1–255 characters).',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { designTypeOption, presetName, customWidth, customHeight, title } = context.propsValue;
+
+    if (designTypeOption === 'preset' && !presetName) {
+      throw new Error('Preset type is required when Design Type is Preset.');
+    }
+    if (designTypeOption === 'custom') {
+      if (!customWidth || !customHeight) {
+        throw new Error('Width and height are required when Design Type is Custom.');
+      }
+      if (customWidth < 40 || customWidth > 8000 || customHeight < 40 || customHeight > 8000) {
+        throw new Error('Width and height must be between 40 and 8000 pixels.');
+      }
+    }
+
+    const body: Record<string, unknown> = {};
+    if (designTypeOption === 'preset') {
+      body['design_type'] = { type: 'preset', name: presetName };
+    } else {
+      body['design_type'] = { type: 'custom', width: customWidth, height: customHeight };
+    }
+    if (title) body['title'] = title;
+
+    return canvaApiRequest(context.auth.access_token, HttpMethod.POST, '/designs', body);
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/export-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/export-design.ts
@@ -1,0 +1,107 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { canvaApiRequest, listDesignsForDropdown } from '../common';
+
+const EXPORT_FORMATS = [
+  { label: 'PDF', value: 'pdf' },
+  { label: 'JPEG', value: 'jpg' },
+  { label: 'PNG', value: 'png' },
+  { label: 'GIF', value: 'gif' },
+  { label: 'PowerPoint (PPTX)', value: 'pptx' },
+  { label: 'MP4 Video', value: 'mp4' },
+];
+
+interface ExportJob {
+  id: string;
+  status: 'failed' | 'in_progress' | 'success';
+  urls?: string[];
+  error?: { code: string; message: string };
+}
+
+async function pollExportJob(accessToken: string, jobId: string): Promise<ExportJob> {
+  const maxAttempts = 20;
+  const delayMs = 3000;
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const response = await canvaApiRequest<{ job: ExportJob }>(
+      accessToken,
+      HttpMethod.GET,
+      `/exports/${jobId}`,
+    );
+
+    if (response.job.status !== 'in_progress') {
+      return response.job;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  throw new Error('Export job timed out. Check Canva for the export status.');
+}
+
+export const exportDesign = createAction({
+  auth: canvaAuth,
+  name: 'export_design',
+  displayName: 'Export Design',
+  description: 'Export a Canva design to PDF, JPG, PNG, GIF, PPTX, or MP4. Returns download URLs valid for 24 hours.',
+  props: {
+    designId: Property.Dropdown({
+      auth: canvaAuth,
+      displayName: 'Design',
+      description: 'The design to export.',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { disabled: true, placeholder: 'Connect your Canva account first.', options: [] };
+        const options = await listDesignsForDropdown(auth as any);
+        return { disabled: false, options };
+      },
+    }),
+    exportFormat: Property.StaticDropdown({
+      displayName: 'Format',
+      description: 'The file format for the export.',
+      required: true,
+      options: { options: EXPORT_FORMATS },
+    }),
+    exportQuality: Property.StaticDropdown({
+      displayName: 'Export Quality',
+      description: 'Quality level for the export (Pro quality requires premium elements to be licensed).',
+      required: false,
+      defaultValue: 'regular',
+      options: {
+        options: [
+          { label: 'Regular', value: 'regular' },
+          { label: 'Pro (Premium)', value: 'pro' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { designId, exportFormat, exportQuality } = context.propsValue;
+
+    const format: Record<string, unknown> = { type: exportFormat };
+    if (exportQuality) format['export_quality'] = exportQuality;
+
+    const createResponse = await canvaApiRequest<{ job: ExportJob }>(
+      context.auth.access_token,
+      HttpMethod.POST,
+      '/exports',
+      { design_id: designId, format },
+    );
+
+    if (createResponse.job.status === 'failed') {
+      throw new Error(`Export failed: ${createResponse.job.error?.message ?? 'Unknown error'}`);
+    }
+
+    if (createResponse.job.status === 'in_progress') {
+      const job = await pollExportJob(context.auth.access_token, createResponse.job.id);
+      if (job.status === 'failed') {
+        throw new Error(`Export failed: ${job.error?.message ?? 'Unknown error'}`);
+      }
+      return job;
+    }
+
+    return createResponse.job;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/find-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/find-design.ts
@@ -1,0 +1,63 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { CANVA_BASE_URL } from '../common';
+
+export const findDesign = createAction({
+  auth: canvaAuth,
+  name: 'find_design',
+  displayName: 'Find Design',
+  description: "Search the user's Canva designs by keyword.",
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: "Keyword to search for among the user's designs (max 255 characters).",
+      required: true,
+    }),
+    ownership: Property.StaticDropdown({
+      displayName: 'Ownership',
+      description: 'Filter designs by ownership.',
+      required: false,
+      defaultValue: 'any',
+      options: {
+        options: [
+          { label: 'Any (owned and shared)', value: 'any' },
+          { label: 'Owned by me', value: 'owned' },
+          { label: 'Shared with me', value: 'shared' },
+        ],
+      },
+    }),
+    sortBy: Property.StaticDropdown({
+      displayName: 'Sort By',
+      description: 'How to sort the results.',
+      required: false,
+      defaultValue: 'relevance',
+      options: {
+        options: [
+          { label: 'Relevance', value: 'relevance' },
+          { label: 'Last Modified (newest first)', value: 'modified_descending' },
+          { label: 'Last Modified (oldest first)', value: 'modified_ascending' },
+          { label: 'Title (A–Z)', value: 'title_ascending' },
+          { label: 'Title (Z–A)', value: 'title_descending' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { query, ownership, sortBy } = context.propsValue;
+    const params = new URLSearchParams({ query });
+    if (ownership) params.set('ownership', ownership);
+    if (sortBy) params.set('sort_by', sortBy);
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${CANVA_BASE_URL}/designs?${params.toString()}`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-asset.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { canvaApiRequest } from '../common';
+
+export const getAsset = createAction({
+  auth: canvaAuth,
+  name: 'get_asset',
+  displayName: 'Get Asset',
+  description: 'Retrieve details about an asset (image) in your Canva library.',
+  props: {
+    assetId: Property.ShortText({
+      displayName: 'Asset ID',
+      description: 'The ID of the asset to retrieve.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    return canvaApiRequest(
+      context.auth.access_token,
+      HttpMethod.GET,
+      `/assets/${context.propsValue.assetId}`,
+    );
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-design.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { canvaApiRequest, listDesignsForDropdown } from '../common';
+
+export const getDesign = createAction({
+  auth: canvaAuth,
+  name: 'get_design',
+  displayName: 'Get Design',
+  description: 'Retrieve metadata for a Canva design including edit/view URLs and thumbnail.',
+  props: {
+    designId: Property.Dropdown({
+      auth: canvaAuth,
+      displayName: 'Design',
+      description: 'The design to retrieve.',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { disabled: true, placeholder: 'Connect your Canva account first.', options: [] };
+        const options = await listDesignsForDropdown(auth as any);
+        return { disabled: false, options };
+      },
+    }),
+  },
+  async run(context) {
+    return canvaApiRequest(
+      context.auth.access_token,
+      HttpMethod.GET,
+      `/designs/${context.propsValue.designId}`,
+    );
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-folder.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-folder.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { canvaApiRequest, listFoldersForDropdown } from '../common';
+
+export const getFolder = createAction({
+  auth: canvaAuth,
+  name: 'get_folder',
+  displayName: 'Get Folder',
+  description: 'Retrieve details about a Canva folder.',
+  props: {
+    folderId: Property.Dropdown({
+      auth: canvaAuth,
+      displayName: 'Folder',
+      description: 'The folder to retrieve.',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { disabled: true, placeholder: 'Connect your Canva account first.', options: [] };
+        const options = await listFoldersForDropdown(auth as any);
+        return { disabled: false, options };
+      },
+    }),
+  },
+  async run(context) {
+    return canvaApiRequest(
+      context.auth.access_token,
+      HttpMethod.GET,
+      `/folders/${context.propsValue.folderId}`,
+    );
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/import-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/import-design.ts
@@ -1,0 +1,111 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { CANVA_BASE_URL, canvaApiRequest } from '../common';
+
+const SUPPORTED_IMPORT_MIME_TYPES: Record<string, string> = {
+  ai: 'application/illustrator',
+  psd: 'image/vnd.adobe.photoshop',
+  key: 'application/vnd.apple.keynote',
+  numbers: 'application/vnd.apple.numbers',
+  pages: 'application/vnd.apple.pages',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  odp: 'application/vnd.oasis.opendocument.presentation',
+  odt: 'application/vnd.oasis.opendocument.text',
+  pdf: 'application/pdf',
+};
+
+interface ImportJob {
+  id: string;
+  status: 'failed' | 'in_progress' | 'success';
+  result?: { design: { id: string } };
+  error?: { code: string; message: string };
+}
+
+async function pollImportJob(accessToken: string, jobId: string): Promise<ImportJob> {
+  const maxAttempts = 20;
+  const delayMs = 3000;
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const response = await canvaApiRequest<{ job: ImportJob }>(
+      accessToken,
+      HttpMethod.GET,
+      `/imports/${jobId}`,
+    );
+
+    if (response.job.status !== 'in_progress') {
+      return response.job;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  throw new Error('Import job timed out. Check Canva for the import status.');
+}
+
+export const importDesign = createAction({
+  auth: canvaAuth,
+  name: 'import_design',
+  displayName: 'Import Design',
+  description: 'Import an external file (PDF, PPTX, DOCX, PSD, AI, etc.) into Canva as a new design.',
+  props: {
+    file: Property.File({
+      displayName: 'File',
+      description: 'Supported: PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, AI, PSD, KEY, ODT, ODP, Pages, Numbers.',
+      required: true,
+    }),
+    designTitle: Property.ShortText({
+      displayName: 'Design Title',
+      description: 'Title for the imported design.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { file, designTitle } = context.propsValue;
+
+    const ext = file.filename?.split('.').pop()?.toLowerCase() ?? '';
+    const mimeType = SUPPORTED_IMPORT_MIME_TYPES[ext];
+    if (!mimeType) {
+      throw new Error(
+        `Unsupported file format: "${ext}". Supported: ${Object.keys(SUPPORTED_IMPORT_MIME_TYPES).join(', ')}.`,
+      );
+    }
+
+    const fileBuffer = Buffer.from(file.base64, 'base64');
+    const titleBase64 = Buffer.from(designTitle.trim()).toString('base64');
+
+    const response = await httpClient.sendRequest<{ job: ImportJob }>({
+      method: HttpMethod.POST,
+      url: `${CANVA_BASE_URL}/imports`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Import-Metadata': JSON.stringify({ title_base64: titleBase64, mime_type: mimeType }),
+      },
+      body: fileBuffer,
+    });
+
+    const job = response.body.job;
+    if (job.status === 'failed') {
+      throw new Error(`Import failed: ${job.error?.message ?? 'Unknown error'}`);
+    }
+
+    if (job.status === 'in_progress') {
+      const finalJob = await pollImportJob(context.auth.access_token, job.id);
+      if (finalJob.status === 'failed') {
+        throw new Error(`Import failed: ${finalJob.error?.message ?? 'Unknown error'}`);
+      }
+      return finalJob;
+    }
+
+    return job;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
+++ b/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { canvaApiRequest, listFoldersForDropdown } from '../common';
+
+export const moveFolderItem = createAction({
+  auth: canvaAuth,
+  name: 'move_folder_item',
+  displayName: 'Move Folder Item',
+  description: 'Move a design or asset from one folder to another.',
+  props: {
+    itemId: Property.ShortText({
+      displayName: 'Item ID',
+      description: 'The ID of the design or asset to move.',
+      required: true,
+    }),
+    toFolderId: Property.Dropdown({
+      auth: canvaAuth,
+      displayName: 'Destination Folder',
+      description: 'The folder to move the item into. Select "Root (Projects)" to move to the top level.',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) return { disabled: true, placeholder: 'Connect your Canva account first.', options: [] };
+        const options = await listFoldersForDropdown(auth as any);
+        return { disabled: false, options };
+      },
+    }),
+  },
+  async run(context) {
+    return canvaApiRequest(
+      context.auth.access_token,
+      HttpMethod.POST,
+      '/folders/move',
+      {
+        item_id: context.propsValue.itemId,
+        to_folder_id: context.propsValue.toFolderId,
+      },
+    );
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { canvaAuth } from '../../index';
+import { CANVA_BASE_URL } from '../common';
+
+export const uploadAsset = createAction({
+  auth: canvaAuth,
+  name: 'upload_asset',
+  displayName: 'Upload Asset',
+  description: 'Upload an image or video file to your Canva asset library.',
+  props: {
+    file: Property.File({
+      displayName: 'File',
+      description: 'Image (JPG, PNG, GIF, WEBP, HEIC, TIFF — max 50 MB) or video (MP4, MOV, WEBM — max 500 MB).',
+      required: true,
+    }),
+    assetName: Property.ShortText({
+      displayName: 'Asset Name',
+      description: 'Name for the asset (max 50 characters).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { file, assetName } = context.propsValue;
+
+    if (assetName.length > 50) {
+      throw new Error('Asset name must be 50 characters or fewer.');
+    }
+
+    const nameBase64 = Buffer.from(assetName.trim()).toString('base64');
+    const fileBuffer = Buffer.from(file.base64, 'base64');
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${CANVA_BASE_URL}/asset-uploads`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Asset-Upload-Metadata': JSON.stringify({ name_base64: nameBase64 }),
+      },
+      body: fileBuffer,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/common/index.ts
+++ b/packages/pieces/community/canva/src/lib/common/index.ts
@@ -1,0 +1,84 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { OAuth2PropertyValue } from '@activepieces/pieces-framework';
+
+export const CANVA_BASE_URL = 'https://api.canva.com/rest/v1';
+
+export async function canvaApiRequest<T>(
+  accessToken: string,
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url: `${CANVA_BASE_URL}${path}`,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: accessToken,
+    },
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body,
+  });
+  return response.body;
+}
+
+export async function listDesignsForDropdown(
+  auth: OAuth2PropertyValue,
+  query?: string,
+): Promise<Array<{ label: string; value: string }>> {
+  const params = new URLSearchParams({ sort_by: 'modified_descending' });
+  if (query?.trim()) params.set('query', query.trim());
+
+  const response = await httpClient.sendRequest<{ items?: Array<{ id: string; title?: string }> }>({
+    method: HttpMethod.GET,
+    url: `${CANVA_BASE_URL}/designs?${params.toString()}`,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: auth.access_token,
+    },
+  });
+
+  return (response.body.items ?? []).map((d) => ({
+    label: d.title ?? d.id,
+    value: d.id,
+  }));
+}
+
+export async function listFoldersForDropdown(
+  auth: OAuth2PropertyValue,
+): Promise<Array<{ label: string; value: string }>> {
+  const result: Array<{ label: string; value: string }> = [
+    { label: 'Root (Projects)', value: 'root' },
+  ];
+
+  try {
+    const response = await httpClient.sendRequest<{
+      items?: Array<{ type: string; folder?: { id: string; name: string } }>;
+    }>({
+      method: HttpMethod.GET,
+      url: `${CANVA_BASE_URL}/folders/root/items?item_types=folder`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.access_token,
+      },
+    });
+
+    for (const item of response.body.items ?? []) {
+      if (item.type === 'folder' && item.folder) {
+        result.push({ label: item.folder.name, value: item.folder.id });
+      }
+    }
+  } catch {
+    // Return root only on error
+  }
+
+  return result;
+}

--- a/packages/pieces/community/canva/tsconfig.json
+++ b/packages/pieces/community/canva/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/canva/tsconfig.lib.json
+++ b/packages/pieces/community/canva/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "../../../../dist/packages/pieces/community/canva",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -193,6 +193,9 @@
       "@activepieces/piece-camb-ai": [
         "packages/pieces/community/camb-ai/src/index.ts"
       ],
+      "@activepieces/piece-canva": [
+        "packages/pieces/community/canva/src/index.ts"
+      ],
       "@activepieces/piece-campaign-monitor": [
         "packages/pieces/community/campaign-monitor/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Adds a Canva integration piece with OAuth2 authentication via the Canva Connect API.

## Actions

| Action | Description |
|--------|-------------|
| Create Design | Create a new design using a preset type or custom dimensions |
| Upload Asset | Upload an image or video to the Canva asset library |
| Import Design | Import an external file (PDF, PPTX, DOCX, PSD, AI, etc.) as a Canva design |
| Export Design | Export a design to PDF, JPG, PNG, GIF, PPTX, or MP4 with async job polling |
| Get Design | Retrieve metadata including edit/view URLs and thumbnail |
| Find Design | Search designs by keyword with ownership and sort filters |
| Move Folder Item | Move a design or asset to a different folder |
| Get Folder | Retrieve folder details |
| Get Asset | Retrieve asset details |
| Custom API Call | Make custom requests to the Canva Connect API |

## Auth

OAuth2 using Canva's Connect API with PKCE (S256).

**Scopes:** `design:content:read`, `design:content:write`, `design:meta:read`, `asset:read`, `asset:write`, `folder:read`, `folder:write`

## Implementation Notes

- Export and import operations use async job polling (up to 60s) with clean error messages
- Dropdowns for designs and folders use dynamic options loaded from the Canva API
- Follows the standard activepieces piece architecture (same patterns as webflow, zoom, etc.)
- TypeScript compiles with `tsc --noEmit` ✅

Fixes #8135
/claim #8135