### PR TITLE
add assign-conversation-to-admin action

### DIFF
--- a/packages/pieces/community/intercom/src/index.ts
+++ b/packages/pieces/community/intercom/src/index.ts
@@ -46,6 +46,7 @@ import { newUserTrigger } from './lib/triggers/new-user';
 import { tagAddedToUserTrigger } from './lib/triggers/tag-added-to-user';
 import { contactUpdatedTrigger } from './lib/triggers/contact-updated';
 import { intercomAuth } from './lib/auth';
+import { assignConversationAction } from './lib/actions/assign-conversation-to-admin';
 
 export const intercom = createPiece({
 	displayName: 'Intercom',
@@ -68,6 +69,7 @@ export const intercom = createPiece({
 		addOrRemoveTagOnContactAction,
 		addOrRemoveTagOnCompanyAction,
 		addOrRemoveTagOnConversationAction,
+		assignConversationAction,
 		createArticleAction,
 		createConversationAction,
 		createTicketAction,

--- a/packages/pieces/community/intercom/src/lib/actions/assign-conversation-to-admin.ts
+++ b/packages/pieces/community/intercom/src/lib/actions/assign-conversation-to-admin.ts
@@ -1,0 +1,40 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { intercomAuth } from '../auth';
+import { commonProps, intercomClient } from '../common';
+import { conversationIdProp } from '../common/props';
+
+export const assignConversationAction = createAction({
+	auth: intercomAuth,
+	name: 'assignConversationAction',
+	displayName: 'Assign conversation to an admin or a team',
+	description: '(Re)assign conversation to a specific admin or team.',
+	props: {
+		from: commonProps.admins({ displayName: 'From (Admin)', required: true }),
+		conversationId:conversationIdProp('Conversation ID', true),
+		assigneeId: Property.ShortText({
+			displayName: 'Assignee ID',
+			description: 'The ID of the admin or team to assign this conversation to',
+			required: true,
+		}),
+		body: Property.ShortText({
+			displayName: 'Message Body',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const client = intercomClient(context.auth);
+
+		const response = await client.conversations.manage({
+			conversation_id: context.propsValue.conversationId!,
+			body: {
+				type: 'admin',
+				message_type: 'assignment',
+				admin_id: context.propsValue.from,
+				assignee_id: context.propsValue.assigneeId,
+				body: context.propsValue.body,
+			},
+		});
+
+		return response;
+	},
+});


### PR DESCRIPTION
## What does this PR do?
Added action for assigning conversation to a team or an admin.

When a customer starts a chat on a website (via Intercom), it usually goes into a general pile. This action allows an automation (the "Active Piece") to automatically pick up that conversation and hand it to a specific admin or team.

### Explain How the Feature Works
Imagine a user setting up an automation. Here is how they would use it:
Step A: The Trigger: Something happens (for example: a VIP customer sends a message).
Step B: This Action (Assign Conversation): The automation platform reaches out to Intercom using this action.
Step C: The Handoff:
The platform says: "Hey Intercom, take Conversation #123."
"Assign it to admin/team #999 (the Assignee)."
"Tell Intercom that Admin #456 (the 'From' ID) is the one making this change."
Step D: The Result: In the Intercom dashboard, the conversation suddenly moves from the "Unassigned" folder into the "Assigned to [Admin/Team Name]" folder.


### Relevant User Scenarios
https://alanhealth.slack.com/archives/C01S8JZH46L/p1762782735505439?thread_ts=1762782735.505439&cid=C01S8JZH46L
