### PR TITLE
feat(pieces): add Luma event management piece

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3926,6 +3926,16 @@
         "tslib": "^2.3.0",
       },
     },
+    "packages/pieces/community/luma": {
+      "name": "@activepieces/piece-luma",
+      "version": "0.1.0",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/lusha": {
       "name": "@activepieces/piece-lusha",
       "version": "0.1.4",
@@ -8607,6 +8617,8 @@
     "@activepieces/piece-loops": ["@activepieces/piece-loops@workspace:packages/pieces/community/loops"],
 
     "@activepieces/piece-lucidya": ["@activepieces/piece-lucidya@workspace:packages/pieces/community/lucidya"],
+
+    "@activepieces/piece-luma": ["@activepieces/piece-luma@workspace:packages/pieces/community/luma"],
 
     "@activepieces/piece-lusha": ["@activepieces/piece-lusha@workspace:packages/pieces/community/lusha"],
 

--- a/packages/pieces/community/luma/.eslintrc.json
+++ b/packages/pieces/community/luma/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/luma/package.json
+++ b/packages/pieces/community/luma/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-luma",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/luma/src/index.ts
+++ b/packages/pieces/community/luma/src/index.ts
@@ -1,0 +1,41 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { lumaListEvents } from './lib/actions/list-events';
+import { lumaCreateEvent } from './lib/actions/create-event';
+import { lumaGetEvent } from './lib/actions/get-event';
+import { lumaGetGuest } from './lib/actions/get-guest';
+
+const markdownDescription = `
+To obtain your API key, go to your [Luma Settings](https://lu.ma/settings) page and generate an API key from the **API** section.
+`;
+
+export const lumaAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: markdownDescription,
+  required: true,
+});
+
+export const luma = createPiece({
+  displayName: 'Luma',
+  description: 'Event management and ticketing platform',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/luma.png',
+  categories: [PieceCategory.MARKETING],
+  auth: lumaAuth,
+  actions: [
+    lumaListEvents,
+    lumaCreateEvent,
+    lumaGetEvent,
+    lumaGetGuest,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://public-api.luma.com',
+      auth: lumaAuth,
+      authMapping: async (auth) => ({
+        'x-luma-api-key': (auth as { secret_text: string }).secret_text,
+      }),
+    }),
+  ],
+  authors: ['Harmatta'],
+  triggers: [],
+});

