### PR TITLE
fix: flush pauseMetadata from Redis to DB when run not yet persisted

### DIFF
--- a/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
+++ b/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
@@ -27,7 +27,7 @@ import { projectService } from '../../project/project-service'
 import { dedupeService } from '../../trigger/dedupe-service'
 import { triggerEventService } from '../../trigger/trigger-events/trigger-event.service'
 import { triggerSourceService } from '../../trigger/trigger-source/trigger-source-service'
-import { RunsMetadataUpsertData } from '../job'
+import { redisMetadataKey, RunsMetadataUpsertData } from '../job'
 import { jobBroker } from '../job-queue/job-broker'
 import { machineService } from '../machine/machine-service'
 
@@ -57,10 +57,23 @@ export function createHandlers(log: FastifyBaseLogger, platformIdForDedicatedWor
 
         async uploadRunLog(input) {
             if (input.pauseMetadata) {
-                await flowRunRepo().update(input.runId, {
+                const result = await flowRunRepo().update(input.runId, {
                     status: input.status,
                     ...spreadIfDefined('pauseMetadata', input.pauseMetadata as PauseMetadata),
                 })
+                if (!result.affected) {
+                    // Run not yet in DB (PRODUCTION runs are created async via queue).
+                    // Force-flush the run metadata from Redis to DB so resume works immediately.
+                    const key = redisMetadataKey(input.runId)
+                    const runMetadata = await distributedStore.hgetJson<RunsMetadataUpsertData>(key)
+                    if (!isNil(runMetadata) && Object.keys(runMetadata).length > 0) {
+                        await flowRunRepo().save({
+                            ...runMetadata,
+                            status: input.status,
+                            pauseMetadata: input.pauseMetadata as PauseMetadata,
+                        })
+                    }
+                }
             }
             const logData: RunsMetadataUpsertData = {
                 id: input.runId,

--- a/packages/server/api/test/integration/ce/flows/flow-run/resume-flow-run.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow-run/resume-flow-run.test.ts
@@ -1,7 +1,10 @@
 import { apId, FlowRunStatus, FlowVersionState, PauseType, RunEnvironment } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
+import { distributedStore } from '../../../../../src/app/database/redis-connections'
 import { pubsub } from '../../../../../src/app/helper/pubsub'
 import { engineResponseWatcher } from '../../../../../src/app/workers/engine-response-watcher'
+import { redisMetadataKey, RunsMetadataUpsertData } from '../../../../../src/app/workers/job'
+import { createHandlers } from '../../../../../src/app/workers/rpc/worker-rpc-service'
 import { createTestContext, TestContext } from '../../../../helpers/test-context'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../../helpers/test-setup'
 import { createMockFlow, createMockFlowRun, createMockFlowVersion } from '../../../../helpers/mocks'
@@ -149,6 +152,66 @@ describe('Resume flow run', () => {
         })
 
         expect(response.statusCode).toBe(404)
+    })
+
+    it('should persist pauseMetadata to DB when run only exists in Redis (race condition)', async () => {
+        const flow = createMockFlow({ projectId: ctx.project.id })
+        await db.save('flow', flow)
+
+        const flowVersion = createMockFlowVersion({
+            flowId: flow.id,
+            state: FlowVersionState.LOCKED,
+        })
+        await db.save('flow_version', flowVersion)
+
+        const runId = apId()
+        const requestId = apId()
+
+        // Simulate queueOrCreateInstantly: run metadata is in Redis but NOT in DB
+        const runMetadata: RunsMetadataUpsertData = {
+            id: runId,
+            projectId: ctx.project.id,
+            flowId: flow.id,
+            flowVersionId: flowVersion.id,
+            environment: RunEnvironment.PRODUCTION,
+            status: FlowRunStatus.RUNNING,
+        }
+        await distributedStore.merge(redisMetadataKey(runId), runMetadata)
+
+        // Call uploadRunLog with pauseMetadata — run does NOT exist in DB yet
+        const handlers = createHandlers(app.log)
+        await handlers.uploadRunLog({
+            runId,
+            projectId: ctx.project.id,
+            status: FlowRunStatus.PAUSED,
+            workerHandlerId: null,
+            httpRequestId: null,
+            pauseMetadata: {
+                type: PauseType.WEBHOOK,
+                requestId,
+                response: {},
+            },
+        })
+
+        // Verify the run was force-flushed to DB with pauseMetadata
+        const dbRun = await db.findOneBy<{ id: string, status: string, pauseMetadata: unknown }>('flow_run', { id: runId })
+        expect(dbRun).not.toBeNull()
+        expect(dbRun!.status).toBe(FlowRunStatus.PAUSED)
+        expect(dbRun!.pauseMetadata).toEqual(expect.objectContaining({
+            type: PauseType.WEBHOOK,
+            requestId,
+        }))
+
+        // Verify resume endpoint works with the persisted pauseMetadata
+        const response = await app.inject({
+            method: 'POST',
+            url: `/api/v1/flow-runs/${runId}/requests/${requestId}`,
+            body: {
+                status: 'success',
+                data: { greeting: 'Hello' },
+            },
+        })
+        expect(response.statusCode).toBe(200)
     })
 
     it('sync: should accept request when DB has matching requestId', async () => {


### PR DESCRIPTION
## Summary
- PRODUCTION runs are created asynchronously via a BullMQ queue, so the DB row may not exist when the engine calls `uploadRunLog` with `pauseMetadata`
- When the direct DB update affects 0 rows (run not yet in DB), the fix reads the full run metadata from the Redis hash and saves it to DB so resume requests work immediately
- Added integration test that simulates the race condition (run in Redis only) and verifies pauseMetadata is persisted and resume works

## Test plan
- [ ] Existing resume tests pass: `npx nx test server-api --testPathPattern="resume-flow-run"`
- [ ] New test verifies the race condition fix (run only in Redis → pauseMetadata flushed to DB)
- [ ] Manual: trigger a flow where the first action is a Delay step in PRODUCTION, verify pauseMetadata appears in DB immediately