### PR TITLE
feat(piece-dydx): add dYdX perpetuals trading data piece [MCP Challenge]

### DIFF
--- a/packages/pieces/community/curve-finance/package.json
+++ b/packages/pieces/community/curve-finance/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@activepieces/piece-curve-finance",
+  "version": "0.0.1",
+  "description": "Curve Finance stablecoin DEX: pools, TVL, APY, gauge data, token prices",
+  "keywords": [
+    "activepieces",
+    "curve",
+    "defi",
+    "stablecoin",
+    "dex",
+    "liquidity"
+  ],
+  "homepage": "",
+  "bugs": {
+    "url": "https://github.com/activepieces/activepieces/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/activepieces/activepieces.git"
+  },
+  "license": "MIT",
+  "author": "",
+  "main": "./src/index.ts",
+  "scripts": {
+    "publish-piece": "node ../../../../.scripts/publish-piece.mjs"
+  },
+  "peerDependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*"
+  }
+}

--- a/packages/pieces/community/curve-finance/src/index.ts
+++ b/packages/pieces/community/curve-finance/src/index.ts
@@ -1,0 +1,16 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { getPools } from './lib/actions/get-pools';
+import { getPoolStats } from './lib/actions/get-pool-stats';
+import { getProtocolStats } from './lib/actions/get-protocol-stats';
+import { getTokenPrice } from './lib/actions/get-token-price';
+import { getGaugeData } from './lib/actions/get-gauge-data';
+
+export const curveFinance = createPiece({
+  displayName: 'Curve Finance',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/curve-finance.png',
+  authors: ['bossco7598'],
+  actions: [getPools, getPoolStats, getProtocolStats, getTokenPrice, getGaugeData],
+  triggers: [],
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-gauge-data.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-gauge-data.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { curveRequest, CHAIN_OPTIONS } from '../curve-api';
+
+export const getGaugeData = createAction({
+  name: 'get_gauge_data',
+  displayName: 'Get Gauge Data',
+  description: 'Get CRV liquidity mining gauge data for a Curve pool including APR and gauge weight',
+  props: {
+    chain: Property.StaticDropdown({
+      displayName: 'Chain',
+      required: true,
+      options: { options: CHAIN_OPTIONS },
+    }),
+    poolAddress: Property.ShortText({
+      displayName: 'Pool Address',
+      description: 'Contract address of the Curve pool',
+      required: true,
+    }),
+  },
+  async run(ctx) {
+    const { chain, poolAddress } = ctx.propsValue;
+    const data = await curveRequest<any>(`/getGaugeRewards/${chain}/${poolAddress}`);
+    return data;
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-pool-stats.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-pool-stats.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { curveRequest, CHAIN_OPTIONS } from '../curve-api';
+
+export const getPoolStats = createAction({
+  name: 'get_pool_stats',
+  displayName: 'Get Pool Stats',
+  description: 'Get detailed statistics for a specific Curve Finance pool',
+  props: {
+    chain: Property.StaticDropdown({
+      displayName: 'Chain',
+      required: true,
+      options: { options: CHAIN_OPTIONS },
+    }),
+    poolAddress: Property.ShortText({
+      displayName: 'Pool Address',
+      description: 'Contract address of the Curve pool',
+      required: true,
+    }),
+  },
+  async run(ctx) {
+    const { chain, poolAddress } = ctx.propsValue;
+    const data = await curveRequest<any>(`/getPool/${chain}/${poolAddress}`);
+    return data;
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-pools.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-pools.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { curveRequest, CHAIN_OPTIONS } from '../curve-api';
+
+export const getPools = createAction({
+  name: 'get_pools',
+  displayName: 'Get Pools',
+  description: 'List all Curve Finance pools on a given chain with TVL, volume, and APY data',
+  props: {
+    chain: Property.StaticDropdown({
+      displayName: 'Chain',
+      description: 'Blockchain network to query',
+      required: true,
+      options: { options: CHAIN_OPTIONS },
+    }),
+    poolType: Property.StaticDropdown({
+      displayName: 'Pool Type',
+      description: 'Filter by pool type',
+      required: false,
+      options: {
+        options: [
+          { label: 'All Pools', value: 'all' },
+          { label: 'Main Pools', value: 'main' },
+          { label: 'Crypto Pools', value: 'crypto' },
+          { label: 'Factory Pools', value: 'factory' },
+        ],
+      },
+    }),
+  },
+  async run(ctx) {
+    const { chain, poolType } = ctx.propsValue;
+    const type = poolType || 'all';
+    const data = await curveRequest<any>(`/getPools/${chain}/${type}`);
+    return data;
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-protocol-stats.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-protocol-stats.ts
@@ -1,0 +1,14 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { curveRequest } from '../curve-api';
+
+export const getProtocolStats = createAction({
+  name: 'get_protocol_stats',
+  displayName: 'Get Protocol Stats',
+  description: 'Get global Curve Finance protocol statistics including total TVL and volume',
+  props: {},
+  async run() {
+    const tvlData = await curveRequest<any>('/getTVL');
+    const volumeData = await curveRequest<any>('/getTotalVolume');
+    return { tvl: tvlData, volume: volumeData };
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-token-price.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-token-price.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { curveRequest, CHAIN_OPTIONS } from '../curve-api';
+
+export const getTokenPrice = createAction({
+  name: 'get_token_price',
+  displayName: 'Get Token Price',
+  description: 'Get the USD price of a token traded on Curve Finance',
+  props: {
+    chain: Property.StaticDropdown({
+      displayName: 'Chain',
+      required: true,
+      options: { options: CHAIN_OPTIONS },
+    }),
+    tokenAddress: Property.ShortText({
+      displayName: 'Token Address',
+      description: 'Contract address of the token (e.g. CRV: 0xD533a949740bb3306d119CC777fa900bA034cd52)',
+      required: true,
+    }),
+  },
+  async run(ctx) {
+    const { chain, tokenAddress } = ctx.propsValue;
+    const data = await curveRequest<any>(`/getTokenPrice/${chain}/${tokenAddress}`);
+    return data;
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/curve-api.ts
+++ b/packages/pieces/community/curve-finance/src/lib/curve-api.ts
@@ -1,0 +1,23 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.curve.fi/v1';
+
+export async function curveRequest<T>(endpoint: string): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method: HttpMethod.GET,
+    url: `${BASE_URL}${endpoint}`,
+    headers: { 'Accept': 'application/json' },
+  });
+  return response.body;
+}
+
+export const CHAIN_OPTIONS = [
+  { label: 'Ethereum', value: 'ethereum' },
+  { label: 'Arbitrum', value: 'arbitrum' },
+  { label: 'Optimism', value: 'optimism' },
+  { label: 'Polygon', value: 'polygon' },
+  { label: 'Base', value: 'base' },
+  { label: 'Avalanche', value: 'avalanche' },
+  { label: 'Fantom', value: 'fantom' },
+  { label: 'xDai/Gnosis', value: 'xdai' },
+];

--- a/packages/pieces/community/curve-finance/tsconfig.json
+++ b/packages/pieces/community/curve-finance/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/pieces/community/dydx/README.md
+++ b/packages/pieces/community/dydx/README.md
@@ -1,0 +1,35 @@
+# dYdX Piece for Activepieces
+
+Integrate [dYdX](https://dydx.exchange) — the leading decentralized perpetuals trading platform — into your Activepieces workflows.
+
+dYdX v4 operates as a standalone Cosmos-based blockchain with a free public indexer API requiring no authentication.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| **Get Perpetual Markets** | List all available perpetual trading pairs |
+| **Get Market Orderbook** | Get real-time orderbook for any market |
+| **Get Market Trades** | Get recent trades for a market |
+| **Get Account Positions** | Get open positions for a dYdX address |
+| **Get Candles** | Get OHLCV candlestick data |
+
+## API
+
+- **Base URL:** `https://indexer.dydx.trade/v4`
+- **Authentication:** None required
+- **Docs:** [dYdX Indexer API](https://indexer.dydx.trade/v4)
+
+## Usage Examples
+
+### Get Markets
+Fetch all available perpetual markets with their current stats.
+
+### Get Orderbook
+Provide a ticker like `BTC-USD` or `ETH-USD` to retrieve the live orderbook.
+
+### Get Candles
+Select a ticker and resolution (1MIN to 1WEEK) to get OHLCV data.
+
+### Get Account Positions
+Provide a dYdX chain address (e.g. `dydx1abc...`) to view open positions.

--- a/packages/pieces/community/dydx/package.json
+++ b/packages/pieces/community/dydx/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@activepieces/piece-dydx",
+  "version": "0.0.1",
+  "description": "dYdX decentralized perpetuals trading data for Activepieces",
+  "main": "src/index.ts",
+  "keywords": ["activepieces", "dydx", "defi", "perpetuals", "trading"],
+  "authors": ["Activepieces"],
+  "license": "MIT",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*"
+  }
+}

--- a/packages/pieces/community/dydx/src/actions/get-account-positions.ts
+++ b/packages/pieces/community/dydx/src/actions/get-account-positions.ts
@@ -1,0 +1,20 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { dydxRequest } from '../lib/dydx-api';
+
+export const getAccountPositions = createAction({
+  name: 'get_account_positions',
+  displayName: 'Get Account Positions',
+  description: 'Get open perpetual positions for a dYdX address',
+  auth: undefined,
+  props: {
+    address: Property.ShortText({
+      displayName: 'dYdX Address',
+      description: 'The dYdX chain address (e.g. dydx1abc...)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { address } = context.propsValue;
+    return await dydxRequest(`/v4/addresses/${address}/subaccounts/0`);
+  },
+});

--- a/packages/pieces/community/dydx/src/actions/get-candles.ts
+++ b/packages/pieces/community/dydx/src/actions/get-candles.ts
@@ -1,0 +1,40 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { dydxRequest } from '../lib/dydx-api';
+
+export const getCandles = createAction({
+  name: 'get_candles',
+  displayName: 'Get Candles',
+  description: 'Get OHLCV candlestick data for a perpetual market on dYdX',
+  auth: undefined,
+  props: {
+    ticker: Property.ShortText({
+      displayName: 'Market Ticker',
+      description: 'The market ticker symbol (e.g. BTC-USD, ETH-USD)',
+      required: true,
+    }),
+    resolution: Property.StaticDropdown({
+      displayName: 'Resolution',
+      description: 'The candle time resolution',
+      required: true,
+      options: {
+        options: [
+          { label: '1 Minute', value: '1MIN' },
+          { label: '5 Minutes', value: '5MINS' },
+          { label: '15 Minutes', value: '15MINS' },
+          { label: '30 Minutes', value: '30MINS' },
+          { label: '1 Hour', value: '1HOUR' },
+          { label: '4 Hours', value: '4HOURS' },
+          { label: '1 Day', value: '1DAY' },
+          { label: '1 Week', value: '1WEEK' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { ticker, resolution } = context.propsValue;
+    return await dydxRequest(`/v4/candles/perpetualMarkets/${ticker}`, {
+      resolution: resolution as string,
+      limit: '24',
+    });
+  },
+});

--- a/packages/pieces/community/dydx/src/actions/get-market-orderbook.ts
+++ b/packages/pieces/community/dydx/src/actions/get-market-orderbook.ts
@@ -1,0 +1,20 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { dydxRequest } from '../lib/dydx-api';
+
+export const getMarketOrderbook = createAction({
+  name: 'get_market_orderbook',
+  displayName: 'Get Market Orderbook',
+  description: 'Get the real-time orderbook for a perpetual market on dYdX',
+  auth: undefined,
+  props: {
+    ticker: Property.ShortText({
+      displayName: 'Market Ticker',
+      description: 'The market ticker symbol (e.g. BTC-USD, ETH-USD)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { ticker } = context.propsValue;
+    return await dydxRequest(`/v4/orderbooks/perpetualMarket/${ticker}`);
+  },
+});

--- a/packages/pieces/community/dydx/src/actions/get-market-trades.ts
+++ b/packages/pieces/community/dydx/src/actions/get-market-trades.ts
@@ -1,0 +1,20 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { dydxRequest } from '../lib/dydx-api';
+
+export const getMarketTrades = createAction({
+  name: 'get_market_trades',
+  displayName: 'Get Market Trades',
+  description: 'Get recent trades for a perpetual market on dYdX',
+  auth: undefined,
+  props: {
+    ticker: Property.ShortText({
+      displayName: 'Market Ticker',
+      description: 'The market ticker symbol (e.g. BTC-USD, ETH-USD)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { ticker } = context.propsValue;
+    return await dydxRequest(`/v4/trades/perpetualMarket/${ticker}`, { limit: '20' });
+  },
+});

--- a/packages/pieces/community/dydx/src/actions/get-markets.ts
+++ b/packages/pieces/community/dydx/src/actions/get-markets.ts
@@ -1,0 +1,13 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { dydxRequest } from '../lib/dydx-api';
+
+export const getMarkets = createAction({
+  name: 'get_markets',
+  displayName: 'Get Perpetual Markets',
+  description: 'Get all available perpetual markets on dYdX',
+  auth: undefined,
+  props: {},
+  async run(context) {
+    return await dydxRequest('/v4/perpetualMarkets', { limit: '100' });
+  },
+});

--- a/packages/pieces/community/dydx/src/index.ts
+++ b/packages/pieces/community/dydx/src/index.ts
@@ -1,0 +1,16 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { getMarkets } from './actions/get-markets';
+import { getMarketOrderbook } from './actions/get-market-orderbook';
+import { getMarketTrades } from './actions/get-market-trades';
+import { getAccountPositions } from './actions/get-account-positions';
+import { getCandles } from './actions/get-candles';
+
+export const dydx = createPiece({
+  displayName: 'dYdX',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/dydx.png',
+  authors: ['bossco7598'],
+  actions: [getMarkets, getMarketOrderbook, getMarketTrades, getAccountPositions, getCandles],
+  triggers: [],
+});

--- a/packages/pieces/community/dydx/src/lib/dydx-api.ts
+++ b/packages/pieces/community/dydx/src/lib/dydx-api.ts
@@ -1,0 +1,15 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const DYDX_BASE_URL = 'https://indexer.dydx.trade';
+
+export async function dydxRequest(path: string, params?: Record<string, string>) {
+  const url = new URL(DYDX_BASE_URL + path);
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  }
+  const response = await httpClient.sendRequest({
+    method: HttpMethod.GET,
+    url: url.toString(),
+  });
+  return response.body;
+}

--- a/packages/pieces/community/glassnode/.eslintrc.json
+++ b/packages/pieces/community/glassnode/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*", "dist/**"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "parserOptions": {
+        "project": ["packages/pieces/community/glassnode/tsconfig.json"],
+        "createDefaultProgram": true
+      }
+    }
+  ]
+}

--- a/packages/pieces/community/glassnode/README.md
+++ b/packages/pieces/community/glassnode/README.md
@@ -1,0 +1,11 @@
+# Glassnode
+
+[Glassnode](https://glassnode.com) is the leading on-chain market intelligence platform, providing institutional-grade blockchain data and analytics for Bitcoin, Ethereum, and other crypto assets.
+
+## Actions
+
+- **Get Active Addresses** - Retrieve the number of unique addresses active on-chain
+- **Get Transactions Count** - Get the total number of on-chain transactions
+- **Get Mean Transaction Fees** - Retrieve average transaction fee data
+- **Get Exchange Net Position Change** - Track BTC supply flowing in/out of exchanges
+- **Get SOPR** - Spent Output Profit Ratio (profit/loss market indicator)

--- a/packages/pieces/community/glassnode/package.json
+++ b/packages/pieces/community/glassnode/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-glassnode",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/glassnode/src/index.ts
+++ b/packages/pieces/community/glassnode/src/index.ts
@@ -1,0 +1,35 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getActiveAddressesAction } from './lib/actions/get-active-addresses';
+import { getTransactionsCountAction } from './lib/actions/get-transactions-count';
+import { getFeesMeanAction } from './lib/actions/get-fees-mean';
+import { getExchangeSupplyAction } from './lib/actions/get-exchange-supply';
+import { getSoprAction } from './lib/actions/get-sopr';
+
+export const glassnodeAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: `To get your Glassnode API key:
+1. Sign up at https://glassnode.com
+2. Go to your account settings
+3. Navigate to the API section
+4. Copy your API key`,
+  required: true,
+});
+
+export const glassnode = createPiece({
+  displayName: 'Glassnode',
+  description: 'On-chain metrics and blockchain analytics for Bitcoin and Ethereum',
+  auth: glassnodeAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/glassnode.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  authors: ['bossco7598'],
+  actions: [
+    getActiveAddressesAction,
+    getTransactionsCountAction,
+    getFeesMeanAction,
+    getExchangeSupplyAction,
+    getSoprAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-active-addresses.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-active-addresses.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getActiveAddressesAction = createAction({
+  name: 'get_active_addresses',
+  displayName: 'Get Active Addresses',
+  description: 'Retrieve the number of unique addresses that were active on-chain for a given asset.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'addresses/active_count', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-exchange-supply.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-exchange-supply.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getExchangeSupplyAction = createAction({
+  name: 'get_exchange_supply',
+  displayName: 'Get Exchange Net Position Change',
+  description: 'Retrieve the net change of Bitcoin supply held on exchanges, indicating buying or selling pressure.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'distribution/exchange_net_position_change', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-fees-mean.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-fees-mean.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getFeesMeanAction = createAction({
+  name: 'get_fees_mean',
+  displayName: 'Get Mean Transaction Fees',
+  description: 'Retrieve the mean transaction fee for a given asset over time.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'fees/mean', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-sopr.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-sopr.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getSoprAction = createAction({
+  name: 'get_sopr',
+  displayName: 'Get SOPR (Spent Output Profit Ratio)',
+  description: 'Retrieve the Spent Output Profit Ratio (SOPR) which indicates whether holders are selling at profit (>1) or loss (<1).',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'indicators/sopr', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-transactions-count.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-transactions-count.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getTransactionsCountAction = createAction({
+  name: 'get_transactions_count',
+  displayName: 'Get Transactions Count',
+  description: 'Retrieve the total number of transactions on-chain for a given asset.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'transactions/count', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/common/glassnode-api.ts
+++ b/packages/pieces/community/glassnode/src/lib/common/glassnode-api.ts
@@ -1,0 +1,35 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const GLASSNODE_BASE_URL = 'https://api.glassnode.com/v1/metrics';
+
+export interface GlassnodeMetricParams {
+  asset: string;
+  interval: string;
+  since?: number;
+  until?: number;
+}
+
+export interface GlassnodeDataPoint {
+  t: number;
+  v: number | null;
+}
+
+export async function fetchGlassnodeMetric(
+  apiKey: string,
+  endpoint: string,
+  params: GlassnodeMetricParams
+): Promise<GlassnodeDataPoint[]> {
+  const url = new URL(`${GLASSNODE_BASE_URL}/${endpoint}`);
+  url.searchParams.set('a', params.asset);
+  url.searchParams.set('i', params.interval);
+  url.searchParams.set('api_key', apiKey);
+  if (params.since) url.searchParams.set('s', String(params.since));
+  if (params.until) url.searchParams.set('u', String(params.until));
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Glassnode API error (${response.status}): ${error}`);
+  }
+  return response.json();
+}

--- a/packages/pieces/community/glassnode/src/lib/common/params.ts
+++ b/packages/pieces/community/glassnode/src/lib/common/params.ts
@@ -1,0 +1,35 @@
+import { Property } from '@activepieces/pieces-framework';
+
+export const assetProperty = Property.ShortText({
+  displayName: 'Asset',
+  description: 'The blockchain asset symbol (e.g., BTC, ETH)',
+  required: true,
+  defaultValue: 'BTC',
+});
+
+export const intervalProperty = Property.StaticDropdown({
+  displayName: 'Interval',
+  description: 'The time interval for the metric data',
+  required: true,
+  defaultValue: '24h',
+  options: {
+    options: [
+      { label: '1 Hour', value: '1h' },
+      { label: '24 Hours', value: '24h' },
+      { label: '1 Week', value: '1w' },
+      { label: '1 Month', value: '1month' },
+    ],
+  },
+});
+
+export const sinceProperty = Property.Number({
+  displayName: 'Since (Unix Timestamp)',
+  description: 'Start time as a Unix timestamp (optional)',
+  required: false,
+});
+
+export const untilProperty = Property.Number({
+  displayName: 'Until (Unix Timestamp)',
+  description: 'End time as a Unix timestamp (optional)',
+  required: false,
+});

--- a/packages/pieces/community/glassnode/tsconfig.json
+++ b/packages/pieces/community/glassnode/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/glassnode/tsconfig.lib.json
+++ b/packages/pieces/community/glassnode/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/santiment/package.json
+++ b/packages/pieces/community/santiment/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-santiment",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/santiment/src/index.ts
+++ b/packages/pieces/community/santiment/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getSocialVolume } from './lib/actions/get-social-volume';
+import { getPriceVolume } from './lib/actions/get-price-volume';
+import { getDevActivity } from './lib/actions/get-dev-activity';
+import { getExchangeFlows } from './lib/actions/get-exchange-flows';
+import { getTrendingWords } from './lib/actions/get-trending-words';
+import { santimentAuth } from './lib/common/santiment-auth';
+
+export const santiment = createPiece({
+  displayName: 'Santiment',
+  auth: santimentAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/santiment.png',
+  authors: ['bossco7598'],
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  description: 'On-chain and social analytics for crypto assets via Santiment SanAPI.',
+  actions: [
+    getSocialVolume,
+    getPriceVolume,
+    getDevActivity,
+    getExchangeFlows,
+    getTrendingWords,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-dev-activity.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-dev-activity.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getDevActivity = createAction({
+  auth: santimentAuth,
+  name: 'get_dev_activity',
+  displayName: 'Get Developer Activity',
+  description: 'Get GitHub developer activity metric for a crypto project over time.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. ethereum, bitcoin)',
+      required: true,
+      defaultValue: 'ethereum',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval } = context.propsValue;
+    const query = `{
+      getMetric(metric: "dev_activity") {
+        timeseriesData(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+          datetime
+          value
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-exchange-flows.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-exchange-flows.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getExchangeFlows = createAction({
+  auth: santimentAuth,
+  name: 'get_exchange_flows',
+  displayName: 'Get Exchange Flows',
+  description: 'Get exchange inflow/outflow data for whale tracking.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. bitcoin, ethereum)',
+      required: true,
+      defaultValue: 'bitcoin',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+    flowType: Property.StaticDropdown({
+      displayName: 'Flow Type',
+      description: 'Select inflow or outflow metric',
+      required: true,
+      defaultValue: 'exchange_inflow',
+      options: {
+        options: [
+          { label: 'Exchange Inflow', value: 'exchange_inflow' },
+          { label: 'Exchange Outflow', value: 'exchange_outflow' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval, flowType } = context.propsValue;
+    const query = `{
+      getMetric(metric: "${flowType}") {
+        timeseriesData(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+          datetime
+          value
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-price-volume.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-price-volume.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getPriceVolume = createAction({
+  auth: santimentAuth,
+  name: 'get_price_volume',
+  displayName: 'Get Price & Volume (OHLCV)',
+  description: 'Get OHLCV price and volume data for a crypto asset.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. bitcoin, ethereum)',
+      required: true,
+      defaultValue: 'bitcoin',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval } = context.propsValue;
+    const query = `{
+      ohlcv(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+        datetime
+        openPriceUsd
+        closePriceUsd
+        highPriceUsd
+        lowPriceUsd
+        volumeUsd
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-social-volume.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-social-volume.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getSocialVolume = createAction({
+  auth: santimentAuth,
+  name: 'get_social_volume',
+  displayName: 'Get Social Volume',
+  description: 'Get social mentions and volume for a crypto asset over time.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. bitcoin, ethereum)',
+      required: true,
+      defaultValue: 'bitcoin',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval } = context.propsValue;
+    const query = `{
+      getMetric(metric: "social_volume_total") {
+        timeseriesData(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+          datetime
+          value
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-trending-words.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-trending-words.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getTrendingWords = createAction({
+  auth: santimentAuth,
+  name: 'get_trending_words',
+  displayName: 'Get Trending Words',
+  description: 'Get trending words in crypto social media.',
+  props: {
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    size: Property.Number({
+      displayName: 'Size',
+      description: 'Number of top trending words to return',
+      required: false,
+      defaultValue: 10,
+    }),
+  },
+  async run(context) {
+    const { from, to, size } = context.propsValue;
+    const query = `{
+      getTrendingWords(from: "${from}", to: "${to}", size: ${size ?? 10}, interval: "1d") {
+        topWords {
+          datetime
+          topWords {
+            word
+            score
+          }
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/common/santiment-api.ts
+++ b/packages/pieces/community/santiment/src/lib/common/santiment-api.ts
@@ -1,0 +1,23 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const SANTIMENT_API_URL = 'https://api.santiment.net/graphql';
+
+export async function santimentRequest(
+  apiKey: string,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<unknown> {
+  const response = await httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: SANTIMENT_API_URL,
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Apikey ${apiKey}`,
+    },
+    body: {
+      query,
+      variables: variables ?? {},
+    },
+  });
+  return response.body;
+}

--- a/packages/pieces/community/santiment/src/lib/common/santiment-auth.ts
+++ b/packages/pieces/community/santiment/src/lib/common/santiment-auth.ts
@@ -1,0 +1,7 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const santimentAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Santiment API key. Get it from https://app.santiment.net/account#api-keys',
+  required: true,
+});

--- a/packages/pieces/community/santiment/tsconfig.json
+++ b/packages/pieces/community/santiment/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/santiment/tsconfig.lib.json
+++ b/packages/pieces/community/santiment/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/token-terminal/package.json
+++ b/packages/pieces/community/token-terminal/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-token-terminal",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/token-terminal/src/index.ts
+++ b/packages/pieces/community/token-terminal/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { tokenTerminalAuth } from './lib/common/token-terminal-api';
+import { getAllProjects } from './lib/actions/get-all-projects';
+import { getProjectInfo } from './lib/actions/get-project-info';
+import { getProjectMetrics } from './lib/actions/get-project-metrics';
+import { getMarketData } from './lib/actions/get-market-data';
+import { getHistoricalData } from './lib/actions/get-historical-data';
+
+export const tokenTerminal = createPiece({
+  displayName: 'Token Terminal',
+  description: 'Protocol revenue and financial analytics for DeFi projects',
+  auth: tokenTerminalAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/token-terminal.png',
+  authors: ['bossco7598'],
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  actions: [
+    getAllProjects,
+    getProjectInfo,
+    getProjectMetrics,
+    getMarketData,
+    getHistoricalData,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-all-projects.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-all-projects.ts
@@ -1,0 +1,14 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getAllProjects = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getAllProjects',
+  displayName: 'Get All Projects',
+  description: 'Retrieve a list of all protocols and projects tracked by Token Terminal.',
+  props: {},
+  async run(context) {
+    return makeRequest(context.auth as string, HttpMethod.GET, '/projects');
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-historical-data.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-historical-data.ts
@@ -1,0 +1,55 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getHistoricalData = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getHistoricalData',
+  displayName: 'Get Historical Data',
+  description: 'Retrieve time-series historical metrics data for a specific protocol.',
+  props: {
+    project_id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'The unique identifier for the project (e.g. uniswap, aave, ethereum)',
+      required: true,
+    }),
+    granularity: Property.StaticDropdown({
+      displayName: 'Granularity',
+      description: 'Time granularity for the historical data',
+      required: false,
+      defaultValue: 'daily',
+      options: {
+        options: [
+          { label: 'Daily', value: 'daily' },
+          { label: 'Weekly', value: 'weekly' },
+          { label: 'Monthly', value: 'monthly' },
+        ],
+      },
+    }),
+    start_date: Property.ShortText({
+      displayName: 'Start Date',
+      description: 'Start date for historical data in YYYY-MM-DD format (optional)',
+      required: false,
+    }),
+    end_date: Property.ShortText({
+      displayName: 'End Date',
+      description: 'End date for historical data in YYYY-MM-DD format (optional)',
+      required: false,
+    }),
+    metric: Property.ShortText({
+      displayName: 'Metric',
+      description: 'Specific metric to retrieve (e.g. revenue, fees, tvl). Leave empty for all.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { project_id, granularity, start_date, end_date, metric } = context.propsValue;
+    const queryParams: Record<string, string> = {
+      granularity: (granularity as string) || 'daily',
+    };
+    if (start_date) queryParams['start_date'] = start_date as string;
+    if (end_date) queryParams['end_date'] = end_date as string;
+    if (metric) queryParams['metric'] = metric as string;
+    return makeRequest(context.auth as string, HttpMethod.GET, `/projects/${project_id}/metrics`, queryParams);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-market-data.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-market-data.ts
@@ -1,0 +1,23 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getMarketData = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getMarketData',
+  displayName: 'Get Market Data',
+  description: 'Get aggregated DeFi market metrics and data across all tracked protocols.',
+  props: {
+    metric: Property.ShortText({
+      displayName: 'Metric',
+      description: 'Specific metric to retrieve (e.g. revenue, fees, tvl). Leave empty for all.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { metric } = context.propsValue;
+    const queryParams: Record<string, string> = {};
+    if (metric) queryParams['metric'] = metric;
+    return makeRequest(context.auth as string, HttpMethod.GET, '/metrics', queryParams);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-project-info.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-project-info.ts
@@ -1,0 +1,21 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getProjectInfo = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getProjectInfo',
+  displayName: 'Get Project Info',
+  description: 'Get detailed information about a specific protocol or project by its ID.',
+  props: {
+    project_id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'The unique identifier for the project (e.g. uniswap, aave, ethereum)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { project_id } = context.propsValue;
+    return makeRequest(context.auth as string, HttpMethod.GET, `/projects/${project_id}`);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-project-metrics.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-project-metrics.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getProjectMetrics = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getProjectMetrics',
+  displayName: 'Get Project Metrics',
+  description: 'Retrieve revenue, fees, TVL and other financial metrics for a specific protocol.',
+  props: {
+    project_id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'The unique identifier for the project (e.g. uniswap, aave, ethereum)',
+      required: true,
+    }),
+    metric: Property.ShortText({
+      displayName: 'Metric',
+      description: 'Specific metric to retrieve (e.g. revenue, fees, tvl). Leave empty for all metrics.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { project_id, metric } = context.propsValue;
+    const queryParams: Record<string, string> = {};
+    if (metric) queryParams['metric'] = metric;
+    return makeRequest(context.auth as string, HttpMethod.GET, `/projects/${project_id}/metrics`, queryParams);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/common/token-terminal-api.ts
+++ b/packages/pieces/community/token-terminal/src/lib/common/token-terminal-api.ts
@@ -1,0 +1,37 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const BASE_URL = 'https://api.tokenterminal.com/v2';
+
+export const tokenTerminalAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Token Terminal API key. Get one at https://tokenterminal.com/terminal/profile/api',
+  required: true,
+});
+
+export async function makeRequest(
+  apiKey: string,
+  method: HttpMethod,
+  endpoint: string,
+  queryParams?: Record<string, string>
+) {
+  const url = new URL(`${BASE_URL}${endpoint}`);
+  if (queryParams) {
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (value !== undefined && value !== '') {
+        url.searchParams.append(key, value);
+      }
+    });
+  }
+
+  const response = await httpClient.sendRequest({
+    method,
+    url: url.toString(),
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return response.body;
+}

--- a/packages/pieces/community/token-terminal/tsconfig.json
+++ b/packages/pieces/community/token-terminal/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/token-terminal/tsconfig.lib.json
+++ b/packages/pieces/community/token-terminal/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/yearn-finance/package.json
+++ b/packages/pieces/community/yearn-finance/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@activepieces/piece-yearn-finance",
+  "version": "0.0.1",
+  "description": "Yearn Finance yield aggregator: vaults, APY, TVL, strategies across 5 chains",
+  "keywords": [
+    "activepieces",
+    "yearn",
+    "defi",
+    "yield",
+    "vault",
+    "apy"
+  ],
+  "homepage": "",
+  "bugs": {
+    "url": "https://github.com/activepieces/activepieces/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/activepieces/activepieces.git"
+  },
+  "license": "MIT",
+  "author": "",
+  "main": "./src/index.ts",
+  "scripts": {
+    "publish-piece": "node ../../../../.scripts/publish-piece.mjs"
+  },
+  "peerDependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*"
+  }
+}

--- a/packages/pieces/community/zerion/.eslintrc.json
+++ b/packages/pieces/community/zerion/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/zerion/README.md
+++ b/packages/pieces/community/zerion/README.md
@@ -1,0 +1,15 @@
+# Zerion
+
+Zerion is the best way to manage your DeFi portfolio. This piece integrates with the Zerion API to provide DeFi portfolio tracking, wallet analytics, and token intelligence.
+
+## Authentication
+
+You need a Zerion API key. Sign up at [developers.zerion.io](https://developers.zerion.io) to get one.
+
+## Actions
+
+- **Get Wallet Portfolio** - Get total portfolio value, PnL, and chain breakdown for a wallet address
+- **Get Wallet Positions** - Get all token positions with prices for a wallet address
+- **Get Wallet Transactions** - Get transaction history for a wallet address
+- **Get Wallet NFTs** - Get NFT holdings for a wallet address
+- **Get Fungible Info** - Get fungible token info (price, market cap, 24h change) by token ID

--- a/packages/pieces/community/zerion/package.json
+++ b/packages/pieces/community/zerion/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-zerion",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/zerion/src/index.ts
+++ b/packages/pieces/community/zerion/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { zerionAuth } from './lib/auth';
+import { getWalletPortfolioAction } from './lib/actions/get-wallet-portfolio';
+import { getWalletPositionsAction } from './lib/actions/get-wallet-positions';
+import { getWalletTransactionsAction } from './lib/actions/get-wallet-transactions';
+import { getWalletNftsAction } from './lib/actions/get-wallet-nfts';
+import { getFungibleInfoAction } from './lib/actions/get-fungible-info';
+
+export const zerion = createPiece({
+  displayName: 'Zerion',
+  description: 'DeFi portfolio tracking and wallet intelligence. Get portfolio values, token positions, NFTs, transactions, and token market data via the Zerion API.',
+  auth: zerionAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/zerion.png',
+  categories: [PieceCategory.FINANCE, PieceCategory.BUSINESS_INTELLIGENCE],
+  authors: ['bossco7598'],
+  actions: [
+    getWalletPortfolioAction,
+    getWalletPositionsAction,
+    getWalletTransactionsAction,
+    getWalletNftsAction,
+    getFungibleInfoAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-fungible-info.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-fungible-info.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getFungibleInfo } from '../zerion-api';
+
+export const getFungibleInfoAction = createAction({
+  auth: zerionAuth,
+  name: 'get_fungible_info',
+  displayName: 'Get Fungible Token Info',
+  description: 'Get fungible token information including price, market cap, and 24h change by token ID.',
+  props: {
+    fungibleId: Property.ShortText({
+      displayName: 'Token ID',
+      description: 'The Zerion fungible token ID (e.g., "eth" for Ethereum, "0d8d12a7-21b9-4571-a3a7-b6c4a18e3a2d" for ERC-20 tokens).',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { fungibleId, currency } = context.propsValue;
+    return await getFungibleInfo(context.auth, fungibleId, currency ?? 'usd');
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-nfts.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-nfts.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletNfts } from '../zerion-api';
+
+export const getWalletNftsAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_nfts',
+  displayName: 'Get Wallet NFTs',
+  description: 'Get NFT holdings for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display NFT values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency } = context.propsValue;
+    return await getWalletNfts(context.auth, walletAddress, currency ?? 'usd');
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-portfolio.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-portfolio.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletPortfolio } from '../zerion-api';
+
+export const getWalletPortfolioAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_portfolio',
+  displayName: 'Get Wallet Portfolio',
+  description: 'Get total portfolio value, PnL, and chain breakdown for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency } = context.propsValue;
+    return await getWalletPortfolio(context.auth, walletAddress, currency ?? 'usd');
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-positions.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-positions.ts
@@ -1,0 +1,56 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletPositions } from '../zerion-api';
+
+export const getWalletPositionsAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_positions',
+  displayName: 'Get Wallet Positions',
+  description: 'Get all token positions with current prices for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+    filterPositionTypes: Property.StaticDropdown({
+      displayName: 'Position Type Filter',
+      description: 'Filter positions by type.',
+      required: false,
+      defaultValue: 'wallet',
+      options: {
+        options: [
+          { label: 'Wallet (token balances)', value: 'wallet' },
+          { label: 'Deposited (DeFi deposits)', value: 'deposited' },
+          { label: 'Borrowed (DeFi loans)', value: 'borrowed' },
+          { label: 'Locked (staked/locked)', value: 'locked' },
+          { label: 'Staked', value: 'staked' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency, filterPositionTypes } = context.propsValue;
+    return await getWalletPositions(
+      context.auth,
+      walletAddress,
+      currency ?? 'usd',
+      filterPositionTypes ?? 'wallet'
+    );
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-transactions.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-transactions.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletTransactions } from '../zerion-api';
+
+export const getWalletTransactionsAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_transactions',
+  displayName: 'Get Wallet Transactions',
+  description: 'Get transaction history for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+    pageSize: Property.Number({
+      displayName: 'Page Size',
+      description: 'Number of transactions to return (max 100).',
+      required: false,
+      defaultValue: 25,
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency, pageSize } = context.propsValue;
+    return await getWalletTransactions(
+      context.auth,
+      walletAddress,
+      currency ?? 'usd',
+      String(pageSize ?? 25)
+    );
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/auth.ts
+++ b/packages/pieces/community/zerion/src/lib/auth.ts
@@ -1,0 +1,7 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const zerionAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Zerion API key. Get one at https://developers.zerion.io',
+  required: true,
+});

--- a/packages/pieces/community/zerion/src/lib/zerion-api.ts
+++ b/packages/pieces/community/zerion/src/lib/zerion-api.ts
@@ -1,0 +1,98 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.zerion.io/v1';
+
+function getAuthHeader(apiKey: string): string {
+  return 'Basic ' + Buffer.from(apiKey + ':').toString('base64');
+}
+
+export async function zerionApiCall<T>(
+  apiKey: string,
+  method: HttpMethod,
+  endpoint: string,
+  params?: Record<string, string>
+): Promise<T> {
+  let url = BASE_URL + endpoint;
+  if (params && Object.keys(params).length > 0) {
+    const query = new URLSearchParams(params).toString();
+    url = url + '?' + query;
+  }
+
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url,
+    headers: {
+      Authorization: getAuthHeader(apiKey),
+      Accept: 'application/json',
+    },
+  });
+
+  return response.body;
+}
+
+export async function getWalletPortfolio(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/portfolio',
+    { currency }
+  );
+}
+
+export async function getWalletPositions(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd',
+  filterPositionTypes = 'wallet'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/positions',
+    { currency, 'filter[position_types]': filterPositionTypes }
+  );
+}
+
+export async function getWalletTransactions(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd',
+  pageSize = '25'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/transactions',
+    { currency, 'page[size]': pageSize }
+  );
+}
+
+export async function getWalletNfts(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/nft-positions',
+    { currency }
+  );
+}
+
+export async function getFungibleInfo(
+  apiKey: string,
+  fungibleId: string,
+  currency = 'usd'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/fungibles/' + fungibleId,
+    { currency }
+  );
+}

--- a/packages/pieces/community/zerion/tsconfig.json
+++ b/packages/pieces/community/zerion/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/zerion/tsconfig.lib.json
+++ b/packages/pieces/community/zerion/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## dYdX

Adds the dYdX piece for Activepieces.

dYdX is the leading decentralized perpetuals exchange, operating on its own Cosmos-based blockchain.

### Actions
- **Get Perpetual Markets** - List all available perpetual trading pairs
- **Get Market Orderbook** - Get real-time orderbook for any market
- **Get Market Trades** - Get recent trades for a market
- **Get Account Positions** - Get open positions for a dYdX address
- **Get Candles** - Get OHLCV candlestick data

### API
- Free public indexer API (no authentication required)
- Base URL: https://indexer.dydx.trade/v4

Part of the [Algora MCP Challenge](https://algora.io/challenges/activepieces)