### PR TITLE
fix: require Node 22.15+ for dev setup zstd compatibility

### DIFF
--- a/tools/setup-dev.js
+++ b/tools/setup-dev.js
@@ -6,13 +6,19 @@ const path = require('path');
 
 // Check Node.js version
 const nodeVersion = execSync('node --version').toString().trim();
-const requiredVersions = ['v18', 'v22', 'v24'];
+const requiredVersions = ['v22.15+', 'v24'];
 
 // Check operating system
 const os = process.platform;
 console.log(`Running on ${os} operating system.`)
 
-if (requiredVersions.some(version => nodeVersion.startsWith(version))) {
+const [major, minor = 0] = nodeVersion.replace(/^v/, '').split('.').map(Number);
+const isCompatibleNodeVersion = requiredVersions.some((version) => {
+  const [requiredMajor, requiredMinor = 0] = version.match(/\d+/g).map(Number);
+  return major === requiredMajor && (minor >= requiredMinor);
+});
+
+if (isCompatibleNodeVersion) {
   console.log(`Node.js version is compatible ${nodeVersion}.`);
 } else {
   console.log(`Node.js version is not compatible. Required version: ${requiredVersions.toString()}`);


### PR DESCRIPTION
## What does this PR do?

updates the dev setup check to require node version that supports `zstd`.
It prevents startup crash on unsupported version node v18.


### Change Details
- `tools/setup-dev.js` now allows:
  - Node 22.15+
  - Node 24
- Older versions are blocked.

Fixes #12290
