### PR TITLE
fix: optimize piece cache to avoid loading all versions from DB

### DIFF
--- a/packages/server/api/src/app/pieces/metadata/piece-cache.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-cache.ts
@@ -2,14 +2,13 @@ import { pieceTranslation } from '@activepieces/pieces-framework'
 import { AppSystemProp } from '@activepieces/server-shared'
 import { ApEnvironment, isNil, LocalesEnum, PieceType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import semVer from 'semver'
 import { lru, LRU } from 'tiny-lru'
 import { In, IsNull } from 'typeorm'
 import { repoFactory } from '../../core/db/repo-factory'
 import { pubsub } from '../../helper/pubsub'
 import { system } from '../../helper/system/system'
 import { PieceMetadataEntity, PieceMetadataSchema } from './piece-metadata-entity'
-import { filterPieceBasedOnType, isSupportedRelease, lastVersionOfEachPiece, loadDevPiecesIfEnabled } from './utils'
+import { filterPieceBasedOnType, isNewerVersion, isSupportedRelease, lastVersionOfEachPiece, loadDevPiecesIfEnabled } from './utils'
 
 const repo = repoFactory(PieceMetadataEntity)
 
@@ -149,7 +148,7 @@ function pickLatestVersionIds(pieces: PieceKey[]): string[] {
     for (const piece of pieces) {
         const key = `${piece.name}:${piece.platformId ?? ''}`
         const existing = latest.get(key)
-        if (isNil(existing) || semVer.gt(piece.version, existing.version)) {
+        if (isNil(existing) || isNewerVersion(piece.version, existing.version)) {
             latest.set(key, piece)
         }
     }

--- a/packages/server/api/src/app/pieces/metadata/utils/piece-cache-utils.ts
+++ b/packages/server/api/src/app/pieces/metadata/utils/piece-cache-utils.ts
@@ -6,29 +6,26 @@ import { system } from '../../../helper/system/system'
 import { PieceRegistryEntry } from '../piece-cache'
 import { PieceMetadataSchema } from '../piece-metadata-entity'
 
-export function sortByNameAndVersionDesc(a: PieceMetadataSchema, b: PieceMetadataSchema): number {
-    if (a.name !== b.name) {
-        return a.name.localeCompare(b.name)
-    }
-    const aValid = semVer.valid(a.version)
-    const bValid = semVer.valid(b.version)
+export function isNewerVersion(a: string, b: string): boolean {
+    const aValid = semVer.valid(a)
+    const bValid = semVer.valid(b)
     if (!aValid && !bValid) {
-        return b.version.localeCompare(a.version)
+        return a.localeCompare(b) > 0
     }
     if (!aValid) {
-        return 1
+        return false
     }
     if (!bValid) {
-        return -1
+        return true
     }
-    return semVer.rcompare(a.version, b.version)
+    return semVer.gt(a, b)
 }
 
 export function lastVersionOfEachPiece(pieces: PieceMetadataSchema[]): PieceMetadataSchema[] {
     const seen = new Map<string, PieceMetadataSchema>()
     for (const piece of pieces) {
         const existing = seen.get(piece.name)
-        if (isNil(existing) || semVer.gt(piece.version, existing.version)) {
+        if (isNil(existing) || isNewerVersion(piece.version, existing.version)) {
             seen.set(piece.name, piece)
         }
     }


### PR DESCRIPTION
## Summary
- **Optimized `fetchLatestPiecesFromDB`**: Instead of loading all piece rows with full metadata and sorting in-memory, now fetches only `id`, `name`, `version`, and `platformId` columns, picks the latest version per piece/platform in-memory using `semver.gt`, then loads full metadata for only those rows via `IN(ids)`.
- **Optimized `fetchRegistryFromDB`**: The registry endpoint now uses a lightweight projection query selecting only the 6 columns needed (`name`, `version`, `platformId`, `pieceType`, `minimumSupportedRelease`, `maximumSupportedRelease`) instead of loading full entities.
- **Simplified `translatePieces`**: Removed the complex per-platform translation logic since the input is already filtered to latest versions only.

## Test plan
- [ ] Verify piece listing returns the same pieces as before (latest version per piece/platform)
- [ ] Verify piece registry endpoint returns correct entries
- [ ] Verify translations work correctly for non-English locales
- [ ] Verify dev pieces still load correctly alongside DB pieces