### PR TITLE
test: add integration tests for 6 untested API endpoint groups

### DIFF
--- a/packages/server/api/test/helpers/mocks/index.ts
+++ b/packages/server/api/test/helpers/mocks/index.ts
@@ -26,6 +26,7 @@ import {
     FileType,
     FilteredPieceBehavior,
     Flow,
+    Folder,
     FlowOperationStatus,
     FlowRun,
     FlowRunStatus,
@@ -61,6 +62,8 @@ import {
     RunEnvironment,
     SigningKey,
     Table,
+    TableWebhook,
+    TableWebhookEventType,
     TeamProjectsLimit,
     Template,
     TemplateStatus,
@@ -555,7 +558,7 @@ export const createMockConnection = (connection: Partial<AppConnection>, ownerId
     }
 }
 
-const createMockTable = ({ projectId }: { projectId: string }): Table => {
+export const createMockTable = ({ projectId }: { projectId: string }): Table => {
     return {
         id: apId(),
         created: faker.date.recent().toISOString(),
@@ -566,7 +569,7 @@ const createMockTable = ({ projectId }: { projectId: string }): Table => {
     }
 }
 
-const createMockField = ({ tableId, projectId }: { tableId: string, projectId: string }): Field => {
+export const createMockField = ({ tableId, projectId }: { tableId: string, projectId: string }): Field => {
     return {
         id: apId(),
         created: faker.date.recent().toISOString(),
@@ -581,7 +584,7 @@ const createMockField = ({ tableId, projectId }: { tableId: string, projectId: s
         type: FieldType.STATIC_DROPDOWN,
     }
 }
-const createMockRecord = ({ tableId, projectId }: { tableId: string, projectId: string }): Record => {
+export const createMockRecord = ({ tableId, projectId }: { tableId: string, projectId: string }): Record => {
     return {
         id: apId(),
         created: faker.date.recent().toISOString(),
@@ -591,7 +594,7 @@ const createMockRecord = ({ tableId, projectId }: { tableId: string, projectId: 
     }
 }
 
-const createMockCell = ({ recordId, fieldId, projectId }: { recordId: string, fieldId: string, projectId: string }): Cell => {
+export const createMockCell = ({ recordId, fieldId, projectId }: { recordId: string, fieldId: string, projectId: string }): Cell => {
     return {
         id: apId(),
         created: faker.date.recent().toISOString(),
@@ -603,6 +606,29 @@ const createMockCell = ({ recordId, fieldId, projectId }: { recordId: string, fi
     }
 }
 
+
+export const createMockFolder = (folder?: Partial<Folder>): Folder => {
+    return {
+        id: folder?.id ?? apId(),
+        created: folder?.created ?? faker.date.recent().toISOString(),
+        updated: folder?.updated ?? faker.date.recent().toISOString(),
+        projectId: folder?.projectId ?? apId(),
+        displayName: folder?.displayName ?? faker.lorem.word(),
+        displayOrder: folder?.displayOrder ?? 0,
+    }
+}
+
+export const createMockTableWebhook = (webhook?: Partial<TableWebhook>): TableWebhook => {
+    return {
+        id: webhook?.id ?? apId(),
+        created: webhook?.created ?? faker.date.recent().toISOString(),
+        updated: webhook?.updated ?? faker.date.recent().toISOString(),
+        projectId: webhook?.projectId ?? apId(),
+        tableId: webhook?.tableId ?? apId(),
+        events: webhook?.events ?? [TableWebhookEventType.RECORD_CREATED],
+        flowId: webhook?.flowId ?? apId(),
+    }
+}
 
 type Solution = {
     table: Table

--- a/packages/server/api/test/integration/ce/ai-providers/ai-provider.test.ts
+++ b/packages/server/api/test/integration/ce/ai-providers/ai-provider.test.ts
@@ -1,0 +1,101 @@
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+import { AIProviderName, apId, PrincipalType } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { generateMockToken } from '../../../helpers/auth'
+import { mockAndSaveAIProvider } from '../../../helpers/mocks'
+import { createTestContext } from '../../../helpers/test-context'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('AI Provider API', () => {
+    describe('GET / (List AI Providers)', () => {
+        it('should list AI providers for the platform', async () => {
+            const ctx = await createTestContext(app!)
+            await mockAndSaveAIProvider({
+                platformId: ctx.platform.id,
+                provider: AIProviderName.OPENAI,
+            })
+
+            const response = await ctx.get('/v1/ai-providers')
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(Array.isArray(body)).toBe(true)
+            const openaiProvider = body.find((p: { provider: string }) => p.provider === AIProviderName.OPENAI)
+            expect(openaiProvider).toBeDefined()
+        })
+
+        it('should return list when no custom providers configured', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get('/v1/ai-providers')
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(Array.isArray(response.json())).toBe(true)
+        })
+    })
+
+    describe('DELETE /:id (Delete AI Provider)', () => {
+        it('should delete an AI provider', async () => {
+            const ctx = await createTestContext(app!)
+            const provider = await mockAndSaveAIProvider({
+                platformId: ctx.platform.id,
+                provider: AIProviderName.ANTHROPIC,
+            })
+
+            const response = await ctx.delete(`/v1/ai-providers/${provider.id}`)
+            expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+        })
+
+        it('should succeed when deleting non-existent provider', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.delete(`/v1/ai-providers/${apId()}`)
+            expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+        })
+    })
+
+    describe('GET /:provider/config (Engine-only)', () => {
+        it('should return provider config for ENGINE principal', async () => {
+            const ctx = await createTestContext(app!)
+            await mockAndSaveAIProvider({
+                platformId: ctx.platform.id,
+                provider: AIProviderName.OPENAI,
+            })
+
+            const engineToken = await generateMockToken({
+                id: ctx.user.id,
+                type: PrincipalType.ENGINE,
+                platform: { id: ctx.platform.id },
+            })
+
+            const response = await app!.inject({
+                method: 'GET',
+                url: `/v1/ai-providers/${AIProviderName.OPENAI}/config`,
+                headers: {
+                    authorization: `Bearer ${engineToken}`,
+                },
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(body.provider).toBe(AIProviderName.OPENAI)
+            expect(body.auth).toBeDefined()
+        })
+
+        it('should reject non-ENGINE principal', async () => {
+            const ctx = await createTestContext(app!)
+            await mockAndSaveAIProvider({
+                platformId: ctx.platform.id,
+                provider: AIProviderName.OPENAI,
+            })
+
+            const response = await ctx.get(`/v1/ai-providers/${AIProviderName.OPENAI}/config`)
+            expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+    })
+})

--- a/packages/server/api/test/integration/ce/flows/flow-run/flow-run.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow-run/flow-run.test.ts
@@ -1,0 +1,135 @@
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../../helpers/test-setup'
+import {
+    apId,
+    FlowRetryStrategy,
+    FlowRunStatus,
+} from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../../helpers/db'
+import {
+    createMockFlow,
+    createMockFlowRun,
+    createMockFlowVersion,
+} from '../../../../helpers/mocks'
+import { createTestContext } from '../../../../helpers/test-context'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Flow Run API', () => {
+    describe('GET /:id (Get Flow Run)', () => {
+        it('should return a flow run by id', async () => {
+            const ctx = await createTestContext(app!)
+
+            const mockFlow = createMockFlow({ projectId: ctx.project.id })
+            await db.save('flow', mockFlow)
+
+            const mockFlowVersion = createMockFlowVersion({ flowId: mockFlow.id })
+            await db.save('flow_version', mockFlowVersion)
+
+            const mockFlowRun = createMockFlowRun({
+                projectId: ctx.project.id,
+                flowId: mockFlow.id,
+                flowVersionId: mockFlowVersion.id,
+                status: FlowRunStatus.SUCCEEDED,
+                logsFileId: null,
+            })
+            await db.save('flow_run', mockFlowRun)
+
+            const response = await ctx.get(`/v1/flow-runs/${mockFlowRun.id}`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(body.id).toBe(mockFlowRun.id)
+            expect(body.projectId).toBe(ctx.project.id)
+            expect(body.flowId).toBe(mockFlow.id)
+        })
+
+        it('should return 404 for non-existent flow run', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get(`/v1/flow-runs/${apId()}`)
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+
+        it('should not return flow run from another project', async () => {
+            const ctx1 = await createTestContext(app!)
+            const ctx2 = await createTestContext(app!)
+
+            const mockFlow = createMockFlow({ projectId: ctx1.project.id })
+            await db.save('flow', mockFlow)
+
+            const mockFlowVersion = createMockFlowVersion({ flowId: mockFlow.id })
+            await db.save('flow_version', mockFlowVersion)
+
+            const mockFlowRun = createMockFlowRun({
+                projectId: ctx1.project.id,
+                flowId: mockFlow.id,
+                flowVersionId: mockFlowVersion.id,
+                logsFileId: null,
+            })
+            await db.save('flow_run', mockFlowRun)
+
+            const response = await ctx2.get(`/v1/flow-runs/${mockFlowRun.id}`)
+            expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+    })
+
+    describe('POST /archive (Bulk Archive)', () => {
+        it('should archive flow runs', async () => {
+            const ctx = await createTestContext(app!)
+
+            const mockFlow = createMockFlow({ projectId: ctx.project.id })
+            await db.save('flow', mockFlow)
+
+            const mockFlowVersion = createMockFlowVersion({ flowId: mockFlow.id })
+            await db.save('flow_version', mockFlowVersion)
+
+            const mockFlowRun = createMockFlowRun({
+                projectId: ctx.project.id,
+                flowId: mockFlow.id,
+                flowVersionId: mockFlowVersion.id,
+                status: FlowRunStatus.SUCCEEDED,
+                logsFileId: null,
+            })
+            await db.save('flow_run', mockFlowRun)
+
+            const response = await ctx.post('/v1/flow-runs/archive', {
+                projectId: ctx.project.id,
+                flowRunIds: [mockFlowRun.id],
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+        })
+    })
+
+    describe('POST /cancel (Bulk Cancel)', () => {
+        it('should handle cancel with no matching runs', async () => {
+            const ctx = await createTestContext(app!)
+
+            const response = await ctx.post('/v1/flow-runs/cancel', {
+                projectId: ctx.project.id,
+                flowRunIds: [apId()],
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+        })
+    })
+
+    describe('POST /retry (Bulk Retry)', () => {
+        it('should handle retry with no matching runs', async () => {
+            const ctx = await createTestContext(app!)
+
+            const response = await ctx.post('/v1/flow-runs/retry', {
+                projectId: ctx.project.id,
+                flowRunIds: [apId()],
+                strategy: FlowRetryStrategy.ON_LATEST_VERSION,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+        })
+    })
+})

--- a/packages/server/api/test/integration/ce/flows/flow-version/flow-version.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow-version/flow-version.test.ts
@@ -1,0 +1,73 @@
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../../helpers/test-setup'
+import { apId } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../../helpers/db'
+import { createMockFlow, createMockFlowVersion } from '../../../../helpers/mocks'
+import { createTestContext } from '../../../../helpers/test-context'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Flow Version API', () => {
+    describe('GET /:flowId/versions (List Flow Versions)', () => {
+        it('should list versions for a flow', async () => {
+            const ctx = await createTestContext(app!)
+            const mockFlow = createMockFlow({ projectId: ctx.project.id })
+            await db.save('flow', mockFlow)
+
+            const version1 = createMockFlowVersion({ flowId: mockFlow.id })
+            const version2 = createMockFlowVersion({ flowId: mockFlow.id })
+            await db.save('flow_version', [version1, version2])
+
+            const response = await ctx.get(`/v1/flows/${mockFlow.id}/versions`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(body.data.length).toBe(2)
+        })
+
+        it('should paginate versions', async () => {
+            const ctx = await createTestContext(app!)
+            const mockFlow = createMockFlow({ projectId: ctx.project.id })
+            await db.save('flow', mockFlow)
+
+            const versions = Array.from({ length: 3 }, () =>
+                createMockFlowVersion({ flowId: mockFlow.id }),
+            )
+            await db.save('flow_version', versions)
+
+            const response = await ctx.get(`/v1/flows/${mockFlow.id}/versions`, {
+                limit: '2',
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(body.data.length).toBe(2)
+            expect(body.next).toBeDefined()
+        })
+
+        it('should return 404 for non-existent flow', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get(`/v1/flows/${apId()}/versions`)
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+
+        it('should not return versions for flow in another project', async () => {
+            const ctx1 = await createTestContext(app!)
+            const ctx2 = await createTestContext(app!)
+            const mockFlow = createMockFlow({ projectId: ctx1.project.id })
+            await db.save('flow', mockFlow)
+            const version = createMockFlowVersion({ flowId: mockFlow.id })
+            await db.save('flow_version', version)
+
+            const response = await ctx2.get(`/v1/flows/${mockFlow.id}/versions`)
+            expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+    })
+})

--- a/packages/server/api/test/integration/ce/folders/folder.test.ts
+++ b/packages/server/api/test/integration/ce/folders/folder.test.ts
@@ -1,0 +1,164 @@
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+import { apId } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../helpers/db'
+import { createMockFolder } from '../../../helpers/mocks'
+import { createTestContext } from '../../../helpers/test-context'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Folder API', () => {
+    describe('POST / (Create Folder)', () => {
+        it('should create a folder', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.post('/v1/folders', {
+                displayName: 'Test Folder',
+                projectId: ctx.project.id,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(body.displayName).toBe('Test Folder')
+            expect(body.projectId).toBe(ctx.project.id)
+            expect(body.id).toBeDefined()
+        })
+    })
+
+    describe('POST /:id (Update Folder)', () => {
+        it('should update folder display name', async () => {
+            const ctx = await createTestContext(app!)
+            const folder = createMockFolder({ projectId: ctx.project.id })
+            await db.save('folder', folder)
+
+            const response = await ctx.post(`/v1/folders/${folder.id}`, {
+                displayName: 'Updated Name',
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().displayName).toBe('Updated Name')
+        })
+
+        it('should return 404 for non-existent folder', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.post(`/v1/folders/${apId()}`, {
+                displayName: 'Updated',
+            })
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+
+        it('should not update folder from another project', async () => {
+            const ctx1 = await createTestContext(app!)
+            const ctx2 = await createTestContext(app!)
+            const folder = createMockFolder({ projectId: ctx1.project.id })
+            await db.save('folder', folder)
+
+            const response = await ctx2.post(`/v1/folders/${folder.id}`, {
+                displayName: 'Hijacked',
+            })
+            expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+    })
+
+    describe('GET /:id (Get Folder)', () => {
+        it('should return a folder by id', async () => {
+            const ctx = await createTestContext(app!)
+            const folder = createMockFolder({ projectId: ctx.project.id })
+            await db.save('folder', folder)
+
+            const response = await ctx.get(`/v1/folders/${folder.id}`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().id).toBe(folder.id)
+            expect(response.json().displayName).toBe(folder.displayName)
+        })
+
+        it('should return 404 for non-existent folder', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get(`/v1/folders/${apId()}`)
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+
+        it('should not return folder from another project', async () => {
+            const ctx1 = await createTestContext(app!)
+            const ctx2 = await createTestContext(app!)
+            const folder = createMockFolder({ projectId: ctx1.project.id })
+            await db.save('folder', folder)
+
+            const response = await ctx2.get(`/v1/folders/${folder.id}`)
+            expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+    })
+
+    describe('GET / (List Folders)', () => {
+        it('should list folders for the project', async () => {
+            const ctx = await createTestContext(app!)
+            const folder1 = createMockFolder({ projectId: ctx.project.id })
+            const folder2 = createMockFolder({ projectId: ctx.project.id })
+            await db.save('folder', [folder1, folder2])
+
+            const response = await ctx.get('/v1/folders', {
+                projectId: ctx.project.id,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().data.length).toBe(2)
+        })
+
+        it('should return empty when no folders exist', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get('/v1/folders', {
+                projectId: ctx.project.id,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().data.length).toBe(0)
+        })
+
+        it('should not list folders from another project', async () => {
+            const ctx1 = await createTestContext(app!)
+            const ctx2 = await createTestContext(app!)
+            const folder = createMockFolder({ projectId: ctx1.project.id })
+            await db.save('folder', folder)
+
+            const response = await ctx2.get('/v1/folders', {
+                projectId: ctx2.project.id,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().data.length).toBe(0)
+        })
+    })
+
+    describe('DELETE /:id (Delete Folder)', () => {
+        it('should delete a folder', async () => {
+            const ctx = await createTestContext(app!)
+            const folder = createMockFolder({ projectId: ctx.project.id })
+            await db.save('folder', folder)
+
+            const response = await ctx.delete(`/v1/folders/${folder.id}`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+
+            const deleted = await db.findOneBy('folder', { id: folder.id })
+            expect(deleted).toBeNull()
+        })
+
+        it('should return 404 for non-existent folder', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.delete(`/v1/folders/${apId()}`)
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+
+        it('should not delete folder from another project', async () => {
+            const ctx1 = await createTestContext(app!)
+            const ctx2 = await createTestContext(app!)
+            const folder = createMockFolder({ projectId: ctx1.project.id })
+            await db.save('folder', folder)
+
+            const response = await ctx2.delete(`/v1/folders/${folder.id}`)
+            expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+    })
+})

--- a/packages/server/api/test/integration/ce/mcp/mcp-server.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-server.test.ts
@@ -1,0 +1,104 @@
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+import { McpServerStatus } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { createTestContext } from '../../../helpers/test-context'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('MCP Server API', () => {
+    describe('GET / (Get MCP Server)', () => {
+        it('should return the MCP server for the project (auto-created)', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get(`/v1/projects/${ctx.project.id}/mcp-server`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(body.projectId).toBe(ctx.project.id)
+            expect(body.token).toBeDefined()
+            expect(body.status).toBeDefined()
+        })
+
+        it('should return same server on subsequent calls', async () => {
+            const ctx = await createTestContext(app!)
+            const response1 = await ctx.get(`/v1/projects/${ctx.project.id}/mcp-server`)
+            const response2 = await ctx.get(`/v1/projects/${ctx.project.id}/mcp-server`)
+            expect(response1.json().id).toBe(response2.json().id)
+        })
+    })
+
+    describe('POST / (Update MCP Server)', () => {
+        it('should update MCP server status to ENABLED', async () => {
+            const ctx = await createTestContext(app!)
+            // Ensure server exists
+            await ctx.get(`/v1/projects/${ctx.project.id}/mcp-server`)
+
+            const response = await ctx.post(`/v1/projects/${ctx.project.id}/mcp-server`, {
+                status: McpServerStatus.ENABLED,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().status).toBe(McpServerStatus.ENABLED)
+        })
+
+        it('should update MCP server status to DISABLED', async () => {
+            const ctx = await createTestContext(app!)
+            await ctx.get(`/v1/projects/${ctx.project.id}/mcp-server`)
+
+            const response = await ctx.post(`/v1/projects/${ctx.project.id}/mcp-server`, {
+                status: McpServerStatus.DISABLED,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().status).toBe(McpServerStatus.DISABLED)
+        })
+    })
+
+    describe('POST /rotate (Rotate Token)', () => {
+        it('should rotate the MCP server token', async () => {
+            const ctx = await createTestContext(app!)
+            const getResponse = await ctx.get(`/v1/projects/${ctx.project.id}/mcp-server`)
+            const originalToken = getResponse.json().token
+
+            const rotateResponse = await ctx.post(`/v1/projects/${ctx.project.id}/mcp-server/rotate`)
+            expect(rotateResponse.statusCode).toBe(StatusCodes.OK)
+            expect(rotateResponse.json().token).not.toBe(originalToken)
+        })
+    })
+
+    describe('POST /http (Streamable HTTP - Public)', () => {
+        it('should reject requests with no auth header', async () => {
+            const ctx = await createTestContext(app!)
+            // Ensure server exists
+            await ctx.get(`/v1/projects/${ctx.project.id}/mcp-server`)
+
+            const response = await app!.inject({
+                method: 'POST',
+                url: `/v1/projects/${ctx.project.id}/mcp-server/http`,
+                headers: {},
+                body: {},
+            })
+            expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+        })
+
+        it('should reject requests with wrong Bearer token', async () => {
+            const ctx = await createTestContext(app!)
+            await ctx.get(`/v1/projects/${ctx.project.id}/mcp-server`)
+
+            const response = await app!.inject({
+                method: 'POST',
+                url: `/v1/projects/${ctx.project.id}/mcp-server/http`,
+                headers: {
+                    authorization: 'Bearer wrong-token',
+                },
+                body: {},
+            })
+            expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+        })
+    })
+})

--- a/packages/server/api/test/integration/ce/tables/field.test.ts
+++ b/packages/server/api/test/integration/ce/tables/field.test.ts
@@ -1,0 +1,143 @@
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+import { apId, FieldType } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../helpers/db'
+import { createMockField, createMockTable } from '../../../helpers/mocks'
+import { createTestContext } from '../../../helpers/test-context'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Field API', () => {
+    describe('POST / (Create Field)', () => {
+        it('should create a TEXT field', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const response = await ctx.post('/v1/fields', {
+                name: 'My Text Field',
+                type: FieldType.TEXT,
+                tableId: table.id,
+            })
+            expect(response.statusCode).toBe(StatusCodes.CREATED)
+            const body = response.json()
+            expect(body.name).toBe('My Text Field')
+            expect(body.type).toBe(FieldType.TEXT)
+            expect(body.tableId).toBe(table.id)
+        })
+
+        it('should create a STATIC_DROPDOWN field with options', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const response = await ctx.post('/v1/fields', {
+                name: 'Status',
+                type: FieldType.STATIC_DROPDOWN,
+                tableId: table.id,
+                data: {
+                    options: [{ value: 'Active' }, { value: 'Inactive' }],
+                },
+            })
+            expect(response.statusCode).toBe(StatusCodes.CREATED)
+            expect(response.json().type).toBe(FieldType.STATIC_DROPDOWN)
+        })
+
+        it('should fail when tableId does not exist', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.post('/v1/fields', {
+                name: 'Orphan Field',
+                type: FieldType.TEXT,
+                tableId: apId(),
+            })
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+    })
+
+    describe('GET / (List Fields)', () => {
+        it('should list fields for a table', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field1 = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            const field2 = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', [field1, field2])
+
+            const response = await ctx.get('/v1/fields', { tableId: table.id })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().length).toBe(2)
+        })
+    })
+
+    describe('GET /:id (Get Field By ID)', () => {
+        it('should return a field by id', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const response = await ctx.get(`/v1/fields/${field.id}`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().id).toBe(field.id)
+            expect(response.json().name).toBe(field.name)
+        })
+
+        it('should return 404 for non-existent field', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get(`/v1/fields/${apId()}`)
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+    })
+
+    describe('POST /:id (Update Field)', () => {
+        it('should update field name', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const response = await ctx.post(`/v1/fields/${field.id}`, {
+                name: 'Renamed Field',
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().name).toBe('Renamed Field')
+        })
+    })
+
+    describe('DELETE /:id (Delete Field)', () => {
+        it('should delete a field', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const response = await ctx.delete(`/v1/fields/${field.id}`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+
+            const deleted = await db.findOneBy('field', { id: field.id })
+            expect(deleted).toBeNull()
+        })
+
+        it('should return 404 for non-existent field', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.delete(`/v1/fields/${apId()}`)
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+    })
+})

--- a/packages/server/api/test/integration/ce/tables/record.test.ts
+++ b/packages/server/api/test/integration/ce/tables/record.test.ts
@@ -1,0 +1,190 @@
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+import { apId } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../helpers/db'
+import {
+    createMockCell,
+    createMockField,
+    createMockRecord,
+    createMockTable,
+} from '../../../helpers/mocks'
+import { createTestContext } from '../../../helpers/test-context'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Record API', () => {
+    describe('POST / (Create Records)', () => {
+        it('should create a single record with cells', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const response = await ctx.post('/v1/records', {
+                tableId: table.id,
+                records: [[{ fieldId: field.id, value: 'hello' }]],
+            })
+            expect(response.statusCode).toBe(StatusCodes.CREATED)
+            const body = response.json()
+            expect(body.length).toBe(1)
+            expect(body[0].cells).toBeDefined()
+        })
+
+        it('should create multiple records at once', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const response = await ctx.post('/v1/records', {
+                tableId: table.id,
+                records: [
+                    [{ fieldId: field.id, value: 'row1' }],
+                    [{ fieldId: field.id, value: 'row2' }],
+                ],
+            })
+            expect(response.statusCode).toBe(StatusCodes.CREATED)
+            expect(response.json().length).toBe(2)
+        })
+
+        it('should fail when tableId does not exist', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.post('/v1/records', {
+                tableId: apId(),
+                records: [[{ fieldId: apId(), value: 'test' }]],
+            })
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+    })
+
+    describe('GET /:id (Get Record By ID)', () => {
+        it('should return a record with populated cells', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const record = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('record', record)
+
+            const cell = createMockCell({ recordId: record.id, fieldId: field.id, projectId: ctx.project.id })
+            await db.save('cell', cell)
+
+            const response = await ctx.get(`/v1/records/${record.id}`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().id).toBe(record.id)
+            expect(response.json().cells).toBeDefined()
+        })
+
+        it('should return 404 for non-existent record', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get(`/v1/records/${apId()}`)
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+    })
+
+    describe('POST /:id (Update Record)', () => {
+        it('should update record cells', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const record = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('record', record)
+
+            const cell = createMockCell({ recordId: record.id, fieldId: field.id, projectId: ctx.project.id })
+            await db.save('cell', cell)
+
+            const response = await ctx.post(`/v1/records/${record.id}`, {
+                tableId: table.id,
+                cells: [{ fieldId: field.id, value: 'updated value' }],
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const cells = response.json().cells
+            expect(cells[field.id].value).toBe('updated value')
+        })
+    })
+
+    describe('DELETE / (Delete Records)', () => {
+        it('should delete records by ids', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const record1 = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            const record2 = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('record', [record1, record2])
+
+            const response = await ctx.inject({
+                method: 'DELETE',
+                url: '/v1/records',
+                body: {
+                    tableId: table.id,
+                    ids: [record1.id, record2.id],
+                },
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+
+            const remaining1 = await db.findOneBy('record', { id: record1.id })
+            const remaining2 = await db.findOneBy('record', { id: record2.id })
+            expect(remaining1).toBeNull()
+            expect(remaining2).toBeNull()
+        })
+    })
+
+    describe('GET / (List Records)', () => {
+        it('should list records for a table', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const record1 = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            const record2 = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('record', [record1, record2])
+
+            const response = await ctx.get('/v1/records', { tableId: table.id })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().data.length).toBe(2)
+        })
+
+        it('should paginate records', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const records = Array.from({ length: 3 }, () =>
+                createMockRecord({ tableId: table.id, projectId: ctx.project.id }),
+            )
+            await db.save('record', records)
+
+            const response = await ctx.get('/v1/records', {
+                tableId: table.id,
+                limit: '2',
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().data.length).toBe(2)
+            expect(response.json().next).toBeDefined()
+        })
+    })
+})

--- a/packages/server/api/test/integration/ce/tables/table.test.ts
+++ b/packages/server/api/test/integration/ce/tables/table.test.ts
@@ -1,0 +1,280 @@
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+import { apId, FieldType, TableWebhookEventType } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../helpers/db'
+import {
+    createMockField,
+    createMockFlow,
+    createMockRecord,
+    createMockCell,
+    createMockTable,
+    createMockTableWebhook,
+} from '../../../helpers/mocks'
+import { createTestContext } from '../../../helpers/test-context'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Table API', () => {
+    describe('POST / (Create Table)', () => {
+        it('should create a table with name', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.post('/v1/tables', {
+                projectId: ctx.project.id,
+                name: 'Test Table',
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(body.name).toBe('Test Table')
+            expect(body.projectId).toBe(ctx.project.id)
+            expect(body.id).toBeDefined()
+        })
+
+        it('should create a table with externalId', async () => {
+            const ctx = await createTestContext(app!)
+            const externalId = apId()
+            const response = await ctx.post('/v1/tables', {
+                projectId: ctx.project.id,
+                name: 'External Table',
+                externalId,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().externalId).toBe(externalId)
+        })
+    })
+
+    describe('POST /:id (Update Table)', () => {
+        it('should update table name', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const response = await ctx.post(`/v1/tables/${table.id}`, {
+                name: 'Updated Table',
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().name).toBe('Updated Table')
+        })
+
+        it('should return 404 for non-existent table', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.post(`/v1/tables/${apId()}`, {
+                name: 'Nope',
+            })
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+
+        it('should not allow updating table from another project', async () => {
+            const ctx1 = await createTestContext(app!)
+            const ctx2 = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx1.project.id })
+            await db.save('table', table)
+
+            const response = await ctx2.post(`/v1/tables/${table.id}`, {
+                name: 'Hijacked',
+            })
+            expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+    })
+
+    describe('GET / (List Tables)', () => {
+        it('should list tables for the project', async () => {
+            const ctx = await createTestContext(app!)
+            const table1 = createMockTable({ projectId: ctx.project.id })
+            const table2 = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', [table1, table2])
+
+            const response = await ctx.get('/v1/tables', {
+                projectId: ctx.project.id,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().data.length).toBe(2)
+        })
+
+        it('should filter tables by name', async () => {
+            const ctx = await createTestContext(app!)
+            const table1 = createMockTable({ projectId: ctx.project.id })
+            table1.name = 'UniqueSearchName'
+            const table2 = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', [table1, table2])
+
+            const response = await ctx.get('/v1/tables', {
+                projectId: ctx.project.id,
+                name: 'UniqueSearchName',
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().data.length).toBe(1)
+            expect(response.json().data[0].name).toBe('UniqueSearchName')
+        })
+
+        it('should not list tables from another project', async () => {
+            const ctx1 = await createTestContext(app!)
+            const ctx2 = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx1.project.id })
+            await db.save('table', table)
+
+            const response = await ctx2.get('/v1/tables', {
+                projectId: ctx2.project.id,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().data.length).toBe(0)
+        })
+    })
+
+    describe('GET /:id (Get Table By ID)', () => {
+        it('should return a table by id', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const response = await ctx.get(`/v1/tables/${table.id}`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().id).toBe(table.id)
+            expect(response.json().name).toBe(table.name)
+        })
+
+        it('should return 404 for non-existent table', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get(`/v1/tables/${apId()}`)
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+    })
+
+    describe('GET /:id/export (Export Table)', () => {
+        it('should export table with fields and rows', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const record = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('record', record)
+
+            const cell = createMockCell({ recordId: record.id, fieldId: field.id, projectId: ctx.project.id })
+            await db.save('cell', cell)
+
+            const response = await ctx.get(`/v1/tables/${table.id}/export`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(body.name).toBe(table.name)
+            expect(body.fields.length).toBe(1)
+            expect(body.rows.length).toBe(1)
+        })
+
+        it('should export empty table', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const response = await ctx.get(`/v1/tables/${table.id}/export`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+            expect(body.rows.length).toBe(0)
+        })
+    })
+
+    describe('DELETE /:id (Delete Table)', () => {
+        it('should delete a table', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const response = await ctx.delete(`/v1/tables/${table.id}`)
+            expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+
+            const deleted = await db.findOneBy('table', { id: table.id })
+            expect(deleted).toBeNull()
+        })
+
+        it('should return 404 for non-existent table', async () => {
+            const ctx = await createTestContext(app!)
+            const response = await ctx.delete(`/v1/tables/${apId()}`)
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+    })
+
+    describe('POST /:id/webhooks (Create Table Webhook)', () => {
+        it('should create a webhook for a table', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const flow = createMockFlow({ projectId: ctx.project.id })
+            await db.save('flow', flow)
+
+            const response = await ctx.post(`/v1/tables/${table.id}/webhooks`, {
+                events: [TableWebhookEventType.RECORD_CREATED],
+                webhookUrl: 'https://example.com/webhook',
+                flowId: flow.id,
+            })
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            expect(response.json().tableId).toBe(table.id)
+        })
+    })
+
+    describe('DELETE /:id/webhooks/:webhookId (Delete Table Webhook)', () => {
+        it('should delete a webhook', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const flow = createMockFlow({ projectId: ctx.project.id })
+            await db.save('flow', flow)
+
+            const webhook = createMockTableWebhook({
+                tableId: table.id,
+                projectId: ctx.project.id,
+                flowId: flow.id,
+            })
+            await db.save('table_webhook', webhook)
+
+            const response = await ctx.delete(`/v1/tables/${table.id}/webhooks/${webhook.id}`)
+            expect(response.statusCode).toBe(StatusCodes.OK)
+        })
+    })
+
+    describe('POST /:id/clear (Clear Table Records)', () => {
+        it('should clear all records from a table', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('field', field)
+
+            const record = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('record', record)
+
+            const cell = createMockCell({ recordId: record.id, fieldId: field.id, projectId: ctx.project.id })
+            await db.save('cell', cell)
+
+            const response = await ctx.post(`/v1/tables/${table.id}/clear`)
+            expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+
+            const remainingRecord = await db.findOneBy('record', { tableId: table.id })
+            expect(remainingRecord).toBeNull()
+        })
+
+        it('should succeed on table with no records', async () => {
+            const ctx = await createTestContext(app!)
+            const table = createMockTable({ projectId: ctx.project.id })
+            await db.save('table', table)
+
+            const response = await ctx.post(`/v1/tables/${table.id}/clear`)
+            expect(response.statusCode).toBe(StatusCodes.NO_CONTENT)
+        })
+    })
+})


### PR DESCRIPTION
## Summary

- Add **72 new integration tests** across **8 test files** for 6 previously untested API endpoint groups:
  - **Tables** (18 tests): CRUD, export, webhooks, clear records
  - **Fields** (9 tests): CRUD for TEXT, STATIC_DROPDOWN types
  - **Records** (9 tests): CRUD, bulk delete, pagination
  - **Folders** (13 tests): CRUD + cross-project isolation
  - **Flow Versions** (4 tests): list + pagination
  - **Flow Runs** (6 tests): get by ID, archive, cancel, retry (previously only list was tested)
  - **MCP Server** (7 tests): auto-creation, status update, token rotation, auth rejection
  - **AI Providers** (6 tests): list, delete, engine-only config access
- Export 4 existing private mock helpers (`createMockTable`, `createMockField`, `createMockRecord`, `createMockCell`) and add 2 new ones (`createMockFolder`, `createMockTableWebhook`)

## Test plan
- [x] All 72 new tests pass
- [x] Full CE suite (107 tests) passes with zero regressions