### PR TITLE
fix(ai): flow tool 500 errors in AI agent

### DIFF
--- a/packages/pieces/community/ai/package.json
+++ b/packages/pieces/community/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ai",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/ai/src/lib/actions/agents/utils.ts
+++ b/packages/pieces/community/ai/src/lib/actions/agents/utils.ts
@@ -113,12 +113,13 @@ export const agentUtils = {
         name: sanitizedName,
         description: toolDescription,
         inputSchema: z.object(inputSchema),
-        execute: async (_inputs: unknown) => {
+        execute: async (inputs: unknown) => {
           return callMcpFlowTool({
             flowId: tool.flow.id,
             publicUrl: params.publicUrl,
             token: params.token,
-            async: !returnsResponse
+            async: !returnsResponse,
+            inputs,
           })
         }
       }
@@ -138,20 +139,31 @@ function isOkSuccess(status: number) {
 async function callMcpFlowTool(params: CallMcpFlowToolParams): Promise<ExecuteToolResponse> {
   const syncSuffix = params.async ? '' : '/sync';
 
-  const response = await httpClient.sendRequest({
-    method: HttpMethod.POST,
-    url: `${params.publicUrl}v1/webhooks/${params.flowId}${syncSuffix}`,
-    authentication: {
-      type: AuthenticationType.BEARER_TOKEN,
-      token: params.token,
-    },
-  });
+  try {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${params.publicUrl}v1/webhooks/${params.flowId}${syncSuffix}`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: params.token,
+      },
+      body: params.inputs,
+    });
 
-  return {
-    status: isOkSuccess(response.status) ? ExecutionToolStatus.SUCCESS : ExecutionToolStatus.FAILED,
-    output: response.body,
-    resolvedInput: {},
-    errorMessage: !isOkSuccess(response.status) ? 'Error' : undefined,
+    return {
+      status: isOkSuccess(response.status) ? ExecutionToolStatus.SUCCESS : ExecutionToolStatus.FAILED,
+      output: response.body,
+      resolvedInput: {},
+      errorMessage: !isOkSuccess(response.status) ? 'Error' : undefined,
+    }
+  }
+  catch (error) {
+    return {
+      status: ExecutionToolStatus.FAILED,
+      output: undefined,
+      resolvedInput: {},
+      errorMessage: error instanceof Error ? error.message : 'Error executing flow tool',
+    }
   }
 }
 
@@ -202,4 +214,5 @@ type CallMcpFlowToolParams = {
   token: string;
   publicUrl: string;
   async: boolean;
+  inputs: unknown;
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in `callMcpFlowTool()` that caused AI agent flow tool calls to fail with HTTP 500 errors:

- **Tool inputs were never sent to the webhook** — the `execute` callback parameter was prefixed with `_` (intentionally unused) and the HTTP POST had no `body`, so the AI model's tool call arguments were silently discarded
- **Unhandled HTTP errors crashed the entire agent** — the axios client throws on non-2xx responses, but `callMcpFlowTool()` had no try/catch, so any webhook failure propagated as an unhandled exception

## Changes

- Renamed `_inputs` → `inputs` and passed it through to `callMcpFlowTool()` as the request `body`
- Wrapped the HTTP call in try/catch, returning an `ExecuteToolResponse` with `FAILED` status on error instead of crashing
- Added `inputs: unknown` to `CallMcpFlowToolParams` type
- Bumped `@activepieces/piece-ai` version `0.1.18` → `0.1.19`

## How to test

1. Create a flow with an **MCP Tool trigger** — add input parameters (e.g. `customer_id`, type: Text, required)
2. Enable "Wait for Response", add a **Reply to MCP Client** action, publish
3. Create another flow with a **Run Agent** action, add the tool flow as an agent tool
4. Set a prompt like "Fetch customer with ID 123", pick an AI model, publish and run
5. Verify inputs arrive at the tool flow trigger and the agent completes successfully
6. Test error case (e.g. disable the tool flow) — verify the agent handles failure gracefully instead of crashing