### PR TITLE
fix: update array property to handle default values within its inner fields

### DIFF
--- a/packages/web/src/app/builder/piece-properties/array-property.tsx
+++ b/packages/web/src/app/builder/piece-properties/array-property.tsx
@@ -32,6 +32,12 @@ type ArrayField = {
 
 const getDefaultValuesForInputs = (arrayProperties: ArraySubProps<boolean>) => {
   return Object.entries(arrayProperties).reduce((acc, [key, value]) => {
+    if (value.defaultValue !== undefined) {
+      return {
+        ...acc,
+        [key]: value.defaultValue,
+      };
+    }
     switch (value.type) {
       case PropertyType.LONG_TEXT:
       case PropertyType.SHORT_TEXT:
@@ -51,10 +57,6 @@ const getDefaultValuesForInputs = (arrayProperties: ArraySubProps<boolean>) => {
       case PropertyType.STATIC_MULTI_SELECT_DROPDOWN:
       case PropertyType.MULTI_SELECT_DROPDOWN:
       case PropertyType.DATE_TIME:
-        return {
-          ...acc,
-          [key]: null,
-        };
       case PropertyType.FILE:
         return {
           ...acc,


### PR DESCRIPTION
## What does this PR do?

This PR fixes a frontend bug where adding a new item to a `Property.Array` ignored the `defaultValue` explicitly defined by the piece developer for nested sub-properties. 

Previously, appending a new array item forced all nested fields to empty strings, `false`, or `null` based purely on their property type, leading to missing data and backend evaluation errors (e.g., `undefined` numbers) if the user didn't manually interact with the field.

### Explain How the Feature Works
The `getDefaultValuesForInputs` function has been updated to check if a `defaultValue` exists on the sub-property schema before applying the standard empty-state fallbacks. 

Now, when a user clicks the **"+ Add Item"** button, the React Hook Form is correctly populated with the developer's intended defaults:
1. It checks `if (value.defaultValue !== undefined)` and applies it if present.
2. If no `defaultValue` is specified, it safely falls through to the existing `switch (value.type)` statement to assign `''`, `false`, or `null`.

### Relevant User Scenarios

* **Improved Piece Developer Experience:** Piece developers can now safely rely on `defaultValue` inside array properties.