### PR TITLE
fix(server): guard against non-array filters in v18 flow migration

### DIFF
--- a/packages/server/api/src/app/flows/flow-version/migrations/migrate-v18-tables-find-records-field-ids.ts
+++ b/packages/server/api/src/app/flows/flow-version/migrations/migrate-v18-tables-find-records-field-ids.ts
@@ -30,7 +30,7 @@ function collectFieldIdsFromFilters(flowVersion: FlowVersion): string[] {
         const input = step.settings?.input as Record<string, unknown> | undefined
         const filters = input?.filters as Record<string, unknown> | undefined
         const filtersArray = filters?.filters as { field?: { id?: string } }[] | undefined
-        if (!filtersArray) {
+        if (!Array.isArray(filtersArray)) {
             return
         }
 
@@ -82,7 +82,7 @@ export const migrateV18TablesFieldIds: Migration = {
             const input = step.settings?.input as Record<string, unknown> | undefined
             const filters = input?.filters as Record<string, unknown> | undefined
             const filtersArray = filters?.filters as { field?: { id?: string, type?: string, name?: string } }[] | undefined
-            if (!filtersArray) {
+            if (!Array.isArray(filtersArray)) {
                 return {
                     ...step,
                     settings: {


### PR DESCRIPTION
## Summary
- Adds `Array.isArray()` checks before iterating `filters.filters` in the v18 flow version migration
- Some saved flows have `filters.filters` as a non-array value (e.g. object), which causes the migration to crash when trying to iterate

## Test plan
- [ ] Deploy and verify flows with non-array filter data migrate without errors
- [ ] Verify flows with valid array filters still migrate correctly