### PR TITLE
feat(pieces-ntfy): add ntfy push notification piece

### DIFF
--- a/packages/pieces/community/ntfy/package.json
+++ b/packages/pieces/community/ntfy/package.json
@@ -1,10 +1,17 @@
 {
   "name": "@activepieces/piece-ntfy",
-  "version": "0.1.0",
-  "description": "ntfy piece for Activepieces",
-  "main": "src/index.ts",
+  "version": "0.2.5",
+  "description": "Send push notifications via ntfy.sh",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
   "dependencies": {
-    "@activepieces/pieces-framework": "latest",
-    "@activepieces/pieces-common": "latest"
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.6.2"
   }
 }

--- a/packages/pieces/community/ntfy/src/actions/send-notification.ts
+++ b/packages/pieces/community/ntfy/src/actions/send-notification.ts
@@ -3,11 +3,16 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 
 export const sendNotification = createAction({
   name: 'send_notification',
-  auth: true, // Requires the piece auth to be configured (if any) or simply skipped if auth is None.
   requireAuth: false,
   displayName: 'Send Notification',
-  description: 'Send a push notification to a ntfy.sh topic',
+  description: 'Send a push notification to a ntfy topic',
   props: {
+    serverUrl: Property.ShortText({
+      displayName: 'Server URL',
+      description: 'The ntfy server URL. Defaults to https://ntfy.sh',
+      required: false,
+      defaultValue: 'https://ntfy.sh',
+    }),
     topic: Property.ShortText({
       displayName: 'Topic',
       description: 'The ntfy topic to send the message to (e.g., my_alerts)',
@@ -45,7 +50,7 @@ export const sendNotification = createAction({
     }),
   },
   async run(context) {
-    const { topic, message, title, priority, tags } = context.propsValue;
+    const { serverUrl, topic, message, title, priority, tags } = context.propsValue;
 
     const headers: Record<string, string> = {
       'Content-Type': 'text/plain',
@@ -55,9 +60,12 @@ export const sendNotification = createAction({
     if (priority) headers['Priority'] = priority.toString();
     if (tags) headers['Tags'] = tags;
 
+    const baseUrl = serverUrl ? serverUrl.replace(/\/$/, '') : 'https://ntfy.sh';
+    const encodedTopic = encodeURIComponent(topic);
+
     const response = await httpClient.sendRequest<string>({
       method: HttpMethod.POST,
-      url: `https://ntfy.sh/${topic}`,
+      url: `${baseUrl}/${encodedTopic}`,
       headers,
       body: message,
     });

--- a/packages/pieces/community/ntfy/src/index.ts
+++ b/packages/pieces/community/ntfy/src/index.ts
@@ -1,11 +1,13 @@
 import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
 import { sendNotification } from './actions/send-notification';
 
 export const ntfy = createPiece({
   displayName: 'ntfy.sh',
   auth: PieceAuth.None(),
-  minimumSupportedRelease: '0.9.0',
-  logoUrl: 'https://cdn.activepieces.com/pieces/ntfy.png', // Assuming or host standard logo
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/ntfy.png',
+  categories: [PieceCategory.COMMUNICATION],
   authors: ['mousko'],
   actions: [
     sendNotification,


### PR DESCRIPTION
This PR introduces a new piece for ntfy.sh to send push notifications. Resolves open bounties for simple webhook notification tools. Tested locally.