### PR TITLE
fix(airtable): Update Record clears select fields when not provided

### DIFF
--- a/packages/pieces/community/airtable/package.json
+++ b/packages/pieces/community/airtable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-airtable",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/airtable/src/lib/actions/update-record.ts
+++ b/packages/pieces/community/airtable/src/lib/actions/update-record.ts
@@ -22,19 +22,24 @@ export const airtableUpdateRecordAction = createAction({
     const personalToken = context.auth;
     const { base: baseId, tableId, recordId, fields } = context.propsValue;
 
-    const fieldsWithoutEmptyStrings: DynamicPropsValue = {};
+    const fieldsWithoutEmptyValues: DynamicPropsValue = {};
 
     Object.keys(fields).forEach((k) => {
-      if (fields[k] !== '') {
-        fieldsWithoutEmptyStrings[k] = fields[k];
+      const value = fields[k];
+      if (value === null || value === undefined || value === '') {
+        return;
       }
+      if (Array.isArray(value) && value.length === 0) {
+        return;
+      }
+      fieldsWithoutEmptyValues[k] = value;
     });
     const updatedFields: Record<string, unknown> =
       await airtableCommon.createNewFields(
         personalToken.secret_text,
         baseId,
         tableId as string,
-        fieldsWithoutEmptyStrings
+        fieldsWithoutEmptyValues
       );
 
     return await airtableCommon.updateRecord({


### PR DESCRIPTION
## Summary
- Fix Update Record action clearing single select and multi-select fields when they are not provided by the user
- The existing code already filters empty strings (`''`), but `null` values (from unselected dropdowns in integrated mode) and empty arrays `[]` (from unselected multi-selects) were still sent to the Airtable API, causing those fields to be cleared

## Changes
- Added `null` and `undefined` filtering alongside the existing `''` filter
- Added empty array `[]` filtering for multi-select fields
- Renamed variable from `fieldsWithoutEmptyStrings` to `fieldsWithoutEmptyValues` to reflect the broader filtering
- Bumped version from 0.6.5 to 0.6.6

## Test plan
- [ ] Configure an Update Record action on a table with single select and multi-select fields
- [ ] Leave select fields unselected (integrated mode) → verify they are not cleared
- [ ] Leave select fields empty in fx mode → verify they are not cleared
- [ ] Provide actual values for select fields → verify they are updated correctly

Fixes #10344

🤖 Generated with [Claude Code](https://claude.com/claude-code)