### PR TITLE
refactor: add lazy loading for heavy route features (ENG-268)

### DIFF
--- a/packages/web/src/app/routes/platform-routes.tsx
+++ b/packages/web/src/app/routes/platform-routes.tsx
@@ -1,29 +1,77 @@
+import React, { Suspense } from 'react';
 import { Navigate } from 'react-router-dom';
 
 import { PageTitle } from '@/app/components/page-title';
 import { Error, Success } from '@/features/billing';
 
+import { LoadingScreen } from '../../components/ui/loading-screen';
 import { PlatformLayout } from '../components/platform-layout';
 
-import SettingsBilling from './platform/billing';
-import EventDestinationsPage from './platform/infra/event-destinations';
-import SettingsHealthPage from './platform/infra/health';
-import TriggerHealthPage from './platform/infra/triggers';
-import SettingsWorkersPage from './platform/infra/workers';
-import ProjectsPage from './platform/projects';
-import { ApiKeysPage } from './platform/security/api-keys';
-import AuditLogsPage from './platform/security/audit-logs';
-import { ProjectRolePage } from './platform/security/project-role';
-import { ProjectRoleUsersTable } from './platform/security/project-role/project-role-users-table';
-import SecretManagersPage from './platform/security/secret-managers';
-import { SigningKeysPage } from './platform/security/signing-keys';
-import { SSOPage } from './platform/security/sso';
-import AIProvidersPage from './platform/setup/ai';
-import { BrandingPage } from './platform/setup/branding';
-import { GlobalConnectionsTable } from './platform/setup/connections';
-import { PlatformPiecesPage } from './platform/setup/pieces';
-import { PlatformTemplatesPage } from './platform/setup/templates';
-import UsersPage from './platform/users';
+const SettingsBilling = React.lazy(() => import('./platform/billing'));
+const EventDestinationsPage = React.lazy(
+  () => import('./platform/infra/event-destinations'),
+);
+const SettingsHealthPage = React.lazy(() => import('./platform/infra/health'));
+const TriggerHealthPage = React.lazy(() => import('./platform/infra/triggers'));
+const SettingsWorkersPage = React.lazy(
+  () => import('./platform/infra/workers'),
+);
+const ProjectsPage = React.lazy(() => import('./platform/projects'));
+const ApiKeysPage = React.lazy(() =>
+  import('./platform/security/api-keys').then((m) => ({
+    default: m.ApiKeysPage,
+  })),
+);
+const AuditLogsPage = React.lazy(
+  () => import('./platform/security/audit-logs'),
+);
+const ProjectRolePage = React.lazy(() =>
+  import('./platform/security/project-role').then((m) => ({
+    default: m.ProjectRolePage,
+  })),
+);
+const ProjectRoleUsersTable = React.lazy(() =>
+  import('./platform/security/project-role/project-role-users-table').then(
+    (m) => ({ default: m.ProjectRoleUsersTable }),
+  ),
+);
+const SecretManagersPage = React.lazy(
+  () => import('./platform/security/secret-managers'),
+);
+const SigningKeysPage = React.lazy(() =>
+  import('./platform/security/signing-keys').then((m) => ({
+    default: m.SigningKeysPage,
+  })),
+);
+const SSOPage = React.lazy(() =>
+  import('./platform/security/sso').then((m) => ({ default: m.SSOPage })),
+);
+const AIProvidersPage = React.lazy(() => import('./platform/setup/ai'));
+const BrandingPage = React.lazy(() =>
+  import('./platform/setup/branding').then((m) => ({
+    default: m.BrandingPage,
+  })),
+);
+const GlobalConnectionsTable = React.lazy(() =>
+  import('./platform/setup/connections').then((m) => ({
+    default: m.GlobalConnectionsTable,
+  })),
+);
+const PlatformPiecesPage = React.lazy(() =>
+  import('./platform/setup/pieces').then((m) => ({
+    default: m.PlatformPiecesPage,
+  })),
+);
+const PlatformTemplatesPage = React.lazy(() =>
+  import('./platform/setup/templates').then((m) => ({
+    default: m.PlatformTemplatesPage,
+  })),
+);
+const UsersPage = React.lazy(() => import('./platform/users'));
+
+function SuspenseWrapper({ children }: { children: React.ReactNode }) {
+  return <Suspense fallback={<LoadingScreen />}>{children}</Suspense>;
+}
 
 export const platformRoutes = [
   {
@@ -41,7 +89,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Projects">
-          <ProjectsPage />
+          <SuspenseWrapper>
+            <ProjectsPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -51,7 +101,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Users">
-          <UsersPage />
+          <SuspenseWrapper>
+            <UsersPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -71,7 +123,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="AI">
-          <AIProvidersPage />
+          <SuspenseWrapper>
+            <AIProvidersPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -81,7 +135,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Pieces">
-          <PlatformPiecesPage />
+          <SuspenseWrapper>
+            <PlatformPiecesPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -91,7 +147,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Connections">
-          <GlobalConnectionsTable />
+          <SuspenseWrapper>
+            <GlobalConnectionsTable />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -101,7 +159,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Templates">
-          <PlatformTemplatesPage />
+          <SuspenseWrapper>
+            <PlatformTemplatesPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -111,7 +171,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Branding">
-          <BrandingPage />
+          <SuspenseWrapper>
+            <BrandingPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -121,7 +183,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Billing">
-          <SettingsBilling />
+          <SuspenseWrapper>
+            <SettingsBilling />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -161,7 +225,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="API Keys">
-          <ApiKeysPage />
+          <SuspenseWrapper>
+            <ApiKeysPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -171,7 +237,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Secret managers">
-          <SecretManagersPage />
+          <SuspenseWrapper>
+            <SecretManagersPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -181,7 +249,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Audit Logs">
-          <AuditLogsPage />
+          <SuspenseWrapper>
+            <AuditLogsPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -191,7 +261,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Signing Keys">
-          <SigningKeysPage />
+          <SuspenseWrapper>
+            <SigningKeysPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -201,7 +273,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="SSO">
-          <SSOPage />
+          <SuspenseWrapper>
+            <SSOPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -211,7 +285,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Project Roles">
-          <ProjectRolePage />
+          <SuspenseWrapper>
+            <ProjectRolePage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -221,7 +297,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Project Role Users">
-          <ProjectRoleUsersTable />
+          <SuspenseWrapper>
+            <ProjectRoleUsersTable />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -241,7 +319,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Workers">
-          <SettingsWorkersPage />
+          <SuspenseWrapper>
+            <SettingsWorkersPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -251,7 +331,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="System Health">
-          <SettingsHealthPage />
+          <SuspenseWrapper>
+            <SettingsHealthPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -261,7 +343,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Trigger Health">
-          <TriggerHealthPage />
+          <SuspenseWrapper>
+            <TriggerHealthPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),
@@ -271,7 +355,9 @@ export const platformRoutes = [
     element: (
       <PlatformLayout>
         <PageTitle title="Event Streaming">
-          <EventDestinationsPage />
+          <SuspenseWrapper>
+            <EventDestinationsPage />
+          </SuspenseWrapper>
         </PageTitle>
       </PlatformLayout>
     ),

--- a/packages/web/src/app/routes/project-routes.tsx
+++ b/packages/web/src/app/routes/project-routes.tsx
@@ -1,27 +1,47 @@
 import { Permission } from '@activepieces/shared';
+import React, { Suspense } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 
 import { PageTitle } from '@/app/components/page-title';
 import { ApTableStateProvider } from '@/features/tables';
 import { routesThatRequireProjectId } from '@/lib/route-utils';
 
+import { LoadingScreen } from '../../components/ui/loading-screen';
 import { BuilderLayout } from '../components/builder-layout';
 import { ProjectDashboardLayout } from '../components/project-layout';
 import { AfterImportFlowRedirect } from '../guards/after-import-flow-redirect';
 import { RoutePermissionGuard } from '../guards/permission-guard';
 import { ProjectRouterWrapper } from '../guards/project-route-wrapper';
 
-import { AppConnectionsPage } from './connections';
-import { FlowsPage } from './flows';
-import { FlowBuilderPage } from './flows/id';
-import AnalyticsPage from './impact';
-import LeaderboardPage from './leaderboard';
-import { ProjectReleasesPage } from './project-release';
-import ViewRelease from './project-release/view-release';
-import { RunsPage } from './runs';
-import { FlowRunPage } from './runs/id';
-import { ApTablesPage } from './tables';
-import { ApTableEditorPage } from './tables/id';
+const FlowsPage = React.lazy(() =>
+  import('./flows').then((m) => ({ default: m.FlowsPage })),
+);
+const FlowBuilderPage = React.lazy(() =>
+  import('./flows/id').then((m) => ({ default: m.FlowBuilderPage })),
+);
+const AnalyticsPage = React.lazy(() => import('./impact'));
+const LeaderboardPage = React.lazy(() => import('./leaderboard'));
+const ProjectReleasesPage = React.lazy(() =>
+  import('./project-release').then((m) => ({
+    default: m.ProjectReleasesPage,
+  })),
+);
+const ViewRelease = React.lazy(() => import('./project-release/view-release'));
+const RunsPage = React.lazy(() =>
+  import('./runs').then((m) => ({ default: m.RunsPage })),
+);
+const FlowRunPage = React.lazy(() =>
+  import('./runs/id').then((m) => ({ default: m.FlowRunPage })),
+);
+const AppConnectionsPage = React.lazy(() =>
+  import('./connections').then((m) => ({ default: m.AppConnectionsPage })),
+);
+const ApTablesPage = React.lazy(() =>
+  import('./tables').then((m) => ({ default: m.ApTablesPage })),
+);
+const ApTableEditorPage = React.lazy(() =>
+  import('./tables/id').then((m) => ({ default: m.ApTableEditorPage })),
+);
 
 const SettingsRerouter = () => {
   const { hash } = useLocation();
@@ -33,6 +53,10 @@ const SettingsRerouter = () => {
   );
 };
 
+function SuspenseWrapper({ children }: { children: React.ReactNode }) {
+  return <Suspense fallback={<LoadingScreen />}>{children}</Suspense>;
+}
+
 export const projectRoutes = [
   ...ProjectRouterWrapper({
     path: routesThatRequireProjectId.flows,
@@ -40,7 +64,9 @@ export const projectRoutes = [
       <ProjectDashboardLayout>
         <RoutePermissionGuard permission={Permission.READ_FLOW}>
           <PageTitle title="Flows">
-            <FlowsPage />
+            <SuspenseWrapper>
+              <FlowsPage />
+            </SuspenseWrapper>
           </PageTitle>
         </RoutePermissionGuard>
       </ProjectDashboardLayout>
@@ -52,7 +78,9 @@ export const projectRoutes = [
       <RoutePermissionGuard permission={Permission.READ_FLOW}>
         <PageTitle title="Builder">
           <BuilderLayout>
-            <FlowBuilderPage />
+            <SuspenseWrapper>
+              <FlowBuilderPage />
+            </SuspenseWrapper>
           </BuilderLayout>
         </PageTitle>
       </RoutePermissionGuard>
@@ -68,7 +96,9 @@ export const projectRoutes = [
       <RoutePermissionGuard permission={Permission.READ_RUN}>
         <PageTitle title="Flow Run">
           <BuilderLayout>
-            <FlowRunPage />
+            <SuspenseWrapper>
+              <FlowRunPage />
+            </SuspenseWrapper>
           </BuilderLayout>
         </PageTitle>
       </RoutePermissionGuard>
@@ -80,7 +110,9 @@ export const projectRoutes = [
       <ProjectDashboardLayout>
         <RoutePermissionGuard permission={Permission.READ_RUN}>
           <PageTitle title="Runs">
-            <RunsPage />
+            <SuspenseWrapper>
+              <RunsPage />
+            </SuspenseWrapper>
           </PageTitle>
         </RoutePermissionGuard>
       </ProjectDashboardLayout>
@@ -91,7 +123,9 @@ export const projectRoutes = [
     element: (
       <ProjectDashboardLayout>
         <PageTitle title="Releases">
-          <ViewRelease />
+          <SuspenseWrapper>
+            <ViewRelease />
+          </SuspenseWrapper>
         </PageTitle>
       </ProjectDashboardLayout>
     ),
@@ -102,7 +136,9 @@ export const projectRoutes = [
       <ProjectDashboardLayout>
         <RoutePermissionGuard permission={Permission.READ_TABLE}>
           <PageTitle title="Tables">
-            <ApTablesPage />
+            <SuspenseWrapper>
+              <ApTablesPage />
+            </SuspenseWrapper>
           </PageTitle>
         </RoutePermissionGuard>
       </ProjectDashboardLayout>
@@ -115,7 +151,9 @@ export const projectRoutes = [
         <PageTitle title="Table">
           <BuilderLayout>
             <ApTableStateProvider>
-              <ApTableEditorPage />
+              <SuspenseWrapper>
+                <ApTableEditorPage />
+              </SuspenseWrapper>
             </ApTableStateProvider>
           </BuilderLayout>
         </PageTitle>
@@ -128,7 +166,9 @@ export const projectRoutes = [
       <ProjectDashboardLayout>
         <RoutePermissionGuard permission={Permission.READ_APP_CONNECTION}>
           <PageTitle title="Connections">
-            <AppConnectionsPage />
+            <SuspenseWrapper>
+              <AppConnectionsPage />
+            </SuspenseWrapper>
           </PageTitle>
         </RoutePermissionGuard>
       </ProjectDashboardLayout>
@@ -139,7 +179,9 @@ export const projectRoutes = [
     element: (
       <ProjectDashboardLayout>
         <PageTitle title="Releases">
-          <ProjectReleasesPage />
+          <SuspenseWrapper>
+            <ProjectReleasesPage />
+          </SuspenseWrapper>
         </PageTitle>
       </ProjectDashboardLayout>
     ),
@@ -157,7 +199,9 @@ export const projectRoutes = [
     element: (
       <ProjectDashboardLayout>
         <PageTitle title="Impact">
-          <AnalyticsPage />
+          <SuspenseWrapper>
+            <AnalyticsPage />
+          </SuspenseWrapper>
         </PageTitle>
       </ProjectDashboardLayout>
     ),
@@ -167,7 +211,9 @@ export const projectRoutes = [
     element: (
       <ProjectDashboardLayout>
         <PageTitle title="Leaderboard">
-          <LeaderboardPage />
+          <SuspenseWrapper>
+            <LeaderboardPage />
+          </SuspenseWrapper>
         </PageTitle>
       </ProjectDashboardLayout>
     ),

--- a/packages/web/src/app/routes/public-routes.tsx
+++ b/packages/web/src/app/routes/public-routes.tsx
@@ -1,16 +1,30 @@
+import React, { Suspense } from 'react';
+
 import { PageTitle } from '@/app/components/page-title';
 
+import { LoadingScreen } from '../../components/ui/loading-screen';
 import { ProjectDashboardLayout } from '../components/project-layout';
 import { TemplateDetailsWrapper } from '../guards/template-details-wrapper';
 
 import NotFoundPage from './404-page';
 import AuthenticatePage from './authenticate';
-import { ChatPage } from './chat';
 import { EmbedPage } from './embed';
 import { EmbeddedConnectionDialog } from './embed/embedded-connection-dialog';
-import { FormPage } from './forms';
 import { RedirectPage } from './redirect';
-import { TemplatesPage } from './templates';
+
+const ChatPage = React.lazy(() =>
+  import('./chat').then((m) => ({ default: m.ChatPage })),
+);
+const FormPage = React.lazy(() =>
+  import('./forms').then((m) => ({ default: m.FormPage })),
+);
+const TemplatesPage = React.lazy(() =>
+  import('./templates').then((m) => ({ default: m.TemplatesPage })),
+);
+
+function SuspenseWrapper({ children }: { children: React.ReactNode }) {
+  return <Suspense fallback={<LoadingScreen />}>{children}</Suspense>;
+}
 
 export const publicRoutes = [
   {
@@ -30,7 +44,9 @@ export const publicRoutes = [
     element: (
       <ProjectDashboardLayout>
         <PageTitle title="Templates">
-          <TemplatesPage />
+          <SuspenseWrapper>
+            <TemplatesPage />
+          </SuspenseWrapper>
         </PageTitle>
       </ProjectDashboardLayout>
     ),
@@ -43,7 +59,9 @@ export const publicRoutes = [
     path: '/forms/:flowId',
     element: (
       <PageTitle title="Forms">
-        <FormPage />
+        <SuspenseWrapper>
+          <FormPage />
+        </SuspenseWrapper>
       </PageTitle>
     ),
   },
@@ -51,7 +69,9 @@ export const publicRoutes = [
     path: '/chats/:flowId',
     element: (
       <PageTitle title="Chats">
-        <ChatPage />
+        <SuspenseWrapper>
+          <ChatPage />
+        </SuspenseWrapper>
       </PageTitle>
     ),
   },


### PR DESCRIPTION
## Summary
- Add `React.lazy()` and `Suspense` to all route components for code splitting
- Project routes: flows, builder, tables, runs, connections, releases, impact, leaderboard
- Platform routes: all ~20 admin sub-pages
- Public routes: chat, forms, templates
- Each lazy route uses `SuspenseWrapper` with `LoadingScreen` fallback

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes (0 errors)
- [x] Vite build succeeds with code splitting