### PR TITLE
fix(slack): handle approval buttons inline and update message after response

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/slack/src/lib/actions/request-approval-direct-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/request-approval-direct-message.ts
@@ -103,7 +103,7 @@ export const requestApprovalDirectMessageAction = createAction({
       const channel = context.resumePayload.queryParams['channel'];
       const messageTs = context.resumePayload.queryParams['messageTs'];
 
-      const token = context.auth.access_token;
+      const token = getBotToken(context.auth as SlackAuthValue);
       try {
         if (token && channel && messageTs) {
           const client = new WebClient(token);

--- a/packages/pieces/community/slack/src/lib/actions/request-approval-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/request-approval-message.ts
@@ -109,7 +109,7 @@ export const requestSendApprovalMessageAction = createAction({
       const channel = context.resumePayload.queryParams['channel'];
       const messageTs = context.resumePayload.queryParams['messageTs'];
 
-      const token = context.auth.access_token;
+      const token = getBotToken(context.auth as SlackAuthValue);
       try {
         if (token && channel && messageTs) {
           const client = new WebClient(token);


### PR DESCRIPTION
## What does this PR do?

Fixes Slack approval flow buttons opening a JSON link in the browser and not getting disabled after clicking.

### Explain How the Feature Works

Previously, the "Request Approval in a Channel" and "Request Approval from a User" actions used Slack button `url` properties, which opened the resume webhook URL directly in the browser — showing raw JSON to the user. Buttons also remained clickable after responding, causing confusion.

This PR makes two changes:

1. **Buttons now use `value` instead of `url`** — Button clicks are handled inline via Slack's interactivity webhook and forwarded server-side by the existing `parseAndReply` handler. No browser tab opens.

2. **Message updates after response** — On flow resume, the Slack message is updated via `chat.update` to replace the interactive buttons with a status indicator (`:white_check_mark: Approved` or `:x: Disapproved`), giving clear visual feedback.

Also adds the missing `channel` query param to the DM approval action so the message can be updated on resume.

### Relevant User Scenarios

- Users running approval workflows via Slack were confused by a browser tab opening with raw JSON when clicking Approve/Disapprove.
- After clicking a button, there was no visual feedback — buttons stayed active, leading to repeated clicks and uncertainty about approval status.
