### PR TITLE
feat: add pCloud piece

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",
@@ -5023,6 +5022,16 @@
         "zod": "4.3.6",
       },
     },
+    "packages/pieces/community/pcloud": {
+      "name": "@activepieces/piece-pcloud",
+      "version": "0.1.0",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/pdf-co": {
       "name": "@activepieces/piece-pdf-co",
       "version": "0.1.3",
@@ -8880,6 +8889,8 @@
     "@activepieces/piece-pastefy": ["@activepieces/piece-pastefy@workspace:packages/pieces/community/pastefy"],
 
     "@activepieces/piece-paywhirl": ["@activepieces/piece-paywhirl@workspace:packages/pieces/community/paywhirl"],
+
+    "@activepieces/piece-pcloud": ["@activepieces/piece-pcloud@workspace:packages/pieces/community/pcloud"],
 
     "@activepieces/piece-pdf": ["@activepieces/piece-pdf@workspace:packages/pieces/core/pdf"],
 

--- a/packages/pieces/community/pcloud/package.json
+++ b/packages/pieces/community/pcloud/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-pcloud",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/pcloud/src/index.ts
+++ b/packages/pieces/community/pcloud/src/index.ts
@@ -1,0 +1,39 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { pcloudAuth } from './lib/auth';
+import { pcloudUploadFile } from './lib/actions/upload-file';
+import { pcloudCreateFolder } from './lib/actions/create-folder';
+import { pcloudDownloadFile } from './lib/actions/download-file';
+import { pcloudCopyFile } from './lib/actions/copy-file';
+import { pcloudFindFile } from './lib/actions/find-file';
+import { pcloudFindFolder } from './lib/actions/find-folder';
+import { pcloudNewFileUploaded } from './lib/triggers/new-file-uploaded';
+import { pcloudFolderCreated } from './lib/triggers/folder-created';
+import { common } from './lib/common';
+
+export const pcloud = createPiece({
+  displayName: 'pCloud',
+  description: 'Secure cloud storage for file management and sharing',
+  auth: pcloudAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/pcloud.png',
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  authors: ['skalaydzhiyski'],
+  actions: [
+    pcloudUploadFile,
+    pcloudCreateFolder,
+    pcloudDownloadFile,
+    pcloudCopyFile,
+    pcloudFindFile,
+    pcloudFindFolder,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.pcloud.com',
+      auth: pcloudAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${auth.access_token}`,
+      }),
+    }),
+  ],
+  triggers: [pcloudNewFileUploaded, pcloudFolderCreated],
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/copy-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/copy-file.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../auth';
+import { common, PcloudCopyFileResponse } from '../common';
+
+export const pcloudCopyFile = createAction({
+  auth: pcloudAuth,
+  name: 'pcloud_copy_file',
+  displayName: 'Copy File',
+  description: 'Copy an existing file to a given folder.',
+  props: {
+    fileId: Property.Number({
+      displayName: 'File ID',
+      description: 'The ID of the file to copy',
+      required: true,
+    }),
+    toFolderId: Property.Number({
+      displayName: 'Destination Folder ID',
+      description: 'The ID of the destination folder',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const result = await common.pcloudRequest<PcloudCopyFileResponse>(
+      context.auth,
+      'copyfile',
+      {
+        fileid: context.propsValue.fileId,
+        tofolderid: context.propsValue.toFolderId,
+      },
+    );
+    return result;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/create-folder.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/create-folder.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../auth';
+import { common, PcloudCreateFolderResponse } from '../common';
+
+export const pcloudCreateFolder = createAction({
+  auth: pcloudAuth,
+  name: 'pcloud_create_folder',
+  displayName: 'Create Folder',
+  description:
+    'Set up structured directories automatically for each new client onboarded through your CRM workflow.',
+  props: {
+    parentFolderId: Property.Number({
+      displayName: 'Parent Folder ID',
+      description: 'The ID of the parent folder. Use 0 for root.',
+      required: true,
+      defaultValue: 0,
+    }),
+    name: Property.ShortText({
+      displayName: 'Folder Name',
+      description: 'The name of the new folder',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const result =
+      await common.pcloudRequest<PcloudCreateFolderResponse>(
+        context.auth,
+        'createfolder',
+        {
+          folderid: context.propsValue.parentFolderId,
+          name: context.propsValue.name,
+        },
+      );
+    return result;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/download-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/download-file.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { pcloudAuth } from '../auth';
+import { common, PcloudFileLink } from '../common';
+
+export const pcloudDownloadFile = createAction({
+  auth: pcloudAuth,
+  name: 'pcloud_download_file',
+  displayName: 'Download File Content',
+  description:
+    'Fetch attachments for email automation workflows or backup scripts that require local copies of cloud-stored data.',
+  props: {
+    fileId: Property.Number({
+      displayName: 'File ID',
+      description: 'The ID of the file to download',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const linkResponse = await common.pcloudRequest<PcloudFileLink>(
+      context.auth,
+      'getfilelink',
+      { fileid: context.propsValue.fileId },
+    );
+
+    const host = linkResponse.hosts[0];
+    const downloadUrl = `https://${host}${linkResponse.path}`;
+    const fileName = linkResponse.path.split('/').pop() ?? 'download';
+
+    const fileResponse = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: downloadUrl,
+      responseType: 'arraybuffer',
+    });
+
+    return {
+      file: await context.files.write({
+        fileName,
+        data: Buffer.from(fileResponse.body),
+      }),
+    };
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/find-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/find-file.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../auth';
+import { common } from '../common';
+
+type PcloudSearchResult = {
+  result: number;
+  metadata: Array<{
+    name: string;
+    fileid: number;
+    size: number;
+    contenttype: string;
+    created: string;
+    modified: string;
+    path: string;
+    parentfolderid: number;
+  }>;
+};
+
+export const pcloudFindFile = createAction({
+  auth: pcloudAuth,
+  name: 'pcloud_find_file',
+  displayName: 'Find File',
+  description:
+    'Find and process all files related to a search query for automated reporting tasks.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'The file name or partial name to search for',
+      required: true,
+    }),
+    path: Property.ShortText({
+      displayName: 'Path',
+      description:
+        'Restrict search to this path (e.g. /Documents). Leave empty for all files.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const params: Record<string, unknown> = {
+      query: context.propsValue.query,
+    };
+    if (context.propsValue.path) {
+      params['path'] = context.propsValue.path;
+    }
+    const result = await common.pcloudRequest<PcloudSearchResult>(
+      context.auth,
+      'searchfile',
+      params,
+    );
+    return result;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/find-folder.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/find-folder.ts
@@ -1,0 +1,54 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../auth';
+import { common, PcloudListFolderResponse, PcloudMetadata } from '../common';
+
+export const pcloudFindFolder = createAction({
+  auth: pcloudAuth,
+  name: 'pcloud_find_folder',
+  displayName: 'Find Folder',
+  description:
+    'Locate project-specific folders before performing batch operations like archiving or sharing.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Folder Name',
+      description: 'The folder name or partial name to search for',
+      required: true,
+    }),
+    parentFolderId: Property.Number({
+      displayName: 'Parent Folder ID',
+      description:
+        'Search within this folder (recursively). Use 0 for root.',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  async run(context) {
+    const result =
+      await common.pcloudRequest<PcloudListFolderResponse>(
+        context.auth,
+        'listfolder',
+        {
+          folderid: context.propsValue.parentFolderId ?? 0,
+          recursive: 1,
+        },
+      );
+
+    const query = context.propsValue.query.toLowerCase();
+    const matches: PcloudMetadata[] = [];
+
+    function searchContents(contents: PcloudMetadata[] | undefined) {
+      if (!contents) return;
+      for (const item of contents) {
+        if (item.isfolder && item.name.toLowerCase().includes(query)) {
+          matches.push(item);
+        }
+        if (item.contents) {
+          searchContents(item.contents);
+        }
+      }
+    }
+
+    searchContents(result.metadata.contents);
+    return { result: 0, folders: matches };
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/pcloud/src/lib/actions/upload-file.ts
@@ -1,0 +1,40 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../auth';
+import { common } from '../common';
+
+export const pcloudUploadFile = createAction({
+  auth: pcloudAuth,
+  name: 'pcloud_upload_file',
+  displayName: 'Upload File',
+  description:
+    'Save generated reports, backups, or exported data from other apps directly into organized cloud folders.',
+  props: {
+    folderId: Property.Number({
+      displayName: 'Folder ID',
+      description: 'The ID of the folder to upload the file to. Use 0 for root.',
+      required: true,
+      defaultValue: 0,
+    }),
+    fileName: Property.ShortText({
+      displayName: 'File Name',
+      description: 'The name for the uploaded file (e.g. report.pdf)',
+      required: true,
+    }),
+    file: Property.File({
+      displayName: 'File',
+      description: 'The file to upload',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const fileData = context.propsValue.file;
+    const fileBuffer = Buffer.from(fileData.base64, 'base64');
+    const result = await common.pcloudUpload(
+      context.auth,
+      context.propsValue.folderId,
+      context.propsValue.fileName,
+      fileBuffer,
+    );
+    return result;
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/auth.ts
+++ b/packages/pieces/community/pcloud/src/lib/auth.ts
@@ -1,0 +1,9 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const pcloudAuth = PieceAuth.OAuth2({
+  description: 'Connect your pCloud account',
+  authUrl: 'https://my.pcloud.com/oauth2/authorize',
+  tokenUrl: 'https://api.pcloud.com/oauth2_token',
+  required: true,
+  scope: [],
+});

--- a/packages/pieces/community/pcloud/src/lib/common.ts
+++ b/packages/pieces/community/pcloud/src/lib/common.ts
@@ -1,0 +1,121 @@
+import {
+  AuthenticationType,
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { OAuth2PropertyValue } from '@activepieces/pieces-framework';
+
+function getBaseUrl(auth: OAuth2PropertyValue): string {
+  const locationId = (auth as Record<string, unknown>)['locationid'];
+  if (locationId === 2) {
+    return 'https://eapi.pcloud.com';
+  }
+  return 'https://api.pcloud.com';
+}
+
+async function pcloudRequest<T>(
+  auth: OAuth2PropertyValue,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<T> {
+  const baseUrl = getBaseUrl(auth);
+  const queryParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) {
+      queryParams.set(key, String(value));
+    }
+  }
+  const url = `${baseUrl}/${method}?${queryParams.toString()}`;
+  const response = await httpClient.sendRequest<T>({
+    method: HttpMethod.GET,
+    url,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: auth.access_token,
+    },
+  });
+  return response.body;
+}
+
+async function pcloudUpload(
+  auth: OAuth2PropertyValue,
+  folderId: number,
+  fileName: string,
+  fileData: Buffer,
+): Promise<PcloudUploadResponse> {
+  const baseUrl = getBaseUrl(auth);
+  const url = `${baseUrl}/uploadfile?folderid=${folderId}&filename=${encodeURIComponent(fileName)}`;
+  const response = await httpClient.sendRequest<PcloudUploadResponse>({
+    method: HttpMethod.PUT,
+    url,
+    body: fileData,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+    },
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: auth.access_token,
+    },
+  });
+  return response.body;
+}
+
+type PcloudMetadata = {
+  name: string;
+  created: string;
+  modified: string;
+  isfolder: boolean;
+  fileid?: number;
+  folderid?: number;
+  size?: number;
+  contenttype?: string;
+  path?: string;
+  parentfolderid?: number;
+  contents?: PcloudMetadata[];
+};
+
+type PcloudListFolderResponse = {
+  result: number;
+  metadata: PcloudMetadata;
+};
+
+type PcloudUploadResponse = {
+  result: number;
+  metadata: PcloudMetadata[];
+  checksums: unknown[];
+  fileids: number[];
+};
+
+type PcloudCreateFolderResponse = {
+  result: number;
+  metadata: PcloudMetadata;
+};
+
+type PcloudCopyFileResponse = {
+  result: number;
+  metadata: PcloudMetadata;
+};
+
+type PcloudFileLink = {
+  result: number;
+  dwltag: string;
+  hash: number;
+  size: number;
+  path: string;
+  hosts: string[];
+};
+
+export const common = {
+  getBaseUrl,
+  pcloudRequest,
+  pcloudUpload,
+};
+
+export type {
+  PcloudMetadata,
+  PcloudListFolderResponse,
+  PcloudUploadResponse,
+  PcloudCreateFolderResponse,
+  PcloudCopyFileResponse,
+  PcloudFileLink,
+};

--- a/packages/pieces/community/pcloud/src/lib/triggers/folder-created.ts
+++ b/packages/pieces/community/pcloud/src/lib/triggers/folder-created.ts
@@ -1,0 +1,96 @@
+import {
+  createTrigger,
+  Property,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../auth';
+import { common, PcloudListFolderResponse, PcloudMetadata } from '../common';
+
+function extractFolders(metadata: PcloudMetadata): PcloudMetadata[] {
+  const folders: PcloudMetadata[] = [];
+  if (metadata.contents) {
+    for (const item of metadata.contents) {
+      if (item.isfolder) {
+        folders.push(item);
+      }
+    }
+  }
+  return folders;
+}
+
+export const pcloudFolderCreated = createTrigger({
+  auth: pcloudAuth,
+  name: 'pcloud_folder_created',
+  displayName: 'Folder Created',
+  description:
+    'Initiate onboarding workflows whenever project folders are created by team members.',
+
+  type: TriggerStrategy.POLLING,
+
+  props: {
+    folderId: Property.Number({
+      displayName: 'Parent Folder ID',
+      description:
+        'The ID of the parent folder to watch for new subfolders. Use 0 for root.',
+      required: true,
+      defaultValue: 0,
+    }),
+  },
+
+  sampleData: {
+    name: 'New Project',
+    folderid: 87654321,
+    created: 'Thu, 27 Mar 2026 12:00:00 +0000',
+    modified: 'Thu, 27 Mar 2026 12:00:00 +0000',
+    isfolder: true,
+  },
+
+  onEnable: async (context) => {
+    const response =
+      await common.pcloudRequest<PcloudListFolderResponse>(
+        context.auth,
+        'listfolder',
+        { folderid: context.propsValue.folderId },
+      );
+    const folders = extractFolders(response.metadata);
+    const knownIds = folders.map((f) => f.folderid).filter(Boolean);
+    await context.store.put('knownFolderIds', knownIds);
+  },
+
+  onDisable: async (context) => {
+    await context.store.delete('knownFolderIds');
+  },
+
+  run: async (context) => {
+    const response =
+      await common.pcloudRequest<PcloudListFolderResponse>(
+        context.auth,
+        'listfolder',
+        { folderid: context.propsValue.folderId },
+      );
+    const folders = extractFolders(response.metadata);
+    const knownIds =
+      (await context.store.get<number[]>('knownFolderIds')) ?? [];
+    const knownSet = new Set(knownIds);
+    const newFolders = folders.filter(
+      (f) => f.folderid && !knownSet.has(f.folderid),
+    );
+
+    if (newFolders.length > 0) {
+      const updatedIds = folders.map((f) => f.folderid).filter(Boolean);
+      await context.store.put('knownFolderIds', updatedIds);
+    }
+
+    return newFolders;
+  },
+
+  test: async (context) => {
+    const response =
+      await common.pcloudRequest<PcloudListFolderResponse>(
+        context.auth,
+        'listfolder',
+        { folderid: context.propsValue.folderId },
+      );
+    return extractFolders(response.metadata).slice(0, 5);
+  },
+});

--- a/packages/pieces/community/pcloud/src/lib/triggers/new-file-uploaded.ts
+++ b/packages/pieces/community/pcloud/src/lib/triggers/new-file-uploaded.ts
@@ -1,0 +1,95 @@
+import {
+  createTrigger,
+  Property,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { pcloudAuth } from '../auth';
+import { common, PcloudListFolderResponse, PcloudMetadata } from '../common';
+
+function extractFiles(metadata: PcloudMetadata): PcloudMetadata[] {
+  const files: PcloudMetadata[] = [];
+  if (metadata.contents) {
+    for (const item of metadata.contents) {
+      if (!item.isfolder) {
+        files.push(item);
+      }
+    }
+  }
+  return files;
+}
+
+export const pcloudNewFileUploaded = createTrigger({
+  auth: pcloudAuth,
+  name: 'pcloud_new_file_uploaded',
+  displayName: 'New File Uploaded',
+  description:
+    'Automatically process or back up files as soon as they are added to a designated folder, such as saving incoming invoices for accounting.',
+
+  type: TriggerStrategy.POLLING,
+
+  props: {
+    folderId: Property.Number({
+      displayName: 'Folder ID',
+      description: 'The ID of the folder to watch. Use 0 for root.',
+      required: true,
+      defaultValue: 0,
+    }),
+  },
+
+  sampleData: {
+    name: 'report.pdf',
+    fileid: 12345678,
+    size: 204800,
+    contenttype: 'application/pdf',
+    created: 'Thu, 27 Mar 2026 12:00:00 +0000',
+    modified: 'Thu, 27 Mar 2026 12:00:00 +0000',
+    isfolder: false,
+  },
+
+  onEnable: async (context) => {
+    const response =
+      await common.pcloudRequest<PcloudListFolderResponse>(
+        context.auth,
+        'listfolder',
+        { folderid: context.propsValue.folderId },
+      );
+    const files = extractFiles(response.metadata);
+    const knownIds = files.map((f) => f.fileid).filter(Boolean);
+    await context.store.put('knownFileIds', knownIds);
+  },
+
+  onDisable: async (context) => {
+    await context.store.delete('knownFileIds');
+  },
+
+  run: async (context) => {
+    const response =
+      await common.pcloudRequest<PcloudListFolderResponse>(
+        context.auth,
+        'listfolder',
+        { folderid: context.propsValue.folderId },
+      );
+    const files = extractFiles(response.metadata);
+    const knownIds =
+      (await context.store.get<number[]>('knownFileIds')) ?? [];
+    const knownSet = new Set(knownIds);
+    const newFiles = files.filter((f) => f.fileid && !knownSet.has(f.fileid));
+
+    if (newFiles.length > 0) {
+      const updatedIds = files.map((f) => f.fileid).filter(Boolean);
+      await context.store.put('knownFileIds', updatedIds);
+    }
+
+    return newFiles;
+  },
+
+  test: async (context) => {
+    const response =
+      await common.pcloudRequest<PcloudListFolderResponse>(
+        context.auth,
+        'listfolder',
+        { folderid: context.propsValue.folderId },
+      );
+    return extractFiles(response.metadata).slice(0, 5);
+  },
+});

--- a/packages/pieces/community/pcloud/tsconfig.json
+++ b/packages/pieces/community/pcloud/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/pcloud/tsconfig.lib.json
+++ b/packages/pieces/community/pcloud/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -869,6 +869,9 @@
       "@activepieces/piece-placid": [
         "packages/pieces/community/placid/src/index.ts"
       ],
+      "@activepieces/piece-pcloud": [
+        "packages/pieces/community/pcloud/src/index.ts"
+      ],
       "@activepieces/piece-podio": [
         "packages/pieces/community/podio/src/index.ts"
       ],


### PR DESCRIPTION
## Summary
- Adds a new community piece for **pCloud** cloud storage integration
- OAuth2 authentication with US/EU region support (api.pcloud.com / eapi.pcloud.com)
- **Triggers**: New File Uploaded, Folder Created (polling-based)
- **Write Actions**: Upload File, Create Folder, Download File Content, Copy File
- **Search Actions**: Find File, Find Folder
- Custom API call action for advanced usage

## Pieces Checklist
- [x] Piece follows the [Piece Development Guidelines](https://www.activepieces.com/docs/developers/building-pieces/overview)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Lint passes (`npm run lint-dev`)
- [x] All triggers, actions, and auth defined per issue spec

## Test plan
- [ ] Connect pCloud OAuth2 account
- [ ] Test upload file action with a sample file
- [ ] Test create folder action
- [ ] Test download file content action
- [ ] Test copy file action
- [ ] Test find file search
- [ ] Test find folder search
- [ ] Test new file uploaded trigger (polling)
- [ ] Test folder created trigger (polling)

Closes #7670

🤖 Generated with [Claude Code](https://claude.com/claude-code)