### PR TITLE
feat: Add DEX Screener piece for real-time DEX trading data [MCP Challenge]

### DIFF
--- a/packages/pieces/community/dex-screener/.eslintrc.json
+++ b/packages/pieces/community/dex-screener/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/dex-screener/README.md
+++ b/packages/pieces/community/dex-screener/README.md
@@ -1,0 +1,15 @@
+# DEX Screener
+
+Real-time DEX trading data from DexScreener across all chains.
+
+## Actions
+
+- **Search Pairs** - Search for trading pairs by token name, symbol, or address
+- **Get Pairs by Token** - Get all trading pairs for a specific token address on a chain
+- **Get Token Profiles** - Get latest token profiles and metadata
+- **Get Latest Boosted Tokens** - Get the latest boosted/promoted tokens
+- **Get Top Boosted Tokens** - Get tokens with the most active boosts
+
+## Authentication
+
+No authentication required. DexScreener API is completely free and public.

--- a/packages/pieces/community/dex-screener/package.json
+++ b/packages/pieces/community/dex-screener/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-dex-screener",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/dex-screener/src/index.ts
+++ b/packages/pieces/community/dex-screener/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { searchPairsAction } from './lib/actions/search-pairs';
+import { getPairsByTokenAction } from './lib/actions/get-pairs-by-token';
+import { getTokenProfilesAction } from './lib/actions/get-token-profiles';
+import { getLatestBoostedTokensAction } from './lib/actions/get-latest-boosted-tokens';
+import { getTopBoostedTokensAction } from './lib/actions/get-top-boosted-tokens';
+
+export const dexScreener = createPiece({
+  displayName: 'DEX Screener',
+  description:
+    'Real-time DEX trading data across all chains. Track token prices, liquidity, trading pairs, and trending tokens powered by DexScreener.',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/dex-screener.png',
+  categories: [PieceCategory.FINANCE_AND_ACCOUNTING],
+  authors: ['bossco7598'],
+  actions: [
+    searchPairsAction,
+    getPairsByTokenAction,
+    getTokenProfilesAction,
+    getLatestBoostedTokensAction,
+    getTopBoostedTokensAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/dex-screener/src/lib/actions/get-latest-boosted-tokens.ts
+++ b/packages/pieces/community/dex-screener/src/lib/actions/get-latest-boosted-tokens.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getLatestBoostedTokens } from '../dexscreener-api';
+
+export const getLatestBoostedTokensAction = createAction({
+  name: 'get_latest_boosted_tokens',
+  displayName: 'Get Latest Boosted Tokens',
+  description: 'Get the latest boosted (trending/promoted) tokens on DexScreener.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Result Limit',
+      description: 'Maximum number of boosted tokens to return (default: 20).',
+      required: false,
+      defaultValue: 20,
+    }),
+  },
+  async run(context) {
+    const { limit } = context.propsValue;
+    const tokens = await getLatestBoostedTokens();
+    const maxResults = limit ?? 20;
+    return {
+      tokens: tokens.slice(0, maxResults),
+      total: tokens.length,
+    };
+  },
+});

--- a/packages/pieces/community/dex-screener/src/lib/actions/get-pairs-by-token.ts
+++ b/packages/pieces/community/dex-screener/src/lib/actions/get-pairs-by-token.ts
@@ -1,0 +1,29 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getPairsByToken } from '../dexscreener-api';
+
+export const getPairsByTokenAction = createAction({
+  name: 'get_pairs_by_token',
+  displayName: 'Get Pairs by Token',
+  description: 'Get all DEX trading pairs for a specific token address on a given blockchain.',
+  props: {
+    chainId: Property.ShortText({
+      displayName: 'Chain ID',
+      description: 'The blockchain identifier (e.g. "ethereum", "solana", "bsc", "arbitrum", "polygon").',
+      required: true,
+    }),
+    tokenAddresses: Property.ShortText({
+      displayName: 'Token Address(es)',
+      description: 'Token contract address or multiple addresses separated by commas (max 30).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { chainId, tokenAddresses } = context.propsValue;
+    const pairs = await getPairsByToken(chainId, tokenAddresses);
+    return {
+      pairs,
+      count: pairs.length,
+      chainId,
+    };
+  },
+});

--- a/packages/pieces/community/dex-screener/src/lib/actions/get-token-profiles.ts
+++ b/packages/pieces/community/dex-screener/src/lib/actions/get-token-profiles.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getLatestTokenProfiles } from '../dexscreener-api';
+
+export const getTokenProfilesAction = createAction({
+  name: 'get_token_profiles',
+  displayName: 'Get Token Profiles',
+  description: 'Get the latest token profiles and metadata from DexScreener.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Result Limit',
+      description: 'Maximum number of token profiles to return (default: 20).',
+      required: false,
+      defaultValue: 20,
+    }),
+  },
+  async run(context) {
+    const { limit } = context.propsValue;
+    const profiles = await getLatestTokenProfiles();
+    const maxResults = limit ?? 20;
+    return {
+      profiles: profiles.slice(0, maxResults),
+      total: profiles.length,
+    };
+  },
+});

