### PR TITLE
feat: Add CoinPaprika piece for free crypto market data [MCP Challenge]

### DIFF
--- a/packages/pieces/community/coinpaprika/.eslintrc.json
+++ b/packages/pieces/community/coinpaprika/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/coinpaprika/package.json
+++ b/packages/pieces/community/coinpaprika/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-coinpaprika",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/coinpaprika/src/index.ts
+++ b/packages/pieces/community/coinpaprika/src/index.ts
@@ -1,0 +1,33 @@
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getCoinTicker } from './lib/actions/get-coin-ticker';
+import { getAllTickers } from './lib/actions/get-all-tickers';
+import { getCoinInfo } from './lib/actions/get-coin-info';
+import { getGlobalMarket } from './lib/actions/get-global-market';
+import { getCoinOhlcv } from './lib/actions/get-coin-ohlcv';
+
+export const coinpaprikaAuth = PieceAuth.SecretText({
+  displayName: 'API Key (Optional)',
+  required: false,
+  description:
+    'Optional API key for higher rate limits. Leave empty to use the free tier without authentication.',
+});
+
+export const coinpaprika = createPiece({
+  displayName: 'CoinPaprika',
+  description:
+    'Free cryptocurrency market data including prices, market cap, OHLCV, and global market overview via the CoinPaprika API.',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/coinpaprika.png',
+  categories: [PieceCategory.FINANCE],
+  auth: coinpaprikaAuth,
+  actions: [
+    getCoinTicker,
+    getAllTickers,
+    getCoinInfo,
+    getGlobalMarket,
+    getCoinOhlcv,
+  ],
+  authors: ['bossco7598'],
+  triggers: [],
+});

--- a/packages/pieces/community/coinpaprika/src/lib/actions/get-all-tickers.ts
+++ b/packages/pieces/community/coinpaprika/src/lib/actions/get-all-tickers.ts
@@ -1,0 +1,38 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coinpaprikaAuth } from '../../index';
+import { COINPAPRIKA_BASE_URL, buildAuthHeaders } from '../common';
+
+export const getAllTickers = createAction({
+  name: 'get_all_tickers',
+  auth: coinpaprikaAuth,
+  displayName: 'Get All Tickers',
+  description:
+    'Fetch ticker data for all cryptocurrencies ranked by market cap. Returns prices, market caps, and 24h/7d changes.',
+  props: {
+    quotes: Property.ShortText({
+      displayName: 'Quote Currencies',
+      description:
+        "Comma-separated list of fiat or crypto quote currencies (e.g. 'USD,BTC'). Defaults to USD.",
+      required: false,
+      defaultValue: 'USD',
+    }),
+  },
+  async run(context) {
+    const quotes = (context.propsValue.quotes ?? 'USD').trim() || 'USD';
+    const url = `${COINPAPRIKA_BASE_URL}/tickers?quotes=${encodeURIComponent(quotes)}`;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      headers: buildAuthHeaders(context.auth),
+    });
+
+    const data = response.body;
+    if (!Array.isArray(data)) {
+      throw new Error('Unexpected response from CoinPaprika: expected an array of tickers.');
+    }
+
+    return { tickers: data, count: data.length };
+  },
+});

--- a/packages/pieces/community/coinpaprika/src/lib/actions/get-coin-info.ts
+++ b/packages/pieces/community/coinpaprika/src/lib/actions/get-coin-info.ts
@@ -1,0 +1,41 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coinpaprikaAuth } from '../../index';
+import { COINPAPRIKA_BASE_URL, buildAuthHeaders } from '../common';
+
+export const getCoinInfo = createAction({
+  name: 'get_coin_info',
+  auth: coinpaprikaAuth,
+  displayName: 'Get Coin Info',
+  description:
+    'Fetch detailed information about a cryptocurrency including description, team, tags, links, and market rank.',
+  props: {
+    coin_id: Property.ShortText({
+      displayName: 'Coin ID',
+      description:
+        "The CoinPaprika coin ID (e.g. 'btc-bitcoin', 'eth-ethereum'). Visit coinpaprika.com to find coin IDs.",
+      required: true,
+    }),
+  },
+  async run(context) {
+    const coinId = context.propsValue.coin_id.trim();
+    if (!coinId) {
+      throw new Error('Coin ID cannot be empty.');
+    }
+
+    const url = `${COINPAPRIKA_BASE_URL}/coins/${encodeURIComponent(coinId)}`;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      headers: buildAuthHeaders(context.auth),
+    });
+
+    const data = response.body;
+    if (!data || typeof data !== 'object') {
+      throw new Error(`Unexpected response from CoinPaprika for coin: ${coinId}`);
+    }
+
+    return data;
+  },
+});

