### PR TITLE
feat: add MCP store tools

### DIFF
--- a/packages/server/api/src/app/mcp/tools/ap-store-delete.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-store-delete.ts
@@ -1,0 +1,63 @@
+import { McpServer, McpToolDefinition } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { storeEntryService } from '../../store-entry/store-entry.service'
+import { mcpToolError } from './mcp-utils'
+import { formatStoreLocation, resolveStoreKey, storeScopeSchema } from './store-utils'
+
+const storeDeleteInput = z.object({
+    key: z.string().describe('The store key to delete.'),
+    scope: storeScopeSchema.describe('PROJECT for project-wide storage, FLOW for flow-scoped storage.'),
+    flowId: z.string().optional().describe('Required when scope is FLOW. Use ap_list_flows to find the flow ID.'),
+})
+
+export const apStoreDeleteTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_store_delete',
+        description: 'Delete a persistent value from project- or flow-scoped storage. This permanently removes the stored value for the selected key.',
+        inputSchema: storeDeleteInput.shape,
+        annotations: { destructiveHint: true, openWorldHint: false },
+        execute: async (args) => {
+            try {
+                const { key, scope, flowId } = storeDeleteInput.parse(args)
+                const resolvedKey = await resolveStoreKey({
+                    key,
+                    scope,
+                    flowId,
+                    projectId: mcp.projectId,
+                    log,
+                })
+
+                const storeEntry = await storeEntryService.getOne({
+                    projectId: mcp.projectId,
+                    key: resolvedKey,
+                })
+
+                if (!storeEntry) {
+                    return {
+                        content: [{
+                            type: 'text',
+                            text: `No value found for ${formatStoreLocation({ key, scope, flowId })}.`,
+                        }],
+                    }
+                }
+
+                await storeEntryService.delete({
+                    projectId: mcp.projectId,
+                    key: resolvedKey,
+                })
+
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `✅ Deleted value for ${formatStoreLocation({ key, scope, flowId })}.`,
+                    }],
+                }
+            }
+            catch (err) {
+                log.error({ err, projectId: mcp.projectId }, 'ap_store_delete failed')
+                return mcpToolError('Failed to delete store value', err)
+            }
+        },
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/ap-store-get.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-store-get.ts
@@ -1,0 +1,58 @@
+import { McpServer, McpToolDefinition } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { storeEntryService } from '../../store-entry/store-entry.service'
+import { mcpToolError } from './mcp-utils'
+import { formatStoreLocation, formatStoreValue, resolveStoreKey, storeScopeSchema } from './store-utils'
+
+const storeGetInput = z.object({
+    key: z.string().describe('The store key to retrieve.'),
+    scope: storeScopeSchema.describe('PROJECT for project-wide storage, FLOW for flow-scoped storage.'),
+    flowId: z.string().optional().describe('Required when scope is FLOW. Use ap_list_flows to find the flow ID.'),
+})
+
+export const apStoreGetTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_store_get',
+        description: 'Get a persistent value from project- or flow-scoped storage. Use PROJECT scope for shared state across the project, or FLOW scope for state scoped to a specific flow.',
+        inputSchema: storeGetInput.shape,
+        annotations: { readOnlyHint: true, openWorldHint: false },
+        execute: async (args) => {
+            try {
+                const { key, scope, flowId } = storeGetInput.parse(args)
+                const resolvedKey = await resolveStoreKey({
+                    key,
+                    scope,
+                    flowId,
+                    projectId: mcp.projectId,
+                    log,
+                })
+
+                const storeEntry = await storeEntryService.getOne({
+                    projectId: mcp.projectId,
+                    key: resolvedKey,
+                })
+
+                if (!storeEntry) {
+                    return {
+                        content: [{
+                            type: 'text',
+                            text: `No value found for ${formatStoreLocation({ key, scope, flowId })}.`,
+                        }],
+                    }
+                }
+
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `✅ Retrieved value for ${formatStoreLocation({ key, scope, flowId })}.\nValue:\n${formatStoreValue(storeEntry.value)}`,
+                    }],
+                }
+            }
+            catch (err) {
+                log.error({ err, projectId: mcp.projectId }, 'ap_store_get failed')
+                return mcpToolError('Failed to get store value', err)
+            }
+        },
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/ap-store-put.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-store-put.ts
@@ -1,0 +1,53 @@
+import { McpServer, McpToolDefinition } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { storeEntryService } from '../../store-entry/store-entry.service'
+import { mcpToolError } from './mcp-utils'
+import { formatStoreLocation, formatStoreValue, resolveStoreKey, storeScopeSchema } from './store-utils'
+
+const storePutInput = z.object({
+    key: z.string().describe('The store key to create or overwrite.'),
+    value: z.unknown().describe('The JSON-serializable value to store.'),
+    scope: storeScopeSchema.describe('PROJECT for project-wide storage, FLOW for flow-scoped storage.'),
+    flowId: z.string().optional().describe('Required when scope is FLOW. Use ap_list_flows to find the flow ID.'),
+})
+
+export const apStorePutTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_store_put',
+        description: 'Store or overwrite a persistent value in project- or flow-scoped storage. Use this to save state that later MCP tool calls or flows can reuse.',
+        inputSchema: storePutInput.shape,
+        annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
+        execute: async (args) => {
+            try {
+                const { key, value, scope, flowId } = storePutInput.parse(args)
+                const resolvedKey = await resolveStoreKey({
+                    key,
+                    scope,
+                    flowId,
+                    projectId: mcp.projectId,
+                    log,
+                })
+
+                await storeEntryService.upsert({
+                    projectId: mcp.projectId,
+                    request: {
+                        key: resolvedKey,
+                        value,
+                    },
+                })
+
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `✅ Stored value for ${formatStoreLocation({ key, scope, flowId })}.\nValue:\n${formatStoreValue(value)}`,
+                    }],
+                }
+            }
+            catch (err) {
+                log.error({ err, projectId: mcp.projectId }, 'ap_store_put failed')
+                return mcpToolError('Failed to store value', err)
+            }
+        },
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/index.ts
+++ b/packages/server/api/src/app/mcp/tools/index.ts
@@ -25,6 +25,9 @@ import { apManageNotesTool } from './ap-manage-notes'
 import { apRenameFlowTool } from './ap-rename-flow'
 import { apRetryRunTool } from './ap-retry-run'
 import { apSetupGuideTool } from './ap-setup-guide'
