### PR TITLE
feat(gmail): add label management, archive, delete actions and starred trigger

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -8,11 +8,19 @@ import { PieceCategory } from '@activepieces/shared';
 import { gmailSendEmailAction } from './lib/actions/send-email-action';
 import { gmailReplyToEmailAction } from './lib/actions/reply-to-email-action';
 import { gmailCreateDraftReplyAction } from './lib/actions/create-draft-reply-action';
+import { gmailAddLabelAction } from './lib/actions/add-label-action';
+import { gmailRemoveLabelAction } from './lib/actions/remove-label-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveThreadLabelAction } from './lib/actions/remove-thread-label-action';
 import { gmailNewEmailTrigger } from './lib/triggers/new-email';
 import { gmailNewLabeledEmailTrigger } from './lib/triggers/new-labeled-email';
 import { requestApprovalInEmail } from './lib/actions/request-approval-in-email';
 import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
+import { gmailNewConversationTrigger } from './lib/triggers/new-conversation';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
 import { gmailAuth } from './lib/auth';
@@ -31,6 +39,12 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailAddLabelAction,
+    gmailRemoveLabelAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveThreadLabelAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -55,12 +69,15 @@ export const gmail = createPiece({
     'AdamSelene',
     'sanket-a11y',
     'onyedikachi-david',
+    'moth-asa',
   ],
   triggers: [
     gmailNewEmailTrigger,
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewStarredEmailTrigger,
+    gmailNewConversationTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
@@ -1,0 +1,37 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailAddLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'add_label_to_email',
+  displayName: 'Add Label to Email',
+  description: 'Attach a label to an individual email.',
+  props: {
+    message_id: GmailProps.message,
+    label: GmailProps.label,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const labelId = context.propsValue.label?.id;
+    if (!labelId) {
+      throw new Error('Please select a label to add.');
+    }
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        addLabelIds: [labelId],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,31 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'archive_email',
+  displayName: 'Archive Email',
+  description: 'Archive an email by removing it from the inbox (moves to All Mail).',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,90 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'create_label',
+  displayName: 'Create Label',
+  description: 'Create a new user label in Gmail.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the new label',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Label List',
+      description: 'Whether this label should appear in the label list',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Show if Unread', value: 'labelShowIfUnread' },
+          { label: 'Hide', value: 'labelHide' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Message List',
+      description: 'Whether messages with this label are shown in the message list',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+    background_color: Property.ShortText({
+      displayName: 'Background Color',
+      description: 'Background color hex code (e.g., #16a765)',
+      required: false,
+    }),
+    text_color: Property.ShortText({
+      displayName: 'Text Color',
+      description: 'Text color hex code (e.g., #ffffff)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const labelBody: {
+      name: string;
+      labelListVisibility?: string;
+      messageListVisibility?: string;
+      color?: { backgroundColor: string; textColor: string };
+    } = {
+      name: context.propsValue.name,
+    };
+
+    if (context.propsValue.label_list_visibility) {
+      labelBody.labelListVisibility = context.propsValue.label_list_visibility;
+    }
+    if (context.propsValue.message_list_visibility) {
+      labelBody.messageListVisibility = context.propsValue.message_list_visibility;
+    }
+    if (context.propsValue.background_color && context.propsValue.text_color) {
+      labelBody.color = {
+        backgroundColor: context.propsValue.background_color,
+        textColor: context.propsValue.text_color,
+      };
+    }
+
+    const response = await gmail.users.labels.create({
+      userId: 'me',
+      requestBody: labelBody,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'delete_email',
+  displayName: 'Delete Email',
+  description: 'Move an email to the Trash folder.',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.trash({
+      userId: 'me',
+      id: context.propsValue.message_id,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
@@ -1,0 +1,37 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_email',
+  displayName: 'Remove Label from Email',
+  description: 'Remove a specific label from an email.',
+  props: {
+    message_id: GmailProps.message,
+    label: GmailProps.label,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const labelId = context.propsValue.label?.id;
+    if (!labelId) {
+      throw new Error('Please select a label to remove.');
+    }
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: [labelId],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-thread-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-thread-label-action.ts
@@ -1,0 +1,37 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveThreadLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_thread',
+  displayName: 'Remove Label from Thread',
+  description: 'Remove a label from all emails in a thread.',
+  props: {
+    thread_id: GmailProps.thread,
+    label: GmailProps.label,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const labelId = context.propsValue.label?.id;
+    if (!labelId) {
+      throw new Error('Please select a label to remove.');
+    }
+
+    const response = await gmail.users.threads.modify({
+      userId: 'me',
+      id: context.propsValue.thread_id,
+      requestBody: {
+        removeLabelIds: [labelId],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/auth.ts
+++ b/packages/pieces/community/gmail/src/lib/auth.ts
@@ -10,5 +10,7 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.labels',
   ],
 });

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,128 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { convertAttachment, parseStream } from '../common/data';
+
+const TRIGGER_KEY = 'starred_message_ids';
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred (checks emails within the last 2 days).',
+  props: {},
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const twoDaysAgo = Math.floor((Date.now() - 2 * 24 * 60 * 60 * 1000) / 1000);
+
+    const response = await gmail.users.messages.list({
+      userId: 'me',
+      q: `is:starred after:${twoDaysAgo}`,
+      maxResults: 100,
+    });
+
+    const existingIds = (response.data.messages || []).map((m) => m.id!);
+    await context.store.put(TRIGGER_KEY, existingIds);
+  },
+  async onDisable(context) {
+    await context.store.delete(TRIGGER_KEY);
+  },
+  async test(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const twoDaysAgo = Math.floor((Date.now() - 2 * 24 * 60 * 60 * 1000) / 1000);
+
+    const response = await gmail.users.messages.list({
+      userId: 'me',
+      q: `is:starred after:${twoDaysAgo}`,
+      maxResults: 5,
+    });
+
+    if (!response.data.messages || response.data.messages.length === 0) {
+      return [];
+    }
+
+    const results = [];
+    for (const msg of response.data.messages.slice(0, 5)) {
+      const rawResponse = await gmail.users.messages.get({
+        userId: 'me',
+        id: msg.id!,
+        format: 'raw',
+      });
+
+      const parsed = await parseStream(
+        Buffer.from(rawResponse.data.raw as string, 'base64').toString('utf-8')
+      );
+
+      results.push({
+        ...parsed,
+        messageId: msg.id,
+        threadId: msg.threadId,
+        attachments: await convertAttachment(parsed.attachments, context.files),
+      });
+    }
+
+    return results;
+  },
+  async run(context) {
+    const knownIds = (await context.store.get<string[]>(TRIGGER_KEY)) || [];
+
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const twoDaysAgo = Math.floor((Date.now() - 2 * 24 * 60 * 60 * 1000) / 1000);
+
+    const response = await gmail.users.messages.list({
+      userId: 'me',
+      q: `is:starred after:${twoDaysAgo}`,
+      maxResults: 100,
+    });
+
+    const currentMessages = response.data.messages || [];
+    const currentIds = currentMessages.map((m) => m.id!);
+
+    const newMessages = currentMessages.filter(
+      (m) => !knownIds.includes(m.id!)
+    );
+
+    await context.store.put(TRIGGER_KEY, currentIds);
+
+    if (newMessages.length === 0) {
+      return [];
+    }
+
+    const results = [];
+    for (const msg of newMessages) {
+      const rawResponse = await gmail.users.messages.get({
+        userId: 'me',
+        id: msg.id!,
+        format: 'raw',
+      });
+
+      const parsed = await parseStream(
+        Buffer.from(rawResponse.data.raw as string, 'base64').toString('utf-8')
+      );
+
+      results.push({
+        ...parsed,
+        messageId: msg.id,
+        threadId: msg.threadId,
+        attachments: await convertAttachment(parsed.attachments, context.files),
+      });
+    }
+
+    return results;
+  },
+});


### PR DESCRIPTION
## Summary

Extends the Gmail piece with **6 new actions** and **1 new trigger** as specified in #8072, plus registers the existing New Conversation trigger.

### New Actions
| Action | Description |
|--------|-------------|
| **Add Label to Email** | Attach a label to an individual email |
| **Remove Label from Email** | Remove a specific label from an email |
| **Create Label** | Create a new user label with visibility and color options |
| **Archive Email** | Archive by removing INBOX label (moves to All Mail) |
| **Delete Email** | Move an email to Trash |
| **Remove Label from Thread** | Strip a label from all emails in a thread |

### New Triggers
| Trigger | Description |
|---------|-------------|
| **New Starred Email** | Fires when an email is starred (checks within 2 days) |
| **New Conversation** | Fires when a new thread begins (was implemented but not registered) |

### Auth Changes
- Added `gmail.modify` scope (required for label/archive/delete operations)
- Added `gmail.labels` scope (required for label management)

### Implementation Notes
- All actions follow existing piece patterns (OAuth2Client, googleapis)
- Reuses shared props (`GmailProps.message`, `GmailProps.thread`, `GmailProps.label`)
- New Starred Email trigger uses polling strategy with `is:starred after:` query
- No existing functionality modified — purely additive changes

/claim #8072