### PR TITLE
fix: correct the build path for piece utils

### DIFF
--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -51,8 +51,8 @@ export async function buildPiece(pieceFolder: string): Promise<{ outputFolder: s
     const packageJson = await readPackageJson(pieceFolder);
 
     await buildPackage(packageJson.name);
-
-    const compiledPath = `dist/packages/${removeStartingSlashes(pieceFolder).split(path.sep + 'packages')[1]}`;
+     
+    const compiledPath = `packages/${removeStartingSlashes(pieceFolder).split(path.sep + 'packages')[1]}/dist`;
 
     await copyFile(path.join(pieceFolder, 'package.json'), path.join(compiledPath, 'package.json'));
 


### PR DESCRIPTION
## What does this PR do?

The change introduced in [this](https://github.com/activepieces/activepieces/pull/11410) pr configures pieces to build in their own respective `dist` folders.  Building custom pieces should follow the same logic, so the build path should be inside of the piece being built by the CLI.  

### Explain How the Feature Works
The compile path is changed to match the way pieces are compiled when using the [piece-script-utils.ts](tools/scripts/utils/piece-script-utils.ts), and target the `dist` folder inside the piece.  
### Relevant User Scenarios

This makes `bun build-pieces <piecename>` work again for pieces in /custom folder
