### PR TITLE
feat(pieces): add twenty crm piece

### DIFF
--- a/packages/pieces/community/twenty/.eslintrc.json
+++ b/packages/pieces/community/twenty/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/twenty/README.md
+++ b/packages/pieces/community/twenty/README.md
@@ -1,0 +1,35 @@
+# Twenty CRM Piece
+
+Twenty is an open-source CRM platform designed to be a flexible alternative to Salesforce. This piece allows you to integrate your Twenty workspace with other tools via Activepieces.
+
+## Setup Instructions
+
+### 1. Get your Workspace URL
+Your Workspace URL (Base URL) is the address you use to access Twenty. 
+* If you are using the cloud version, it looks like: `https://[your-workspace].twenty.com`
+* If you are self-hosting, it is the URL of your local or hosted instance.
+
+### 2. Generate an API Key
+1. Log in to your Twenty workspace.
+2. Navigate to **Settings** > **Developers** > **API Keys**.
+3. Click **+ New Key**.
+4. Give it a name (e.g., "Activepieces") and copy the generated token.
+
+---
+
+## Supported Triggers
+
+### New Person
+- **Type**: Polling
+- **Description**: Triggers whenever a new person record is created in your workspace.
+
+## Supported Actions
+
+### Create Contact
+- **Description**: Creates a new person record.
+- **Fields**: First Name (Required), Last Name, Email.
+
+---
+
+## Authors
+- [Akash5908](https://github.com/Akash5908)

--- a/packages/pieces/community/twenty/package.json
+++ b/packages/pieces/community/twenty/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-twenty",
+  "version": "0.0.2",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/twenty/src/index.ts
+++ b/packages/pieces/community/twenty/src/index.ts
@@ -1,0 +1,21 @@
+import {
+  createPiece,
+  PieceAuth,
+  Property,
+} from '@activepieces/pieces-framework';
+import { createContact } from './lib/actions/create-contact';
+import { newPerson } from './lib/triggers/new-person';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { twentyAuth } from './lib/auth';
+
+
+export const twenty = createPiece({
+  displayName: 'Twenty',
+  description: 'Open-source CRM platform.',
+  auth: twentyAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-website/public/images/symbol.png',
+  authors: ['Akash5908'],
+  actions: [createContact],
+  triggers: [newPerson],
+});

--- a/packages/pieces/community/twenty/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/twenty/src/lib/actions/create-contact.ts
@@ -1,0 +1,59 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { twentyAuth } from '../auth';
+
+export const createContact = createAction({
+  auth: twentyAuth,
+  name: 'create_contact',
+  displayName: 'Create Contact',
+  description: 'Creates a new person record in your Twenty CRM workspace.',
+  props: {
+    
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      required: true,
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: false,
+    }),
+  },
+ async run(context) {
+    // 1. Get the auth object
+    const auth = context.auth as any;
+
+    // 2. Extract values with fallbacks to handle framework nesting
+    const baseUrl = auth?.props.base_url || "";
+    const apiKey = auth?.props.api_key || "";
+
+    if (!baseUrl || !apiKey) {
+        throw new Error("Connection data is missing. Please try deleting and recreating your Twenty connection.");
+    }
+
+   const sanitizedUrl = baseUrl.replace(/\/$/, '');
+   
+    const { firstName, lastName, email } = context?.propsValue;
+
+    const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${sanitizedUrl}/rest/people`,
+        headers: {
+            'Authorization': `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+        },
+        body: {
+          name: {
+            firstName,
+            lastName
+          },
+            emails: email ? { primaryEmail: email } : undefined,
+        },
+    });
+
+    return response.body;
+},
+});

