### PR TITLE
fix: handle deleted flow runs gracefully in metadata queue

### DIFF
--- a/packages/server/api/src/app/flows/flow-run/flow-runs-queue.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-runs-queue.ts
@@ -54,7 +54,7 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
                             }
 
                             const existingFlowRun = await flowRunRepo().findOneBy({ id: job.data.runId })
-                            let savedFlowRun: FlowRun | null = null
+                            let savedFlowRun: FlowRun
                             if (!isNil(existingFlowRun)) {
                                 await flowRunRepo().update(job.data.runId, {
                                     ...spreadIfDefined('projectId', runMetadata.projectId),
@@ -94,10 +94,6 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
                                     return
                                 }
                                 savedFlowRun = await flowRunRepo().save(runMetadata)
-                            }
-
-                            if (isNil(savedFlowRun)) {
-                                return
                             }
 
                             const parentRunId = savedFlowRun.parentRunId


### PR DESCRIPTION
## Summary
- Replace `findOneByOrFail` with `findOneBy` + null guards in `flow-runs-queue.ts` to prevent `EntityNotFoundError` when a flow run is deleted during metadata processing
- Fixes race condition where a flow run can be deleted (by user or cleanup) between the initial check and re-fetch, causing unhandled errors in the BullMQ worker

## Test plan
- [ ] Verify flow run metadata updates still work correctly for existing runs
- [ ] Verify that deleting a flow run while metadata is being processed no longer throws EntityNotFoundError
- [ ] Verify parent run failure marking still works when parent exists
- [ ] Verify graceful skip when parent run has been deleted