### PR TITLE
fix(docs): correct typo in Discord server access instruction

### DIFF
--- a/docs/handbook/engineering/onboarding/onboarding-check-list.mdx
+++ b/docs/handbook/engineering/onboarding/onboarding-check-list.mdx
@@ -12,7 +12,7 @@ This guide provides a checklist for the new hire onboarding process.
 ## 📧 Essentials
 
 - [ ] Set up your @activepieces.com email account and setup 2FA
-- [ ] Confirm access to out private Discord server.
+- [ ] Confirm access to our private Discord server.
 - [ ] Get Invited to the Activepieces Github Organization and Setup 2FA
 - [ ] Get Assigned to a buddy who will be your onboarding buddy.
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a typo in the Onboarding checklist essentials section:

"Confirm access to out private Discord server" -> "Confirm access to our private Discord server"

