### PR TITLE
feat(pcloud): add pCloud cloud storage piece

### DIFF
--- a/packages/pieces/community/pcloud/.eslintrc.json
+++ b/packages/pieces/community/pcloud/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/pcloud/package.json
+++ b/packages/pieces/community/pcloud/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-pcloud",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/pcloud/src/index.ts
+++ b/packages/pieces/community/pcloud/src/index.ts
@@ -1,0 +1,38 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { pcloudAuth } from './lib/auth';
+import { pcloudUploadFile } from './lib/actions/upload-file';
+import { pcloudCreateFolder } from './lib/actions/create-folder';
+import { pcloudDownloadFile } from './lib/actions/download-file';
+import { pcloudCopyFile } from './lib/actions/copy-file';
+import { pcloudFindFile } from './lib/actions/find-file';
+import { pcloudFindFolder } from './lib/actions/find-folder';
+import { pcloudNewFile } from './lib/triggers/new-file';
+import { pcloudNewFolder } from './lib/triggers/new-folder';
+
+export const pcloud = createPiece({
+  displayName: 'pCloud',
+  description: 'Secure cloud storage and file management',
+  auth: pcloudAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/pcloud.png',
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  authors: ['optimus-fulcria'],
+  actions: [
+    pcloudUploadFile,
+    pcloudCreateFolder,
+    pcloudDownloadFile,
+    pcloudCopyFile,
+    pcloudFindFile,
+    pcloudFindFolder,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.pcloud.com',
+      auth: pcloudAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${(auth as { access_token: string }).access_token}`,
+      }),
+    }),
+  ],
+  triggers: [pcloudNewFile, pcloudNewFolder],
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/copy-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/copy-file.ts
@@ -1,0 +1,56 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { pcloudAuth } from '../auth';
+import { pcloudCommon } from '../common';
+
+export const pcloudCopyFile = createAction({
+  auth: pcloudAuth,
+  name: 'copy_pcloud_file',
+  description: 'Copy a file to another folder in pCloud',
+  displayName: 'Copy File',
+  props: {
+    fileId: Property.Number({
+      displayName: 'File ID',
+      description: 'The ID of the file to copy',
+      required: true,
+    }),
+    toFolderId: Property.Number({
+      displayName: 'Destination Folder ID',
+      description: 'The ID of the destination folder',
+      required: true,
+    }),
+    overwrite: Property.Checkbox({
+      displayName: 'Overwrite',
+      description:
+        'If a file with the same name exists in the destination, overwrite it.',
+      defaultValue: false,
+      required: false,
+    }),
+  },
+  async run(context) {
+    const queryParams: Record<string, string> = {
+      fileid: context.propsValue.fileId.toString(),
+      tofolderid: context.propsValue.toFolderId.toString(),
+    };
+
+    if (context.propsValue.overwrite) {
+      queryParams['noover'] = '0';
+    }
+
+    const result = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${pcloudCommon.baseUrl}/copyfile`,
+      queryParams,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+
+    return result.body;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/create-folder.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/create-folder.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { pcloudAuth } from '../auth';
+import { pcloudCommon } from '../common';
+
+export const pcloudCreateFolder = createAction({
+  auth: pcloudAuth,
+  name: 'create_pcloud_folder',
+  description: 'Create a new folder in pCloud',
+  displayName: 'Create Folder',
+  props: {
+    parentFolderId: Property.Number({
+      displayName: 'Parent Folder ID',
+      description: 'The ID of the parent folder. Use 0 for root folder.',
+      required: true,
+      defaultValue: 0,
+    }),
+    name: Property.ShortText({
+      displayName: 'Folder Name',
+      description: 'The name of the new folder',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const result = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${pcloudCommon.baseUrl}/createfolder`,
+      queryParams: {
+        folderid: context.propsValue.parentFolderId.toString(),
+        name: context.propsValue.name,
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+
+    return result.body;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/download-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/download-file.ts
@@ -1,0 +1,59 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { pcloudAuth } from '../auth';
+import { pcloudCommon } from '../common';
+
+export const pcloudDownloadFile = createAction({
+  auth: pcloudAuth,
+  name: 'download_pcloud_file',
+  description: 'Download file content from pCloud',
+  displayName: 'Download File Content',
+  props: {
+    fileId: Property.Number({
+      displayName: 'File ID',
+      description: 'The ID of the file to download',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const linkResult = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${pcloudCommon.baseUrl}/getfilelink`,
+      queryParams: {
+        fileid: context.propsValue.fileId.toString(),
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+
+    const body = linkResult.body as {
+      hosts: string[];
+      path: string;
+    };
+
+    if (!body.hosts || !body.path) {
+      throw new Error(
+        'Failed to get download link: ' + JSON.stringify(linkResult.body)
+      );
+    }
+
+    const downloadUrl = 'https://' + body.hosts[0] + body.path;
+
+    const fileResult = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: downloadUrl,
+    });
+
+    return {
+      downloadUrl,
+      fileName: body.path.split('/').pop(),
+      data: fileResult.body,
+    };
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/find-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/find-file.ts
@@ -1,0 +1,92 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { pcloudAuth } from '../auth';
+import { pcloudCommon } from '../common';
+
+export const pcloudFindFile = createAction({
+  auth: pcloudAuth,
+  name: 'find_pcloud_file',
+  description: 'Search for files by name in pCloud',
+  displayName: 'Find File',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'The file name or part of it to search for',
+      required: true,
+    }),
+    folderId: Property.Number({
+      displayName: 'Folder ID',
+      description:
+        'Search within a specific folder. Use 0 for root (searches all files).',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  async run(context) {
+    const result = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${pcloudCommon.baseUrl}/listfolder`,
+      queryParams: {
+        folderid: (context.propsValue.folderId ?? 0).toString(),
+        recursive: '1',
+        showdeleted: '0',
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+
+    const body = result.body as {
+      metadata?: { contents?: Array<Record<string, unknown>> };
+    };
+    const contents = body?.metadata?.contents ?? [];
+    const query = context.propsValue.query.toLowerCase();
+
+    const matchingFiles = findMatchingItems(contents, query, false);
+
+    return {
+      results: matchingFiles,
+      count: matchingFiles.length,
+    };
+  },
+});
+
+export function findMatchingItems(
+  contents: Array<Record<string, unknown>>,
+  query: string,
+  isFolderSearch: boolean
+): Array<Record<string, unknown>> {
+  const results: Array<Record<string, unknown>> = [];
+
+  for (const item of contents) {
+    const name = (item['name'] as string) ?? '';
+    const isFolder = item['isfolder'] as boolean;
+
+    if (isFolderSearch && isFolder && name.toLowerCase().includes(query)) {
+      results.push(item);
+    } else if (
+      !isFolderSearch &&
+      !isFolder &&
+      name.toLowerCase().includes(query)
+    ) {
+      results.push(item);
+    }
+
+    if (isFolder && item['contents']) {
+      results.push(
+        ...findMatchingItems(
+          item['contents'] as Array<Record<string, unknown>>,
+          query,
+          isFolderSearch
+        )
+      );
+    }
+  }
+
+  return results;
+}

--- a/packages/pieces/community/pcloud/src/lib/actions/find-folder.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/find-folder.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { pcloudAuth } from '../auth';
+import { pcloudCommon } from '../common';
+import { findMatchingItems } from './find-file';
+
+export const pcloudFindFolder = createAction({
+  auth: pcloudAuth,
+  name: 'find_pcloud_folder',
+  description: 'Search for folders by name in pCloud',
+  displayName: 'Find Folder',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'The folder name or part of it to search for',
+      required: true,
+    }),
+    parentFolderId: Property.Number({
+      displayName: 'Parent Folder ID',
+      description:
+        'Search within a specific folder. Use 0 for root (searches all folders).',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  async run(context) {
+    const result = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${pcloudCommon.baseUrl}/listfolder`,
+      queryParams: {
+        folderid: (context.propsValue.parentFolderId ?? 0).toString(),
+        recursive: '1',
+        showdeleted: '0',
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+
+    const body = result.body as {
+      metadata?: { contents?: Array<Record<string, unknown>> };
+    };
+    const contents = body?.metadata?.contents ?? [];
+    const query = context.propsValue.query.toLowerCase();
+
+    const matchingFolders = findMatchingItems(contents, query, true);
+
+    return {
+      results: matchingFolders,
+      count: matchingFolders.length,
+    };
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/upload-file.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { pcloudAuth } from '../auth';
+import { pcloudCommon } from '../common';
+
+export const pcloudUploadFile = createAction({
+  auth: pcloudAuth,
+  name: 'upload_pcloud_file',
+  description: 'Upload a file to a pCloud folder',
+  displayName: 'Upload File',
+  props: {
+    folderId: pcloudCommon.folderIdProp,
+    filename: Property.ShortText({
+      displayName: 'File Name',
+      description: 'The name for the uploaded file (e.g. report.pdf)',
+      required: true,
+    }),
+    file: Property.File({
+      displayName: 'File',
+      description: 'The file to upload',
+      required: true,
+    }),
+    renameIfExists: Property.Checkbox({
+      displayName: 'Rename if exists',
+      description:
+        'If a file with the same name already exists, rename the new file automatically.',
+      defaultValue: false,
+      required: false,
+    }),
+  },
+  async run(context) {
+    const fileBuffer = Buffer.from(context.propsValue.file.base64, 'base64');
+
+    const result = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${pcloudCommon.baseUrl}/uploadfile`,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+      },
+      queryParams: {
+        folderid: context.propsValue.folderId.toString(),
+        filename: context.propsValue.filename,
+        renameifexists: context.propsValue.renameIfExists ? '1' : '0',
+      },
+      body: fileBuffer,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+
+    return result.body;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/auth.ts
+++ b/packages/pieces/community/pcloud/src/lib/auth.ts
@@ -1,0 +1,10 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const pcloudAuth = PieceAuth.OAuth2({
+  description:
+    'Connect your pCloud account. Note: pCloud has two data centers (US and EU). The correct API endpoint is determined by your account location.',
+  authUrl: 'https://my.pcloud.com/oauth2/authorize',
+  tokenUrl: 'https://api.pcloud.com/oauth2_token',
+  required: true,
+  scope: [],
+});

--- a/packages/pieces/community/pcloud/src/lib/common/index.ts
+++ b/packages/pieces/community/pcloud/src/lib/common/index.ts
@@ -1,0 +1,17 @@
+import { Property } from '@activepieces/pieces-framework';
+
+export const pcloudCommon = {
+  baseUrl: 'https://api.pcloud.com',
+  eBaseUrl: 'https://eapi.pcloud.com',
+
+  folderIdProp: Property.Number({
+    displayName: 'Folder ID',
+    description: 'The ID of the folder. Use 0 for root folder.',
+    required: true,
+    defaultValue: 0,
+  }),
+
+  getApiUrl(locationId?: number): string {
+    return locationId === 2 ? this.eBaseUrl : this.baseUrl;
+  },
+};

--- a/packages/pieces/community/pcloud/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/triggers/new-file.ts
@@ -1,0 +1,109 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import dayjs from 'dayjs';
+import { pcloudAuth } from '../auth';
+import { pcloudCommon } from '../common';
+
+const polling: Polling<
+  { access_token: string },
+  { folderId?: number }
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue }) => {
+    const folderId = propsValue.folderId ?? 0;
+
+    const result = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${pcloudCommon.baseUrl}/listfolder`,
+      queryParams: {
+        folderid: folderId.toString(),
+        recursive: '0',
+        showdeleted: '0',
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.access_token,
+      },
+    });
+
+    const body = result.body as {
+      metadata?: { contents?: Array<Record<string, unknown>> };
+    };
+    const contents = body?.metadata?.contents ?? [];
+
+    const files = contents.filter(
+      (item) => !(item['isfolder'] as boolean)
+    );
+
+    return files.map((file) => ({
+      epochMilliSeconds: dayjs(file['modified'] as string).valueOf(),
+      data: file,
+    }));
+  },
+};
+
+export const pcloudNewFile = createTrigger({
+  auth: pcloudAuth,
+  name: 'new_file_uploaded',
+  displayName: 'New File Uploaded',
+  description: 'Triggers when a new file is uploaded to a folder',
+  props: {
+    folderId: Property.Number({
+      displayName: 'Folder ID',
+      description:
+        'The folder to watch for new files. Use 0 for root folder.',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  onEnable: async (context) => {
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  onDisable: async (context) => {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  run: async (context) => {
+    return await pollingHelper.poll(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  test: async (context) => {
+    return await pollingHelper.test(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  sampleData: {
+    name: 'example.pdf',
+    created: '2026-01-15T10:30:00+0000',
+    modified: '2026-01-15T10:30:00+0000',
+    fileid: 123456789,
+    size: 1048576,
+    contenttype: 'application/pdf',
+    isfolder: false,
+    parentfolderid: 0,
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/triggers/new-folder.ts
+++ b/packages/pieces/community/pcloud/src/lib/triggers/new-folder.ts
@@ -1,0 +1,107 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import dayjs from 'dayjs';
+import { pcloudAuth } from '../auth';
+import { pcloudCommon } from '../common';
+
+const polling: Polling<
+  { access_token: string },
+  { parentFolderId?: number }
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue }) => {
+    const folderId = propsValue.parentFolderId ?? 0;
+
+    const result = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${pcloudCommon.baseUrl}/listfolder`,
+      queryParams: {
+        folderid: folderId.toString(),
+        recursive: '0',
+        showdeleted: '0',
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.access_token,
+      },
+    });
+
+    const body = result.body as {
+      metadata?: { contents?: Array<Record<string, unknown>> };
+    };
+    const contents = body?.metadata?.contents ?? [];
+
+    const folders = contents.filter(
+      (item) => item['isfolder'] as boolean
+    );
+
+    return folders.map((folder) => ({
+      epochMilliSeconds: dayjs(folder['modified'] as string).valueOf(),
+      data: folder,
+    }));
+  },
+};
+
+export const pcloudNewFolder = createTrigger({
+  auth: pcloudAuth,
+  name: 'new_folder_created',
+  displayName: 'Folder Created',
+  description: 'Triggers when a new folder is created',
+  props: {
+    parentFolderId: Property.Number({
+      displayName: 'Parent Folder ID',
+      description:
+        'The folder to watch for new subfolders. Use 0 for root folder.',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  onEnable: async (context) => {
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  onDisable: async (context) => {
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  run: async (context) => {
+    return await pollingHelper.poll(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  test: async (context) => {
+    return await pollingHelper.test(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
+  },
+  sampleData: {
+    name: 'New Project',
+    created: '2026-01-15T10:30:00+0000',
+    modified: '2026-01-15T10:30:00+0000',
+    folderid: 987654321,
+    isfolder: true,
+    parentfolderid: 0,
+  },
+});

--- a/packages/pieces/community/pcloud/tsconfig.json
+++ b/packages/pieces/community/pcloud/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/pcloud/tsconfig.lib.json
+++ b/packages/pieces/community/pcloud/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- Adds new pCloud piece for secure cloud storage integration
- Implements all features requested in #7670

## Features
### Triggers (Polling)
- **New File Uploaded** - Triggers when a new file is uploaded to a specified folder
- **Folder Created** - Triggers when a new folder is created

### Write Actions
- **Upload File** - Upload a file to a pCloud folder
- **Create Folder** - Create a new folder in pCloud
- **Download File Content** - Download file content from pCloud
- **Copy File** - Copy a file to another folder

### Search Actions
- **Find File** - Search for files by name (recursive)
- **Find Folder** - Search for folders by name (recursive)

### Custom API Call
- Generic custom API call action for any pCloud API endpoint

## Authentication
- OAuth2 (authorization code flow)
- Auth URL: `https://my.pcloud.com/oauth2/authorize`
- Token URL: `https://api.pcloud.com/oauth2_token`

## Test Plan
- [ ] OAuth2 connection with free pCloud account
- [ ] Upload file to root and subfolder
- [ ] Create folder, verify it appears
- [ ] Download file content by file ID
- [ ] Copy file to different folder
- [ ] Find file/folder by name
- [ ] New file trigger fires on upload
- [ ] New folder trigger fires on creation

Addresses #7670