### PR TITLE
fix: simplify form-data fields to single value input

### DIFF
--- a/packages/pieces/common/src/lib/helpers/index.ts
+++ b/packages/pieces/common/src/lib/helpers/index.ts
@@ -231,24 +231,10 @@ i.e ${getBaseUrlForDescription(baseUrl, auth)}/resource or /resource`,
                     displayName: 'Field Name',
                     required: true,
                   }),
-                  fieldType: Property.StaticDropdown({
-                    displayName: 'Field Type',
-                    required: true,
-                    options: {
-                      disabled: false,
-                      options: [
-                        { label: 'Text', value: 'text' },
-                        { label: 'File', value: 'file' },
-                      ],
-                    },
-                  }),
-                  textFieldValue: Property.LongText({
-                    displayName: 'Text Field Value',
+                  value: Property.File({
+                    displayName: 'Value',
                     required: false,
-                  }),
-                  fileFieldValue: Property.File({
-                    displayName: 'File Field Value',
-                    required: false,
+                    description: 'Enter text or pass a file from a previous step.',
                   }),
                 },
               });
@@ -337,24 +323,18 @@ i.e ${getBaseUrlForDescription(baseUrl, auth)}/resource or /resource`,
           if (body_type === 'form_data') {
             const formBodyInput = bodyInput as Array<{
               fieldName: string;
-              fieldType: 'text' | 'file';
-              textFieldValue?: string;
-              fileFieldValue?: ApFile;
+              value?: ApFile | string;
             }>;
 
             const formData = new FormData();
 
-            for (const {
-              fieldName,
-              fieldType,
-              textFieldValue,
-              fileFieldValue,
-            } of formBodyInput) {
-              if (fieldType === 'text' && !isEmpty(textFieldValue)) {
-                formData.append(fieldName, textFieldValue);
-              } else if (fieldType === 'file' && !isEmpty(fileFieldValue)) {
-                formData.append(fieldName, fileFieldValue!.data, {
-                  filename: fileFieldValue?.filename,
+            for (const { fieldName, value } of formBodyInput) {
+              if (isEmpty(value)) continue;
+              if (typeof value === 'string') {
+                formData.append(fieldName, value);
+              } else {
+                formData.append(fieldName, (value as ApFile).data, {
+                  filename: (value as ApFile).filename,
                 });
               }
             }

--- a/packages/pieces/community/http-oauth2/src/lib/actions/send-oauth2-http-request.ts
+++ b/packages/pieces/community/http-oauth2/src/lib/actions/send-oauth2-http-request.ts
@@ -11,11 +11,12 @@ import {
 } from '@activepieces/pieces-common';
 import { httpOauth2Auth } from '../..';
 import {
+  ApFile,
   createAction,
   DynamicPropsValue,
   Property,
 } from '@activepieces/pieces-framework';
-import { assertNotNullOrUndefined } from '@activepieces/shared';
+import { assertNotNullOrUndefined, isEmpty } from '@activepieces/shared';
 import FormData from 'form-data';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import axios from 'axios';
@@ -106,9 +107,20 @@ export const httpOauth2RequestAction = createAction({
             });
             break;
           case 'form_data':
-            fields['data'] = Property.Object({
+            fields['data'] = Property.Array({
               displayName: 'Form Data',
               required: true,
+              properties: {
+                fieldName: Property.ShortText({
+                  displayName: 'Field Name',
+                  required: true,
+                }),
+                value: Property.File({
+                  displayName: 'Value',
+                  required: false,
+                  description: 'Enter text or pass a file from a previous step.',
+                }),
+              },
             });
             break;
         }
@@ -199,10 +211,24 @@ export const httpOauth2RequestAction = createAction({
     if (body) {
       const bodyInput = body['data'];
       if (body_type === 'form_data') {
+        const formBodyInput = bodyInput as Array<{
+          fieldName: string;
+          value?: ApFile | string;
+        }>;
+
         const formData = new FormData();
-        for (const key in bodyInput) {
-          formData.append(key, bodyInput[key]);
+
+        for (const { fieldName, value } of formBodyInput) {
+          if (isEmpty(value)) continue;
+          if (typeof value === 'string') {
+            formData.append(fieldName, value);
+          } else {
+            formData.append(fieldName, (value as ApFile).data, {
+              filename: (value as ApFile).filename,
+            });
+          }
         }
+
         request.body = formData;
         request.headers = { ...request.headers, ...formData.getHeaders() };
       } else {

--- a/packages/pieces/core/http/src/lib/actions/send-http-request-action.ts
+++ b/packages/pieces/core/http/src/lib/actions/send-http-request-action.ts
@@ -160,28 +160,14 @@ export const httpSendRequestAction = createAction({
               properties: {
                 fieldName: Property.ShortText({
                   displayName: 'Field Name',
-                  required: true
-                }),
-                fieldType: Property.StaticDropdown({
-                  displayName: 'Field Type',
                   required: true,
-                  options: {
-                    disabled: false,
-                    options: [
-                      { label: 'Text', value: 'text' },
-                      { label: 'File', value: 'file' }
-                    ]
-                  }
                 }),
-                textFieldValue: Property.LongText({
-                  displayName: 'Text Field Value',
-                  required: false
+                value: Property.File({
+                  displayName: 'Value',
+                  required: false,
+                  description: 'Enter text or pass a file from a previous step.',
                 }),
-                fileFieldValue: Property.File({
-                  displayName: 'File Field Value',
-                  required: false
-                })
-              }
+              },
             });
             break;
         }
@@ -323,18 +309,19 @@ export const httpSendRequestAction = createAction({
       if (body_type === 'form_data') {
         const formBodyInput = bodyInput as Array<{
           fieldName: string;
-          fieldType: 'text' | 'file';
-          textFieldValue?: string;
-          fileFieldValue?: ApFile;
+          value?: ApFile | string;
         }>;
 
         const formData = new FormData();
 
-        for (const { fieldName, fieldType, textFieldValue, fileFieldValue } of formBodyInput) {
-          if (fieldType === 'text' && !isEmpty(textFieldValue)) {
-            formData.append(fieldName, textFieldValue);
-          } else if (fieldType === 'file' && !isEmpty(fileFieldValue)) {
-            formData.append(fieldName, fileFieldValue!.data,{filename:fileFieldValue?.filename});
+        for (const { fieldName, value } of formBodyInput) {
+          if (isEmpty(value)) continue;
+          if (typeof value === 'string') {
+            formData.append(fieldName, value);
+          } else {
+            formData.append(fieldName, (value as ApFile).data, {
+              filename: (value as ApFile).filename,
+            });
           }
         }
 


### PR DESCRIPTION
### What does this PR do?

Simplifies the form data UI for HTTP steps by replacing the three-field setup (Field Type dropdown + Text Field Value + File Field Value) with a single **Value** field that automatically handles both text strings and file inputs based on what is passed in.

### Explain How the Feature Works

When building an HTTP request with `form_data` body type, each form entry now only requires two fields:
- **Field Name** - the form key
- **Value** - accepts either typed text or a file passed from a previous step

The runtime detects the value type (`typeof value === 'string'`) and appends it to the FormData accordingly. No explicit type selection needed.

Changes applied consistently across all three HTTP action implementations: `helpers/index.ts`, `send-http-request-action.ts`, and `send-oauth2-http-request.ts`.

### Relevant User Scenarios

- User wants to POST a file upload via form data — previously had to select "File" from a dropdown, now just passes the file directly into Value
- User wants to send a text field via form data — previously had to select "Text" and fill a separate text input, now just types into Value
- Multi-agent / automation builders who wire file outputs from previous steps into HTTP form fields with less configuration friction

fixes #11263
