### PR TITLE
feat(piece-acala): add Acala Network Polkadot DeFi hub piece [MCP Challenge]

### DIFF
--- a/packages/pieces/community/acala/.eslintrc.json
+++ b/packages/pieces/community/acala/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/acala/README.md
+++ b/packages/pieces/community/acala/README.md
@@ -1,0 +1,13 @@
+# Acala Network
+
+Acala is a DeFi hub and Layer-1 parachain on Polkadot, offering a stablecoin (aUSD), liquid staking (LDOT), and an AMM DEX. ACA is the governance token.
+
+## Actions
+
+- **Get Protocol TVL** – Fetch current Total Value Locked for Acala via DeFiLlama
+- **Get ACA Price** – Fetch current ACA token price and market data via CoinGecko
+- **Get Chain Breakdown** – Fetch TVL breakdown by chain for Acala via DeFiLlama
+- **Get TVL History** – Fetch last 30 days of historical TVL data for Acala via DeFiLlama
+- **Get Protocol Stats** – Fetch key protocol statistics (TVL, chains, category) for Acala via DeFiLlama
+
+All APIs are free and require no authentication.

--- a/packages/pieces/community/acala/package.json
+++ b/packages/pieces/community/acala/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@activepieces/piece-acala",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/acala/src/index.ts
+++ b/packages/pieces/community/acala/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getProtocolTvl } from './lib/actions/get-protocol-tvl';
+import { getAcaPrice } from './lib/actions/get-aca-price';
+import { getChainBreakdown } from './lib/actions/get-chain-breakdown';
+import { getTvlHistory } from './lib/actions/get-tvl-history';
+import { getProtocolStats } from './lib/actions/get-protocol-stats';
+
+export const acala = createPiece({
+  displayName: 'Acala Network',
+  description:
+    'Acala is a DeFi hub and Layer-1 parachain on Polkadot, offering a stablecoin (aUSD), liquid staking (LDOT), and an AMM DEX. Fetch TVL, price, and protocol statistics using free public APIs.',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/acala.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  authors: ['bossco7598'],
+  actions: [
+    getProtocolTvl,
+    getAcaPrice,
+    getChainBreakdown,
+    getTvlHistory,
+    getProtocolStats,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/acala/src/lib/actions/get-aca-price.ts
+++ b/packages/pieces/community/acala/src/lib/actions/get-aca-price.ts
@@ -1,0 +1,41 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getAcaPrice = createAction({
+  name: 'get-aca-price',
+  displayName: 'Get ACA Price',
+  description:
+    'Fetch the current ACA token price, market cap, and 24h volume from CoinGecko.',
+  auth: undefined,
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.coingecko.com/api/v3/coins/acala',
+      queryParams: {
+        localization: 'false',
+        tickers: 'false',
+        community_data: 'false',
+        developer_data: 'false',
+        sparkline: 'false',
+      },
+    });
+    const data = response.body as Record<string, unknown>;
+    const marketData = data['market_data'] as Record<string, unknown> | undefined;
+    const usd = (obj: Record<string, unknown> | undefined) =>
+      obj ? (obj as Record<string, unknown>)['usd'] : null;
+    return {
+      id: data['id'],
+      symbol: data['symbol'],
+      name: data['name'],
+      current_price_usd: usd(marketData?.['current_price'] as Record<string, unknown> | undefined),
+      market_cap_usd: usd(marketData?.['market_cap'] as Record<string, unknown> | undefined),
+      total_volume_usd: usd(marketData?.['total_volume'] as Record<string, unknown> | undefined),
+      price_change_24h: marketData?.['price_change_24h'],
+      price_change_percentage_24h: marketData?.['price_change_percentage_24h'],
+      circulating_supply: marketData?.['circulating_supply'],
+      total_supply: marketData?.['total_supply'],
+      last_updated: marketData?.['last_updated'],
+    };
+  },
+});

--- a/packages/pieces/community/acala/src/lib/actions/get-chain-breakdown.ts
+++ b/packages/pieces/community/acala/src/lib/actions/get-chain-breakdown.ts
@@ -1,0 +1,24 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getChainBreakdown = createAction({
+  name: 'get-chain-breakdown',
+  displayName: 'Get Chain Breakdown',
+  description:
+    'Fetch the TVL breakdown by chain for Acala Network from DeFiLlama.',
+  auth: undefined,
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/acala',
+    });
+    const data = response.body as Record<string, unknown>;
+    return {
+      name: data['name'],
+      currentChainTvls: data['currentChainTvls'],
+      chainTvls: data['chainTvls'],
+      chains: data['chains'],
+    };
+  },
+});

--- a/packages/pieces/community/acala/src/lib/actions/get-protocol-stats.ts
+++ b/packages/pieces/community/acala/src/lib/actions/get-protocol-stats.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getProtocolStats = createAction({
+  name: 'get-protocol-stats',
+  displayName: 'Get Protocol Stats',
+  description:
+    'Fetch key protocol statistics for Acala Network including TVL, chains, and category from DeFiLlama.',
+  auth: undefined,
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/acala',
+    });
+    const data = response.body as Record<string, unknown>;
+
+    const tvlHistory = data['tvl'] as Array<{ date: number; totalLiquidityUSD: number }> | undefined;
+    const latestTvl =
+      tvlHistory && Array.isArray(tvlHistory) && tvlHistory.length > 0
+        ? tvlHistory[tvlHistory.length - 1]?.totalLiquidityUSD
+        : null;
+
+    return {
+      name: data['name'],
+      symbol: data['symbol'],
+      category: data['category'],
+      chains: data['chains'],
+      chain_count: Array.isArray(data['chains']) ? (data['chains'] as unknown[]).length : 0,
+      current_tvl_usd: latestTvl,
+      current_chain_tvls: data['currentChainTvls'],
+      mcap: data['mcap'],
+      slug: data['slug'],
+      url: data['url'],
+      twitter: data['twitter'],
+      description: data['description'],
+    };
+  },
+});

--- a/packages/pieces/community/acala/src/lib/actions/get-protocol-tvl.ts
+++ b/packages/pieces/community/acala/src/lib/actions/get-protocol-tvl.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getProtocolTvl = createAction({
+  name: 'get-protocol-tvl',
+  displayName: 'Get Protocol TVL',
+  description:
+    'Fetch the current Total Value Locked (TVL) for Acala Network from DeFiLlama.',
+  auth: undefined,
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/acala',
+    });
+    const data = response.body as Record<string, unknown>;
+    return {
+      name: data['name'],
+      symbol: data['symbol'],
+      tvl: data['tvl'],
+      currentChainTvls: data['currentChainTvls'],
+      category: data['category'],
+      chains: data['chains'],
+      mcap: data['mcap'],
+      description: data['description'],
+    };
+  },
+});

--- a/packages/pieces/community/acala/src/lib/actions/get-tvl-history.ts
+++ b/packages/pieces/community/acala/src/lib/actions/get-tvl-history.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getTvlHistory = createAction({
+  name: 'get-tvl-history',
+  displayName: 'Get TVL History',
+  description:
+    'Fetch the last 30 days of historical TVL data for Acala Network from DeFiLlama.',
+  auth: undefined,
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/acala',
+    });
+    const data = response.body as Record<string, unknown>;
+    const tvlHistory = data['tvl'] as Array<{ date: number; totalLiquidityUSD: number }> | undefined;
+
+    if (!tvlHistory || !Array.isArray(tvlHistory)) {
+      return { history: [] };
+    }
+
+    // Return the last 30 data points
+    const last30 = tvlHistory.slice(-30);
+    const history = last30.map((entry) => ({
+      date: new Date(entry.date * 1000).toISOString().split('T')[0],
+      timestamp: entry.date,
+      tvl_usd: entry.totalLiquidityUSD,
+    }));
+
+    return {
+      protocol: data['name'],
+      history,
+      oldest_date: history[0]?.date,
+      latest_date: history[history.length - 1]?.date,
+      latest_tvl_usd: history[history.length - 1]?.tvl_usd,
+    };
+  },
+});

--- a/packages/pieces/community/acala/tsconfig.json
+++ b/packages/pieces/community/acala/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/acala/tsconfig.lib.json
+++ b/packages/pieces/community/acala/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/curve-finance/package.json
+++ b/packages/pieces/community/curve-finance/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@activepieces/piece-curve-finance",
+  "version": "0.0.1",
+  "description": "Curve Finance stablecoin DEX: pools, TVL, APY, gauge data, token prices",
+  "keywords": [
+    "activepieces",
+    "curve",
+    "defi",
+    "stablecoin",
+    "dex",
+    "liquidity"
+  ],
+  "homepage": "",
+  "bugs": {
+    "url": "https://github.com/activepieces/activepieces/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/activepieces/activepieces.git"
+  },
+  "license": "MIT",
+  "author": "",
+  "main": "./src/index.ts",
+  "scripts": {
+    "publish-piece": "node ../../../../.scripts/publish-piece.mjs"
+  },
+  "peerDependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*"
+  }
+}

