### PR TITLE
feat: add CoinRanking piece

### DIFF
--- a/packages/pieces/community/coinranking/.eslintrc.json
+++ b/packages/pieces/community/coinranking/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/coinranking/README.md
+++ b/packages/pieces/community/coinranking/README.md
@@ -1,0 +1,15 @@
+# CoinRanking
+
+[CoinRanking](https://coinranking.com) provides real-time and historical cryptocurrency market data.
+
+## Actions
+
+- **Get Coins** — List top coins with price, market cap, 24h volume, and change.
+- **Get Coin Details** — Detailed info for a specific coin by UUID.
+- **Get Coin Price History** — Historical price data over configurable time periods.
+- **Get Exchanges** — List tracked crypto exchanges with volume data.
+- **Search Coins** — Search coins by name or symbol.
+
+## Auth
+
+Obtain a free API key at [https://developers.coinranking.com](https://developers.coinranking.com/api/documentation).

--- a/packages/pieces/community/coinranking/package.json
+++ b/packages/pieces/community/coinranking/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@activepieces/piece-coinranking",
+  "version": "0.0.1",
+  "description": "CoinRanking crypto market data — coins, prices, history, exchanges, and search",
+  "type": "commonjs",
+  "keywords": [
+    "activepieces",
+    "crypto",
+    "coinranking",
+    "market-data",
+    "prices"
+  ],
+  "homepage": "https://activepieces.com",
+  "license": "MIT",
+  "main": "./dist/src/index.js",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/coinranking/src/index.ts
+++ b/packages/pieces/community/coinranking/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece, PieceAuth, PieceCategory } from '@activepieces/pieces-framework';
+import { getCoins } from './lib/actions/get-coins';
+import { getCoinDetails } from './lib/actions/get-coin-details';
+import { getCoinPriceHistory } from './lib/actions/get-coin-price-history';
+import { getExchanges } from './lib/actions/get-exchanges';
+import { searchCoins } from './lib/actions/search-coins';
+
+export const coinrankingAuth = PieceAuth.SecretText({
+  displayName: 'CoinRanking API Key',
+  required: true,
+  description:
+    'Get your free API key at https://developers.coinranking.com/api/documentation. It will be sent as the x-access-token header.',
+});
+
+export const coinranking = createPiece({
+  displayName: 'CoinRanking',
+  description:
+    'Access real-time and historical crypto market data including prices, market caps, volumes, exchanges, and coin details via the CoinRanking API.',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/coinranking.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  auth: coinrankingAuth,
+  authors: ['bossco7598'],
+  actions: [getCoins, getCoinDetails, getCoinPriceHistory, getExchanges, searchCoins],
+  triggers: [],
+});

--- a/packages/pieces/community/coinranking/src/lib/actions/get-coin-details.ts
+++ b/packages/pieces/community/coinranking/src/lib/actions/get-coin-details.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coinrankingAuth } from '../../index';
+import { coinrankingRequest } from '../coinranking-api';
+
+export const getCoinDetails = createAction({
+  name: 'get_coin_details',
+  displayName: 'Get Coin Details',
+  description:
+    'Get detailed information for a specific coin by its CoinRanking UUID (e.g. Qwsogvtv82FCd for Bitcoin).',
+  auth: coinrankingAuth,
+  props: {
+    coinUuid: Property.ShortText({
+      displayName: 'Coin UUID',
+      description:
+        'The CoinRanking UUID of the coin. Bitcoin = Qwsogvtv82FCd, Ethereum = razxDUgYGNAdQ',
+      required: true,
+      defaultValue: 'Qwsogvtv82FCd',
+    }),
+    timePeriod: Property.StaticDropdown({
+      displayName: 'Time Period',
+      description: 'Time period for price change calculation',
+      required: false,
+      defaultValue: '24h',
+      options: {
+        options: [
+          { label: '1 hour', value: '1h' },
+          { label: '3 hours', value: '3h' },
+          { label: '12 hours', value: '12h' },
+          { label: '24 hours', value: '24h' },
+          { label: '7 days', value: '7d' },
+          { label: '30 days', value: '30d' },
+          { label: '3 months', value: '3m' },
+          { label: '1 year', value: '1y' },
+          { label: '3 years', value: '3y' },
+          { label: '5 years', value: '5y' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { coinUuid, timePeriod } = context.propsValue;
+    return coinrankingRequest(
+      context.auth,
+      `/coin/${encodeURIComponent(coinUuid)}`,
+      { timePeriod: timePeriod ?? '24h' }
+    );
+  },
+});

--- a/packages/pieces/community/coinranking/src/lib/actions/get-coin-price-history.ts
+++ b/packages/pieces/community/coinranking/src/lib/actions/get-coin-price-history.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coinrankingAuth } from '../../index';
+import { coinrankingRequest } from '../coinranking-api';
+
+export const getCoinPriceHistory = createAction({
+  name: 'get_coin_price_history',
+  displayName: 'Get Coin Price History',
+  description:
+    'Retrieve historical price data for a coin over a chosen time period.',
+  auth: coinrankingAuth,
+  props: {
+    coinUuid: Property.ShortText({
+      displayName: 'Coin UUID',
+      description:
+        'The CoinRanking UUID of the coin. Bitcoin = Qwsogvtv82FCd, Ethereum = razxDUgYGNAdQ',
+      required: true,
+      defaultValue: 'Qwsogvtv82FCd',
+    }),
+    timePeriod: Property.StaticDropdown({
+      displayName: 'Time Period',
+      description: 'Time range for price history',
+      required: false,
+      defaultValue: '24h',
+      options: {
+        options: [
+          { label: '1 hour', value: '1h' },
+          { label: '3 hours', value: '3h' },
+          { label: '12 hours', value: '12h' },
+          { label: '24 hours', value: '24h' },
+          { label: '7 days', value: '7d' },
+          { label: '30 days', value: '30d' },
+          { label: '3 months', value: '3m' },
+          { label: '1 year', value: '1y' },
+          { label: '3 years', value: '3y' },
+          { label: '5 years', value: '5y' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { coinUuid, timePeriod } = context.propsValue;
+    return coinrankingRequest(
+      context.auth,
+      `/coin/${encodeURIComponent(coinUuid)}/history`,
+      { timePeriod: timePeriod ?? '24h' }
+    );
+  },
+});

--- a/packages/pieces/community/coinranking/src/lib/actions/get-coins.ts
+++ b/packages/pieces/community/coinranking/src/lib/actions/get-coins.ts
@@ -1,0 +1,83 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coinrankingAuth } from '../../index';
+import { coinrankingRequest } from '../coinranking-api';
+
+export const getCoins = createAction({
+  name: 'get_coins',
+  displayName: 'Get Coins',
+  description:
+    'List cryptocurrencies with price, market cap, 24h volume, and percentage change.',
+  auth: coinrankingAuth,
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Number of coins to return (max 100)',
+      required: false,
+      defaultValue: 20,
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      description: 'Pagination offset',
+      required: false,
+      defaultValue: 0,
+    }),
+    orderBy: Property.StaticDropdown({
+      displayName: 'Order By',
+      description: 'Sort coins by this field',
+      required: false,
+      defaultValue: 'marketCap',
+      options: {
+        options: [
+          { label: 'Market Cap', value: 'marketCap' },
+          { label: 'Price', value: 'price' },
+          { label: '24h Volume', value: '24hVolume' },
+          { label: 'Change', value: 'change' },
+          { label: 'Listed At', value: 'listedAt' },
+        ],
+      },
+    }),
+    orderDirection: Property.StaticDropdown({
+      displayName: 'Order Direction',
+      description: 'Ascending or descending',
+      required: false,
+      defaultValue: 'desc',
+      options: {
+        options: [
+          { label: 'Descending', value: 'desc' },
+          { label: 'Ascending', value: 'asc' },
+        ],
+      },
+    }),
+    timePeriod: Property.StaticDropdown({
+      displayName: 'Time Period',
+      description: 'Time period for price change calculation',
+      required: false,
+      defaultValue: '24h',
+      options: {
+        options: [
+          { label: '1 hour', value: '1h' },
+          { label: '3 hours', value: '3h' },
+          { label: '12 hours', value: '12h' },
+          { label: '24 hours', value: '24h' },
+          { label: '7 days', value: '7d' },
+          { label: '30 days', value: '30d' },
+          { label: '3 months', value: '3m' },
+          { label: '1 year', value: '1y' },
+          { label: '3 years', value: '3y' },
+          { label: '5 years', value: '5y' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { limit, offset, orderBy, orderDirection, timePeriod } =
+      context.propsValue;
+    return coinrankingRequest(context.auth, '/coins', {
+      limit,
+      offset,
+      orderBy: orderBy ?? 'marketCap',
+      orderDirection: orderDirection ?? 'desc',
+      timePeriod: timePeriod ?? '24h',
+    });
+  },
+});

--- a/packages/pieces/community/coinranking/src/lib/actions/get-exchanges.ts
+++ b/packages/pieces/community/coinranking/src/lib/actions/get-exchanges.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coinrankingAuth } from '../../index';
+import { coinrankingRequest } from '../coinranking-api';
+
+export const getExchanges = createAction({
+  name: 'get_exchanges',
+  displayName: 'Get Exchanges',
+  description:
+    'List crypto exchanges tracked by CoinRanking with volume and market data.',
+  auth: coinrankingAuth,
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Number of exchanges to return (max 100)',
+      required: false,
+      defaultValue: 20,
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      description: 'Pagination offset',
+      required: false,
+      defaultValue: 0,
+    }),
+    orderBy: Property.StaticDropdown({
+      displayName: 'Order By',
+      description: 'Sort exchanges by this field',
+      required: false,
+      defaultValue: '24hVolume',
+      options: {
+        options: [
+          { label: '24h Volume', value: '24hVolume' },
+          { label: 'Number of Markets', value: 'numberOfMarkets' },
+        ],
+      },
+    }),
+    orderDirection: Property.StaticDropdown({
+      displayName: 'Order Direction',
+      description: 'Ascending or descending',
+      required: false,
+      defaultValue: 'desc',
+      options: {
+        options: [
+          { label: 'Descending', value: 'desc' },
+          { label: 'Ascending', value: 'asc' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { limit, offset, orderBy, orderDirection } = context.propsValue;
+    return coinrankingRequest(context.auth, '/exchanges', {
+      limit,
+      offset,
+      orderBy: orderBy ?? '24hVolume',
+      orderDirection: orderDirection ?? 'desc',
+    });
+  },
+});

--- a/packages/pieces/community/coinranking/src/lib/actions/search-coins.ts
+++ b/packages/pieces/community/coinranking/src/lib/actions/search-coins.ts
@@ -1,0 +1,30 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { coinrankingAuth } from '../../index';
+import { coinrankingRequest } from '../coinranking-api';
+
+export const searchCoins = createAction({
+  name: 'search_coins',
+  displayName: 'Search Coins',
+  description: 'Search for coins by name or symbol and return matching results.',
+  auth: coinrankingAuth,
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'Name or symbol to search for (e.g. "Bitcoin" or "BTC")',
+      required: true,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of results to return (max 100)',
+      required: false,
+      defaultValue: 10,
+    }),
+  },
+  async run(context) {
+    const { query, limit } = context.propsValue;
+    return coinrankingRequest(context.auth, '/search-suggestions', {
+      query,
+      limit,
+    });
+  },
+});

--- a/packages/pieces/community/coinranking/src/lib/coinranking-api.ts
+++ b/packages/pieces/community/coinranking/src/lib/coinranking-api.ts
@@ -1,0 +1,35 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.coinranking.com/v2';
+
+export async function coinrankingRequest<T>(
+  apiKey: string,
+  path: string,
+  queryParams?: Record<string, string | number | undefined>
+): Promise<T> {
+  const url = new URL(BASE_URL + path);
+
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      if (value !== undefined && value !== '') {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  const response = await httpClient.sendRequest<T>({
+    method: HttpMethod.GET,
+    url: url.toString(),
+    headers: {
+      'x-access-token': apiKey,
+    },
+  });
+
+  if (response.status !== 200) {
+    throw new Error(
+      `CoinRanking API error ${response.status}: ${JSON.stringify(response.body)}`
+    );
+  }
+
+  return response.body;
+}

--- a/packages/pieces/community/coinranking/tsconfig.json
+++ b/packages/pieces/community/coinranking/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/coinranking/tsconfig.lib.json
+++ b/packages/pieces/community/coinranking/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## feat: add CoinRanking piece

This PR adds a new community piece for [CoinRanking](https://coinranking.com), a free and comprehensive cryptocurrency market data API.

### Actions (5)

| Action | Description |
|--------|-------------|
| **Get Coins** | List cryptocurrencies with price, market cap, 24h volume, and percentage change. Supports sorting, pagination, and custom time periods. |
| **Get Coin Details** | Fetch detailed info for a specific coin by its CoinRanking UUID (name, symbol, price, market cap, supply, links, etc.). |
| **Get Coin Price History** | Retrieve historical price data for a coin over configurable time ranges (1h to 5y). |
| **Get Exchanges** | List tracked crypto exchanges with 24h volume, number of markets, and more. |
| **Search Coins** | Search for coins by name or symbol and return matching results. |

### Auth

Uses `PieceAuth.SecretText` — users provide their CoinRanking API key, which is passed as the `x-access-token` header. Free tier available at https://developers.coinranking.com.

### Category

`BUSINESS_INTELLIGENCE`

---

Part of the [Algora bounty challenge](https://algora.io) for Activepieces MCP pieces ($200/PR).
