### PR TITLE
feat(slack): add support for multiple user or usergroup mentions

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/slack/src/lib/common/props.ts
+++ b/packages/pieces/community/slack/src/lib/common/props.ts
@@ -104,25 +104,8 @@ export const userId = <R extends boolean>(required: R) =>
           options: [],
         };
       }
-
-    const accessToken = getBotToken(auth as SlackAuthValue);
-
-      const client = new WebClient(accessToken);
-      const users: { label: string; value: string }[] = [];
-      for await (const page of client.paginate('users.list', {
-        limit: 1000, // Only limits page size, not total number of results
-      })) {
-        const response = page as UsersListResponse;
-        if (response.members) {
-          users.push(
-            ...response.members
-              .filter((member) => !member.deleted)
-              .map((member) => {
-                return { label: member.name || '', value: member.id || '' };
-              })
-          );
-        }
-      }
+      const accessToken = getBotToken(auth as SlackAuthValue);
+      const users = await getUsers(accessToken);
       return {
         disabled: false,
         placeholder: 'Select User',
@@ -130,6 +113,59 @@ export const userId = <R extends boolean>(required: R) =>
       };
     },
   });
+
+export const userIds = Property.MultiSelectDropdown({
+  auth: slackAuth,
+  displayName: 'Users',
+  required: false,
+  refreshers: [],
+  async options({ auth }) {
+    if (!auth) {
+      return {
+        disabled: true,
+        placeholder: 'connect slack account',
+        options: [],
+      };
+    }
+    const accessToken = getBotToken(auth as SlackAuthValue);
+    const users = await getUsers(accessToken);
+    return {
+      disabled: false,
+      placeholder: 'Select Users',
+      options: users,
+    };
+  },
+});
+
+export const usergroupIds = Property.MultiSelectDropdown({
+  auth: slackAuth,
+  displayName: 'User Groups',
+  required: false,
+  refreshers: [],
+  async options({ auth }) {
+    if (!auth) {
+      return {
+        disabled: true,
+        placeholder: 'connect slack account',
+        options: [],
+      };
+    }
+    const accessToken = getBotToken(auth as SlackAuthValue);
+    const client = new WebClient(accessToken);
+    const response = await client.usergroups.list();
+    const usergroups = (response.usergroups ?? [])
+      .filter((ug) => !ug.date_delete)
+      .map((ug) => ({
+        label: ug.handle || ug.name || '',
+        value: ug.id || '',
+      }));
+    return {
+      disabled: false,
+      placeholder: 'Select User Groups',
+      options: usergroups,
+    };
+  },
+});
 
 export const text = Property.LongText({
   displayName: 'Message',
@@ -158,6 +194,27 @@ export const actions = Property.Array({
     }),
   },
 });
+
+async function getUsers(accessToken: string) {
+  const client = new WebClient(accessToken);
+  const users: { label: string; value: string }[] = [];
+  for await (const page of client.paginate('users.list', {
+    limit: 1000,
+  })) {
+    const response = page as UsersListResponse;
+    if (response.members) {
+      users.push(
+        ...response.members
+          .filter((member) => !member.deleted)
+          .map((member) => ({
+            label: member.name || '',
+            value: member.id || '',
+          }))
+      );
+    }
+  }
+  return users;
+}
 
 export async function getChannels(accessToken: string) {
   const client = new WebClient(accessToken);

--- a/packages/pieces/community/slack/src/lib/triggers/new-mention.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-mention.ts
@@ -3,7 +3,7 @@ import {
   TriggerStrategy,
   createTrigger,
 } from '@activepieces/pieces-framework';
-import { getChannels, multiSelectChannelInfo, userId } from '../common/props';
+import { getChannels, multiSelectChannelInfo, userIds, usergroupIds } from '../common/props';
 import { slackAuth } from '../auth';
 import { getBotToken, getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
@@ -11,10 +11,11 @@ export const newMention = createTrigger({
   auth: slackAuth,
   name: 'new_mention',
   displayName: 'New Mention in Channel',
-  description: 'Triggers when a username is mentioned.',
+  description: 'Triggers when a user or user group is mentioned.',
   props: {
     info: multiSelectChannelInfo,
-    user: userId(true),
+    users: userIds,
+    usergroups: usergroupIds,
     channels: Property.MultiSelectDropdown({
       auth: slackAuth,
       displayName: 'Channels',
@@ -46,7 +47,7 @@ export const newMention = createTrigger({
     }),
     removeMention: Property.Checkbox({
       displayName: 'Remove Mention from Message',
-      description: 'If enabled, provides a clean_text field with the user mention removed from the message.',
+      description: 'If enabled, provides a clean_text field with the user and user group mentions removed from the message.',
       required: true,
       defaultValue: false,
     }),
@@ -67,35 +68,50 @@ export const newMention = createTrigger({
   run: async (context) => {
     const payloadBody = context.payload.body as PayloadBody;
     const channels = (context.propsValue.channels as string[]) ?? [];
+    const users = (context.propsValue.users as string[]) ?? [];
+    const usergroups = (context.propsValue.usergroups as string[]) ?? [];
 
     // check if it's channel message
 		if (!['channel','group'].includes(payloadBody.event.channel_type)) {
 			return [];
 		}
 
-
-    if (channels.length === 0 || channels.includes(payloadBody.event.channel)) {
-      // check for bot messages
-      if (context.propsValue.ignoreBots && payloadBody.event.bot_id) {
-        return [];
-      }
-      // check for mention
-      if (
-        context.propsValue.user &&
-        payloadBody.event.text?.includes(`<@${context.propsValue.user}>`)
-      ) {
-        if (context.propsValue.removeMention) {
-          const mentionRegex = new RegExp(`<@${context.propsValue.user}>`, 'g');
-          const cleanText = (payloadBody.event.text ?? '')
-            .replace(mentionRegex, '')
-            .trim();
-          return [{ ...payloadBody.event, clean_text: cleanText }];
-        }
-        return [payloadBody.event];
-      }
+    if (channels.length > 0 && !channels.includes(payloadBody.event.channel)) {
+      return [];
     }
 
-    return [];
+    // check for bot messages
+    if (context.propsValue.ignoreBots && payloadBody.event.bot_id) {
+      return [];
+    }
+
+    const text = payloadBody.event.text ?? '';
+
+    const userMentioned = users.some((uid) => text.includes(`<@${uid}>`));
+    const usergroupMentioned = usergroups.some((gid) =>
+      new RegExp(`<!subteam\\^${gid}(\\|[^>]*)?>`).test(text)
+    );
+
+    if (!userMentioned && !usergroupMentioned) {
+      return [];
+    }
+
+    if (context.propsValue.removeMention) {
+      let cleanText = text;
+      for (const uid of users) {
+        cleanText = cleanText.replace(new RegExp(`<@${uid}>`, 'g'), '');
+      }
+      for (const gid of usergroups) {
+        cleanText = cleanText.replace(
+          new RegExp(`<!subteam\\^${gid}(\\|[^>]*)?>`, 'g'),
+          ''
+        );
+      }
+      cleanText = cleanText.trim();
+      return [{ ...payloadBody.event, clean_text: cleanText }];
+    }
+
+    return [payloadBody.event];
   },
 });
 


### PR DESCRIPTION
## What does this PR do?

We want to be able to trigger a flow when mentioning a **usergroup**
Also add support for multiple users and uaergroups (the trigger runs when at least once of them is mentioned in a message)

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