--- a/packages/pieces/community/coinpaprika/src/lib/actions/get-coin-ohlcv.ts
+++ b/packages/pieces/community/coinpaprika/src/lib/actions/get-coin-ohlcv.ts
@@ -1,0 +1,111 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coinpaprikaAuth } from '../../index';
+import { COINPAPRIKA_BASE_URL, buildAuthHeaders } from '../common';
+
+export const getCoinOhlcv = createAction({
+  name: 'get_coin_ohlcv',
+  auth: coinpaprikaAuth,
+  displayName: 'Get Coin OHLCV Historical Data',
+  description:
+    'Fetch historical OHLCV (Open, High, Low, Close, Volume) candlestick data for a specific cryptocurrency.',
+  props: {
+    coin_id: Property.ShortText({
+      displayName: 'Coin ID',
+      description:
+        "The CoinPaprika coin ID (e.g. 'btc-bitcoin', 'eth-ethereum'). Visit coinpaprika.com to find coin IDs.",
+      required: true,
+    }),
+    start: Property.ShortText({
+      displayName: 'Start Date',
+      description:
+        "Start date in ISO 8601 format (e.g. '2024-01-01' or '2024-01-01T00:00:00Z').",
+      required: true,
+    }),
+    end: Property.ShortText({
+      displayName: 'End Date',
+      description:
+        "End date in ISO 8601 format (e.g. '2024-01-31' or '2024-01-31T23:59:59Z'). Defaults to current date.",
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description:
+        'Maximum number of candles to return (1–366). Defaults to 1.',
+      required: false,
+      defaultValue: 1,
+    }),
+    quote: Property.ShortText({
+      displayName: 'Quote Currency',
+      description: "Quote currency for price data (e.g. 'usd', 'btc'). Defaults to 'usd'.",
+      required: false,
+      defaultValue: 'usd',
+    }),
+    interval: Property.StaticDropdown({
+      displayName: 'Interval',
+      description: 'Time interval for each candle.',
+      required: false,
+      defaultValue: '24h',
+      options: {
+        options: [
+          { label: '15 minutes', value: '15m' },
+          { label: '30 minutes', value: '30m' },
+          { label: '1 hour', value: '1h' },
+          { label: '6 hours', value: '6h' },
+          { label: '12 hours', value: '12h' },
+          { label: '24 hours (1 day)', value: '24h' },
+          { label: '7 days', value: '7d' },
+          { label: '14 days', value: '14d' },
+          { label: '30 days', value: '30d' },
+          { label: '90 days', value: '90d' },
+          { label: '365 days', value: '365d' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const coinId = context.propsValue.coin_id.trim();
+    if (!coinId) {
+      throw new Error('Coin ID cannot be empty.');
+    }
+
+    const start = context.propsValue.start.trim();
+    if (!start) {
+      throw new Error('Start date cannot be empty.');
+    }
+
+    const limitRaw = context.propsValue.limit ?? 1;
+    const limit = Math.max(1, Math.min(366, Math.floor(Number(limitRaw))));
+
+    const quote = (context.propsValue.quote ?? 'usd').trim().toLowerCase() || 'usd';
+    const interval = context.propsValue.interval ?? '24h';
+
+    const params = new URLSearchParams({
+      start,
+      limit: String(limit),
+      quote,
+      interval,
+    });
+
+    if (context.propsValue.end && context.propsValue.end.trim()) {
+      params.set('end', context.propsValue.end.trim());
+    }
+
+    const url = `${COINPAPRIKA_BASE_URL}/coins/${encodeURIComponent(coinId)}/ohlcv/historical?${params.toString()}`;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      headers: buildAuthHeaders(context.auth),
+    });
+
+    const data = response.body;
+    if (!Array.isArray(data)) {
+      throw new Error(
+        `Unexpected response from CoinPaprika OHLCV endpoint for coin: ${coinId}`
+      );
+    }
+
+    return { ohlcv: data, count: data.length, coin_id: coinId };
+  },
+});

--- a/packages/pieces/community/coinpaprika/src/lib/actions/get-coin-ticker.ts
+++ b/packages/pieces/community/coinpaprika/src/lib/actions/get-coin-ticker.ts
@@ -1,0 +1,49 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coinpaprikaAuth } from '../../index';
+import { COINPAPRIKA_BASE_URL, buildAuthHeaders } from '../common';
+
+export const getCoinTicker = createAction({
+  name: 'get_coin_ticker',
+  auth: coinpaprikaAuth,
+  displayName: 'Get Coin Ticker',
+  description:
+    'Fetch current price, market cap, volume, and other ticker data for a specific cryptocurrency.',
+  props: {
+    coin_id: Property.ShortText({
+      displayName: 'Coin ID',
+      description:
+        "The CoinPaprika coin ID (e.g. 'btc-bitcoin', 'eth-ethereum'). Visit coinpaprika.com to find coin IDs.",
+      required: true,
+    }),
+    quotes: Property.ShortText({
+      displayName: 'Quote Currencies',
+      description:
+        "Comma-separated list of fiat or crypto quote currencies (e.g. 'USD,BTC'). Defaults to USD.",
+      required: false,
+      defaultValue: 'USD',
+    }),
+  },
+  async run(context) {
+    const coinId = context.propsValue.coin_id.trim();
+    if (!coinId) {
+      throw new Error('Coin ID cannot be empty.');
+    }
+
+    const quotes = (context.propsValue.quotes ?? 'USD').trim() || 'USD';
+    const url = `${COINPAPRIKA_BASE_URL}/tickers/${encodeURIComponent(coinId)}?quotes=${encodeURIComponent(quotes)}`;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      headers: buildAuthHeaders(context.auth),
+    });
+
+    const data = response.body;
+    if (!data || typeof data !== 'object') {
+      throw new Error(`Unexpected response from CoinPaprika for coin: ${coinId}`);
+    }
+
+    return data;
+  },
+});

