### PR TITLE
fix: bump pieces-common, pieces-framework & Microsoft piece versions

### DIFF
--- a/packages/pieces/community/common/package.json
+++ b/packages/pieces/community/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/packages/pieces/community/framework/package.json
+++ b/packages/pieces/community/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/packages/pieces/community/microsoft-365-people/package.json
+++ b/packages/pieces/community/microsoft-365-people/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-365-people",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/packages/pieces/community/microsoft-365-planner/package.json
+++ b/packages/pieces/community/microsoft-365-planner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-365-planner",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/packages/pieces/community/microsoft-excel-365/package.json
+++ b/packages/pieces/community/microsoft-excel-365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-excel-365",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-onedrive/package.json
+++ b/packages/pieces/community/microsoft-onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-onedrive",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-onenote/package.json
+++ b/packages/pieces/community/microsoft-onenote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-onenote",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/packages/pieces/community/microsoft-outlook/package.json
+++ b/packages/pieces/community/microsoft-outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-outlook",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-sharepoint/package.json
+++ b/packages/pieces/community/microsoft-sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-sharepoint",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-teams/package.json
+++ b/packages/pieces/community/microsoft-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-teams",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-todo/package.json
+++ b/packages/pieces/community/microsoft-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-todo",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",


### PR DESCRIPTION
## Summary
- `pieces-common@0.11.6` and `pieces-framework@0.25.4` were published with `@activepieces/shared@0.37.0`, but the Microsoft pieces were published with `@activepieces/shared@0.38.3`, causing a dependency mismatch at runtime
- Bump `pieces-common` to `0.11.7` and `pieces-framework` to `0.25.5` so they get republished with the correct `@activepieces/shared@0.38.3`
- Bump all Microsoft 365 pieces so they get republished with the updated common/framework versions

## Test plan
- [ ] Verify pieces-common and pieces-framework publish with correct shared version
- [ ] Verify Microsoft pieces install and run correctly after publishing