### PR TITLE
feat: add deploy-staging-skip-freeze option to CD workflow

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -13,6 +13,7 @@ on:
         type: choice
         options:
           - deploy-staging         # Re-deploy to staging (e.g., after infra change)
+          - deploy-staging-skip-freeze  # Deploy to staging, ignoring the freeze window
           - promote-to-production  # Hotfix: promote staging to prod immediately
           - weekly-release         # Trigger official release manually
 
@@ -40,7 +41,7 @@ jobs:
     needs: [check-freeze]
     if: |
       (github.event_name == 'push' && needs.check-freeze.outputs.frozen == 'false') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy-staging')
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.action == 'deploy-staging' || github.event.inputs.action == 'deploy-staging-skip-freeze'))
     runs-on: depot-ubuntu-24.04
     concurrency:
       group: deploy-staging


### PR DESCRIPTION
## Summary
- Adds a new `deploy-staging-skip-freeze` option to the Continuous Delivery workflow dispatch
- When selected, deploys to staging immediately regardless of the freeze window (5 PM - 9 AM UTC)
- Useful for urgent staging deployments that can't wait for the freeze window to end

## Test plan
- [ ] Verify the new option appears in the GitHub Actions workflow dispatch dropdown
- [ ] Trigger `deploy-staging-skip-freeze` during freeze hours and confirm it proceeds