### PR TITLE
refactor: consolidate NOT_FOUND error codes into ENTITY_NOT_FOUND

### DIFF
--- a/packages/server/api/src/app/file/file.service.ts
+++ b/packages/server/api/src/app/file/file.service.ts
@@ -95,9 +95,11 @@ export const fileService = (log: FastifyBaseLogger) => ({
         const file = await this.getFile(params)
         if (isNil(file)) {
             throw new ActivepiecesError({
-                code: ErrorCode.FILE_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    id: params.fileId,
+                    entityType: 'file',
+                    entityId: params.fileId,
+                    message: 'File not found',
                 },
             })
         }
@@ -123,9 +125,11 @@ export const fileService = (log: FastifyBaseLogger) => ({
         })
         if (isNil(file)) {
             throw new ActivepiecesError({
-                code: ErrorCode.FILE_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    id: fileId,
+                    entityType: 'file',
+                    entityId: fileId,
+                    message: 'File not found',
                 },
             })
         }

--- a/packages/server/api/src/app/flows/flow-run/flow-run-controller.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-controller.ts
@@ -101,9 +101,11 @@ export const flowRunController: FastifyPluginAsyncTypebox = async (app) => {
 
         if (isNil(flowRun)) {
             throw new ActivepiecesError({
-                code: ErrorCode.FLOW_RUN_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    id: req.params.id,
+                    entityType: 'flow_run',
+                    entityId: req.params.id,
+                    message: 'Flow run not found',
                 },
             })
         }

