### PR TITLE
fix(server): bypass concurrent-edit guard for service principal calls

### DIFF
--- a/packages/server/api/src/app/flows/flow/flow.controller.ts
+++ b/packages/server/api/src/app/flows/flow/flow.controller.ts
@@ -113,7 +113,9 @@ export const flowController: FastifyPluginAsyncZod = async (app) => {
                 PlatformUsageMetric.ACTIVE_FLOWS,
             )
         }
-        await assertThatFlowIsNotBeingUsed(flow, userId)
+        if (request.principal.type !== PrincipalType.SERVICE) {
+            await assertThatFlowIsNotBeingUsed(flow, userId)
+        }
         const updatedFlow = await flowService(request.log).update({
             id: request.params.id,
             userId: request.principal.type === PrincipalType.SERVICE ? null : userId,


### PR DESCRIPTION
## Summary

- `assertThatFlowIsNotBeingUsed` raised a 409 FLOW_IN_USE error when the
  same API key updated a flow twice within one minute, because the service
  principal has no `userId` (`null`), which never equals `flow.version.updatedBy`
- The guard is designed to protect against *different human users* editing
  concurrently; it is meaningless for API key calls where `userId` is always `null`
- Skip the check entirely when `request.principal.type === PrincipalType.SERVICE`,
  consistent with line 119 which already sets `userId: null` for service principals

## Test plan

- [ ] Update a flow via API key twice in quick succession — no 409 returned
- [ ] Two different human users editing the same flow within 1 minute — 409 still returned
- [ ] Single human user editing their own flow — no 409 returned