### PR TITLE
feat: add LunarCrush piece

### DIFF
--- a/packages/pieces/community/lunarcrush/.eslintrc.json
+++ b/packages/pieces/community/lunarcrush/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/lunarcrush/package.json
+++ b/packages/pieces/community/lunarcrush/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-lunarcrush",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/lunarcrush/src/index.ts
+++ b/packages/pieces/community/lunarcrush/src/index.ts
@@ -1,0 +1,32 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getCoinSocialData } from './lib/actions/get-coin-social-data';
+import { getTrendingCoins } from './lib/actions/get-trending-coins';
+import { getCoinNews } from './lib/actions/get-coin-news';
+import { getInfluencers } from './lib/actions/get-influencers';
+import { getCoinTimeSeries } from './lib/actions/get-coin-time-series';
+
+const lunarCrushAuth = PieceAuth.SecretText({
+  displayName: 'LunarCrush API Key',
+  required: true,
+  description: 'Your LunarCrush API key. Get one at https://lunarcrush.com/developers',
+});
+
+export const lunarcrush = createPiece({
+  displayName: 'LunarCrush',
+  description:
+    'Access crypto social sentiment data, trending coins, influencer analytics, and market intelligence from LunarCrush.',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/lunarcrush.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  auth: lunarCrushAuth,
+  authors: ['bossco7598'],
+  actions: [
+    getCoinSocialData,
+    getTrendingCoins,
+    getCoinNews,
+    getInfluencers,
+    getCoinTimeSeries,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/lunarcrush/src/lib/actions/get-coin-news.ts
+++ b/packages/pieces/community/lunarcrush/src/lib/actions/get-coin-news.ts
@@ -1,0 +1,36 @@
+import { createAction, Property, PieceAuth } from '@activepieces/pieces-framework';
+import { lunarCrushRequest } from '../lunarcrush-api';
+
+export const getCoinNews = createAction({
+  name: 'get_coin_news',
+  displayName: 'Get Coin News',
+  description: 'Fetch recent news articles and social posts for a specific cryptocurrency.',
+  props: {
+    coin: Property.ShortText({
+      displayName: 'Coin Symbol or Slug',
+      description: 'The coin symbol or slug (e.g. "bitcoin" or "BTC")',
+      required: true,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Number of news articles to return (default: 20, max: 100)',
+      required: false,
+      defaultValue: 20,
+    }),
+  },
+  auth: PieceAuth.SecretText({
+    displayName: 'LunarCrush API Key',
+    required: true,
+    description: 'Your LunarCrush API key. Get one at https://lunarcrush.com/developers',
+  }),
+  async run({ propsValue, auth }) {
+    const coin = propsValue.coin.trim().toLowerCase();
+    const limit = Math.min(Math.max(1, propsValue.limit ?? 20), 100);
+    const data = await lunarCrushRequest(
+      auth as string,
+      `/coins/${encodeURIComponent(coin)}/news/v1`,
+      { limit }
+    );
+    return data;
+  },
+});

--- a/packages/pieces/community/lunarcrush/src/lib/actions/get-coin-social-data.ts
+++ b/packages/pieces/community/lunarcrush/src/lib/actions/get-coin-social-data.ts
@@ -1,0 +1,28 @@
+import { createAction, Property, PieceAuth } from '@activepieces/pieces-framework';
+import { lunarCrushRequest } from '../lunarcrush-api';
+
+export const getCoinSocialData = createAction({
+  name: 'get_coin_social_data',
+  displayName: 'Get Coin Social Data',
+  description: 'Fetch social volume, sentiment score, and interactions for a specific cryptocurrency.',
+  props: {
+    coin: Property.ShortText({
+      displayName: 'Coin Symbol or Slug',
+      description: 'The coin symbol or slug (e.g. "bitcoin" or "BTC")',
+      required: true,
+    }),
+  },
+  auth: PieceAuth.SecretText({
+    displayName: 'LunarCrush API Key',
+    required: true,
+    description: 'Your LunarCrush API key. Get one at https://lunarcrush.com/developers',
+  }),
+  async run({ propsValue, auth }) {
+    const coin = propsValue.coin.trim().toLowerCase();
+    const data = await lunarCrushRequest(
+      auth as string,
+      `/coins/${encodeURIComponent(coin)}/v1`
+    );
+    return data;
+  },
+});

--- a/packages/pieces/community/lunarcrush/src/lib/actions/get-coin-time-series.ts
+++ b/packages/pieces/community/lunarcrush/src/lib/actions/get-coin-time-series.ts
@@ -1,0 +1,61 @@
+import { createAction, Property, PieceAuth } from '@activepieces/pieces-framework';
+import { lunarCrushRequest } from '../lunarcrush-api';
+
+export const getCoinTimeSeries = createAction({
+  name: 'get_coin_time_series',
+  displayName: 'Get Coin Time Series',
+  description: 'Fetch historical social and market data time series for a specific cryptocurrency.',
+  props: {
+    coin: Property.ShortText({
+      displayName: 'Coin Symbol or Slug',
+      description: 'The coin symbol or slug (e.g. "bitcoin" or "BTC")',
+      required: true,
+    }),
+    bucket: Property.StaticDropdown({
+      displayName: 'Time Bucket',
+      description: 'Time interval for each data point',
+      required: false,
+      defaultValue: 'day',
+      options: {
+        options: [
+          { label: 'Hour', value: 'hour' },
+          { label: 'Day', value: 'day' },
+          { label: 'Week', value: 'week' },
+        ],
+      },
+    }),
+    start: Property.Number({
+      displayName: 'Start Time (Unix timestamp)',
+      description: 'Start of the time range as a Unix timestamp (seconds). Defaults to 30 days ago.',
+      required: false,
+    }),
+    end: Property.Number({
+      displayName: 'End Time (Unix timestamp)',
+      description: 'End of the time range as a Unix timestamp (seconds). Defaults to now.',
+      required: false,
+    }),
+  },
+  auth: PieceAuth.SecretText({
+    displayName: 'LunarCrush API Key',
+    required: true,
+    description: 'Your LunarCrush API key. Get one at https://lunarcrush.com/developers',
+  }),
+  async run({ propsValue, auth }) {
+    const coin = propsValue.coin.trim().toLowerCase();
+    const nowSec = Math.floor(Date.now() / 1000);
+    const thirtyDaysAgo = nowSec - 30 * 24 * 60 * 60;
+
+    const params: Record<string, string | number> = {
+      bucket: (propsValue.bucket as string) ?? 'day',
+      start: propsValue.start ?? thirtyDaysAgo,
+      end: propsValue.end ?? nowSec,
+    };
+
+    const data = await lunarCrushRequest(
+      auth as string,
+      `/coins/${encodeURIComponent(coin)}/time-series/v2`,
+      params
+    );
+    return data;
+  },
+});

--- a/packages/pieces/community/lunarcrush/src/lib/actions/get-influencers.ts
+++ b/packages/pieces/community/lunarcrush/src/lib/actions/get-influencers.ts
@@ -1,0 +1,48 @@
+import { createAction, Property, PieceAuth } from '@activepieces/pieces-framework';
+import { lunarCrushRequest } from '../lunarcrush-api';
+
+export const getInfluencers = createAction({
+  name: 'get_influencers',
+  displayName: 'Get Top Crypto Influencers',
+  description: 'Fetch a list of top cryptocurrency social media influencers ranked by engagement and reach.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Number of influencers to return (default: 20, max: 100)',
+      required: false,
+      defaultValue: 20,
+    }),
+    network: Property.StaticDropdown({
+      displayName: 'Social Network',
+      description: 'Filter influencers by social network',
+      required: false,
+      defaultValue: 'all',
+      options: {
+        options: [
+          { label: 'All Networks', value: 'all' },
+          { label: 'Twitter/X', value: 'twitter' },
+          { label: 'Reddit', value: 'reddit' },
+          { label: 'YouTube', value: 'youtube' },
+        ],
+      },
+    }),
+  },
+  auth: PieceAuth.SecretText({
+    displayName: 'LunarCrush API Key',
+    required: true,
+    description: 'Your LunarCrush API key. Get one at https://lunarcrush.com/developers',
+  }),
+  async run({ propsValue, auth }) {
+    const limit = Math.min(Math.max(1, propsValue.limit ?? 20), 100);
+    const params: Record<string, string | number> = { limit };
+    if (propsValue.network && propsValue.network !== 'all') {
+      params['network'] = propsValue.network as string;
+    }
+    const data = await lunarCrushRequest(
+      auth as string,
+      '/influencers/list/v1',
+      params
+    );
+    return data;
+  },
+});

