### PR TITLE
fix(ai): update allowed AI model list and fix Anthropic model ID mismatch

### DIFF
--- a/packages/web/src/features/agents/ai-model/hooks.ts
+++ b/packages/web/src/features/agents/ai-model/hooks.ts
@@ -39,9 +39,7 @@ const GOOGLE_MODELS = [
   'gemini-3.1-pro-preview',
 ] as const;
 
-const X_AI_OPENROUTER_MODELS = [
-  'grok-4.1-fast',
-] as const;
+const X_AI_OPENROUTER_MODELS = ['grok-4.1-fast'] as const;
 
 const ALLOWED_MODELS_BY_PROVIDER: Partial<Record<Provider, readonly string[]>> =
   {


### PR DESCRIPTION
## Summary

- **Fix Anthropic provider showing only Haiku**: Anthropic's direct API uses dashes (`claude-opus-4-6`) while OpenRouter uses dots (`claude-opus-4.6`). The same model ID array was used for both, so Opus and Sonnet didn't match when selecting the Anthropic provider directly. Split into `ANTHROPIC_MODELS` (dashes, for direct API) and `ANTHROPIC_OPENROUTER_MODELS` (dots, for activepieces/OpenRouter provider).
- **Update to latest models**: Added Claude Sonnet 4.6, Claude Opus 4.6, Gemini 3.1 Pro. Removed legacy Claude Sonnet 4.5, Claude Opus 4.5, Gemini 3 Pro.
- **Trim x-ai models**: Removed the x-ai direct provider entry (server-side provider was already deleted). Kept only `grok-4.1-fast` via OpenRouter.
- **No migration needed**: The allowed model lists are purely UI dropdown filters. Existing flows store the model ID in step config and pass it directly to the AI provider at runtime — no validation against the allowlist occurs.

## Test plan

- [ ] Select **Anthropic** as provider in an agent step → verify Haiku, Sonnet 4.6, and Opus 4.6 appear
- [ ] Select **Activepieces** as provider → verify Anthropic models (with dots), Google, OpenAI, and Grok 4.1 Fast appear
- [ ] Select **Google** as provider → verify Gemini 3.1 Pro Preview appears, Gemini 3 Pro Preview is gone
- [ ] Confirm existing flows using old models (e.g. Claude Sonnet 4.5) still execute without errors