### PR TITLE
fix(server): check pgvector availability before CREATE EXTENSION

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1773627989514-AddPgVectorExtension.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1773627989514-AddPgVectorExtension.ts
@@ -8,12 +8,15 @@ export class AddPgVectorExtension1773627989514 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         log.info('[AddPgVectorExtension1773627989514] up')
-        try {
+        const extensionAvailable = await queryRunner.query(`
+            SELECT COUNT(*) as count FROM pg_available_extensions WHERE name = 'vector'
+        `)
+        if (Number(extensionAvailable[0]?.count) > 0) {
             await queryRunner.query(`
                 CREATE EXTENSION IF NOT EXISTS "vector"
             `)
         }
-        catch {
+        else {
             log.warn('[Migration] pgvector extension is not available — knowledge base vector search will not work. Install pgvector on your PostgreSQL server to enable this feature.')
         }
         log.info('[AddPgVectorExtension1773627989514] done')


### PR DESCRIPTION
## Summary
- The pgvector migration used a try/catch around `CREATE EXTENSION "vector"`, but when the extension isn't installed, PostgreSQL aborts the transaction. The JS catch swallows the error but the PG transaction stays in a failed state, causing the subsequent `INSERT INTO migrations` to fail and preventing server startup.
- Fixed by querying `pg_available_extensions` first to check if pgvector is available, avoiding the failing `CREATE EXTENSION` entirely.

## Test plan
- [ ] Start server on a PostgreSQL instance **without** pgvector installed — server should start successfully with a warning log
- [ ] Start server on a PostgreSQL instance **with** pgvector installed — extension should be created as before