### PR TITLE
fix(server): prevent waitUntilFinished race condition for user interaction jobs

### DIFF
--- a/packages/server/api/src/app/workers/job-queue/job-queue.ts
+++ b/packages/server/api/src/app/workers/job-queue/job-queue.ts
@@ -86,7 +86,10 @@ export const jobQueue = (log: FastifyBaseLogger) => ({
                     delay: !isNil(dependOnJobId) ? apDayjsDuration(1, 'year').asMilliseconds() : params.delay,
                     jobId: params.id,
                     removeOnFail: data.jobType === WorkerJobType.EVENT_DESTINATION,
-                    ...isUserInteractionJob(data.jobType) ? { attempts: 1 } : {},
+                    ...isUserInteractionJob(data.jobType) ? {
+                        attempts: 1,
+                        removeOnComplete: { age: 300 },
+                    } : {},
                 })
             }
         }


### PR DESCRIPTION
## Summary
- Fixes "Missing key for job ... isFinished" 500 errors on `/v1/pieces/options` and other user interaction endpoints
- Overrides `removeOnComplete` with `{ age: 300 }` (5 min) for user interaction jobs (`EXECUTE_PROPERTY`, `EXECUTE_VALIDATION`, `EXECUTE_TRIGGER_HOOK`, `EXECUTE_EXTRACT_PIECE_INFORMATION`) so BullMQ's `waitUntilFinished` can read the result before the job hash is deleted from Redis
- Non-interaction jobs remain unaffected (still use the queue default `removeOnComplete: true`)

## Test plan
- [ ] Open the flow builder, add a piece action with a dynamic dropdown, and confirm options load without errors
- [ ] Check server logs for absence of "Missing key for job" errors
- [ ] Verify Redis keys are cleaned up after 5 minutes (`redis-cli keys "bull:*"`)