### PR TITLE
fix: s3 upload timeout and add PM2 cluster mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -473,7 +473,7 @@
     },
     "packages/pieces/community/ai": {
       "name": "@activepieces/piece-ai",
-      "version": "0.1.21",
+      "version": "0.2.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7471,6 +7471,7 @@
         "@segment/analytics-next": "1.72.0",
         "@segment/analytics-node": "2.2.0",
         "@sentry/node": "7.120.0",
+        "@smithy/node-http-handler": "4.4.14",
         "@socket.io/redis-adapter": "8.3.0",
         "ai": "^6.0.0",
         "ai-gateway-provider": "3.1.1",
@@ -7625,7 +7626,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "dependencies": {
         "deepmerge-ts": "7.1.0",
         "nanoid": "3.3.8",

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,10 +3,12 @@
 export AP_CONTAINER_TYPE="${AP_CONTAINER_TYPE:-WORKER_AND_APP}"
 export AP_WORKERS="${AP_WORKERS:-1}"
 export AP_PORT="${AP_PORT:-80}"
+export AP_PM2_CLUSTER_MODE="${AP_PM2_CLUSTER_MODE:-false}"
 
 echo "AP_CONTAINER_TYPE: $AP_CONTAINER_TYPE"
 echo "AP_WORKERS: $AP_WORKERS"
 echo "AP_PORT: $AP_PORT"
+echo "AP_PM2_CLUSTER_MODE: $AP_PM2_CLUSTER_MODE"
 
 # Auto-generate worker token if not set and JWT secret is available
 if [ -z "$AP_WORKER_TOKEN" ] && [ -n "$AP_JWT_SECRET" ]; then
@@ -27,13 +29,20 @@ fi
 APPS=""
 
 if [ "$AP_CONTAINER_TYPE" = "APP" ] || [ "$AP_CONTAINER_TYPE" = "WORKER_AND_APP" ]; then
+    if [ "$AP_PM2_CLUSTER_MODE" = "true" ]; then
+        APP_INSTANCES=0
+        APP_EXEC_MODE="cluster"
+    else
+        APP_INSTANCES=1
+        APP_EXEC_MODE="fork"
+    fi
     APPS="${APPS}
     {
         name: 'activepieces-app',
         script: 'packages/server/api/dist/src/bootstrap.js',
         node_args: '--enable-source-maps',
-        instances: 1,
-        exec_mode: 'fork',
+        instances: ${APP_INSTANCES},
+        exec_mode: '${APP_EXEC_MODE}',
         env: { AP_CONTAINER_TYPE: 'APP' }
     },"
 fi

--- a/packages/server/api/package.json
+++ b/packages/server/api/package.json
@@ -22,6 +22,7 @@
     "@authenio/samlify-node-xmllint": "2.0.0",
     "@aws-sdk/client-s3": "3.974.0",
     "@aws-sdk/s3-request-presigner": "3.894.0",
+    "@smithy/node-http-handler": "4.4.14",
     "@bull-board/api": "6.10.1",
     "@bull-board/fastify": "6.10.1",
     "@electric-sql/pglite": "0.3.14",

--- a/packages/server/api/src/app/file/s3-helper.ts
+++ b/packages/server/api/src/app/file/s3-helper.ts
@@ -2,6 +2,7 @@ import { Readable } from 'stream'
 import { apId, FileType, isNil, ProjectId } from '@activepieces/shared'
 import { DeleteObjectsCommand, GetObjectCommand, PutObjectCommand, S3, S3ClientConfig } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
 import contentDisposition from 'content-disposition'
 import dayjs from 'dayjs'
 import { FastifyBaseLogger } from 'fastify'
@@ -137,7 +138,12 @@ export const s3Helper = (log: FastifyBaseLogger) => ({
 
 const chunkArray = (array: string[], chunkSize: number) => Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, i) => array.slice(i * chunkSize, (i + 1) * chunkSize))
 
-const getS3Client = () => {
+let cachedS3Client: S3 | null = null
+
+const getS3Client = (): S3 => {
+    if (cachedS3Client) {
+        return cachedS3Client
+    }
     const useIRSA = system.getBoolean(AppSystemProp.S3_USE_IRSA)
     const region = system.get<string>(AppSystemProp.S3_REGION)
     const endpoint = system.get<string>(AppSystemProp.S3_ENDPOINT)
@@ -145,6 +151,11 @@ const getS3Client = () => {
         region,
         forcePathStyle: endpoint ? true : undefined,
         endpoint,
+        requestHandler: new NodeHttpHandler({
+            connectionTimeout: 5_000,
+            requestTimeout: 120_000,
+        }),
+        maxAttempts: 3,
     }
     if (!useIRSA) {
         const accessKeyId = system.getOrThrow<string>(AppSystemProp.S3_ACCESS_KEY_ID)
@@ -154,7 +165,8 @@ const getS3Client = () => {
             secretAccessKey,
         }
     }
-    return new S3(options)
+    cachedS3Client = new S3(options)
+    return cachedS3Client
 }
 
 const getS3BucketName = () => {


### PR DESCRIPTION
## Summary
- **S3 singleton client**: reuse HTTP connection pool instead of creating a new `S3` instance per call, with `connectionTimeout: 5s`, `requestTimeout: 120s`, and `maxAttempts: 3`
- **PM2 cluster mode**: add `AP_PM2_CLUSTER_MODE=true` env var to run the APP process with one instance per CPU core via PM2 cluster mode

## Test plan
- [ ] Deploy to staging, verify S3 ETIMEDOUT errors reduce/disappear
- [ ] Test `AP_PM2_CLUSTER_MODE=true` spins up one APP instance per core
- [ ] Test default behavior (single fork) is unchanged without the flag