--- a/packages/pieces/community/curve-finance/src/index.ts
+++ b/packages/pieces/community/curve-finance/src/index.ts
@@ -1,0 +1,16 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { getPools } from './lib/actions/get-pools';
+import { getPoolStats } from './lib/actions/get-pool-stats';
+import { getProtocolStats } from './lib/actions/get-protocol-stats';
+import { getTokenPrice } from './lib/actions/get-token-price';
+import { getGaugeData } from './lib/actions/get-gauge-data';
+
+export const curveFinance = createPiece({
+  displayName: 'Curve Finance',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/curve-finance.png',
+  authors: ['bossco7598'],
+  actions: [getPools, getPoolStats, getProtocolStats, getTokenPrice, getGaugeData],
+  triggers: [],
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-gauge-data.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-gauge-data.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { curveRequest, CHAIN_OPTIONS } from '../curve-api';
+
+export const getGaugeData = createAction({
+  name: 'get_gauge_data',
+  displayName: 'Get Gauge Data',
+  description: 'Get CRV liquidity mining gauge data for a Curve pool including APR and gauge weight',
+  props: {
+    chain: Property.StaticDropdown({
+      displayName: 'Chain',
+      required: true,
+      options: { options: CHAIN_OPTIONS },
+    }),
+    poolAddress: Property.ShortText({
+      displayName: 'Pool Address',
+      description: 'Contract address of the Curve pool',
+      required: true,
+    }),
+  },
+  async run(ctx) {
+    const { chain, poolAddress } = ctx.propsValue;
+    const data = await curveRequest<any>(`/getGaugeRewards/${chain}/${poolAddress}`);
+    return data;
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-pool-stats.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-pool-stats.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { curveRequest, CHAIN_OPTIONS } from '../curve-api';
+
+export const getPoolStats = createAction({
+  name: 'get_pool_stats',
+  displayName: 'Get Pool Stats',
+  description: 'Get detailed statistics for a specific Curve Finance pool',
+  props: {
+    chain: Property.StaticDropdown({
+      displayName: 'Chain',
+      required: true,
+      options: { options: CHAIN_OPTIONS },
+    }),
+    poolAddress: Property.ShortText({
+      displayName: 'Pool Address',
+      description: 'Contract address of the Curve pool',
+      required: true,
+    }),
+  },
+  async run(ctx) {
+    const { chain, poolAddress } = ctx.propsValue;
+    const data = await curveRequest<any>(`/getPool/${chain}/${poolAddress}`);
+    return data;
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-pools.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-pools.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { curveRequest, CHAIN_OPTIONS } from '../curve-api';
+
+export const getPools = createAction({
+  name: 'get_pools',
+  displayName: 'Get Pools',
+  description: 'List all Curve Finance pools on a given chain with TVL, volume, and APY data',
+  props: {
+    chain: Property.StaticDropdown({
+      displayName: 'Chain',
+      description: 'Blockchain network to query',
+      required: true,
+      options: { options: CHAIN_OPTIONS },
+    }),
+    poolType: Property.StaticDropdown({
+      displayName: 'Pool Type',
+      description: 'Filter by pool type',
+      required: false,
+      options: {
+        options: [
+          { label: 'All Pools', value: 'all' },
+          { label: 'Main Pools', value: 'main' },
+          { label: 'Crypto Pools', value: 'crypto' },
+          { label: 'Factory Pools', value: 'factory' },
+        ],
+      },
+    }),
+  },
+  async run(ctx) {
+    const { chain, poolType } = ctx.propsValue;
+    const type = poolType || 'all';
+    const data = await curveRequest<any>(`/getPools/${chain}/${type}`);
+    return data;
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-protocol-stats.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-protocol-stats.ts
@@ -1,0 +1,14 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { curveRequest } from '../curve-api';
+
+export const getProtocolStats = createAction({
+  name: 'get_protocol_stats',
+  displayName: 'Get Protocol Stats',
+  description: 'Get global Curve Finance protocol statistics including total TVL and volume',
+  props: {},
+  async run() {
+    const tvlData = await curveRequest<any>('/getTVL');
+    const volumeData = await curveRequest<any>('/getTotalVolume');
+    return { tvl: tvlData, volume: volumeData };
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/actions/get-token-price.ts
+++ b/packages/pieces/community/curve-finance/src/lib/actions/get-token-price.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { curveRequest, CHAIN_OPTIONS } from '../curve-api';
+
+export const getTokenPrice = createAction({
+  name: 'get_token_price',
+  displayName: 'Get Token Price',
+  description: 'Get the USD price of a token traded on Curve Finance',
+  props: {
+    chain: Property.StaticDropdown({
+      displayName: 'Chain',
+      required: true,
+      options: { options: CHAIN_OPTIONS },
+    }),
+    tokenAddress: Property.ShortText({
+      displayName: 'Token Address',
+      description: 'Contract address of the token (e.g. CRV: 0xD533a949740bb3306d119CC777fa900bA034cd52)',
+      required: true,
+    }),
+  },
+  async run(ctx) {
+    const { chain, tokenAddress } = ctx.propsValue;
+    const data = await curveRequest<any>(`/getTokenPrice/${chain}/${tokenAddress}`);
+    return data;
+  },
+});

--- a/packages/pieces/community/curve-finance/src/lib/curve-api.ts
+++ b/packages/pieces/community/curve-finance/src/lib/curve-api.ts
@@ -1,0 +1,23 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.curve.fi/v1';
+
+export async function curveRequest<T>(endpoint: string): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method: HttpMethod.GET,
+    url: `${BASE_URL}${endpoint}`,
+    headers: { 'Accept': 'application/json' },
+  });
+  return response.body;
+}
+
+export const CHAIN_OPTIONS = [
+  { label: 'Ethereum', value: 'ethereum' },
+  { label: 'Arbitrum', value: 'arbitrum' },
+  { label: 'Optimism', value: 'optimism' },
+  { label: 'Polygon', value: 'polygon' },
+  { label: 'Base', value: 'base' },
+  { label: 'Avalanche', value: 'avalanche' },
+  { label: 'Fantom', value: 'fantom' },
+  { label: 'xDai/Gnosis', value: 'xdai' },
+];

--- a/packages/pieces/community/curve-finance/tsconfig.json
+++ b/packages/pieces/community/curve-finance/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/pieces/community/glassnode/.eslintrc.json
+++ b/packages/pieces/community/glassnode/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*", "dist/**"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "parserOptions": {
+        "project": ["packages/pieces/community/glassnode/tsconfig.json"],
+        "createDefaultProgram": true
+      }
+    }
+  ]
+}

--- a/packages/pieces/community/glassnode/README.md
+++ b/packages/pieces/community/glassnode/README.md
@@ -1,0 +1,11 @@
+# Glassnode
+
+[Glassnode](https://glassnode.com) is the leading on-chain market intelligence platform, providing institutional-grade blockchain data and analytics for Bitcoin, Ethereum, and other crypto assets.
+
+## Actions
+
+- **Get Active Addresses** - Retrieve the number of unique addresses active on-chain
+- **Get Transactions Count** - Get the total number of on-chain transactions
+- **Get Mean Transaction Fees** - Retrieve average transaction fee data
+- **Get Exchange Net Position Change** - Track BTC supply flowing in/out of exchanges
+- **Get SOPR** - Spent Output Profit Ratio (profit/loss market indicator)

--- a/packages/pieces/community/glassnode/package.json
+++ b/packages/pieces/community/glassnode/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-glassnode",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/glassnode/src/index.ts
+++ b/packages/pieces/community/glassnode/src/index.ts
@@ -1,0 +1,35 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getActiveAddressesAction } from './lib/actions/get-active-addresses';
+import { getTransactionsCountAction } from './lib/actions/get-transactions-count';
+import { getFeesMeanAction } from './lib/actions/get-fees-mean';
+import { getExchangeSupplyAction } from './lib/actions/get-exchange-supply';
+import { getSoprAction } from './lib/actions/get-sopr';
+
+export const glassnodeAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: `To get your Glassnode API key:
+1. Sign up at https://glassnode.com
+2. Go to your account settings
+3. Navigate to the API section
+4. Copy your API key`,
+  required: true,
+});
+
+export const glassnode = createPiece({
+  displayName: 'Glassnode',
+  description: 'On-chain metrics and blockchain analytics for Bitcoin and Ethereum',
+  auth: glassnodeAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/glassnode.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  authors: ['bossco7598'],
+  actions: [
+    getActiveAddressesAction,
+    getTransactionsCountAction,
+    getFeesMeanAction,
+    getExchangeSupplyAction,
+    getSoprAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-active-addresses.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-active-addresses.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getActiveAddressesAction = createAction({
+  name: 'get_active_addresses',
+  displayName: 'Get Active Addresses',
+  description: 'Retrieve the number of unique addresses that were active on-chain for a given asset.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'addresses/active_count', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-exchange-supply.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-exchange-supply.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getExchangeSupplyAction = createAction({
+  name: 'get_exchange_supply',
+  displayName: 'Get Exchange Net Position Change',
+  description: 'Retrieve the net change of Bitcoin supply held on exchanges, indicating buying or selling pressure.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'distribution/exchange_net_position_change', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-fees-mean.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-fees-mean.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getFeesMeanAction = createAction({
+  name: 'get_fees_mean',
+  displayName: 'Get Mean Transaction Fees',
+  description: 'Retrieve the mean transaction fee for a given asset over time.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'fees/mean', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-sopr.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-sopr.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getSoprAction = createAction({
+  name: 'get_sopr',
+  displayName: 'Get SOPR (Spent Output Profit Ratio)',
+  description: 'Retrieve the Spent Output Profit Ratio (SOPR) which indicates whether holders are selling at profit (>1) or loss (<1).',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'indicators/sopr', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/actions/get-transactions-count.ts
+++ b/packages/pieces/community/glassnode/src/lib/actions/get-transactions-count.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { glassnodeAuth } from '../../index';
+import { fetchGlassnodeMetric } from '../common/glassnode-api';
+import {
+  assetProperty,
+  intervalProperty,
+  sinceProperty,
+  untilProperty,
+} from '../common/params';
+
+export const getTransactionsCountAction = createAction({
+  name: 'get_transactions_count',
+  displayName: 'Get Transactions Count',
+  description: 'Retrieve the total number of transactions on-chain for a given asset.',
+  auth: glassnodeAuth,
+  props: {
+    asset: assetProperty,
+    interval: intervalProperty,
+    since: sinceProperty,
+    until: untilProperty,
+  },
+  async run(context) {
+    const { asset, interval, since, until } = context.propsValue;
+    const apiKey = context.auth as string;
+    return fetchGlassnodeMetric(apiKey, 'transactions/count', {
+      asset,
+      interval,
+      since: since ?? undefined,
+      until: until ?? undefined,
+    });
+  },
+});

--- a/packages/pieces/community/glassnode/src/lib/common/glassnode-api.ts
+++ b/packages/pieces/community/glassnode/src/lib/common/glassnode-api.ts
@@ -1,0 +1,35 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+
+export const GLASSNODE_BASE_URL = 'https://api.glassnode.com/v1/metrics';
+
+export interface GlassnodeMetricParams {
+  asset: string;
+  interval: string;
+  since?: number;
+  until?: number;
+}
+
+export interface GlassnodeDataPoint {
+  t: number;
+  v: number | null;
+}
+
+export async function fetchGlassnodeMetric(
+  apiKey: string,
+  endpoint: string,
+  params: GlassnodeMetricParams
+): Promise<GlassnodeDataPoint[]> {
+  const url = new URL(`${GLASSNODE_BASE_URL}/${endpoint}`);
+  url.searchParams.set('a', params.asset);
+  url.searchParams.set('i', params.interval);
+  url.searchParams.set('api_key', apiKey);
+  if (params.since) url.searchParams.set('s', String(params.since));
+  if (params.until) url.searchParams.set('u', String(params.until));
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Glassnode API error (${response.status}): ${error}`);
+  }
+  return response.json();
+}

--- a/packages/pieces/community/glassnode/src/lib/common/params.ts
+++ b/packages/pieces/community/glassnode/src/lib/common/params.ts
@@ -1,0 +1,35 @@
+import { Property } from '@activepieces/pieces-framework';
+
+export const assetProperty = Property.ShortText({
+  displayName: 'Asset',
+  description: 'The blockchain asset symbol (e.g., BTC, ETH)',
+  required: true,
+  defaultValue: 'BTC',
+});
+
+export const intervalProperty = Property.StaticDropdown({
+  displayName: 'Interval',
+  description: 'The time interval for the metric data',
+  required: true,
+  defaultValue: '24h',
+  options: {
+    options: [
+      { label: '1 Hour', value: '1h' },
+      { label: '24 Hours', value: '24h' },
+      { label: '1 Week', value: '1w' },
+      { label: '1 Month', value: '1month' },
+    ],
+  },
+});
+
+export const sinceProperty = Property.Number({
+  displayName: 'Since (Unix Timestamp)',
+  description: 'Start time as a Unix timestamp (optional)',
+  required: false,
+});
+
+export const untilProperty = Property.Number({
+  displayName: 'Until (Unix Timestamp)',
+  description: 'End time as a Unix timestamp (optional)',
+  required: false,
+});

--- a/packages/pieces/community/glassnode/tsconfig.json
+++ b/packages/pieces/community/glassnode/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/glassnode/tsconfig.lib.json
+++ b/packages/pieces/community/glassnode/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/goldfinch/.eslintrc.json
+++ b/packages/pieces/community/goldfinch/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/goldfinch/README.md
+++ b/packages/pieces/community/goldfinch/README.md
@@ -1,0 +1,5 @@
+# Goldfinch
+
+Goldfinch is a decentralized credit protocol that enables crypto loans without crypto collateral, focusing on real-world borrowers in emerging markets. GFI is the governance token.
+
+This piece provides actions to monitor Goldfinch protocol metrics including TVL, GFI token price, chain breakdown, TVL history, and key protocol statistics — all via free public APIs (no API key required).

--- a/packages/pieces/community/goldfinch/package.json
+++ b/packages/pieces/community/goldfinch/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-goldfinch",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/goldfinch/src/index.ts
+++ b/packages/pieces/community/goldfinch/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getProtocolTvl } from './lib/actions/get-protocol-tvl';
+import { getGfiPrice } from './lib/actions/get-gfi-price';
+import { getChainBreakdown } from './lib/actions/get-chain-breakdown';
+import { getTvlHistory } from './lib/actions/get-tvl-history';
+import { getProtocolStats } from './lib/actions/get-protocol-stats';
+
+export const goldfinch = createPiece({
+  displayName: 'Goldfinch',
+  description:
+    'Goldfinch is a decentralized credit protocol that enables crypto loans without crypto collateral, focusing on real-world borrowers in emerging markets. Monitor TVL, GFI price, chain breakdown, historical TVL, and protocol stats — all via free public APIs.',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  auth: undefined,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/goldfinch.png',
+  authors: ['bossco7598'],
+  actions: [
+    getProtocolTvl,
+    getGfiPrice,
+    getChainBreakdown,
+    getTvlHistory,
+    getProtocolStats,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/goldfinch/src/lib/actions/get-chain-breakdown.ts
+++ b/packages/pieces/community/goldfinch/src/lib/actions/get-chain-breakdown.ts
@@ -1,0 +1,34 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getChainBreakdown = createAction({
+  name: 'get_chain_breakdown',
+  displayName: 'Get Chain TVL Breakdown',
+  description: 'Fetches the TVL breakdown by blockchain for the Goldfinch protocol from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest<Record<string, unknown>>({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/goldfinch',
+    });
+
+    const data = response.body;
+    const currentChainTvls = data['currentChainTvls'] as Record<string, number> | undefined;
+    const chains = data['chains'] as string[] | undefined;
+
+    const breakdown = currentChainTvls
+      ? Object.entries(currentChainTvls).map(([chain, tvl]) => ({
+          chain,
+          tvl_usd: tvl,
+        }))
+      : [];
+
+    breakdown.sort((a, b) => b.tvl_usd - a.tvl_usd);
+
+    return {
+      chains: chains ?? [],
+      chain_tvl_breakdown: breakdown,
+      total_chains: breakdown.length,
+    };
+  },
+});

--- a/packages/pieces/community/goldfinch/src/lib/actions/get-gfi-price.ts
+++ b/packages/pieces/community/goldfinch/src/lib/actions/get-gfi-price.ts
@@ -1,0 +1,59 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+interface CoinGeckoResponse {
+  id: string;
+  symbol: string;
+  name: string;
+  market_data: {
+    current_price: Record<string, number>;
+    market_cap: Record<string, number>;
+    total_volume: Record<string, number>;
+    price_change_percentage_24h: number;
+    price_change_percentage_7d: number;
+    price_change_percentage_30d: number;
+    circulating_supply: number;
+    total_supply: number;
+    max_supply: number;
+  };
+  last_updated: string;
+}
+
+export const getGfiPrice = createAction({
+  name: 'get_gfi_price',
+  displayName: 'Get GFI Token Price',
+  description: 'Fetches the current GFI token price and market data from CoinGecko.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest<CoinGeckoResponse>({
+      method: HttpMethod.GET,
+      url: 'https://api.coingecko.com/api/v3/coins/goldfinch',
+      queryParams: {
+        localization: 'false',
+        tickers: 'false',
+        community_data: 'false',
+        developer_data: 'false',
+        sparkline: 'false',
+      },
+    });
+
+    const data = response.body;
+    const marketData = data.market_data;
+
+    return {
+      id: data.id,
+      symbol: data.symbol,
+      name: data.name,
+      price_usd: marketData.current_price['usd'],
+      market_cap_usd: marketData.market_cap['usd'],
+      total_volume_usd: marketData.total_volume['usd'],
+      price_change_24h_percent: marketData.price_change_percentage_24h,
+      price_change_7d_percent: marketData.price_change_percentage_7d,
+      price_change_30d_percent: marketData.price_change_percentage_30d,
+      circulating_supply: marketData.circulating_supply,
+      total_supply: marketData.total_supply,
+      max_supply: marketData.max_supply,
+      last_updated: data.last_updated,
+    };
+  },
+});

--- a/packages/pieces/community/goldfinch/src/lib/actions/get-protocol-stats.ts
+++ b/packages/pieces/community/goldfinch/src/lib/actions/get-protocol-stats.ts
@@ -1,0 +1,47 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getProtocolStats = createAction({
+  name: 'get_protocol_stats',
+  displayName: 'Get Protocol Stats',
+  description: 'Fetches key Goldfinch protocol statistics including TVL, chains, category, and more from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest<Record<string, unknown>>({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/goldfinch',
+    });
+
+    const data = response.body;
+    const currentChainTvls = data['currentChainTvls'] as Record<string, number> | undefined;
+    const chains = data['chains'] as string[] | undefined;
+    const tvlArray = data['tvl'] as Array<{ date: number; totalLiquidityUSD: number }> | undefined;
+
+    const latestTvl = tvlArray && tvlArray.length > 0
+      ? tvlArray[tvlArray.length - 1]?.totalLiquidityUSD
+      : undefined;
+
+    const allTimePeakEntry = tvlArray && tvlArray.length > 0
+      ? tvlArray.reduce((max, point) =>
+          point.totalLiquidityUSD > max.totalLiquidityUSD ? point : max
+        )
+      : undefined;
+
+    return {
+      name: data['name'],
+      symbol: data['symbol'],
+      category: data['category'],
+      description: data['description'],
+      url: data['url'],
+      twitter: data['twitter'],
+      current_tvl_usd: latestTvl,
+      current_chain_tvls: currentChainTvls ?? {},
+      chains: chains ?? [],
+      chain_count: chains?.length ?? 0,
+      all_time_peak_tvl_usd: allTimePeakEntry?.totalLiquidityUSD,
+      all_time_peak_date: allTimePeakEntry
+        ? new Date(allTimePeakEntry.date * 1000).toISOString().split('T')[0]
+        : null,
+    };
+  },
+});

--- a/packages/pieces/community/goldfinch/src/lib/actions/get-protocol-tvl.ts
+++ b/packages/pieces/community/goldfinch/src/lib/actions/get-protocol-tvl.ts
@@ -1,0 +1,29 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getProtocolTvl = createAction({
+  name: 'get_protocol_tvl',
+  displayName: 'Get Protocol TVL',
+  description: 'Fetches the current Total Value Locked (TVL) for the Goldfinch protocol from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest<Record<string, unknown>>({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/goldfinch',
+    });
+
+    const data = response.body;
+
+    return {
+      name: data['name'],
+      symbol: data['symbol'],
+      tvl: data['tvl'],
+      chainTvls: data['chainTvls'],
+      currentChainTvls: data['currentChainTvls'],
+      category: data['category'],
+      chains: data['chains'],
+      url: data['url'],
+      description: data['description'],
+    };
+  },
+});

--- a/packages/pieces/community/goldfinch/src/lib/actions/get-tvl-history.ts
+++ b/packages/pieces/community/goldfinch/src/lib/actions/get-tvl-history.ts
@@ -1,0 +1,48 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+interface TvlDataPoint {
+  date: number;
+  totalLiquidityUSD: number;
+}
+
+export const getTvlHistory = createAction({
+  name: 'get_tvl_history',
+  displayName: 'Get TVL History (Last 30 Days)',
+  description: 'Fetches the historical TVL data for Goldfinch over the last 30 days from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest<Record<string, unknown>>({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/goldfinch',
+    });
+
+    const data = response.body;
+    const tvlArray = data['tvl'] as TvlDataPoint[] | undefined;
+
+    if (!tvlArray || tvlArray.length === 0) {
+      return {
+        history: [],
+        days_returned: 0,
+        start_date: null,
+        end_date: null,
+      };
+    }
+
+    const thirtyDaysAgo = Math.floor(Date.now() / 1000) - 30 * 24 * 60 * 60;
+    const last30Days = tvlArray.filter((point) => point.date >= thirtyDaysAgo);
+
+    const history = last30Days.map((point) => ({
+      date: new Date(point.date * 1000).toISOString().split('T')[0],
+      timestamp: point.date,
+      tvl_usd: point.totalLiquidityUSD,
+    }));
+
+    return {
+      history,
+      days_returned: history.length,
+      start_date: history[0]?.date ?? null,
+      end_date: history[history.length - 1]?.date ?? null,
+    };
+  },
+});

--- a/packages/pieces/community/goldfinch/tsconfig.json
+++ b/packages/pieces/community/goldfinch/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/goldfinch/tsconfig.lib.json
+++ b/packages/pieces/community/goldfinch/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/kyberswap/package.json
+++ b/packages/pieces/community/kyberswap/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-kyberswap",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/kyberswap/src/index.ts
+++ b/packages/pieces/community/kyberswap/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getProtocolTvlAction } from './lib/actions/get-protocol-tvl';
+import { getKncPriceAction } from './lib/actions/get-knc-price';
+import { getChainBreakdownAction } from './lib/actions/get-chain-breakdown';
+import { getTvlHistoryAction } from './lib/actions/get-tvl-history';
+import { getProtocolStatsAction } from './lib/actions/get-protocol-stats';
+
+export const kyberswap = createPiece({
+  displayName: 'KyberSwap',
+  description:
+    'KyberSwap is a multichain DEX aggregator and liquidity protocol that aggregates liquidity from multiple decentralized exchanges to provide the best swap rates. Access KNC token prices, protocol TVL, chain breakdowns, and historical data.',
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/kyberswap.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  auth: undefined,
+  authors: ['bossco7598'],
+  actions: [
+    getProtocolTvlAction,
+    getKncPriceAction,
+    getChainBreakdownAction,
+    getTvlHistoryAction,
+    getProtocolStatsAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/kyberswap/src/lib/actions/get-chain-breakdown.ts
+++ b/packages/pieces/community/kyberswap/src/lib/actions/get-chain-breakdown.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getChainBreakdownAction = createAction({
+  name: 'get_chain_breakdown',
+  displayName: 'Get Chain TVL Breakdown',
+  description: 'Fetch the TVL breakdown by blockchain for KyberSwap from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/kyberswap',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const chainTvls = data['chainTvls'] as Record<string, Record<string, unknown>> | undefined;
+
+    if (!chainTvls) {
+      return { chains: [], total_chains: 0 };
+    }
+
+    const chains = Object.entries(chainTvls)
+      .map(([chain, info]) => {
+        const tvlArr = info['tvl'] as Array<{ date: number; totalLiquidityUSD: number }> | undefined;
+        const latestTvl = tvlArr && tvlArr.length > 0 ? tvlArr[tvlArr.length - 1]?.totalLiquidityUSD : 0;
+        return {
+          chain,
+          tvl_usd: latestTvl ?? 0,
+        };
+      })
+      .filter(c => c.tvl_usd > 0)
+      .sort((a, b) => b.tvl_usd - a.tvl_usd);
+
+    return {
+      chains,
+      total_chains: chains.length,
+    };
+  },
+});

--- a/packages/pieces/community/kyberswap/src/lib/actions/get-knc-price.ts
+++ b/packages/pieces/community/kyberswap/src/lib/actions/get-knc-price.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getKncPriceAction = createAction({
+  name: 'get_knc_price',
+  displayName: 'Get KNC Price',
+  description: 'Fetch the current price and market data for Kyber Network Crystal (KNC) token from CoinGecko.',
+  props: {
+    vsCurrency: Property.ShortText({
+      displayName: 'vs Currency',
+      description: 'Currency to compare against (e.g. usd, eur, btc)',
+      required: false,
+      defaultValue: 'usd',
+    }),
+  },
+  async run(context) {
+    const vsCurrency = (context.propsValue.vsCurrency || 'usd').toLowerCase();
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.coingecko.com/api/v3/coins/kyber-network-crystal',
+      queryParams: {
+        localization: 'false',
+        tickers: 'false',
+        community_data: 'false',
+        developer_data: 'false',
+        sparkline: 'false',
+      },
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const marketData = data['market_data'] as Record<string, unknown> | undefined;
+    const currentPrice = marketData?.['current_price'] as Record<string, number> | undefined;
+    const marketCap = marketData?.['market_cap'] as Record<string, number> | undefined;
+    const totalVolume = marketData?.['total_volume'] as Record<string, number> | undefined;
+    const priceChange24h = marketData?.['price_change_percentage_24h'] as number | undefined;
+    const priceChange7d = marketData?.['price_change_percentage_7d'] as number | undefined;
+
+    return {
+      id: data['id'],
+      symbol: data['symbol'],
+      name: data['name'],
+      current_price: currentPrice?.[vsCurrency],
+      market_cap: marketCap?.[vsCurrency],
+      total_volume: totalVolume?.[vsCurrency],
+      price_change_24h_percent: priceChange24h,
+      price_change_7d_percent: priceChange7d,
+      vs_currency: vsCurrency,
+      last_updated: (marketData?.['last_updated'] as string) || null,
+    };
+  },
+});

--- a/packages/pieces/community/kyberswap/src/lib/actions/get-protocol-stats.ts
+++ b/packages/pieces/community/kyberswap/src/lib/actions/get-protocol-stats.ts
@@ -1,0 +1,40 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getProtocolStatsAction = createAction({
+  name: 'get_protocol_stats',
+  displayName: 'Get Protocol Stats',
+  description: 'Fetch key statistics for KyberSwap including TVL, chain count, category, and audit info from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/kyberswap',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const chains = (data['chains'] as string[]) || [];
+    const tvlArr = data['tvl'] as Array<{ date: number; totalLiquidityUSD: number }> | undefined;
+    const latestTvl = tvlArr && tvlArr.length > 0 ? tvlArr[tvlArr.length - 1]?.totalLiquidityUSD : 0;
+
+    const audits = data['audits'] as string | undefined;
+    const audit_links = data['audit_links'] as string[] | undefined;
+
+    return {
+      name: data['name'],
+      slug: data['slug'],
+      symbol: data['symbol'],
+      category: data['category'],
+      current_tvl_usd: latestTvl ?? 0,
+      total_chains: chains.length,
+      chains,
+      description: data['description'],
+      url: data['url'],
+      twitter: data['twitter'],
+      audits: audits || 'N/A',
+      audit_links: audit_links || [],
+      gecko_id: data['gecko_id'],
+      cmcId: data['cmcId'],
+    };
+  },
+});

--- a/packages/pieces/community/kyberswap/src/lib/actions/get-protocol-tvl.ts
+++ b/packages/pieces/community/kyberswap/src/lib/actions/get-protocol-tvl.ts
@@ -1,0 +1,29 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/shared';
+
+export const getProtocolTvlAction = createAction({
+  name: 'get_protocol_tvl',
+  displayName: 'Get Protocol TVL',
+  description: 'Fetch the current Total Value Locked (TVL) for KyberSwap from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/kyberswap',
+    });
+
+    const data = response.body as Record<string, unknown>;
+
+    return {
+      name: data['name'],
+      tvl: data['tvl'],
+      symbol: data['symbol'],
+      category: data['category'],
+      chains: data['chains'],
+      description: data['description'],
+      url: data['url'],
+      twitter: data['twitter'],
+    };
+  },
+});

--- a/packages/pieces/community/kyberswap/src/lib/actions/get-tvl-history.ts
+++ b/packages/pieces/community/kyberswap/src/lib/actions/get-tvl-history.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getTvlHistoryAction = createAction({
+  name: 'get_tvl_history',
+  displayName: 'Get TVL History',
+  description: 'Fetch the last 30 days of historical TVL data for KyberSwap from DeFiLlama.',
+  props: {
+    days: Property.Number({
+      displayName: 'Number of Days',
+      description: 'Number of historical days to return (default: 30, max: 90)',
+      required: false,
+      defaultValue: 30,
+    }),
+  },
+  async run(context) {
+    const days = Math.min(Math.max(1, context.propsValue.days ?? 30), 90);
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/kyberswap',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const tvlArr = data['tvl'] as Array<{ date: number; totalLiquidityUSD: number }> | undefined;
+
+    if (!tvlArr || tvlArr.length === 0) {
+      return { history: [], days_returned: 0 };
+    }
+
+    const cutoff = Date.now() / 1000 - days * 86400;
+    const history = tvlArr
+      .filter(entry => entry.date >= cutoff)
+      .map(entry => ({
+        date: new Date(entry.date * 1000).toISOString().split('T')[0],
+        timestamp: entry.date,
+        tvl_usd: entry.totalLiquidityUSD,
+      }));
+
+    return {
+      history,
+      days_requested: days,
+      days_returned: history.length,
+    };
+  },
+});

--- a/packages/pieces/community/kyberswap/tsconfig.json
+++ b/packages/pieces/community/kyberswap/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/kyberswap/tsconfig.lib.json
+++ b/packages/pieces/community/kyberswap/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/liquity/package.json
+++ b/packages/pieces/community/liquity/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@activepieces/piece-liquity",
+  "version": "0.0.1",
+  "description": "Liquity decentralized borrowing protocol: TVL, LUSD price, LQTY price, chain breakdown, historical data",
+  "keywords": [
+    "activepieces",
+    "liquity",
+    "defi",
+    "borrowing",
+    "lusd",
+    "lqty",
+    "ethereum",
+    "stablecoin"
+  ],
+  "homepage": "",
+  "bugs": {
+    "url": "https://github.com/activepieces/activepieces/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/activepieces/activepieces.git"
+  },
+  "license": "MIT",
+  "author": "",
+  "main": "./src/index.ts",
+  "scripts": {
+    "publish-piece": "node ../../../../.scripts/publish-piece.mjs"
+  },
+  "peerDependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*"
+  }
+}

--- a/packages/pieces/community/liquity/project.json
+++ b/packages/pieces/community/liquity/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "piece-liquity",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/liquity/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "options": {
+        "outputPath": "dist/packages/pieces/community/liquity",
+        "tsConfig": "packages/pieces/community/liquity/tsconfig.json",
+        "packageJson": "packages/pieces/community/liquity/package.json",
+        "main": "packages/pieces/community/liquity/src/index.ts",
+        "assets": []
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/liquity/src/index.ts
+++ b/packages/pieces/community/liquity/src/index.ts
@@ -1,0 +1,19 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getProtocolTvl } from './lib/actions/get-protocol-tvl';
+import { getLusdPrice } from './lib/actions/get-lusd-price';
+import { getLqtyPrice } from './lib/actions/get-lqty-price';
+import { getChainBreakdown } from './lib/actions/get-chain-breakdown';
+import { getTvlHistory } from './lib/actions/get-tvl-history';
+
+export const liquity = createPiece({
+  displayName: 'Liquity',
+  description: 'Liquity decentralized borrowing protocol — interest-free loans against ETH collateral, paid in LUSD stablecoin',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/liquity.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  authors: ['bossco7598'],
+  actions: [getProtocolTvl, getLusdPrice, getLqtyPrice, getChainBreakdown, getTvlHistory],
+  triggers: [],
+});

--- a/packages/pieces/community/liquity/src/lib/actions/get-chain-breakdown.ts
+++ b/packages/pieces/community/liquity/src/lib/actions/get-chain-breakdown.ts
@@ -1,0 +1,26 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { defiLlamaRequest } from '../liquity-api';
+
+export const getChainBreakdown = createAction({
+  name: 'get_chain_breakdown',
+  displayName: 'Get Chain TVL Breakdown',
+  description: 'Get the TVL breakdown for Liquity across all supported chains via DeFiLlama',
+  props: {},
+  async run() {
+    const data = await defiLlamaRequest<any>('/protocol/liquity');
+    const currentChainTvls = data.currentChainTvls ?? {};
+    const chains = Object.entries(currentChainTvls).map(([chain, tvl]) => ({
+      chain,
+      tvlUSD: tvl as number,
+    }));
+    chains.sort((a, b) => b.tvlUSD - a.tvlUSD);
+    const totalTvl = chains.reduce((sum, c) => sum + c.tvlUSD, 0);
+    return {
+      protocol: data.name,
+      totalTvlUSD: totalTvl,
+      chainCount: chains.length,
+      chains,
+      lastUpdated: new Date().toISOString(),
+    };
+  },
+});

--- a/packages/pieces/community/liquity/src/lib/actions/get-lqty-price.ts
+++ b/packages/pieces/community/liquity/src/lib/actions/get-lqty-price.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { coinGeckoRequest } from '../liquity-api';
+
+export const getLqtyPrice = createAction({
+  name: 'get_lqty_price',
+  displayName: 'Get LQTY Price',
+  description: 'Get the current price and market data for LQTY governance token via CoinGecko',
+  props: {},
+  async run() {
+    const data = await coinGeckoRequest<any>('/coins/liquity?localization=false&tickers=false&community_data=false&developer_data=false');
+    const market = data.market_data ?? {};
+    return {
+      id: data.id,
+      symbol: data.symbol,
+      name: data.name,
+      priceUSD: market.current_price?.usd,
+      marketCapUSD: market.market_cap?.usd,
+      totalSupply: market.total_supply,
+      circulatingSupply: market.circulating_supply,
+      priceChange24hPercent: market.price_change_percentage_24h,
+      priceChange7dPercent: market.price_change_percentage_7d,
+      allTimeHighUSD: market.ath?.usd,
+      allTimeLowUSD: market.atl?.usd,
+      fullyDilutedValuationUSD: market.fully_diluted_valuation?.usd,
+      lastUpdated: market.last_updated,
+    };
+  },
+});

--- a/packages/pieces/community/liquity/src/lib/actions/get-lusd-price.ts
+++ b/packages/pieces/community/liquity/src/lib/actions/get-lusd-price.ts
@@ -1,0 +1,27 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { coinGeckoRequest } from '../liquity-api';
+
+export const getLusdPrice = createAction({
+  name: 'get_lusd_price',
+  displayName: 'Get LUSD Price',
+  description: 'Get the current price and market data for LUSD stablecoin (Liquity USD) via CoinGecko',
+  props: {},
+  async run() {
+    const data = await coinGeckoRequest<any>('/coins/liquity-usd?localization=false&tickers=false&community_data=false&developer_data=false');
+    const market = data.market_data ?? {};
+    return {
+      id: data.id,
+      symbol: data.symbol,
+      name: data.name,
+      priceUSD: market.current_price?.usd,
+      marketCapUSD: market.market_cap?.usd,
+      totalSupply: market.total_supply,
+      circulatingSupply: market.circulating_supply,
+      priceChange24hPercent: market.price_change_percentage_24h,
+      priceChange7dPercent: market.price_change_percentage_7d,
+      allTimeHighUSD: market.ath?.usd,
+      allTimeLowUSD: market.atl?.usd,
+      lastUpdated: market.last_updated,
+    };
+  },
+});

--- a/packages/pieces/community/liquity/src/lib/actions/get-protocol-tvl.ts
+++ b/packages/pieces/community/liquity/src/lib/actions/get-protocol-tvl.ts
@@ -1,0 +1,26 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { defiLlamaRequest } from '../liquity-api';
+
+export const getProtocolTvl = createAction({
+  name: 'get_protocol_tvl',
+  displayName: 'Get Protocol TVL',
+  description: 'Get the current Total Value Locked (TVL) for the Liquity protocol via DeFiLlama',
+  props: {},
+  async run() {
+    const data = await defiLlamaRequest<any>('/protocol/liquity');
+    const currentTvl = data.currentChainTvls ?? {};
+    const totalTvl = data.tvl ? data.tvl[data.tvl.length - 1]?.totalLiquidityUSD : undefined;
+    return {
+      name: data.name,
+      symbol: data.symbol,
+      description: data.description,
+      totalTvlUSD: totalTvl,
+      currentChainTvls: currentTvl,
+      category: data.category,
+      chains: data.chains,
+      url: data.url,
+      twitter: data.twitter,
+      gecko_id: data.gecko_id,
+    };
+  },
+});

--- a/packages/pieces/community/liquity/src/lib/actions/get-tvl-history.ts
+++ b/packages/pieces/community/liquity/src/lib/actions/get-tvl-history.ts
@@ -1,0 +1,38 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { defiLlamaRequest } from '../liquity-api';
+
+export const getTvlHistory = createAction({
+  name: 'get_tvl_history',
+  displayName: 'Get TVL History (Last 30 Days)',
+  description: 'Get the last 30 days of historical TVL data for Liquity via DeFiLlama',
+  props: {},
+  async run() {
+    const data = await defiLlamaRequest<any>('/protocol/liquity');
+    const tvlSeries: Array<{ date: number; totalLiquidityUSD: number }> = data.tvl ?? [];
+    
+    // Get last 30 days
+    const thirtyDaysAgo = Math.floor(Date.now() / 1000) - 30 * 24 * 60 * 60;
+    const recent = tvlSeries.filter((entry) => entry.date >= thirtyDaysAgo);
+    
+    const history = recent.map((entry) => ({
+      date: new Date(entry.date * 1000).toISOString().split('T')[0],
+      timestamp: entry.date,
+      tvlUSD: entry.totalLiquidityUSD,
+    }));
+
+    const tvlValues = history.map((h) => h.tvlUSD);
+    const maxTvl = tvlValues.length ? Math.max(...tvlValues) : 0;
+    const minTvl = tvlValues.length ? Math.min(...tvlValues) : 0;
+    const latestTvl = history.length ? history[history.length - 1].tvlUSD : 0;
+
+    return {
+      protocol: data.name,
+      periodDays: 30,
+      dataPoints: history.length,
+      latestTvlUSD: latestTvl,
+      maxTvlUSD: maxTvl,
+      minTvlUSD: minTvl,
+      history,
+    };
+  },
+});

--- a/packages/pieces/community/liquity/src/lib/liquity-api.ts
+++ b/packages/pieces/community/liquity/src/lib/liquity-api.ts
@@ -1,0 +1,22 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const DEFILLAMA_BASE = 'https://api.llama.fi';
+const COINGECKO_BASE = 'https://api.coingecko.com/api/v3';
+
+export async function defiLlamaRequest<T>(endpoint: string): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method: HttpMethod.GET,
+    url: `${DEFILLAMA_BASE}${endpoint}`,
+    headers: { 'Accept': 'application/json' },
+  });
+  return response.body;
+}
+
+export async function coinGeckoRequest<T>(endpoint: string): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method: HttpMethod.GET,
+    url: `${COINGECKO_BASE}${endpoint}`,
+    headers: { 'Accept': 'application/json' },
+  });
+  return response.body;
+}

--- a/packages/pieces/community/liquity/tsconfig.json
+++ b/packages/pieces/community/liquity/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/pieces/community/orca/.eslintrc.json
+++ b/packages/pieces/community/orca/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/orca/README.md
+++ b/packages/pieces/community/orca/README.md
@@ -1,0 +1,16 @@
+# Orca
+
+Orca is the leading decentralized exchange (DEX) on Solana, known for its concentrated liquidity "Whirlpools" feature. It provides capital-efficient token swaps and is governed by the ORCA token.
+
+## Actions
+
+- **Get Protocol TVL** - Fetch current Total Value Locked for Orca via DeFiLlama
+- **Get ORCA Price** - Get the current ORCA token price via CoinGecko
+- **Get Chain Breakdown** - Get TVL breakdown by chain via DeFiLlama
+- **Get TVL History** - Get last 30 days of historical TVL data via DeFiLlama
+- **Get Protocol Stats** - Get key protocol statistics (TVL, chains, category) via DeFiLlama
+
+## APIs Used
+
+- [DeFiLlama API](https://defillama.com/docs/api) - Free, no authentication required
+- [CoinGecko API](https://www.coingecko.com/en/api) - Free tier, no authentication required

--- a/packages/pieces/community/orca/package.json
+++ b/packages/pieces/community/orca/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-orca",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/orca/src/index.ts
+++ b/packages/pieces/community/orca/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getProtocolTvl } from './lib/actions/get-protocol-tvl';
+import { getOrcaPrice } from './lib/actions/get-orca-price';
+import { getChainBreakdown } from './lib/actions/get-chain-breakdown';
+import { getTvlHistory } from './lib/actions/get-tvl-history';
+import { getProtocolStats } from './lib/actions/get-protocol-stats';
+
+export const orca = createPiece({
+  displayName: 'Orca',
+  auth: PieceAuth.None(),
+  description:
+    'Orca is the leading DEX on Solana known for its concentrated liquidity Whirlpools. Fetch TVL, price, chain breakdown, historical data, and protocol stats — all from free public APIs.',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/orca.png',
+  authors: ['bossco7598'],
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  actions: [
+    getProtocolTvl,
+    getOrcaPrice,
+    getChainBreakdown,
+    getTvlHistory,
+    getProtocolStats,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/orca/src/lib/actions/get-chain-breakdown.ts
+++ b/packages/pieces/community/orca/src/lib/actions/get-chain-breakdown.ts
@@ -1,0 +1,41 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+export const getChainBreakdown = createAction({
+  name: 'getChainBreakdown',
+  displayName: 'Get Chain Breakdown',
+  description:
+    'Get the TVL breakdown for Orca by blockchain chain from DeFiLlama.',
+  props: {},
+  auth: undefined,
+  async run() {
+    const response = await httpClient.sendRequest<Record<string, unknown>>({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/orca',
+    });
+
+    const data = response.body;
+    const currentChainTvls = data['currentChainTvls'] as Record<
+      string,
+      number
+    >;
+    const chains = data['chains'] as string[];
+
+    const breakdown = Object.entries(currentChainTvls).map(
+      ([chain, tvl]: [string, number]) => ({
+        chain,
+        tvlUSD: tvl,
+      })
+    );
+
+    breakdown.sort((a, b) => b.tvlUSD - a.tvlUSD);
+
+    const totalTvl = breakdown.reduce((sum, item) => sum + item.tvlUSD, 0);
+
+    return {
+      chains,
+      chainBreakdown: breakdown,
+      totalTvlUSD: totalTvl,
+    };
+  },
+});

--- a/packages/pieces/community/orca/src/lib/actions/get-orca-price.ts
+++ b/packages/pieces/community/orca/src/lib/actions/get-orca-price.ts
@@ -1,0 +1,44 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+export const getOrcaPrice = createAction({
+  name: 'getOrcaPrice',
+  displayName: 'Get ORCA Price',
+  description:
+    'Fetch the current ORCA token price, market cap, and 24h trading volume from CoinGecko.',
+  props: {},
+  auth: undefined,
+  async run() {
+    const response = await httpClient.sendRequest<Record<string, unknown>>({
+      method: HttpMethod.GET,
+      url: 'https://api.coingecko.com/api/v3/coins/orca',
+      queryParams: {
+        localization: 'false',
+        tickers: 'false',
+        community_data: 'false',
+        developer_data: 'false',
+        sparkline: 'false',
+      },
+    });
+
+    const data = response.body;
+    const marketData = data['market_data'] as Record<string, unknown>;
+    const currentPrice = marketData['current_price'] as Record<string, number>;
+    const marketCap = marketData['market_cap'] as Record<string, number>;
+    const totalVolume = marketData['total_volume'] as Record<string, number>;
+    const priceChange24h = marketData[
+      'price_change_percentage_24h'
+    ] as number;
+
+    return {
+      id: data['id'],
+      name: data['name'],
+      symbol: data['symbol'],
+      priceUSD: currentPrice['usd'],
+      marketCapUSD: marketCap['usd'],
+      volume24hUSD: totalVolume['usd'],
+      priceChange24hPercent: priceChange24h,
+      lastUpdated: data['last_updated'],
+    };
+  },
+});

--- a/packages/pieces/community/orca/src/lib/actions/get-protocol-stats.ts
+++ b/packages/pieces/community/orca/src/lib/actions/get-protocol-stats.ts
@@ -1,0 +1,62 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+interface TvlDataPoint {
+  date: number;
+  totalLiquidityUSD: number;
+}
+
+export const getProtocolStats = createAction({
+  name: 'getProtocolStats',
+  displayName: 'Get Protocol Stats',
+  description:
+    'Get key protocol statistics for Orca including TVL, chains, category, and description from DeFiLlama.',
+  props: {},
+  auth: undefined,
+  async run() {
+    const response = await httpClient.sendRequest<Record<string, unknown>>({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/orca',
+    });
+
+    const data = response.body;
+    const tvlArray = data['tvl'] as TvlDataPoint[];
+    const latestTvl =
+      tvlArray && tvlArray.length > 0
+        ? tvlArray[tvlArray.length - 1].totalLiquidityUSD
+        : 0;
+
+    const currentChainTvls = data['currentChainTvls'] as Record<
+      string,
+      number
+    >;
+    const chains = data['chains'] as string[];
+
+    const allTimeHighEntry =
+      tvlArray && tvlArray.length > 0
+        ? tvlArray.reduce((max, point) =>
+            point.totalLiquidityUSD > max.totalLiquidityUSD ? point : max
+          )
+        : null;
+
+    return {
+      name: data['name'],
+      symbol: data['symbol'],
+      category: data['category'],
+      description: data['description'],
+      currentTvlUSD: latestTvl,
+      chains,
+      chainCount: chains ? chains.length : 0,
+      currentChainTvls,
+      allTimeHighTvlUSD: allTimeHighEntry
+        ? allTimeHighEntry.totalLiquidityUSD
+        : 0,
+      allTimeHighDate: allTimeHighEntry
+        ? new Date(allTimeHighEntry.date * 1000).toISOString().split('T')[0]
+        : null,
+      url: data['url'],
+      twitter: data['twitter'],
+      gecko_id: data['gecko_id'],
+    };
+  },
+});

--- a/packages/pieces/community/orca/src/lib/actions/get-protocol-tvl.ts
+++ b/packages/pieces/community/orca/src/lib/actions/get-protocol-tvl.ts
@@ -1,0 +1,41 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+export const getProtocolTvl = createAction({
+  name: 'getProtocolTvl',
+  displayName: 'Get Protocol TVL',
+  description:
+    'Fetch the current Total Value Locked (TVL) for Orca DEX from DeFiLlama.',
+  props: {},
+  auth: undefined,
+  async run() {
+    const response = await httpClient.sendRequest<{
+      tvl: number;
+      name: string;
+      symbol: string;
+      chains: string[];
+      currentChainTvls: Record<string, number>;
+    }>({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/orca',
+    });
+
+    const data = response.body;
+    const tvlArray = (data as Record<string, unknown>)['tvl'] as Array<{
+      date: number;
+      totalLiquidityUSD: number;
+    }>;
+    const latestTvl =
+      tvlArray && tvlArray.length > 0
+        ? tvlArray[tvlArray.length - 1].totalLiquidityUSD
+        : 0;
+
+    return {
+      name: (data as Record<string, unknown>)['name'],
+      symbol: (data as Record<string, unknown>)['symbol'],
+      currentTvlUSD: latestTvl,
+      chains: (data as Record<string, unknown>)['chains'],
+      currentChainTvls: (data as Record<string, unknown>)['currentChainTvls'],
+    };
+  },
+});

--- a/packages/pieces/community/orca/src/lib/actions/get-tvl-history.ts
+++ b/packages/pieces/community/orca/src/lib/actions/get-tvl-history.ts
@@ -1,0 +1,49 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+interface TvlDataPoint {
+  date: number;
+  totalLiquidityUSD: number;
+}
+
+export const getTvlHistory = createAction({
+  name: 'getTvlHistory',
+  displayName: 'Get TVL History',
+  description:
+    'Fetch the last 30 days of historical Total Value Locked (TVL) data for Orca from DeFiLlama.',
+  props: {},
+  auth: undefined,
+  async run() {
+    const response = await httpClient.sendRequest<Record<string, unknown>>({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/orca',
+    });
+
+    const data = response.body;
+    const tvlArray = data['tvl'] as TvlDataPoint[];
+
+    const thirtyDaysAgo = Math.floor(Date.now() / 1000) - 30 * 24 * 60 * 60;
+    const last30Days = tvlArray
+      .filter((point) => point.date >= thirtyDaysAgo)
+      .map((point) => ({
+        date: new Date(point.date * 1000).toISOString().split('T')[0],
+        timestamp: point.date,
+        tvlUSD: point.totalLiquidityUSD,
+      }));
+
+    const latest = last30Days[last30Days.length - 1];
+    const oldest = last30Days[0];
+    const changePercent =
+      oldest && latest
+        ? ((latest.tvlUSD - oldest.tvlUSD) / oldest.tvlUSD) * 100
+        : 0;
+
+    return {
+      dataPoints: last30Days,
+      latestTvlUSD: latest ? latest.tvlUSD : 0,
+      oldestTvlUSD: oldest ? oldest.tvlUSD : 0,
+      change30dPercent: Math.round(changePercent * 100) / 100,
+      dataPointCount: last30Days.length,
+    };
+  },
+});

--- a/packages/pieces/community/orca/tsconfig.json
+++ b/packages/pieces/community/orca/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/orca/tsconfig.lib.json
+++ b/packages/pieces/community/orca/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/pangolin/.eslintrc.json
+++ b/packages/pieces/community/pangolin/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/pangolin/package.json
+++ b/packages/pieces/community/pangolin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-pangolin",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/pangolin/src/index.ts
+++ b/packages/pieces/community/pangolin/src/index.ts
@@ -1,0 +1,26 @@
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getProtocolTvlAction } from './lib/actions/get-protocol-tvl';
+import { getPngPriceAction } from './lib/actions/get-png-price';
+import { getChainBreakdownAction } from './lib/actions/get-chain-breakdown';
+import { getTvlHistoryAction } from './lib/actions/get-tvl-history';
+import { getProtocolStatsAction } from './lib/actions/get-protocol-stats';
+
+export const pangolin = createPiece({
+  displayName: 'Pangolin',
+  description:
+    'Pangolin is a community-driven decentralized exchange (DEX) on Avalanche. It uses an automated market maker (AMM) model similar to Uniswap v2. PNG is the governance and reward token.',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/pangolin.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  auth: PieceAuth.None(),
+  authors: ['bossco7598'],
+  actions: [
+    getProtocolTvlAction,
+    getPngPriceAction,
+    getChainBreakdownAction,
+    getTvlHistoryAction,
+    getProtocolStatsAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/pangolin/src/lib/actions/get-chain-breakdown.ts
+++ b/packages/pieces/community/pangolin/src/lib/actions/get-chain-breakdown.ts
@@ -1,0 +1,35 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getChainBreakdownAction = createAction({
+  name: 'get_chain_breakdown',
+  displayName: 'Get TVL by Chain',
+  description:
+    'Fetch a breakdown of the Pangolin protocol TVL by blockchain chain from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/pangolin',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const currentChainTvls = data['currentChainTvls'] as Record<string, number> | undefined;
+    const chains = data['chains'] as string[] | undefined;
+
+    const breakdown = Object.entries(currentChainTvls ?? {}).map(([chain, tvl]) => ({
+      chain,
+      tvl,
+    }));
+
+    // Sort by TVL descending
+    breakdown.sort((a, b) => b.tvl - a.tvl);
+
+    return {
+      total_tvl: data['tvl'],
+      chains_count: (chains ?? []).length,
+      chains: chains ?? [],
+      chain_breakdown: breakdown,
+    };
+  },
+});

--- a/packages/pieces/community/pangolin/src/lib/actions/get-png-price.ts
+++ b/packages/pieces/community/pangolin/src/lib/actions/get-png-price.ts
@@ -1,0 +1,40 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getPngPriceAction = createAction({
+  name: 'get_png_price',
+  displayName: 'Get PNG Token Price',
+  description:
+    'Fetch the current price and market data for the PNG (Pangolin) governance token from CoinGecko.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.coingecko.com/api/v3/coins/pangolin',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const marketData = data['market_data'] as Record<string, unknown> | undefined;
+    const currentPrice = marketData?.['current_price'] as Record<string, number> | undefined;
+    const marketCap = marketData?.['market_cap'] as Record<string, number> | undefined;
+    const totalVolume = marketData?.['total_volume'] as Record<string, number> | undefined;
+    const priceChangePercentage24h = marketData?.['price_change_percentage_24h'] as number | undefined;
+    const priceChangePercentage7d = marketData?.['price_change_percentage_7d'] as number | undefined;
+
+    return {
+      id: data['id'],
+      symbol: data['symbol'],
+      name: data['name'],
+      current_price_usd: currentPrice?.['usd'],
+      market_cap_usd: marketCap?.['usd'],
+      total_volume_usd: totalVolume?.['usd'],
+      price_change_percentage_24h: priceChangePercentage24h,
+      price_change_percentage_7d: priceChangePercentage7d,
+      circulating_supply: (marketData?.['circulating_supply'] as number) ?? null,
+      total_supply: (marketData?.['total_supply'] as number) ?? null,
+      max_supply: (marketData?.['max_supply'] as number) ?? null,
+      ath_usd: (marketData?.['ath'] as Record<string, number> | undefined)?.['usd'],
+      last_updated: marketData?.['last_updated'],
+    };
+  },
+});

--- a/packages/pieces/community/pangolin/src/lib/actions/get-protocol-stats.ts
+++ b/packages/pieces/community/pangolin/src/lib/actions/get-protocol-stats.ts
@@ -1,0 +1,55 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getProtocolStatsAction = createAction({
+  name: 'get_protocol_stats',
+  displayName: 'Get Protocol Stats',
+  description:
+    'Fetch key statistics for the Pangolin protocol including TVL, chain count, and category from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/pangolin',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const currentChainTvls = data['currentChainTvls'] as Record<string, number> | undefined;
+    const chains = data['chains'] as string[] | undefined;
+    const tvlHistory = data['tvl'] as Array<{ date: number; totalLiquidityUSD: number }> | undefined;
+
+    // Compute 24h and 7d TVL change if history available
+    let change24h: number | null = null;
+    let change7d: number | null = null;
+
+    if (tvlHistory && tvlHistory.length > 0) {
+      const latestTvl = tvlHistory[tvlHistory.length - 1]?.totalLiquidityUSD ?? 0;
+      const tvl24hAgo = tvlHistory[tvlHistory.length - 2]?.totalLiquidityUSD ?? 0;
+      const tvl7dAgo = tvlHistory.length >= 8 ? (tvlHistory[tvlHistory.length - 8]?.totalLiquidityUSD ?? 0) : 0;
+
+      if (tvl24hAgo > 0) {
+        change24h = parseFloat((((latestTvl - tvl24hAgo) / tvl24hAgo) * 100).toFixed(2));
+      }
+      if (tvl7dAgo > 0) {
+        change7d = parseFloat((((latestTvl - tvl7dAgo) / tvl7dAgo) * 100).toFixed(2));
+      }
+    }
+
+    return {
+      name: data['name'],
+      slug: data['slug'],
+      symbol: data['symbol'],
+      category: data['category'],
+      tvl: data['tvl'] instanceof Array ? (data['tvl'] as Array<{ totalLiquidityUSD: number }>).slice(-1)[0]?.totalLiquidityUSD : data['tvl'],
+      current_chain_tvls: currentChainTvls ?? {},
+      chains: chains ?? [],
+      chains_count: (chains ?? []).length,
+      change_24h_percent: change24h,
+      change_7d_percent: change7d,
+      protocol_url: data['url'],
+      description: data['description'],
+      gecko_id: data['gecko_id'],
+      cmc_id: data['cmcId'],
+    };
+  },
+});

--- a/packages/pieces/community/pangolin/src/lib/actions/get-protocol-tvl.ts
+++ b/packages/pieces/community/pangolin/src/lib/actions/get-protocol-tvl.ts
@@ -1,0 +1,30 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getProtocolTvlAction = createAction({
+  name: 'get_protocol_tvl',
+  displayName: 'Get Protocol TVL',
+  description:
+    'Fetch the current Total Value Locked (TVL) for the Pangolin protocol from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/pangolin',
+    });
+
+    const data = response.body as Record<string, unknown>;
+
+    return {
+      name: data['name'],
+      symbol: data['symbol'],
+      tvl: data['tvl'],
+      currentChainTvls: data['currentChainTvls'],
+      category: data['category'],
+      chains: data['chains'],
+      description: data['description'],
+      url: data['url'],
+      twitter: data['twitter'],
+    };
+  },
+});

--- a/packages/pieces/community/pangolin/src/lib/actions/get-tvl-history.ts
+++ b/packages/pieces/community/pangolin/src/lib/actions/get-tvl-history.ts
@@ -1,0 +1,41 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getTvlHistoryAction = createAction({
+  name: 'get_tvl_history',
+  displayName: 'Get TVL History (30 Days)',
+  description:
+    'Fetch the last 30 days of historical TVL data for the Pangolin protocol from DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/pangolin',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const tvlHistory = data['tvl'] as Array<{ date: number; totalLiquidityUSD: number }> | undefined;
+
+    if (!tvlHistory || !Array.isArray(tvlHistory)) {
+      return { history: [], count: 0 };
+    }
+
+    // Get last 30 days
+    const last30Days = tvlHistory.slice(-30).map((entry) => ({
+      date: new Date(entry.date * 1000).toISOString().split('T')[0],
+      timestamp: entry.date,
+      tvl_usd: entry.totalLiquidityUSD,
+    }));
+
+    const latestTvl = last30Days[last30Days.length - 1]?.tvl_usd ?? 0;
+    const earliestTvl = last30Days[0]?.tvl_usd ?? 0;
+    const change30d = earliestTvl > 0 ? ((latestTvl - earliestTvl) / earliestTvl) * 100 : 0;
+
+    return {
+      history: last30Days,
+      count: last30Days.length,
+      latest_tvl_usd: latestTvl,
+      change_30d_percent: parseFloat(change30d.toFixed(2)),
+    };
+  },
+});

--- a/packages/pieces/community/pangolin/tsconfig.json
+++ b/packages/pieces/community/pangolin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/pangolin/tsconfig.lib.json
+++ b/packages/pieces/community/pangolin/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/santiment/package.json
+++ b/packages/pieces/community/santiment/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-santiment",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/santiment/src/index.ts
+++ b/packages/pieces/community/santiment/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getSocialVolume } from './lib/actions/get-social-volume';
+import { getPriceVolume } from './lib/actions/get-price-volume';
+import { getDevActivity } from './lib/actions/get-dev-activity';
+import { getExchangeFlows } from './lib/actions/get-exchange-flows';
+import { getTrendingWords } from './lib/actions/get-trending-words';
+import { santimentAuth } from './lib/common/santiment-auth';
+
+export const santiment = createPiece({
+  displayName: 'Santiment',
+  auth: santimentAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/santiment.png',
+  authors: ['bossco7598'],
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  description: 'On-chain and social analytics for crypto assets via Santiment SanAPI.',
+  actions: [
+    getSocialVolume,
+    getPriceVolume,
+    getDevActivity,
+    getExchangeFlows,
+    getTrendingWords,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-dev-activity.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-dev-activity.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getDevActivity = createAction({
+  auth: santimentAuth,
+  name: 'get_dev_activity',
+  displayName: 'Get Developer Activity',
+  description: 'Get GitHub developer activity metric for a crypto project over time.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. ethereum, bitcoin)',
+      required: true,
+      defaultValue: 'ethereum',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval } = context.propsValue;
+    const query = `{
+      getMetric(metric: "dev_activity") {
+        timeseriesData(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+          datetime
+          value
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-exchange-flows.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-exchange-flows.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getExchangeFlows = createAction({
+  auth: santimentAuth,
+  name: 'get_exchange_flows',
+  displayName: 'Get Exchange Flows',
+  description: 'Get exchange inflow/outflow data for whale tracking.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. bitcoin, ethereum)',
+      required: true,
+      defaultValue: 'bitcoin',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+    flowType: Property.StaticDropdown({
+      displayName: 'Flow Type',
+      description: 'Select inflow or outflow metric',
+      required: true,
+      defaultValue: 'exchange_inflow',
+      options: {
+        options: [
+          { label: 'Exchange Inflow', value: 'exchange_inflow' },
+          { label: 'Exchange Outflow', value: 'exchange_outflow' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval, flowType } = context.propsValue;
+    const query = `{
+      getMetric(metric: "${flowType}") {
+        timeseriesData(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+          datetime
+          value
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-price-volume.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-price-volume.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getPriceVolume = createAction({
+  auth: santimentAuth,
+  name: 'get_price_volume',
+  displayName: 'Get Price & Volume (OHLCV)',
+  description: 'Get OHLCV price and volume data for a crypto asset.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. bitcoin, ethereum)',
+      required: true,
+      defaultValue: 'bitcoin',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval } = context.propsValue;
+    const query = `{
+      ohlcv(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+        datetime
+        openPriceUsd
+        closePriceUsd
+        highPriceUsd
+        lowPriceUsd
+        volumeUsd
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-social-volume.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-social-volume.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getSocialVolume = createAction({
+  auth: santimentAuth,
+  name: 'get_social_volume',
+  displayName: 'Get Social Volume',
+  description: 'Get social mentions and volume for a crypto asset over time.',
+  props: {
+    slug: Property.ShortText({
+      displayName: 'Asset Slug',
+      description: 'The asset slug (e.g. bitcoin, ethereum)',
+      required: true,
+      defaultValue: 'bitcoin',
+    }),
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    interval: Property.ShortText({
+      displayName: 'Interval',
+      description: 'Time interval (e.g. 1d, 1h, 7d)',
+      required: false,
+      defaultValue: '1d',
+    }),
+  },
+  async run(context) {
+    const { slug, from, to, interval } = context.propsValue;
+    const query = `{
+      getMetric(metric: "social_volume_total") {
+        timeseriesData(slug: "${slug}", from: "${from}", to: "${to}", interval: "${interval ?? '1d'}") {
+          datetime
+          value
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/actions/get-trending-words.ts
+++ b/packages/pieces/community/santiment/src/lib/actions/get-trending-words.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { santimentAuth } from '../common/santiment-auth';
+import { santimentRequest } from '../common/santiment-api';
+
+export const getTrendingWords = createAction({
+  auth: santimentAuth,
+  name: 'get_trending_words',
+  displayName: 'Get Trending Words',
+  description: 'Get trending words in crypto social media.',
+  props: {
+    from: Property.ShortText({
+      displayName: 'From Date',
+      description: 'Start date in ISO format (e.g. 2024-01-01T00:00:00Z)',
+      required: true,
+    }),
+    to: Property.ShortText({
+      displayName: 'To Date',
+      description: 'End date in ISO format (e.g. 2024-01-07T00:00:00Z)',
+      required: true,
+    }),
+    size: Property.Number({
+      displayName: 'Size',
+      description: 'Number of top trending words to return',
+      required: false,
+      defaultValue: 10,
+    }),
+  },
+  async run(context) {
+    const { from, to, size } = context.propsValue;
+    const query = `{
+      getTrendingWords(from: "${from}", to: "${to}", size: ${size ?? 10}, interval: "1d") {
+        topWords {
+          datetime
+          topWords {
+            word
+            score
+          }
+        }
+      }
+    }`;
+    return await santimentRequest(context.auth as string, query);
+  },
+});

--- a/packages/pieces/community/santiment/src/lib/common/santiment-api.ts
+++ b/packages/pieces/community/santiment/src/lib/common/santiment-api.ts
@@ -1,0 +1,23 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const SANTIMENT_API_URL = 'https://api.santiment.net/graphql';
+
+export async function santimentRequest(
+  apiKey: string,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<unknown> {
+  const response = await httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: SANTIMENT_API_URL,
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Apikey ${apiKey}`,
+    },
+    body: {
+      query,
+      variables: variables ?? {},
+    },
+  });
+  return response.body;
+}

--- a/packages/pieces/community/santiment/src/lib/common/santiment-auth.ts
+++ b/packages/pieces/community/santiment/src/lib/common/santiment-auth.ts
@@ -1,0 +1,7 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const santimentAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Santiment API key. Get it from https://app.santiment.net/account#api-keys',
+  required: true,
+});

--- a/packages/pieces/community/santiment/tsconfig.json
+++ b/packages/pieces/community/santiment/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/santiment/tsconfig.lib.json
+++ b/packages/pieces/community/santiment/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/token-terminal/package.json
+++ b/packages/pieces/community/token-terminal/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-token-terminal",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/token-terminal/src/index.ts
+++ b/packages/pieces/community/token-terminal/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { tokenTerminalAuth } from './lib/common/token-terminal-api';
+import { getAllProjects } from './lib/actions/get-all-projects';
+import { getProjectInfo } from './lib/actions/get-project-info';
+import { getProjectMetrics } from './lib/actions/get-project-metrics';
+import { getMarketData } from './lib/actions/get-market-data';
+import { getHistoricalData } from './lib/actions/get-historical-data';
+
+export const tokenTerminal = createPiece({
+  displayName: 'Token Terminal',
+  description: 'Protocol revenue and financial analytics for DeFi projects',
+  auth: tokenTerminalAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/token-terminal.png',
+  authors: ['bossco7598'],
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  actions: [
+    getAllProjects,
+    getProjectInfo,
+    getProjectMetrics,
+    getMarketData,
+    getHistoricalData,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-all-projects.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-all-projects.ts
@@ -1,0 +1,14 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getAllProjects = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getAllProjects',
+  displayName: 'Get All Projects',
+  description: 'Retrieve a list of all protocols and projects tracked by Token Terminal.',
+  props: {},
+  async run(context) {
+    return makeRequest(context.auth as string, HttpMethod.GET, '/projects');
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-historical-data.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-historical-data.ts
@@ -1,0 +1,55 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getHistoricalData = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getHistoricalData',
+  displayName: 'Get Historical Data',
+  description: 'Retrieve time-series historical metrics data for a specific protocol.',
+  props: {
+    project_id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'The unique identifier for the project (e.g. uniswap, aave, ethereum)',
+      required: true,
+    }),
+    granularity: Property.StaticDropdown({
+      displayName: 'Granularity',
+      description: 'Time granularity for the historical data',
+      required: false,
+      defaultValue: 'daily',
+      options: {
+        options: [
+          { label: 'Daily', value: 'daily' },
+          { label: 'Weekly', value: 'weekly' },
+          { label: 'Monthly', value: 'monthly' },
+        ],
+      },
+    }),
+    start_date: Property.ShortText({
+      displayName: 'Start Date',
+      description: 'Start date for historical data in YYYY-MM-DD format (optional)',
+      required: false,
+    }),
+    end_date: Property.ShortText({
+      displayName: 'End Date',
+      description: 'End date for historical data in YYYY-MM-DD format (optional)',
+      required: false,
+    }),
+    metric: Property.ShortText({
+      displayName: 'Metric',
+      description: 'Specific metric to retrieve (e.g. revenue, fees, tvl). Leave empty for all.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { project_id, granularity, start_date, end_date, metric } = context.propsValue;
+    const queryParams: Record<string, string> = {
+      granularity: (granularity as string) || 'daily',
+    };
+    if (start_date) queryParams['start_date'] = start_date as string;
+    if (end_date) queryParams['end_date'] = end_date as string;
+    if (metric) queryParams['metric'] = metric as string;
+    return makeRequest(context.auth as string, HttpMethod.GET, `/projects/${project_id}/metrics`, queryParams);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-market-data.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-market-data.ts
@@ -1,0 +1,23 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getMarketData = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getMarketData',
+  displayName: 'Get Market Data',
+  description: 'Get aggregated DeFi market metrics and data across all tracked protocols.',
+  props: {
+    metric: Property.ShortText({
+      displayName: 'Metric',
+      description: 'Specific metric to retrieve (e.g. revenue, fees, tvl). Leave empty for all.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { metric } = context.propsValue;
+    const queryParams: Record<string, string> = {};
+    if (metric) queryParams['metric'] = metric;
+    return makeRequest(context.auth as string, HttpMethod.GET, '/metrics', queryParams);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-project-info.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-project-info.ts
@@ -1,0 +1,21 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getProjectInfo = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getProjectInfo',
+  displayName: 'Get Project Info',
+  description: 'Get detailed information about a specific protocol or project by its ID.',
+  props: {
+    project_id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'The unique identifier for the project (e.g. uniswap, aave, ethereum)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { project_id } = context.propsValue;
+    return makeRequest(context.auth as string, HttpMethod.GET, `/projects/${project_id}`);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/actions/get-project-metrics.ts
+++ b/packages/pieces/community/token-terminal/src/lib/actions/get-project-metrics.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tokenTerminalAuth, makeRequest } from '../common/token-terminal-api';
+
+export const getProjectMetrics = createAction({
+  auth: tokenTerminalAuth,
+  name: 'getProjectMetrics',
+  displayName: 'Get Project Metrics',
+  description: 'Retrieve revenue, fees, TVL and other financial metrics for a specific protocol.',
+  props: {
+    project_id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'The unique identifier for the project (e.g. uniswap, aave, ethereum)',
+      required: true,
+    }),
+    metric: Property.ShortText({
+      displayName: 'Metric',
+      description: 'Specific metric to retrieve (e.g. revenue, fees, tvl). Leave empty for all metrics.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { project_id, metric } = context.propsValue;
+    const queryParams: Record<string, string> = {};
+    if (metric) queryParams['metric'] = metric;
+    return makeRequest(context.auth as string, HttpMethod.GET, `/projects/${project_id}/metrics`, queryParams);
+  },
+});

--- a/packages/pieces/community/token-terminal/src/lib/common/token-terminal-api.ts
+++ b/packages/pieces/community/token-terminal/src/lib/common/token-terminal-api.ts
@@ -1,0 +1,37 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const BASE_URL = 'https://api.tokenterminal.com/v2';
+
+export const tokenTerminalAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Token Terminal API key. Get one at https://tokenterminal.com/terminal/profile/api',
+  required: true,
+});
+
+export async function makeRequest(
+  apiKey: string,
+  method: HttpMethod,
+  endpoint: string,
+  queryParams?: Record<string, string>
+) {
+  const url = new URL(`${BASE_URL}${endpoint}`);
+  if (queryParams) {
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (value !== undefined && value !== '') {
+        url.searchParams.append(key, value);
+      }
+    });
+  }
+
+  const response = await httpClient.sendRequest({
+    method,
+    url: url.toString(),
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return response.body;
+}

--- a/packages/pieces/community/token-terminal/tsconfig.json
+++ b/packages/pieces/community/token-terminal/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/token-terminal/tsconfig.lib.json
+++ b/packages/pieces/community/token-terminal/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/wonderland/.eslintrc.json
+++ b/packages/pieces/community/wonderland/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/wonderland/README.md
+++ b/packages/pieces/community/wonderland/README.md
@@ -1,0 +1,16 @@
+# Wonderland (TIME) Piece for Activepieces
+
+Wonderland is a decentralized reserve currency protocol built on the Avalanche blockchain, forked from OlympusDAO. Users stake TIME tokens to earn rebase rewards and receive MEMO (staked TIME). wMEMO is the wrapped version of MEMO.
+
+## Actions
+
+- **Get Protocol TVL** — Fetch total value locked across all chains via DeFiLlama
+- **Get TIME Price** — Fetch current TIME token price, market cap, and volume via CoinGecko
+- **Get wMEMO Price** — Fetch current wMEMO token price, market cap, and volume via CoinGecko
+- **Get Chain Breakdown** — Fetch TVL breakdown by blockchain chain via DeFiLlama
+- **Get TVL History** — Fetch the last 30 days of historical TVL data via DeFiLlama
+
+## APIs Used
+
+- [DeFiLlama API](https://defillama.com/docs/api) — Free, no authentication required
+- [CoinGecko API](https://www.coingecko.com/en/api) — Free tier, no authentication required

--- a/packages/pieces/community/wonderland/package.json
+++ b/packages/pieces/community/wonderland/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-wonderland",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/wonderland/src/index.ts
+++ b/packages/pieces/community/wonderland/src/index.ts
@@ -1,0 +1,26 @@
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getProtocolTvl } from './lib/actions/get-protocol-tvl';
+import { getTimePrice } from './lib/actions/get-time-price';
+import { getWmemoPrice } from './lib/actions/get-wmemo-price';
+import { getChainBreakdown } from './lib/actions/get-chain-breakdown';
+import { getTvlHistory } from './lib/actions/get-tvl-history';
+
+export const wonderland = createPiece({
+  displayName: 'Wonderland (TIME)',
+  description:
+    'Fetch on-chain data for Wonderland — a decentralized reserve currency protocol on Avalanche (forked from OlympusDAO). Monitor TIME and wMEMO token prices, protocol TVL, and chain breakdowns.',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/wonderland.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE],
+  auth: PieceAuth.None(),
+  actions: [
+    getProtocolTvl,
+    getTimePrice,
+    getWmemoPrice,
+    getChainBreakdown,
+    getTvlHistory,
+  ],
+  authors: ['bossco7598'],
+  triggers: [],
+});

--- a/packages/pieces/community/wonderland/src/lib/actions/get-chain-breakdown.ts
+++ b/packages/pieces/community/wonderland/src/lib/actions/get-chain-breakdown.ts
@@ -1,0 +1,32 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getChainBreakdown = createAction({
+  name: 'get_chain_breakdown',
+  displayName: 'Get Chain Breakdown',
+  description: 'Fetch the TVL breakdown by blockchain chain for the Wonderland protocol via DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/wonderland',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const currentChainTvls = data['currentChainTvls'] as Record<string, number> | undefined;
+
+    const chains = currentChainTvls
+      ? Object.entries(currentChainTvls)
+          .map(([chain, tvl]) => ({ chain, tvl }))
+          .sort((a, b) => b.tvl - a.tvl)
+      : [];
+
+    const totalTvl = chains.reduce((sum, c) => sum + c.tvl, 0);
+
+    return {
+      total_tvl: totalTvl,
+      chain_count: chains.length,
+      chains,
+    };
+  },
+});

--- a/packages/pieces/community/wonderland/src/lib/actions/get-protocol-tvl.ts
+++ b/packages/pieces/community/wonderland/src/lib/actions/get-protocol-tvl.ts
@@ -1,0 +1,28 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getProtocolTvl = createAction({
+  name: 'get_protocol_tvl',
+  displayName: 'Get Protocol TVL',
+  description: 'Fetch the total value locked (TVL) for the Wonderland protocol across all chains via DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/wonderland',
+    });
+
+    const data = response.body as Record<string, unknown>;
+
+    return {
+      name: data['name'],
+      symbol: data['symbol'],
+      chain: data['chain'],
+      tvl: data['tvl'],
+      currentChainTvls: data['currentChainTvls'],
+      description: data['description'],
+      url: data['url'],
+      twitter: data['twitter'],
+    };
+  },
+});

--- a/packages/pieces/community/wonderland/src/lib/actions/get-time-price.ts
+++ b/packages/pieces/community/wonderland/src/lib/actions/get-time-price.ts
@@ -1,0 +1,33 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getTimePrice = createAction({
+  name: 'get_time_price',
+  displayName: 'Get TIME Price',
+  description: 'Fetch the current price, market cap, and 24h volume for the TIME token via CoinGecko.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.coingecko.com/api/v3/coins/wonderland',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const marketData = data['market_data'] as Record<string, unknown> | undefined;
+    const currentPrice = marketData?.['current_price'] as Record<string, number> | undefined;
+    const marketCap = marketData?.['market_cap'] as Record<string, number> | undefined;
+    const totalVolume = marketData?.['total_volume'] as Record<string, number> | undefined;
+    const priceChangePercentage24h = marketData?.['price_change_percentage_24h'] as number | undefined;
+
+    return {
+      id: data['id'],
+      symbol: data['symbol'],
+      name: data['name'],
+      price_usd: currentPrice?.['usd'],
+      market_cap_usd: marketCap?.['usd'],
+      total_volume_usd: totalVolume?.['usd'],
+      price_change_percentage_24h: priceChangePercentage24h,
+      last_updated: marketData?.['last_updated'],
+    };
+  },
+});

--- a/packages/pieces/community/wonderland/src/lib/actions/get-tvl-history.ts
+++ b/packages/pieces/community/wonderland/src/lib/actions/get-tvl-history.ts
@@ -1,0 +1,40 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getTvlHistory = createAction({
+  name: 'get_tvl_history',
+  displayName: 'Get TVL History',
+  description: 'Fetch the last 30 days of historical TVL data for the Wonderland protocol via DeFiLlama.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.llama.fi/protocol/wonderland',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const tvlHistory = data['tvl'] as Array<{ date: number; totalLiquidityUSD: number }> | undefined;
+
+    if (!tvlHistory || tvlHistory.length === 0) {
+      return { history: [], data_points: 0 };
+    }
+
+    // Take the last 30 entries
+    const last30Days = tvlHistory.slice(-30).map((entry) => ({
+      date: new Date(entry.date * 1000).toISOString().split('T')[0],
+      timestamp: entry.date,
+      tvl_usd: entry.totalLiquidityUSD,
+    }));
+
+    const latestTvl = last30Days[last30Days.length - 1]?.tvl_usd ?? 0;
+    const earliestTvl = last30Days[0]?.tvl_usd ?? 0;
+    const tvlChange30d = earliestTvl > 0 ? ((latestTvl - earliestTvl) / earliestTvl) * 100 : 0;
+
+    return {
+      data_points: last30Days.length,
+      latest_tvl_usd: latestTvl,
+      tvl_change_30d_percent: Math.round(tvlChange30d * 100) / 100,
+      history: last30Days,
+    };
+  },
+});

--- a/packages/pieces/community/wonderland/src/lib/actions/get-wmemo-price.ts
+++ b/packages/pieces/community/wonderland/src/lib/actions/get-wmemo-price.ts
@@ -1,0 +1,33 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction } from '@activepieces/pieces-framework';
+
+export const getWmemoPrice = createAction({
+  name: 'get_wmemo_price',
+  displayName: 'Get wMEMO Price',
+  description: 'Fetch the current price, market cap, and 24h volume for the wMEMO token (wrapped MEMO) via CoinGecko.',
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.coingecko.com/api/v3/coins/wrapped-memory',
+    });
+
+    const data = response.body as Record<string, unknown>;
+    const marketData = data['market_data'] as Record<string, unknown> | undefined;
+    const currentPrice = marketData?.['current_price'] as Record<string, number> | undefined;
+    const marketCap = marketData?.['market_cap'] as Record<string, number> | undefined;
+    const totalVolume = marketData?.['total_volume'] as Record<string, number> | undefined;
+    const priceChangePercentage24h = marketData?.['price_change_percentage_24h'] as number | undefined;
+
+    return {
+      id: data['id'],
+      symbol: data['symbol'],
+      name: data['name'],
+      price_usd: currentPrice?.['usd'],
+      market_cap_usd: marketCap?.['usd'],
+      total_volume_usd: totalVolume?.['usd'],
+      price_change_percentage_24h: priceChangePercentage24h,
+      last_updated: marketData?.['last_updated'],
+    };
+  },
+});

--- a/packages/pieces/community/wonderland/tsconfig.json
+++ b/packages/pieces/community/wonderland/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/wonderland/tsconfig.lib.json
+++ b/packages/pieces/community/wonderland/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/yearn-finance/package.json
+++ b/packages/pieces/community/yearn-finance/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@activepieces/piece-yearn-finance",
+  "version": "0.0.1",
+  "description": "Yearn Finance yield aggregator: vaults, APY, TVL, strategies across 5 chains",
+  "keywords": [
+    "activepieces",
+    "yearn",
+    "defi",
+    "yield",
+    "vault",
+    "apy"
+  ],
+  "homepage": "",
+  "bugs": {
+    "url": "https://github.com/activepieces/activepieces/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/activepieces/activepieces.git"
+  },
+  "license": "MIT",
+  "author": "",
+  "main": "./src/index.ts",
+  "scripts": {
+    "publish-piece": "node ../../../../.scripts/publish-piece.mjs"
+  },
+  "peerDependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*"
+  }
+}

--- a/packages/pieces/community/zerion/.eslintrc.json
+++ b/packages/pieces/community/zerion/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/zerion/README.md
+++ b/packages/pieces/community/zerion/README.md
@@ -1,0 +1,15 @@
+# Zerion
+
+Zerion is the best way to manage your DeFi portfolio. This piece integrates with the Zerion API to provide DeFi portfolio tracking, wallet analytics, and token intelligence.
+
+## Authentication
+
+You need a Zerion API key. Sign up at [developers.zerion.io](https://developers.zerion.io) to get one.
+
+## Actions
+
+- **Get Wallet Portfolio** - Get total portfolio value, PnL, and chain breakdown for a wallet address
+- **Get Wallet Positions** - Get all token positions with prices for a wallet address
+- **Get Wallet Transactions** - Get transaction history for a wallet address
+- **Get Wallet NFTs** - Get NFT holdings for a wallet address
+- **Get Fungible Info** - Get fungible token info (price, market cap, 24h change) by token ID

--- a/packages/pieces/community/zerion/package.json
+++ b/packages/pieces/community/zerion/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-zerion",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/zerion/src/index.ts
+++ b/packages/pieces/community/zerion/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { zerionAuth } from './lib/auth';
+import { getWalletPortfolioAction } from './lib/actions/get-wallet-portfolio';
+import { getWalletPositionsAction } from './lib/actions/get-wallet-positions';
+import { getWalletTransactionsAction } from './lib/actions/get-wallet-transactions';
+import { getWalletNftsAction } from './lib/actions/get-wallet-nfts';
+import { getFungibleInfoAction } from './lib/actions/get-fungible-info';
+
+export const zerion = createPiece({
+  displayName: 'Zerion',
+  description: 'DeFi portfolio tracking and wallet intelligence. Get portfolio values, token positions, NFTs, transactions, and token market data via the Zerion API.',
+  auth: zerionAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/zerion.png',
+  categories: [PieceCategory.FINANCE, PieceCategory.BUSINESS_INTELLIGENCE],
+  authors: ['bossco7598'],
+  actions: [
+    getWalletPortfolioAction,
+    getWalletPositionsAction,
+    getWalletTransactionsAction,
+    getWalletNftsAction,
+    getFungibleInfoAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-fungible-info.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-fungible-info.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getFungibleInfo } from '../zerion-api';
+
+export const getFungibleInfoAction = createAction({
+  auth: zerionAuth,
+  name: 'get_fungible_info',
+  displayName: 'Get Fungible Token Info',
+  description: 'Get fungible token information including price, market cap, and 24h change by token ID.',
+  props: {
+    fungibleId: Property.ShortText({
+      displayName: 'Token ID',
+      description: 'The Zerion fungible token ID (e.g., "eth" for Ethereum, "0d8d12a7-21b9-4571-a3a7-b6c4a18e3a2d" for ERC-20 tokens).',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { fungibleId, currency } = context.propsValue;
+    return await getFungibleInfo(context.auth, fungibleId, currency ?? 'usd');
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-nfts.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-nfts.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletNfts } from '../zerion-api';
+
+export const getWalletNftsAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_nfts',
+  displayName: 'Get Wallet NFTs',
+  description: 'Get NFT holdings for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display NFT values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency } = context.propsValue;
+    return await getWalletNfts(context.auth, walletAddress, currency ?? 'usd');
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-portfolio.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-portfolio.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletPortfolio } from '../zerion-api';
+
+export const getWalletPortfolioAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_portfolio',
+  displayName: 'Get Wallet Portfolio',
+  description: 'Get total portfolio value, PnL, and chain breakdown for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency } = context.propsValue;
+    return await getWalletPortfolio(context.auth, walletAddress, currency ?? 'usd');
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-positions.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-positions.ts
@@ -1,0 +1,56 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletPositions } from '../zerion-api';
+
+export const getWalletPositionsAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_positions',
+  displayName: 'Get Wallet Positions',
+  description: 'Get all token positions with current prices for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+    filterPositionTypes: Property.StaticDropdown({
+      displayName: 'Position Type Filter',
+      description: 'Filter positions by type.',
+      required: false,
+      defaultValue: 'wallet',
+      options: {
+        options: [
+          { label: 'Wallet (token balances)', value: 'wallet' },
+          { label: 'Deposited (DeFi deposits)', value: 'deposited' },
+          { label: 'Borrowed (DeFi loans)', value: 'borrowed' },
+          { label: 'Locked (staked/locked)', value: 'locked' },
+          { label: 'Staked', value: 'staked' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency, filterPositionTypes } = context.propsValue;
+    return await getWalletPositions(
+      context.auth,
+      walletAddress,
+      currency ?? 'usd',
+      filterPositionTypes ?? 'wallet'
+    );
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/actions/get-wallet-transactions.ts
+++ b/packages/pieces/community/zerion/src/lib/actions/get-wallet-transactions.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zerionAuth } from '../auth';
+import { getWalletTransactions } from '../zerion-api';
+
+export const getWalletTransactionsAction = createAction({
+  auth: zerionAuth,
+  name: 'get_wallet_transactions',
+  displayName: 'Get Wallet Transactions',
+  description: 'Get transaction history for a wallet address.',
+  props: {
+    walletAddress: Property.ShortText({
+      displayName: 'Wallet Address',
+      description: 'The Ethereum wallet address (0x...) or ENS name.',
+      required: true,
+    }),
+    currency: Property.StaticDropdown({
+      displayName: 'Currency',
+      description: 'The currency to display values in.',
+      required: false,
+      defaultValue: 'usd',
+      options: {
+        options: [
+          { label: 'USD', value: 'usd' },
+          { label: 'EUR', value: 'eur' },
+          { label: 'GBP', value: 'gbp' },
+          { label: 'BTC', value: 'btc' },
+          { label: 'ETH', value: 'eth' },
+        ],
+      },
+    }),
+    pageSize: Property.Number({
+      displayName: 'Page Size',
+      description: 'Number of transactions to return (max 100).',
+      required: false,
+      defaultValue: 25,
+    }),
+  },
+  async run(context) {
+    const { walletAddress, currency, pageSize } = context.propsValue;
+    return await getWalletTransactions(
+      context.auth,
+      walletAddress,
+      currency ?? 'usd',
+      String(pageSize ?? 25)
+    );
+  },
+});

--- a/packages/pieces/community/zerion/src/lib/auth.ts
+++ b/packages/pieces/community/zerion/src/lib/auth.ts
@@ -1,0 +1,7 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const zerionAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Zerion API key. Get one at https://developers.zerion.io',
+  required: true,
+});

--- a/packages/pieces/community/zerion/src/lib/zerion-api.ts
+++ b/packages/pieces/community/zerion/src/lib/zerion-api.ts
@@ -1,0 +1,98 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.zerion.io/v1';
+
+function getAuthHeader(apiKey: string): string {
+  return 'Basic ' + Buffer.from(apiKey + ':').toString('base64');
+}
+
+export async function zerionApiCall<T>(
+  apiKey: string,
+  method: HttpMethod,
+  endpoint: string,
+  params?: Record<string, string>
+): Promise<T> {
+  let url = BASE_URL + endpoint;
+  if (params && Object.keys(params).length > 0) {
+    const query = new URLSearchParams(params).toString();
+    url = url + '?' + query;
+  }
+
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url,
+    headers: {
+      Authorization: getAuthHeader(apiKey),
+      Accept: 'application/json',
+    },
+  });
+
+  return response.body;
+}
+
+export async function getWalletPortfolio(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/portfolio',
+    { currency }
+  );
+}
+
+export async function getWalletPositions(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd',
+  filterPositionTypes = 'wallet'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/positions',
+    { currency, 'filter[position_types]': filterPositionTypes }
+  );
+}
+
+export async function getWalletTransactions(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd',
+  pageSize = '25'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/transactions',
+    { currency, 'page[size]': pageSize }
+  );
+}
+
+export async function getWalletNfts(
+  apiKey: string,
+  walletAddress: string,
+  currency = 'usd'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/wallets/' + walletAddress + '/nft-positions',
+    { currency }
+  );
+}
+
+export async function getFungibleInfo(
+  apiKey: string,
+  fungibleId: string,
+  currency = 'usd'
+): Promise<unknown> {
+  return zerionApiCall(
+    apiKey,
+    HttpMethod.GET,
+    '/fungibles/' + fungibleId,
+    { currency }
+  );
+}

--- a/packages/pieces/community/zerion/tsconfig.json
+++ b/packages/pieces/community/zerion/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/zerion/tsconfig.lib.json
+++ b/packages/pieces/community/zerion/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Acala Network — Polkadot DeFi Hub Integration

**Acala** is a decentralized finance hub and Layer-1 parachain built on the Polkadot ecosystem. It offers:
- 🪙 **aUSD** — a decentralized stablecoin
- 💧 **LDOT** — liquid staking derivative for DOT
- 🔄 **AMM DEX** — native decentralized exchange
- 🏛️ **ACA** — governance and utility token

---

## Actions (5 total — no API key required)

| Action | API | Description |
|--------|-----|-------------|
| `get-protocol-tvl` | DeFiLlama `/protocol/acala` | Current Total Value Locked with chain breakdown |
| `get-aca-price` | CoinGecko `/coins/acala` | ACA token price, market cap, 24h volume |
| `get-chain-breakdown` | DeFiLlama `/protocol/acala` | TVL breakdown per chain (Acala, Karura, etc.) |
| `get-tvl-history` | DeFiLlama `/protocol/acala` | Last 30 days of historical TVL data |
| `get-protocol-stats` | DeFiLlama `/protocol/acala` | Aggregated stats: TVL, chains count, category, mcap |

---

## Technical Details

- **Category:** `BUSINESS_INTELLIGENCE`
- **Auth:** None required — all APIs are free and public
- **HTTP Client:** Uses `httpClient` from `@activepieces/pieces-common` exclusively
- **APIs Used:**
  - DeFiLlama: `https://api.llama.fi/protocol/acala` (free, no key)
  - CoinGecko: `https://api.coingecko.com/api/v3/coins/acala` (free, no key)

---

Submitted as part of the Algora MCP Challenge 🏆