### PR TITLE
refactor: extract mcpToolError helper for MCP tools

### DIFF
--- a/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
@@ -12,6 +12,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const addBranchInput = z.object({
     flowId: z.string(),
@@ -95,10 +96,7 @@ export const apAddBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Add branch failed: ${message}` }],
-                }
+                return mcpToolError('Add branch failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -15,6 +15,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const addStepInput = z.object({
     flowId: z.string(),
@@ -168,13 +169,7 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `❌ Step add failed: ${message}`,
-                    }],
-                }
+                return mcpToolError('Step add failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-change-flow-status.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-change-flow-status.ts
@@ -10,6 +10,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const changeFlowStatusInput = z.object({
     flowId: z.string(),
@@ -64,10 +65,7 @@ export const apChangeFlowStatusTool = (mcp: McpServer, log: FastifyBaseLogger): 
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Status change failed: ${message}` }],
-                }
+                return mcpToolError('Status change failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
@@ -2,6 +2,7 @@ import { McpServer, McpToolDefinition } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
+import { mcpToolError } from './mcp-utils'
 
 export const apCreateFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
@@ -29,13 +30,7 @@ export const apCreateFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `❌ Flow creation failed: ${message}`,
-                    }],
-                }
+                return mcpToolError('Flow creation failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-delete-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-branch.ts
@@ -11,6 +11,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const deleteBranchInput = z.object({
     flowId: z.string(),
@@ -88,10 +89,7 @@ export const apDeleteBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Delete branch failed: ${message}` }],
-                }
+                return mcpToolError('Delete branch failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
@@ -10,6 +10,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const deleteStepInput = z.object({
     flowId: z.string(),
@@ -66,13 +67,7 @@ export const apDeleteStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `❌ Step delete failed: ${message}`,
-                    }],
-                }
+                return mcpToolError('Step delete failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
@@ -14,6 +14,7 @@ import type { Step } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
+import { mcpToolError } from './mcp-utils'
 
 type StepInfo = {
     name: string
@@ -228,13 +229,7 @@ export const apFlowStructureTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 return { content: [{ type: 'text', text }] }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `❌ Failed to get flow structure: ${message}`,
-                    }],
-                }
+                return mcpToolError('Failed to get flow structure', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
@@ -8,6 +8,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { appConnectionService } from '../../app-connection/app-connection-service/app-connection-service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const statusEnum = z.nativeEnum(AppConnectionStatus)
 
@@ -74,10 +75,7 @@ export const apListConnectionsTool = (mcp: McpServer, log: FastifyBaseLogger): M
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Failed to list connections: ${message}` }],
-                }
+                return mcpToolError('Failed to list connections', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
@@ -1,6 +1,7 @@
 import { McpServer, McpToolDefinition } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { flowService } from '../../flows/flow/flow.service'
+import { mcpToolError } from './mcp-utils'
 
 export const apListFlowsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
@@ -23,13 +24,7 @@ export const apListFlowsTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `❌ Failed to list flows: ${message}`,
-                    }],
-                }
+                return mcpToolError('Failed to list flows', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
@@ -8,6 +8,7 @@ import {
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
+import { mcpToolError } from './mcp-utils'
 
 const listPiecesSchema = z.object({
     categories: z.array(z.enum(Object.values(PieceCategory) as [string, ...string[]])).optional(),
@@ -94,10 +95,7 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Failed to list pieces: ${message}` }],
-                }
+                return mcpToolError('Failed to list pieces', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-lock-and-publish.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-lock-and-publish.ts
@@ -11,6 +11,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const lockAndPublishInput = z.object({
     flowId: z.string(),
@@ -65,10 +66,7 @@ export const apLockAndPublishTool = (mcp: McpServer, log: FastifyBaseLogger): Mc
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Publish failed: ${message}` }],
-                }
+                return mcpToolError('Publish failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-manage-notes.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-manage-notes.ts
@@ -11,6 +11,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const manageNotesInput = z.object({
     flowId: z.string(),
@@ -135,10 +136,7 @@ export const apManageNotesTool = (mcp: McpServer, log: FastifyBaseLogger): McpTo
                 return { content: [{ type: 'text', text: messages[op] }] }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Note operation failed: ${message}` }],
-                }
+                return mcpToolError('Note operation failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-rename-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-rename-flow.ts
@@ -9,6 +9,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const renameFlowInput = z.object({
     flowId: z.string(),
@@ -53,10 +54,7 @@ export const apRenameFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Flow rename failed: ${message}` }],
-                }
+                return mcpToolError('Flow rename failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -12,6 +12,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const updateStepInput = z.object({
     flowId: z.string(),
@@ -144,10 +145,7 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Step update failed: ${message}` }],
-                }
+                return mcpToolError('Step update failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
@@ -11,6 +11,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
+import { mcpToolError } from './mcp-utils'
 
 const updateTriggerInput = z.object({
     flowId: z.string(),
@@ -109,10 +110,7 @@ export const apUpdateTriggerTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 }
             }
             catch (err) {
-                const message = err instanceof Error ? err.message : String(err)
-                return {
-                    content: [{ type: 'text', text: `❌ Trigger update failed: ${message}` }],
-                }
+                return mcpToolError('Trigger update failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -1,0 +1,4 @@
+export function mcpToolError(prefix: string, err: unknown): { content: [{ type: 'text', text: string }] } {
+    const message = err instanceof Error ? err.message : String(err)
+    return { content: [{ type: 'text', text: `❌ ${prefix}: ${message}` }] }
+}


### PR DESCRIPTION
## Summary
- Extract repeated error formatting pattern into a shared `mcpToolError` helper in `mcp-utils.ts`
- Update all 15 existing MCP tools to use the new helper, removing ~60 lines of duplicated code

## Test plan
- [ ] Verify lint passes with 0 errors
- [ ] Verify MCP tools still return proper error messages when operations fail