### PR TITLE
fix(linear): remove team scoping for new comment webhook on linear side

### DIFF
--- a/packages/pieces/community/linear/package.json
+++ b/packages/pieces/community/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-linear",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/linear/src/lib/triggers/new-comment.ts
+++ b/packages/pieces/community/linear/src/lib/triggers/new-comment.ts
@@ -39,19 +39,13 @@ export const linearNewComment = createTrigger({
   type: TriggerStrategy.WEBHOOK,
   async onEnable(context) {
     const client = makeClient(context.auth);
-    const teamIds = context.propsValue['team_ids'] as string[] | undefined;
 
-    const baseConfig = {
+    const webhook = await client.createWebhook({
       label: 'ActivePieces New Comment',
       url: context.webhookUrl,
       resourceTypes: ['Comment'],
-    };
-
-    const webhook = await client.createWebhook(
-      teamIds && teamIds.length === 1
-        ? { ...baseConfig, teamId: teamIds[0] }
-        : { ...baseConfig, allPublicTeams: true },
-    );
+      allPublicTeams: true,
+    });
 
     if (webhook.success && webhook.webhook) {
       await context.store?.put<WebhookInformation>('_new_comment_trigger', {


### PR DESCRIPTION
## What does this PR do?

Comments are not scoped to a given team on Linear side - so the webhook would not work with a single team selected

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
