### PR TITLE
feat: Add CryptoPanic piece for crypto news and sentiment [MCP Challenge]

### DIFF
--- a/packages/pieces/community/cryptopanic/package.json
+++ b/packages/pieces/community/cryptopanic/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-cryptopanic",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/cryptopanic/src/i18n/translation.json
+++ b/packages/pieces/community/cryptopanic/src/i18n/translation.json
@@ -1,0 +1,22 @@
+{
+  "CryptoPanic": "CryptoPanic",
+  "Get the latest crypto news and sentiment from CryptoPanic": "Get the latest crypto news and sentiment from CryptoPanic",
+  "API Key": "API Key",
+  "CryptoPanic API key (optional, for more data)": "CryptoPanic API key (optional, for more data)",
+  "Get Latest News": "Get Latest News",
+  "Fetch the latest crypto news posts from CryptoPanic": "Fetch the latest crypto news posts from CryptoPanic",
+  "Get Hot News": "Get Hot News",
+  "Fetch hot/trending crypto news from CryptoPanic": "Fetch hot/trending crypto news from CryptoPanic",
+  "Get News for Specific Coins": "Get News for Specific Coins",
+  "Fetch news for specific cryptocurrencies from CryptoPanic": "Fetch news for specific cryptocurrencies from CryptoPanic",
+  "Get Bullish Posts": "Get Bullish Posts",
+  "Fetch bullish sentiment posts from CryptoPanic": "Fetch bullish sentiment posts from CryptoPanic",
+  "Get Bearish Posts": "Get Bearish Posts",
+  "Fetch bearish sentiment posts from CryptoPanic": "Fetch bearish sentiment posts from CryptoPanic",
+  "Kind": "Kind",
+  "Filter by content kind (news, media, or all)": "Filter by content kind (news, media, or all)",
+  "Currencies": "Currencies",
+  "Comma-separated list of currency symbols (e.g. BTC,ETH)": "Comma-separated list of currency symbols (e.g. BTC,ETH)",
+  "Regions": "Regions",
+  "Comma-separated language codes (e.g. en,de)": "Comma-separated language codes (e.g. en,de)"
+}

--- a/packages/pieces/community/cryptopanic/src/index.ts
+++ b/packages/pieces/community/cryptopanic/src/index.ts
@@ -1,0 +1,31 @@
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getLatestNews } from './lib/actions/get-latest-news';
+import { getHotNews } from './lib/actions/get-hot-news';
+import { getCoinNews } from './lib/actions/get-coin-news';
+import { getBullishPosts } from './lib/actions/get-bullish-posts';
+import { getBearishPosts } from './lib/actions/get-bearish-posts';
+
+export const cryptoPanicAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'CryptoPanic API key (optional, for more data). Leave blank to use public access.',
+  required: false,
+});
+
+export const cryptopanic = createPiece({
+  displayName: 'CryptoPanic',
+  description: 'Get the latest crypto news and sentiment from CryptoPanic',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/cryptopanic.png',
+  categories: [PieceCategory.FINANCE],
+  auth: cryptoPanicAuth,
+  actions: [
+    getLatestNews,
+    getHotNews,
+    getCoinNews,
+    getBullishPosts,
+    getBearishPosts,
+  ],
+  authors: ['bossco7598'],
+  triggers: [],
+});

