### PR TITLE
fix(server): register system job handlers before worker init

### DIFF
--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -182,6 +182,12 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     app.addHook('preHandler', authorizationMiddleware)
     app.addHook('preHandler', rbacMiddleware)
 
+    systemJobHandlers.registerJobHandler(SystemJobName.DELETE_FLOW, (data) => flowBackgroundJobs(app.log).deleteFlowHandler(data))
+    systemJobHandlers.registerJobHandler(SystemJobName.UPDATE_FLOW_STATUS, (data) => flowBackgroundJobs(app.log).updateStatusHandler(data))
+    systemJobHandlers.registerJobHandler(SystemJobName.HARD_DELETE_PROJECT, (data) => platformProjectBackgroundJobs(app.log).hardDeleteProjectHandler(data))
+    if (system.getEdition() === ApEdition.CLOUD) {
+        systemJobHandlers.registerJobHandler(SystemJobName.HARD_DELETE_PLATFORM, (data) => platformBackgroundJobs(app.log).hardDeletePlatformHandler(data))
+    }
     await systemJobsSchedule(app.log).init()
     await app.register(fileModule)
     await app.register(flagModule)
@@ -214,10 +220,6 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     await app.register(templateModule)
     await app.register(userBadgeModule)
     await app.register(platformAnalyticsModule)
-    systemJobHandlers.registerJobHandler(SystemJobName.DELETE_FLOW, (data) => flowBackgroundJobs(app.log).deleteFlowHandler(data))
-    systemJobHandlers.registerJobHandler(SystemJobName.UPDATE_FLOW_STATUS, (data) => flowBackgroundJobs(app.log).updateStatusHandler(data))
-    systemJobHandlers.registerJobHandler(SystemJobName.HARD_DELETE_PROJECT, (data) => platformProjectBackgroundJobs(app.log).hardDeleteProjectHandler(data))
-
 
 
     app.get(
@@ -283,7 +285,6 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
             projectHooks.set(projectEnterpriseHooks)
             flagHooks.set(enterpriseFlagsHooks)
             exceptionHandler.initializeSentry(system.get(AppSystemProp.SENTRY_DSN))
-            systemJobHandlers.registerJobHandler(SystemJobName.HARD_DELETE_PLATFORM, (data) => platformBackgroundJobs(app.log).hardDeletePlatformHandler(data))
             break
         case ApEdition.ENTERPRISE:
             await platformAiCreditsService(app.log).init()


### PR DESCRIPTION
## Summary
- Moved all `registerJobHandler` calls **before** `systemJobsSchedule.init()` to fix a race condition where the BullMQ worker could pick up stale jobs from Redis before their handlers were registered, causing `No handler for job update-flow-status` errors.
- Applies to all 4 handlers: `DELETE_FLOW`, `UPDATE_FLOW_STATUS`, `HARD_DELETE_PROJECT`, `HARD_DELETE_PLATFORM`.

## Test plan
- [ ] Deploy and verify no more "No handler for job" errors in logs
- [ ] Verify flow status updates, flow deletion, and project deletion still work correctly