--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -154,7 +154,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
                 return this.start({
                     flowId: oldFlowRun.flowId,
                     payload,
-                    platformId: await projectService.getPlatformId(oldFlowRun.projectId),
+                    platformId: await projectService(log).getPlatformId(oldFlowRun.projectId),
                     executionType: ExecutionType.BEGIN,
                     progressUpdateType: ProgressUpdateType.NONE,
                     synchronousHandlerId: undefined,
@@ -232,9 +232,11 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
 
         if (isNil(flowRun)) {
             throw new ActivepiecesError({
-                code: ErrorCode.FLOW_RUN_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    id: flowRunId,
+                    entityType: 'flow_run',
+                    entityId: flowRunId,
+                    message: 'Flow run not found',
                 },
             })
         }
@@ -242,7 +244,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
 
         const pauseMetadata = flowRun.pauseMetadata
         const matchRequestId = isNil(pauseMetadata) || (pauseMetadata.type === PauseType.WEBHOOK && requestId === pauseMetadata.requestId)
-        const platformId = await projectService.getPlatformId(flowRun.projectId)
+        const platformId = await projectService(log).getPlatformId(flowRun.projectId)
         if (matchRequestId || !checkRequestId) {
             return addToQueue({
                 payload,
@@ -346,7 +348,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
             executionType: ExecutionType.BEGIN,
             synchronousHandlerId: undefined,
             httpRequestId: undefined,
-            platformId: await projectService.getPlatformId(projectId),
+            platformId: await projectService(log).getPlatformId(projectId),
             executeTrigger: false,
             progressUpdateType: ProgressUpdateType.TEST_FLOW,
             sampleData: !isNil(stepNameToTest) ? await sampleDataService(log).getSampleDataForFlow(projectId, flowVersion, SampleDataFileType.OUTPUT) : undefined,
@@ -371,7 +373,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
             executionType: ExecutionType.BEGIN,
             synchronousHandlerId: undefined,
             httpRequestId: undefined,
-            platformId: await projectService.getPlatformId(projectId),
+            platformId: await projectService(log).getPlatformId(projectId),
             executeTrigger: false,
             progressUpdateType: ProgressUpdateType.TEST_FLOW,
             sampleData: undefined,
@@ -390,9 +392,11 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
 
         if (isNil(flowRun)) {
             throw new ActivepiecesError({
-                code: ErrorCode.FLOW_RUN_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    id: params.id,
+                    entityType: 'flow_run',
+                    entityId: params.id,
+                    message: 'Flow run not found',
                 },
             })
         }
@@ -441,7 +445,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
         await addToQueue({
             payload,
             flowRun,
-            platformId: await projectService.getPlatformId(flowRun.projectId),
+            platformId: await projectService(log).getPlatformId(flowRun.projectId),
             synchronousHandlerId,
             httpRequestId: requestId,
             executeTrigger: false,

--- a/packages/server/api/src/app/flows/flow-run/logs/flow-run-logs-controller.ts
+++ b/packages/server/api/src/app/flows/flow-run/logs/flow-run-logs-controller.ts
@@ -62,9 +62,11 @@ export const flowRunLogsController: FastifyPluginAsyncTypebox = async (app) => {
         const logs = await flowRunLogsService(request.log).getLogs(decodedToken)
         if (isNil(logs)) {
             throw new ActivepiecesError({
-                code: ErrorCode.FILE_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    id: decodedToken.logsFileId,
+                    entityType: 'file',
+                    entityId: decodedToken.logsFileId,
+                    message: 'Logs file not found',
                 },
             })
         }

--- a/packages/server/api/src/app/flows/flow/human-input/human-input.service.ts
+++ b/packages/server/api/src/app/flows/flow/human-input/human-input.service.ts
@@ -38,9 +38,10 @@ export const humanInputService = (log: FastifyBaseLogger) => ({
         const flow = await getPopulatedFlowById(log, flowId, useDraft)
         if (!isFormTrigger(flow)) {
             throw new ActivepiecesError({
-                code: ErrorCode.FLOW_FORM_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    flowId,
+                    entityType: 'flow_form',
+                    entityId: flowId,
                     message: 'Flow form not found in draft version of flow.',
                 },
             })
@@ -48,7 +49,7 @@ export const humanInputService = (log: FastifyBaseLogger) => ({
         const pieceVersion = await pieceMetadataService(log).resolveExactVersion({
             name: FORMS_PIECE_NAME,
             version: flow.version.trigger.settings.pieceVersion,
-            platformId: await projectService.getPlatformId(flow.projectId),
+            platformId: await projectService(log).getPlatformId(flow.projectId),
         })
         const triggerSettings = flow.version.trigger.settings
         return {
@@ -65,15 +66,16 @@ export const humanInputService = (log: FastifyBaseLogger) => ({
             || flow.version.trigger.settings.triggerName !== 'chat_submission'
             || flow.version.trigger.settings.pieceName !== FORMS_PIECE_NAME) {
             throw new ActivepiecesError({
-                code: ErrorCode.FLOW_FORM_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    flowId,
+                    entityType: 'flow_form',
+                    entityId: flowId,
                     message: 'Flow chat ui not found in draft version of flow.',
                 },
             })
         }
-        const platformId = await projectService.getPlatformId(flow.projectId)
-        const platform = await platformService.getOneOrThrow(platformId)
+        const platformId = await projectService(log).getPlatformId(flow.projectId)
+        const platform = await platformService(log).getOneOrThrow(platformId)
         return {
             id: flow.id,
             title: flow.version.displayName,

--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -18,10 +18,8 @@ export const errorHandler = async (
             [ErrorCode.FEATURE_DISABLED]: StatusCodes.PAYMENT_REQUIRED,
             [ErrorCode.AI_CREDIT_LIMIT_EXCEEDED]: StatusCodes.PAYMENT_REQUIRED,
             [ErrorCode.PERMISSION_DENIED]: StatusCodes.FORBIDDEN,
-            [ErrorCode.FILE_NOT_FOUND]: StatusCodes.NOT_FOUND,
             [ErrorCode.ENTITY_NOT_FOUND]: StatusCodes.NOT_FOUND,
             [ErrorCode.EXISTING_USER]: StatusCodes.CONFLICT,
-            [ErrorCode.PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER]: StatusCodes.NOT_IMPLEMENTED,
             [ErrorCode.EXISTING_ALERT_CHANNEL]: StatusCodes.CONFLICT,
             [ErrorCode.FLOW_IN_USE]: StatusCodes.CONFLICT,
             [ErrorCode.FLOW_OPERATION_IN_PROGRESS]: StatusCodes.CONFLICT,
@@ -55,7 +53,7 @@ export const errorHandler = async (
         })
     }
     else {
-        request.log.error('[errorHandler]: ' + JSON.stringify(error))
+        request.log.error({ err: error }, '[errorHandler]')
         if (
             !error.statusCode ||
       error.statusCode === StatusCodes.INTERNAL_SERVER_ERROR.valueOf()

--- a/packages/server/api/src/app/trigger/app-event-routing/app-event-routing.module.ts
+++ b/packages/server/api/src/app/trigger/app-event-routing/app-event-routing.module.ts
@@ -78,11 +78,11 @@ export const appEventRoutingController: FastifyPluginAsyncTypebox = async (
             const piece = appWebhooks[pieceUrl]
             if (isNil(piece)) {
                 throw new ActivepiecesError({
-                    code: ErrorCode.PIECE_NOT_FOUND,
+                    code: ErrorCode.ENTITY_NOT_FOUND,
                     params: {
-                        pieceName: pieceUrl,
-                        pieceVersion: 'latest',
-                        message: 'Pieces is not found in app event routing',
+                        entityType: 'piece',
+                        entityId: pieceUrl,
+                        message: 'Piece is not found in app event routing',
                     },
                 })
             }
@@ -129,7 +129,7 @@ export const appEventRoutingController: FastifyPluginAsyncTypebox = async (
                     return
                 }
                 const flowVersionIdToRun = await webhookHandler.getFlowVersionIdToRun(WebhookFlowVersionToRun.LOCKED_FALL_BACK_TO_LATEST, flow)
-                const platformId = await projectService.getPlatformId(listener.projectId)
+                const platformId = await projectService(request.log).getPlatformId(listener.projectId)
                 return jobQueue(request.log).add({
                     id: requestId,
                     type: JobType.ONE_TIME,

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-utils.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-utils.ts
@@ -21,11 +21,16 @@ export const triggerUtils = (log: FastifyBaseLogger) => ({
         })
         if (isNil(pieceTrigger)) {
             throw new ActivepiecesError({
-                code: ErrorCode.PIECE_TRIGGER_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    pieceName: flowVersion.trigger.settings.pieceName,
-                    pieceVersion: flowVersion.trigger.settings.pieceVersion,
-                    triggerName: flowVersion.trigger.settings.triggerName,
+                    entityType: 'piece_trigger',
+                    entityId: flowVersion.trigger.settings.triggerName,
+                    message: `Trigger not found for piece ${flowVersion.trigger.settings.pieceName}@${flowVersion.trigger.settings.pieceVersion}`,
+                    extra: {
+                        pieceName: flowVersion.trigger.settings.pieceName,
+                        pieceVersion: flowVersion.trigger.settings.pieceVersion,
+                        triggerName: flowVersion.trigger.settings.triggerName,
+                    },
                 },
             })
         }
@@ -47,7 +52,7 @@ export const triggerUtils = (log: FastifyBaseLogger) => ({
         })
     },
     async getPieceTriggerByName({ pieceName, pieceVersion, triggerName, projectId }: GetPieceTriggerByNameParams): Promise<TriggerBase | null> {
-        const platformId = await projectService.getPlatformId(projectId)
+        const platformId = await projectService(log).getPlatformId(projectId)
         const piece = await pieceMetadataService(log).get({
             platformId,
             name: pieceName,

--- a/packages/server/engine/src/lib/helper/piece-loader.ts
+++ b/packages/server/engine/src/lib/helper/piece-loader.ts
@@ -57,11 +57,12 @@ export const pieceLoader = {
 
         if (isNil(pieceAction)) {
             throw new ActivepiecesError({
-                code: ErrorCode.STEP_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    pieceName,
-                    pieceVersion,
-                    stepName: actionName,
+                    entityType: 'step',
+                    entityId: actionName,
+                    message: `Action not found for piece ${pieceName}@${pieceVersion}`,
+                    extra: { pieceName, pieceVersion },
                 },
             })
         }
@@ -79,11 +80,12 @@ export const pieceLoader = {
 
         if (isNil(actionOrTrigger)) {
             throw new ActivepiecesError({
-                code: ErrorCode.STEP_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    pieceName,
-                    pieceVersion,
-                    stepName: actionOrTriggerName,
+                    entityType: 'step',
+                    entityId: actionOrTriggerName,
+                    message: `Step not found for piece ${pieceName}@${pieceVersion}`,
+                    extra: { pieceName, pieceVersion },
                 },
             })
         }
@@ -92,12 +94,12 @@ export const pieceLoader = {
 
         if (isNil(property)) {
             throw new ActivepiecesError({
-                code: ErrorCode.CONFIG_NOT_FOUND,
+                code: ErrorCode.ENTITY_NOT_FOUND,
                 params: {
-                    pieceName,
-                    pieceVersion,
-                    stepName: actionOrTriggerName,
-                    configName: propertyName,
+                    entityType: 'config',
+                    entityId: propertyName,
+                    message: `Config not found for step ${actionOrTriggerName} in piece ${pieceName}@${pieceVersion}`,
+                    extra: { pieceName, pieceVersion, stepName: actionOrTriggerName },
                 },
             })
         }

--- a/packages/shared/src/lib/automation/flows/util/flow-structure-util.ts
+++ b/packages/shared/src/lib/automation/flows/util/flow-structure-util.ts
@@ -24,9 +24,11 @@ function getActionOrThrow(name: string, flowRoot: Step): FlowAction {
     const step = getStepOrThrow(name, flowRoot)
     if (!isAction(step.type)) {
         throw new ActivepiecesError({
-            code: ErrorCode.STEP_NOT_FOUND,
+            code: ErrorCode.ENTITY_NOT_FOUND,
             params: {
-                stepName: name,
+                entityType: 'step',
+                entityId: name,
+                message: 'Step is not an action',
             },
         })
     }
@@ -37,9 +39,11 @@ function getTriggerOrThrow(name: string, flowRoot: Step): FlowTrigger {
     const step = getStepOrThrow(name, flowRoot)
     if (!isTrigger(step.type)) {
         throw new ActivepiecesError({
-            code: ErrorCode.STEP_NOT_FOUND,
+            code: ErrorCode.ENTITY_NOT_FOUND,
             params: {
-                stepName: name,
+                entityType: 'step',
+                entityId: name,
+                message: 'Step is not a trigger',
             },
         })
     }
@@ -54,9 +58,11 @@ function getStepOrThrow(name: string, flowRoot: Step): Step {
     const step = getStep(name, flowRoot)
     if (isNil(step)) {
         throw new ActivepiecesError({
-            code: ErrorCode.STEP_NOT_FOUND,
+            code: ErrorCode.ENTITY_NOT_FOUND,
             params: {
-                stepName: name,
+                entityType: 'step',
+                entityId: name,
+                message: 'Step not found',
             },
         })
     }

--- a/packages/shared/src/lib/automation/pieces/utils.ts
+++ b/packages/shared/src/lib/automation/pieces/utils.ts
@@ -49,11 +49,12 @@ export const extractPieceFromModule = <T>(params: ExtractPieceFromModuleParams):
     }
 
     throw new ActivepiecesError({
-        code: ErrorCode.PIECE_NOT_FOUND,
+        code: ErrorCode.ENTITY_NOT_FOUND,
         params: {
-            pieceName,
-            pieceVersion,
-            message: `Failed to extract piece from module, found constructors: ${constructors.join(', ')}`,
+            entityType: 'piece',
+            entityId: pieceName,
+            message: `Failed to extract piece from module (version: ${pieceVersion}), found constructors: ${constructors.join(', ')}`,
+            extra: { pieceName, pieceVersion },
         },
     })
 }

--- a/packages/shared/src/lib/core/common/activepieces-error.ts
+++ b/packages/shared/src/lib/core/common/activepieces-error.ts
@@ -1,10 +1,8 @@
-import type { FlowRunId } from '../../automation/flow-run/flow-run'
 import type { FlowId } from '../../automation/flows/flow'
 import type { FlowVersionId } from '../../automation/flows/flow-version'
 import type { PlatformUsageMetric } from '../../management/platform'
 import type { ProjectId } from '../../management/project'
 import type { ProjectRole } from '../../management/project-role/project-role'
-import type { FileId } from '../file'
 import type { UserId } from '../user'
 import type { ApId } from './id-generator'
 import type { Permission } from './security'
@@ -26,18 +24,13 @@ export class ActivepiecesError extends Error {
 export type ApErrorParams =
     | AuthenticationParams
     | AuthorizationErrorParams
-    | ConfigNotFoundErrorParams
     | EmailIsNotVerifiedErrorParams
     | EngineOperationFailureParams
     | EntityNotFoundErrorParams
     | ExistingUserErrorParams
-    | FileNotFoundErrorParams
-    | FlowFormNotFoundError
-    | FlowNotFoundErrorParams
     | FlowIsLockedErrorParams
     | FlowOperationErrorParams
     | FlowOperationInProgressErrorParams
-    | FlowRunNotFoundErrorParams
     | InvalidApiKeyParams
     | InvalidAppConnectionParams
     | InvalidBearerTokenParams
@@ -52,12 +45,9 @@ export type ApErrorParams =
     | OpenAiFailedErrorParams
     | PauseMetadataMissingErrorParams
     | PermissionDeniedErrorParams
-    | PieceNotFoundErrorParams
-    | PieceTriggerNotFoundErrorParams
     | QuotaExceededParams
     | FeatureDisabledErrorParams
     | SignUpDisabledParams
-    | StepNotFoundErrorParams
     | SystemInvalidErrorParams
     | SystemPropNotDefinedErrorParams
     | TestTriggerFailedErrorParams
@@ -70,7 +60,6 @@ export type ApErrorParams =
     | EmailAuthIsDisabledParams
     | ExistingAlertChannelErrorParams
     | EmailAlreadyHasActivationKey
-    | ProviderProxyConfigNotFoundParams
     | AIProviderModelNotSupportedParams
     | AIProviderNotSupportedParams
     | AIRequestNotSupportedParams
@@ -148,8 +137,6 @@ export type SessionExpiredParams = BaseErrorParams<ErrorCode.SESSION_EXPIRED, {
 
 export type NoChatResponseParams = BaseErrorParams<ErrorCode.NO_CHAT_RESPONSE, Record<string, never>>
 
-export type FileNotFoundErrorParams = BaseErrorParams<ErrorCode.FILE_NOT_FOUND, { id: FileId }>
-
 export type EmailAuthIsDisabledParams = BaseErrorParams<ErrorCode.EMAIL_AUTH_DISABLED, Record<string, never>>
 
 export type AuthorizationErrorParams = BaseErrorParams<
@@ -179,20 +166,6 @@ export type SystemInvalidErrorParams = BaseErrorParams<
 ErrorCode.SYSTEM_PROP_INVALID,
 {
     prop: string
-}
->
-
-export type FlowNotFoundErrorParams = BaseErrorParams<
-ErrorCode.FLOW_NOT_FOUND,
-{
-    id: FlowId
-}
->
-
-export type FlowRunNotFoundErrorParams = BaseErrorParams<
-ErrorCode.FLOW_RUN_NOT_FOUND,
-{
-    id: FlowRunId
 }
 >
 
@@ -230,33 +203,6 @@ ErrorCode.EXISTING_USER,
 }
 >
 
-export type StepNotFoundErrorParams = BaseErrorParams<
-ErrorCode.STEP_NOT_FOUND,
-{
-    pieceName?: string
-    pieceVersion?: string
-    stepName: string
-}
->
-
-export type PieceNotFoundErrorParams = BaseErrorParams<
-ErrorCode.PIECE_NOT_FOUND,
-{
-    pieceName: string
-    pieceVersion: string | undefined
-    message: string
-}
->
-
-export type PieceTriggerNotFoundErrorParams = BaseErrorParams<
-ErrorCode.PIECE_TRIGGER_NOT_FOUND,
-{
-    pieceName: string
-    pieceVersion: string
-    triggerName: string | undefined
-}
->
-
 export type TriggerFailedErrorParams = BaseErrorParams<
 ErrorCode.TRIGGER_FAILED,
 {
@@ -267,16 +213,6 @@ ErrorCode.TRIGGER_FAILED,
 }
 >
 
-
-export type ConfigNotFoundErrorParams = BaseErrorParams<
-ErrorCode.CONFIG_NOT_FOUND,
-{
-    pieceName: string
-    pieceVersion: string
-    stepName: string
-    configName: string
-}
->
 
 export type JobRemovalFailureErrorParams = BaseErrorParams<
 ErrorCode.JOB_REMOVAL_FAILURE,
@@ -309,13 +245,6 @@ ErrorCode.FLOW_OPERATION_IN_PROGRESS, {
     message: string
 }>
 
-export type FlowFormNotFoundError = BaseErrorParams<
-ErrorCode.FLOW_FORM_NOT_FOUND,
-{
-    flowId: FlowVersionId
-    message: string
-}>
-
 export type FlowIsLockedErrorParams = BaseErrorParams<
 ErrorCode.FLOW_IN_USE,
 {
@@ -343,6 +272,7 @@ ErrorCode.ENTITY_NOT_FOUND,
     message?: string
     entityType?: string
     entityId?: string
+    extra?: Record<string, unknown>
 }
 >
 
@@ -412,12 +342,6 @@ export type ErrorUpdatingSubscriptionParams = BaseErrorParams<
 ErrorCode.ERROR_UPDATING_SUBSCRIPTION,
 {
     message: string
-}>
-
-export type ProviderProxyConfigNotFoundParams = BaseErrorParams<
-ErrorCode.PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER,
-{
-    provider: string
 }>
 
 export type AIProviderModelNotSupportedParams = BaseErrorParams<ErrorCode.AI_MODEL_NOT_SUPPORTED, {
@@ -542,11 +466,9 @@ export enum ErrorCode {
     ERROR_UPDATING_SUBSCRIPTION = 'ERROR_UPDATING_SUBSCRIPTION',
     AUTHENTICATION = 'AUTHENTICATION',
     AUTHORIZATION = 'AUTHORIZATION',
-    PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER = 'PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER',
     AI_MODEL_NOT_SUPPORTED = 'AI_MODEL_NOT_SUPPORTED',
     AI_PROVIDER_NOT_SUPPORTED = 'AI_PROVIDER_NOT_SUPPORTED',
     AI_REQUEST_NOT_SUPPORTED = 'AI_REQUEST_NOT_SUPPORTED',
-    CONFIG_NOT_FOUND = 'CONFIG_NOT_FOUND',
     DOMAIN_NOT_ALLOWED = 'DOMAIN_NOT_ALLOWED',
     EMAIL_IS_NOT_VERIFIED = 'EMAIL_IS_NOT_VERIFIED',
     ENGINE_OPERATION_FAILURE = 'ENGINE_OPERATION_FAILURE',
@@ -559,14 +481,9 @@ export enum ErrorCode {
     EXISTING_USER = 'EXISTING_USER',
     EXISTING_ALERT_CHANNEL = 'EXISTING_ALERT_CHANNEL',
     PROJECT_EXTERNAL_ID_ALREADY_EXISTS = 'PROJECT_EXTERNAL_ID_ALREADY_EXISTS',
-    FLOW_FORM_NOT_FOUND = 'FLOW_FORM_NOT_FOUND',
-    FILE_NOT_FOUND = 'FILE_NOT_FOUND',
-    FLOW_INSTANCE_NOT_FOUND = 'INSTANCE_NOT_FOUND',
-    FLOW_NOT_FOUND = 'FLOW_NOT_FOUND',
     FLOW_OPERATION_INVALID = 'FLOW_OPERATION_INVALID',
     FLOW_OPERATION_IN_PROGRESS = 'FLOW_OPERATION_IN_PROGRESS',
     FLOW_IN_USE = 'FLOW_IN_USE',
-    FLOW_RUN_NOT_FOUND = 'FLOW_RUN_NOT_FOUND',
     INVALID_API_KEY = 'INVALID_API_KEY',
     INVALID_APP_CONNECTION = 'INVALID_APP_CONNECTION',
     INVALID_BEARER_TOKEN = 'INVALID_BEARER_TOKEN',
@@ -582,13 +499,10 @@ export enum ErrorCode {
     OPEN_AI_FAILED = 'OPEN_AI_FAILED',
     PAUSE_METADATA_MISSING = 'PAUSE_METADATA_MISSING',
     PERMISSION_DENIED = 'PERMISSION_DENIED',
-    PIECE_NOT_FOUND = 'PIECE_NOT_FOUND',
-    PIECE_TRIGGER_NOT_FOUND = 'PIECE_TRIGGER_NOT_FOUND',
     QUOTA_EXCEEDED = 'QUOTA_EXCEEDED',
     FEATURE_DISABLED = 'FEATURE_DISABLED',
     AI_CREDIT_LIMIT_EXCEEDED = 'AI_CREDIT_LIMIT_EXCEEDED',
     SIGN_UP_DISABLED = 'SIGN_UP_DISABLED',
-    STEP_NOT_FOUND = 'STEP_NOT_FOUND',
     SYSTEM_PROP_INVALID = 'SYSTEM_PROP_INVALID',
     SYSTEM_PROP_NOT_DEFINED = 'SYSTEM_PROP_NOT_DEFINED',
     TEST_TRIGGER_FAILED = 'TEST_TRIGGER_FAILED',

--- a/packages/web/src/features/chat/chat-message-list/error-bubble.tsx
+++ b/packages/web/src/features/chat/chat-message-list/error-bubble.tsx
@@ -37,10 +37,15 @@ const formatError = (
           chat link with you for assistance.
         </span>
       );
-    case ErrorCode.FLOW_NOT_FOUND:
-      return (
-        <span>The chat flow you are trying to access no longer exists.</span>
-      );
+    case ErrorCode.ENTITY_NOT_FOUND:
+      if (error.params.entityType === 'flow') {
+        return (
+          <span>
+            The chat flow you are trying to access no longer exists.
+          </span>
+        );
+      }
+      return <span>Something went wrong. Please try again.</span>;
     case ErrorCode.VALIDATION:
       return <span>{`Validation error: ${error.params.message}`}</span>;
     default:


### PR DESCRIPTION
## Summary
- Consolidates 10 specialized "not found" error codes (`FILE_NOT_FOUND`, `FLOW_NOT_FOUND`, `FLOW_RUN_NOT_FOUND`, `FLOW_FORM_NOT_FOUND`, `FLOW_INSTANCE_NOT_FOUND`, `PIECE_NOT_FOUND`, `PIECE_TRIGGER_NOT_FOUND`, `STEP_NOT_FOUND`, `CONFIG_NOT_FOUND`, `PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER`) into the existing `ENTITY_NOT_FOUND` error code
- All throw sites now use `ENTITY_NOT_FOUND` with structured fields: `entityType`, `entityId`, `message`, and `extra` (for unstructured context like pieceName/pieceVersion)
- Removes 10 enum values, 9 type definitions, and 2 error handler mappings (dead code)
- Ensures all not-found errors correctly return HTTP 404 (previously most fell through to default 400)

## Error Codes Removed
| Error Code | Entity Type |
|---|---|
| `FILE_NOT_FOUND` | `file` |
| `FLOW_NOT_FOUND` | `flow` |
| `FLOW_RUN_NOT_FOUND` | `flow_run` |
| `FLOW_FORM_NOT_FOUND` | `flow_form` |
| `FLOW_INSTANCE_NOT_FOUND` | dead code |
| `PIECE_NOT_FOUND` | `piece` |
| `PIECE_TRIGGER_NOT_FOUND` | `piece_trigger` |
| `STEP_NOT_FOUND` | `step` |
| `CONFIG_NOT_FOUND` | `config` |
| `PROVIDER_PROXY_CONFIG_NOT_FOUND_FOR_PROVIDER` | dead code |

## Files Modified (13)
- `packages/shared/src/lib/core/common/activepieces-error.ts` — enum + type cleanup
- `packages/server/api/src/app/helper/error-handler.ts` — removed redundant status code mappings
- 9 backend/shared/engine files — migrated throw sites
- `packages/web/src/features/chat/chat-message-list/error-bubble.tsx` — updated frontend switch case

## Test plan
- [x] `shared` package builds successfully
- [x] `engine` package builds successfully
- [x] `web` package builds successfully
- [ ] Run full test suite
- [ ] Verify 404 responses for not-found entities in API