### PR TITLE
fix: replace systeminformation shell spawn with check-disk-space

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7834,6 +7834,7 @@
       "dependencies": {
         "@activepieces/shared": "workspace:*",
         "async-mutex": "0.4.0",
+        "check-disk-space": "3.4.0",
         "dayjs": "1.11.9",
         "systeminformation": "5.25.11",
       },
@@ -11761,6 +11762,8 @@
     "character-reference-invalid": ["character-reference-invalid@1.1.4", "", {}, "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
+    "check-disk-space": ["check-disk-space@3.4.0", "", {}, "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@activepieces/shared": "workspace:*",
     "async-mutex": "0.4.0",
+    "check-disk-space": "3.4.0",
     "dayjs": "1.11.9",
     "systeminformation": "5.25.11"
   },

--- a/packages/server/utils/src/system-usage.ts
+++ b/packages/server/utils/src/system-usage.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import os from 'os'
 import { MachineInformation, tryCatch } from '@activepieces/shared'
+import checkDiskSpace from 'check-disk-space'
 import si from 'systeminformation'
 import { fileSystemUtils } from './file-system-utils'
 
@@ -89,16 +90,13 @@ export const systemUsage = {
 
     async getDiskInfo(): Promise<MachineInformation['diskInfo']> {
         const { data, error } = await tryCatch(async () => {
-            const disks = await si.fsSize()
-            const root = disks.find(d => d.mount === '/') ?? disks[0]
-            if (!root) {
-                return { total: 0, free: 0, used: 0, percentage: 0 }
-            }
+            const { size, free } = await checkDiskSpace('/')
+            const used = size - free
             return {
-                total: root.size,
-                free: root.available,
-                used: root.used,
-                percentage: root.use,
+                total: size,
+                free,
+                used,
+                percentage: size > 0 ? (used / size) * 100 : 0,
             }
         })
         if (error) {

--- a/packages/server/utils/test/system-usage.test.ts
+++ b/packages/server/utils/test/system-usage.test.ts
@@ -18,18 +18,22 @@ vi.mock('../src/file-system-utils', () => ({
 vi.mock('systeminformation', () => ({
     default: {
         mem: vi.fn(),
-        fsSize: vi.fn(),
     },
 }))
 
+vi.mock('check-disk-space', () => ({
+    default: vi.fn(),
+}))
+
 import fs from 'fs'
+import checkDiskSpace from 'check-disk-space'
 import si from 'systeminformation'
 import { fileSystemUtils } from '../src/file-system-utils'
 
 const mockFileExists = vi.mocked(fileSystemUtils.fileExists)
 const mockReadFile = vi.mocked(fs.promises.readFile)
 const mockMem = vi.mocked(si.mem)
-const mockFsSize = vi.mocked(si.fsSize)
+const mockCheckDiskSpace = vi.mocked(checkDiskSpace)
 
 function mockCgroupFile(path: string, content: string) {
     mockFileExists.mockImplementation(async (p: string) => p === path)
@@ -143,11 +147,8 @@ describe('getContainerMemoryUsage', () => {
 })
 
 describe('getDiskInfo', () => {
-    it('should return disk info from root mount', async () => {
-        mockFsSize.mockResolvedValue([
-            { mount: '/boot', size: 500_000_000, available: 400_000_000, used: 100_000_000, use: 20 },
-            { mount: '/', size: 100_000_000_000, available: 40_000_000_000, used: 60_000_000_000, use: 60 },
-        ] as never)
+    it('should return disk info', async () => {
+        mockCheckDiskSpace.mockResolvedValue({ diskPath: '/', size: 100_000_000_000, free: 40_000_000_000 })
 
         const result = await systemUsage.getDiskInfo()
         expect(result).toEqual({
@@ -158,29 +159,8 @@ describe('getDiskInfo', () => {
         })
     })
 
-    it('should return zeros when si.fsSize() throws', async () => {
-        mockFsSize.mockRejectedValue(new Error('disk error'))
-
-        const result = await systemUsage.getDiskInfo()
-        expect(result).toEqual({ total: 0, free: 0, used: 0, percentage: 0 })
-    })
-
-    it('should use first disk when no root mount found', async () => {
-        mockFsSize.mockResolvedValue([
-            { mount: '/data', size: 50_000_000_000, available: 25_000_000_000, used: 25_000_000_000, use: 50 },
-        ] as never)
-
-        const result = await systemUsage.getDiskInfo()
-        expect(result).toEqual({
-            total: 50_000_000_000,
-            free: 25_000_000_000,
-            used: 25_000_000_000,
-            percentage: 50,
-        })
-    })
-
-    it('should return zeros when no disks are returned', async () => {
-        mockFsSize.mockResolvedValue([] as never)
+    it('should return zeros when checkDiskSpace throws', async () => {
+        mockCheckDiskSpace.mockRejectedValue(new Error('disk error'))
 
         const result = await systemUsage.getDiskInfo()
         expect(result).toEqual({ total: 0, free: 0, used: 0, percentage: 0 })


### PR DESCRIPTION
## Summary

- Replaces `si.fsSize()` from the `systeminformation` package with [`check-disk-space`](https://github.com/Alex-D/check-disk-space) for disk usage reporting
- `systeminformation` internally spawns a `df` shell process to get disk info, which was flagged as a security risk by EDR tooling
- `check-disk-space` uses native Node.js APIs (no shell spawn) and returns the same `{ size, free }` shape we need
- Updated tests to mock `check-disk-space` instead of `si.fsSize`