--- a/packages/pieces/community/dex-screener/src/lib/actions/get-top-boosted-tokens.ts
+++ b/packages/pieces/community/dex-screener/src/lib/actions/get-top-boosted-tokens.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getTopBoostedTokens } from '../dexscreener-api';
+
+export const getTopBoostedTokensAction = createAction({
+  name: 'get_top_boosted_tokens',
+  displayName: 'Get Top Boosted Tokens',
+  description: 'Get the tokens with the most active boosts on DexScreener.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Result Limit',
+      description: 'Maximum number of tokens to return (default: 20).',
+      required: false,
+      defaultValue: 20,
+    }),
+  },
+  async run(context) {
+    const { limit } = context.propsValue;
+    const tokens = await getTopBoostedTokens();
+    const maxResults = limit ?? 20;
+    return {
+      tokens: tokens.slice(0, maxResults),
+      total: tokens.length,
+    };
+  },
+});

--- a/packages/pieces/community/dex-screener/src/lib/actions/search-pairs.ts
+++ b/packages/pieces/community/dex-screener/src/lib/actions/search-pairs.ts
@@ -1,0 +1,30 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { searchPairs } from '../dexscreener-api';
+
+export const searchPairsAction = createAction({
+  name: 'search_pairs',
+  displayName: 'Search Pairs',
+  description: 'Search for DEX trading pairs by token name, symbol, or address.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'Token name, symbol, or contract address to search for (e.g. "WBTC", "SOL", or a contract address).',
+      required: true,
+    }),
+    limit: Property.Number({
+      displayName: 'Result Limit',
+      description: 'Maximum number of pairs to return (default: 10, max: 30).',
+      required: false,
+      defaultValue: 10,
+    }),
+  },
+  async run(context) {
+    const { query, limit } = context.propsValue;
+    const pairs = await searchPairs(query);
+    const maxResults = Math.min(limit ?? 10, 30);
+    return {
+      pairs: pairs.slice(0, maxResults),
+      total: pairs.length,
+    };
+  },
+});

