### PR TITLE
fix(ai): fix agent tool schema for Array and JSON property types

### DIFF
--- a/packages/server/engine/src/lib/tools/index.ts
+++ b/packages/server/engine/src/lib/tools/index.ts
@@ -276,7 +276,7 @@ async function propertyToSchema(propertyName: string, property: PieceProperty, o
                 schema = z.array(await buildObjectSchemaFromProperties(property.properties, operation, resolvedInput))
             }
             else {
-                schema = z.array(z.string())
+                schema = z.array(z.union([z.string(), z.number(), z.boolean(), z.object({}).loose()]))
             }
             break
         }
@@ -308,7 +308,7 @@ async function propertyToSchema(propertyName: string, property: PieceProperty, o
     return property.required ? schema : schema.nullable()
 }
 
-async function buildObjectSchemaFromProperties(properties: Record<string, PieceProperty>, operation: ExecuteToolOperation, resolvedInput: Record<string, unknown>): Promise<z.ZodObject<Record<string, z.ZodTypeAny>>> {
+async function buildObjectSchemaFromProperties(properties: Record<string, PieceProperty>, operation: ExecuteToolOperation, resolvedInput: Record<string, unknown>): Promise<z.ZodTypeAny> {
     const entries = Object.entries(properties)
     const schemas = await Promise.all(entries.map(([key, value]) =>
         propertyToSchema(key, value, operation, resolvedInput),
@@ -317,7 +317,7 @@ async function buildObjectSchemaFromProperties(properties: Record<string, PieceP
     for (let i = 0; i < entries.length; i++) {
         schemaMap[entries[i][0]] = schemas[i]
     }
-    return z.object(schemaMap)
+    return z.object(schemaMap).loose()
 }
 
 async function buildDynamicSchema(propertyName: string, operation: ExecuteToolOperation, resolvedInput: Record<string, unknown>): Promise<z.ZodTypeAny> {


### PR DESCRIPTION
## Summary

- **PropertyType.JSON** was mapped to `z.object({}).loose()`, causing the LLM to generate a single object instead of an array of objects. This broke actions like Google Sheets "Add Multiple Rows" which expect `[{col1: "v1"}, {col2: "v2"}]`. Now accepts both objects and arrays of objects.
- **PropertyType.ARRAY** ignored child `properties`, so structured arrays (e.g. rows with typed column headers) were described as `z.array(z.string())` — the LLM had no knowledge of the expected object shape. Now builds a typed object schema from child properties when available.
- **PropertyType.ARRAY** used `return` instead of `schema = ... break`, bypassing the description and nullable handling at the end of `propertyToSchema`.
- Extracted shared `buildObjectSchemaFromProperties` helper (used by both ARRAY and DYNAMIC cases) with parallel schema resolution via `Promise.all`.

## Test plan

- [x] TypeScript compiles cleanly
- [ ] Use the AI agent with Google Sheets "Add Multiple Rows" tool — verify it passes an array of row objects (not a flat string array)
- [ ] Verify agent works with actions using `Property.Json` that expect arrays (e.g. bulk insert actions)
- [ ] Verify agent works with simple `Property.Array` fields (no child properties) — should still accept string arrays