### PR TITLE
fix: batch-delete flow_run rows and add missing cascade indices

### DIFF
--- a/packages/server/api/src/app/analytics/platform-analytics-report.entity.ts
+++ b/packages/server/api/src/app/analytics/platform-analytics-report.entity.ts
@@ -35,6 +35,13 @@ export const PlatformAnalyticsReportEntity = new EntitySchema<PlatformAnalyticsR
             nullable: false,
         },
     },    
+    indices: [
+        {
+            name: 'idx_platform_analytics_report_platform_id',
+            columns: ['platformId'],
+            unique: false,
+        },
+    ],
     relations: {
         platform: {
             target: 'platform',

--- a/packages/server/api/src/app/database/migration/postgres/1774100000000-AddMissingCascadeDeleteIndices.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1774100000000-AddMissingCascadeDeleteIndices.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddMissingCascadeDeleteIndices1774100000000 implements MigrationInterface {
+    name = 'AddMissingCascadeDeleteIndices1774100000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('CREATE INDEX "idx_table_webhook_flow_id" ON "table_webhook" ("flowId")')
+        await queryRunner.query('CREATE INDEX "idx_template_platform_id" ON "template" ("platformId")')
+        await queryRunner.query('CREATE INDEX "idx_custom_domain_platform_id" ON "custom_domain" ("platformId")')
+        await queryRunner.query('CREATE INDEX "idx_platform_analytics_report_platform_id" ON "platform_analytics_report" ("platformId")')
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP INDEX "idx_platform_analytics_report_platform_id"')
+        await queryRunner.query('DROP INDEX "idx_custom_domain_platform_id"')
+        await queryRunner.query('DROP INDEX "idx_template_platform_id"')
+        await queryRunner.query('DROP INDEX "idx_table_webhook_flow_id"')
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -345,6 +345,7 @@ import { AddEnabledToolsToMcpServer1772027509096 } from './migration/postgres/17
 import { AddFlowProjectIdStatusIndex1772027509097 } from './migration/postgres/1772027509097-AddFlowProjectIdStatusIndex'
 import { AddProjectPlatformIdIndex1773930744000 } from './migration/postgres/1773930744000-AddProjectPlatformIdIndex'
 import { ReAddAgentsEnabledToPlatformPlan1774000000000 } from './migration/postgres/1774000000000-ReAddAgentsEnabledToPlatformPlan'
+import { AddMissingCascadeDeleteIndices1774100000000 } from './migration/postgres/1774100000000-AddMissingCascadeDeleteIndices'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -706,6 +707,7 @@ export const getMigrations = (): (new () => MigrationInterface)[] => {
         AddFlowProjectIdStatusIndex1772027509097,
         AddProjectPlatformIdIndex1773930744000,
         ReAddAgentsEnabledToPlatformPlan1774000000000,
+        AddMissingCascadeDeleteIndices1774100000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/ee/custom-domains/custom-domain.entity.ts
+++ b/packages/server/api/src/app/ee/custom-domains/custom-domain.entity.ts
@@ -34,6 +34,11 @@ export const CustomDomainEntity = new EntitySchema<CustomDomainSchema>({
             unique: true,
             columns: ['domain'],
         },
+        {
+            name: 'idx_custom_domain_platform_id',
+            columns: ['platformId'],
+            unique: false,
+        },
     ],
     relations: {
         platform: {

--- a/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
@@ -1,11 +1,12 @@
 import { AppConnectionScope, assertNotNullOrUndefined } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { ArrayContains, In } from 'typeorm'
+import { ArrayContains } from 'typeorm'
 import { appConnectionsRepo } from '../../app-connection/app-connection-service/app-connection-service'
 import { repoFactory } from '../../core/db/repo-factory'
 import { transaction } from '../../core/db/transaction'
 import { flowExecutionCache } from '../../flows/flow/flow-execution-cache'
 import { flowSideEffects } from '../../flows/flow/flow-service-side-effects'
+import { batchDeleteByFlowId } from '../../flows/flow/flow.jobs'
 import { flowRepo } from '../../flows/flow/flow.repo'
 import { SystemJobData, SystemJobName } from '../../helper/system-jobs/common'
 import { systemJobsSchedule } from '../../helper/system-jobs/system-job'
@@ -41,10 +42,12 @@ export const platformProjectBackgroundJobs = (log: FastifyBaseLogger) => ({
 
         const flowIds = allFlows.map(flow => flow.id)
 
+        for (const flowId of flowIds) {
+            await batchDeleteByFlowId(flowId)
+            await flowRepo().delete({ id: flowId })
+        }
+
         await transaction(async (entityManager) => {
-            if (flowIds.length > 0) {
-                await flowRepo(entityManager).delete({ id: In(flowIds) })
-            }
             await appConnectionsRepo(entityManager).delete({
                 scope: AppConnectionScope.PROJECT,
                 projectIds: ArrayContains([projectId]),

--- a/packages/server/api/src/app/flows/flow/flow.jobs.ts
+++ b/packages/server/api/src/app/flows/flow/flow.jobs.ts
@@ -3,11 +3,32 @@ import { FastifyBaseLogger } from 'fastify'
 import { websocketService } from '../../core/websockets.service'
 import { SystemJobData, SystemJobName } from '../../helper/system-jobs/common'
 import { systemJobsSchedule } from '../../helper/system-jobs/system-job'
-import { flowVersionService } from '../flow-version/flow-version.service'
+import { flowRunRepo } from '../flow-run/flow-run-service'
+import { flowVersionRepo, flowVersionService } from '../flow-version/flow-version.service'
 import { flowExecutionCache } from './flow-execution-cache'
 import { flowSideEffects } from './flow-service-side-effects'
 import { flowRepo } from './flow.repo'
 import { flowService } from './flow.service'
+
+const BATCH_SIZE = 1000
+
+export async function batchDeleteByFlowId(flowId: string): Promise<void> {
+    let deleted: number
+    do {
+        const result = await flowRunRepo()
+            .createQueryBuilder()
+            .delete()
+            .where('id IN (SELECT id FROM flow_run WHERE "flowId" = :flowId LIMIT :limit)', { flowId, limit: BATCH_SIZE })
+            .execute()
+        deleted = result.affected ?? 0
+    } while (deleted > 0)
+
+    await flowVersionRepo()
+        .createQueryBuilder()
+        .delete()
+        .where('"flowId" = :flowId', { flowId })
+        .execute()
+}
 
 export const flowBackgroundJobs = (log: FastifyBaseLogger) => ({
 
@@ -31,6 +52,7 @@ export const flowBackgroundJobs = (log: FastifyBaseLogger) => ({
                 preDeleteDone: true,
             })
         }
+        await batchDeleteByFlowId(flow.id)
         await flowRepo().delete({ id: flow.id })
         await flowExecutionCache(log).invalidate(flow.id)
     },

--- a/packages/server/api/src/app/tables/table/table-webhook.entity.ts
+++ b/packages/server/api/src/app/tables/table/table-webhook.entity.ts
@@ -29,6 +29,13 @@ export const TableWebhookEntity = new EntitySchema<TableWebhookSchema>({
             nullable: false,
         },
     },
+    indices: [
+        {
+            name: 'idx_table_webhook_flow_id',
+            columns: ['flowId'],
+            unique: false,
+        },
+    ],
     relations: {
         project: {
             type: 'many-to-one',

--- a/packages/server/api/src/app/template/template.entity.ts
+++ b/packages/server/api/src/app/template/template.entity.ts
@@ -78,6 +78,11 @@ export const TemplateEntity = new EntitySchema<TemplateSchema>({
             columns: ['categories'],
             unique: false,
         },
+        {
+            name: 'idx_template_platform_id',
+            columns: ['platformId'],
+            unique: false,
+        },
     ],
     relations: {
         platform: {


### PR DESCRIPTION
## Summary
- Batch-delete `flow_run` rows (1000 at a time) and `flow_version` rows before removing the parent flow, preventing unbounded CASCADE deletes that hit PostgreSQL `statement_timeout`
- Refactor project deletion to delete flows one at a time (with batch pre-deletion) instead of a single bulk `DELETE ... IN(...)` transaction
- Add missing database indices on `flowId`/`platformId` columns used during CASCADE lookups (`table_webhook`, `template`, `custom_domain`, `platform_analytics_report`)

## Test plan
- [ ] Run migration against a test database — verify 4 indices are created
- [ ] Delete a flow with many runs — confirm no statement timeout
- [ ] Delete a platform end-to-end — confirm all child entities are cleaned up
- [ ] Verify DELETE_FLOW job retries still work correctly