### PR TITLE
chore: release v0.79.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   activepieces:
-    image: ghcr.io/activepieces/activepieces:0.78.2
+    image: ghcr.io/activepieces/activepieces:0.79.0
     container_name: activepieces
     restart: unless-stopped
     ## Enable the following line if you already use AP_EXECUTION_MODE with SANDBOX_PROCESS or old activepieces, checking the breaking change documentation for more info.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.78.2",
+  "version": "0.79.0",
   "rcVersion": "0.78.0-rc.0",
   "packageManager": "bun@1.3.3",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump version to 0.79.0 in package.json and docker-compose.yml

## Test plan
- [ ] CI passes
- [ ] Docker build succeeds