### PR TITLE
fix(server): fix custom pieces failing in dedicated workers

### DIFF
--- a/packages/server/api/src/app/workers/machine/machine-service.ts
+++ b/packages/server/api/src/app/workers/machine/machine-service.ts
@@ -132,7 +132,7 @@ async function getExecutionMode(log: FastifyBaseLogger, platformIdForDedicatedWo
         return executionMode
     }
     if (dedicatedWorkerConfig.trustedEnvironment) {
-        return ExecutionMode.SANDBOX_PROCESS
+        return ExecutionMode.SANDBOX_CODE_ONLY
     }
     return ExecutionMode.SANDBOX_CODE_AND_PROCESS
 }

--- a/packages/server/api/test/unit/app/workers/machine/machine-service.test.ts
+++ b/packages/server/api/test/unit/app/workers/machine/machine-service.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ExecutionMode } from '@activepieces/shared'
+
+vi.mock('../../../../../src/app/workers/machine/machine-cache', () => ({
+    workerMachineCache: vi.fn(() => ({
+        findOne: vi.fn().mockResolvedValue(null),
+        upsert: vi.fn().mockResolvedValue(undefined),
+    })),
+}))
+
+vi.mock('../../../../../src/app/workers/machine/worker-id-generator', () => ({
+    workerIdGenerator: {
+        allocate: vi.fn().mockResolvedValue(0),
+        renew: vi.fn().mockResolvedValue(undefined),
+        release: vi.fn().mockResolvedValue(undefined),
+    },
+}))
+
+vi.mock('../../../../../src/app/helper/system/system', () => ({
+    system: {
+        getOrThrow: vi.fn().mockReturnValue('test-value'),
+        getNumberOrThrow: vi.fn().mockReturnValue(60),
+        get: vi.fn().mockReturnValue(undefined),
+    },
+}))
+
+vi.mock('../../../../../src/app/ee/custom-domains/domain-helper', () => ({
+    domainHelper: {
+        getPublicUrl: vi.fn().mockResolvedValue('https://example.com'),
+    },
+}))
+
+vi.mock('../../../../../src/app/ee/platform/platform-plan/platform-dedicated-workers', () => ({
+    dedicatedWorkers: vi.fn(),
+}))
+
+import { machineService } from '../../../../../src/app/workers/machine/machine-service'
+import { dedicatedWorkers } from '../../../../../src/app/ee/platform/platform-plan/platform-dedicated-workers'
+import { system } from '../../../../../src/app/helper/system/system'
+
+const mockLog = {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    child: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    silent: vi.fn(),
+    level: 'info',
+} as any
+
+const mockHealthcheck = {
+    workerId: 'test-worker-1',
+    cpuUsagePercentage: 10,
+    ramUsagePercentage: 20,
+    totalAvailableRamInBytes: 1024,
+    diskInfo: {
+        total: 1000,
+        free: 500,
+        used: 500,
+        percentage: 50,
+    },
+}
+
+describe('machineService — getExecutionMode', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        // Clear settings cache by re-importing (settingsCache is module-scoped)
+        vi.resetModules()
+    })
+
+    it('should return SANDBOX_CODE_ONLY for trusted dedicated worker', async () => {
+        vi.mocked(system.getOrThrow).mockReturnValue(ExecutionMode.SANDBOX_PROCESS as any)
+        vi.mocked(dedicatedWorkers).mockReturnValue({
+            getWorkerConfig: vi.fn().mockResolvedValue({ trustedEnvironment: true }),
+            getPlatformIds: vi.fn(),
+            isEnabledForPlatform: vi.fn(),
+            updateWorkerConfig: vi.fn(),
+        } as any)
+
+        const { machineService: freshMachineService } = await import('../../../../../src/app/workers/machine/machine-service')
+        const result = await freshMachineService(mockLog).onConnection(mockHealthcheck, 'platform-123')
+
+        expect(result.EXECUTION_MODE).toBe(ExecutionMode.SANDBOX_CODE_ONLY)
+    })
+
+    it('should return SANDBOX_CODE_AND_PROCESS for untrusted dedicated worker', async () => {
+        vi.mocked(system.getOrThrow).mockReturnValue(ExecutionMode.SANDBOX_PROCESS as any)
+        vi.mocked(dedicatedWorkers).mockReturnValue({
+            getWorkerConfig: vi.fn().mockResolvedValue({ trustedEnvironment: false }),
+            getPlatformIds: vi.fn(),
+            isEnabledForPlatform: vi.fn(),
+            updateWorkerConfig: vi.fn(),
+        } as any)
+
+        const { machineService: freshMachineService } = await import('../../../../../src/app/workers/machine/machine-service')
+        const result = await freshMachineService(mockLog).onConnection(mockHealthcheck, 'platform-456')
+
+        expect(result.EXECUTION_MODE).toBe(ExecutionMode.SANDBOX_CODE_AND_PROCESS)
+    })
+
+    it('should return system default for shared workers (no platformId)', async () => {
+        vi.mocked(system.getOrThrow).mockReturnValue(ExecutionMode.SANDBOX_PROCESS as any)
+
+        const { machineService: freshMachineService } = await import('../../../../../src/app/workers/machine/machine-service')
+        const result = await freshMachineService(mockLog).onConnection(mockHealthcheck)
+
+        expect(result.EXECUTION_MODE).toBe(ExecutionMode.SANDBOX_PROCESS)
+    })
+
+    it('should return system default when dedicated worker config is null', async () => {
+        vi.mocked(system.getOrThrow).mockReturnValue(ExecutionMode.SANDBOX_PROCESS as any)
+        vi.mocked(dedicatedWorkers).mockReturnValue({
+            getWorkerConfig: vi.fn().mockResolvedValue(null),
+            getPlatformIds: vi.fn(),
+            isEnabledForPlatform: vi.fn(),
+            updateWorkerConfig: vi.fn(),
+        } as any)
+
+        const { machineService: freshMachineService } = await import('../../../../../src/app/workers/machine/machine-service')
+        const result = await freshMachineService(mockLog).onConnection(mockHealthcheck, 'platform-789')
+
+        expect(result.EXECUTION_MODE).toBe(ExecutionMode.SANDBOX_PROCESS)
+    })
+})

