### PR TITLE
docs: add handbook changelog

### DIFF
--- a/docs/about/changelog.mdx
+++ b/docs/about/changelog.mdx
@@ -18,3 +18,5 @@ All changes now go through a dedicated staging environment before reaching produ
 [Read more about our release cycle](/handbook/engineering/onboarding/release-cycle)
 
 </Update>
+
+For previous releases, see the [GitHub Releases](https://github.com/activepieces/activepieces/releases) page.


### PR DESCRIPTION
## Summary

- Create `docs/handbook/changelog.mdx` using Mintlify's `Update` component format
- First entry documents the staging environment & unified CD pipeline changes
- Added to handbook navigation in `docs.json`

## Test plan

- [ ] Changelog page renders in docs under Handbook tab
- [ ] Update component shows with March 2026 label and table of contents