### PR TITLE
fix: restore nanoid and cron-validator in engine

### DIFF
--- a/packages/server/engine/package.json
+++ b/packages/server/engine/package.json
@@ -14,10 +14,12 @@
     "@activepieces/shared": "workspace:*",
     "ai": "^6.0.0",
     "async-mutex": "0.4.0",
+    "cron-validator": "1.3.1",
     "dayjs": "1.11.9",
     "fetch-retry": "6.0.0",
     "isolated-vm": "6.0.2",
     "mime-types": "2.1.35",
+    "nanoid": "3.3.8",
     "socket.io-client": "4.8.1",
     "tslib": "2.6.2",
     "zod": "4.3.6"

--- a/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
@@ -1,6 +1,6 @@
-import crypto from 'node:crypto'
 import { assertEqual, EngineGenericError, executionJournal, FailedStep, FlowActionType, FlowRunStatus, GenericStepOutput, isNil, LoopStepOutput, LoopStepResult, PauseMetadata, PauseType, RespondResponse, StepOutput, StepOutputStatus } from '@activepieces/shared'
 import dayjs from 'dayjs'
+import { nanoid } from 'nanoid'
 import { loggingUtils } from '../../helper/logging-utils'
 import { StepExecutionPath } from './step-execution-path'
 
@@ -35,7 +35,7 @@ export class FlowExecutorContext {
     constructor(copyFrom?: FlowExecutorContext) {
         this.tags = copyFrom?.tags ?? []
         this.steps = copyFrom?.steps ?? {}
-        this.pauseRequestId = copyFrom?.pauseRequestId ?? crypto.randomUUID()
+        this.pauseRequestId = copyFrom?.pauseRequestId ?? nanoid()
         this.duration = copyFrom?.duration ?? -1
         this.verdict = copyFrom?.verdict ?? { status: FlowRunStatus.RUNNING }
         this.currentPath = copyFrom?.currentPath ?? StepExecutionPath.empty()

--- a/packages/server/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/server/engine/src/lib/helper/trigger-helper.ts
@@ -1,6 +1,7 @@
 import { inspect } from 'node:util'
 import { PiecePropertyMap, StaticPropsValue, TriggerStrategy } from '@activepieces/pieces-framework'
 import { assertEqual, AUTHENTICATION_PROPERTY_NAME, EngineGenericError, EventPayload, ExecuteTriggerOperation, ExecuteTriggerResponse, FlowTrigger, InvalidCronExpressionError, isNil, PieceTrigger, PropertySettings, ScheduleOptions, TriggerHookType, TriggerSourceScheduleType } from '@activepieces/shared'
+import { isValidCron } from 'cron-validator'
 import { EngineConstants } from '../handler/context/engine-constants'
 import { FlowExecutorContext } from '../handler/context/flow-execution-context'
 import { createFlowsContext } from '../services/flows.service'
@@ -111,7 +112,7 @@ export const triggerHelper = {
                 },
             },
             setSchedule(request: ScheduleOptions) {
-                if (!isSimpleValidCron(request.cronExpression)) {
+                if (!isValidCron(request.cronExpression)) {
                     throw new InvalidCronExpressionError(request.cronExpression)
                 }
                 scheduleOptions = {
@@ -299,14 +300,6 @@ async function prepareTriggerExecution({ pieceName, pieceVersion, triggerName, i
     }
 
     return { piece, pieceTrigger, processedInput }
-}
-
-function isSimpleValidCron(expression: string): boolean {
-    const parts = expression.trim().split(/\s+/)
-    if (parts.length < 5 || parts.length > 6) {
-        return false
-    }
-    return parts.every((part) => /^[\d,\-*/]+$/.test(part))
 }
 
 type PrepareTriggerExecutionParams = {


### PR DESCRIPTION
## Summary
- Restore `nanoid` and `cron-validator` dependencies that were inlined during bundle optimization
- Bundle size unchanged at 1.2MB (these are tiny deps)

## Test plan
- [x] Build passes
- [x] Lint: 0 errors
- [x] Tests: 172/172 pass