### PR TITLE
fix: resolve merge conflict in bun.lock for @activepieces/shared version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7846,11 +7846,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-<<<<<<< HEAD
-      "version": "0.46.1",
-=======
       "version": "0.47.0",
->>>>>>> upstream/main
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",


### PR DESCRIPTION
## Summary
- Resolved merge conflict in `bun.lock` that was causing `bun` to fail with a `SyntaxError` when loading the lockfile
- Conflict was between `@activepieces/shared` version `0.46.1` (HEAD) and `0.47.0` (upstream/main)
- Resolved by keeping `0.47.0`, matching the version in `packages/shared/package.json`

## Test plan
- [x] Run `bun install` to verify the lockfile is valid and installs without errors