### PR TITLE
feat(gmail): extend with label management, archive, delete & starred trigger (#8072)

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -8,13 +8,22 @@ import { PieceCategory } from '@activepieces/shared';
 import { gmailSendEmailAction } from './lib/actions/send-email-action';
 import { gmailReplyToEmailAction } from './lib/actions/reply-to-email-action';
 import { gmailCreateDraftReplyAction } from './lib/actions/create-draft-reply-action';
+import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailSearchMailAction } from './lib/actions/search-email-action';
+import { gmailGetThread } from './lib/actions/get-thread-action';
+import { gmailAddLabelAction } from './lib/actions/add-label-action';
+import { gmailRemoveLabelAction } from './lib/actions/remove-label-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
+import { requestApprovalInEmail } from './lib/actions/request-approval-in-email';
 import { gmailNewEmailTrigger } from './lib/triggers/new-email';
 import { gmailNewLabeledEmailTrigger } from './lib/triggers/new-labeled-email';
-import { requestApprovalInEmail } from './lib/actions/request-approval-in-email';
 import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
-import { gmailSearchMailAction } from './lib/actions/search-email-action';
-import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailNewConversationTrigger } from './lib/triggers/new-conversation';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
 import { gmailAuth } from './lib/auth';
 
 export const gmail = createPiece({
@@ -31,6 +40,13 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailGetThread,
+    gmailAddLabelAction,
+    gmailRemoveLabelAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -61,6 +77,8 @@ export const gmail = createPiece({
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewConversationTrigger,
+    gmailNewStarredEmailTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
@@ -1,0 +1,34 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailAddLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_add_label',
+  displayName: 'Add Label to Email',
+  description: 'Add a label to an email message.',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        addLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,30 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_archive_email',
+  displayName: 'Archive Email',
+  description: 'Archive an email by removing it from the inbox.',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,61 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_create_label',
+  displayName: 'Create Label',
+  description: 'Create a new label in your Gmail account.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the label to create',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Label List',
+      description: 'Whether the label is shown in the label list',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Hide', value: 'labelHide' },
+          { label: 'Show if Unread', value: 'labelShowIfUnread' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Show in Message List',
+      description: 'Whether the label is shown in the message list',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.labels.create({
+      userId: 'me',
+      requestBody: {
+        name: context.propsValue.name,
+        labelListVisibility: context.propsValue.label_list_visibility ?? 'labelShow',
+        messageListVisibility: context.propsValue.message_list_visibility ?? 'show',
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,27 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_delete_email',
+  displayName: 'Delete Email',
+  description: 'Move an email to the trash.',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.trash({
+      userId: 'me',
+      id: context.propsValue.message_id,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
@@ -1,0 +1,34 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailRemoveLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label',
+  displayName: 'Remove Label from Email',
+  description: 'Remove a label from an email message.',
+  props: {
+    message_id: GmailProps.message,
+    label: {
+      ...GmailProps.label,
+      required: true,
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,34 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { GmailProps } from '../common/props';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_thread',
+  displayName: 'Remove Label from Thread',
+  description: 'Remove a label from an entire email thread.',
+  props: {
+    thread_id: GmailProps.thread,
+    label: {
+      ...GmailProps.label,
+      required: true,
+    },
+  },
+  async run(context) {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.threads.modify({
+      userId: 'me',
+      id: context.propsValue.thread_id,
+      requestBody: {
+        removeLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/auth.ts
+++ b/packages/pieces/community/gmail/src/lib/auth.ts
@@ -10,5 +10,7 @@ export const gmailAuth = PieceAuth.OAuth2({
     'email',
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.labels',
   ],
 });

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,167 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  FilesService,
+} from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'googleapis-common';
+import { parseStream, convertAttachment } from '../common/data';
+
+async function enrichStarredMessage({
+  gmail,
+  messageId,
+  files,
+}: {
+  gmail: any;
+  messageId: string;
+  files: FilesService;
+}) {
+  const rawMailResponse = await gmail.users.messages.get({
+    userId: 'me',
+    id: messageId,
+    format: 'raw',
+  });
+
+  const threadResponse = await gmail.users.threads.get({
+    userId: 'me',
+    id: rawMailResponse.data.threadId!,
+  });
+
+  const parsedMailResponse = await parseStream(
+    Buffer.from(rawMailResponse.data.raw as string, 'base64').toString('utf-8')
+  );
+
+  return {
+    message: {
+      ...parsedMailResponse,
+      attachments: await convertAttachment(
+        parsedMailResponse.attachments,
+        files
+      ),
+    },
+    thread: threadResponse.data,
+    starredAt: Date.now(),
+  };
+}
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred',
+  props: {},
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  onEnable: async (context) => {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const profile = await gmail.users.getProfile({ userId: 'me' });
+    await context.store.put('lastHistoryId', profile.data.historyId);
+  },
+  onDisable: async (context) => {
+    await context.store.delete('lastHistoryId');
+  },
+  run: async (context) => {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const lastHistoryId = await context.store.get('lastHistoryId');
+
+    try {
+      const historyResponse = await gmail.users.history.list({
+        userId: 'me',
+        startHistoryId: lastHistoryId as string,
+        historyTypes: ['labelAdded'],
+      });
+
+      const starredMessages = new Map<string, string>();
+
+      if (historyResponse.data.history) {
+        for (const history of historyResponse.data.history) {
+          if (history.labelsAdded) {
+            for (const labelAdded of history.labelsAdded) {
+              if (
+                labelAdded.labelIds?.includes('STARRED') &&
+                labelAdded.message?.id
+              ) {
+                starredMessages.set(
+                  labelAdded.message.id,
+                  history.id?.toString() || ''
+                );
+              }
+            }
+          }
+        }
+      }
+
+      const results = [];
+
+      for (const [messageId, historyId] of starredMessages) {
+        if (lastHistoryId !== historyId) {
+          const enrichedMessage = await enrichStarredMessage({
+            gmail,
+            messageId,
+            files: context.files,
+          });
+
+          results.push({
+            id: historyId,
+            data: enrichedMessage,
+          });
+        }
+      }
+
+      if (historyResponse.data.historyId) {
+        await context.store.put(
+          'lastHistoryId',
+          historyResponse.data.historyId
+        );
+      }
+
+      return results;
+    } catch (error: any) {
+      if (error.code === 404) {
+        const profile = await gmail.users.getProfile({ userId: 'me' });
+        await context.store.put('lastHistoryId', profile.data.historyId);
+        return [];
+      }
+      throw error;
+    }
+  },
+  test: async (context) => {
+    const authClient = new OAuth2Client();
+    authClient.setCredentials(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const messagesResponse = await gmail.users.messages.list({
+      userId: 'me',
+      labelIds: ['STARRED'],
+      maxResults: 5,
+    });
+
+    const results = [];
+
+    if (messagesResponse.data.messages) {
+      for (const message of messagesResponse.data.messages) {
+        if (!message.id) continue;
+
+        const enrichedMessage = await enrichStarredMessage({
+          gmail,
+          messageId: message.id,
+          files: context.files,
+        });
+
+        results.push({
+          id: message.id,
+          data: enrichedMessage,
+        });
+      }
+    }
+
+    return results;
+  },
+});


### PR DESCRIPTION
## Summary

Extends the Gmail piece with the missing actions and triggers specified in issue #8072:

**New Actions (6):**
- **Add Label to Email** — `gmail.users.messages.modify` with `addLabelIds`
- **Remove Label from Email** — `gmail.users.messages.modify` with `removeLabelIds`
- **Create Label** — `gmail.users.labels.create` with visibility options
- **Archive Email** — removes `INBOX` label via `gmail.users.messages.modify`
- **Delete Email** — moves to trash via `gmail.users.messages.trash`
- **Remove Label from Thread** — `gmail.users.threads.modify` with `removeLabelIds`

**New Trigger (1):**
- **New Starred Email** — uses Gmail History API (`labelAdded` with `STARRED` label) for efficient polling

**Bug Fixes (2):**
- Registered existing `New Conversation` trigger (was implemented but not wired in `index.ts`)
- Registered existing `Get Thread` action (was implemented but not wired in `index.ts`)

**Auth Scope Update:**
- Added `gmail.modify` scope (required for label/archive/delete operations)
- Added `gmail.labels` scope (required for label creation)

All new code follows the existing Pattern A (`googleapis` SDK with `OAuth2Client`) consistent with recent Gmail piece code.

Closes #8072

## Test plan
- [ ] Verify OAuth2 re-authentication prompts for new scopes
- [ ] Test Add/Remove Label actions with user-created and system labels
- [ ] Test Create Label with different visibility options
- [ ] Test Archive Email removes from inbox
- [ ] Test Delete Email moves to trash
- [ ] Test Remove Label from Thread affects all messages in thread
- [ ] Test New Starred Email trigger fires when starring an email
- [ ] Verify New Conversation trigger and Get Thread action work after registration