--- a/packages/pieces/community/twenty/src/lib/auth.ts
+++ b/packages/pieces/community/twenty/src/lib/auth.ts
@@ -1,0 +1,37 @@
+// src/lib/auth.ts
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const twentyAuth = PieceAuth.CustomAuth({
+  description: 'Connect to your Twenty instance',
+  required: true,
+  props: {
+    base_url: Property.ShortText({
+      displayName: 'Instance URL',
+      description: 'The URL of your Twenty instance (e.g., https://app.twenty.com)',
+      required: true,
+    }),
+    api_key: PieceAuth.SecretText({
+      displayName: 'API Key',
+      description: 'Your Twenty API Key',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+  
+      const sanitizedUrl = auth.base_url.replace(/\/$/, '');
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${sanitizedUrl}/rest/people`,
+        headers: {
+          Authorization: `Bearer ${auth.api_key}`,
+        },
+        queryParams: {
+          'page[size]': '1',
+        },
+      });
+      return { valid: true };
+   
+    
+  },
+});

--- a/packages/pieces/community/twenty/src/lib/triggers/new-person.ts
+++ b/packages/pieces/community/twenty/src/lib/triggers/new-person.ts
@@ -1,0 +1,65 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import dayjs from 'dayjs';
+import { twentyAuth } from '../auth';
+
+const polling: Polling<any, any> = {
+    strategy: DedupeStrategy.TIMEBASED,
+    items: async ({ auth }) => {
+        // 1. Look inside auth.props first, then fallback to auth directly
+        const base_url = auth?.props?.base_url || auth?.base_url || "";
+        const api_key = auth?.props?.api_key || auth?.api_key || "";
+
+        if (!base_url) {
+            throw new Error("Please provide your Twenty CRM Base URL in the connection settings.");
+        }
+        
+        const sanitizedUrl = base_url.replace(/\/$/, '');
+
+        const response = await httpClient.sendRequest<{ data: { people: any[] } }>({
+            method: HttpMethod.GET,
+            url: `${sanitizedUrl}/rest/people`,
+            headers: { 
+                Authorization: `Bearer ${api_key}`,
+            },
+            queryParams: {
+                'sort[createdAt]': 'desc'
+            }
+        });
+
+       const items = response.body.data?.people || [];
+
+        return items.map((item) => ({
+            epochMilliSeconds: dayjs(item.createdAt).valueOf(),
+            data: item,
+        }));
+    }
+}
+
+export const newPerson = createTrigger({
+    auth: twentyAuth,
+    name: 'new_person',
+    displayName: 'New Person',
+    description: 'Triggers when a new person is created in Twenty CRM.',
+    requireAuth: true,
+    props: {},
+    type: TriggerStrategy.POLLING,
+    sampleData: {
+        id: "303030-3030-3030",
+        firstName: "Akash",
+        lastName: "Kumar",
+        createdAt: "2026-02-27T10:00:00Z"
+    },
+    async test(context) {
+        return await pollingHelper.test(polling, context);
+    },
+    async onEnable(context) {
+        await pollingHelper.onEnable(polling, context);
+    },
+    async onDisable(context) {
+        await pollingHelper.onDisable(polling, context);
+    },
+    async run(context) {
+        return await pollingHelper.poll(polling, context);
+    },
+});

--- a/packages/pieces/community/twenty/tsconfig.json
+++ b/packages/pieces/community/twenty/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/twenty/tsconfig.lib.json
+++ b/packages/pieces/community/twenty/tsconfig.lib.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
This PR adds a new integration for Twenty CRM, an open-source CRM platform. The piece includes essential authentication, a polling trigger, and a contact creation action.

Key Technical Implementations:

-     Custom Authentication: Implemented PieceAuth.CustomAuth requiring base_url and api_key. Added robust handling for the Activepieces-specific auth.props nesting to ensure connection data is correctly retrieved.

-     Polling Trigger (New Person): Created a time-based deduplication trigger for the /rest/people endpoint. Configured with requireAuth: true to ensure secure access to user credentials.

-     Create Contact Action: Implemented a POST request to create new person records. Handled Twenty CRM's specific nested payload structure (nesting firstName and lastName inside a name object).

-     Validation Logic: Added a validate function to the authentication block to verify credentials against the Twenty API before saving the connection.

Changes:

-     Added packages/pieces/community/twenty/src/lib/auth.ts.

-     Added packages/pieces/community/twenty/src/lib/triggers/new-person.ts.

-     Added packages/pieces/community/twenty/src/lib/actions/create-contact.ts.

-     Added packages/pieces/community/twenty/README.md with setup instructions.

Testing:

-     Verified trigger successfully fetches person records from a Twenty cloud instance.

-     Verified "Create Contact" action successfully creates records with correctly mapped name and email objects.