### PR TITLE
fix(platform): coerce multipart form data booleans and arrays

### DIFF
--- a/packages/server/api/test/integration/cloud/platform/platform.test.ts
+++ b/packages/server/api/test/integration/cloud/platform/platform.test.ts
@@ -133,6 +133,61 @@ describe('Platform API', () => {
             expect(responseBody.favIconUrl.startsWith(baseUrl)).toBeTruthy()
         }),
 
+        it('updates platform with boolean and array fields via multipart form data', async () => {
+            const { mockOwner, mockPlatform } = await mockAndSaveBasicSetup({
+                plan: {
+                    embeddingEnabled: false,
+                },
+                platform: {
+                },
+            })
+            const testToken = await generateMockToken({
+                type: PrincipalType.USER,
+                id: mockOwner.id,
+                platform: { id: mockPlatform.id },
+            })
+            const formData = new FormData()
+            formData.append('logoIcon', new Blob([faker.image.urlPlaceholder()], { type: 'image/png' }))
+            formData.append('fullLogo', new Blob([faker.image.urlPlaceholder()], { type: 'image/png' }))
+            formData.append('favIcon', new Blob([faker.image.urlPlaceholder()], { type: 'image/png' }))
+            formData.append('cloudAuthEnabled', 'false')
+            formData.append('emailAuthEnabled', 'false')
+            formData.append('enforceAllowedAuthDomains', 'true')
+            formData.append('filteredPieceNames', 'piece-1')
+            formData.append('allowedAuthDomains', 'example.com')
+            formData.append('pinnedPieces', 'pinned-1')
+            formData.append('name', 'updated name')
+            formData.append('filteredPieceBehavior', 'ALLOWED')
+
+            // act
+            const response = await app?.inject({
+                method: 'POST',
+                url: `/v1/platforms/${mockPlatform.id}`,
+                headers: {
+                    authorization: `Bearer ${testToken}`,
+                },
+                body: formData,
+            })
+
+            // assert
+            const responseBody = response?.json()
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(responseBody.cloudAuthEnabled).toBe(false)
+            expect(responseBody.emailAuthEnabled).toBe(false)
+            expect(responseBody.enforceAllowedAuthDomains).toBe(true)
+            expect(responseBody.filteredPieceNames).toStrictEqual(['piece-1'])
+            expect(responseBody.allowedAuthDomains).toStrictEqual(['example.com'])
+            expect(responseBody.pinnedPieces).toStrictEqual(['pinned-1'])
+            expect(responseBody.name).toBe('updated name')
+            expect(responseBody.filteredPieceBehavior).toBe('ALLOWED')
+
+            const baseUrl = 'http://localhost:4200/api/v1/platforms/assets'
+            expect(responseBody.logoIconUrl.startsWith(baseUrl)).toBeTruthy()
+            expect(responseBody.fullLogoUrl.startsWith(baseUrl)).toBeTruthy()
+            expect(responseBody.favIconUrl.startsWith(baseUrl)).toBeTruthy()
+        }),
+
         it('fails if user is not owner', async () => {
             // arrange
             const { mockPlatform } = await mockAndSaveBasicSetup()

--- a/packages/shared/src/lib/management/platform/platform.request.ts
+++ b/packages/shared/src/lib/management/platform/platform.request.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { SAFE_STRING_PATTERN } from '../../core/common'
+import { OptionalArrayFromQuery, OptionalBooleanFromQuery } from '../../core/common/base-model'
 import { ApId } from '../../core/common/id-generator'
 import { ApMultipartFile } from '../../core/common/multipart-file'
 import { FederatedAuthnProviderConfig } from '../../core/federated-authn'
@@ -18,14 +19,14 @@ export const UpdatePlatformRequestBody = z.object({
     logoIcon: ApMultipartFile.optional(),
     fullLogo: ApMultipartFile.optional(),
     favIcon: ApMultipartFile.optional(),
-    filteredPieceNames: z.array(z.string()).optional(),
+    filteredPieceNames: OptionalArrayFromQuery(z.string()),
     filteredPieceBehavior: z.nativeEnum(FilteredPieceBehavior).optional(),
     federatedAuthProviders: FederatedAuthnProviderConfig.optional(),
-    cloudAuthEnabled: z.boolean().optional(),
-    emailAuthEnabled: z.boolean().optional(),
-    allowedAuthDomains: z.array(z.string()).optional(),
-    enforceAllowedAuthDomains: z.boolean().optional(),
-    pinnedPieces: z.array(z.string()).optional(),
+    cloudAuthEnabled: OptionalBooleanFromQuery,
+    emailAuthEnabled: OptionalBooleanFromQuery,
+    allowedAuthDomains: OptionalArrayFromQuery(z.string()),
+    enforceAllowedAuthDomains: OptionalBooleanFromQuery,
+    pinnedPieces: OptionalArrayFromQuery(z.string()),
 })
 
 export type UpdatePlatformRequestBody = z.infer<typeof UpdatePlatformRequestBody>


### PR DESCRIPTION
## Summary
- Replace strict `z.boolean().optional()` and `z.array(z.string()).optional()` with `OptionalBooleanFromQuery` and `OptionalArrayFromQuery` in `UpdatePlatformRequestBody` so multipart form data string values (`"true"`, `"false"`, single strings for arrays) are correctly coerced
- Add integration test covering multipart form submission with boolean strings, array-as-string, and file uploads

## Test plan
- [x] All 12 existing platform tests pass
- [x] New test verifies booleans are coerced from strings and arrays from single values via multipart form data
- [x] `npx turbo lint -- --fix` passes with 0 errors