### PR TITLE
fix: propagate actual error through engine response watcher on INTERNAL_ERROR

### DIFF
--- a/packages/server/api/src/app/workers/job-queue/job-broker.ts
+++ b/packages/server/api/src/app/workers/job-queue/job-broker.ts
@@ -1,4 +1,4 @@
-import { ConsumeJobRequest, ConsumeJobResponse, ConsumeJobResponseStatus, ExecutionType, isNil, JobData, tryCatch } from '@activepieces/shared'
+import { ConsumeJobRequest, ConsumeJobResponse, ConsumeJobResponseStatus, EngineResponseStatus, ExecutionType, isNil, JobData, tryCatch } from '@activepieces/shared'
 import { Worker as BullMQWorker, Job } from 'bullmq'
 import { BullMQOtel } from 'bullmq-otel'
 import { FastifyBaseLogger } from 'fastify'
@@ -178,7 +178,11 @@ export const jobBroker = (log: FastifyBaseLogger) => ({
             if (input.status === ConsumeJobResponseStatus.INTERNAL_ERROR) {
                 await job.moveToFailed(new Error(input.errorMessage ?? 'Internal error'), token)
                 if (userJobData) {
-                    await engineResponseWatcher(log).publish(userJobData.webserverId, userJobData.requestId, undefined)
+                    await engineResponseWatcher(log).publish(userJobData.webserverId, userJobData.requestId, {
+                        status: EngineResponseStatus.INTERNAL_ERROR,
+                        response: undefined,
+                        error: input.errorMessage ?? 'Internal error',
+                    })
                 }
                 return
             }
@@ -191,7 +195,11 @@ export const jobBroker = (log: FastifyBaseLogger) => ({
         if (error) {
             log.error({ jobId: input.jobId, error: String(error) }, '[jobBroker] Failed to move job to final state')
             if (userJobData) {
-                await engineResponseWatcher(log).publish(userJobData.webserverId, userJobData.requestId, undefined)
+                await engineResponseWatcher(log).publish(userJobData.webserverId, userJobData.requestId, {
+                    status: EngineResponseStatus.INTERNAL_ERROR,
+                    response: undefined,
+                    error: String(error),
+                })
             }
         }
 

--- a/packages/server/api/test/integration/ce/workers/job-broker-error-propagation.test.ts
+++ b/packages/server/api/test/integration/ce/workers/job-broker-error-propagation.test.ts
@@ -1,0 +1,172 @@
+import { FastifyInstance } from 'fastify'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+import { mockAndSaveBasicSetup } from '../../../helpers/mocks'
+import { jobBroker } from '../../../../src/app/workers/job-queue/job-broker'
+import { jobQueue, JobType } from '../../../../src/app/workers/job-queue/job-queue'
+import { engineResponseWatcher } from '../../../../src/app/workers/engine-response-watcher'
+import {
+    apId,
+    ConsumeJobResponseStatus,
+    EngineResponseStatus,
+    LATEST_JOB_DATA_SCHEMA_VERSION,
+    TriggerHookType,
+    WorkerJobType,
+} from '@activepieces/shared'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+    await jobBroker(app.log).init()
+})
+
+afterAll(async () => {
+    await jobBroker(app.log).close()
+    await teardownTestEnvironment()
+})
+
+describe('Job broker error propagation', () => {
+    it('should propagate INTERNAL_ERROR with errorMessage through engine response watcher', async () => {
+        const { mockPlatform, mockProject } = await mockAndSaveBasicSetup()
+        const requestId = apId()
+        const webserverId = engineResponseWatcher(app.log).getServerId()
+
+        const jobData = {
+            jobType: WorkerJobType.EXECUTE_TRIGGER_HOOK,
+            platformId: mockPlatform.id,
+            projectId: mockProject.id,
+            schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
+            flowId: apId(),
+            flowVersionId: apId(),
+            test: false,
+            hookType: TriggerHookType.ON_ENABLE,
+            requestId,
+            webserverId,
+        }
+
+        const jobId = apId()
+        await jobQueue(app.log).add({
+            type: JobType.ONE_TIME,
+            id: jobId,
+            data: jobData,
+        })
+
+        await jobBroker(app.log).poll()
+
+        const listenerPromise = engineResponseWatcher(app.log).oneTimeListener(
+            requestId,
+            true,
+            5000,
+            undefined,
+        )
+
+        await jobBroker(app.log).completeJob({
+            jobId,
+            status: ConsumeJobResponseStatus.INTERNAL_ERROR,
+            errorMessage: 'Sandbox timeout',
+        })
+
+        const result = await listenerPromise
+        expect(result).toEqual({
+            status: EngineResponseStatus.INTERNAL_ERROR,
+            response: undefined,
+            error: 'Sandbox timeout',
+        })
+    })
+
+    it('should use default error message when INTERNAL_ERROR has no errorMessage', async () => {
+        const { mockPlatform, mockProject } = await mockAndSaveBasicSetup()
+        const requestId = apId()
+        const webserverId = engineResponseWatcher(app.log).getServerId()
+
+        const jobData = {
+            jobType: WorkerJobType.EXECUTE_TRIGGER_HOOK,
+            platformId: mockPlatform.id,
+            projectId: mockProject.id,
+            schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
+            flowId: apId(),
+            flowVersionId: apId(),
+            test: false,
+            hookType: TriggerHookType.ON_ENABLE,
+            requestId,
+            webserverId,
+        }
+
+        const jobId = apId()
+        await jobQueue(app.log).add({
+            type: JobType.ONE_TIME,
+            id: jobId,
+            data: jobData,
+        })
+
+        await jobBroker(app.log).poll()
+
+        const listenerPromise = engineResponseWatcher(app.log).oneTimeListener(
+            requestId,
+            true,
+            5000,
+            undefined,
+        )
+
+        await jobBroker(app.log).completeJob({
+            jobId,
+            status: ConsumeJobResponseStatus.INTERNAL_ERROR,
+        })
+
+        const result = await listenerPromise
+        expect(result).toEqual({
+            status: EngineResponseStatus.INTERNAL_ERROR,
+            response: undefined,
+            error: 'Internal error',
+        })
+    })
+
+    it('should pass through OK response as-is (regression guard)', async () => {
+        const { mockPlatform, mockProject } = await mockAndSaveBasicSetup()
+        const requestId = apId()
+        const webserverId = engineResponseWatcher(app.log).getServerId()
+
+        const jobData = {
+            jobType: WorkerJobType.EXECUTE_TRIGGER_HOOK,
+            platformId: mockPlatform.id,
+            projectId: mockProject.id,
+            schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
+            flowId: apId(),
+            flowVersionId: apId(),
+            test: false,
+            hookType: TriggerHookType.ON_ENABLE,
+            requestId,
+            webserverId,
+        }
+
+        const jobId = apId()
+        await jobQueue(app.log).add({
+            type: JobType.ONE_TIME,
+            id: jobId,
+            data: jobData,
+        })
+
+        await jobBroker(app.log).poll()
+
+        const expectedResponse = {
+            status: EngineResponseStatus.OK,
+            response: { message: 'trigger enabled' },
+        }
+
+        const listenerPromise = engineResponseWatcher(app.log).oneTimeListener(
+            requestId,
+            true,
+            5000,
+            undefined,
+        )
+
+        await jobBroker(app.log).completeJob({
+            jobId,
+            status: ConsumeJobResponseStatus.OK,
+            response: expectedResponse,
+        })
+
+        const result = await listenerPromise
+        expect(result).toEqual(expectedResponse)
+    })
+})


### PR DESCRIPTION
## Summary
- When a worker reports `INTERNAL_ERROR` for a user-interaction job (e.g., `EXECUTE_TRIGGER_HOOK`), the job broker was publishing `undefined` to the engine response watcher instead of the actual error message
- This caused `assertEngineResponseIsOk()` to throw a generic `"Engine response is undefined"` error, losing the real error — resulting in 335 failed system jobs in Redis and 146 flows stuck with non-NONE `operationStatus`
- Now publishes a structured `{ status: INTERNAL_ERROR, response: undefined, error: ... }` object so the downstream handler surfaces the actual error

## Test plan
- [x] Added integration test `job-broker-error-propagation.test.ts` with 3 cases:
  - INTERNAL_ERROR with errorMessage → propagates actual error string
  - INTERNAL_ERROR without errorMessage → defaults to `'Internal error'`
  - OK response passes through as-is (regression guard)
- [x] All 3 tests pass against real Redis/BullMQ/pub-sub (no mocks)