### PR TITLE
feat(pieces): add Tapfiliate affiliate tracking piece

### DIFF
--- a/packages/pieces/community/tapfiliate/.eslintrc.json
+++ b/packages/pieces/community/tapfiliate/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/tapfiliate/package.json
+++ b/packages/pieces/community/tapfiliate/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-tapfiliate",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/tapfiliate/src/index.ts
+++ b/packages/pieces/community/tapfiliate/src/index.ts
@@ -1,0 +1,86 @@
+import {
+  createCustomApiCallAction,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createAffiliateAction } from './lib/actions/create-affiliate';
+import { createConversionAction } from './lib/actions/create-conversion';
+import { getAffiliateAction } from './lib/actions/get-affiliate';
+import { listAffiliatesAction } from './lib/actions/list-affiliates';
+import {
+  TAPFILIATE_BASE_URL,
+  tapfiliateApiCall,
+} from './lib/common/tapfiliate.client';
+
+type TapfiliateValidateAuth = {
+  apiKey?: string;
+};
+
+export const tapfiliateAuth = PieceAuth.CustomAuth({
+  description: `To obtain your API key:
+
+1. Log in to your Tapfiliate account.
+2. Open your account settings.
+3. Find the API key section.
+4. Copy the API key and paste it here.`,
+  required: true,
+  props: {
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API Key',
+      description: 'Tapfiliate REST API key sent in the X-Api-Key header.',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    const authValue = auth as TapfiliateValidateAuth;
+
+    if (!authValue?.apiKey) {
+      return {
+        valid: false,
+        error: 'API Key is required.',
+      };
+    }
+
+    try {
+      await tapfiliateApiCall({
+        method: HttpMethod.GET,
+        path: '/affiliates/',
+        apiKey: authValue.apiKey,
+      });
+
+      return {
+        valid: true,
+      };
+    } catch {
+      return {
+        valid: false,
+        error: 'Invalid API Key.',
+      };
+    }
+  },
+});
+
+export const tapfiliate = createPiece({
+  displayName: 'Tapfiliate',
+  description: 'Affiliate tracking and conversion management platform.',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://tapfiliate.com/img/logo-square-social.png',
+  categories: [PieceCategory.MARKETING, PieceCategory.SALES_AND_CRM],
+  authors: ['Harmatta'],
+  auth: tapfiliateAuth,
+  actions: [
+    createAffiliateAction,
+    getAffiliateAction,
+    listAffiliatesAction,
+    createConversionAction,
+    createCustomApiCallAction({
+      baseUrl: () => TAPFILIATE_BASE_URL,
+      auth: tapfiliateAuth,
+      authMapping: async (auth) => ({
+        'X-Api-Key': auth.props.apiKey,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/tapfiliate/src/lib/actions/create-affiliate.ts
+++ b/packages/pieces/community/tapfiliate/src/lib/actions/create-affiliate.ts
@@ -1,0 +1,132 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { tapfiliateAuth } from '../..';
+import { tapfiliateApiCall } from '../common/tapfiliate.client';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export const createAffiliateAction = createAction({
+  auth: tapfiliateAuth,
+  name: 'create_affiliate',
+  displayName: 'Create Affiliate',
+  description: 'Creates a new affiliate in Tapfiliate.',
+  props: {
+    firstname: Property.ShortText({
+      displayName: 'First Name',
+      required: true,
+    }),
+    lastname: Property.ShortText({
+      displayName: 'Last Name',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: true,
+    }),
+    password: Property.ShortText({
+      displayName: 'Password',
+      description: 'Optional password for the new affiliate account.',
+      required: false,
+    }),
+    companyName: Property.ShortText({
+      displayName: 'Company Name',
+      required: false,
+    }),
+    companyDescription: Property.LongText({
+      displayName: 'Company Description',
+      required: false,
+    }),
+    addressLine1: Property.ShortText({
+      displayName: 'Address Line 1',
+      required: false,
+    }),
+    addressLine2: Property.ShortText({
+      displayName: 'Address Line 2',
+      required: false,
+    }),
+    postalCode: Property.ShortText({
+      displayName: 'Postal Code',
+      required: false,
+    }),
+    city: Property.ShortText({
+      displayName: 'City',
+      required: false,
+    }),
+    state: Property.ShortText({
+      displayName: 'State',
+      required: false,
+    }),
+    countryCode: Property.ShortText({
+      displayName: 'Country Code',
+      description: 'ISO 3166-1 alpha-2 code, e.g. US or NL.',
+      required: false,
+    }),
+    customFields: Property.Json({
+      displayName: 'Custom Fields',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const company =
+      context.propsValue.companyName || context.propsValue.companyDescription
+        ? {
+            ...(context.propsValue.companyName
+              ? { name: context.propsValue.companyName }
+              : {}),
+            ...(context.propsValue.companyDescription
+              ? { description: context.propsValue.companyDescription }
+              : {}),
+          }
+        : undefined;
+
+    const address =
+      context.propsValue.addressLine1 ||
+      context.propsValue.addressLine2 ||
+      context.propsValue.postalCode ||
+      context.propsValue.city ||
+      context.propsValue.state ||
+      context.propsValue.countryCode
+        ? {
+            ...(context.propsValue.addressLine1
+              ? { address: context.propsValue.addressLine1 }
+              : {}),
+            ...(context.propsValue.addressLine2
+              ? { address_two: context.propsValue.addressLine2 }
+              : {}),
+            ...(context.propsValue.postalCode
+              ? { postal_code: context.propsValue.postalCode }
+              : {}),
+            ...(context.propsValue.city ? { city: context.propsValue.city } : {}),
+            ...(context.propsValue.state
+              ? { state: context.propsValue.state }
+              : {}),
+            ...(context.propsValue.countryCode
+              ? { country: { code: context.propsValue.countryCode } }
+              : {}),
+          }
+        : undefined;
+
+    const customFields = isRecord(context.propsValue.customFields)
+      ? context.propsValue.customFields
+      : undefined;
+
+    return await tapfiliateApiCall({
+      method: HttpMethod.POST,
+      path: '/affiliates/',
+      apiKey: context.auth.props.apiKey,
+      body: {
+        firstname: context.propsValue.firstname,
+        lastname: context.propsValue.lastname,
+        email: context.propsValue.email,
+        ...(context.propsValue.password
+          ? { password: context.propsValue.password }
+          : {}),
+        ...(company ? { company } : {}),
+        ...(address ? { address } : {}),
+        ...(customFields ? { custom_fields: customFields } : {}),
+      },
+    });
+  },
+});

--- a/packages/pieces/community/tapfiliate/src/lib/actions/create-conversion.ts
+++ b/packages/pieces/community/tapfiliate/src/lib/actions/create-conversion.ts
@@ -1,0 +1,134 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { tapfiliateAuth } from '../..';
+import { tapfiliateApiCall } from '../common/tapfiliate.client';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export const createConversionAction = createAction({
+  auth: tapfiliateAuth,
+  name: 'create_conversion',
+  displayName: 'Create Conversion',
+  description: 'Creates a conversion in Tapfiliate.',
+  props: {
+    referralCode: Property.ShortText({
+      displayName: 'Referral Code',
+      required: false,
+    }),
+    trackingId: Property.ShortText({
+      displayName: 'Tracking ID',
+      required: false,
+    }),
+    clickId: Property.ShortText({
+      displayName: 'Click ID',
+      required: false,
+    }),
+    coupon: Property.ShortText({
+      displayName: 'Coupon',
+      required: false,
+    }),
+    currency: Property.ShortText({
+      displayName: 'Currency',
+      description: 'Three-letter ISO currency code such as USD or EUR.',
+      required: false,
+    }),
+    assetId: Property.ShortText({
+      displayName: 'Asset ID',
+      required: false,
+    }),
+    sourceId: Property.ShortText({
+      displayName: 'Source ID',
+      required: false,
+    }),
+    externalId: Property.ShortText({
+      displayName: 'External ID',
+      description: 'Unique ID such as an order number.',
+      required: false,
+    }),
+    amount: Property.Number({
+      displayName: 'Amount',
+      required: false,
+    }),
+    customerId: Property.ShortText({
+      displayName: 'Customer ID',
+      required: false,
+    }),
+    commissionType: Property.ShortText({
+      displayName: 'Commission Type',
+      required: false,
+    }),
+    programGroup: Property.ShortText({
+      displayName: 'Program Group',
+      required: false,
+    }),
+    userAgent: Property.LongText({
+      displayName: 'User Agent',
+      required: false,
+    }),
+    ip: Property.ShortText({
+      displayName: 'IP Address',
+      required: false,
+    }),
+    metaData: Property.Json({
+      displayName: 'Meta Data',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const metaData = isRecord(context.propsValue.metaData)
+      ? context.propsValue.metaData
+      : undefined;
+
+    return await tapfiliateApiCall({
+      method: HttpMethod.POST,
+      path: '/conversions/',
+      apiKey: context.auth.props.apiKey,
+      body: {
+        ...(context.propsValue.referralCode
+          ? { referral_code: context.propsValue.referralCode }
+          : {}),
+        ...(context.propsValue.trackingId
+          ? { tracking_id: context.propsValue.trackingId }
+          : {}),
+        ...(context.propsValue.clickId
+          ? { click_id: context.propsValue.clickId }
+          : {}),
+        ...(context.propsValue.coupon
+          ? { coupon: context.propsValue.coupon }
+          : {}),
+        ...(context.propsValue.currency
+          ? { currency: context.propsValue.currency }
+          : {}),
+        ...(context.propsValue.assetId
+          ? { asset_id: context.propsValue.assetId }
+          : {}),
+        ...(context.propsValue.sourceId
+          ? { source_id: context.propsValue.sourceId }
+          : {}),
+        ...(context.propsValue.externalId
+          ? { external_id: context.propsValue.externalId }
+          : {}),
+        ...(context.propsValue.amount !== undefined &&
+        context.propsValue.amount !== null
+          ? { amount: context.propsValue.amount }
+          : {}),
+        ...(context.propsValue.customerId
+          ? { customer_id: context.propsValue.customerId }
+          : {}),
+        ...(context.propsValue.commissionType
+          ? { commission_type: context.propsValue.commissionType }
+          : {}),
+        ...(context.propsValue.programGroup
+          ? { program_group: context.propsValue.programGroup }
+          : {}),
+        ...(context.propsValue.userAgent
+          ? { user_agent: context.propsValue.userAgent }
+          : {}),
+        ...(context.propsValue.ip ? { ip: context.propsValue.ip } : {}),
+        ...(metaData ? { meta_data: metaData } : {}),
+      },
+    });
+  },
+});

--- a/packages/pieces/community/tapfiliate/src/lib/actions/get-affiliate.ts
+++ b/packages/pieces/community/tapfiliate/src/lib/actions/get-affiliate.ts
@@ -1,0 +1,24 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { tapfiliateAuth } from '../..';
+import { tapfiliateApiCall } from '../common/tapfiliate.client';
+
+export const getAffiliateAction = createAction({
+  auth: tapfiliateAuth,
+  name: 'get_affiliate',
+  displayName: 'Get Affiliate',
+  description: 'Retrieves a Tapfiliate affiliate by ID.',
+  props: {
+    affiliateId: Property.ShortText({
+      displayName: 'Affiliate ID',
+      required: true,
+    }),
+  },
+  async run(context) {
+    return await tapfiliateApiCall({
+      method: HttpMethod.GET,
+      path: `/affiliates/${context.propsValue.affiliateId}/`,
+      apiKey: context.auth.props.apiKey,
+    });
+  },
+});

--- a/packages/pieces/community/tapfiliate/src/lib/actions/list-affiliates.ts
+++ b/packages/pieces/community/tapfiliate/src/lib/actions/list-affiliates.ts
@@ -1,0 +1,55 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { tapfiliateAuth } from '../..';
+import {
+  buildTapfiliateQuery,
+  tapfiliateApiCall,
+} from '../common/tapfiliate.client';
+
+export const listAffiliatesAction = createAction({
+  auth: tapfiliateAuth,
+  name: 'list_affiliates',
+  displayName: 'List Affiliates',
+  description: 'Lists affiliates with optional Tapfiliate filters.',
+  props: {
+    clickId: Property.ShortText({
+      displayName: 'Click ID',
+      required: false,
+    }),
+    sourceId: Property.ShortText({
+      displayName: 'Source ID',
+      required: false,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: false,
+    }),
+    referralCode: Property.ShortText({
+      displayName: 'Referral Code',
+      required: false,
+    }),
+    parentId: Property.ShortText({
+      displayName: 'Parent Affiliate ID',
+      required: false,
+    }),
+    affiliateGroupId: Property.ShortText({
+      displayName: 'Affiliate Group ID',
+      required: false,
+    }),
+  },
+  async run(context) {
+    return await tapfiliateApiCall({
+      method: HttpMethod.GET,
+      path: '/affiliates/',
+      apiKey: context.auth.props.apiKey,
+      query: buildTapfiliateQuery({
+        click_id: context.propsValue.clickId,
+        source_id: context.propsValue.sourceId,
+        email: context.propsValue.email,
+        referral_code: context.propsValue.referralCode,
+        parent_id: context.propsValue.parentId,
+        affiliate_group_id: context.propsValue.affiliateGroupId,
+      }),
+    });
+  },
+});

--- a/packages/pieces/community/tapfiliate/src/lib/common/tapfiliate.client.ts
+++ b/packages/pieces/community/tapfiliate/src/lib/common/tapfiliate.client.ts
@@ -1,0 +1,71 @@
+import {
+  HttpMessageBody,
+  HttpMethod,
+  QueryParams,
+  httpClient,
+} from '@activepieces/pieces-common';
+
+export const TAPFILIATE_BASE_URL = 'https://api.tapfiliate.com/1.6';
+
+function shouldKeepValue(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  return true;
+}
+
+export function buildTapfiliateQuery(
+  values?: Record<string, unknown>
+): QueryParams {
+  const query: QueryParams = {};
+
+  if (!values) {
+    return query;
+  }
+
+  for (const [key, value] of Object.entries(values)) {
+    if (!shouldKeepValue(value)) {
+      continue;
+    }
+
+    query[key] = String(value);
+  }
+
+  return query;
+}
+
+type TapfiliateApiCallParams = {
+  method: HttpMethod;
+  path: string;
+  apiKey: string;
+  apiBaseUrl?: string;
+  query?: QueryParams;
+  body?: unknown;
+};
+
+export async function tapfiliateApiCall<T extends HttpMessageBody>({
+  method,
+  path,
+  apiKey,
+  apiBaseUrl = TAPFILIATE_BASE_URL,
+  query,
+  body,
+}: TapfiliateApiCallParams): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url: `${apiBaseUrl}${path}`,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Api-Key': apiKey,
+    },
+    queryParams: query,
+    body,
+  });
+
+  return response.body;
+}

--- a/packages/pieces/community/tapfiliate/tsconfig.json
+++ b/packages/pieces/community/tapfiliate/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/tapfiliate/tsconfig.lib.json
+++ b/packages/pieces/community/tapfiliate/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1116,6 +1116,9 @@
       "@activepieces/piece-tally": [
         "packages/pieces/community/tally/src/index.ts"
       ],
+      "@activepieces/piece-tapfiliate": [
+        "packages/pieces/community/tapfiliate/src/index.ts"
+      ],
       "@activepieces/piece-tarvent": [
         "packages/pieces/community/tarvent/src/index.ts"
       ],


### PR DESCRIPTION
Closes #12162

## Summary
Adds Tapfiliate integration piece with actions: Create Affiliate, Get Affiliate, List Affiliates, Create Conversion.

## Auth
Custom auth via API key (X-Api-Key header).

## Testing
- `bun install --ignore-scripts`
- `npx turbo build --filter=@activepieces/piece-tapfiliate`
- `npx turbo lint --filter=@activepieces/piece-tapfiliate`