### PR TITLE
fix: resolve piece loader to file path for ESM compatibility

### DIFF
--- a/packages/engine/src/lib/helper/piece-loader.ts
+++ b/packages/engine/src/lib/helper/piece-loader.ts
@@ -185,7 +185,7 @@ async function traverseAllParentFoldersToFindPiece(packageName: string): Promise
         const piecePath = path.resolve(currentDir, 'pieces', packageName, 'node_modules', trimVersionFromAlias(packageName))
 
         if (await utils.folderExists(piecePath)) {
-            return piecePath
+            return path.join(piecePath, 'src', 'index.js')
         }
 
         const parentDir = path.dirname(currentDir)


### PR DESCRIPTION
## Summary
- Fixed `traverseAllParentFoldersToFindPiece` in the engine's piece-loader to return a file path (`src/index.js`) instead of a directory path
- This matches the behavior of `findInDistFolder` which already returns an explicit file path

## Problem
The engine uses `await import(piecePath)` to load pieces at runtime. ESM does not support directory imports, causing all pieces to fail in production with:
```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '/root/pieces/@activepieces/piece-telegram-bot-0.5.5/node_modules/@activepieces/piece-telegram-bot' is not supported resolving ES modules
```

## Test plan
- [x] Engine builds successfully
- [x] The fix aligns with how dev pieces are already loaded (explicit `src/index.js` path)