### PR TITLE
docs: add database migration rule to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@
 
 - Always prefix `git push` with `CLAUDE_PUSH=yes` to auto-approve the pre-push lint/test gate, e.g. `CLAUDE_PUSH=yes git push -u origin HEAD`.
 
+## Database Migrations
+
+- Before creating or modifying a database migration, **always read the [Database Migrations Playbook](https://www.activepieces.com/docs/handbook/engineering/playbooks/database-migration#database-migrations)** first. Follow its instructions for generating and structuring migrations.
+
 ## Verification
 
 - Always run `npm run lint-dev` as part of any verification step before considering a task complete.


### PR DESCRIPTION
## What does this PR do?

Adds a **Database Migrations** section to `CLAUDE.md` (symlinked from `AGENTS.md`) that requires consulting the [Database Migrations Playbook](https://www.activepieces.com/docs/handbook/engineering/playbooks/database-migration#database-migrations) before creating or modifying any migration.

### Explain How the Feature Works

The playbook link already existed in the "Useful Links" section, but there was no explicit rule enforcing its use. This adds a dedicated section so AI coding assistants always follow the migration playbook when generating or editing migrations.