--- a/packages/pieces/community/coinpaprika/src/lib/actions/get-global-market.ts
+++ b/packages/pieces/community/coinpaprika/src/lib/actions/get-global-market.ts
@@ -1,0 +1,29 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+import { coinpaprikaAuth } from '../../index';
+import { COINPAPRIKA_BASE_URL, buildAuthHeaders } from '../common';
+
+export const getGlobalMarket = createAction({
+  name: 'get_global_market',
+  auth: coinpaprikaAuth,
+  displayName: 'Get Global Market Overview',
+  description:
+    'Fetch global cryptocurrency market data including total market cap, Bitcoin dominance, 24h volume, and number of active cryptocurrencies.',
+  props: {},
+  async run(context) {
+    const url = `${COINPAPRIKA_BASE_URL}/global`;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      headers: buildAuthHeaders(context.auth),
+    });
+
+    const data = response.body;
+    if (!data || typeof data !== 'object') {
+      throw new Error('Unexpected response from CoinPaprika global endpoint.');
+    }
+
+    return data;
+  },
+});

--- a/packages/pieces/community/coinpaprika/src/lib/common.ts
+++ b/packages/pieces/community/coinpaprika/src/lib/common.ts
@@ -1,0 +1,10 @@
+export const COINPAPRIKA_BASE_URL = 'https://api.coinpaprika.com/v1';
+
+export function buildAuthHeaders(
+  apiKey: string | null | undefined
+): Record<string, string> {
+  if (apiKey && apiKey.trim().length > 0) {
+    return { Authorization: `Bearer ${apiKey.trim()}` };
+  }
+  return {};
+}

--- a/packages/pieces/community/coinpaprika/tsconfig.json
+++ b/packages/pieces/community/coinpaprika/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/coinpaprika/tsconfig.lib.json
+++ b/packages/pieces/community/coinpaprika/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -155,6 +155,9 @@
       "@activepieces/piece-binance": [
         "packages/pieces/community/binance/src/index.ts"
       ],
+      "@activepieces/piece-coinpaprika": [
+        "packages/pieces/community/coinpaprika/src/index.ts"
+      ],
       "@activepieces/piece-bitly": [
         "packages/pieces/community/bitly/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Adds a new **CoinPaprika** piece providing free cryptocurrency market data via the [CoinPaprika API](https://api.coinpaprika.com/).

CoinPaprika offers a completely free tier (no API key required) with comprehensive crypto market data, making it highly accessible for Activepieces users.

## Actions Implemented (5)

| Action | Description |
|--------|-------------|
| **Get Coin Ticker** | Fetch current price, market cap, 24h/7d change, ATH, and volume for a specific coin |
| **Get All Tickers** | Fetch ticker data for all cryptocurrencies ranked by market cap |
| **Get Coin Info** | Fetch detailed info: description, team, tags, links, website, rank |
| **Get Global Market Overview** | Fetch total market cap, BTC dominance, volume, active currencies |
| **Get Coin OHLCV Historical Data** | Fetch historical candlestick data with configurable interval and date range |

## API Details

- **Base URL:** `https://api.coinpaprika.com/v1`
- **Authentication:** Optional — free tier works without a key; API key enables higher rate limits
- **No cost** for basic usage

## Implementation Notes

- Uses `httpClient.sendRequest` from `@activepieces/pieces-common` ✅
- Category: `PieceCategory.FINANCE` ✅
- `package.json` main: `./dist/src/index.js` ✅
- All dependencies in `dependencies` (not `peerDependencies`) ✅
- Path alias added to `tsconfig.base.json` ✅
- Defensive null/empty checks on all API responses ✅
- Whitespace trimmed from all user-supplied coin IDs ✅
- Bounds checking on numeric inputs (e.g., OHLCV limit clamped 1–366) ✅

## Checklist

- [x] Piece follows the existing piece structure
- [x] Uses `httpClient.sendRequest` (not native fetch)
- [x] `PieceCategory.FINANCE` set
- [x] Optional auth (free API, no key required for basic use)
- [x] tsconfig.base.json alias added
- [x] Input validation and defensive error handling