+import { apStoreDeleteTool } from './ap-store-delete'
+import { apStoreGetTool } from './ap-store-get'
+import { apStorePutTool } from './ap-store-put'
 import { apTestFlowTool } from './ap-test-flow'
 import { apTestStepTool } from './ap-test-step'
 import { apUpdateRecordTool } from './ap-update-record'
@@ -65,6 +68,9 @@ export const ALL_CONTROLLABLE_TOOL_NAMES: string[] = [
     'ap_insert_records',
     'ap_update_record',
     'ap_delete_records',
+    'ap_store_get',
+    'ap_store_put',
+    'ap_store_delete',
     'ap_test_flow',
     'ap_test_step',
     'ap_retry_run',
@@ -95,6 +101,9 @@ export const activepiecesTools = (mcp: McpServer, log: FastifyBaseLogger): McpTo
     apInsertRecordsTool(mcp, log),
     apUpdateRecordTool(mcp, log),
     apDeleteRecordsTool(mcp, log),
+    apStoreGetTool(mcp, log),
+    apStorePutTool(mcp, log),
+    apStoreDeleteTool(mcp, log),
     apListRunsTool(mcp, log),
     apGetRunTool(mcp, log),
     apTestFlowTool(mcp, log),

--- a/packages/server/api/src/app/mcp/tools/store-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/store-utils.ts
@@ -1,0 +1,69 @@
+import { ProjectId } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { flowService } from '../../flows/flow/flow.service'
+
+export async function resolveStoreKey(params: ResolveStoreKeyParams): Promise<string> {
+    const { key, scope } = params
+    if (scope === 'PROJECT') {
+        return key
+    }
+
+    const flowId = await validateFlowScope(params)
+    return `flow_${flowId}/${key}`
+}
+
+export function formatStoreLocation({ key, scope, flowId }: FormatStoreLocationParams): string {
+    if (scope === 'PROJECT') {
+        return `key "${key}" in PROJECT scope`
+    }
+    return `key "${key}" in FLOW scope for flow "${flowId}"`
+}
+
+export function formatStoreValue(value: unknown): string {
+    if (value === undefined) {
+        return 'undefined'
+    }
+
+    const serializedValue = JSON.stringify(value, null, 2)
+    return serializedValue ?? 'undefined'
+}
+
+async function validateFlowScope({
+    flowId,
+    projectId,
+    log,
+}: ResolveStoreKeyParams): Promise<string> {
+    if (!flowId) {
+        throw new Error('flowId is required when scope is FLOW.')
+    }
+
+    const flow = await flowService(log).getOne({
+        id: flowId,
+        projectId,
+    })
+
+    if (!flow) {
+        throw new Error(`Flow "${flowId}" not found in the current project.`)
+    }
+
+    return flowId
+}
+
+export const storeScopeSchema = z.enum(['PROJECT', 'FLOW'])
+
+type ResolveStoreKeyParams = {
+    key: string
+    scope: StoreToolScope
+    flowId?: string
+    projectId: ProjectId
+    log: FastifyBaseLogger
+}
+
+type FormatStoreLocationParams = {
+    key: string
+    scope: StoreToolScope
+    flowId?: string
+}
+
+export type StoreToolScope = z.infer<typeof storeScopeSchema>

--- a/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
+++ b/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
@@ -154,6 +154,26 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
     ],
   },
   {
+    label: 'Storage',
+    tools: [
+      {
+        name: 'ap_store_get',
+        description:
+          'Get a persistent value from project- or flow-scoped storage',
+      },
+      {
+        name: 'ap_store_put',
+        description:
+          'Store or overwrite a persistent value in project- or flow-scoped storage',
+      },
+      {
+        name: 'ap_store_delete',
+        description:
+          'Delete a persistent value from project- or flow-scoped storage',
+      },
+    ],
+  },
+  {
     label: 'Testing & Runs',
     tools: [
       {


### PR DESCRIPTION
## What does this PR do?

Adds three new MCP tools for persistent storage in Activepieces:

- `ap_store_get`
- `ap_store_put`
- `ap_store_delete`

These tools expose project-scoped and flow-scoped key-value storage through MCP, so external agents can persist and retrieve state across tool calls.

### Explain How the Feature Works

The new MCP tools use the existing Activepieces store entry service and follow the same storage key pattern used by `ctx.store` at runtime.

Supported scopes:
- `PROJECT`: stores values at the project level
- `FLOW`: stores values under a specific flow using `flow_<flowId>/<key>`

For flow-scoped operations, the tool validates that the provided `flowId` belongs to the current project before reading or writing data.

The tools are also registered in the MCP server settings UI so they can be enabled or disabled like the other internal MCP tools.

### Relevant User Scenarios

- An external agent wants to save state between multiple MCP tool calls.
- An agent needs project-wide memory, such as saved preferences, mappings, or checkpoints.
- An agent needs flow-specific memory without leaking data across flows.
- An agent wants to clean up stored state after a workflow completes.

Fixes #12305 