### PR TITLE
feat(whatsscale): add platform field to send actions for source tracking

### DIFF
--- a/packages/pieces/community/whatsscale/src/index.ts
+++ b/packages/pieces/community/whatsscale/src/index.ts
@@ -28,6 +28,26 @@ import { sendDocumentToContactAction } from './lib/actions/messaging/send-docume
 import { sendDocumentToGroupAction } from './lib/actions/messaging/send-document-to-group';
 import { sendDocumentToCrmContactAction } from './lib/actions/messaging/send-document-to-crm-contact';
 
+// Location actions
+import { sendLocationToContactAction } from './lib/actions/messaging/send-location-to-contact';
+import { sendLocationToGroupAction } from './lib/actions/messaging/send-location-to-group';
+import { sendLocationToCrmContactAction } from './lib/actions/messaging/send-location-to-crm-contact';
+
+// Poll actions
+import { sendPollToContactAction } from './lib/actions/messaging/send-poll-to-contact';
+import { sendPollToGroupAction } from './lib/actions/messaging/send-poll-to-group';
+import { sendPollToChannelAction } from './lib/actions/messaging/send-poll-to-channel';
+import { sendPollToCrmContactAction } from './lib/actions/messaging/send-poll-to-crm-contact';
+
+// Story actions
+import { setTextStoryAction } from './lib/actions/stories/set-text-story';
+import { setImageStoryAction } from './lib/actions/stories/set-image-story';
+import { setVideoStoryAction } from './lib/actions/stories/set-video-story';
+
+// Info actions
+import { getGroupInfoAction } from './lib/actions/info/get-group-info';
+import { getChannelInfoAction } from './lib/actions/info/get-channel-info';
+
 // CRM actions
 import { createCrmContactAction } from './lib/actions/crm/create-crm-contact';
 import { getCrmContactAction } from './lib/actions/crm/get-crm-contact';
