### PR TITLE
fix: fix table overflow, skeleton, and panel scroll issues

### DIFF
--- a/packages/web/src/app/components/platform-layout.tsx
+++ b/packages/web/src/app/components/platform-layout.tsx
@@ -21,7 +21,7 @@ export function PlatformLayout({ children }: { children: React.ReactNode }) {
           <PlatformSidebar />
           <SidebarInset className="flex flex-col h-full overflow-hidden bg-sidebar">
             <div className="flex-1 flex flex-col p-1.5 overflow-hidden">
-              <div className="flex flex-col h-full bg-background rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border">
+              <div className="flex flex-col h-full bg-background rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border overflow-hidden">
                 <div className="flex-1 overflow-auto scrollbar-none px-2 pb-2">
                   {children}
                 </div>

--- a/packages/web/src/app/components/project-layout/index.tsx
+++ b/packages/web/src/app/components/project-layout/index.tsx
@@ -87,14 +87,14 @@ export function ProjectDashboardLayout({
         {!isEmbedded && <ProjectDashboardSidebar />}
         <SidebarInset className="flex flex-col h-full overflow-hidden bg-sidebar">
           <div className={cn("flex-1 flex flex-col overflow-hidden", !isEmbedded && "p-1.5")}>
-            <div className={cn("flex flex-col h-full bg-background", isEmbedded ? "border-l" : "rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border")}>
+            <div className={cn("flex flex-col h-full bg-background overflow-hidden", isEmbedded ? "border-l" : "rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border")}>
               {!hideHeader && (
                 <>
                   <ProjectDashboardLayoutHeader key={currentProjectId} />
                   <Separator className="mb-5" />
                 </>
               )}
-              <div className="flex-1 overflow-auto  px-2"> {children} </div>
+              <div className="flex-1 overflow-auto px-3"> {children} </div>
             </div>
           </div>
         </SidebarInset>

--- a/packages/web/src/features/automations/components/automations-table.tsx
+++ b/packages/web/src/features/automations/components/automations-table.tsx
@@ -76,7 +76,7 @@ export const AutomationsTable = ({
   const groups = groupTreeItemsByFolder(items);
 
   return (
-    <div className="-mx-4 overflow-x-auto">
+    <div className="-mx-3 overflow-x-auto">
       <div className="min-w-[1000px]">
         <div className="flex items-center h-10 text-xs border-b border-t font-medium text-foreground bg-background">
           <div className="w-10 shrink-0 pl-4 pr-1">
@@ -116,10 +116,10 @@ export const AutomationsTable = ({
         </div>
 
         {isLoading ? (
-          <div>
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex items-center h-10 px-2">
-                <Skeleton className="h-6 w-full" />
+          <div className="p-2">
+            {Array.from({ length: 10 }).map((_, i) => (
+              <div key={i} className="w-full h-10 mb-4 rounded-sm">
+                <Skeleton className="w-full min-h-10" />
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Fix automations table horizontal overflow by adjusting negative margin to match new `px-3` padding
- Improve automations table loading skeleton to match `DataTableSkeleton` pattern
- Add `overflow-hidden` to card containers in platform and project layouts to prevent whole panel from scrolling

## Test plan
- [ ] Verify automations table has no horizontal overflow
- [ ] Verify loading skeleton matches other tables
- [ ] Verify scrolling within platform admin and project dashboard stays inside the card