### PR TITLE
feat: remove legacy redis keys on startup

### DIFF
--- a/packages/server/api/src/app/workers/migrations/delete-legacy-redis-keys.ts
+++ b/packages/server/api/src/app/workers/migrations/delete-legacy-redis-keys.ts
@@ -1,0 +1,33 @@
+
+import { isNil } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { redisHelper } from '../../database/redis'
+import { redisConnections } from '../../database/redis-connections'
+
+const DELETE_LEGACY_REDIS_KEYS_KEY = 'delete_legacy_redis_keys'
+
+const LEGACY_PATTERNS = [
+    'tasks:project:*',
+    'tasks:platform:*',
+    'project-usage:*',
+    'project-*-usage-tasks:*',
+]
+
+export const deleteLegacyRedisKeys = (log: FastifyBaseLogger) => ({
+    async run(): Promise<void> {
+        const redisConnection = await redisConnections.useExisting()
+        const isMigrated = await redisConnection.get(DELETE_LEGACY_REDIS_KEYS_KEY)
+        if (!isNil(isMigrated)) {
+            log.info('[deleteLegacyRedisKeys] Already migrated, skipping')
+            return
+        }
+        for (const pattern of LEGACY_PATTERNS) {
+            const keys = await redisHelper.scanAll(redisConnection, pattern)
+            log.info({ pattern, count: keys.length }, '[deleteLegacyRedisKeys] Found legacy keys')
+            if (keys.length > 0) {
+                await redisConnection.del(...keys)
+            }
+        }
+        await redisConnection.set(DELETE_LEGACY_REDIS_KEYS_KEY, 'true')
+    },
+})

--- a/packages/server/api/src/app/workers/migrations/queue-migration-runner.ts
+++ b/packages/server/api/src/app/workers/migrations/queue-migration-runner.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs'
 import { FastifyBaseLogger } from 'fastify'
 import { distributedLock, redisConnections } from '../../database/redis-connections'
+import { deleteLegacyRedisKeys } from './delete-legacy-redis-keys'
 import { deleteStaleRunMetadata } from './delete-stale-run-metadata'
 import { refillPausedRuns } from './refill-paused-jobs'
 import { refillPollingJobs } from './refill-polling-jobs'
@@ -26,6 +27,7 @@ export const queueMigration = (log: FastifyBaseLogger) => ({
                 await removeRateLimitJobsQueue(log).run()
                 await refillPausedRuns(log).run()
                 await deleteStaleRunMetadata(log).run()
+                await deleteLegacyRedisKeys(log).run()
             },
         })
       


### PR DESCRIPTION
## Summary
- Add startup migration to scan and delete unused legacy Redis keys (`tasks:project:*`, `tasks:platform:*`, `project-usage:*`, `project-*-usage-tasks:*`)
- Uses idempotency guard key so migration only runs once

Closes GIT-1321