### PR TITLE
fix: update Dockerfile to use renamed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 COPY . .
 
 # Build frontend, engine, and server API
-RUN npx turbo run build --filter=react-ui --filter=@activepieces/engine --filter=server-api
+RUN npx turbo run build --filter=web --filter=@activepieces/engine --filter=api
 
 # Remove piece directories not needed at runtime (keeps only the 4 pieces server-api imports)
 # Then regenerate bun.lock so it matches the trimmed workspace
@@ -122,7 +122,7 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
     bun install --production
 
 # Copy frontend files to Nginx document root
-COPY --from=build /usr/src/app/dist/packages/react-ui /usr/share/nginx/html/
+COPY --from=build /usr/src/app/dist/packages/web /usr/share/nginx/html/
 
 LABEL service=activepieces
 


### PR DESCRIPTION
## Summary
- Update turbo build filter from `react-ui` to `web` and `server-api` to `api` to match renamed packages
- Update frontend COPY path from `dist/packages/react-ui` to `dist/packages/web`

## Test plan
- [ ] Build the Docker image and verify it starts correctly
- [ ] Verify the frontend is served at the root path