### PR TITLE
fix(ai): pass Buffer directly to Vercel AI SDK instead of data URL

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -472,7 +472,7 @@
     },
     "packages/pieces/community/ai": {
       "name": "@activepieces/piece-ai",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/ai/package.json
+++ b/packages/pieces/community/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ai",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/ai/src/lib/actions/utility/extract-structured-data.ts
+++ b/packages/pieces/community/ai/src/lib/actions/utility/extract-structured-data.ts
@@ -229,15 +229,15 @@ export const extractStructuredData = createAction({
 				}
 				const fileType = file.extension ? mime.lookup(file.extension) : 'image/jpeg';
 
-				if (fileType && fileType.startsWith('image') && file.base64) {
+				if (fileType && fileType.startsWith('image') && file.data) {
 					contentParts.push({
 						type: 'image',
-						image: `data:${fileType};base64,${file.base64}`,
+						image: file.data,
 					});
-				} else if (fileType && fileType.startsWith('application/pdf') && file.base64) {
+				} else if (fileType && fileType.startsWith('application/pdf') && file.data) {
 					contentParts.push({
 						type: 'file',
-						data: `data:${fileType};base64,${file.base64}`,
+						data: file.data,
 						mediaType: fileType,
 						filename: file.filename,
 					});


### PR DESCRIPTION
## What does this PR do?

Fixes `URL scheme must be http or https, got data:` error in the **Extract Structured Data** action when an image or PDF URL is provided in the Files field.

The engine downloads the file and stores it in an `ApFile` with a `data` Buffer. The previous code reconstructed a `data:base64` URL string and passed it to the Vercel AI SDK — which AI providers (OpenAI, Anthropic, etc.) reject with the above error.

The fix passes `file.data` (a `Buffer`) directly, which is a valid `DataContent` type accepted by both `ImagePart` and `FilePart` in the Vercel AI SDK.

### Explain How the Feature Works

**Before:**
```typescript
image: `data:${fileType};base64,${file.base64}` // ❌ rejected by providers
```

**After:**
```typescript
image: file.data // ✅ Buffer, valid DataContent
```

### Relevant User Scenarios

- User provides an HTTPS image URL in the Files field of Extract Structured Data → previously threw `URL scheme must be http or https, got data:`, now works correctly
- Same fix applies to PDF inputs passed via URL