### PR TITLE
fix(server): pass platformId when resolving custom pieces

### DIFF
--- a/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
+++ b/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
@@ -162,6 +162,7 @@ export function createHandlers(log: FastifyBaseLogger, platformIdForDedicatedWor
                 name: input.name,
                 version: input.version,
                 projectId: input.projectId,
+                platformId: input.platformId,
             })
         },
 

--- a/packages/server/api/test/integration/ce/pieces/piece-metadata.test.ts
+++ b/packages/server/api/test/integration/ce/pieces/piece-metadata.test.ts
@@ -9,6 +9,7 @@ import { FastifyBaseLogger, FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { databaseConnection } from '../../../../src/app/database/database-connection'
 import { pieceCache } from '../../../../src/app/pieces/metadata/piece-cache'
+import { pieceMetadataService } from '../../../../src/app/pieces/metadata/piece-metadata-service'
 import { generateMockToken } from '../../../helpers/auth'
 import { db } from '../../../helpers/db'
 import {
@@ -200,6 +201,48 @@ describe('Piece Metadata CE API', () => {
 
             // Sync should succeed (200) or be accepted
             expect([StatusCodes.OK, StatusCodes.NO_CONTENT]).toContain(response?.statusCode)
+        })
+    })
+
+    describe('pieceMetadataService.get() — custom pieces', () => {
+        it('should return undefined for custom piece when platformId is not provided', async () => {
+            const platformId = apId()
+            const mockPiece = createMockPieceMetadata({
+                name: '@custom/my-piece',
+                pieceType: PieceType.CUSTOM,
+                packageType: PackageType.REGISTRY,
+                platformId,
+                version: '0.1.0',
+            })
+            await db.save('piece_metadata', mockPiece)
+            await pieceCache(mockLog).setup()
+
+            const result = await pieceMetadataService(mockLog).get({
+                name: '@custom/my-piece',
+                version: '0.1.0',
+            })
+            expect(result).toBeUndefined()
+        })
+
+        it('should return custom piece when platformId is provided', async () => {
+            const platformId = apId()
+            const mockPiece = createMockPieceMetadata({
+                name: '@custom/my-piece',
+                pieceType: PieceType.CUSTOM,
+                packageType: PackageType.REGISTRY,
+                platformId,
+                version: '0.1.0',
+            })
+            await db.save('piece_metadata', mockPiece)
+            await pieceCache(mockLog).setup()
+
+            const result = await pieceMetadataService(mockLog).get({
+                name: '@custom/my-piece',
+                version: '0.1.0',
+                platformId,
+            })
+            expect(result).toBeDefined()
+            expect(result?.name).toBe('@custom/my-piece')
         })
     })
 })

--- a/packages/server/worker/src/lib/cache/pieces/piece-cache.ts
+++ b/packages/server/worker/src/lib/cache/pieces/piece-cache.ts
@@ -57,6 +57,7 @@ async function getPiecePackage(query: PieceCacheKey, apiClient: WorkerToApiContr
     const pieceMetadata = await apiClient.getPiece({
         name: query.pieceName,
         version: query.pieceVersion,
+        platformId: query.platformId,
     }) as { packageType: PackageType, name: string, version: string, pieceType: PieceType, archiveId?: string } | null
 
     if (!pieceMetadata) {

--- a/packages/shared/src/lib/automation/workers/worker-contract.ts
+++ b/packages/shared/src/lib/automation/workers/worker-contract.ts
@@ -27,6 +27,7 @@ export type GetPieceRequest = {
     name: string
     version?: string
     projectId?: string
+    platformId?: string
 }
 
 export type WorkerToApiContract = {


### PR DESCRIPTION
## Summary
- Custom pieces always failed to resolve in the worker with `Cannot read properties of null (reading 'packageType')` because `platformId` was never forwarded through the `getPiece` call chain
- Added `platformId` to `GetPieceRequest` contract, passed it from the worker's `getPiecePackage()`, and forwarded it in the API's RPC handler to `pieceMetadataService.get()`
- Added integration tests verifying custom pieces require `platformId` to be found

## Test plan
- [x] Existing piece metadata tests pass (9/9)
- [x] New test: custom piece returns `undefined` without `platformId`
- [x] New test: custom piece is found when `platformId` is provided