### PR TITLE
fix(ci): prevent build race condition and increase deletion test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,16 +101,7 @@ jobs:
           npx turbo run test --filter=@activepieces/engine --filter=@activepieces/shared &
           pids+=($!)
 
-          npx turbo run test-ce --filter=api &
-          pids+=($!)
-
-          npx turbo run test-ee --filter=api &
-          pids+=($!)
-
-          npx turbo run test-cloud --filter=api &
-          pids+=($!)
-
-          npx turbo run check-migrations --filter=api &
+          npx turbo run test-ce test-ee test-cloud check-migrations --filter=api &
           pids+=($!)
 
           status=0

--- a/packages/server/api/test/integration/cloud/platform/platform.test.ts
+++ b/packages/server/api/test/integration/cloud/platform/platform.test.ts
@@ -19,7 +19,7 @@ import { checkIfSolutionExistsInDb, createMockConnection, createMockFlow, create
 
 let app: FastifyInstance | null = null
 
-async function waitForDeletionJobs(jobIds: string[], timeoutMs = 30000) {
+async function waitForDeletionJobs(jobIds: string[], timeoutMs = 60000) {
     const start = Date.now()
     for (const jobId of jobIds) {
         while (Date.now() - start < timeoutMs) {


### PR DESCRIPTION
## Summary
- **Build race condition**: Running 4 separate `turbo run` processes for api tests in parallel caused multiple `tsc` instances to write to the same `dist/` directories simultaneously (`pieces-common`), resulting in intermittent `TS2305: Module has no exported member` errors (e.g. piece-slack build failures). Fixed by consolidating into a single `turbo run test-ce test-ee test-cloud check-migrations --filter=api` invocation so turbo's internal scheduler handles dependencies correctly.
- **Flaky deletion timeout**: The `waitForDeletionJobs` timeout in `platform.test.ts` was 30s, but CI runners under load regularly exceed this (30558ms observed). Increased to 60s.

## Test plan
- [x] Platform tests pass locally (14/14)
- [x] CI should no longer hit the piece-slack build race condition
- [x] Deletion test has sufficient timeout headroom for CI