### PR TITLE
feat: project update max concurrent jobs

### DIFF
--- a/packages/server/api/src/app/project/project-service.ts
+++ b/packages/server/api/src/app/project/project-service.ts
@@ -86,7 +86,7 @@ export const projectService = (log: FastifyBaseLogger) => ({
             ...spreadIfDefined('externalId', externalId),
             ...spreadIfDefined('releasesEnabled', request.releasesEnabled),
             ...spreadIfDefined('metadata', request.metadata),
-            ...spreadIfDefined('maxConcurrentJobs', request.maxConcurrentJobs),
+            ...maxConcurrentJobsUpdatePatch(request.maxConcurrentJobs),
         }
 
         const teamUpdate = request.type === ProjectType.TEAM ? {
@@ -96,15 +96,7 @@ export const projectService = (log: FastifyBaseLogger) => ({
 
         await projectRepo(entityManager).update({ id: projectId }, { ...baseUpdate, ...teamUpdate })
 
-        if (!isNil(request.maxConcurrentJobs)) {
-            const key = getProjectMaxConcurrentJobsKey(projectId)
-            if (request.maxConcurrentJobs <= 0) {
-                await distributedStore.delete(key)
-            }
-            else {
-                await distributedStore.put(key, request.maxConcurrentJobs)
-            }
-        }
+        await syncMaxConcurrentJobsStore(projectId, request.maxConcurrentJobs)
 
         return this.getOneOrThrow(projectId)
     },
@@ -265,6 +257,31 @@ async function assertExternalIdIsUnique(externalId: string | undefined | null, p
                 },
             })
         }
+    }
+}
+
+function maxConcurrentJobsUpdatePatch(maxConcurrentJobs: number | undefined): { maxConcurrentJobs: number | null } | Record<string, never> {
+    if (maxConcurrentJobs == null) {
+        return {}
+    }
+    const value = maxConcurrentJobs
+    if (value <= 0) {
+        return { maxConcurrentJobs: null }
+    }
+    return { maxConcurrentJobs: value }
+}
+
+async function syncMaxConcurrentJobsStore(projectId: ProjectId, maxConcurrentJobs: number | undefined): Promise<void> {
+    if (maxConcurrentJobs == null) {
+        return
+    }
+    const value = maxConcurrentJobs
+    const key = getProjectMaxConcurrentJobsKey(projectId)
+    if (value <= 0) {
+        await distributedStore.delete(key)
+    }
+    else {
+        await distributedStore.put(key, value)
     }
 }
 

--- a/packages/server/api/src/app/project/project-service.ts
+++ b/packages/server/api/src/app/project/project-service.ts
@@ -95,6 +95,17 @@ export const projectService = (log: FastifyBaseLogger) => ({
         } : {}
 
         await projectRepo(entityManager).update({ id: projectId }, { ...baseUpdate, ...teamUpdate })
+
+        if (!isNil(request.maxConcurrentJobs)) {
+            const key = getProjectMaxConcurrentJobsKey(projectId)
+            if (request.maxConcurrentJobs <= 0) {
+                await distributedStore.delete(key)
+            }
+            else {
+                await distributedStore.put(key, request.maxConcurrentJobs)
+            }
+        }
+
         return this.getOneOrThrow(projectId)
     },
 

--- a/packages/server/api/test/integration/cloud/project/project.test.ts
+++ b/packages/server/api/test/integration/cloud/project/project.test.ts
@@ -14,6 +14,8 @@ import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { generateMockToken } from '../../../helpers/auth'
 import { databaseConnection } from '../../../../src/app/database/database-connection'