--- a/packages/server/engine/src/lib/helper/piece-loader.ts
+++ b/packages/server/engine/src/lib/helper/piece-loader.ts
@@ -180,6 +180,14 @@ async function findDistPackageJsonFiles(dirPath: string): Promise<string[]> {
 
 
 async function traverseAllParentFoldersToFindPiece(packageName: string): Promise<string | null> {
+    const customPaths = (process.env.AP_CUSTOM_PIECES_PATHS ?? '').split(':').filter(Boolean)
+    for (const customPath of customPaths) {
+        const piecePath = path.resolve(customPath, 'pieces', packageName, 'node_modules', trimVersionFromAlias(packageName))
+        if (await utils.folderExists(piecePath)) {
+            return path.join(piecePath, 'src', 'index.js')
+        }
+    }
+
     const rootDir = path.parse(__dirname).root
     let currentDir = __dirname
     const maxIterations = currentDir.split(path.sep).length

--- a/packages/server/worker/src/lib/sandbox/sandbox.ts
+++ b/packages/server/worker/src/lib/sandbox/sandbox.ts
@@ -1,9 +1,11 @@
 import { ChildProcess } from 'child_process'
 import { createServer, Server as HttpServer } from 'http'
+import path from 'path'
 import { ActivepiecesError, assertNotNullOrUndefined, createNotifyServer, createRpcClient, createRpcServer, EngineContract, EngineOperation, EngineOperationType, EngineResponse, EngineStderr, EngineStdout, ErrorCode, isNil, WorkerContract, WorkerNotifyContract } from '@activepieces/shared'
 import { Socket, Server as SocketIOServer } from 'socket.io'
 import treeKill from 'tree-kill'
-import { Sandbox, SandboxInitOptions, SandboxLogger, SandboxOptions, SandboxProcessMaker, SandboxResult } from './types'
+import { getGlobalCachePathLatestVersion } from '../cache/cache-paths'
+import { Sandbox, SandboxInitOptions, SandboxLogger, SandboxMount, SandboxOptions, SandboxProcessMaker, SandboxResult } from './types'
 
 export function createSandbox(
     log: SandboxLogger,
@@ -88,13 +90,25 @@ export function createSandbox(
 
             const port = createSocketServer()
 
+            const customPieceMounts: SandboxMount[] = []
+            if (platformId) {
+                const customPiecesHostPath = path.resolve(getGlobalCachePathLatestVersion(), 'custom_pieces', platformId)
+                customPieceMounts.push({
+                    hostPath: customPiecesHostPath,
+                    sandboxPath: '/root/custom_pieces',
+                })
+            }
+
             childProcess = await processMaker.create({
                 sandboxId,
                 command: options.command ?? [],
-                mounts: [...(options.baseMounts ?? []), ...mounts],
+                mounts: [...(options.baseMounts ?? []), ...mounts, ...customPieceMounts],
                 env: {
                     ...options.env,
                     AP_SANDBOX_WS_PORT: String(port),
+                    ...(customPieceMounts.length > 0
+                        ? { AP_CUSTOM_PIECES_PATHS: '/root/custom_pieces' }
+                        : {}),
                 },
                 resourceLimits: {
                     memoryBytes: options.memoryLimitMb * 1024 * 1024,

--- a/packages/server/worker/test/lib/sandbox/sandbox.test.ts
+++ b/packages/server/worker/test/lib/sandbox/sandbox.test.ts
@@ -14,6 +14,10 @@ vi.mock('tree-kill', () => ({
     default: treeKillMock,
 }))
 
+vi.mock('../../../src/lib/cache/cache-paths', () => ({
+    getGlobalCachePathLatestVersion: vi.fn(() => '/tmp/test-cache'),
+}))
+
 function createMockLogger(): SandboxLogger {
     return {
         info: vi.fn(),
@@ -102,10 +106,15 @@ describe('createSandbox', () => {
                 expect.objectContaining({
                     sandboxId: 'sb-1',
                     command: [],
-                    mounts: [],
+                    mounts: expect.arrayContaining([
+                        expect.objectContaining({
+                            sandboxPath: '/root/custom_pieces',
+                        }),
+                    ]),
                     env: expect.objectContaining({
                         MY_VAR: 'value',
                         AP_SANDBOX_WS_PORT: expect.any(String),
+                        AP_CUSTOM_PIECES_PATHS: '/root/custom_pieces',
                     }),
                     resourceLimits: {
                         memoryBytes: 256 * 1024 * 1024,
@@ -114,6 +123,19 @@ describe('createSandbox', () => {
                     },
                 }),
             )
+        })
+
+        it('does not add custom piece mount when platformId is empty', async () => {
+            const log = createMockLogger()
+            const workerHandlers = createMockWorkerHandlers()
+            testPM = createTestProcessMaker()
+            sandbox = createSandbox(log, 'sb-no-mount', defaultOptions, testPM.maker, workerHandlers)
+
+            await sandbox.start({ flowVersionId: 'fv-1', platformId: '', mounts: [] })
+
+            const createCall = (testPM.maker.create as ReturnType<typeof vi.fn>).mock.calls[0][0]
+            expect(createCall.mounts).toEqual([])
+            expect(createCall.env.AP_CUSTOM_PIECES_PATHS).toBeUndefined()
         })
 
         it('is idempotent when already connected', async () => {


### PR DESCRIPTION
## Summary
- **Inverted execution mode**: Trusted dedicated workers (`trustedEnvironment: true`) were incorrectly assigned `SANDBOX_PROCESS` (full isolate) instead of `SANDBOX_CODE_ONLY` (lighter sandbox). Swapped the return values in `getExecutionMode()`.
- **Custom piece dir not mounted**: When isolate mode is used, custom pieces installed to `custom_pieces/<platformId>/` were never mounted into the sandbox. `sandbox.start()` now adds the mount and sets `AP_CUSTOM_PIECES_PATHS` env var when `platformId` is provided.
- **Engine piece-loader**: `traverseAllParentFoldersToFindPiece()` now checks `AP_CUSTOM_PIECES_PATHS` before the parent folder traversal, so the engine can find custom pieces inside the sandbox.

## Test plan
- [x] Unit tests for `getExecutionMode` — verifies trusted returns `SANDBOX_CODE_ONLY`, untrusted returns `SANDBOX_CODE_AND_PROCESS`, shared returns system default
- [x] Unit tests for sandbox custom piece mount — verifies mount + env var added when `platformId` is set, and not added when empty
- [x] Build passes (`npx turbo run build --filter=api --filter=worker --filter=@activepieces/engine`)
- [x] Lint passes (`npx turbo lint -- --fix`)