### PR TITLE
fix: prevent isolate box-id exceeding 999 on worker reconnect

### DIFF
--- a/packages/server/sandbox/src/lib/sandbox-pool.ts
+++ b/packages/server/sandbox/src/lib/sandbox-pool.ts
@@ -9,6 +9,7 @@ export function createSandboxPool(sandboxFactory: SandboxFactory): SandboxPool {
     let workerConcurrency = 0
     let reusable = false
     let getGeneration: () => number = () => 0
+    let initialized = false
 
     return {
         getTotalSandboxes: () => {
@@ -18,10 +19,13 @@ export function createSandboxPool(sandboxFactory: SandboxFactory): SandboxPool {
             return sandboxQueue.length
         },
         init: (_log: SandboxLogger, options: SandboxPoolInitOptions) => {
-            workerConcurrency = options.concurrency
             reusable = options.reusable
             getGeneration = options.getGeneration
-            sandboxQueue = Array.from({ length: workerConcurrency }, () => nanoid())
+            if (!initialized || workerConcurrency !== options.concurrency) {
+                workerConcurrency = options.concurrency
+                sandboxQueue = Array.from({ length: workerConcurrency }, () => nanoid())
+                initialized = true
+            }
         },
         allocate: async (log: SandboxLogger): Promise<Sandbox> => {
             const sandboxId = sandboxQueue.shift()


### PR DESCRIPTION
## Summary

`sandboxPool.init()` is called on every socket reconnect to the API. Each call generates fresh `nanoid()` IDs via `Array.from({ length: workerConcurrency }, () => nanoid())`. In `isolate-process.ts`, `sandboxIndex` maps each unique sandbox ID string to a sequential integer for the `--box-id` argument — and never cleans up old entries.

After `ceil(1000 / WORKER_CONCURRENCY)` reconnects, the counter exceeds 999 and isolate throws:
```
Sandbox ID out of range (allowed: 0-999)
```

## Fix

Make `sandboxPool.init()` idempotent: skip regenerating IDs if the pool is already initialized with the same concurrency. The same `nanoid` strings are reused across reconnects, so `sandboxIndex` stays permanently bounded at `WORKER_CONCURRENCY` entries.

## Test plan
- [ ] Simulate multiple worker reconnects and verify box-ids stay within 0–999
- [ ] Verify workers continue to function normally after reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)