### PR TITLE
fix: resolve statement timeouts in background jobs

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1774400000000-AddUserIdentityIdIndex.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1774400000000-AddUserIdentityIdIndex.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddUserIdentityIdIndex1774400000000 implements MigrationInterface {
+    name = 'AddUserIdentityIdIndex1774400000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('CREATE INDEX "idx_user_identity_id" ON "user" ("identityId")')
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP INDEX "idx_user_identity_id"')
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -346,6 +346,7 @@ import { AddFlowProjectIdStatusIndex1772027509097 } from './migration/postgres/1
 import { AddProjectPlatformIdIndex1773930744000 } from './migration/postgres/1773930744000-AddProjectPlatformIdIndex'
 import { ReAddAgentsEnabledToPlatformPlan1774000000000 } from './migration/postgres/1774000000000-ReAddAgentsEnabledToPlatformPlan'
 import { AddMissingCascadeDeleteIndices1774100000000 } from './migration/postgres/1774100000000-AddMissingCascadeDeleteIndices'
+import { AddUserIdentityIdIndex1774400000000 } from './migration/postgres/1774400000000-AddUserIdentityIdIndex'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -708,6 +709,7 @@ export const getMigrations = (): (new () => MigrationInterface)[] => {
         AddProjectPlatformIdIndex1773930744000,
         ReAddAgentsEnabledToPlatformPlan1774000000000,
         AddMissingCascadeDeleteIndices1774100000000,
+        AddUserIdentityIdIndex1774400000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/flows/flow/flow.jobs.ts
+++ b/packages/server/api/src/app/flows/flow/flow.jobs.ts
@@ -25,11 +25,14 @@ export async function batchDeleteByFlowId(flowId: string): Promise<void> {
 
     await flowRepo().update({ id: flowId }, { publishedVersionId: null })
 
-    await flowVersionRepo()
-        .createQueryBuilder()
-        .delete()
-        .where('"flowId" = :flowId', { flowId })
-        .execute()
+    do {
+        const result = await flowVersionRepo()
+            .createQueryBuilder()
+            .delete()
+            .where('id IN (SELECT id FROM flow_version WHERE "flowId" = :flowId LIMIT :limit)', { flowId, limit: BATCH_SIZE })
+            .execute()
+        deleted = result.affected ?? 0
+    } while (deleted > 0)
 }
 
 export const flowBackgroundJobs = (log: FastifyBaseLogger) => ({

--- a/packages/server/api/src/app/user/user-entity.ts
+++ b/packages/server/api/src/app/user/user-entity.ts
@@ -47,6 +47,10 @@ export const UserEntity = new EntitySchema<UserSchema>({
             columns: ['platformId', 'externalId'],
             unique: true,
         },
+        {
+            name: 'idx_user_identity_id',
+            columns: ['identityId'],
+        },
     ],
     relations: {
         projects: {


### PR DESCRIPTION
## Summary
- Add `idx_user_identity_id` index on `user.identityId` so `hardDeletePlatformHandler` can look up users by identity without full table scan
- Batch flow version deletion in `deleteFlowHandler` using the same batch pattern as flow run deletion, preventing timeouts on large flows

## Test plan
- [ ] Verify migration creates the index correctly on a fresh DB
- [ ] Verify flow deletion works for flows with many versions
- [ ] Confirm `npm run lint-dev` passes