--- a/packages/pieces/community/dex-screener/src/lib/dexscreener-api.ts
+++ b/packages/pieces/community/dex-screener/src/lib/dexscreener-api.ts
@@ -1,0 +1,107 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.dexscreener.com';
+
+export interface DexPair {
+  chainId: string;
+  dexId: string;
+  url: string;
+  pairAddress: string;
+  baseToken: {
+    address: string;
+    name: string;
+    symbol: string;
+  };
+  quoteToken: {
+    address: string;
+    name: string;
+    symbol: string;
+  };
+  priceNative: string;
+  priceUsd?: string;
+  txns?: Record<string, unknown>;
+  volume?: Record<string, unknown>;
+  priceChange?: Record<string, unknown>;
+  liquidity?: {
+    usd?: number;
+    base: number;
+    quote: number;
+  };
+  fdv?: number;
+  marketCap?: number;
+  pairCreatedAt?: number;
+}
+
+export interface TokenProfile {
+  url: string;
+  chainId: string;
+  tokenAddress: string;
+  icon?: string;
+  header?: string;
+  description?: string;
+  links?: Array<{
+    type?: string;
+    label?: string;
+    url: string;
+  }>;
+}
+
+export interface BoostedToken {
+  url: string;
+  chainId: string;
+  tokenAddress: string;
+  amount?: number;
+  totalAmount?: number;
+  icon?: string;
+  header?: string;
+  description?: string;
+  links?: Array<{
+    type?: string;
+    label?: string;
+    url: string;
+  }>;
+}
+
+export async function searchPairs(query: string): Promise<DexPair[]> {
+  const response = await httpClient.sendRequest<{ pairs: DexPair[] | null }>({
+    method: HttpMethod.GET,
+    url: `${BASE_URL}/latest/dex/search`,
+    queryParams: { q: query },
+  });
+  return response.body.pairs ?? [];
+}
+
+export async function getPairsByToken(
+  chainId: string,
+  tokenAddresses: string
+): Promise<DexPair[]> {
+  const response = await httpClient.sendRequest<DexPair[]>({
+    method: HttpMethod.GET,
+    url: `${BASE_URL}/tokens/v1/${chainId}/${tokenAddresses}`,
+  });
+  return response.body ?? [];
+}
+
+export async function getLatestTokenProfiles(): Promise<TokenProfile[]> {
+  const response = await httpClient.sendRequest<TokenProfile[]>({
+    method: HttpMethod.GET,
+    url: `${BASE_URL}/token-profiles/latest/v1`,
+  });
+  return response.body ?? [];
+}
+
+export async function getLatestBoostedTokens(): Promise<BoostedToken[]> {
+  const response = await httpClient.sendRequest<BoostedToken[]>({
+    method: HttpMethod.GET,
+    url: `${BASE_URL}/token-boosts/latest/v1`,
+  });
+  return response.body ?? [];
+}
+
+export async function getTopBoostedTokens(): Promise<BoostedToken[]> {
+  const response = await httpClient.sendRequest<BoostedToken[]>({
+    method: HttpMethod.GET,
+    url: `${BASE_URL}/token-boosts/top/v1`,
+  });
+  return response.body ?? [];
+}

--- a/packages/pieces/community/dex-screener/tsconfig.json
+++ b/packages/pieces/community/dex-screener/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/dex-screener/tsconfig.lib.json
+++ b/packages/pieces/community/dex-screener/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## DEX Screener Piece for Activepieces

This PR adds a new community piece for **DEX Screener** — the leading real-time DEX trading data aggregator covering all major blockchains.

### What it does

DEX Screener provides free, real-time data on decentralized exchange (DEX) trading pairs, token prices, liquidity, and trending tokens across Ethereum, Solana, BSC, Arbitrum, Polygon, and hundreds of other chains.

### Actions (5)

| Action | Description |
|--------|-------------|
| **Search Pairs** | Search for DEX trading pairs by token name, symbol, or contract address |
| **Get Pairs by Token** | Get all trading pairs for a specific token address on a given blockchain |
| **Get Token Profiles** | Get the latest token profiles and metadata from DexScreener |
| **Get Latest Boosted Tokens** | Get the latest boosted/trending/promoted tokens |
| **Get Top Boosted Tokens** | Get tokens with the most active boosts across all chains |

### Authentication

No authentication required — DexScreener API is completely free and public, no API key needed.

### API Endpoints Used

- `GET https://api.dexscreener.com/latest/dex/search?q={query}` — search pairs
- `GET https://api.dexscreener.com/tokens/v1/{chainId}/{tokenAddresses}` — pairs by token
- `GET https://api.dexscreener.com/token-profiles/latest/v1` — latest token profiles
- `GET https://api.dexscreener.com/token-boosts/latest/v1` — latest boosted tokens
- `GET https://api.dexscreener.com/token-boosts/top/v1` — top boosted tokens

### Use Cases

- Monitor token prices and liquidity across DEXs
- Track trending/boosted tokens for trading signals
- Build crypto trading dashboards and alerts
- Research token metadata and social links
- Automate DeFi portfolio monitoring

---

*This piece is submitted as part of the [Activepieces MCP Challenge](https://algora.io) bounty on Algora.*