--- a/packages/pieces/community/lunarcrush/src/lib/actions/get-trending-coins.ts
+++ b/packages/pieces/community/lunarcrush/src/lib/actions/get-trending-coins.ts
@@ -1,0 +1,30 @@
+import { createAction, Property, PieceAuth } from '@activepieces/pieces-framework';
+import { lunarCrushRequest } from '../lunarcrush-api';
+
+export const getTrendingCoins = createAction({
+  name: 'get_trending_coins',
+  displayName: 'Get Trending Coins',
+  description: 'Fetch the top cryptocurrencies ranked by social activity and engagement.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Number of coins to return (default: 10, max: 100)',
+      required: false,
+      defaultValue: 10,
+    }),
+  },
+  auth: PieceAuth.SecretText({
+    displayName: 'LunarCrush API Key',
+    required: true,
+    description: 'Your LunarCrush API key. Get one at https://lunarcrush.com/developers',
+  }),
+  async run({ propsValue, auth }) {
+    const limit = Math.min(Math.max(1, propsValue.limit ?? 10), 100);
+    const data = await lunarCrushRequest(
+      auth as string,
+      '/coins/list/v2',
+      { limit, sort: 'social_volume_global', desc: 1 }
+    );
+    return data;
+  },
+});

--- a/packages/pieces/community/lunarcrush/src/lib/lunarcrush-api.ts
+++ b/packages/pieces/community/lunarcrush/src/lib/lunarcrush-api.ts
@@ -1,0 +1,29 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://lunarcrush.com/api4/public';
+
+export async function lunarCrushRequest<T>(
+  apiKey: string,
+  endpoint: string,
+  params?: Record<string, string | number>
+): Promise<T> {
+  const url = new URL(`${BASE_URL}${endpoint}`);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  const response = await httpClient.sendRequest<T>({
+    method: HttpMethod.GET,
+    url: url.toString(),
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: 'application/json',
+    },
+  });
+
+  return response.body;
+}

