### PR TITLE
fix: handle missing piece metadata & webhook URL double-slash

### DIFF
--- a/packages/server/worker/src/lib/execute/jobs/execute-polling.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-polling.ts
@@ -42,7 +42,7 @@ export const executePollingJob: JobHandler<PollingJobData> = {
                 {
                     hookType: TriggerHookType.RUN,
                     flowVersion,
-                    webhookUrl: getWebhookUrl(settings.PUBLIC_URL, data.flowId),
+                    webhookUrl: getWebhookUrl(ctx.publicApiUrl, data.flowId),
                     test: false,
                     projectId: data.projectId,
                     platformId: data.platformId,

--- a/packages/server/worker/src/lib/execute/jobs/execute-trigger-hook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-trigger-hook.ts
@@ -39,7 +39,7 @@ export const executeTriggerHookJob: JobHandler<ExecuteTriggerHookJobData> = {
                 {
                     hookType: data.hookType,
                     flowVersion,
-                    webhookUrl: getWebhookUrl(settings.PUBLIC_URL, data.flowId, data.test),
+                    webhookUrl: getWebhookUrl(ctx.publicApiUrl, data.flowId, data.test),
                     triggerPayload: data.triggerPayload,
                     test: data.test,
                     projectId: data.projectId,

--- a/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
@@ -47,7 +47,7 @@ export const executeWebhookJob: JobHandler<WebhookJobData> = {
             return {}
         }
 
-        const { appWebhookUrl, webhookSecret } = getAppWebhookDetails(flowVersion, settings.PUBLIC_URL, settings.APP_WEBHOOK_SECRETS)
+        const { appWebhookUrl, webhookSecret } = getAppWebhookDetails(flowVersion, ctx.publicApiUrl, settings.APP_WEBHOOK_SECRETS)
 
         const provisioned = await provisionFlowPieces({ flowVersion, platformId: data.platformId, flowId: data.flowId, projectId: data.projectId, log: ctx.log, apiClient: ctx.apiClient })
         if (!provisioned) {
@@ -68,7 +68,7 @@ export const executeWebhookJob: JobHandler<WebhookJobData> = {
                     {
                         hookType: TriggerHookType.RUN,
                         flowVersion,
-                        webhookUrl: getWebhookUrl(settings.PUBLIC_URL, data.flowId, true),
+                        webhookUrl: getWebhookUrl(ctx.publicApiUrl, data.flowId, true),
                         triggerPayload: resolvedPayload as TriggerPayload,
                         test: true,
                         projectId: data.projectId,
@@ -105,7 +105,7 @@ export const executeWebhookJob: JobHandler<WebhookJobData> = {
                 {
                     hookType: TriggerHookType.RUN,
                     flowVersion,
-                    webhookUrl: getWebhookUrl(settings.PUBLIC_URL, data.flowId),
+                    webhookUrl: getWebhookUrl(ctx.publicApiUrl, data.flowId),
                     triggerPayload: resolvedPayload as TriggerPayload,
                     test: false,
                     projectId: data.projectId,

--- a/packages/server/worker/src/lib/execute/jobs/renew-webhook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/renew-webhook.ts
@@ -41,7 +41,7 @@ export const renewWebhookJob: JobHandler<RenewWebhookJobData> = {
                 {
                     hookType: TriggerHookType.RENEW,
                     flowVersion,
-                    webhookUrl: getWebhookUrl(settings.PUBLIC_URL, data.flowId),
+                    webhookUrl: getWebhookUrl(ctx.publicApiUrl, data.flowId),
                     test: false,
                     projectId: data.projectId,
                     platformId: data.platformId,

--- a/packages/server/worker/src/lib/execute/utils/webhook-url.ts
+++ b/packages/server/worker/src/lib/execute/utils/webhook-url.ts
@@ -1,8 +1,10 @@
 export function getWebhookUrl(publicApiUrl: string, flowId: string, simulate?: boolean): string {
     const suffix = simulate ? '/test' : ''
-    return `${publicApiUrl}/v1/webhooks/${flowId}${suffix}`
+    const cleanUrl = publicApiUrl.replace(/\/+$/, '')
+    return `${cleanUrl}/v1/webhooks/${flowId}${suffix}`
 }
 
 export function getAppWebhookUrl(publicApiUrl: string, appName: string): string {
-    return `${publicApiUrl}/v1/app-events/${appName}`
+    const cleanUrl = publicApiUrl.replace(/\/+$/, '')
+    return `${cleanUrl}/v1/app-events/${appName}`
 }

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -195,7 +195,7 @@ async function executeJob(apiClient: WorkerToApiContract, job: ConsumeJobRequest
     })
 }
 
-function ensurePublicApiUrl(publicUrl: string): string {
+export function ensurePublicApiUrl(publicUrl: string): string {
     if (publicUrl.endsWith('/api/')) return publicUrl
     if (publicUrl.endsWith('/api')) return publicUrl + '/'
     if (publicUrl.endsWith('/')) return publicUrl + 'api/'

--- a/packages/server/worker/test/lib/execute/utils/webhook-url.test.ts
+++ b/packages/server/worker/test/lib/execute/utils/webhook-url.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import { getWebhookUrl, getAppWebhookUrl } from '../../../../src/lib/execute/utils/webhook-url'
+import { ensurePublicApiUrl } from '../../../../src/lib/worker'
+
+describe('getWebhookUrl', () => {
+    const flowId = 'flow-123'
+
+    it('strips trailing slash to avoid double slash', () => {
+        expect(getWebhookUrl('https://example.com/api/', flowId))
+            .toBe('https://example.com/api/v1/webhooks/flow-123')
+    })
+
+    it('works when URL has no trailing slash', () => {
+        expect(getWebhookUrl('https://example.com/api', flowId))
+            .toBe('https://example.com/api/v1/webhooks/flow-123')
+    })
+
+    it('handles URL ending in /api/', () => {
+        expect(getWebhookUrl('https://example.com/api/', flowId))
+            .toBe('https://example.com/api/v1/webhooks/flow-123')
+    })
+
+    it('handles URL ending in /api', () => {
+        expect(getWebhookUrl('https://example.com/api', flowId))
+            .toBe('https://example.com/api/v1/webhooks/flow-123')
+    })
+
+    it('appends /test suffix when simulate is true', () => {
+        expect(getWebhookUrl('https://example.com/api/', flowId, true))
+            .toBe('https://example.com/api/v1/webhooks/flow-123/test')
+    })
+
+    it('does not append /test when simulate is false', () => {
+        expect(getWebhookUrl('https://example.com/api/', flowId, false))
+            .toBe('https://example.com/api/v1/webhooks/flow-123')
+    })
+
+    it('does not append /test when simulate is undefined', () => {
+        expect(getWebhookUrl('https://example.com/api/', flowId, undefined))
+            .toBe('https://example.com/api/v1/webhooks/flow-123')
+    })
+})
+
+describe('getAppWebhookUrl', () => {
+    it('strips trailing slash to avoid double slash', () => {
+        expect(getAppWebhookUrl('https://example.com/api/', 'slack'))
+            .toBe('https://example.com/api/v1/app-events/slack')
+    })
+
+    it('works when URL has no trailing slash', () => {
+        expect(getAppWebhookUrl('https://example.com/api', 'slack'))
+            .toBe('https://example.com/api/v1/app-events/slack')
+    })
+
+    it('produces correct path', () => {
+        expect(getAppWebhookUrl('https://example.com/api/', 'google-sheets'))
+            .toBe('https://example.com/api/v1/app-events/google-sheets')
+    })
+})
+
+describe('ensurePublicApiUrl', () => {
+    it('returns as-is when URL already ends with /api/', () => {
+        expect(ensurePublicApiUrl('https://example.com/api/'))
+            .toBe('https://example.com/api/')
+    })
+
+    it('adds trailing slash when URL ends with /api', () => {
+        expect(ensurePublicApiUrl('https://example.com/api'))
+            .toBe('https://example.com/api/')
+    })
+
+    it('appends api/ when URL ends with /', () => {
+        expect(ensurePublicApiUrl('https://example.com/'))
+            .toBe('https://example.com/api/')
+    })
+
+    it('appends /api/ when URL has no trailing slash', () => {
+        expect(ensurePublicApiUrl('https://example.com'))
+            .toBe('https://example.com/api/')
+    })
+})
+
+describe('end-to-end: ensurePublicApiUrl + getWebhookUrl', () => {
+    const flowId = 'flow-456'
+
+    it.each([
+        'https://example.com',
+        'https://example.com/',
+        'https://example.com/api',
+        'https://example.com/api/',
+    ])('produces correct webhook URL for publicUrl=%s', (publicUrl) => {
+        const apiUrl = ensurePublicApiUrl(publicUrl)
+        expect(getWebhookUrl(apiUrl, flowId))
+            .toBe('https://example.com/api/v1/webhooks/flow-456')
+    })
+
+    it.each([
+        'https://example.com',
+        'https://example.com/',
+        'https://example.com/api',
+        'https://example.com/api/',
+    ])('produces correct app webhook URL for publicUrl=%s', (publicUrl) => {
+        const apiUrl = ensurePublicApiUrl(publicUrl)
+        expect(getAppWebhookUrl(apiUrl, 'slack'))
+            .toBe('https://example.com/api/v1/app-events/slack')
+    })
+})
+
+describe('regression: cloud.activepieces.com double-slash bug', () => {
+    const flowId = 'flow-abc'
+
+    it('old behavior would produce double slash — fixed behavior produces correct URL', () => {
+        // Before the fix, PUBLIC_URL was used directly (e.g. "https://cloud.activepieces.com/")
+        // which produced "https://cloud.activepieces.com//v1/webhooks/flow-abc"
+        const publicUrl = 'https://cloud.activepieces.com/'
+        const apiUrl = ensurePublicApiUrl(publicUrl)
+        expect(apiUrl).toBe('https://cloud.activepieces.com/api/')
+        expect(getWebhookUrl(apiUrl, flowId))
+            .toBe('https://cloud.activepieces.com/api/v1/webhooks/flow-abc')
+    })
+
+    it('handles cloud URL without trailing slash', () => {
+        const publicUrl = 'https://cloud.activepieces.com'
+        const apiUrl = ensurePublicApiUrl(publicUrl)
+        expect(getWebhookUrl(apiUrl, flowId))
+            .toBe('https://cloud.activepieces.com/api/v1/webhooks/flow-abc')
+    })
+
+    it('produces correct app webhook URL for cloud', () => {
+        const publicUrl = 'https://cloud.activepieces.com'
+        const apiUrl = ensurePublicApiUrl(publicUrl)
+        expect(getAppWebhookUrl(apiUrl, 'slack'))
+            .toBe('https://cloud.activepieces.com/api/v1/app-events/slack')
+    })
+})


### PR DESCRIPTION
## Summary
- Gracefully handle missing piece metadata in worker jobs by disabling the flow instead of crashing, scoped to `PieceNotFoundError`
- Fix webhook URLs missing the `/api/` prefix — all callers now use `ctx.publicApiUrl` (built via `ensurePublicApiUrl`) instead of `settings.PUBLIC_URL`, and trailing slashes are stripped defensively
- Coerce null cell values to empty string in record service

## Test plan
- [ ] 25 unit tests for webhook URL construction (`webhook-url.test.ts`)
- [ ] 10 unit tests for flow helpers / piece provisioning (`flow-helpers.test.ts`)
- [ ] Full worker test suite passes (73 tests, 7 files)
- [ ] Regression test for exact cloud.activepieces.com double-slash scenario