### PR TITLE
fix: prevent subflow infinite loop when waiting for response

### DIFF
--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -244,9 +244,10 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
 
 
         const pauseMetadata = flowRun.pauseMetadata
-        const matchRequestId = isNil(pauseMetadata) || (pauseMetadata.type === PauseType.WEBHOOK && requestId === pauseMetadata.requestId)
+        const matchRequestId = !isNil(pauseMetadata) && pauseMetadata.type === PauseType.WEBHOOK && requestId === pauseMetadata.requestId
         const platformId = await projectService(log).getPlatformId(flowRun.projectId)
         if (matchRequestId || !checkRequestId) {
+            await flowRunSideEffects(log).onResume(flowRun)
             return addToQueue({
                 payload,
                 flowRun,
@@ -258,8 +259,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
                 executionType,
             }, log)
         }
-        await flowRunSideEffects(log).onResume(flowRun)
-        return flowRun
+        return null
     },
 
     async start({


### PR DESCRIPTION
## Summary
- Guard `flowRunService.resume()` to require actual pause metadata before resuming, preventing premature resume when DB hasn't been updated yet
- Return `null` instead of silently accepting resume via `onResume` side effect when flow isn't actually paused
- Move `onResume` event firing inside the successful resume path so it only fires on actual resumes

## Root Cause
In multi-instance setups, the child flow's `promoteChildRuns` could trigger before the parent's execution state was fully persisted to S3. The `matchRequestId` check treated `null` pause metadata as a match (`isNil(pauseMetadata) || ...`), allowing the resume to proceed with incomplete state. This caused the call-flow step to re-execute as BEGIN instead of RESUME, triggering the child flow again in an infinite loop.

## Test plan
- [ ] Create parent flow with "Call Flow" action (`waitForResponse: true`) and child flow with "Callable Flow" trigger + "Return Response"
- [ ] Test on multi-instance setup — verify no infinite loop
- [ ] Verify parent pauses, child executes, parent resumes exactly once
- [ ] Test `waitForResponse: false` — parent shouldn't pause
- [ ] Test retry from failed step still works (`checkRequestId: false` path)