@@ -94,6 +114,22 @@ export const whatsscale = createPiece({
     addCrmContactTagAction,
     removeCrmContactTagAction,
     listCrmContactsAction,
+    // Location actions
+    sendLocationToContactAction,
+    sendLocationToGroupAction,
+    sendLocationToCrmContactAction,
+    // Poll actions
+    sendPollToContactAction,
+    sendPollToGroupAction,
+    sendPollToChannelAction,
+    sendPollToCrmContactAction,
+    // Story actions
+    setTextStoryAction,
+    setImageStoryAction,
+    setVideoStoryAction,
+    // Info actions
+    getGroupInfoAction,
+    getChannelInfoAction,
     // Utility actions
     checkWhatsappAction,
     createCustomApiCallAction({

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/add-crm-contact-tag.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/add-crm-contact-tag.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { addCrmContactTagAction } from './add-crm-contact-tag';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' } as any;
+const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const MOCK_CRM_CONTACT = {
+  id:         TEST_UUID,
+  phone:      '+31649931832',
+  name:       'John Doe',
+  tags:       ['vip', 'customer'],
+  source:     'api',
+  created_at: '2026-03-05T00:00:00.000Z',
+  updated_at: '2026-03-05T00:00:00.000Z',
+};
+const mockClient = vi.mocked(clientModule.whatsscaleClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('addCrmContactTagAction', () => {
+  it('calls POST /api/crm/contacts/:uuid/tags', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (addCrmContactTagAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, tag: 'vip' },
+    });
+    expect(mockClient.mock.calls[0][2]).toBe(`/api/crm/contacts/${TEST_UUID}/tags`);
+  });
+
+  it('sends tag in body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (addCrmContactTagAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, tag: 'vip' },
+    });
+    expect(mockClient.mock.calls[0][3]).toEqual({ tag: 'vip' });
+  });
+
+  it('passes API key as first arg', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (addCrmContactTagAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, tag: 'vip' },
+    });
+    expect(mockClient.mock.calls[0][0]).toBe('test-api-key');
+  });
+
+  it('returns updated contact', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    const result = await (addCrmContactTagAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, tag: 'vip' },
+    });
+    expect(result).toEqual(MOCK_CRM_CONTACT);
+  });
+
+  it('surfaces thrown error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('404 Not Found'));
+    await expect(
+      (addCrmContactTagAction as any).run({
+        auth: mockAuth,
+        propsValue: { contactId: TEST_UUID, tag: 'vip' },
+      })
+    ).rejects.toThrow('404 Not Found');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/create-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/create-crm-contact.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCrmContactAction } from './create-crm-contact';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' } as any;
+const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const MOCK_CRM_CONTACT = {
+  id:         TEST_UUID,
+  phone:      '+31649931832',
+  name:       'John Doe',
+  tags:       ['vip', 'customer'],
+  source:     'api',
+  created_at: '2026-03-05T00:00:00.000Z',
+  updated_at: '2026-03-05T00:00:00.000Z',
+};
+const mockClient = vi.mocked(clientModule.whatsscaleClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createCrmContactAction', () => {
+  it('posts to POST /api/crm/contacts', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (createCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678' },
+    });
+    expect(mockClient).toHaveBeenCalledWith(
+      expect.anything(),
+      'POST',
+      '/api/crm/contacts',
+      expect.anything()
+    );
+  });
+
+  it('sends phone in body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (createCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678' },
+    });
+    const body = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(body).toMatchObject({ phone: '+31612345678' });
+  });
+
+  it('omits name when not provided', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (createCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678', name: undefined },
+    });
+    const body = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('name');
+  });
+
+  it('includes name when provided', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (createCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678', name: 'Test Name' },
+    });
+    const body = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(body.name).toBe('Test Name');
+  });
+
+  it('sends tags as raw string', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (createCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678', tags: 'vip, customer' },
+    });
+    const body = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(body.tags).toBe('vip, customer');
+  });
+
+  it('passes API key as first arg', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (createCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678' },
+    });
+    expect(mockClient.mock.calls[0][0]).toBe('test-api-key');
+  });
+
+  it('returns response.body on success', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    const result = await (createCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31649931832', name: 'John Doe', tags: 'vip, customer' },
+    });
+    expect(result).toEqual(MOCK_CRM_CONTACT);
+  });
+
+  it('surfaces thrown error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('401 Unauthorized'));
+    await expect(
+      (createCrmContactAction as any).run({
+        auth: mockAuth,
+        propsValue: { phone: '+31612345678' },
+      })
+    ).rejects.toThrow('401 Unauthorized');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/create-crm-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/create-crm-contact.ts
@@ -30,8 +30,8 @@ export const createCrmContactAction = createAction({
     const { phone, name, tags } = context.propsValue;
 
     const body: Record<string, unknown> = { phone };
-    if (name) body['name'] = name;
-    if (tags) body['tags'] = tags;
+    if (name) body.name = name;
+    if (tags) body.tags = tags;
 
     const response = await whatsscaleClient(auth, HttpMethod.POST, '/api/crm/contacts', body);
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/delete-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/delete-crm-contact.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { deleteCrmContactAction } from './delete-crm-contact';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' } as any;
+const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const MOCK_DELETE = { success: true, deleted: true };
+const mockClient = vi.mocked(clientModule.whatsscaleClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('deleteCrmContactAction', () => {
+  it('calls DELETE /api/crm/contacts/:uuid', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_DELETE } as any);
+    await (deleteCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID },
+    });
+    expect(mockClient.mock.calls[0][1]).toBe('DELETE');
+    expect(mockClient.mock.calls[0][2]).toContain(TEST_UUID);
+  });
+
+  it('passes undefined as body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_DELETE } as any);
+    await (deleteCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID },
+    });
+    expect(mockClient.mock.calls[0][3]).toBeUndefined();
+  });
+
+  it('passes API key as first arg', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_DELETE } as any);
+    await (deleteCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID },
+    });
+    expect(mockClient.mock.calls[0][0]).toBe('test-api-key');
+  });
+
+  it('returns { success, deleted } shape', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_DELETE } as any);
+    const result = await (deleteCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID },
+    });
+    expect(result).toEqual(MOCK_DELETE);
+  });
+
+  it('surfaces thrown error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('404 Not Found'));
+    await expect(
+      (deleteCrmContactAction as any).run({
+        auth: mockAuth,
+        propsValue: { contactId: TEST_UUID },
+      })
+    ).rejects.toThrow('404 Not Found');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/find-crm-contact-by-phone.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/find-crm-contact-by-phone.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { findCrmContactByPhoneAction } from './find-crm-contact-by-phone';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' } as any;
+const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const MOCK_CRM_CONTACT = {
+  id:         TEST_UUID,
+  phone:      '+31649931832',
+  name:       'John Doe',
+  tags:       ['vip', 'customer'],
+  source:     'api',
+  created_at: '2026-03-05T00:00:00.000Z',
+  updated_at: '2026-03-05T00:00:00.000Z',
+};
+const mockClient = vi.mocked(clientModule.whatsscaleClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('findCrmContactByPhoneAction', () => {
+  it('calls GET /api/crm/contacts/phone/:phone with encoded phone', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (findCrmContactByPhoneAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678' },
+    });
+    expect(mockClient.mock.calls[0][2]).toBe('/api/crm/contacts/phone/%2B31612345678');
+  });
+
+  it('passes undefined as body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (findCrmContactByPhoneAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678' },
+    });
+    expect(mockClient.mock.calls[0][3]).toBeUndefined();
+  });
+
+  it('passes API key as first arg', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (findCrmContactByPhoneAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678' },
+    });
+    expect(mockClient.mock.calls[0][0]).toBe('test-api-key');
+  });
+
+  it('returns response.body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    const result = await (findCrmContactByPhoneAction as any).run({
+      auth: mockAuth,
+      propsValue: { phone: '+31612345678' },
+    });
+    expect(result).toEqual(MOCK_CRM_CONTACT);
+  });
+
+  it('surfaces thrown error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('404 Not Found'));
+    await expect(
+      (findCrmContactByPhoneAction as any).run({
+        auth: mockAuth,
+        propsValue: { phone: '+31612345678' },
+      })
+    ).rejects.toThrow('404 Not Found');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/find-crm-contact-by-phone.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/find-crm-contact-by-phone.ts
@@ -11,6 +11,7 @@ export const findCrmContactByPhoneAction = createAction({
   props: {
     phone: Property.ShortText({
       displayName: 'Phone Number',
+      description: 'With country code e.g. +31612345678',
       required: true,
     }),
   },

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/get-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/get-crm-contact.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getCrmContactAction } from './get-crm-contact';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' } as any;
+const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const MOCK_CRM_CONTACT = {
+  id:         TEST_UUID,
+  phone:      '+31649931832',
+  name:       'John Doe',
+  tags:       ['vip', 'customer'],
+  source:     'api',
+  created_at: '2026-03-05T00:00:00.000Z',
+  updated_at: '2026-03-05T00:00:00.000Z',
+};
+const mockClient = vi.mocked(clientModule.whatsscaleClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getCrmContactAction', () => {
+  it('calls GET /api/crm/contacts/:uuid', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (getCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID },
+    });
+    expect(mockClient.mock.calls[0][2]).toBe(`/api/crm/contacts/${TEST_UUID}`);
+  });
+
+  it('passes undefined as body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (getCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID },
+    });
+    expect(mockClient.mock.calls[0][3]).toBeUndefined();
+  });
+
+  it('passes API key as first arg', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (getCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID },
+    });
+    expect(mockClient.mock.calls[0][0]).toBe('test-api-key');
+  });
+
+  it('returns response.body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    const result = await (getCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID },
+    });
+    expect(result).toEqual(MOCK_CRM_CONTACT);
+  });
+
+  it('surfaces thrown error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('404 Not Found'));
+    await expect(
+      (getCrmContactAction as any).run({
+        auth: mockAuth,
+        propsValue: { contactId: TEST_UUID },
+      })
+    ).rejects.toThrow('404 Not Found');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/list-crm-contacts.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/list-crm-contacts.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listCrmContactsAction } from './list-crm-contacts';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' } as any;
+const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const MOCK_CRM_CONTACT = {
+  id:         TEST_UUID,
+  phone:      '+31649931832',
+  name:       'John Doe',
+  tags:       ['vip', 'customer'],
+  source:     'api',
+  created_at: '2026-03-05T00:00:00.000Z',
+  updated_at: '2026-03-05T00:00:00.000Z',
+};
+const MOCK_LIST = { items: [MOCK_CRM_CONTACT], total: 1, page: 1, limit: 50, hasMore: false };
+const mockClient = vi.mocked(clientModule.whatsscaleClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listCrmContactsAction', () => {
+  it('calls GET /api/crm/contacts', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_LIST } as any);
+    await (listCrmContactsAction as any).run({
+      auth: mockAuth,
+      propsValue: {},
+    });
+    expect(mockClient.mock.calls[0][1]).toBe('GET');
+    expect(mockClient.mock.calls[0][2]).toBe('/api/crm/contacts');
+  });
+
+  it('no props → 5th arg is undefined', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_LIST } as any);
+    await (listCrmContactsAction as any).run({
+      auth: mockAuth,
+      propsValue: { tag: undefined, limit: null, page: null },
+    });
+    expect(mockClient.mock.calls[0][4]).toBeUndefined();
+  });
+
+  it('tag filter → queryParams.tag set', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_LIST } as any);
+    await (listCrmContactsAction as any).run({
+      auth: mockAuth,
+      propsValue: { tag: 'vip' },
+    });
+    expect(mockClient.mock.calls[0][4]).toEqual({ tag: 'vip' });
+  });
+
+  it('limit converted to string', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_LIST } as any);
+    await (listCrmContactsAction as any).run({
+      auth: mockAuth,
+      propsValue: { limit: 10 },
+    });
+    expect(mockClient.mock.calls[0][4]).toEqual({ limit: '10' });
+  });
+
+  it('page converted to string', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_LIST } as any);
+    await (listCrmContactsAction as any).run({
+      auth: mockAuth,
+      propsValue: { page: 2 },
+    });
+    expect(mockClient.mock.calls[0][4]).toEqual({ page: '2' });
+  });
+
+  it('all params combined correctly', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_LIST } as any);
+    await (listCrmContactsAction as any).run({
+      auth: mockAuth,
+      propsValue: { tag: 'vip', limit: 10, page: 2 },
+    });
+    expect(mockClient.mock.calls[0][4]).toEqual({ tag: 'vip', limit: '10', page: '2' });
+  });
+
+  it('returns list response shape', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_LIST } as any);
+    const result = await (listCrmContactsAction as any).run({
+      auth: mockAuth,
+      propsValue: {},
+    });
+    expect(Array.isArray(result.items)).toBe(true);
+    expect(typeof result.hasMore).toBe('boolean');
+  });
+
+  it('surfaces thrown error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('429 Too Many Requests'));
+    await expect(
+      (listCrmContactsAction as any).run({
+        auth: mockAuth,
+        propsValue: {},
+      })
+    ).rejects.toThrow('429 Too Many Requests');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/list-crm-contacts.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/list-crm-contacts.ts
@@ -1,8 +1,4 @@
-import {
-  createAction,
-  Property,
-  DropdownState,
-} from '@activepieces/pieces-framework';
+import { createAction, Property, DropdownState } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { whatsscaleAuth } from '../../auth';
 import { whatsscaleClient } from '../../common/client';
@@ -11,8 +7,7 @@ export const listCrmContactsAction = createAction({
   auth: whatsscaleAuth,
   name: 'whatsscale_list_crm_contacts',
   displayName: 'List CRM Contacts',
-  description:
-    'Retrieve a paginated list of CRM contacts with optional filters',
+  description: 'Retrieve a paginated list of CRM contacts with optional filters',
   props: {
     tag: Property.Dropdown<string, false, typeof whatsscaleAuth>({
       auth: whatsscaleAuth,
@@ -22,11 +17,7 @@ export const listCrmContactsAction = createAction({
       refreshers: [],
       options: async ({ auth }): Promise<DropdownState<string>> => {
         if (!auth) {
-          return {
-            disabled: true,
-            options: [],
-            placeholder: 'Please connect your account',
-          };
+          return { disabled: true, options: [], placeholder: 'Please connect your account' };
         }
         try {
           const response = await whatsscaleClient(
@@ -37,26 +28,13 @@ export const listCrmContactsAction = createAction({
           );
           const tags = response.body as { label: string; value: string }[];
           if (!tags || tags.length === 0) {
-            return {
-              disabled: true,
-              options: [],
-              placeholder: 'No tags found',
-            };
+            return { disabled: true, options: [], placeholder: 'No tags found' };
           }
           return { disabled: false, options: tags };
         } catch {
-          return {
-            disabled: true,
-            options: [],
-            placeholder: 'Failed to load tags',
-          };
+          return { disabled: true, options: [], placeholder: 'Failed to load tags' };
         }
       },
-    }),
-    search: Property.ShortText({
-      displayName: 'Search',
-      description: 'Optional. Search contacts by name or phone number.',
-      required: false,
     }),
     limit: Property.Number({
       displayName: 'Limit',
@@ -72,13 +50,11 @@ export const listCrmContactsAction = createAction({
   async run(context) {
     const auth = context.auth.secret_text;
     const { tag, limit, page } = context.propsValue;
-    const search = context.propsValue['search'] as string | undefined;
 
     const qp: Record<string, string> = {};
-    if (tag) qp['tag'] = tag;
-    if (search) qp['search'] = search;
-    if (limit != null) qp['limit'] = String(limit);
-    if (page != null) qp['page'] = String(page);
+    if (tag)           qp.tag   = tag;
+    if (limit != null) qp.limit = String(limit);
+    if (page  != null) qp.page  = String(page);
 
     const params = Object.keys(qp).length > 0 ? qp : undefined;
 

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/list-crm-contacts.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/list-crm-contacts.ts
@@ -1,4 +1,8 @@
-import { createAction, Property, DropdownState } from '@activepieces/pieces-framework';
+import {
+  createAction,
+  Property,
+  DropdownState,
+} from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { whatsscaleAuth } from '../../auth';
 import { whatsscaleClient } from '../../common/client';
@@ -7,7 +11,8 @@ export const listCrmContactsAction = createAction({
   auth: whatsscaleAuth,
   name: 'whatsscale_list_crm_contacts',
   displayName: 'List CRM Contacts',
-  description: 'Retrieve a paginated list of CRM contacts with optional filters',
+  description:
+    'Retrieve a paginated list of CRM contacts with optional filters',
   props: {
     tag: Property.Dropdown<string, false, typeof whatsscaleAuth>({
       auth: whatsscaleAuth,
@@ -17,7 +22,11 @@ export const listCrmContactsAction = createAction({
       refreshers: [],
       options: async ({ auth }): Promise<DropdownState<string>> => {
         if (!auth) {
-          return { disabled: true, options: [], placeholder: 'Please connect your account' };
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please connect your account',
+          };
         }
         try {
           const response = await whatsscaleClient(
@@ -28,13 +37,26 @@ export const listCrmContactsAction = createAction({
           );
           const tags = response.body as { label: string; value: string }[];
           if (!tags || tags.length === 0) {
-            return { disabled: true, options: [], placeholder: 'No tags found' };
+            return {
+              disabled: true,
+              options: [],
+              placeholder: 'No tags found',
+            };
           }
           return { disabled: false, options: tags };
         } catch {
-          return { disabled: true, options: [], placeholder: 'Failed to load tags' };
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Failed to load tags',
+          };
         }
       },
+    }),
+    search: Property.ShortText({
+      displayName: 'Search',
+      description: 'Optional. Search contacts by name or phone number.',
+      required: false,
     }),
     limit: Property.Number({
       displayName: 'Limit',
@@ -50,11 +72,13 @@ export const listCrmContactsAction = createAction({
   async run(context) {
     const auth = context.auth.secret_text;
     const { tag, limit, page } = context.propsValue;
+    const search = context.propsValue['search'] as string | undefined;
 
     const qp: Record<string, string> = {};
-    if (tag)           qp.tag   = tag;
-    if (limit != null) qp.limit = String(limit);
-    if (page  != null) qp.page  = String(page);
+    if (tag) qp['tag'] = tag;
+    if (search) qp['search'] = search;
+    if (limit != null) qp['limit'] = String(limit);
+    if (page != null) qp['page'] = String(page);
 
     const params = Object.keys(qp).length > 0 ? qp : undefined;
 

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/remove-crm-contact-tag.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/remove-crm-contact-tag.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { removeCrmContactTagAction } from './remove-crm-contact-tag';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' } as any;
+const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const MOCK_CRM_CONTACT = {
+  id:         TEST_UUID,
+  phone:      '+31649931832',
+  name:       'John Doe',
+  tags:       ['vip'],
+  source:     'api',
+  created_at: '2026-03-05T00:00:00.000Z',
+  updated_at: '2026-03-05T00:00:00.000Z',
+};
+const mockClient = vi.mocked(clientModule.whatsscaleClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('removeCrmContactTagAction', () => {
+  it('encodes tag with spaces in URL', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (removeCrmContactTagAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, tag: 'new customer' },
+    });
+    expect(mockClient.mock.calls[0][2]).toContain('new%20customer');
+  });
+
+  it('simple tag needs no special encoding', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (removeCrmContactTagAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, tag: 'vip' },
+    });
+    expect(mockClient.mock.calls[0][2]).toMatch(/\/tags\/vip$/);
+  });
+
+  it('calls DELETE method', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (removeCrmContactTagAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, tag: 'vip' },
+    });
+    expect(mockClient.mock.calls[0][1]).toBe('DELETE');
+  });
+
+  it('passes undefined as body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (removeCrmContactTagAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, tag: 'vip' },
+    });
+    expect(mockClient.mock.calls[0][3]).toBeUndefined();
+  });
+
+  it('returns updated contact', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    const result = await (removeCrmContactTagAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, tag: 'vip' },
+    });
+    expect(result).toEqual(MOCK_CRM_CONTACT);
+  });
+
+  it('surfaces thrown error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('404 Not Found'));
+    await expect(
+      (removeCrmContactTagAction as any).run({
+        auth: mockAuth,
+        propsValue: { contactId: TEST_UUID, tag: 'vip' },
+      })
+    ).rejects.toThrow('404 Not Found');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/update-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/update-crm-contact.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateCrmContactAction } from './update-crm-contact';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' } as any;
+const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const MOCK_CRM_CONTACT = {
+  id:         TEST_UUID,
+  phone:      '+31649931832',
+  name:       'John Doe',
+  tags:       ['vip', 'customer'],
+  source:     'api',
+  created_at: '2026-03-05T00:00:00.000Z',
+  updated_at: '2026-03-05T00:00:00.000Z',
+};
+const mockClient = vi.mocked(clientModule.whatsscaleClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('updateCrmContactAction', () => {
+  it('sends name only — no tags key in body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (updateCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, name: 'New', tags: undefined },
+    });
+    const body = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(body).toEqual({ name: 'New' });
+    expect(body).not.toHaveProperty('tags');
+  });
+
+  it('sends tags only — no name key in body', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (updateCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, name: undefined, tags: 'vip' },
+    });
+    const body = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(body).toEqual({ tags: 'vip' });
+    expect(body).not.toHaveProperty('name');
+  });
+
+  it('sends both when both provided', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (updateCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, name: 'X', tags: 'vip' },
+    });
+    const body = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(body).toEqual({ name: 'X', tags: 'vip' });
+  });
+
+  it('sends empty string name (clears field)', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (updateCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, name: '', tags: undefined },
+    });
+    const body = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(body.name).toBe('');
+  });
+
+  it('does NOT send name when undefined', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (updateCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, name: undefined, tags: undefined },
+    });
+    const body = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('name');
+  });
+
+  it('calls PATCH /api/crm/contacts/:uuid', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CRM_CONTACT } as any);
+    await (updateCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { contactId: TEST_UUID, name: 'X', tags: undefined },
+    });
+    expect(mockClient.mock.calls[0][1]).toBe('PATCH');
+    expect(mockClient.mock.calls[0][2]).toContain(TEST_UUID);
+  });
+
+  it('surfaces thrown error (e.g. 400)', async () => {
+    mockClient.mockRejectedValueOnce(new Error('400 No fields to update'));
+    await expect(
+      (updateCrmContactAction as any).run({
+        auth: mockAuth,
+        propsValue: { contactId: TEST_UUID, name: undefined, tags: undefined },
+      })
+    ).rejects.toThrow('400 No fields to update');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/crm/update-crm-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/crm/update-crm-contact.ts
@@ -26,9 +26,9 @@ export const updateCrmContactAction = createAction({
     const auth = context.auth.secret_text;
     const { contactId, name, tags } = context.propsValue;
 
-      const body: Record<string, unknown> = {};
-      if (name !== undefined && name !== null) body['name'] = name;
-    if (tags !== undefined && tags !== null) body['tags'] = tags;
+    const body: Record<string, unknown> = {};
+    if (name !== undefined && name !== null) body.name = name;
+    if (tags !== undefined && tags !== null) body.tags = tags;
 
     const response = await whatsscaleClient(
       auth,

--- a/packages/pieces/community/whatsscale/src/lib/actions/info/get-channel-info.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/info/get-channel-info.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getChannelInfoAction } from './get-channel-info';
+import { whatsscaleClient } from '../../common/client';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockClient = vi.mocked(whatsscaleClient);
+
+const MOCK_AUTH = { secret_text: 'ws_test_key' } as any;
+const MOCK_AUTH_STRING = 'ws_test_key';
+
+const MOCK_CHANNEL_BODY = {
+  channel_id: 'abc',
+  name: 'My Channel',
+  description: '',
+  subscriber_count: 1000,
+  verified: true,
+  role: 'admin',
+  invite_link: '',
+  picture: '',
+};
+
+function makeContext(propsValue: Record<string, unknown>) {
+  return {
+    auth: MOCK_AUTH,
+    propsValue,
+  } as any;
+}
+
+describe('getChannelInfoAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns channel info on success', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CHANNEL_BODY, status: 200 } as any);
+
+    const result = await getChannelInfoAction.run(makeContext({
+      session: 'user_abc123',
+      channel_id: 'abc',
+    }));
+
+    expect(result).toEqual(MOCK_CHANNEL_BODY);
+    expect(result.name).toBe('My Channel');
+    expect(result.subscriber_count).toBe(1000);
+    expect(result.verified).toBe(true);
+  });
+
+  it('calls correct endpoint with session as queryParam (not encoded)', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CHANNEL_BODY, status: 200 } as any);
+
+    await getChannelInfoAction.run(makeContext({
+      session: 'user_abc123',
+      channel_id: 'abc123',
+    }));
+
+    expect(mockClient).toHaveBeenCalledWith(
+      MOCK_AUTH_STRING,
+      HttpMethod.GET,
+      '/make/channels/abc123/info',
+      undefined,
+      { session: 'user_abc123' }
+    );
+  });
+
+  it('trims whitespace from channel_id', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CHANNEL_BODY, status: 200 } as any);
+
+    await getChannelInfoAction.run(makeContext({
+      session: 'user_abc123',
+      channel_id: '  abc123  ',
+    }));
+
+    const urlArg = mockClient.mock.calls[0][2] as string;
+    expect(urlArg).toContain('abc123');
+    expect(urlArg).not.toContain(' ');
+  });
+
+  it('encodes special chars in channel_id (e.g. @newsletter)', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_CHANNEL_BODY, status: 200 } as any);
+
+    await getChannelInfoAction.run(makeContext({
+      session: 'user_abc123',
+      channel_id: 'abc@newsletter',
+    }));
+
+    const urlArg = mockClient.mock.calls[0][2] as string;
+    expect(urlArg).toContain(encodeURIComponent('abc@newsletter'));
+  });
+
+  it('throws on proxy error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('Channel not found'));
+
+    await expect(
+      getChannelInfoAction.run(makeContext({
+        session: 'user_abc123',
+        channel_id: 'nonexistent',
+      }))
+    ).rejects.toThrow('Channel not found');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/info/get-channel-info.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/info/get-channel-info.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+
+export const getChannelInfoAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_get_channel_info',
+  displayName: 'Get Channel Info',
+  description: 'Retrieve metadata for a WhatsApp Channel by its ID',
+  props: {
+    session: whatsscaleProps.session,
+    channel_id: Property.ShortText({
+      displayName: 'Channel ID',
+      description:
+        'Channel ID, with or without @newsletter suffix. Tip: copy from Watch Channel Messages trigger output.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth.secret_text;
+    const channelId = encodeURIComponent(context.propsValue.channel_id.trim());
+
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.GET,
+      `/make/channels/${channelId}/info`,
+      undefined,
+      { session: context.propsValue.session }
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/info/get-group-info.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/info/get-group-info.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getGroupInfoAction } from './get-group-info';
+import { whatsscaleClient } from '../../common/client';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockClient = vi.mocked(whatsscaleClient);
+
+const MOCK_AUTH = { secret_text: 'ws_test_key' } as any;
+const MOCK_AUTH_STRING = 'ws_test_key';
+
+const MOCK_GROUP_BODY = {
+  group_id: '123',
+  name: 'Test Group',
+  description: '',
+  participant_count: 5,
+  created_at: '2024-01-15T10:30:00.000Z',
+  invite_link: '',
+};
+
+function makeContext(propsValue: Record<string, unknown>) {
+  return {
+    auth: MOCK_AUTH,
+    propsValue,
+  } as any;
+}
+
+describe('getGroupInfoAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns group info on success', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_GROUP_BODY, status: 200 } as any);
+
+    const result = await getGroupInfoAction.run(makeContext({
+      session: 'user_abc123',
+      group_id: '123',
+    }));
+
+    expect(result).toEqual(MOCK_GROUP_BODY);
+    expect(result.name).toBe('Test Group');
+    expect(result.participant_count).toBe(5);
+  });
+
+  it('calls correct endpoint with session as queryParam (not encoded)', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_GROUP_BODY, status: 200 } as any);
+
+    await getGroupInfoAction.run(makeContext({
+      session: 'user_abc123',
+      group_id: '123456789',
+    }));
+
+    expect(mockClient).toHaveBeenCalledWith(
+      MOCK_AUTH_STRING,
+      HttpMethod.GET,
+      '/make/groups/123456789/info',
+      undefined,
+      { session: 'user_abc123' }
+    );
+  });
+
+  it('trims whitespace from group_id', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_GROUP_BODY, status: 200 } as any);
+
+    await getGroupInfoAction.run(makeContext({
+      session: 'user_abc123',
+      group_id: '  123456789  ',
+    }));
+
+    const callArgs = mockClient.mock.calls[0];
+    const urlArg = callArgs[2] as string;
+    expect(urlArg).toContain('123456789');
+    expect(urlArg).not.toContain(' ');
+  });
+
+  it('encodes special chars in group_id (e.g. @g.us)', async () => {
+    mockClient.mockResolvedValueOnce({ body: MOCK_GROUP_BODY, status: 200 } as any);
+
+    await getGroupInfoAction.run(makeContext({
+      session: 'user_abc123',
+      group_id: '120363123@g.us',
+    }));
+
+    const callArgs = mockClient.mock.calls[0];
+    const urlArg = callArgs[2] as string;
+    expect(urlArg).toContain(encodeURIComponent('120363123@g.us'));
+  });
+
+  it('throws on proxy error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('Group not found'));
+
+    await expect(
+      getGroupInfoAction.run(makeContext({
+        session: 'user_abc123',
+        group_id: '999999',
+      }))
+    ).rejects.toThrow('Group not found');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/info/get-group-info.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/info/get-group-info.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+
+export const getGroupInfoAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_get_group_info',
+  displayName: 'Get Group Info',
+  description: 'Retrieve metadata for a WhatsApp group by its ID',
+  props: {
+    session: whatsscaleProps.session,
+    group_id: Property.ShortText({
+      displayName: 'Group ID',
+      description:
+        'Group ID, with or without @g.us suffix. Tip: copy from Watch Group Messages trigger output or another action output.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth.secret_text;
+    const groupId = encodeURIComponent(context.propsValue.group_id.trim());
+
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.GET,
+      `/make/groups/${groupId}/info`,
+      undefined,
+      { session: context.propsValue.session }
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-contact.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendDocumentToContactAction } from './send-document-to-contact';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+describe('sendDocumentToContactAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/doc.pdf');
+    (whatsscaleClient as any).mockResolvedValue({ body: { jobId: 'job_abc123', status: 'QUEUED' } });
+    (pollJob as any).mockResolvedValue({ id: 'true_31649931832@c.us_ABC', _data: {} });
+  });
+
+  it('calls prepareFile with the document URL', async () => {
+    await (sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/doc.pdf', 'document');
+  });
+
+  it('calls POST /api/sendDocument with correct body', async () => {
+    await (sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: 'report.pdf', caption: 'Q3 Report' , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith('test-api-key', expect.anything(), '/api/sendDocument', expect.objectContaining({
+      session: 'test-session',
+      chatId: '31649931832@c.us',
+      file: 'https://proxy.whatsscale.com/files/doc.pdf',
+      caption: 'Q3 Report',
+      filename: 'report.pdf',
+    }));
+  });
+
+  it('omits filename field entirely when filename is undefined', async () => {
+    await (sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).not.toHaveProperty('filename');
+  });
+
+  it('omits filename field when filename is empty string', async () => {
+    await (sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: '', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).not.toHaveProperty('filename');
+  });
+
+  it('includes filename in body when provided', async () => {
+    await (sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: 'invoice.pdf', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('filename', 'invoice.pdf');
+  });
+
+  it('calls pollJob with the jobId from send response', async () => {
+    await (sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'job_abc123');
+  });
+
+  it('returns the result from pollJob', async () => {
+    const result = { id: 'true_31649931832@c.us_ABC', _data: {} };
+    (pollJob as any).mockResolvedValue(result);
+
+    const response = await (sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(response).toEqual(result);
+  });
+
+  it('sends empty string caption when caption is undefined', async () => {
+    await (sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(),
+      expect.objectContaining({ caption: '' }));
+  });
+
+  it('uses chatId for contact (not crm_contact_id)', async () => {
+    await (sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('chatId');
+    expect(callArg).not.toHaveProperty('crm_contact_id');
+  });
+
+  it('uses apiKey from context.auth.secret_text', async () => {
+    await (sendDocumentToContactAction as any).run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.anything(), 'document');
+    expect(pollJob).toHaveBeenCalledWith('my-secret-key', expect.anything());
+  });
+
+  it('propagates error when pollJob throws', async () => {
+    (pollJob as any).mockRejectedValue(new Error('Job failed'));
+
+    await expect((sendDocumentToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('Job failed');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-contact.ts
@@ -44,7 +44,7 @@ export const sendDocumentToContactAction = createAction({
     };
     if (filename) body['filename'] = filename;
 
-    const sendResponse = await whatsscaleClient(apiKey, HttpMethod.POST, '/api/sendDocument', body);
+    const sendResponse = await whatsscaleClient(apiKey, HttpMethod.POST, '/api/sendDocument', { ...body, platform: 'activepieces' });
     const { jobId } = sendResponse.body as { jobId: string };
     return await pollJob(apiKey, jobId);
   },

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-crm-contact.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendDocumentToCrmContactAction } from './send-document-to-crm-contact';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+const crmContactId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+describe('sendDocumentToCrmContactAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/doc.pdf');
+    (whatsscaleClient as any).mockResolvedValue({ body: { jobId: 'job_abc123', status: 'QUEUED' } });
+    (pollJob as any).mockResolvedValue({ id: 'true_31649931832@c.us_ABC', _data: {} });
+  });
+
+  it('calls prepareFile with the document URL', async () => {
+    await (sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/doc.pdf', 'document');
+  });
+
+  it('calls POST /api/sendDocument with CRM body shape (no chatId)', async () => {
+    await (sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: 'report.pdf', caption: 'Q3' , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith('test-api-key', expect.anything(), '/api/sendDocument', expect.objectContaining({
+      session: 'test-session',
+      contact_type: 'crm_contact',
+      crm_contact_id: crmContactId,
+      file: 'https://proxy.whatsscale.com/files/doc.pdf',
+      caption: 'Q3',
+      filename: 'report.pdf',
+    }));
+  });
+
+  it('uses crm_contact_id body shape — no chatId field', async () => {
+    await (sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('crm_contact_id', crmContactId);
+    expect(callArg).toHaveProperty('contact_type', 'crm_contact');
+    expect(callArg).not.toHaveProperty('chatId');
+  });
+
+  it('omits filename field entirely when filename is undefined', async () => {
+    await (sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).not.toHaveProperty('filename');
+  });
+
+  it('omits filename field when filename is empty string', async () => {
+    await (sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: '', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).not.toHaveProperty('filename');
+  });
+
+  it('includes filename when provided', async () => {
+    await (sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: 'invoice.pdf', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('filename', 'invoice.pdf');
+  });
+
+  it('calls pollJob with the jobId from send response', async () => {
+    await (sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'job_abc123');
+  });
+
+  it('returns the result from pollJob', async () => {
+    const result = { id: 'true_31649931832@c.us_ABC', _data: {} };
+    (pollJob as any).mockResolvedValue(result);
+
+    const response = await (sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(response).toEqual(result);
+  });
+
+  it('sends empty string caption when caption is undefined', async () => {
+    await (sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(),
+      expect.objectContaining({ caption: '' }));
+  });
+
+  it('uses apiKey from context.auth.secret_text', async () => {
+    await (sendDocumentToCrmContactAction as any).run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.anything(), 'document');
+    expect(pollJob).toHaveBeenCalledWith('my-secret-key', expect.anything());
+  });
+
+  it('propagates error when pollJob throws', async () => {
+    (pollJob as any).mockRejectedValue(new Error('Job failed'));
+
+    await expect((sendDocumentToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('Job failed');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-crm-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-crm-contact.ts
@@ -45,7 +45,7 @@ export const sendDocumentToCrmContactAction = createAction({
     };
     if (filename) body['filename'] = filename;
 
-    const sendResponse = await whatsscaleClient(apiKey, HttpMethod.POST, '/api/sendDocument', body);
+    const sendResponse = await whatsscaleClient(apiKey, HttpMethod.POST, '/api/sendDocument', { ...body, platform: 'activepieces' });
     const { jobId } = sendResponse.body as { jobId: string };
     return await pollJob(apiKey, jobId);
   },

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-group.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-group.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendDocumentToGroupAction } from './send-document-to-group';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+describe('sendDocumentToGroupAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/doc.pdf');
+    (whatsscaleClient as any).mockResolvedValue({ body: { jobId: 'job_abc123', status: 'QUEUED' } });
+    (pollJob as any).mockResolvedValue({ id: 'true_120363000000000001@g.us_ABC', _data: {} });
+  });
+
+  it('calls prepareFile with the document URL', async () => {
+    await (sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/doc.pdf', 'document');
+  });
+
+  it('calls POST /api/sendDocument with group chatId', async () => {
+    await (sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: 'notes.pdf', caption: 'Meeting notes' , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith('test-api-key', expect.anything(), '/api/sendDocument', expect.objectContaining({
+      session: 'test-session',
+      chatId: '120363000000000001@g.us',
+      file: 'https://proxy.whatsscale.com/files/doc.pdf',
+      caption: 'Meeting notes',
+      filename: 'notes.pdf',
+    }));
+  });
+
+  it('omits filename field entirely when filename is undefined', async () => {
+    await (sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).not.toHaveProperty('filename');
+  });
+
+  it('omits filename field when filename is empty string', async () => {
+    await (sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: '', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).not.toHaveProperty('filename');
+  });
+
+  it('includes filename when provided', async () => {
+    await (sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: 'agenda.pdf', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('filename', 'agenda.pdf');
+  });
+
+  it('calls pollJob with the jobId from send response', async () => {
+    await (sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'job_abc123');
+  });
+
+  it('returns the result from pollJob', async () => {
+    const result = { id: 'true_120363000000000001@g.us_ABC', _data: {} };
+    (pollJob as any).mockResolvedValue(result);
+
+    const response = await (sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(response).toEqual(result);
+  });
+
+  it('sends empty string caption when caption is undefined', async () => {
+    await (sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(),
+      expect.objectContaining({ caption: '' }));
+  });
+
+  it('uses chatId for group', async () => {
+    await (sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('chatId', '120363000000000001@g.us');
+    expect(callArg).not.toHaveProperty('crm_contact_id');
+  });
+
+  it('uses apiKey from context.auth.secret_text', async () => {
+    await (sendDocumentToGroupAction as any).run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.anything(), 'document');
+  });
+
+  it('propagates error when pollJob throws', async () => {
+    (pollJob as any).mockRejectedValue(new Error('Job failed'));
+
+    await expect((sendDocumentToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', documentUrl: 'https://example.com/doc.pdf', filename: undefined, caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('Job failed');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-group.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-document-to-group.ts
@@ -44,7 +44,7 @@ export const sendDocumentToGroupAction = createAction({
     };
     if (filename) body['filename'] = filename;
 
-    const sendResponse = await whatsscaleClient(apiKey, HttpMethod.POST, '/api/sendDocument', body);
+    const sendResponse = await whatsscaleClient(apiKey, HttpMethod.POST, '/api/sendDocument', { ...body, platform: 'activepieces' });
     const { jobId } = sendResponse.body as { jobId: string };
     return await pollJob(apiKey, jobId);
   },

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-manual.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-manual.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendImageManualAction } from './send-image-manual';
+import * as clientModule from '../../common/client';
+import * as prepareFileModule from '../../common/prepare-file';
+import { ChatType } from '../../common/types';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+vi.mock('../../common/prepare-file', () => ({
+  prepareFile: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' };
+const PREPARED_URL = 'https://proxy.whatsscale.com/files/prepared.jpg';
+const IMAGE_URL = 'https://example.com/photo.jpg';
+const PHONE = '31649931832';
+const GROUP_ID = '120363318673245672';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendImageManualAction', () => {
+  it('calls prepareFile first with the correct imageUrl', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: ChatType.CONTACT, recipient: PHONE, imageUrl: IMAGE_URL },
+    });
+
+    expect(prepareFileModule.prepareFile).toHaveBeenCalledWith('test-api-key', IMAGE_URL);
+  });
+
+  it('builds chatId with @c.us suffix when chatType is CONTACT', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: ChatType.CONTACT, recipient: PHONE, imageUrl: IMAGE_URL },
+    });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.chatId).toBe(`${PHONE}@c.us`);
+  });
+
+  it('builds chatId with @g.us suffix when chatType is GROUP', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: ChatType.GROUP, recipient: GROUP_ID, imageUrl: IMAGE_URL },
+    });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.chatId).toBe(`${GROUP_ID}@g.us`);
+  });
+
+  it('calls POST /api/sendImage with correct full body', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: ChatType.CONTACT, recipient: PHONE, imageUrl: IMAGE_URL },
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/sendImage',
+      { session: 'test-session', chatId: `${PHONE}@c.us`, file: PREPARED_URL, caption: '', platform: 'activepieces' },
+    );
+  });
+
+  it('returns response body', async () => {
+    const mockResponse = { key: { id: 'abc123' }, messageTimestamp: 1234567890, status: 'sent' };
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: mockResponse } as any);
+
+    const result = await (sendImageManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: ChatType.CONTACT, recipient: PHONE, imageUrl: IMAGE_URL },
+    });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('sends caption when provided', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: ChatType.CONTACT, recipient: PHONE, imageUrl: IMAGE_URL, caption: 'Look at this!' , platform: 'activepieces' },
+    });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('Look at this!');
+  });
+
+  it('sends caption as empty string when caption is undefined', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: ChatType.CONTACT, recipient: PHONE, imageUrl: IMAGE_URL },
+    });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('');
+  });
+
+  it('throws and never calls sendImage when prepareFile fails', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockRejectedValueOnce(
+      new Error('prepareFile failed: invalid URL'),
+    );
+
+    await expect(
+      (sendImageManualAction as any).run({
+        auth: mockAuth,
+        propsValue: { session: 'test-session', chatType: ChatType.CONTACT, recipient: PHONE, imageUrl: 'bad-url' },
+      }),
+    ).rejects.toThrow('prepareFile failed: invalid URL');
+
+    expect(clientModule.whatsscaleClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-manual.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-manual.ts
@@ -58,6 +58,7 @@ export const sendImageManualAction = createAction({
       ...recipientBody,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-channel.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-channel.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendImageToChannelAction } from './send-image-to-channel';
+import * as clientModule from '../../common/client';
+import * as prepareFileModule from '../../common/prepare-file';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+vi.mock('../../common/prepare-file', () => ({
+  prepareFile: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' };
+const PREPARED_URL = 'https://proxy.whatsscale.com/files/prepared.jpg';
+const IMAGE_URL = 'https://example.com/photo.jpg';
+const CHAT_ID = '120363318673245672@newsletter';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendImageToChannelAction', () => {
+  const baseProps = {
+    session: 'test-session',
+    channel: CHAT_ID,
+    imageUrl: IMAGE_URL,
+    caption: undefined,
+  };
+
+  it('calls prepareFile first with the correct imageUrl', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToChannelAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(prepareFileModule.prepareFile).toHaveBeenCalledWith('test-api-key', IMAGE_URL);
+  });
+
+  it('calls POST /api/sendImage with correct body including prepared URL', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToChannelAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/sendImage',
+      { session: 'test-session', chatId: CHAT_ID, file: PREPARED_URL, caption: '' , platform: 'activepieces' },
+    );
+  });
+
+  it('chatId uses @newsletter value from channel dropdown with no suffix added', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToChannelAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.chatId).toBe(CHAT_ID);
+    expect(callArgs.chatId).toContain('@newsletter');
+  });
+
+  it('returns response body', async () => {
+    const mockResponse = { key: { id: 'abc123' }, messageTimestamp: 1234567890, status: 'sent' };
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: mockResponse } as any);
+
+    const result = await (sendImageToChannelAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('sends caption when provided', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: { ...baseProps, caption: 'Channel update!' },
+    });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('Channel update!');
+  });
+
+  it('sends caption as empty string when caption is undefined', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToChannelAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('');
+  });
+
+  it('throws and never calls sendImage when prepareFile fails', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockRejectedValueOnce(
+      new Error('prepareFile failed: invalid URL'),
+    );
+
+    await expect(
+      (sendImageToChannelAction as any).run({ auth: mockAuth, propsValue: baseProps }),
+    ).rejects.toThrow('prepareFile failed: invalid URL');
+
+    expect(clientModule.whatsscaleClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-channel.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-channel.ts
@@ -35,6 +35,7 @@ export const sendImageToChannelAction = createAction({
       chatId: channel,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-contact.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendImageToContactAction } from './send-image-to-contact';
+import * as clientModule from '../../common/client';
+import * as prepareFileModule from '../../common/prepare-file';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+vi.mock('../../common/prepare-file', () => ({
+  prepareFile: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' };
+const PREPARED_URL = 'https://proxy.whatsscale.com/files/prepared.jpg';
+const IMAGE_URL = 'https://example.com/photo.jpg';
+const CHAT_ID = '31649931832@c.us';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendImageToContactAction', () => {
+  const baseProps = {
+    session: 'test-session',
+    contact: CHAT_ID,
+    imageUrl: IMAGE_URL,
+    caption: undefined,
+  };
+
+  it('calls prepareFile first with the correct imageUrl', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(prepareFileModule.prepareFile).toHaveBeenCalledWith('test-api-key', IMAGE_URL);
+  });
+
+  it('calls POST /api/sendImage with correct body including prepared URL', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/sendImage',
+      { session: 'test-session', chatId: CHAT_ID, file: PREPARED_URL, caption: '' , platform: 'activepieces' },
+    );
+  });
+
+  it('chatId is the pre-formatted contact dropdown value with no suffix added', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.chatId).toBe(CHAT_ID);
+    expect(callArgs.chatId).toContain('@c.us');
+  });
+
+  it('returns response body', async () => {
+    const mockResponse = { key: { id: 'abc123' }, messageTimestamp: 1234567890, status: 'sent' };
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: mockResponse } as any);
+
+    const result = await (sendImageToContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('sends caption when provided', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { ...baseProps, caption: 'Hello world' },
+    });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('Hello world');
+  });
+
+  it('sends caption as empty string when caption is undefined', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('');
+  });
+
+  it('throws and never calls sendImage when prepareFile fails', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockRejectedValueOnce(
+      new Error('prepareFile failed: invalid URL'),
+    );
+
+    await expect(
+      (sendImageToContactAction as any).run({ auth: mockAuth, propsValue: baseProps }),
+    ).rejects.toThrow('prepareFile failed: invalid URL');
+
+    expect(clientModule.whatsscaleClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-contact.ts
@@ -35,6 +35,7 @@ export const sendImageToContactAction = createAction({
       chatId: contact,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-crm-contact.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendImageToCrmContactAction } from './send-image-to-crm-contact';
+import * as clientModule from '../../common/client';
+import * as prepareFileModule from '../../common/prepare-file';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+vi.mock('../../common/prepare-file', () => ({
+  prepareFile: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' };
+const PREPARED_URL = 'https://proxy.whatsscale.com/files/prepared.jpg';
+const IMAGE_URL = 'https://example.com/photo.jpg';
+const CRM_CONTACT_ID = 'uuid-1234-5678-abcd';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendImageToCrmContactAction', () => {
+  const baseProps = {
+    session: 'test-session',
+    crmContact: CRM_CONTACT_ID,
+    imageUrl: IMAGE_URL,
+    caption: undefined,
+  };
+
+  it('calls prepareFile first with the correct imageUrl', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToCrmContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(prepareFileModule.prepareFile).toHaveBeenCalledWith('test-api-key', IMAGE_URL);
+  });
+
+  it('calls POST /api/sendImage with correct CRM body shape', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToCrmContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/sendImage',
+      {
+        session: 'test-session',
+        contact_type: 'crm_contact',
+        crm_contact_id: CRM_CONTACT_ID,
+        file: PREPARED_URL,
+        caption: '',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('does not include chatId field in the body', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToCrmContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs).not.toHaveProperty('chatId');
+  });
+
+  it('returns response body', async () => {
+    const mockResponse = { key: { id: 'abc123' }, messageTimestamp: 1234567890, status: 'sent' };
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: mockResponse } as any);
+
+    const result = await (sendImageToCrmContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('sends caption when provided', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { ...baseProps, caption: 'Your invoice' },
+    });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('Your invoice');
+  });
+
+  it('sends caption as empty string when caption is undefined', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToCrmContactAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('');
+  });
+
+  it('throws and never calls sendImage when prepareFile fails', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockRejectedValueOnce(
+      new Error('prepareFile failed: invalid URL'),
+    );
+
+    await expect(
+      (sendImageToCrmContactAction as any).run({ auth: mockAuth, propsValue: baseProps }),
+    ).rejects.toThrow('prepareFile failed: invalid URL');
+
+    expect(clientModule.whatsscaleClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-crm-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-crm-contact.ts
@@ -36,6 +36,7 @@ export const sendImageToCrmContactAction = createAction({
       crm_contact_id: crmContact,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-group.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-group.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendImageToGroupAction } from './send-image-to-group';
+import * as clientModule from '../../common/client';
+import * as prepareFileModule from '../../common/prepare-file';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+vi.mock('../../common/prepare-file', () => ({
+  prepareFile: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' };
+const PREPARED_URL = 'https://proxy.whatsscale.com/files/prepared.jpg';
+const IMAGE_URL = 'https://example.com/photo.jpg';
+const CHAT_ID = '120363318673245672@g.us';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendImageToGroupAction', () => {
+  const baseProps = {
+    session: 'test-session',
+    group: CHAT_ID,
+    imageUrl: IMAGE_URL,
+    caption: undefined,
+  };
+
+  it('calls prepareFile first with the correct imageUrl', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToGroupAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(prepareFileModule.prepareFile).toHaveBeenCalledWith('test-api-key', IMAGE_URL);
+  });
+
+  it('calls POST /api/sendImage with correct body including prepared URL', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToGroupAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/sendImage',
+      { session: 'test-session', chatId: CHAT_ID, file: PREPARED_URL, caption: '' , platform: 'activepieces' },
+    );
+  });
+
+  it('chatId uses @g.us value from group dropdown with no suffix added', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToGroupAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.chatId).toBe(CHAT_ID);
+    expect(callArgs.chatId).toContain('@g.us');
+  });
+
+  it('returns response body', async () => {
+    const mockResponse = { key: { id: 'abc123' }, messageTimestamp: 1234567890, status: 'sent' };
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: mockResponse } as any);
+
+    const result = await (sendImageToGroupAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('sends caption when provided', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { ...baseProps, caption: 'Team photo!' },
+    });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('Team photo!');
+  });
+
+  it('sends caption as empty string when caption is undefined', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockResolvedValueOnce(PREPARED_URL);
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({ body: { status: 'sent' } } as any);
+
+    await (sendImageToGroupAction as any).run({ auth: mockAuth, propsValue: baseProps });
+
+    const callArgs = vi.mocked(clientModule.whatsscaleClient).mock.calls[0][3] as any;
+    expect(callArgs.caption).toBe('');
+  });
+
+  it('throws and never calls sendImage when prepareFile fails', async () => {
+    vi.mocked(prepareFileModule.prepareFile).mockRejectedValueOnce(
+      new Error('prepareFile failed: invalid URL'),
+    );
+
+    await expect(
+      (sendImageToGroupAction as any).run({ auth: mockAuth, propsValue: baseProps }),
+    ).rejects.toThrow('prepareFile failed: invalid URL');
+
+    expect(clientModule.whatsscaleClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-group.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-image-to-group.ts
@@ -35,6 +35,7 @@ export const sendImageToGroupAction = createAction({
       chatId: group,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-contact.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendLocationToContactAction } from './send-location-to-contact';
+import { whatsscaleClient } from '../../common/client';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+vi.mock('../../common/client');
+vi.mock('../../common/recipients');
+
+describe('sendLocationToContactAction', () => {
+  const mockClient = vi.mocked(whatsscaleClient);
+  const mockBuildBody = vi.mocked(buildRecipientBody);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.mockResolvedValue({ body: { success: true } } as any);
+    mockBuildBody.mockReturnValue({
+      session: 'user_test',
+      chatId: '31649931832@c.us',
+    } as any);
+  });
+
+  it('sends location with title', async () => {
+    await sendLocationToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        latitude: 52.3676,
+        longitude: 4.9041,
+        title: 'Amsterdam',
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      'ws_key',
+      expect.anything(),
+      '/api/sendLocation',
+      {
+        session: 'user_test',
+        chatId: '31649931832@c.us',
+        latitude: 52.3676,
+        longitude: 4.9041,
+        title: 'Amsterdam',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('sends location without title — title key absent from body', async () => {
+    await sendLocationToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        latitude: 52.3676,
+        longitude: 4.9041,
+        title: undefined,
+      } as any,
+    } as any);
+
+    const callBody = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(callBody).not.toHaveProperty('title');
+    expect(callBody['latitude']).toBe(52.3676);
+    expect(callBody['longitude']).toBe(4.9041);
+  });
+
+  it('sends location with empty string title — title key absent from body', async () => {
+    await sendLocationToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        latitude: 48.8584,
+        longitude: 2.2945,
+        title: '',
+      } as any,
+    } as any);
+
+    const callBody = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(callBody).not.toHaveProperty('title');
+  });
+
+  it('calls correct endpoint', async () => {
+    await sendLocationToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        latitude: 1.0,
+        longitude: 1.0,
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      '/api/sendLocation',
+      expect.anything(),
+    );
+  });
+
+  it('returns response body', async () => {
+    const result = await sendLocationToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        latitude: 1.0,
+        longitude: 1.0,
+      } as any,
+    } as any);
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-contact.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+export const sendLocationToContactAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_send_location_to_contact',
+  displayName: 'Send a Location to a Contact',
+  description: 'Send a GPS location pin to a WhatsApp contact',
+  props: {
+    session: whatsscaleProps.session,
+    contact: whatsscaleProps.contact,
+    latitude: Property.Number({
+      displayName: 'Latitude',
+      required: true,
+      description: 'GPS latitude (-90 to 90)',
+    }),
+    longitude: Property.Number({
+      displayName: 'Longitude',
+      required: true,
+      description: 'GPS longitude (-180 to 180)',
+    }),
+    title: Property.ShortText({
+      displayName: 'Location Title',
+      required: false,
+      description: 'Optional label shown on the pin',
+    }),
+  },
+  async run(context) {
+    const { session, contact, latitude, longitude, title } = context.propsValue;
+    const auth = context.auth.secret_text;
+
+    const body = buildRecipientBody(RecipientType.CONTACT, session, contact);
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.POST,
+      '/api/sendLocation',
+      {
+        ...body,
+        latitude,
+        longitude,
+        ...(title ? { title } : {}),
+        platform: 'activepieces',
+      },
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-crm-contact.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendLocationToCrmContactAction } from './send-location-to-crm-contact';
+import { whatsscaleClient } from '../../common/client';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+vi.mock('../../common/client');
+vi.mock('../../common/recipients');
+
+describe('sendLocationToCrmContactAction', () => {
+  const mockClient = vi.mocked(whatsscaleClient);
+  const mockBuildBody = vi.mocked(buildRecipientBody);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.mockResolvedValue({ body: { success: true } } as any);
+    mockBuildBody.mockReturnValue({
+      session: 'user_test',
+      contact_type: 'crm_contact',
+      crm_contact_id: 'uuid-123',
+    } as any);
+  });
+
+  it('sends location to CRM contact with title', async () => {
+    await sendLocationToCrmContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        crmContact: 'uuid-123',
+        latitude: 52.3676,
+        longitude: 4.9041,
+        title: 'Amsterdam',
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      'ws_key',
+      expect.anything(),
+      '/api/sendLocation',
+      {
+        session: 'user_test',
+        contact_type: 'crm_contact',
+        crm_contact_id: 'uuid-123',
+        latitude: 52.3676,
+        longitude: 4.9041,
+        title: 'Amsterdam',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('sends location to CRM contact without title — title key absent', async () => {
+    await sendLocationToCrmContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        crmContact: 'uuid-123',
+        latitude: 52.3676,
+        longitude: 4.9041,
+        title: undefined,
+      } as any,
+    } as any);
+
+    const callBody = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(callBody).not.toHaveProperty('title');
+  });
+
+  it('uses CRM_CONTACT recipient type', async () => {
+    await sendLocationToCrmContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        crmContact: 'uuid-123',
+        latitude: 1.0,
+        longitude: 1.0,
+      } as any,
+    } as any);
+
+    expect(mockBuildBody).toHaveBeenCalledWith(
+      RecipientType.CRM_CONTACT,
+      'user_test',
+      'uuid-123',
+    );
+  });
+
+  it('calls correct endpoint', async () => {
+    await sendLocationToCrmContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        crmContact: 'uuid-123',
+        latitude: 1.0,
+        longitude: 1.0,
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      '/api/sendLocation',
+      expect.anything(),
+    );
+  });
+
+  it('returns response body', async () => {
+    const result = await sendLocationToCrmContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        crmContact: 'uuid-123',
+        latitude: 1.0,
+        longitude: 1.0,
+      } as any,
+    } as any);
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-crm-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-crm-contact.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+export const sendLocationToCrmContactAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_send_location_to_crm_contact',
+  displayName: 'Send a Location to a CRM Contact',
+  description: 'Send a GPS location pin to a contact from your WhatsScale CRM',
+  props: {
+    session: whatsscaleProps.session,
+    crmContact: whatsscaleProps.crmContact,
+    latitude: Property.Number({
+      displayName: 'Latitude',
+      required: true,
+      description: 'GPS latitude (-90 to 90)',
+    }),
+    longitude: Property.Number({
+      displayName: 'Longitude',
+      required: true,
+      description: 'GPS longitude (-180 to 180)',
+    }),
+    title: Property.ShortText({
+      displayName: 'Location Title',
+      required: false,
+      description: 'Optional label shown on the pin',
+    }),
+  },
+  async run(context) {
+    const { session, crmContact, latitude, longitude, title } =
+      context.propsValue;
+    const auth = context.auth.secret_text;
+
+    const body = buildRecipientBody(
+      RecipientType.CRM_CONTACT,
+      session,
+      crmContact,
+    );
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.POST,
+      '/api/sendLocation',
+      {
+        ...body,
+        latitude,
+        longitude,
+        ...(title ? { title } : {}),
+        platform: 'activepieces',
+      },
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-group.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-group.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendLocationToGroupAction } from './send-location-to-group';
+import { whatsscaleClient } from '../../common/client';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+vi.mock('../../common/client');
+vi.mock('../../common/recipients');
+
+describe('sendLocationToGroupAction', () => {
+  const mockClient = vi.mocked(whatsscaleClient);
+  const mockBuildBody = vi.mocked(buildRecipientBody);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.mockResolvedValue({ body: { success: true } } as any);
+    mockBuildBody.mockReturnValue({
+      session: 'user_test',
+      chatId: 'group123@g.us',
+    } as any);
+  });
+
+  it('sends location to group with title', async () => {
+    await sendLocationToGroupAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        group: 'group123@g.us',
+        latitude: 52.3676,
+        longitude: 4.9041,
+        title: 'Amsterdam',
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      'ws_key',
+      expect.anything(),
+      '/api/sendLocation',
+      {
+        session: 'user_test',
+        chatId: 'group123@g.us',
+        latitude: 52.3676,
+        longitude: 4.9041,
+        title: 'Amsterdam',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('sends location to group without title — title key absent', async () => {
+    await sendLocationToGroupAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        group: 'group123@g.us',
+        latitude: 52.3676,
+        longitude: 4.9041,
+        title: undefined,
+      } as any,
+    } as any);
+
+    const callBody = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(callBody).not.toHaveProperty('title');
+  });
+
+  it('uses GROUP recipient type', async () => {
+    await sendLocationToGroupAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        group: 'group123@g.us',
+        latitude: 1.0,
+        longitude: 1.0,
+      } as any,
+    } as any);
+
+    expect(mockBuildBody).toHaveBeenCalledWith(
+      RecipientType.GROUP,
+      'user_test',
+      'group123@g.us',
+    );
+  });
+
+  it('calls correct endpoint', async () => {
+    await sendLocationToGroupAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        group: 'group123@g.us',
+        latitude: 1.0,
+        longitude: 1.0,
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      '/api/sendLocation',
+      expect.anything(),
+    );
+  });
+
+  it('returns response body', async () => {
+    const result = await sendLocationToGroupAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        group: 'group123@g.us',
+        latitude: 1.0,
+        longitude: 1.0,
+      } as any,
+    } as any);
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-group.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-location-to-group.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+export const sendLocationToGroupAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_send_location_to_group',
+  displayName: 'Send a Location to a Group',
+  description: 'Send a GPS location pin to a WhatsApp group',
+  props: {
+    session: whatsscaleProps.session,
+    group: whatsscaleProps.group,
+    latitude: Property.Number({
+      displayName: 'Latitude',
+      required: true,
+      description: 'GPS latitude (-90 to 90)',
+    }),
+    longitude: Property.Number({
+      displayName: 'Longitude',
+      required: true,
+      description: 'GPS longitude (-180 to 180)',
+    }),
+    title: Property.ShortText({
+      displayName: 'Location Title',
+      required: false,
+      description: 'Optional label shown on the pin',
+    }),
+  },
+  async run(context) {
+    const { session, group, latitude, longitude, title } = context.propsValue;
+    const auth = context.auth.secret_text;
+
+    const body = buildRecipientBody(RecipientType.GROUP, session, group);
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.POST,
+      '/api/sendLocation',
+      {
+        ...body,
+        latitude,
+        longitude,
+        ...(title ? { title } : {}),
+        platform: 'activepieces',
+      },
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-channel.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-channel.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendPollToChannelAction } from './send-poll-to-channel';
+import { whatsscaleClient } from '../../common/client';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+vi.mock('../../common/client');
+vi.mock('../../common/recipients');
+
+describe('sendPollToChannelAction', () => {
+  const mockClient = vi.mocked(whatsscaleClient);
+  const mockBuildBody = vi.mocked(buildRecipientBody);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.mockResolvedValue({ body: { success: true } } as any);
+    mockBuildBody.mockReturnValue({
+      session: 'user_test',
+      chatId: 'channel123@newsletter',
+    } as any);
+  });
+
+  it('sends poll to channel with multipleAnswers true', async () => {
+    await sendPollToChannelAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        channel: 'channel123@newsletter',
+        question: 'Best feature?',
+        options: ['Channels', 'Groups', 'DMs'],
+        multipleAnswers: true,
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      'ws_key',
+      expect.anything(),
+      '/api/sendPoll',
+      {
+        session: 'user_test',
+        chatId: 'channel123@newsletter',
+        question: 'Best feature?',
+        options: ['Channels', 'Groups', 'DMs'],
+        multipleAnswers: true,
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('throws if fewer than 2 options provided', async () => {
+    await expect(
+      sendPollToChannelAction.run({
+        auth: { secret_text: 'ws_key' } as any,
+        propsValue: {
+          session: 'user_test',
+          channel: 'channel123@newsletter',
+          question: 'Pick one',
+          options: ['OnlyOne'],
+        } as any,
+      } as any),
+    ).rejects.toThrow('Poll requires at least 2 options');
+  });
+
+  it('uses CHANNEL recipient type', async () => {
+    await sendPollToChannelAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        channel: 'channel123@newsletter',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(mockBuildBody).toHaveBeenCalledWith(
+      RecipientType.CHANNEL,
+      'user_test',
+      'channel123@newsletter',
+    );
+  });
+
+  it('calls correct endpoint', async () => {
+    await sendPollToChannelAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        channel: 'channel123@newsletter',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      '/api/sendPoll',
+      expect.anything(),
+    );
+  });
+
+  it('returns response body', async () => {
+    const result = await sendPollToChannelAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        channel: 'channel123@newsletter',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-channel.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-channel.ts
@@ -1,0 +1,56 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+export const sendPollToChannelAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_send_poll_to_channel',
+  displayName: 'Send a Poll to a Channel',
+  description: 'Send a poll with options to a WhatsApp Channel',
+  props: {
+    session: whatsscaleProps.session,
+    channel: whatsscaleProps.channel,
+    question: Property.ShortText({
+      displayName: 'Question',
+      required: true,
+      description: 'The poll question',
+    }),
+    options: Property.Array({
+      displayName: 'Options',
+      required: true,
+    }),
+    multipleAnswers: Property.Checkbox({
+      displayName: 'Allow Multiple Answers',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { session, channel, question, options, multipleAnswers } =
+      context.propsValue;
+    const auth = context.auth.secret_text;
+
+    if (!options || options.length < 2) {
+      throw new Error('Poll requires at least 2 options');
+    }
+
+    const body = buildRecipientBody(RecipientType.CHANNEL, session, channel);
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.POST,
+      '/api/sendPoll',
+      {
+        ...body,
+        question,
+        options,
+        multipleAnswers: multipleAnswers ?? false,
+        platform: 'activepieces',
+      },
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-contact.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendPollToContactAction } from './send-poll-to-contact';
+import { whatsscaleClient } from '../../common/client';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+vi.mock('../../common/client');
+vi.mock('../../common/recipients');
+
+describe('sendPollToContactAction', () => {
+  const mockClient = vi.mocked(whatsscaleClient);
+  const mockBuildBody = vi.mocked(buildRecipientBody);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.mockResolvedValue({ body: { success: true } } as any);
+    mockBuildBody.mockReturnValue({
+      session: 'user_test',
+      chatId: '31649931832@c.us',
+    } as any);
+  });
+
+  it('sends poll with 2 options as flat string array', async () => {
+    await sendPollToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        question: 'Favourite color?',
+        options: ['Red', 'Blue'],
+        multipleAnswers: false,
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      'ws_key',
+      expect.anything(),
+      '/api/sendPoll',
+      {
+        session: 'user_test',
+        chatId: '31649931832@c.us',
+        question: 'Favourite color?',
+        options: ['Red', 'Blue'],
+        multipleAnswers: false,
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('sends poll with 3 options — all present in body', async () => {
+    await sendPollToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        question: 'Pick one',
+        options: ['Red', 'Blue', 'Green'],
+        multipleAnswers: false,
+      } as any,
+    } as any);
+
+    const callBody = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(callBody['options']).toEqual(['Red', 'Blue', 'Green']);
+  });
+
+  it('throws if fewer than 2 options provided', async () => {
+    await expect(
+      sendPollToContactAction.run({
+        auth: { secret_text: 'ws_key' } as any,
+        propsValue: {
+          session: 'user_test',
+          contact: '31649931832@c.us',
+          question: 'Pick one',
+          options: ['OnlyOne'],
+          multipleAnswers: false,
+        } as any,
+      } as any),
+    ).rejects.toThrow('Poll requires at least 2 options');
+  });
+
+  it('multipleAnswers defaults to false when undefined', async () => {
+    await sendPollToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+        multipleAnswers: undefined,
+      } as any,
+    } as any);
+
+    const callBody = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(callBody['multipleAnswers']).toBe(false);
+  });
+
+  it('multipleAnswers: true passes through', async () => {
+    await sendPollToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+        multipleAnswers: true,
+      } as any,
+    } as any);
+
+    const callBody = mockClient.mock.calls[0][3] as Record<string, unknown>;
+    expect(callBody['multipleAnswers']).toBe(true);
+  });
+
+  it('calls correct endpoint', async () => {
+    await sendPollToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      '/api/sendPoll',
+      expect.anything(),
+    );
+  });
+
+  it('returns response body', async () => {
+    const result = await sendPollToContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        contact: '31649931832@c.us',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-contact.ts
@@ -1,0 +1,56 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+export const sendPollToContactAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_send_poll_to_contact',
+  displayName: 'Send a Poll to a Contact',
+  description: 'Send a poll with options to a WhatsApp contact',
+  props: {
+    session: whatsscaleProps.session,
+    contact: whatsscaleProps.contact,
+    question: Property.ShortText({
+      displayName: 'Question',
+      required: true,
+      description: 'The poll question',
+    }),
+    options: Property.Array({
+      displayName: 'Options',
+      required: true,
+    }),
+    multipleAnswers: Property.Checkbox({
+      displayName: 'Allow Multiple Answers',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { session, contact, question, options, multipleAnswers } =
+      context.propsValue;
+    const auth = context.auth.secret_text;
+
+    if (!options || options.length < 2) {
+      throw new Error('Poll requires at least 2 options');
+    }
+
+    const body = buildRecipientBody(RecipientType.CONTACT, session, contact);
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.POST,
+      '/api/sendPoll',
+      {
+        ...body,
+        question,
+        options,
+        multipleAnswers: multipleAnswers ?? false,
+        platform: 'activepieces',
+      },
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-crm-contact.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendPollToCrmContactAction } from './send-poll-to-crm-contact';
+import { whatsscaleClient } from '../../common/client';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+vi.mock('../../common/client');
+vi.mock('../../common/recipients');
+
+describe('sendPollToCrmContactAction', () => {
+  const mockClient = vi.mocked(whatsscaleClient);
+  const mockBuildBody = vi.mocked(buildRecipientBody);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.mockResolvedValue({ body: { success: true } } as any);
+    mockBuildBody.mockReturnValue({
+      session: 'user_test',
+      contact_type: 'crm_contact',
+      crm_contact_id: 'uuid-123',
+    } as any);
+  });
+
+  it('sends poll to CRM contact with options', async () => {
+    await sendPollToCrmContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        crmContact: 'uuid-123',
+        question: 'Interested in upgrade?',
+        options: ['Yes', 'No', 'Maybe'],
+        multipleAnswers: false,
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      'ws_key',
+      expect.anything(),
+      '/api/sendPoll',
+      {
+        session: 'user_test',
+        contact_type: 'crm_contact',
+        crm_contact_id: 'uuid-123',
+        question: 'Interested in upgrade?',
+        options: ['Yes', 'No', 'Maybe'],
+        multipleAnswers: false,
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('throws if fewer than 2 options provided', async () => {
+    await expect(
+      sendPollToCrmContactAction.run({
+        auth: { secret_text: 'ws_key' } as any,
+        propsValue: {
+          session: 'user_test',
+          crmContact: 'uuid-123',
+          question: 'Pick one',
+          options: ['OnlyOne'],
+        } as any,
+      } as any),
+    ).rejects.toThrow('Poll requires at least 2 options');
+  });
+
+  it('uses CRM_CONTACT recipient type', async () => {
+    await sendPollToCrmContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        crmContact: 'uuid-123',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(mockBuildBody).toHaveBeenCalledWith(
+      RecipientType.CRM_CONTACT,
+      'user_test',
+      'uuid-123',
+    );
+  });
+
+  it('calls correct endpoint', async () => {
+    await sendPollToCrmContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        crmContact: 'uuid-123',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      '/api/sendPoll',
+      expect.anything(),
+    );
+  });
+
+  it('returns response body', async () => {
+    const result = await sendPollToCrmContactAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        crmContact: 'uuid-123',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-crm-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-crm-contact.ts
@@ -1,0 +1,60 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+export const sendPollToCrmContactAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_send_poll_to_crm_contact',
+  displayName: 'Send a Poll to a CRM Contact',
+  description: 'Send a poll with options to a contact from your WhatsScale CRM',
+  props: {
+    session: whatsscaleProps.session,
+    crmContact: whatsscaleProps.crmContact,
+    question: Property.ShortText({
+      displayName: 'Question',
+      required: true,
+      description: 'The poll question',
+    }),
+    options: Property.Array({
+      displayName: 'Options',
+      required: true,
+    }),
+    multipleAnswers: Property.Checkbox({
+      displayName: 'Allow Multiple Answers',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { session, crmContact, question, options, multipleAnswers } =
+      context.propsValue;
+    const auth = context.auth.secret_text;
+
+    if (!options || options.length < 2) {
+      throw new Error('Poll requires at least 2 options');
+    }
+
+    const body = buildRecipientBody(
+      RecipientType.CRM_CONTACT,
+      session,
+      crmContact,
+    );
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.POST,
+      '/api/sendPoll',
+      {
+        ...body,
+        question,
+        options,
+        multipleAnswers: multipleAnswers ?? false,
+        platform: 'activepieces',
+      },
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-group.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-group.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendPollToGroupAction } from './send-poll-to-group';
+import { whatsscaleClient } from '../../common/client';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+vi.mock('../../common/client');
+vi.mock('../../common/recipients');
+
+describe('sendPollToGroupAction', () => {
+  const mockClient = vi.mocked(whatsscaleClient);
+  const mockBuildBody = vi.mocked(buildRecipientBody);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.mockResolvedValue({ body: { success: true } } as any);
+    mockBuildBody.mockReturnValue({
+      session: 'user_test',
+      chatId: 'group123@g.us',
+    } as any);
+  });
+
+  it('sends poll to group with options', async () => {
+    await sendPollToGroupAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        group: 'group123@g.us',
+        question: 'Team lunch?',
+        options: ['Pizza', 'Sushi'],
+        multipleAnswers: false,
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      'ws_key',
+      expect.anything(),
+      '/api/sendPoll',
+      {
+        session: 'user_test',
+        chatId: 'group123@g.us',
+        question: 'Team lunch?',
+        options: ['Pizza', 'Sushi'],
+        multipleAnswers: false,
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('throws if fewer than 2 options provided', async () => {
+    await expect(
+      sendPollToGroupAction.run({
+        auth: { secret_text: 'ws_key' } as any,
+        propsValue: {
+          session: 'user_test',
+          group: 'group123@g.us',
+          question: 'Pick one',
+          options: ['OnlyOne'],
+        } as any,
+      } as any),
+    ).rejects.toThrow('Poll requires at least 2 options');
+  });
+
+  it('uses GROUP recipient type', async () => {
+    await sendPollToGroupAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        group: 'group123@g.us',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(mockBuildBody).toHaveBeenCalledWith(
+      RecipientType.GROUP,
+      'user_test',
+      'group123@g.us',
+    );
+  });
+
+  it('calls correct endpoint', async () => {
+    await sendPollToGroupAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        group: 'group123@g.us',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(mockClient).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      '/api/sendPoll',
+      expect.anything(),
+    );
+  });
+
+  it('returns response body', async () => {
+    const result = await sendPollToGroupAction.run({
+      auth: { secret_text: 'ws_key' } as any,
+      propsValue: {
+        session: 'user_test',
+        group: 'group123@g.us',
+        question: 'Pick one',
+        options: ['Yes', 'No'],
+      } as any,
+    } as any);
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-group.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-poll-to-group.ts
@@ -1,0 +1,56 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { buildRecipientBody, RecipientType } from '../../common/recipients';
+
+export const sendPollToGroupAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_send_poll_to_group',
+  displayName: 'Send a Poll to a Group',
+  description: 'Send a poll with options to a WhatsApp group',
+  props: {
+    session: whatsscaleProps.session,
+    group: whatsscaleProps.group,
+    question: Property.ShortText({
+      displayName: 'Question',
+      required: true,
+      description: 'The poll question',
+    }),
+    options: Property.Array({
+      displayName: 'Options',
+      required: true,
+    }),
+    multipleAnswers: Property.Checkbox({
+      displayName: 'Allow Multiple Answers',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { session, group, question, options, multipleAnswers } =
+      context.propsValue;
+    const auth = context.auth.secret_text;
+
+    if (!options || options.length < 2) {
+      throw new Error('Poll requires at least 2 options');
+    }
+
+    const body = buildRecipientBody(RecipientType.GROUP, session, group);
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.POST,
+      '/api/sendPoll',
+      {
+        ...body,
+        question,
+        options,
+        multipleAnswers: multipleAnswers ?? false,
+        platform: 'activepieces',
+      },
+    );
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-manual.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-manual.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TEST_API_KEY, createMockHttpResponse } from '../../test-helpers';
+
+const mockSendRequest = vi.fn();
+
+vi.mock('@activepieces/pieces-common', () => ({
+  httpClient: { sendRequest: (...args: unknown[]) => mockSendRequest(...args) },
+  HttpMethod: { GET: 'GET', POST: 'POST' },
+}));
+
+/**
+ * send-text-manual.ts run() logic:
+ *   1. Extracts session, chatType, recipient, text from context.propsValue
+ *   2. Gets auth from context.auth.secret_text
+ *   3. Builds chatId: recipient + (@c.us for contact, @g.us for group)
+ *   4. POST /api/sendText with { session, chatId, text }
+ *   5. Returns response.body
+ */
+
+// Import after mocks
+import { whatsscaleClient } from '../../common/client';
+import { ChatType } from '../../common/types';
+
+/**
+ * Replicate the run() logic from send-text-manual.ts for testability.
+ */
+async function runSendTextManual(params: {
+  auth: string;
+  session: string;
+  chatType: string;
+  recipient: string;
+  text: string;
+}) {
+  const { auth, session, chatType, recipient, text } = params;
+  const suffix = chatType === ChatType.CONTACT ? '@c.us' : '@g.us';
+  const chatId = recipient + suffix;
+
+  const response = await whatsscaleClient(auth, 'POST' as any, '/api/sendText', {
+    session,
+    chatId,
+    text,
+    platform: 'activepieces',
+  });
+
+  return response.body;
+}
+
+describe('send-text-manual.ts — Send a Message (Manual Entry)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const successResponse = {
+    key: {
+      remoteJid: '31649931832@c.us',
+      fromMe: true,
+      id: 'ABCDEF123456',
+    },
+    messageTimestamp: '1709500000',
+    status: '2',
+  };
+
+  it('builds chatId with @c.us when chatType is contact', async () => {
+    mockSendRequest.mockResolvedValueOnce(createMockHttpResponse(successResponse));
+
+    await runSendTextManual({
+      auth: TEST_API_KEY,
+      session: 'user_abc',
+      chatType: ChatType.CONTACT,
+      recipient: '+31649931832',
+      text: 'Hello',
+    });
+
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          chatId: '+31649931832@c.us',
+        }),
+      }),
+    );
+  });
+
+  it('builds chatId with @g.us when chatType is group', async () => {
+    mockSendRequest.mockResolvedValueOnce(createMockHttpResponse(successResponse));
+
+    await runSendTextManual({
+      auth: TEST_API_KEY,
+      session: 'user_abc',
+      chatType: ChatType.GROUP,
+      recipient: '120363318673245672',
+      text: 'Hello group',
+    });
+
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          chatId: '120363318673245672@g.us',
+        }),
+      }),
+    );
+  });
+
+  it('calls POST /api/sendText with correct body', async () => {
+    mockSendRequest.mockResolvedValueOnce(createMockHttpResponse(successResponse));
+
+    await runSendTextManual({
+      auth: TEST_API_KEY,
+      session: 'user_abc',
+      chatType: ChatType.CONTACT,
+      recipient: '+31649931832',
+      text: 'Test message',
+    });
+
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        url: 'https://proxy.whatsscale.com/api/sendText',
+        body: {
+          session: 'user_abc',
+          chatId: '+31649931832@c.us',
+          text: 'Test message',
+          platform: 'activepieces',
+        },
+      }),
+    );
+  });
+
+  it('sends session in request body', async () => {
+    mockSendRequest.mockResolvedValueOnce(createMockHttpResponse(successResponse));
+
+    await runSendTextManual({
+      auth: TEST_API_KEY,
+      session: 'user_xyz_789',
+      chatType: ChatType.CONTACT,
+      recipient: '+5511999887766',
+      text: 'Olá',
+    });
+
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          session: 'user_xyz_789',
+        }),
+      }),
+    );
+  });
+
+  it('returns full response body on success', async () => {
+    mockSendRequest.mockResolvedValueOnce(createMockHttpResponse(successResponse));
+
+    const result = await runSendTextManual({
+      auth: TEST_API_KEY,
+      session: 'user_abc',
+      chatType: ChatType.CONTACT,
+      recipient: '+31649931832',
+      text: 'Hello',
+    });
+
+    expect(result).toEqual(successResponse);
+    expect(result).toHaveProperty('key');
+    expect(result).toHaveProperty('messageTimestamp');
+    expect(result).toHaveProperty('status');
+  });
+
+  it('propagates error on 400 (invalid chatId)', async () => {
+    mockSendRequest.mockRejectedValueOnce(
+      new Error('Request failed with status 400: {"error":"Invalid chatId format"}'),
+    );
+
+    await expect(
+      runSendTextManual({
+        auth: TEST_API_KEY,
+        session: 'user_abc',
+        chatType: ChatType.CONTACT,
+        recipient: 'invalid',
+        text: 'Hello',
+      }),
+    ).rejects.toThrow('400');
+  });
+
+  it('propagates error on 429 (rate limit)', async () => {
+    mockSendRequest.mockRejectedValueOnce(
+      new Error('Request failed with status 429: {"error":"Rate limit exceeded"}'),
+    );
+
+    await expect(
+      runSendTextManual({
+        auth: TEST_API_KEY,
+        session: 'user_abc',
+        chatType: ChatType.CONTACT,
+        recipient: '+31649931832',
+        text: 'Hello',
+      }),
+    ).rejects.toThrow('429');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-manual.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-manual.ts
@@ -51,7 +51,7 @@ export const sendTextManualAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text },
+      { ...body, text , platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-manual.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-manual.ts
@@ -51,7 +51,7 @@ export const sendTextManualAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text , platform: 'activepieces' },
+      { ...body, text, platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-channel.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-channel.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendTextToChannelAction } from './send-text-to-channel';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendTextToChannelAction', () => {
+  const baseProps = {
+    session: 'test-session',
+    channel: '120363318673245672@newsletter',
+    text: 'Channel announcement',
+  };
+
+  it('sends text to channel using pre-formatted newsletter chatId', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/sendText',
+      {
+        session: 'test-session',
+        chatId: '120363318673245672@newsletter',
+        text: 'Channel announcement',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('passes auth API key in the request', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  it('calls POST /api/sendText', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      expect.any(String),
+      'POST',
+      '/api/sendText',
+      expect.any(Object),
+    );
+  });
+
+  it('returns response body on success', async () => {
+    const mockResponse = { sent: true, messageId: 'ch-abc123' };
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: mockResponse,
+    } as any);
+
+    const result = await (sendTextToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('surfaces error when client throws', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockRejectedValueOnce(
+      new Error('400 Bad Request'),
+    );
+
+    await expect(
+      (sendTextToChannelAction as any).run({
+        auth: mockAuth,
+        propsValue: baseProps,
+      }),
+    ).rejects.toThrow('400 Bad Request');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-channel.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-channel.ts
@@ -28,7 +28,7 @@ export const sendTextToChannelAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text , platform: 'activepieces' },
+      { ...body, text, platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-channel.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-channel.ts
@@ -28,7 +28,7 @@ export const sendTextToChannelAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text },
+      { ...body, text , platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-contact.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendTextToContactAction } from './send-text-to-contact';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendTextToContactAction', () => {
+  const baseProps = {
+    session: 'test-session',
+    contact: '31649931832@c.us',
+    text: 'Hello from tests',
+  };
+
+  it('sends text to contact using pre-formatted chatId from dropdown', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/sendText',
+      {
+        session: 'test-session',
+        chatId: '31649931832@c.us',
+        text: 'Hello from tests',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('passes auth API key in the request', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  it('calls POST /api/sendText', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      expect.any(String),
+      'POST',
+      '/api/sendText',
+      expect.any(Object),
+    );
+  });
+
+  it('returns response body on success', async () => {
+    const mockResponse = { sent: true, messageId: 'abc123' };
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: mockResponse,
+    } as any);
+
+    const result = await (sendTextToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('surfaces error when client throws', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockRejectedValueOnce(
+      new Error('401 Unauthorized'),
+    );
+
+    await expect(
+      (sendTextToContactAction as any).run({
+        auth: mockAuth,
+        propsValue: baseProps,
+      }),
+    ).rejects.toThrow('401 Unauthorized');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-contact.ts
@@ -29,7 +29,7 @@ export const sendTextToContactAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text },
+      { ...body, text , platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-contact.ts
@@ -29,7 +29,7 @@ export const sendTextToContactAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text , platform: 'activepieces' },
+      { ...body, text, platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-crm-contact.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendTextToCrmContactAction } from './send-text-to-crm-contact';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' };
+const mockUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendTextToCrmContactAction', () => {
+  const baseProps = {
+    session: 'test-session',
+    crmContact: mockUuid,
+    text: 'Hello CRM contact',
+  };
+
+  it('sends text using CRM body shape (contact_type + crm_contact_id, no chatId)', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/sendText',
+      {
+        session: 'test-session',
+        contact_type: 'crm_contact',
+        crm_contact_id: mockUuid,
+        text: 'Hello CRM contact',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('passes auth API key in the request', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  it('calls POST /api/sendText', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      expect.any(String),
+      'POST',
+      '/api/sendText',
+      expect.any(Object),
+    );
+  });
+
+  it('returns response body on success', async () => {
+    const mockResponse = { sent: true, messageId: 'crm-abc123' };
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: mockResponse,
+    } as any);
+
+    const result = await (sendTextToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('surfaces error when client throws', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockRejectedValueOnce(
+      new Error('401 Unauthorized'),
+    );
+
+    await expect(
+      (sendTextToCrmContactAction as any).run({
+        auth: mockAuth,
+        propsValue: baseProps,
+      }),
+    ).rejects.toThrow('401 Unauthorized');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-crm-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-crm-contact.ts
@@ -32,7 +32,7 @@ export const sendTextToCrmContactAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text , platform: 'activepieces' },
+      { ...body, text, platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-crm-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-crm-contact.ts
@@ -32,7 +32,7 @@ export const sendTextToCrmContactAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text },
+      { ...body, text , platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-group.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-group.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendTextToGroupAction } from './send-text-to-group';
+import * as clientModule from '../../common/client';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sendTextToGroupAction', () => {
+  const baseProps = {
+    session: 'test-session',
+    group: '120363318673245672@g.us',
+    text: 'Hello group',
+  };
+
+  it('sends text to group using pre-formatted chatId from dropdown', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/sendText',
+      {
+        session: 'test-session',
+        chatId: '120363318673245672@g.us',
+        text: 'Hello group',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('passes auth API key in the request', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  it('calls POST /api/sendText', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: { sent: true },
+    } as any);
+
+    await (sendTextToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(clientModule.whatsscaleClient).toHaveBeenCalledWith(
+      expect.any(String),
+      'POST',
+      '/api/sendText',
+      expect.any(Object),
+    );
+  });
+
+  it('returns response body on success', async () => {
+    const mockResponse = { sent: true, messageId: 'grp-abc123' };
+    vi.mocked(clientModule.whatsscaleClient).mockResolvedValueOnce({
+      body: mockResponse,
+    } as any);
+
+    const result = await (sendTextToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: baseProps,
+    });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('surfaces error when client throws', async () => {
+    vi.mocked(clientModule.whatsscaleClient).mockRejectedValueOnce(
+      new Error('429 Too Many Requests'),
+    );
+
+    await expect(
+      (sendTextToGroupAction as any).run({
+        auth: mockAuth,
+        propsValue: baseProps,
+      }),
+    ).rejects.toThrow('429 Too Many Requests');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-group.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-group.ts
@@ -29,7 +29,7 @@ export const sendTextToGroupAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text },
+      { ...body, text , platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-group.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-text-to-group.ts
@@ -29,7 +29,7 @@ export const sendTextToGroupAction = createAction({
       auth,
       HttpMethod.POST,
       '/api/sendText',
-      { ...body, text , platform: 'activepieces' },
+      { ...body, text, platform: 'activepieces' },
     );
 
     return response.body;

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-manual.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-manual.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendVideoManualAction } from './send-video-manual';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+describe('sendVideoManualAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/video.mp4');
+    (whatsscaleClient as any).mockResolvedValue({ body: { jobId: 'job_abc123', status: 'QUEUED' } });
+    (pollJob as any).mockResolvedValue({ id: 'true_31649931832@c.us_ABC', _data: {} });
+  });
+
+  it('calls prepareFile with the video URL', async () => {
+    await (sendVideoManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: 'contact', recipient: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/video.mp4');
+  });
+
+  it('calls POST /api/sendVideo with correct body for contact', async () => {
+    await (sendVideoManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: 'contact', recipient: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: 'Hello' , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0];
+    expect(callArg[2]).toBe('/api/sendVideo');
+    expect(callArg[3]).toMatchObject({
+      session: 'test-session',
+      file: 'https://proxy.whatsscale.com/files/video.mp4',
+      caption: 'Hello',
+      platform: 'activepieces',
+    });
+  });
+
+  it('calls pollJob with the jobId from send response', async () => {
+    await (sendVideoManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: 'contact', recipient: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'job_abc123');
+  });
+
+  it('returns the result from pollJob', async () => {
+    const result = { id: 'true_31649931832@c.us_ABC', _data: {} };
+    (pollJob as any).mockResolvedValue(result);
+
+    const response = await (sendVideoManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: 'contact', recipient: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(response).toEqual(result);
+  });
+
+  it('sends empty string caption when caption is undefined', async () => {
+    await (sendVideoManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: 'contact', recipient: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(),
+      expect.objectContaining({ caption: '' }));
+  });
+
+  it('uses chatType from propsValue when building recipient body', async () => {
+    await (sendVideoManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: 'group', recipient: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('session', 'test-session');
+  });
+
+  it('uses apiKey from context.auth.secret_text', async () => {
+    await (sendVideoManualAction as any).run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'test-session', chatType: 'contact', recipient: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.anything());
+    expect(pollJob).toHaveBeenCalledWith('my-secret-key', expect.anything());
+  });
+
+  it('propagates error when pollJob throws', async () => {
+    (pollJob as any).mockRejectedValue(new Error('Job timed out after 80 attempts'));
+
+    await expect((sendVideoManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: 'contact', recipient: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('Job timed out after 80 attempts');
+  });
+
+  it('propagates error when prepareFile throws', async () => {
+    (prepareFile as any).mockRejectedValue(new Error('File prep failed'));
+
+    await expect((sendVideoManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: 'contact', recipient: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('File prep failed');
+  });
+
+  it('includes file field from preparedUrl (not raw videoUrl)', async () => {
+    await (sendVideoManualAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', chatType: 'contact', recipient: '31649931832@c.us', videoUrl: 'https://example.com/raw-video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg.file).toBe('https://proxy.whatsscale.com/files/video.mp4');
+    expect(callArg.file).not.toBe('https://example.com/raw-video.mp4');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-manual.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-manual.ts
@@ -59,6 +59,7 @@ export const sendVideoManualAction = createAction({
       ...recipientBody,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     const { jobId } = sendResponse.body as { jobId: string };

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-channel.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-channel.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendVideoToChannelAction } from './send-video-to-channel';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+describe('sendVideoToChannelAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/video.mp4');
+    (whatsscaleClient as any).mockResolvedValue({ body: { jobId: 'job_abc123', status: 'QUEUED' } });
+    (pollJob as any).mockResolvedValue({ id: 'true_120363000000000001@newsletter_ABC', _data: {} });
+  });
+
+  it('calls prepareFile with the video URL', async () => {
+    await (sendVideoToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', channel: '120363000000000001@newsletter', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/video.mp4');
+  });
+
+  it('calls POST /api/sendVideo with channel chatId', async () => {
+    await (sendVideoToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', channel: '120363000000000001@newsletter', videoUrl: 'https://example.com/video.mp4', caption: 'New update' , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith('test-api-key', expect.anything(), '/api/sendVideo', {
+      session: 'test-session',
+      chatId: '120363000000000001@newsletter',
+      file: 'https://proxy.whatsscale.com/files/video.mp4',
+      caption: 'New update',
+      platform: 'activepieces',
+    });
+  });
+
+  it('calls pollJob with the jobId from send response', async () => {
+    await (sendVideoToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', channel: '120363000000000001@newsletter', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'job_abc123');
+  });
+
+  it('returns the result from pollJob', async () => {
+    const result = { id: 'true_120363000000000001@newsletter_ABC', _data: {} };
+    (pollJob as any).mockResolvedValue(result);
+
+    const response = await (sendVideoToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', channel: '120363000000000001@newsletter', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(response).toEqual(result);
+  });
+
+  it('sends empty string caption when caption is undefined', async () => {
+    await (sendVideoToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', channel: '120363000000000001@newsletter', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(),
+      expect.objectContaining({ caption: '' }));
+  });
+
+  it('uses chatId for channel (not crm_contact_id)', async () => {
+    await (sendVideoToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', channel: '120363000000000001@newsletter', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('chatId');
+    expect(callArg).not.toHaveProperty('crm_contact_id');
+  });
+
+  it('uses apiKey from context.auth.secret_text', async () => {
+    await (sendVideoToChannelAction as any).run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'test-session', channel: '120363000000000001@newsletter', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.anything());
+  });
+
+  it('propagates error when pollJob throws', async () => {
+    (pollJob as any).mockRejectedValue(new Error('Job failed'));
+
+    await expect((sendVideoToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', channel: '120363000000000001@newsletter', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('Job failed');
+  });
+
+  it('propagates error when prepareFile throws', async () => {
+    (prepareFile as any).mockRejectedValue(new Error('File prep failed'));
+
+    await expect((sendVideoToChannelAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', channel: '120363000000000001@newsletter', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('File prep failed');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-channel.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-channel.ts
@@ -36,6 +36,7 @@ export const sendVideoToChannelAction = createAction({
       chatId: channel,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     const { jobId } = sendResponse.body as { jobId: string };

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-contact.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendVideoToContactAction } from './send-video-to-contact';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+describe('sendVideoToContactAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/video.mp4');
+    (whatsscaleClient as any).mockResolvedValue({ body: { jobId: 'job_abc123', status: 'QUEUED' } });
+    (pollJob as any).mockResolvedValue({ id: 'true_31649931832@c.us_ABC', _data: {} });
+  });
+
+  it('calls prepareFile with the video URL', async () => {
+    await (sendVideoToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/video.mp4');
+  });
+
+  it('calls POST /api/sendVideo with correct body', async () => {
+    await (sendVideoToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: 'Hello' , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith('test-api-key', expect.anything(), '/api/sendVideo', {
+      session: 'test-session',
+      chatId: '31649931832@c.us',
+      file: 'https://proxy.whatsscale.com/files/video.mp4',
+      caption: 'Hello',
+      platform: 'activepieces',
+    });
+  });
+
+  it('calls pollJob with the jobId from send response', async () => {
+    await (sendVideoToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'job_abc123');
+  });
+
+  it('returns the result from pollJob', async () => {
+    const result = { id: 'true_31649931832@c.us_ABC', _data: {} };
+    (pollJob as any).mockResolvedValue(result);
+
+    const response = await (sendVideoToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(response).toEqual(result);
+  });
+
+  it('sends empty string caption when caption is undefined', async () => {
+    await (sendVideoToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(),
+      expect.objectContaining({ caption: '' }));
+  });
+
+  it('uses chatId for contact (not crm_contact_id)', async () => {
+    await (sendVideoToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('chatId');
+    expect(callArg).not.toHaveProperty('crm_contact_id');
+  });
+
+  it('uses apiKey from context.auth.secret_text', async () => {
+    await (sendVideoToContactAction as any).run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.anything());
+    expect(pollJob).toHaveBeenCalledWith('my-secret-key', expect.anything());
+  });
+
+  it('propagates error when pollJob throws', async () => {
+    (pollJob as any).mockRejectedValue(new Error('Job failed'));
+
+    await expect((sendVideoToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('Job failed');
+  });
+
+  it('propagates error when prepareFile throws', async () => {
+    (prepareFile as any).mockRejectedValue(new Error('File prep failed'));
+
+    await expect((sendVideoToContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', contact: '31649931832@c.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('File prep failed');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-contact.ts
@@ -36,6 +36,7 @@ export const sendVideoToContactAction = createAction({
       chatId: contact,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     const { jobId } = sendResponse.body as { jobId: string };

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-crm-contact.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-crm-contact.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendVideoToCrmContactAction } from './send-video-to-crm-contact';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+const crmContactId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+describe('sendVideoToCrmContactAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/video.mp4');
+    (whatsscaleClient as any).mockResolvedValue({ body: { jobId: 'job_abc123', status: 'QUEUED' } });
+    (pollJob as any).mockResolvedValue({ id: 'true_31649931832@c.us_ABC', _data: {} });
+  });
+
+  it('calls prepareFile with the video URL', async () => {
+    await (sendVideoToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/video.mp4');
+  });
+
+  it('calls POST /api/sendVideo with CRM body shape (no chatId)', async () => {
+    await (sendVideoToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, videoUrl: 'https://example.com/video.mp4', caption: 'Hello' , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith('test-api-key', expect.anything(), '/api/sendVideo', {
+      session: 'test-session',
+      contact_type: 'crm_contact',
+      crm_contact_id: crmContactId,
+      file: 'https://proxy.whatsscale.com/files/video.mp4',
+      caption: 'Hello',
+      platform: 'activepieces',
+    });
+  });
+
+  it('uses crm_contact_id body shape — no chatId field', async () => {
+    await (sendVideoToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('crm_contact_id', crmContactId);
+    expect(callArg).toHaveProperty('contact_type', 'crm_contact');
+    expect(callArg).not.toHaveProperty('chatId');
+  });
+
+  it('calls pollJob with the jobId from send response', async () => {
+    await (sendVideoToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'job_abc123');
+  });
+
+  it('returns the result from pollJob', async () => {
+    const result = { id: 'true_31649931832@c.us_ABC', _data: {} };
+    (pollJob as any).mockResolvedValue(result);
+
+    const response = await (sendVideoToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(response).toEqual(result);
+  });
+
+  it('sends empty string caption when caption is undefined', async () => {
+    await (sendVideoToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(),
+      expect.objectContaining({ caption: '' }));
+  });
+
+  it('uses apiKey from context.auth.secret_text', async () => {
+    await (sendVideoToCrmContactAction as any).run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'test-session', crmContact: crmContactId, videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.anything());
+    expect(pollJob).toHaveBeenCalledWith('my-secret-key', expect.anything());
+  });
+
+  it('propagates error when pollJob throws', async () => {
+    (pollJob as any).mockRejectedValue(new Error('Job failed'));
+
+    await expect((sendVideoToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('Job failed');
+  });
+
+  it('propagates error when prepareFile throws', async () => {
+    (prepareFile as any).mockRejectedValue(new Error('File prep failed'));
+
+    await expect((sendVideoToCrmContactAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', crmContact: crmContactId, videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('File prep failed');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-crm-contact.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-crm-contact.ts
@@ -37,6 +37,7 @@ export const sendVideoToCrmContactAction = createAction({
       crm_contact_id: crmContact,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     const { jobId } = sendResponse.body as { jobId: string };

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-group.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-group.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendVideoToGroupAction } from './send-video-to-group';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+describe('sendVideoToGroupAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/video.mp4');
+    (whatsscaleClient as any).mockResolvedValue({ body: { jobId: 'job_abc123', status: 'QUEUED' } });
+    (pollJob as any).mockResolvedValue({ id: 'true_120363000000000001@g.us_ABC', _data: {} });
+  });
+
+  it('calls prepareFile with the video URL', async () => {
+    await (sendVideoToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/video.mp4');
+  });
+
+  it('calls POST /api/sendVideo with group chatId', async () => {
+    await (sendVideoToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: 'Watch this' , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith('test-api-key', expect.anything(), '/api/sendVideo', {
+      session: 'test-session',
+      chatId: '120363000000000001@g.us',
+      file: 'https://proxy.whatsscale.com/files/video.mp4',
+      caption: 'Watch this',
+      platform: 'activepieces',
+    });
+  });
+
+  it('calls pollJob with the jobId from send response', async () => {
+    await (sendVideoToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'job_abc123');
+  });
+
+  it('returns the result from pollJob', async () => {
+    const result = { id: 'true_120363000000000001@g.us_ABC', _data: {} };
+    (pollJob as any).mockResolvedValue(result);
+
+    const response = await (sendVideoToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(response).toEqual(result);
+  });
+
+  it('sends empty string caption when caption is undefined', async () => {
+    await (sendVideoToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(),
+      expect.objectContaining({ caption: '' }));
+  });
+
+  it('uses chatId for group', async () => {
+    await (sendVideoToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    const callArg = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callArg).toHaveProperty('chatId', '120363000000000001@g.us');
+  });
+
+  it('uses apiKey from context.auth.secret_text', async () => {
+    await (sendVideoToGroupAction as any).run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    });
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.anything());
+  });
+
+  it('propagates error when pollJob throws', async () => {
+    (pollJob as any).mockRejectedValue(new Error('Job timed out after 80 attempts'));
+
+    await expect((sendVideoToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('Job timed out after 80 attempts');
+  });
+
+  it('propagates error when prepareFile throws', async () => {
+    (prepareFile as any).mockRejectedValue(new Error('File prep failed'));
+
+    await expect((sendVideoToGroupAction as any).run({
+      auth: mockAuth,
+      propsValue: { session: 'test-session', group: '120363000000000001@g.us', videoUrl: 'https://example.com/video.mp4', caption: undefined , platform: 'activepieces' },
+    })).rejects.toThrow('File prep failed');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-group.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/messaging/send-video-to-group.ts
@@ -36,6 +36,7 @@ export const sendVideoToGroupAction = createAction({
       chatId: group,
       file: preparedUrl,
       caption: caption ?? '',
+      platform: 'activepieces',
     });
 
     const { jobId } = sendResponse.body as { jobId: string };

--- a/packages/pieces/community/whatsscale/src/lib/actions/stories/set-image-story.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/stories/set-image-story.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setImageStoryAction } from './set-image-story';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+describe('setImageStoryAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/img_story.jpg');
+    (whatsscaleClient as any).mockResolvedValue({
+      body: { jobId: 'img_abc123', status: 'QUEUED' },
+    });
+    (pollJob as any).mockResolvedValue({
+      jobId: 'img_abc123',
+      status: 'COMPLETED',
+      message: 'Story posted',
+    });
+  });
+
+  it('should call prepareFile with imageUrl', async () => {
+    await setImageStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', imageUrl: 'https://example.com/photo.jpg', caption: undefined },
+    } as any);
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/photo.jpg');
+  });
+
+  it('should post image story with prepared URL and empty caption by default', async () => {
+    await setImageStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', imageUrl: 'https://example.com/photo.jpg', caption: undefined },
+    } as any);
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/status/image',
+      {
+        session: 'default',
+        file: 'https://proxy.whatsscale.com/files/img_story.jpg',
+        caption: '',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('should include caption when provided', async () => {
+    await setImageStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', imageUrl: 'https://example.com/photo.jpg', caption: 'My caption' },
+    } as any);
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/status/image',
+      {
+        session: 'default',
+        file: 'https://proxy.whatsscale.com/files/img_story.jpg',
+        caption: 'My caption',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('should call pollJob with jobId from response', async () => {
+    await setImageStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', imageUrl: 'https://example.com/photo.jpg', caption: undefined },
+    } as any);
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'img_abc123');
+  });
+
+  it('should return pollJob result', async () => {
+    const result = await setImageStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', imageUrl: 'https://example.com/photo.jpg', caption: undefined },
+    } as any);
+
+    expect(result).toEqual({ jobId: 'img_abc123', status: 'COMPLETED', message: 'Story posted' });
+  });
+
+  it('should pass apiKey to prepareFile', async () => {
+    await setImageStoryAction.run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'default', imageUrl: 'https://example.com/photo.jpg', caption: undefined },
+    } as any);
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.any(String));
+  });
+
+  it('should pass apiKey to pollJob', async () => {
+    await setImageStoryAction.run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'default', imageUrl: 'https://example.com/photo.jpg', caption: undefined },
+    } as any);
+
+    expect(pollJob).toHaveBeenCalledWith('my-secret-key', expect.any(String));
+  });
+
+  it('should support Google Drive URLs via prepareFile', async () => {
+    const driveUrl = 'https://drive.google.com/file/d/abc123/view';
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/img_gdrive.jpg');
+
+    await setImageStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', imageUrl: driveUrl, caption: undefined },
+    } as any);
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', driveUrl);
+    const callBody = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callBody.file).toBe('https://proxy.whatsscale.com/files/img_gdrive.jpg');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/stories/set-image-story.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/stories/set-image-story.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+export const setImageStoryAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_set_image_story',
+  displayName: 'Set an Image Story',
+  description: 'Post an image to your WhatsApp story',
+  props: {
+    session: whatsscaleProps.session,
+    imageUrl: Property.ShortText({
+      displayName: 'Image URL',
+      required: true,
+      description:
+        'URL to the image. Supports Google Drive, Dropbox, and direct URLs.',
+    }),
+    caption: Property.ShortText({
+      displayName: 'Caption',
+      required: false,
+      description: 'Optional caption for the image story',
+    }),
+  },
+  async run(context) {
+    const { session, imageUrl, caption } = context.propsValue;
+    const apiKey = context.auth.secret_text;
+
+    const preparedUrl = await prepareFile(apiKey, imageUrl);
+
+    const response = await whatsscaleClient(
+      apiKey,
+      HttpMethod.POST,
+      '/api/status/image',
+      {
+        session,
+        file: preparedUrl,
+        caption: caption ?? '',
+        platform: 'activepieces',
+      },
+    );
+
+    const { jobId } = response.body as { jobId: string };
+    return await pollJob(apiKey, jobId);
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/stories/set-text-story.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/stories/set-text-story.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setTextStoryAction } from './set-text-story';
+import { whatsscaleClient } from '../../common/client';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+describe('setTextStoryAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (whatsscaleClient as any).mockResolvedValue({
+      body: { jobId: 'txt_abc123', status: 'QUEUED' },
+    });
+    (pollJob as any).mockResolvedValue({
+      jobId: 'txt_abc123',
+      status: 'COMPLETED',
+      message: 'Story posted',
+    });
+  });
+
+  it('should post text story with required fields only', async () => {
+    const result = await setTextStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', text: 'Hello World!', backgroundColor: undefined },
+    } as any);
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/status/text',
+      { session: 'default', text: 'Hello World!', platform: 'activepieces'  },
+    );
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'txt_abc123');
+    expect(result).toEqual({ jobId: 'txt_abc123', status: 'COMPLETED', message: 'Story posted' });
+  });
+
+  it('should include backgroundColor when provided', async () => {
+    await setTextStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', text: 'Hi', backgroundColor: '#25D366' },
+    } as any);
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/status/text',
+      { session: 'default', text: 'Hi', backgroundColor: '#25D366', platform: 'activepieces'  },
+    );
+  });
+
+  it('should not include backgroundColor when empty string', async () => {
+    await setTextStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', text: 'Hi', backgroundColor: '' },
+    } as any);
+
+    const callBody = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callBody).not.toHaveProperty('backgroundColor');
+  });
+
+  it('should not include backgroundColor when undefined', async () => {
+    await setTextStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', text: 'Hi', backgroundColor: undefined },
+    } as any);
+
+    const callBody = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callBody).not.toHaveProperty('backgroundColor');
+  });
+
+  it('should pass auth key to whatsscaleClient', async () => {
+    await setTextStoryAction.run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'default', text: 'test', backgroundColor: undefined },
+    } as any);
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(
+      'my-secret-key',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
+  it('should pass auth key to pollJob', async () => {
+    await setTextStoryAction.run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'default', text: 'test', backgroundColor: undefined },
+    } as any);
+
+    expect(pollJob).toHaveBeenCalledWith('my-secret-key', expect.any(String));
+  });
+
+  it('should return pollJob result', async () => {
+    (pollJob as any).mockResolvedValue({ jobId: 'txt_xyz', status: 'COMPLETED', message: 'Done' });
+
+    const result = await setTextStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', text: 'test', backgroundColor: undefined },
+    } as any);
+
+    expect(result).toEqual({ jobId: 'txt_xyz', status: 'COMPLETED', message: 'Done' });
+  });
+
+  it('should not include font in request body', async () => {
+    await setTextStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', text: 'test', backgroundColor: undefined },
+    } as any);
+
+    const callBody = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callBody).not.toHaveProperty('font');
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/stories/set-text-story.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/stories/set-text-story.ts
@@ -28,7 +28,7 @@ export const setTextStoryAction = createAction({
     const auth = context.auth.secret_text;
 
     const body: Record<string, unknown> = { session, text };
-    if (backgroundColor) body['backgroundColor'] = backgroundColor;
+    if (backgroundColor) body.backgroundColor = backgroundColor;
 
     const response = await whatsscaleClient(
       auth,

--- a/packages/pieces/community/whatsscale/src/lib/actions/stories/set-text-story.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/stories/set-text-story.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { pollJob } from '../../common/poll-job';
+
+export const setTextStoryAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_set_text_story',
+  displayName: 'Set a Text Story',
+  description: 'Post a text status update to your WhatsApp story',
+  props: {
+    session: whatsscaleProps.session,
+    text: Property.ShortText({
+      displayName: 'Story Text',
+      required: true,
+      description: 'Text to display in your WhatsApp story',
+    }),
+    backgroundColor: Property.ShortText({
+      displayName: 'Background Color',
+      required: false,
+      description: 'Hex color code (e.g. #25D366 for WhatsApp green)',
+    }),
+  },
+  async run(context) {
+    const { session, text, backgroundColor } = context.propsValue;
+    const auth = context.auth.secret_text;
+
+    const body: Record<string, unknown> = { session, text };
+    if (backgroundColor) body['backgroundColor'] = backgroundColor;
+
+    const response = await whatsscaleClient(
+      auth,
+      HttpMethod.POST,
+      '/api/status/text',
+      { ...body, platform: 'activepieces' },
+    );
+
+    const { jobId } = response.body as { jobId: string };
+    return await pollJob(auth, jobId);
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/stories/set-video-story.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/stories/set-video-story.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setVideoStoryAction } from './set-video-story';
+import { whatsscaleClient } from '../../common/client';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+vi.mock('../../common/client', () => ({ whatsscaleClient: vi.fn() }));
+vi.mock('../../common/prepare-file', () => ({ prepareFile: vi.fn() }));
+vi.mock('../../common/poll-job', () => ({ pollJob: vi.fn() }));
+
+const mockAuth = { secret_text: 'test-api-key' };
+
+describe('setVideoStoryAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/vid_story.mp4');
+    (whatsscaleClient as any).mockResolvedValue({
+      body: { jobId: 'vid_abc123', status: 'QUEUED' },
+    });
+    (pollJob as any).mockResolvedValue({
+      jobId: 'vid_abc123',
+      status: 'COMPLETED',
+      message: 'Story posted',
+    });
+  });
+
+  it('should call prepareFile with videoUrl', async () => {
+    await setVideoStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', videoUrl: 'https://example.com/clip.mp4', caption: undefined },
+    } as any);
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', 'https://example.com/clip.mp4');
+  });
+
+  it('should post video story with prepared URL and empty caption by default', async () => {
+    await setVideoStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', videoUrl: 'https://example.com/clip.mp4', caption: undefined },
+    } as any);
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/status/video',
+      {
+        session: 'default',
+        file: 'https://proxy.whatsscale.com/files/vid_story.mp4',
+        caption: '',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('should include caption when provided', async () => {
+    await setVideoStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', videoUrl: 'https://example.com/clip.mp4', caption: 'Watch this!' },
+    } as any);
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(
+      'test-api-key',
+      'POST',
+      '/api/status/video',
+      {
+        session: 'default',
+        file: 'https://proxy.whatsscale.com/files/vid_story.mp4',
+        caption: 'Watch this!',
+        platform: 'activepieces',
+      },
+    );
+  });
+
+  it('should call pollJob with jobId from response', async () => {
+    await setVideoStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', videoUrl: 'https://example.com/clip.mp4', caption: undefined },
+    } as any);
+
+    expect(pollJob).toHaveBeenCalledWith('test-api-key', 'vid_abc123');
+  });
+
+  it('should return pollJob result', async () => {
+    const result = await setVideoStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', videoUrl: 'https://example.com/clip.mp4', caption: undefined },
+    } as any);
+
+    expect(result).toEqual({ jobId: 'vid_abc123', status: 'COMPLETED', message: 'Story posted' });
+  });
+
+  it('should pass apiKey to prepareFile', async () => {
+    await setVideoStoryAction.run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'default', videoUrl: 'https://example.com/clip.mp4', caption: undefined },
+    } as any);
+
+    expect(prepareFile).toHaveBeenCalledWith('my-secret-key', expect.any(String));
+  });
+
+  it('should pass apiKey to pollJob', async () => {
+    await setVideoStoryAction.run({
+      auth: { secret_text: 'my-secret-key' },
+      propsValue: { session: 'default', videoUrl: 'https://example.com/clip.mp4', caption: undefined },
+    } as any);
+
+    expect(pollJob).toHaveBeenCalledWith('my-secret-key', expect.any(String));
+  });
+
+  it('should support Google Drive URLs via prepareFile', async () => {
+    const driveUrl = 'https://drive.google.com/file/d/abc123/view';
+    (prepareFile as any).mockResolvedValue('https://proxy.whatsscale.com/files/vid_gdrive.mp4');
+
+    await setVideoStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', videoUrl: driveUrl, caption: undefined },
+    } as any);
+
+    expect(prepareFile).toHaveBeenCalledWith('test-api-key', driveUrl);
+    const callBody = (whatsscaleClient as any).mock.calls[0][3];
+    expect(callBody.file).toBe('https://proxy.whatsscale.com/files/vid_gdrive.mp4');
+  });
+
+  it('should use /api/status/video endpoint (not image)', async () => {
+    await setVideoStoryAction.run({
+      auth: mockAuth,
+      propsValue: { session: 'default', videoUrl: 'https://example.com/clip.mp4', caption: undefined },
+    } as any);
+
+    expect(whatsscaleClient).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      '/api/status/video',
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/stories/set-video-story.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/stories/set-video-story.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { whatsscaleAuth } from '../../auth';
+import { whatsscaleClient } from '../../common/client';
+import { whatsscaleProps } from '../../common/props';
+import { prepareFile } from '../../common/prepare-file';
+import { pollJob } from '../../common/poll-job';
+
+export const setVideoStoryAction = createAction({
+  auth: whatsscaleAuth,
+  name: 'whatsscale_set_video_story',
+  displayName: 'Set a Video Story',
+  description: 'Post a video to your WhatsApp story',
+  props: {
+    session: whatsscaleProps.session,
+    videoUrl: Property.ShortText({
+      displayName: 'Video URL',
+      required: true,
+      description:
+        'URL to the video. Supports Google Drive, Dropbox, and direct URLs.',
+    }),
+    caption: Property.ShortText({
+      displayName: 'Caption',
+      required: false,
+      description: 'Optional caption for the video story',
+    }),
+  },
+  async run(context) {
+    const { session, videoUrl, caption } = context.propsValue;
+    const apiKey = context.auth.secret_text;
+
+    const preparedUrl = await prepareFile(apiKey, videoUrl);
+
+    const response = await whatsscaleClient(
+      apiKey,
+      HttpMethod.POST,
+      '/api/status/video',
+      {
+        session,
+        file: preparedUrl,
+        caption: caption ?? '',
+        platform: 'activepieces',
+      },
+    );
+
+    const { jobId } = response.body as { jobId: string };
+    return await pollJob(apiKey, jobId);
+  },
+});

--- a/packages/pieces/community/whatsscale/src/lib/actions/utility/check-whatsapp.test.ts
+++ b/packages/pieces/community/whatsscale/src/lib/actions/utility/check-whatsapp.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkWhatsappAction } from './check-whatsapp';
+import { whatsscaleClient } from '../../common/client';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+vi.mock('../../common/client', () => ({
+  whatsscaleClient: vi.fn(),
+}));
+
+const mockClient = vi.mocked(whatsscaleClient);
+
+const MOCK_AUTH = { secret_text: 'ws_test_key' } as any;
+const MOCK_AUTH_STRING = 'ws_test_key';
+
+function makeContext(propsValue: Record<string, unknown>) {
+  return {
+    auth: MOCK_AUTH,
+    propsValue,
+  } as any;
+}
+
+describe('checkWhatsappAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns exists=true for a valid WhatsApp number', async () => {
+    const mockBody = {
+      numberExists: true,
+      phone: '+31612345678',
+      phoneFormatted: '31612345678',
+      chatId: '31612345678@c.us',
+    };
+    mockClient.mockResolvedValueOnce({ body: mockBody, status: 200 } as any);
+
+    const result = await checkWhatsappAction.run(makeContext({
+      session: 'sess1',
+      phone: '+31612345678',
+    }));
+
+    expect(result.numberExists).toBe(true);
+    expect(result.chatId).toBe('31612345678@c.us');
+  });
+
+  it('returns exists=false for a non-WhatsApp number', async () => {
+    const mockBody = {
+      numberExists: false,
+      phone: '+99999999999',
+      phoneFormatted: '99999999999',
+      chatId: '99999999999@c.us',
+    };
+    mockClient.mockResolvedValueOnce({ body: mockBody, status: 200 } as any);
+
+    const result = await checkWhatsappAction.run(makeContext({
+      session: 'sess1',
+      phone: '+99999999999',
+    }));
+
+    expect(result.numberExists).toBe(false);
+  });
+
+  it('calls /make/checkWhatsapp with POST (not /api/checkWhatsapp)', async () => {
+    mockClient.mockResolvedValueOnce({
+      body: { numberExists: true, phone: '+31612345678', phoneFormatted: '31612345678', chatId: '31612345678@c.us' },
+      status: 200,
+    } as any);
+
+    await checkWhatsappAction.run(makeContext({
+      session: 'sess1',
+      phone: '+31612345678',
+    }));
+
+    expect(mockClient).toHaveBeenCalledWith(
+      MOCK_AUTH_STRING,
+      HttpMethod.POST,
+      '/make/checkWhatsapp',
+      { session: 'sess1', phone: '+31612345678' }
+    );
+  });
+
+  it('passes phone exactly as entered — no normalization', async () => {
+    mockClient.mockResolvedValueOnce({
+      body: { numberExists: true, phone: '+1 (234) 567-8900', phoneFormatted: '12345678900', chatId: '12345678900@c.us' },
+      status: 200,
+    } as any);
+
+    await checkWhatsappAction.run(makeContext({
+      session: 'sess1',
+      phone: '+1 (234) 567-8900',
+    }));
+
+    const bodyArg = mockClient.mock.calls[0][3] as any;
+    expect(bodyArg.phone).toBe('+1 (234) 567-8900');
+  });
+
+  it('throws on proxy error', async () => {
+    mockClient.mockRejectedValueOnce(new Error('Session not found'));
+
+    await expect(
+      checkWhatsappAction.run(makeContext({
+        session: 'bad_session',
+        phone: '+31612345678',
+      }))
+    ).rejects.toThrow('Session not found');
+  });
+
+  it('returns all 4 response fields', async () => {
+    const mockBody = {
+      numberExists: true,
+      phone: '+31612345678',
+      phoneFormatted: '31612345678',
+      chatId: '31612345678@c.us',
+    };
+    mockClient.mockResolvedValueOnce({ body: mockBody, status: 200 } as any);
+
+    const result = await checkWhatsappAction.run(makeContext({
+      session: 'sess1',
+      phone: '+31612345678',
+    }));
+
+    expect(result).toHaveProperty('numberExists');
+    expect(result).toHaveProperty('phone');
+    expect(result).toHaveProperty('phoneFormatted');
+    expect(result).toHaveProperty('chatId');
+  });
+
+  it('chatId is present even when numberExists=false (may be synthetic)', async () => {
+    const mockBody = {
+      numberExists: false,
+      phone: '+99999',
+      phoneFormatted: '99999',
+      chatId: '99999@c.us',
+    };
+    mockClient.mockResolvedValueOnce({ body: mockBody, status: 200 } as any);
+
+    const result = await checkWhatsappAction.run(makeContext({
+      session: 'sess1',
+      phone: '+99999',
+    }));
+
+    expect(result.chatId).toBeDefined();
+    expect(result.numberExists).toBe(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds `platform: 'activepieces'` to the request body of all 28 send actions (messaging, stories, location, poll).

This allows the WhatsScale proxy to tag message_history records with the correct source platform, enabling analytics to distinguish messages sent from Activepieces vs other platforms (Make.com, dashboard, scheduler, etc.).

CRM, info, and utility actions are unchanged — they don't send WhatsApp messages.
