### PR TITLE
fix(telegram-bot): update file URL construction to use secret_text for authentication

### DIFF
--- a/packages/pieces/community/telegram-bot/package.json
+++ b/packages/pieces/community/telegram-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-telegram-bot",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/telegram-bot/src/lib/action/get-file.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/get-file.action.ts
@@ -45,7 +45,7 @@ export const telegramGetFileAction = createAction({
     const fileInfo = fileInfoResponse.body.result;
 
     if (ctx.propsValue.download && fileInfo.file_path) {
-      const fileUrl = `https://api.telegram.org/file/bot${ctx.auth}/${fileInfo.file_path}`;
+      const fileUrl = `https://api.telegram.org/file/bot${ctx.auth.secret_text}/${fileInfo.file_path}`;
       
       const fileResponse = await httpClient.sendRequest({
         method: HttpMethod.GET,
@@ -64,7 +64,7 @@ export const telegramGetFileAction = createAction({
     return {
       file_info: fileInfo,
       file_url: fileInfo.file_path 
-        ? `https://api.telegram.org/file/bot${ctx.auth}/${fileInfo.file_path}`
+        ? `https://api.telegram.org/file/bot${ctx.auth.secret_text}/${fileInfo.file_path}`
         : undefined,
     };
   },


### PR DESCRIPTION
## What does this PR do?

Fixes the Telegram Bot "Get File" action failing due to incorrect authentication token access. The action was using `ctx.auth` directly instead of `ctx.auth.secret_text`, which caused API calls to the Telegram file endpoint to fail.

### Explain How the Feature Works

The `get-file` action constructs URLs to download files from the Telegram Bot API. These URLs require the bot token in the path (`/file/bot<token>/<file_path>`). Previously, the code passed the entire auth object instead of extracting the secret text, resulting in malformed URLs and failed requests.

This patch updates both occurrences in `get-file.action.ts` to use `ctx.auth.secret_text`.

### Relevant User Scenarios

- Users attempting to download files (photos, documents, voice messages, etc.) received from Telegram chats via the "Get File" action would encounter errors because the constructed file URL contained `[object Object]` instead of the actual bot token.

Fixes # (issue)
