### PR TITLE
fix(cli): resolve workspace deps in sync-pieces

### DIFF
--- a/packages/cli/src/lib/utils/piece-utils.ts
+++ b/packages/cli/src/lib/utils/piece-utils.ts
@@ -7,6 +7,7 @@ import axios from 'axios'
 import chalk from 'chalk'
 import FormData from 'form-data';
 import fs from 'fs';
+import { buildWorkspaceVersionMap, resolveWorkspaceDependencies } from '../../../../../tools/scripts/utils/workspace-utils';
 
 export const piecesPath = () => path.join(cwd(), 'packages', 'pieces')
 export const customPiecePath = () => path.join(piecesPath(), 'custom')
@@ -51,10 +52,12 @@ export async function buildPiece(pieceFolder: string): Promise<{ outputFolder: s
     const packageJson = await readPackageJson(pieceFolder);
 
     await buildPackage(packageJson.name);
-     
+
     const compiledPath = `packages/${removeStartingSlashes(pieceFolder).split(path.sep + 'packages')[1]}/dist`;
 
     await copyFile(path.join(pieceFolder, 'package.json'), path.join(compiledPath, 'package.json'));
+
+    resolveWorkspaceDepsInPackageJson(path.join(compiledPath, 'package.json'), cwd());
 
     const { stdout } = await exec('npm pack --json', { cwd: compiledPath });
     const tarFileName = JSON.parse(stdout)[0].filename;
@@ -175,3 +178,12 @@ export const assertPieceExists = async (pieceName: string | null) => {
   export const removeStartingSlashes = (str: string) => {
     return str.startsWith('/') ? str.slice(1) : str;
   }
+
+function resolveWorkspaceDepsInPackageJson(packageJsonPath: string, rootDir: string): void {
+    const versionMap = buildWorkspaceVersionMap(rootDir)
+    const json = JSON.parse(fs.readFileSync(packageJsonPath).toString())
+    json.dependencies = resolveWorkspaceDependencies(json.dependencies, versionMap)
+    json.devDependencies = resolveWorkspaceDependencies(json.devDependencies, versionMap)
+    json.peerDependencies = resolveWorkspaceDependencies(json.peerDependencies, versionMap)
+    fs.writeFileSync(packageJsonPath, JSON.stringify(json, null, 2))
+}

--- a/tools/scripts/utils/publish-npm-package.ts
+++ b/tools/scripts/utils/publish-npm-package.ts
@@ -1,66 +1,10 @@
 import assert from 'node:assert'
 import { argv } from 'node:process'
 import { execSync } from 'node:child_process'
-import { existsSync, readFileSync, writeFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { readPackageJson } from './files'
 import { packagePrePublishChecks } from './package-pre-publish-checks'
-
-function buildWorkspaceVersionMap(): Map<string, string> {
-  const versionMap = new Map<string, string>()
-  const rootPkg = JSON.parse(readFileSync('package.json').toString())
-  const workspacePatterns: string[] = rootPkg.workspaces ?? []
-
-  for (const pattern of workspacePatterns) {
-    if (pattern.endsWith('/*')) {
-      const dir = pattern.slice(0, -2)
-      if (!existsSync(dir)) {
-        continue
-      }
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (entry.isDirectory()) {
-          const pkgPath = join(dir, entry.name, 'package.json')
-          if (existsSync(pkgPath)) {
-            const pkg = JSON.parse(readFileSync(pkgPath).toString())
-            versionMap.set(pkg.name, pkg.version)
-          }
-        }
-      }
-    } else {
-      const pkgPath = join(pattern, 'package.json')
-      if (existsSync(pkgPath)) {
-        const pkg = JSON.parse(readFileSync(pkgPath).toString())
-        versionMap.set(pkg.name, pkg.version)
-      }
-    }
-  }
-
-  return versionMap
-}
-
-function resolveWorkspaceDependencies(
-  deps: Record<string, string> | undefined,
-  versionMap: Map<string, string>,
-): Record<string, string> | undefined {
-  if (!deps) {
-    return deps
-  }
-  const resolved: Record<string, string> = {}
-  for (const [name, version] of Object.entries(deps)) {
-    if (version.startsWith('workspace:')) {
-      const resolvedVersion = versionMap.get(name)
-      if (resolvedVersion) {
-        resolved[name] = resolvedVersion
-        console.info(`[publishPackage] resolved ${name}: ${version} -> ${resolvedVersion}`)
-      } else {
-        throw new Error(`[publishPackage] failed to resolve workspace dependency ${name}: ${version}. Package not found in workspace.`)
-      }
-    } else {
-      resolved[name] = version
-    }
-  }
-  return resolved
-}
+import { buildWorkspaceVersionMap, resolveWorkspaceDependencies } from './workspace-utils'
 
 function assertNoUnresolvedWorkspaceDeps(packageJsonPath: string): void {
   const json = JSON.parse(readFileSync(packageJsonPath).toString())
@@ -104,7 +48,7 @@ export const publishNpmPackage = async (path: string): Promise<void> => {
   const { version } = await readPackageJson(path)
 
   // Update version and resolve workspace dependencies in dist package.json before publishing
-  const versionMap = buildWorkspaceVersionMap()
+  const versionMap = buildWorkspaceVersionMap(process.cwd())
   const json = JSON.parse(readFileSync(`${outputPath}/package.json`).toString())
   json.version = version
   json.main = './src/index.js'

--- a/tools/scripts/utils/workspace-utils.ts
+++ b/tools/scripts/utils/workspace-utils.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+export function buildWorkspaceVersionMap(rootDir: string): Map<string, string> {
+  const versionMap = new Map<string, string>()
+  const rootPkg = JSON.parse(readFileSync(join(rootDir, 'package.json')).toString())
+  const workspacePatterns: string[] = rootPkg.workspaces ?? []
+
+  for (const pattern of workspacePatterns) {
+    if (pattern.endsWith('/*')) {
+      const dir = join(rootDir, pattern.slice(0, -2))
+      if (!existsSync(dir)) {
+        continue
+      }
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+          const pkgPath = join(dir, entry.name, 'package.json')
+          if (existsSync(pkgPath)) {
+            const pkg = JSON.parse(readFileSync(pkgPath).toString())
+            versionMap.set(pkg.name, pkg.version)
+          }
+        }
+      }
+    } else {
+      const pkgPath = join(rootDir, pattern, 'package.json')
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath).toString())
+        versionMap.set(pkg.name, pkg.version)
+      }
+    }
+  }
+
+  return versionMap
+}
+
+export function resolveWorkspaceDependencies(
+  deps: Record<string, string> | undefined,
+  versionMap: Map<string, string>,
+): Record<string, string> | undefined {
+  if (!deps) {
+    return deps
+  }
+  const resolved: Record<string, string> = {}
+  for (const [name, version] of Object.entries(deps)) {
+    if (version.startsWith('workspace:')) {
+      const resolvedVersion = versionMap.get(name)
+      if (resolvedVersion) {
+        resolved[name] = resolvedVersion
+      } else {
+        throw new Error(`Failed to resolve workspace dependency ${name}: ${version}. Package not found in workspace.`)
+      }
+    } else {
+      resolved[name] = version
+    }
+  }
+  return resolved
+}


### PR DESCRIPTION
## Summary

- The `sync-pieces` CLI command was copying `package.json` into the dist folder and running `npm pack` without resolving `workspace:*` dependency references to actual versions. This meant uploaded piece archives contained unresolved workspace references instead of exact versions.
- Extracted `buildWorkspaceVersionMap` and `resolveWorkspaceDependencies` into a shared `tools/scripts/utils/workspace-utils.ts` module (previously duplicated only in `publish-npm-package.ts`).
- Added a `resolveWorkspaceDepsInPackageJson` step in `buildPiece()` that resolves all `workspace:*` references in `dependencies`, `devDependencies`, and `peerDependencies` before `npm pack`.

## Test plan

- [ ] Run `npm run sync-pieces -- --apiUrl <url>` and verify the uploaded piece archive contains resolved version numbers instead of `workspace:*`
- [ ] Run `npm run publish-piece` and verify npm publishing still resolves workspace deps correctly