### PR TITLE
fix: restore rounded card layout for cloud and unify spacing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",

--- a/packages/web/src/app/components/builder-layout/index.tsx
+++ b/packages/web/src/app/components/builder-layout/index.tsx
@@ -4,6 +4,7 @@ import { useEmbedding } from '@/components/providers/embed-provider';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar-shadcn';
 import { PurchaseExtraFlowsDialog } from '@/features/billing';
 import { flagsHooks } from '@/hooks/flags-hooks';
+import { cn } from '@/lib/utils';
 
 import { ProjectDashboardSidebar } from '../sidebar/dashboard';
 
@@ -15,8 +16,8 @@ export function BuilderLayout({ children }: { children: React.ReactNode }) {
     <SidebarProvider hoverMode={true} defaultOpen={false}>
       {!embedState.isEmbedded && <ProjectDashboardSidebar />}
       <SidebarInset className="flex flex-col h-full overflow-hidden bg-sidebar">
-        <div className="flex-1 flex flex-col  overflow-hidden">
-          <div className="flex flex-col h-full bg-background border-l overflow-hidden">
+        <div className={cn("flex-1 flex flex-col overflow-hidden", !embedState.isEmbedded && "p-1.5")}>
+          <div className={cn("flex flex-col h-full bg-background overflow-hidden", embedState.isEmbedded ? "border-l" : "rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border")}>
             {children}
           </div>
         </div>

--- a/packages/web/src/app/components/dashboard-page-header.tsx
+++ b/packages/web/src/app/components/dashboard-page-header.tsx
@@ -14,7 +14,7 @@ export const DashboardPageHeader = ({
       title={title}
       description={description}
       rightContent={children}
-      className="min-w-full z-30 "
+      className="min-w-full z-30 px-3"
     />
   );
 };

--- a/packages/web/src/app/components/platform-layout.tsx
+++ b/packages/web/src/app/components/platform-layout.tsx
@@ -20,9 +20,9 @@ export function PlatformLayout({ children }: { children: React.ReactNode }) {
         <SidebarProvider open={true}>
           <PlatformSidebar />
           <SidebarInset className="flex flex-col h-full overflow-hidden bg-sidebar">
-            <div className="flex-1 flex flex-col p-2 pt-3 pb-3 overflow-hidden">
+            <div className="flex-1 flex flex-col p-1.5 overflow-hidden">
               <div className="flex flex-col h-full bg-background rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border">
-                <div className="flex-1 overflow-auto scrollbar-none px-4 pb-4">
+                <div className="flex-1 overflow-auto scrollbar-none px-2 pb-2">
                   {children}
                 </div>
               </div>

--- a/packages/web/src/app/components/project-layout/index.tsx
+++ b/packages/web/src/app/components/project-layout/index.tsx
@@ -12,6 +12,7 @@ import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar-shadcn';
 import { PurchaseExtraFlowsDialog } from '@/features/billing';
 import { projectHooks } from '@/features/projects';
 import { flagsHooks } from '@/hooks/flags-hooks';
+import { cn } from '@/lib/utils';
 
 import { authenticationSession } from '../../../lib/authentication-session';
 import { ProjectDashboardSidebar } from '../sidebar/dashboard';
@@ -85,15 +86,15 @@ export function ProjectDashboardLayout({
       <SidebarProvider hoverMode={true}>
         {!isEmbedded && <ProjectDashboardSidebar />}
         <SidebarInset className="flex flex-col h-full overflow-hidden bg-sidebar">
-          <div className="flex-1 flex flex-col  overflow-hidden">
-            <div className="flex flex-col h-full bg-background border-l">
+          <div className={cn("flex-1 flex flex-col overflow-hidden", !isEmbedded && "p-1.5")}>
+            <div className={cn("flex flex-col h-full bg-background", isEmbedded ? "border-l" : "rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border")}>
               {!hideHeader && (
                 <>
                   <ProjectDashboardLayoutHeader key={currentProjectId} />
                   <Separator className="mb-5" />
                 </>
               )}
-              <div className="flex-1 overflow-auto  px-4"> {children} </div>
+              <div className="flex-1 overflow-auto  px-2"> {children} </div>
             </div>
           </div>
         </SidebarInset>

--- a/packages/web/src/app/components/project-layout/project-dashboard-layout-header.tsx
+++ b/packages/web/src/app/components/project-layout/project-dashboard-layout-header.tsx
@@ -111,7 +111,7 @@ export const ProjectDashboardLayoutHeader = () => {
   return (
     <div className="flex flex-col gap-1">
       {!isEmbedded && <ProjectDashboardPageHeader />}
-      <Tabs className="px-4">
+      <Tabs className="px-3">
         {!embedState.hideSideNav && (
           <TabsList variant="outline">
             {visiblePrimaryTabs.map((tab) => (

--- a/packages/web/src/app/components/project-layout/project-dashboard-page-header.tsx
+++ b/packages/web/src/app/components/project-layout/project-dashboard-page-header.tsx
@@ -178,7 +178,7 @@ export const ProjectDashboardPageHeader = ({
         description={description}
         rightContent={rightContent}
         showSidebarToggle={true}
-        className="min-w-full px-4"
+        className="min-w-full px-3"
       />
       <InviteUserDialog open={inviteOpen} setOpen={setInviteOpen} />
       <ProjectSettingsDialog


### PR DESCRIPTION
## Summary
- Restore rounded card design with shadow for cloud (non-embedded) usage in `BuilderLayout` and `ProjectDashboardLayout`, matching the platform admin layout style
- Keep flat `border-l` design for embedded contexts
- Unify padding to `p-1.5` across platform admin, builder, and project layouts
- Align page header padding (`px-3`) across project dashboard and platform admin pages

## Test plan
- [ ] Verify cloud dashboard/builder shows rounded card with shadow
- [ ] Verify embedded mode preserves flat layout with left border
- [ ] Verify platform admin pages have consistent spacing with project pages