--- a/packages/pieces/community/cryptopanic/src/lib/actions/get-bearish-posts.ts
+++ b/packages/pieces/community/cryptopanic/src/lib/actions/get-bearish-posts.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { cryptoPanicAuth } from '../../index';
+import { fetchCryptoPanicPosts } from '../common/cryptopanic-api';
+
+export const getBearishPosts = createAction({
+  name: 'get_bearish_posts',
+  displayName: 'Get Bearish Posts',
+  description: 'Fetch bearish sentiment posts from CryptoPanic',
+  auth: cryptoPanicAuth,
+  props: {
+    currencies: Property.ShortText({
+      displayName: 'Currencies',
+      description: 'Comma-separated list of currency symbols (e.g. BTC,ETH)',
+      required: false,
+    }),
+    regions: Property.ShortText({
+      displayName: 'Regions',
+      description: 'Comma-separated language codes (e.g. en,de)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const apiKey = context.auth as string | null | undefined;
+    const { currencies, regions } = context.propsValue;
+
+    return await fetchCryptoPanicPosts({
+      apiKey: apiKey ?? null,
+      filter: 'bearish',
+      currencies: currencies ?? undefined,
+      regions: regions ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/cryptopanic/src/lib/actions/get-bullish-posts.ts
+++ b/packages/pieces/community/cryptopanic/src/lib/actions/get-bullish-posts.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { cryptoPanicAuth } from '../../index';
+import { fetchCryptoPanicPosts } from '../common/cryptopanic-api';
+
+export const getBullishPosts = createAction({
+  name: 'get_bullish_posts',
+  displayName: 'Get Bullish Posts',
+  description: 'Fetch bullish sentiment posts from CryptoPanic',
+  auth: cryptoPanicAuth,
+  props: {
+    currencies: Property.ShortText({
+      displayName: 'Currencies',
+      description: 'Comma-separated list of currency symbols (e.g. BTC,ETH)',
+      required: false,
+    }),
+    regions: Property.ShortText({
+      displayName: 'Regions',
+      description: 'Comma-separated language codes (e.g. en,de)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const apiKey = context.auth as string | null | undefined;
+    const { currencies, regions } = context.propsValue;
+
+    return await fetchCryptoPanicPosts({
+      apiKey: apiKey ?? null,
+      filter: 'bullish',
+      currencies: currencies ?? undefined,
+      regions: regions ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/cryptopanic/src/lib/actions/get-coin-news.ts
+++ b/packages/pieces/community/cryptopanic/src/lib/actions/get-coin-news.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { cryptoPanicAuth } from '../../index';
+import { fetchCryptoPanicPosts } from '../common/cryptopanic-api';
+
+export const getCoinNews = createAction({
+  name: 'get_coin_news',
+  displayName: 'Get News for Specific Coins',
+  description: 'Fetch news for specific cryptocurrencies from CryptoPanic',
+  auth: cryptoPanicAuth,
+  props: {
+    currencies: Property.ShortText({
+      displayName: 'Currencies',
+      description: 'Comma-separated list of currency symbols (e.g. BTC,ETH)',
+      required: true,
+    }),
+    kind: Property.StaticDropdown({
+      displayName: 'Kind',
+      description: 'Filter by content kind (news, media, or all)',
+      required: false,
+      defaultValue: 'all',
+      options: {
+        options: [
+          { label: 'All', value: 'all' },
+          { label: 'News', value: 'news' },
+          { label: 'Media', value: 'media' },
+        ],
+      },
+    }),
+    regions: Property.ShortText({
+      displayName: 'Regions',
+      description: 'Comma-separated language codes (e.g. en,de)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const apiKey = context.auth as string | null | undefined;
+    const { currencies, kind, regions } = context.propsValue;
+
+    return await fetchCryptoPanicPosts({
+      apiKey: apiKey ?? null,
+      currencies: (currencies ?? '').trim(),
+      kind: kind ?? 'all',
+      regions: regions ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/cryptopanic/src/lib/actions/get-hot-news.ts
+++ b/packages/pieces/community/cryptopanic/src/lib/actions/get-hot-news.ts
@@ -1,0 +1,34 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { cryptoPanicAuth } from '../../index';
+import { fetchCryptoPanicPosts } from '../common/cryptopanic-api';
+
+export const getHotNews = createAction({
+  name: 'get_hot_news',
+  displayName: 'Get Hot News',
+  description: 'Fetch hot/trending crypto news from CryptoPanic',
+  auth: cryptoPanicAuth,
+  props: {
+    currencies: Property.ShortText({
+      displayName: 'Currencies',
+      description: 'Comma-separated list of currency symbols (e.g. BTC,ETH)',
+      required: false,
+    }),
+    regions: Property.ShortText({
+      displayName: 'Regions',
+      description: 'Comma-separated language codes (e.g. en,de)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const apiKey = context.auth as string | null | undefined;
+    const { currencies, regions } = context.propsValue;
+
+    return await fetchCryptoPanicPosts({
+      apiKey: apiKey ?? null,
+      kind: 'news',
+      filter: 'hot',
+      currencies: currencies ?? undefined,
+      regions: regions ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/cryptopanic/src/lib/actions/get-latest-news.ts
+++ b/packages/pieces/community/cryptopanic/src/lib/actions/get-latest-news.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { cryptoPanicAuth } from '../../index';
+import { fetchCryptoPanicPosts } from '../common/cryptopanic-api';
+
+export const getLatestNews = createAction({
+  name: 'get_latest_news',
+  displayName: 'Get Latest News',
+  description: 'Fetch the latest crypto news posts from CryptoPanic',
+  auth: cryptoPanicAuth,
+  props: {
+    kind: Property.StaticDropdown({
+      displayName: 'Kind',
+      description: 'Filter by content kind (news, media, or all)',
+      required: false,
+      defaultValue: 'all',
+      options: {
+        options: [
+          { label: 'All', value: 'all' },
+          { label: 'News', value: 'news' },
+          { label: 'Media', value: 'media' },
+        ],
+      },
+    }),
+    currencies: Property.ShortText({
+      displayName: 'Currencies',
+      description: 'Comma-separated list of currency symbols (e.g. BTC,ETH)',
+      required: false,
+    }),
+    regions: Property.ShortText({
+      displayName: 'Regions',
+      description: 'Comma-separated language codes (e.g. en,de)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const apiKey = context.auth as string | null | undefined;
+    const { kind, currencies, regions } = context.propsValue;
+
+    return await fetchCryptoPanicPosts({
+      apiKey: apiKey ?? null,
+      kind: kind ?? 'all',
+      currencies: currencies ?? undefined,
+      regions: regions ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/cryptopanic/src/lib/common/cryptopanic-api.ts
+++ b/packages/pieces/community/cryptopanic/src/lib/common/cryptopanic-api.ts
@@ -1,0 +1,86 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const CRYPTOPANIC_BASE_URL = 'https://cryptopanic.com/api/v1';
+
+export interface CryptoPanicPost {
+  id: number;
+  title: string;
+  published_at: string;
+  url: string;
+  domain: string;
+  currencies?: Array<{ code: string; title: string; slug: string; url: string }>;
+  votes?: {
+    negative: number;
+    positive: number;
+    important: number;
+    liked: number;
+    disliked: number;
+    lol: number;
+    toxic: number;
+    saved: number;
+    comments: number;
+  };
+  kind: string;
+  source?: { title: string; region: string; domain: string };
+}
+
+export interface CryptoPanicResponse {
+  count: number;
+  next?: string | null;
+  previous?: string | null;
+  results: CryptoPanicPost[];
+}
+
+export interface FetchPostsParams {
+  apiKey?: string | null;
+  public?: boolean;
+  kind?: string;
+  filter?: string;
+  currencies?: string;
+  regions?: string;
+}
+
+export async function fetchCryptoPanicPosts(params: FetchPostsParams): Promise<CryptoPanicResponse> {
+  const queryParams = new URLSearchParams();
+
+  if (params.apiKey && params.apiKey.trim()) {
+    queryParams.set('auth_token', params.apiKey.trim());
+  }
+
+  queryParams.set('public', 'true');
+
+  if (params.kind && params.kind.trim() && params.kind.trim() !== 'all') {
+    queryParams.set('kind', params.kind.trim());
+  }
+
+  if (params.filter && params.filter.trim()) {
+    queryParams.set('filter', params.filter.trim());
+  }
+
+  if (params.currencies && params.currencies.trim()) {
+    queryParams.set('currencies', params.currencies.trim().toUpperCase());
+  }
+
+  if (params.regions && params.regions.trim()) {
+    queryParams.set('regions', params.regions.trim());
+  }
+
+  const url = `${CRYPTOPANIC_BASE_URL}/posts/?${queryParams.toString()}`;
+
+  const response = await httpClient.sendRequest<CryptoPanicResponse>({
+    method: HttpMethod.GET,
+    url,
+    headers: {
+      'Accept': 'application/json',
+    },
+  });
+
+  const data = response.body;
+
+  return {
+    count: data?.count ?? 0,
+    next: data?.next ?? null,
+    previous: data?.previous ?? null,
+    results: data?.results ?? [],
+  };
+}

--- a/packages/pieces/community/cryptopanic/tsconfig.json
+++ b/packages/pieces/community/cryptopanic/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/cryptopanic/tsconfig.lib.json
+++ b/packages/pieces/community/cryptopanic/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1824,6 +1824,9 @@
       ],
       "@activepieces/piece-coralogix": [
         "packages/pieces/community/coralogix/src/index.ts"
+      ],
+      "@activepieces/piece-cryptopanic": [
+        "packages/pieces/community/cryptopanic/src/index.ts"
       ]
     },
     "resolveJsonModule": true


### PR DESCRIPTION
## CryptoPanic Piece

Adds a new community piece for the [CryptoPanic API](https://cryptopanic.com/developers/api/) — a popular crypto news aggregator with sentiment analysis.

### Actions

| Action | Description |
|--------|-------------|
| **Get Latest News** | Fetch the latest crypto news posts (filter by kind: news/media/all) |
| **Get Hot News** | Fetch hot/trending crypto news (filter=hot) |
| **Get News for Specific Coins** | Fetch news filtered by currency symbols (e.g. BTC, ETH) |
| **Get Bullish Posts** | Fetch posts with bullish sentiment |
| **Get Bearish Posts** | Fetch posts with bearish sentiment |

### Features

- ✅ **Optional API key** — works with public access, API key unlocks more data
- ✅ Uses `httpClient.sendRequest` from `@activepieces/pieces-common`
- ✅ Category: `PieceCategory.FINANCE`
- ✅ Defensive null/undefined handling
- ✅ Input whitespace trimming
- ✅ Path alias added to `tsconfig.base.json`
- ✅ All deps in `dependencies`

### Testing

The CryptoPanic public API requires no authentication for basic posts:
```
GET https://cryptopanic.com/api/v1/posts/?public=true
GET https://cryptopanic.com/api/v1/posts/?public=true&kind=news&filter=hot
GET https://cryptopanic.com/api/v1/posts/?public=true&currencies=BTC,ETH
GET https://cryptopanic.com/api/v1/posts/?public=true&filter=bullish
GET https://cryptopanic.com/api/v1/posts/?public=true&filter=bearish
```

### MCP Challenge

This piece is submitted as part of the Activepieces MCP Challenge.