--- a/packages/pieces/community/luma/src/lib/actions/create-event.ts
+++ b/packages/pieces/community/luma/src/lib/actions/create-event.ts
@@ -1,0 +1,83 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../..';
+
+export const lumaCreateEvent = createAction({
+  auth: lumaAuth,
+  name: 'create_event',
+  displayName: 'Create Event',
+  description: 'Create a new event on your Luma Calendar',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Event Name',
+      description: 'The name of the event',
+      required: true,
+    }),
+    start_at: Property.ShortText({
+      displayName: 'Start At',
+      description:
+        'The start date and time of the event in ISO 8601 format (e.g. 2024-01-01T10:00:00Z)',
+      required: true,
+    }),
+    end_at: Property.ShortText({
+      displayName: 'End At',
+      description:
+        'The end date and time of the event in ISO 8601 format (e.g. 2024-01-01T12:00:00Z)',
+      required: true,
+    }),
+    timezone: Property.ShortText({
+      displayName: 'Timezone',
+      description: 'The timezone for the event (e.g. America/New_York)',
+      required: false,
+    }),
+    require_rsvp_approval: Property.Checkbox({
+      displayName: 'Require RSVP Approval',
+      description: 'Whether guests need approval to attend',
+      required: false,
+      defaultValue: false,
+    }),
+    meeting_url: Property.ShortText({
+      displayName: 'Meeting URL',
+      description: 'The virtual meeting link for the event',
+      required: false,
+    }),
+    geo_address_json: Property.Object({
+      displayName: 'Location',
+      description: 'The location object for the event',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const body: Record<string, unknown> = {
+      name: context.propsValue.name,
+      start_at: context.propsValue.start_at,
+      end_at: context.propsValue.end_at,
+    };
+
+    if (context.propsValue.timezone) {
+      body['timezone'] = context.propsValue.timezone;
+    }
+    if (context.propsValue.require_rsvp_approval !== undefined) {
+      body['require_rsvp_approval'] =
+        context.propsValue.require_rsvp_approval;
+    }
+    if (context.propsValue.meeting_url) {
+      body['meeting_url'] = context.propsValue.meeting_url;
+    }
+    if (context.propsValue.geo_address_json) {
+      body['geo_address_json'] = context.propsValue.geo_address_json;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://public-api.luma.com/v1/event/create',
+      headers: {
+        'x-luma-api-key': context.auth.secret_text,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/luma/src/lib/actions/get-event.ts
+++ b/packages/pieces/community/luma/src/lib/actions/get-event.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../..';
+
+export const lumaGetEvent = createAction({
+  auth: lumaAuth,
+  name: 'get_event',
+  displayName: 'Get Event',
+  description: 'Get details about a specific event',
+  props: {
+    event_api_id: Property.ShortText({
+      displayName: 'Event API ID',
+      description: 'The API ID of the event to retrieve',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://public-api.luma.com/v1/event/get',
+      headers: {
+        'x-luma-api-key': context.auth.secret_text,
+      },
+      queryParams: {
+        event_api_id: context.propsValue.event_api_id,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/luma/src/lib/actions/get-guest.ts
+++ b/packages/pieces/community/luma/src/lib/actions/get-guest.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../..';
+
+export const lumaGetGuest = createAction({
+  auth: lumaAuth,
+  name: 'get_guest',
+  displayName: 'Get Guest',
+  description:
+    'Get an event guest by looking them up by their ID or email',
+  props: {
+    event_api_id: Property.ShortText({
+      displayName: 'Event API ID',
+      description: 'The API ID of the event',
+      required: true,
+    }),
+    guest_api_id: Property.ShortText({
+      displayName: 'Guest API ID',
+      description: 'The API ID of the guest (provide this or email)',
+      required: false,
+    }),
+    email: Property.ShortText({
+      displayName: 'Guest Email',
+      description:
+        'The email address of the guest (provide this or Guest API ID)',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const queryParams: Record<string, string> = {
+      event_api_id: context.propsValue.event_api_id,
+    };
+
+    if (context.propsValue.guest_api_id) {
+      queryParams['guest_api_id'] = context.propsValue.guest_api_id;
+    }
+    if (context.propsValue.email) {
+      queryParams['email'] = context.propsValue.email;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://public-api.luma.com/v1/event/get-guest',
+      headers: {
+        'x-luma-api-key': context.auth.secret_text,
+      },
+      queryParams,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/luma/src/lib/actions/list-events.ts
+++ b/packages/pieces/community/luma/src/lib/actions/list-events.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../..';
+
+export const lumaListEvents = createAction({
+  auth: lumaAuth,
+  name: 'list_events',
+  displayName: 'List Events',
+  description: 'List all events managed by your Luma Calendar',
+  props: {},
+  async run(context) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://public-api.luma.com/v1/calendar/list-events',
+      headers: {
+        'x-luma-api-key': context.auth.secret_text,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/luma/tsconfig.json
+++ b/packages/pieces/community/luma/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/luma/tsconfig.lib.json
+++ b/packages/pieces/community/luma/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -656,6 +656,9 @@
       "@activepieces/piece-lusha": [
         "packages/pieces/community/lusha/src/index.ts"
       ],
+      "@activepieces/piece-luma": [
+        "packages/pieces/community/luma/src/index.ts"
+      ],
       "@activepieces/piece-magical-api": [
         "packages/pieces/community/magical-api/src/index.ts"
       ],


### PR DESCRIPTION
Closes #12171

## Summary
Adds a new Luma integration piece for the [lu.ma](https://lu.ma) event management platform.

### Actions
- **List Events** — List all events managed by your Luma Calendar
- **Create Event** — Create a new event with name, start/end time, timezone, RSVP settings, meeting URL, and location
- **Get Event** — Retrieve details of a specific event by API ID
- **Get Guest** — Look up a guest by their API ID or email address
- **Custom API Call** — Make custom requests to the Luma API

## Auth
Uses a Luma API key sent in the `x-luma-api-key` header. API keys are managed per Luma Calendar and can be generated from the [Luma Settings](https://lu.ma/settings) page.

## Verified
- `npx turbo build --filter=@activepieces/piece-luma` — ✅ PASS
- `npx turbo lint --filter=@activepieces/piece-luma` — ✅ PASS
- No `any` types used
- Follows existing piece conventions (modeled after posthog, cal-com)