### PR TITLE
fix: optimize Docker image by removing unused pieces and locale packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,13 +73,15 @@ COPY . .
 RUN npx turbo run build --filter=react-ui --filter=@activepieces/engine --filter=server-api
 
 # Remove piece directories not needed at runtime (keeps only the 4 pieces server-api imports)
+# Then regenerate bun.lock so it matches the trimmed workspace
 RUN rm -rf packages/pieces/core packages/pieces/custom && \
     find packages/pieces/community -mindepth 1 -maxdepth 1 -type d \
       ! -name slack \
       ! -name square \
       ! -name facebook-leads \
       ! -name intercom \
-      -exec rm -rf {} +
+      -exec rm -rf {} + && \
+    rm -f bun.lock && bun install
 
 ### STAGE 2: Run ###
 FROM base AS run
@@ -115,9 +117,9 @@ COPY --from=build /usr/src/app/packages ./packages
 # Copy built engine
 COPY --from=build /usr/src/app/dist/packages/engine/ ./dist/packages/engine/
 
-# Install production dependencies (remove lockfile first since pieces were trimmed from workspace)
+# Regenerate lockfile and install production dependencies (pieces were trimmed from workspace)
 RUN --mount=type=cache,target=/root/.bun/install/cache \
-    rm -f bun.lock && bun install --production
+    bun install --production
 
 # Copy frontend files to Nginx document root
 COPY --from=build /usr/src/app/dist/packages/react-ui /usr/share/nginx/html/


### PR DESCRIPTION
## Summary
- Replace `locales-all` with targeted `en_US.UTF-8` locale generation to reduce image size
- Remove unused piece directories from the build stage, keeping only the 4 pieces server-api imports (slack, square, facebook-leads, intercom)
- Remove frozen lockfile constraint in production install since pieces were trimmed from workspace

## Test plan
- [ ] Build the Docker image and verify it starts correctly
- [ ] Verify the 4 required pieces (slack, square, facebook-leads, intercom) are available
- [ ] Compare image size before and after changes