### PR TITLE
fix(server): add missing index on project.platformId

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1773930744000-AddProjectPlatformIdIndex.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1773930744000-AddProjectPlatformIdIndex.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddProjectPlatformIdIndex1773930744000 implements MigrationInterface {
+    name = 'AddProjectPlatformIdIndex1773930744000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS "idx_project_platform_id" ON "project" ("platformId")
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX "idx_project_platform_id"
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -342,6 +342,7 @@ import { AddSecretManagersFlag1771167183104 } from './migration/postgres/1771167
 import { AddSecretManagerConnectionEntity1772000000000 } from './migration/postgres/1772000000000-AddSecretManagerConnectionEntity'
 import { AddPreSelectForNewProjectsToAppConnection1772027509095 } from './migration/postgres/1772027509095-AddPreSelectForNewProjectsToAppConnection'
 import { AddEnabledToolsToMcpServer1772027509096 } from './migration/postgres/1772027509096-AddEnabledToolsToMcpServer'
+import { AddProjectPlatformIdIndex1773930744000 } from './migration/postgres/1773930744000-AddProjectPlatformIdIndex'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -700,6 +701,7 @@ export const getMigrations = (): (new () => MigrationInterface)[] => {
         AddSecretManagerConnectionEntity1772000000000,
         AddPreSelectForNewProjectsToAppConnection1772027509095,
         AddEnabledToolsToMcpServer1772027509096,
+        AddProjectPlatformIdIndex1773930744000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/project/project-entity.ts
+++ b/packages/server/api/src/app/project/project-entity.ts
@@ -88,6 +88,11 @@ export const ProjectEntity = new EntitySchema<ProjectSchema>({
             where: 'deleted IS NULL',
             unique: true,
         },
+        {
+            name: 'idx_project_platform_id',
+            columns: ['platformId'],
+            unique: false,
+        },
     ],
     relations: {
         owner: {


### PR DESCRIPTION
## Summary
- The `project` table had no standalone index on `platformId` — only a partial composite unique index `(platformId, externalId) WHERE deleted IS NULL`
- Queries filtering by `platformId` alone (e.g. `getProjectIdsByPlatform`) fell back to **sequential scans on 262K+ rows**, taking ~1.6s per query
- This caused the `GET /v1/platforms/:id` endpoint to take **9-11 seconds** on production

## Test plan
- [ ] Verify migration runs successfully (`CREATE INDEX IF NOT EXISTS`)
- [ ] Confirm `EXPLAIN ANALYZE SELECT * FROM project WHERE "platformId" = '...'` uses index scan instead of seq scan
- [ ] Confirm `GET /v1/platforms/:id` response time drops from ~11s to <500ms