### PR TITLE
fix: enable watch mode for backend serve

### DIFF
--- a/packages/server/api/package.json
+++ b/packages/server/api/package.json
@@ -125,7 +125,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.app.json",
-    "serve": "cd ../../.. && npx tsx --tsconfig packages/server/api/tsconfig.app.json packages/server/api/src/bootstrap.ts",
+    "serve": "cd ../../.. && npx tsx watch --tsconfig packages/server/api/tsconfig.app.json packages/server/api/src/bootstrap.ts",
     "lint": "eslint 'src/**/*.ts'",
     "test": "npm run test-ce && npm run test-ee && npm run test-cloud",
     "test-unit": "vitest run test/unit --bail 1 --passWithNoTests=false",


### PR DESCRIPTION
## Summary
- Added `watch` flag to the `tsx` command in the server-api `serve` script so the backend automatically reloads when files change during development.

## Test plan
- Run `npm run serve:backend` and verify the server starts
- Modify a backend source file and verify the server automatically restarts