--- a/packages/pieces/community/lunarcrush/tsconfig.json
+++ b/packages/pieces/community/lunarcrush/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/lunarcrush/tsconfig.lib.json
+++ b/packages/pieces/community/lunarcrush/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a new **LunarCrush** community piece providing crypto social sentiment data, trending coins, influencer analytics, and historical time series via the [LunarCrush API](https://lunarcrush.com/developers/api/endpoints).

LunarCrush is a leading crypto social intelligence platform that tracks social media activity, sentiment, and market data across thousands of cryptocurrencies.

## Actions Implemented (5)

| Action | Description |
|--------|-------------|
| **Get Coin Social Data** | Fetch social volume, sentiment score, interactions, and market data for a specific coin |
| **Get Trending Coins** | Fetch top cryptocurrencies ranked by social activity and engagement |
| **Get Coin News** | Fetch recent news articles and social posts for a specific cryptocurrency |
| **Get Top Crypto Influencers** | Fetch top crypto social media influencers ranked by engagement (filterable by network) |
| **Get Coin Time Series** | Fetch historical social + market data with configurable time bucket (hour/day/week) |

## API Details

- **Base URL:** `https://lunarcrush.com/api4/public`
- **Authentication:** Bearer token (users bring their own LunarCrush API key)
- **Free tier available** at https://lunarcrush.com/developers

## Implementation Notes

- Uses `httpClient.sendRequest` from `@activepieces/pieces-common` ✅
- Category: `PieceCategory.BUSINESS_INTELLIGENCE` ✅
- `PieceAuth.SecretText` for API key ✅
- `minimumSupportedRelease: '0.36.1'` ✅
- Input validation and bounds checking ✅
- Whitespace trimming on all user-supplied coin identifiers ✅

## MCP Challenge

This piece is submitted as part of the [Activepieces MCP Challenge](https://algora.io) bounty program.