### PR TITLE
fix(tests): move enterprise flags tests to ee/ directory

### DIFF
--- a/packages/server/api/test/integration/ce/flags/flags.test.ts
+++ b/packages/server/api/test/integration/ce/flags/flags.test.ts
@@ -1,9 +1,5 @@
-import { ApFlagId } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
-import { db } from '../../../helpers/db'
-import { createMockCustomDomain } from '../../../helpers/mocks'
-import { createTestContext, TestContext } from '../../../helpers/test-context'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
 let app: FastifyInstance | null = null
@@ -31,72 +27,6 @@ describe('Flags API', () => {
             expect(typeof body.ENVIRONMENT).toBe('string')
             expect(body).toHaveProperty('WEBHOOK_URL_PREFIX')
             expect(typeof body.WEBHOOK_URL_PREFIX).toBe('string')
-        })
-
-        it('should return platform theme when authenticated', async () => {
-            const ctx = await createTestContext(app!, {
-                platform: {
-                    primaryColor: '#ff0000',
-                    name: 'Custom Platform',
-                    fullLogoUrl: 'https://example.com/full-logo.png',
-                    favIconUrl: 'https://example.com/favicon.ico',
-                    logoIconUrl: 'https://example.com/logo-icon.svg',
-                },
-                plan: {
-                    customAppearanceEnabled: true,
-                },
-            })
-
-            const response = await ctx.get('/v1/flags')
-
-            expect(response.statusCode).toBe(StatusCodes.OK)
-            const body = response.json()
-
-            expect(body).toHaveProperty(ApFlagId.THEME)
-            const theme = body[ApFlagId.THEME]
-            expect(theme.websiteName).toBe('Custom Platform')
-            expect(theme.logos.fullLogoUrl).toBe('https://example.com/full-logo.png')
-            expect(theme.logos.favIconUrl).toBe('https://example.com/favicon.ico')
-            expect(theme.logos.logoIconUrl).toBe('https://example.com/logo-icon.svg')
-            expect(theme.colors.primary.default).toBe('#ff0000')
-        })
-
-        it('should resolve platform from custom domain when unauthenticated', async () => {
-            const ctx = await createTestContext(app!, {
-                platform: {
-                    primaryColor: '#00ff00',
-                    name: 'Domain Platform',
-                    fullLogoUrl: 'https://example.com/domain-logo.png',
-                    favIconUrl: 'https://example.com/domain-favicon.ico',
-                    logoIconUrl: 'https://example.com/domain-icon.svg',
-                },
-                plan: {
-                    customAppearanceEnabled: true,
-                },
-            })
-
-            const mockCustomDomain = createMockCustomDomain({
-                platformId: ctx.platform.id,
-                domain: 'custom.example.com',
-            })
-            await db.save('custom_domain', mockCustomDomain)
-
-            const response = await app?.inject({
-                method: 'GET',
-                url: '/v1/flags',
-                headers: {
-                    Host: 'custom.example.com',
-                },
-            })
-
-            expect(response?.statusCode).toBe(StatusCodes.OK)
-            const body = response?.json()
-
-            expect(body).toHaveProperty(ApFlagId.THEME)
-            const theme = body[ApFlagId.THEME]
-            expect(theme.websiteName).toBe('Domain Platform')
-            expect(theme.logos.fullLogoUrl).toBe('https://example.com/domain-logo.png')
-            expect(theme.colors.primary.default).toBe('#00ff00')
         })
     })
 })

--- a/packages/server/api/test/integration/ee/flags/flags.test.ts
+++ b/packages/server/api/test/integration/ee/flags/flags.test.ts
@@ -1,0 +1,87 @@
+import { ApFlagId } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../helpers/db'
+import { createMockCustomDomain } from '../../../helpers/mocks'
+import { createTestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Flags API', () => {
+    describe('GET /v1/flags', () => {
+        it('should return platform theme when authenticated', async () => {
+            const ctx = await createTestContext(app!, {
+                platform: {
+                    primaryColor: '#ff0000',
+                    name: 'Custom Platform',
+                    fullLogoUrl: 'https://example.com/full-logo.png',
+                    favIconUrl: 'https://example.com/favicon.ico',
+                    logoIconUrl: 'https://example.com/logo-icon.svg',
+                },
+                plan: {
+                    customAppearanceEnabled: true,
+                },
+            })
+
+            const response = await ctx.get('/v1/flags')
+
+            expect(response.statusCode).toBe(StatusCodes.OK)
+            const body = response.json()
+
+            expect(body).toHaveProperty(ApFlagId.THEME)
+            const theme = body[ApFlagId.THEME]
+            expect(theme.websiteName).toBe('Custom Platform')
+            expect(theme.logos.fullLogoUrl).toBe('https://example.com/full-logo.png')
+            expect(theme.logos.favIconUrl).toBe('https://example.com/favicon.ico')
+            expect(theme.logos.logoIconUrl).toBe('https://example.com/logo-icon.svg')
+            expect(theme.colors.primary.default).toBe('#ff0000')
+        })
+
+        it('should resolve platform from custom domain when unauthenticated', async () => {
+            const ctx = await createTestContext(app!, {
+                platform: {
+                    primaryColor: '#00ff00',
+                    name: 'Domain Platform',
+                    fullLogoUrl: 'https://example.com/domain-logo.png',
+                    favIconUrl: 'https://example.com/domain-favicon.ico',
+                    logoIconUrl: 'https://example.com/domain-icon.svg',
+                },
+                plan: {
+                    customAppearanceEnabled: true,
+                },
+            })
+
+            const mockCustomDomain = createMockCustomDomain({
+                platformId: ctx.platform.id,
+                domain: 'custom.example.com',
+            })
+            await db.save('custom_domain', mockCustomDomain)
+
+            const response = await app?.inject({
+                method: 'GET',
+                url: '/v1/flags',
+                headers: {
+                    Host: 'custom.example.com',
+                },
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const body = response?.json()
+
+            expect(body).toHaveProperty(ApFlagId.THEME)
+            const theme = body[ApFlagId.THEME]
+            expect(theme.websiteName).toBe('Domain Platform')
+            expect(theme.logos.fullLogoUrl).toBe('https://example.com/domain-logo.png')
+            expect(theme.colors.primary.default).toBe('#00ff00')
+        })
+    })
+})


### PR DESCRIPTION
## Summary
- Addresses review comments from #11641
- Moved authenticated theme and custom domain flags tests from `ce/flags/` to `ee/flags/` since they depend on enterprise flags hooks and `customAppearanceEnabled`
- Kept only the unauthenticated test in `ce/flags/`
- Removed unused `TestContext` import

## Test plan
- [x] CE test (`ce/flags/flags.test.ts`) — unauthenticated flags request returns 200
- [x] EE test (`ee/flags/flags.test.ts`) — authenticated request returns platform's custom theme
- [x] EE test (`ee/flags/flags.test.ts`) — custom domain Host header resolves platform theme