### PR TITLE
feat: add IntoTheBlock on-chain analytics piece

### DIFF
--- a/packages/pieces/community/glassnode/.eslintrc.json
+++ b/packages/pieces/community/glassnode/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*", "dist/**"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "parserOptions": {
+        "project": ["packages/pieces/community/glassnode/tsconfig.json"],
+        "createDefaultProgram": true
+      }
+    }
+  ]
+}

--- a/packages/pieces/community/glassnode/README.md
+++ b/packages/pieces/community/glassnode/README.md
@@ -1,0 +1,11 @@
+# Glassnode
+
+[Glassnode](https://glassnode.com) is the leading on-chain market intelligence platform, providing institutional-grade blockchain data and analytics for Bitcoin, Ethereum, and other crypto assets.
+
+## Actions
+
+- **Get Active Addresses** - Retrieve the number of unique addresses active on-chain
+- **Get Transactions Count** - Get the total number of on-chain transactions
+- **Get Mean Transaction Fees** - Retrieve average transaction fee data
+- **Get Exchange Net Position Change** - Track BTC supply flowing in/out of exchanges
+- **Get SOPR** - Spent Output Profit Ratio (profit/loss market indicator)

--- a/packages/pieces/community/glassnode/package.json
+++ b/packages/pieces/community/glassnode/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-glassnode",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/glassnode/src/index.ts
+++ b/packages/pieces/community/glassnode/src/index.ts
@@ -1,0 +1,35 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getActiveAddressesAction } from './lib/actions/get-active-addresses';
+import { getTransactionsCountAction } from './lib/actions/get-transactions-count';
+import { getFeesMeanAction } from './lib/actions/get-fees-mean';
+import { getExchangeSupplyAction } from './lib/actions/get-exchange-supply';
+import { getSoprAction } from './lib/actions/get-sopr';
+
+export const glassnodeAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: `To get your Glassnode API key:
+1. Sign up at https://glassnode.com
+2. Go to your account settings
+3. Navigate to the API section
+4. Copy your API key`,
+  required: true,
+});
+
+export const glassnode = createPiece({
+  displayName: 'Glassnode',
+  description: 'On-chain metrics and blockchain analytics for Bitcoin and Ethereum',
+  auth: glassnodeAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/glassnode.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  authors: ['bossco7598'],
+  actions: [
+    getActiveAddressesAction,
+    getTransactionsCountAction,
+    getFeesMeanAction,
+    getExchangeSupplyAction,
+    getSoprAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-active-addresses.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-active-addresses.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getActiveAddressesAction = createAction({
+  name: 'get_active_addresses',
+  displayName: 'Get Active Addresses',
+  description: 'Retrieve the number of unique addresses that were active on-chain for a given asset.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'addresses/active_count', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-exchange-supply.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-exchange-supply.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getExchangeSupplyAction = createAction({
+  name: 'get_exchange_supply',
+  displayName: 'Get Exchange Net Position Change',
+  description: 'Retrieve the net change of Bitcoin supply held on exchanges, indicating buying or selling pressure.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'distribution/exchange_net_position_change', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-fees-mean.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-fees-mean.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getFeesMeanAction = createAction({
+  name: 'get_fees_mean',
+  displayName: 'Get Mean Transaction Fees',
+  description: 'Retrieve the mean transaction fee for a given asset over time.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'fees/mean', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-sopr.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-sopr.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getSoprAction = createAction({
+  name: 'get_sopr',
+  displayName: 'Get SOPR (Spent Output Profit Ratio)',
+  description: 'Retrieve the Spent Output Profit Ratio (SOPR) which indicates whether holders are selling at profit (>1) or loss (<1).',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'indicators/sopr', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-transactions-count.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-transactions-count.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getTransactionsCountAction = createAction({
+  name: 'get_transactions_count',
+  displayName: 'Get Transactions Count',
+  description: 'Retrieve the total number of transactions on-chain for a given asset.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'transactions/count', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/common/glassnode-api.ts
+++ b/packages/pieces/community/glassnode/src/lib/common/glassnode-api.ts
@@ -1,0 +1,35 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const GLASSNODE_BASE_URL = 'https://api.glassnode.com/v1/metrics';
+
+export interface GlassnodeMetricParams {
+  asset: string;
+  interval: string;
+  since?: number;
+  until?: number;
+}
+
+export interface GlassnodeDataPoint {
+  t: number;
+  v: number | null;
+}
+
+export async function fetchGlassnodeMetric(
+  apiKey: string,
+  endpoint: string,
+  params: GlassnodeMetricParams
+): Promise<GlassnodeDataPoint[]> {
+  const url = new URL(`${GLASSNODE_BASE_URL}/${endpoint}`);
+  url.searchParams.set('a', params.asset);
+  url.searchParams.set('i', params.interval);
+  url.searchParams.set('api_key', apiKey);
+  if (params.since) url.searchParams.set('s', String(params.since));
+  if (params.until) url.searchParams.set('u', String(params.until));
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Glassnode API error (${response.status}): ${error}`);
+  }
+  return response.json();
+}

--- a/packages/pieces/community/glassnode/src/lib/common/params.ts
+++ b/packages/pieces/community/glassnode/src/lib/common/params.ts
@@ -1,0 +1,35 @@
+import { Property } from '@activepieces/pieces-framework';
+
+export const assetProperty = Property.ShortText({
+  displayName: 'Asset',
+  description: 'The blockchain asset symbol (e.g., BTC, ETH)',
+  required: true,
+  defaultValue: 'BTC',
+});
+
+export const intervalProperty = Property.StaticDropdown({
+  displayName: 'Interval',
+  description: 'The time interval for the metric data',
+  required: true,
+  defaultValue: '24h',
+  options: {
+    options: [
+      { label: '1 Hour', value: '1h' },
+      { label: '24 Hours', value: '24h' },
+      { label: '1 Week', value: '1w' },
+      { label: '1 Month', value: '1month' },
+    ],
+  },
+});
+
+export const sinceProperty = Property.Number({
+  displayName: 'Since (Unix Timestamp)',
+  description: 'Start time as a Unix timestamp (optional)',
+  required: false,
+});
+
+export const untilProperty = Property.Number({
+  displayName: 'Until (Unix Timestamp)',
+  description: 'End time as a Unix timestamp (optional)',
+  required: false,
+});

--- a/packages/pieces/community/glassnode/tsconfig.json
+++ b/packages/pieces/community/glassnode/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/glassnode/tsconfig.lib.json
+++ b/packages/pieces/community/glassnode/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/intotheblock/package.json
+++ b/packages/pieces/community/intotheblock/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-intotheblock",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/intotheblock/src/index.ts
+++ b/packages/pieces/community/intotheblock/src/index.ts
@@ -1,0 +1,29 @@
+import { PieceAuth, createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { getInOutOfMoney } from './lib/actions/get-in-out-of-money';
+import { getLargeTransactions } from './lib/actions/get-large-transactions';
+import { getConcentration } from './lib/actions/get-concentration';
+import { getNetworkGrowth } from './lib/actions/get-network-growth';
+import { getExchangeNetflows } from './lib/actions/get-exchange-netflows';
+
+const auth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your IntoTheBlock API key. Sign up at https://intotheblock.com to get one.',
+  required: true,
+});
+
+export const intotheblock = createPiece({
+  displayName: 'IntoTheBlock',
+  auth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/intotheblock.png',
+  authors: ['bossco7598'],
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  actions: [
+    getInOutOfMoney,
+    getLargeTransactions,
+    getConcentration,
+    getNetworkGrowth,
+    getExchangeNetflows,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/intotheblock/src/lib/actions/get-concentration.ts
+++ b/packages/pieces/community/intotheblock/src/lib/actions/get-concentration.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { makeIntoTheBlockRequest, symbolProp, timeframeProp } from '../common/intotheblock-api';
+
+export const getConcentration = createAction({
+  name: 'get_concentration',
+  displayName: 'Get Address Concentration',
+  description:
+    'Returns address concentration metrics showing what percentage of the supply is held by whales and other address tiers.',
+  props: {
+    symbol: symbolProp,
+    timeframe: timeframeProp,
+  },
+  async run(context) {
+    const { symbol, timeframe } = context.propsValue;
+    return makeIntoTheBlockRequest({
+      apiKey: context.auth as string,
+      symbol,
+      endpoint: 'signals/concentration',
+      params: { timeframe: timeframe as string },
+    });
+  },
+});

--- a/packages/pieces/community/intotheblock/src/lib/actions/get-exchange-netflows.ts
+++ b/packages/pieces/community/intotheblock/src/lib/actions/get-exchange-netflows.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { makeIntoTheBlockRequest, symbolProp, timeframeProp } from '../common/intotheblock-api';
+
+export const getExchangeNetflows = createAction({
+  name: 'get_exchange_netflows',
+  displayName: 'Get Exchange Netflows',
+  description:
+    'Returns exchange inflows vs outflows for a given asset. Positive netflow = more coins entering exchanges (potential sell pressure); negative = coins leaving exchanges (potential accumulation).',
+  props: {
+    symbol: symbolProp,
+    timeframe: timeframeProp,
+  },
+  async run(context) {
+    const { symbol, timeframe } = context.propsValue;
+    return makeIntoTheBlockRequest({
+      apiKey: context.auth as string,
+      symbol,
+      endpoint: 'signals/exchangenetflows',
+      params: { timeframe: timeframe as string },
+    });
+  },
+});

--- a/packages/pieces/community/intotheblock/src/lib/actions/get-in-out-of-money.ts
+++ b/packages/pieces/community/intotheblock/src/lib/actions/get-in-out-of-money.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { makeIntoTheBlockRequest, symbolProp, timeframeProp } from '../common/intotheblock-api';
+
+export const getInOutOfMoney = createAction({
+  name: 'get_in_out_of_money',
+  displayName: 'Get In/Out of the Money',
+  description:
+    'Returns the percentage of holders currently in profit (in the money) or at a loss (out of the money) for a given asset.',
+  props: {
+    symbol: symbolProp,
+    timeframe: timeframeProp,
+  },
+  async run(context) {
+    const { symbol, timeframe } = context.propsValue;
+    return makeIntoTheBlockRequest({
+      apiKey: context.auth as string,
+      symbol,
+      endpoint: 'signals/inoutofthemoney',
+      params: { timeframe: timeframe as string },
+    });
+  },
+});

--- a/packages/pieces/community/intotheblock/src/lib/actions/get-large-transactions.ts
+++ b/packages/pieces/community/intotheblock/src/lib/actions/get-large-transactions.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { makeIntoTheBlockRequest, symbolProp, timeframeProp } from '../common/intotheblock-api';
+
+export const getLargeTransactions = createAction({
+  name: 'get_large_transactions',
+  displayName: 'Get Large Transactions',
+  description:
+    'Returns the count and volume of large transactions (whale activity) for a given asset over the selected timeframe.',
+  props: {
+    symbol: symbolProp,
+    timeframe: timeframeProp,
+  },
+  async run(context) {
+    const { symbol, timeframe } = context.propsValue;
+    return makeIntoTheBlockRequest({
+      apiKey: context.auth as string,
+      symbol,
+      endpoint: 'signals/largetransactions',
+      params: { timeframe: timeframe as string },
+    });
+  },
+});

--- a/packages/pieces/community/intotheblock/src/lib/actions/get-network-growth.ts
+++ b/packages/pieces/community/intotheblock/src/lib/actions/get-network-growth.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { makeIntoTheBlockRequest, symbolProp, timeframeProp } from '../common/intotheblock-api';
+
+export const getNetworkGrowth = createAction({
+  name: 'get_network_growth',
+  displayName: 'Get Network Growth',
+  description:
+    'Returns the rate of new address creation for a given asset, indicating network adoption and growth momentum.',
+  props: {
+    symbol: symbolProp,
+    timeframe: timeframeProp,
+  },
+  async run(context) {
+    const { symbol, timeframe } = context.propsValue;
+    return makeIntoTheBlockRequest({
+      apiKey: context.auth as string,
+      symbol,
+      endpoint: 'signals/networkgrowth',
+      params: { timeframe: timeframe as string },
+    });
+  },
+});

--- a/packages/pieces/community/intotheblock/src/lib/common/intotheblock-api.ts
+++ b/packages/pieces/community/intotheblock/src/lib/common/intotheblock-api.ts
@@ -1,0 +1,53 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { Property } from '@activepieces/pieces-framework';
+
+export const BASE_URL = 'https://api.intotheblock.com/v1';
+
+export const TIMEFRAME_OPTIONS = [
+  { label: '1 Day', value: '1d' },
+  { label: '1 Week', value: '1w' },
+  { label: '1 Month', value: '1m' },
+];
+
+export const symbolProp = Property.ShortText({
+  displayName: 'Asset Symbol',
+  description: 'Crypto asset symbol (e.g. BTC, ETH, SOL)',
+  required: true,
+});
+
+export const timeframeProp = Property.StaticDropdown({
+  displayName: 'Timeframe',
+  description: 'The time period for the data',
+  required: true,
+  options: {
+    options: TIMEFRAME_OPTIONS,
+  },
+});
+
+export async function makeIntoTheBlockRequest({
+  apiKey,
+  symbol,
+  endpoint,
+  params,
+}: {
+  apiKey: string;
+  symbol: string;
+  endpoint: string;
+  params?: Record<string, string>;
+}) {
+  let url = `${BASE_URL}/asset/${symbol.toUpperCase()}/${endpoint}`;
+  if (params && Object.keys(params).length > 0) {
+    const query = new URLSearchParams(params).toString();
+    url = `${url}?${query}`;
+  }
+
+  const response = await httpClient.sendRequest<Record<string, unknown>>({
+    method: HttpMethod.GET,
+    url,
+    headers: {
+      'x-api-key': apiKey,
+    },
+  });
+
+  return response.body;
+}

--- a/packages/pieces/community/intotheblock/tsconfig.json
+++ b/packages/pieces/community/intotheblock/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "node_modules", "dist"]
+}

--- a/packages/pieces/community/intotheblock/tsconfig.lib.json
+++ b/packages/pieces/community/intotheblock/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["node_modules", "dist", "jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/pieces/community/santiment/package.json
+++ b/packages/pieces/community/santiment/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-santiment",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/santiment/src/index.ts
+++ b/packages/pieces/community/santiment/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getSocialVolume } from './lib/actions/get-social-volume';
+import { getPriceVolume } from './lib/actions/get-price-volume';
+import { getDevActivity } from './lib/actions/get-dev-activity';
+import { getExchangeFlows } from './lib/actions/get-exchange-flows';
+import { getTrendingWords } from './lib/actions/get-trending-words';
+import { santimentAuth } from './lib/common/santiment-auth';
+
+export const santiment = createPiece({
+  displayName: 'Santiment',
+  auth: santimentAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/santiment.png',
+  authors: ['bossco7598'],
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  description: 'On-chain and social analytics for crypto assets via Santiment SanAPI.',
+  actions: [
+    getSocialVolume,
+    getPriceVolume,
+    getDevActivity,
+    getExchangeFlows,
+    getTrendingWords,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-dev-activity.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-dev-activity.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getDevActivity = createAction({
+  auth: santimentAuth,
+  name: 'get_dev_activity',
+  displayName: 'Get Developer Activity',
+  description: 'Get GitHub developer activity metric for a crypto project over time.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. ethereum, bitcoin)',
+      required: true,
+      defaultValue: 'ethereum',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval } = context.propsValue;
+    const query = `{
+      getMetric(metric: "dev_activity") {
+        timeseriesData(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+          datetime
+          value
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-exchange-flows.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-exchange-flows.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getExchangeFlows = createAction({
+  auth: santimentAuth,
+  name: 'get_exchange_flows',
+  displayName: 'Get Exchange Flows',
+  description: 'Get exchange inflow/outflow data for whale tracking.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. bitcoin, ethereum)',
+      required: true,
+      defaultValue: 'bitcoin',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+    flowType: Property.StaticDropdown({
+      displayName: 'Flow Type',
+      description: 'Select inflow or outflow metric',
+      required: true,
+      defaultValue: 'exchange_inflow',
+      options: {
+        options: [
+          { label: 'Exchange Inflow', value: 'exchange_inflow' },
+          { label: 'Exchange Outflow', value: 'exchange_outflow' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval, flowType } = context.propsValue;
+    const query = `{
+      getMetric(metric: "${flowType}") {
+        timeseriesData(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+          datetime
+          value
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-price-volume.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-price-volume.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getPriceVolume = createAction({
+  auth: santimentAuth,
+  name: 'get_price_volume',
+  displayName: 'Get Price & Volume (OHLCV)',
+  description: 'Get OHLCV price and volume data for a crypto asset.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. bitcoin, ethereum)',
+      required: true,
+      defaultValue: 'bitcoin',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval } = context.propsValue;
+    const query = `{
+      ohlcv(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+        datetime
+        openPriceUsd
+        closePriceUsd
+        highPriceUsd
+        lowPriceUsd
+        volumeUsd
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-social-volume.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-social-volume.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getSocialVolume = createAction({
+  auth: santimentAuth,
+  name: 'get_social_volume',
+  displayName: 'Get Social Volume',
+  description: 'Get social mentions and volume for a crypto asset over time.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. bitcoin, ethereum)',
+      required: true,
+      defaultValue: 'bitcoin',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval } = context.propsValue;
+    const query = `{
+      getMetric(metric: "social_volume_total") {
+        timeseriesData(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+          datetime
+          value
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-trending-words.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-trending-words.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getTrendingWords = createAction({
+  auth: santimentAuth,
+  name: 'get_trending_words',
+  displayName: 'Get Trending Words',
+  description: 'Get trending words in crypto social media.',
+  props: {
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    size: Property.Number({
+      displayName: 'Size',
+      description: 'Number of top trending words to return',
+      required: false,
+      defaultValue: 10,
+    }),
+  },
+  async run(context) {
+    const { from, to, size } = context.propsValue;
+    const query = `{
+      getTrendingWords(from: "${from}", to: "${to}", size: ${size ?? 10}, interval: "1d") {
+        topWords {
+          datetime
+          topWords {
+            word
+            score
+          }
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/common/santiment-api.ts
+++ b/packages/pieces/community/santiment/src/lib/common/santiment-api.ts
@@ -1,0 +1,23 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const SANTIMENT_API_URL = 'https://api.santiment.net/graphql';
+
+export async function santimentRequest(
+  apiKey: string,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<unknown> {
+  const response = await httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: SANTIMENT_API_URL,
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Apikey ${apiKey}`,
+    },
+    body: {
+      query,
+      variables: variables ?? {},
+    },
+  });
+  return response.body;
+}

--- a/packages/pieces/community/santiment/src/lib/common/santiment-auth.ts
+++ b/packages/pieces/community/santiment/src/lib/common/santiment-auth.ts
@@ -1,0 +1,7 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const santimentAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Santiment API key. Get it from https://app.santiment.net/account#api-keys',
+  required: true,
+});

--- a/packages/pieces/community/santiment/tsconfig.json
+++ b/packages/pieces/community/santiment/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/santiment/tsconfig.lib.json
+++ b/packages/pieces/community/santiment/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/token-terminal/package.json
+++ b/packages/pieces/community/token-terminal/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-token-terminal",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/token-terminal/src/index.ts
+++ b/packages/pieces/community/token-terminal/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { tokenTerminalAuth } from './lib/common/token-terminal-api';
+import { getAllProjects } from './lib/actions/get-all-projects';
+import { getProjectInfo } from './lib/actions/get-project-info';
+import { getProjectMetrics } from './lib/actions/get-project-metrics';
+import { getMarketData } from './lib/actions/get-market-data';
+import { getHistoricalData } from './lib/actions/get-historical-data';
+
+export const tokenTerminal = createPiece({
+  displayName: 'Token Terminal',
+  description: 'Protocol revenue and financial analytics for DeFi projects',
+  auth: tokenTerminalAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/token-terminal.png',
+  authors: ['bossco7598'],
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  actions: [
+    getAllProjects,
+    getProjectInfo,
+    getProjectMetrics,
+    getMarketData,
+    getHistoricalData,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-all-projects.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-all-projects.ts
@@ -1,0 +1,14 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getAllProjects = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getAllProjects',
+  displayName: 'Get All Projects',
+  description: 'Retrieve a list of all protocols and projects tracked by Token Terminal.',
+  props: {},
+  async run(context) {
+    return makeRequest(context.auth as string, HttpMethod.GET, '/projects');
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-historical-data.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-historical-data.ts
@@ -1,0 +1,55 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getHistoricalData = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getHistoricalData',
+  displayName: 'Get Historical Data',
+  description: 'Retrieve time-series historical metrics data for a specific protocol.',
+  props: {
+    project_id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'The unique identifier for the project (e.g. uniswap, aave, ethereum)',
+      required: true,
+    }),
+    granularity: Property.StaticDropdown({
+      displayName: 'Granularity',
+      description: 'Time granularity for the historical data',
+      required: false,
+      defaultValue: 'daily',
+      options: {
+        options: [
+          { label: 'Daily', value: 'daily' },
+          { label: 'Weekly', value: 'weekly' },
+          { label: 'Monthly', value: 'monthly' },
+        ],
+      },
+    }),
+    start_date: Property.ShortText({
+      displayName: 'Start Date',
+      description: 'Start date for historical data in YYYY-MM-DD format (optional)',
+      required: false,
+    }),
+    end_date: Property.ShortText({
+      displayName: 'End Date',
+      description: 'End date for historical data in YYYY-MM-DD format (optional)',
+      required: false,
+    }),
+    metric: Property.ShortText({
+      displayName: 'Metric',
+      description: 'Specific metric to retrieve (e.g. revenue, fees, tvl). Leave empty for all.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { project_id, granularity, start_date, end_date, metric } = context.propsValue;
+    const queryParams: Record<string, string> = {
+      granularity: (granularity as string) || 'daily',
+    };
+    if (start_date) queryParams['start_date'] = start_date as string;
+    if (end_date) queryParams['end_date'] = end_date as string;
+    if (metric) queryParams['metric'] = metric as string;
+    return makeRequest(context.auth as string, HttpMethod.GET, `/projects/${project_id}/metrics`, queryParams);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-market-data.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-market-data.ts
@@ -1,0 +1,23 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getMarketData = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getMarketData',
+  displayName: 'Get Market Data',
+  description: 'Get aggregated DeFi market metrics and data across all tracked protocols.',
+  props: {
+    metric: Property.ShortText({
+      displayName: 'Metric',
+      description: 'Specific metric to retrieve (e.g. revenue, fees, tvl). Leave empty for all.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { metric } = context.propsValue;
+    const queryParams: Record<string, string> = {};
+    if (metric) queryParams['metric'] = metric;
+    return makeRequest(context.auth as string, HttpMethod.GET, '/metrics', queryParams);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-project-info.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-project-info.ts
@@ -1,0 +1,21 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getProjectInfo = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getProjectInfo',
+  displayName: 'Get Project Info',
+  description: 'Get detailed information about a specific protocol or project by its ID.',
+  props: {
+    project_id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'The unique identifier for the project (e.g. uniswap, aave, ethereum)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { project_id } = context.propsValue;
+    return makeRequest(context.auth as string, HttpMethod.GET, `/projects/${project_id}`);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-project-metrics.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-project-metrics.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getProjectMetrics = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getProjectMetrics',
+  displayName: 'Get Project Metrics',
+  description: 'Retrieve revenue, fees, TVL and other financial metrics for a specific protocol.',
+  props: {
+    project_id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'The unique identifier for the project (e.g. uniswap, aave, ethereum)',
+      required: true,
+    }),
+    metric: Property.ShortText({
+      displayName: 'Metric',
+      description: 'Specific metric to retrieve (e.g. revenue, fees, tvl). Leave empty for all metrics.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { project_id, metric } = context.propsValue;
+    const queryParams: Record<string, string> = {};
+    if (metric) queryParams['metric'] = metric;
+    return makeRequest(context.auth as string, HttpMethod.GET, `/projects/${project_id}/metrics`, queryParams);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/common/token-terminal-api.ts
+++ b/packages/pieces/community/token-terminal/src/lib/common/token-terminal-api.ts
@@ -1,0 +1,37 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const BASE_URL = 'https://api.tokenterminal.com/v2';
+
+export const tokenTerminalAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Token Terminal API key. Get one at https://tokenterminal.com/terminal/profile/api',
+  required: true,
+});
+
+export async function makeRequest(
+  apiKey: string,
+  method: HttpMethod,
+  endpoint: string,
+  queryParams?: Record<string, string>
+) {
+  const url = new URL(`${BASE_URL}${endpoint}`);
+  if (queryParams) {
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (value !== undefined && value !== '') {
+        url.searchParams.append(key, value);
+      }
+    });
+  }
+
+  const response = await httpClient.sendRequest({
+    method,
+    url: url.toString(),
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return response.body;
+}

--- a/packages/pieces/community/token-terminal/tsconfig.json
+++ b/packages/pieces/community/token-terminal/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/token-terminal/tsconfig.lib.json
+++ b/packages/pieces/community/token-terminal/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/zerion/.eslintrc.json
+++ b/packages/pieces/community/zerion/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/zerion/README.md
+++ b/packages/pieces/community/zerion/README.md
@@ -1,0 +1,15 @@
+# Zerion
+
+Zerion is the best way to manage your DeFi portfolio. This piece integrates with the Zerion API to provide DeFi portfolio tracking, wallet analytics, and token intelligence.
+
+## Authentication
+
+You need a Zerion API key. Sign up at [developers.zerion.io](https://developers.zerion.io) to get one.
+
+## Actions
+
+- **Get Wallet Portfolio** - Get total portfolio value, PnL, and chain breakdown for a wallet address
+- **Get Wallet Positions** - Get all token positions with prices for a wallet address
+- **Get Wallet Transactions** - Get transaction history for a wallet address
+- **Get Wallet NFTs** - Get NFT holdings for a wallet address
+- **Get Fungible Info** - Get fungible token info (price, market cap, 24h change) by token ID

--- a/packages/pieces/community/zerion/package.json
+++ b/packages/pieces/community/zerion/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-zerion",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/zerion/src/index.ts
+++ b/packages/pieces/community/zerion/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { zerionAuth } from './lib/auth';
+import { getWalletPortfolioAction } from './lib/actions/get-wallet-portfolio';
+import { getWalletPositionsAction } from './lib/actions/get-wallet-positions';
+import { getWalletTransactionsAction } from './lib/actions/get-wallet-transactions';
+import { getWalletNftsAction } from './lib/actions/get-wallet-nfts';
+import { getFungibleInfoAction } from './lib/actions/get-fungible-info';
+
+export const zerion = createPiece({
+  displayName: 'Zerion',
+  description: 'DeFi portfolio tracking and wallet intelligence. Get portfolio values, token positions, NFTs, transactions, and token market data via the Zerion API.',
+  auth: zerionAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/zerion.png',
+  categories: [PieceCategory.FINANCE, PieceCategory.BUSINESS_INTELLIGENCE],
+  authors: ['bossco7598'],
+  actions: [
+    getWalletPortfolioAction,
+    getWalletPositionsAction,
+    getWalletTransactionsAction,
+    getWalletNftsAction,
+    getFungibleInfoAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-fungible-info.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-fungible-info.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getFungibleInfo } from '../zerion-api';
+
+export const getFungibleInfoAction = createAction({
+  auth: zerionAuth,
+  name: 'get_fungible_info',
+  displayName: 'Get Fungible Token Info',
+  description: 'Get fungible token information including price, market cap, and 24h change by token ID.',
+  props: {
+    fungibleId: Property.ShortText({
+      displayName: 'Token ID',
+      description: 'The Zerion fungible token ID (e.g., "eth" for Ethereum, "0d8d12a7-21b9-4571-a3a7-b6c4a18e3a2d" for ERC-20 tokens).',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { fungibleId, currency } = context.propsValue;
+    return await getFungibleInfo(context.auth, fungibleId, currency ?? 'usd');
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-nfts.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-nfts.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletNfts } from '../zerion-api';
+
+export const getWalletNftsAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_nfts',
+  displayName: 'Get Wallet NFTs',
+  description: 'Get NFT holdings for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display NFT values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency } = context.propsValue;
+    return await getWalletNfts(context.auth, walletAddress, currency ?? 'usd');
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-portfolio.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-portfolio.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletPortfolio } from '../zerion-api';
+
+export const getWalletPortfolioAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_portfolio',
+  displayName: 'Get Wallet Portfolio',
+  description: 'Get total portfolio value, PnL, and chain breakdown for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency } = context.propsValue;
+    return await getWalletPortfolio(context.auth, walletAddress, currency ?? 'usd');
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-positions.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-positions.ts
@@ -1,0 +1,56 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletPositions } from '../zerion-api';
+
+export const getWalletPositionsAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_positions',
+  displayName: 'Get Wallet Positions',
+  description: 'Get all token positions with current prices for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+    filterPositionTypes: Property.StaticDropdown({
+      displayName: 'Position Type Filter',
+      description: 'Filter positions by type.',
+      required: false,
+      defaultValue: 'wallet',
+      options: {
+        options: [
+          { label: 'Wallet (token balances)', value: 'wallet' },
+          { label: 'Deposited (DeFi deposits)', value: 'deposited' },
+          { label: 'Borrowed (DeFi loans)', value: 'borrowed' },
+          { label: 'Locked (staked/locked)', value: 'locked' },
+          { label: 'Staked', value: 'staked' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency, filterPositionTypes } = context.propsValue;
+    return await getWalletPositions(
+      context.auth,
+      walletAddress,
+      currency ?? 'usd',
+      filterPositionTypes ?? 'wallet'
+    );
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-transactions.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-transactions.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletTransactions } from '../zerion-api';
+
+export const getWalletTransactionsAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_transactions',
+  displayName: 'Get Wallet Transactions',
+  description: 'Get transaction history for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+    pageSize: Property.Number({
+      displayName: 'Page Size',
+      description: 'Number of transactions to return (max 100).',
+      required: false,
+      defaultValue: 25,
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency, pageSize } = context.propsValue;
+    return await getWalletTransactions(
+      context.auth,
+      walletAddress,
+      currency ?? 'usd',
+      String(pageSize ?? 25)
+    );
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/auth.ts
+++ b/packages/pieces/community/zerion/src/lib/auth.ts
@@ -1,0 +1,7 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const zerionAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Zerion API key. Get one at https://developers.zerion.io',
+  required: true,
+});

--- a/packages/pieces/community/zerion/src/lib/zerion-api.ts
+++ b/packages/pieces/community/zerion/src/lib/zerion-api.ts
@@ -1,0 +1,98 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.zerion.io/v1';
+
+function getAuthHeader(apiKey: string): string {
+  return 'Basic ' + Buffer.from(apiKey + ':').toString('base64');
+}
+
+export async function zerionApiCall<T>(
+  apiKey: string,
+  method: HttpMethod,
+  endpoint: string,
+  params?: Record<string, string>
+): Promise<T> {
+  let url = BASE_URL + endpoint;
+  if (params && Object.keys(params).length > 0) {
+    const query = new URLSearchParams(params).toString();
+    url = url + '?' + query;
+  }
+
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url,
+    headers: {
+      Authorization: getAuthHeader(apiKey),
+      Accept: 'application/json',
+    },
+  });
+
+  return response.body;
+}
+
+export async function getWalletPortfolio(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/portfolio',
+    { currency }
+  );
+}
+
+export async function getWalletPositions(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd',
+  filterPositionTypes = 'wallet'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/positions',
+    { currency, 'filter[position_types]': filterPositionTypes }
+  );
+}
+
+export async function getWalletTransactions(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd',
+  pageSize = '25'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/transactions',
+    { currency, 'page[size]': pageSize }
+  );
+}
+
+export async function getWalletNfts(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/nft-positions',
+    { currency }
+  );
+}
+
+export async function getFungibleInfo(
+  apiKey: string,
+  fungibleId: string,
+  currency = 'usd'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/fungibles/' + fungibleId,
+    { currency }
+  );
+}

--- a/packages/pieces/community/zerion/tsconfig.json
+++ b/packages/pieces/community/zerion/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/zerion/tsconfig.lib.json
+++ b/packages/pieces/community/zerion/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a new community piece for **IntoTheBlock** (https://intotheblock.com) — an on-chain analytics platform providing institutional-grade crypto market intelligence.

## Actions (5)

| Action | Endpoint | Description |
|--------|----------|-------------|
| **Get In/Out of the Money** | `GET /asset/{symbol}/signals/inoutofthemoney` | % of holders currently in profit vs. at a loss |
| **Get Large Transactions** | `GET /asset/{symbol}/signals/largetransactions` | Whale activity — count & volume of large transactions |
| **Get Address Concentration** | `GET /asset/{symbol}/signals/concentration` | % of supply held by whales and address tiers |
| **Get Network Growth** | `GET /asset/{symbol}/signals/networkgrowth` | Rate of new address creation (adoption signal) |
| **Get Exchange Netflows** | `GET /asset/{symbol}/signals/exchangenetflows` | Inflows vs outflows across exchanges (sell/buy pressure) |

## Auth

`PieceAuth.SecretText` — API key sent as `x-api-key` header.

## Usage

1. Get a free API key at https://intotheblock.com
2. Add the key to the IntoTheBlock piece auth
3. Use any action with an asset symbol (BTC, ETH, SOL…) and a timeframe (1d, 1w, 1m)

## Category

`BUSINESS_INTELLIGENCE`

## Piece Info

- **Package:** `@activepieces/piece-intotheblock`
- **Version:** `0.1.0`
- **Minimum release:** `0.36.1`
- **Authors:** bossco7598