+import { distributedStore, redisConnections } from '../../../../src/app/database/redis-connections'
+import { getProjectMaxConcurrentJobsKey } from '../../../../src/app/database/redis/keys'
 import { db } from '../../../helpers/db'
 import {
     createMockApiKey,
@@ -382,6 +384,135 @@ describe('Project API', () => {
             expect(responseBody.id).toBe(mockProject.id)
             expect(responseBody.displayName).toBe(request.displayName)
             expect(responseBody.metadata).toEqual(metadata)
+        })
+
+        it('it should set maxConcurrentJobs in redis when value is positive', async () => {
+            const { mockOwner: mockUser, mockPlatform } = await mockAndSaveBasicSetup()
+
+            mockUser.platformId = mockPlatform.id
+            mockUser.platformRole = PlatformRole.ADMIN
+
+            await db.save('user', mockUser)
+
+            const mockProject = createMockProject({
+                ownerId: mockUser.id,
+                platformId: mockPlatform.id,
+            })
+            await db.save('project', mockProject)
+
+            const testToken = await generateMockToken({
+                type: PrincipalType.USER,
+                id: mockUser.id,
+                platform: {
+                    id: mockPlatform.id,
+                },
+            })
+
+            const maxConcurrentJobs = 7
+            const redisKey = getProjectMaxConcurrentJobsKey(mockProject.id)
+
+            const response = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/projects/' + mockProject.id,
+                body: {
+                    displayName: faker.animal.bird(),
+                    maxConcurrentJobs,
+                },
+                headers: {
+                    authorization: `Bearer ${testToken}`,
+                },
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(await distributedStore.get<number>(redisKey)).toBe(maxConcurrentJobs)
+
+            const redis = await redisConnections.useExisting()
+            await redis.del(redisKey)
+        })
+
+        it('it should remove maxConcurrentJobs in redis when value is zero', async () => {
+            const { mockOwner: mockUser, mockPlatform } = await mockAndSaveBasicSetup()
+
+            mockUser.platformId = mockPlatform.id
+            mockUser.platformRole = PlatformRole.ADMIN
+
+            await db.save('user', mockUser)
+
+            const mockProject = createMockProject({
+                ownerId: mockUser.id,
+                platformId: mockPlatform.id,
+            })
+            await db.save('project', mockProject)
+
+            const testToken = await generateMockToken({
+                type: PrincipalType.USER,
+                id: mockUser.id,
+                platform: {
+                    id: mockPlatform.id,
+                },
+            })
+
+            const redisKey = getProjectMaxConcurrentJobsKey(mockProject.id)
+            await distributedStore.put(redisKey, 4)
+
+            const response = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/projects/' + mockProject.id,
+                body: {
+                    displayName: faker.animal.bird(),
+                    maxConcurrentJobs: 0,
+                },
+                headers: {
+                    authorization: `Bearer ${testToken}`,
+                },
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(await distributedStore.get<number>(redisKey)).toBeNull()
+        })
+
+        it('it should keep maxConcurrentJobs in redis unchanged when value is omitted', async () => {
+            const { mockOwner: mockUser, mockPlatform } = await mockAndSaveBasicSetup()
+
+            mockUser.platformId = mockPlatform.id
+            mockUser.platformRole = PlatformRole.ADMIN
+
+            await db.save('user', mockUser)
+
+            const mockProject = createMockProject({
+                ownerId: mockUser.id,
+                platformId: mockPlatform.id,
+            })
+            await db.save('project', mockProject)
+
+            const testToken = await generateMockToken({
+                type: PrincipalType.USER,
+                id: mockUser.id,
+                platform: {
+                    id: mockPlatform.id,
+                },
+            })
+
+            const redisKey = getProjectMaxConcurrentJobsKey(mockProject.id)
+            const existingMaxConcurrentJobs = 11
+            await distributedStore.put(redisKey, existingMaxConcurrentJobs)
+
+            const response = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/projects/' + mockProject.id,
+                body: {
+                    displayName: faker.animal.bird(),
+                },
+                headers: {
+                    authorization: `Bearer ${testToken}`,
+                },
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(await distributedStore.get<number>(redisKey)).toBe(existingMaxConcurrentJobs)
+
+            const redis = await redisConnections.useExisting()
+            await redis.del(redisKey)
         })
     })
 

--- a/packages/shared/src/lib/management/project/project-requests.ts
+++ b/packages/shared/src/lib/management/project/project-requests.ts
@@ -15,6 +15,7 @@ export const UpdateProjectPlatformRequest = z.object({
         piecesFilterType: z.nativeEnum(PiecesFilterType).optional(),
     }).optional(),
     globalConnectionExternalIds: z.array(z.string()).optional(),
+    maxConcurrentJobs: z.number().nonnegative({ message: 'Max concurrent jobs must be a positive number' }).optional(),
 })
 
 export type UpdateProjectPlatformRequest = z.infer<typeof UpdateProjectPlatformRequest>

--- a/packages/shared/src/lib/management/project/project-requests.ts
+++ b/packages/shared/src/lib/management/project/project-requests.ts
@@ -15,7 +15,7 @@ export const UpdateProjectPlatformRequest = z.object({
         piecesFilterType: z.nativeEnum(PiecesFilterType).optional(),
     }).optional(),
     globalConnectionExternalIds: z.array(z.string()).optional(),
-    maxConcurrentJobs: z.number().nonnegative({ message: 'Max concurrent jobs must be a positive number' }).optional(),
+    maxConcurrentJobs: z.number().nonnegative({ message: 'Max concurrent jobs must be zero or positive number' }).optional(),
 })
 
 export type UpdateProjectPlatformRequest = z.infer<typeof UpdateProjectPlatformRequest>


### PR DESCRIPTION

## What does this PR do?

This PR extends the **platform project update** flow so **`maxConcurrentJobs` can be set, cleared, or left unchanged** when updating a project when in the enterprise or cloud version. When a positive value is sent, it is written to **Redis** under the project’s max-concurrent-jobs key. When **`0` is sent**, that Redis entry is **removed** (no per-project override). When the field is **omitted**, the existing Redis value is **not** touched. The shared **`UpdateProjectPlatformRequest`** schema now includes optional **`maxConcurrentJobs`** (non-negative). **Integration tests** cover: setting a positive value, clearing with zero, and preserving Redis when the field is omitted.

### Explain How the Feature Works

Clients call the existing project update API (e.g. `POST /api/v1/projects/:id`) with an optional `maxConcurrentJobs` in the body. The server updates the project record as before, then synchronizes Redis: **positive** values are stored; **zero** deletes the key; **undefined** skips Redis updates so prior limits remain.  
<!-- [Insert the video link here] -->

### Relevant User Scenarios

- **Tune throughput per project** — Platform admins can raise or lower how many jobs may run concurrently for a specific project without redeploying.  
- **Remove a custom limit** — Sending `maxConcurrentJobs: 0` clears the Redis override so default/global behavior applies again.  
- **Safe partial updates** — Updating display name or other fields without sending `maxConcurrentJobs` does not accidentally reset an existing per-project limit in Redis.  
