### PR TITLE
fix: worker configs dialog was closing automatically when workers pag…

### DIFF
--- a/packages/react-ui/src/app/routes/platform/infra/workers/index.tsx
+++ b/packages/react-ui/src/app/routes/platform/infra/workers/index.tsx
@@ -1,7 +1,9 @@
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { t } from 'i18next';
 import {
+  Info,
   InfoIcon,
   Network,
   Server,
@@ -18,7 +20,8 @@ import {
 import { DashboardPageHeader } from '@/app/components/dashboard-page-header';
 import { CircularIcon } from '@/components/custom/circular-icon';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { DataTable } from '@/components/ui/data-table';
+import { Button } from '@/components/ui/button';
+import { DataTable, RowDataWithActions } from '@/components/ui/data-table';
 import { DataTableColumnHeader } from '@/components/ui/data-table/data-table-column-header';
 import { workersApi } from '@/features/platform-admin/lib/workers-api';
 import { flagsHooks } from '@/hooks/flags-hooks';
@@ -96,6 +99,25 @@ export default function WorkersPage() {
     queryFn: async () =>
       showDemoData ? DEMO_WORKERS_DATA : await workersApi.list(),
   });
+
+  const [openWorkerProps, setOpenWorkerProps] = useState<Record<string, string> | null>(null);
+
+  const actions = useMemo(
+    () => [
+      (row: RowDataWithActions<WorkerMachineWithStatus>) => (
+        <Button
+          variant="outline"
+          size="sm"
+          className="flex items-center gap-2"
+          onClick={() => setOpenWorkerProps(row.information.workerProps)}
+        >
+          <Info size={14} />
+          {t('Configs')}
+        </Button>
+      ),
+    ],
+    [],
+  );
 
   return (
     <div className="flex flex-col w-full gap-4">
@@ -306,14 +328,19 @@ export default function WorkersPage() {
             },
           },
         ]}
-        actions={[
-          (row) => (
-            <WorkerConfigsModal workerProps={row.information.workerProps} />
-          ),
-        ]}
+        actions={actions}
         page={{ data: workersData ?? [], previous: '', next: '' }}
         isLoading={isLoading}
       />
+      {openWorkerProps !== null && (
+        <WorkerConfigsModal
+          workerProps={openWorkerProps}
+          isOpen={true}
+          onOpenChange={(open) => {
+            if (!open) setOpenWorkerProps(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/packages/react-ui/src/app/routes/platform/infra/workers/worker-configs-dialog.tsx
+++ b/packages/react-ui/src/app/routes/platform/infra/workers/worker-configs-dialog.tsx
@@ -1,32 +1,27 @@
 import { t } from 'i18next';
-import { Info } from 'lucide-react';
-import React, { useState } from 'react';
+import React from 'react';
 
-import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 
 interface Props {
   workerProps: Record<string, string>;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
-export const WorkerConfigsModal: React.FC<Props> = ({ workerProps }) => {
-  const [isOpen, setIsOpen] = useState(false);
-
+export const WorkerConfigsModal: React.FC<Props> = ({
+  workerProps,
+  isOpen,
+  onOpenChange,
+}) => {
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="flex items-center gap-2">
-          <Info size={14} />
-          {t('Configs')}
-        </Button>
-      </DialogTrigger>
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="w-[95vw] max-w-[600px] max-h-[80vh]">
         <DialogHeader>
           <DialogTitle>{t('Environment Variables')}</DialogTitle>

--- a/packages/react-ui/src/components/ui/data-table/index.tsx
+++ b/packages/react-ui/src/components/ui/data-table/index.tsx
@@ -228,7 +228,7 @@ export function DataTable<
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     ...(clientPagination && { getPaginationRowModel: getPaginationRowModel() }),
-    getRowId: () => apId(),
+    getRowId: (row, index) => row.id ?? String(index),
     initialState: {
       pagination: {
         pageSize: parseInt(startingLimit),


### PR DESCRIPTION
## What does this PR do?

Fixes the Workers Configs dialog being automatically dismissed ~2 seconds after opening due to the polling interval triggering a re-render that unmounted the dialog.

### Explain How the Feature Works

The `WorkerConfigsModal` was rendered inline inside the `actions` array factory function. Every poll cycle re-evaluated `actions`, creating new component instances and unmounting the open dialog.

The fix:
- Lifts modal state (`openWorkerProps`) out of the `actions` array using `useState`
- Wraps `actions` in `useMemo` for referential stability across re-renders
- Renders the dialog as a sibling element in JSX, decoupling its lifecycle from the table
- Fixes `DataTable.getRowId` to use `row.id` as a stable key instead of always generating a random ID via `apId()`

### Relevant User Scenarios

- Navigate to Platform → Infrastructure → Workers
- Click the Configs button on any worker row
- Previously: dialog closes on its own within ~2 seconds
- Now: dialog stays open until explicitly dismissed

Fixes #12033
