### PR TITLE
fix(engine): set step error message when flow log size is exceeded

### DIFF
--- a/packages/server/engine/src/lib/handler/flow-executor.ts
+++ b/packages/server/engine/src/lib/handler/flow-executor.ts
@@ -121,7 +121,8 @@ const failIfLogSizeExceeded = async (flowExecutionContext: FlowExecutorContext, 
             type: action.type,
             status: StepOutputStatus.FAILED,
             output: undefined,
-        }))
+        })
+        .setErrorMessage('Flow run data size exceeded the maximum allowed size'))
         .setVerdict({
             status: FlowRunStatus.LOG_SIZE_EXCEEDED,
             failedStep: {

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -78,7 +78,7 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData> = {
                     return {}
                 }
                 if (e.error.code === ErrorCode.SANDBOX_LOG_SIZE_EXCEEDED) {
-                    await reportFlowStatus(ctx, data, FlowRunStatus.INTERNAL_ERROR)
+                    await reportFlowStatus(ctx, data, FlowRunStatus.LOG_SIZE_EXCEEDED)
                     return {}
                 }
             }


### PR DESCRIPTION
  Summary                                                         
                                                                                                                                       
  - Set errorMessage on the step output in failIfLogSizeExceeded so the frontend displays the actual error instead of "No output"
  - Fix worker reporting INTERNAL_ERROR instead of LOG_SIZE_EXCEEDED when the sandbox catches a log size exceeded error     