### PR TITLE
fix: use latest flow version when testing trigger with APP_WEBHOOK

### DIFF
--- a/packages/server/api/src/app/trigger/app-event-routing/app-event-routing.module.ts
+++ b/packages/server/api/src/app/trigger/app-event-routing/app-event-routing.module.ts
@@ -126,7 +126,14 @@ export const appEventRoutingController: FastifyPluginAsyncZod = async (
                 if (isNil(flow)) {
                     return
                 }
-                const flowVersionIdToRun = await webhookService.getFlowVersionIdToRun(WebhookFlowVersionToRun.LOCKED_FALL_BACK_TO_LATEST, flow)
+                const isSimulating = await triggerSourceService(request.log).existsByFlowId({
+                    flowId: listener.flowId,
+                    simulate: true,
+                })
+                const flowVersionIdToRun = await webhookService.getFlowVersionIdToRun(
+                    isSimulating ? WebhookFlowVersionToRun.LATEST : WebhookFlowVersionToRun.LOCKED_FALL_BACK_TO_LATEST,
+                    flow,
+                )
                 const platformId = await projectService(request.log).getPlatformId(listener.projectId)
                 const jobPayload = await payloadOffloader.offloadPayload(request.log, payload, listener.projectId, platformId)
                 return jobQueue(request.log).add({
@@ -140,11 +147,8 @@ export const appEventRoutingController: FastifyPluginAsyncZod = async (
                         payload: jobPayload,
                         flowId: listener.flowId,
                         jobType: WorkerJobType.EXECUTE_WEBHOOK,
-                        runEnvironment: RunEnvironment.PRODUCTION,
-                        saveSampleData: await triggerSourceService(request.log).existsByFlowId({
-                            flowId: listener.flowId,
-                            simulate: true,
-                        }),
+                        runEnvironment: isSimulating ? RunEnvironment.TESTING : RunEnvironment.PRODUCTION,
+                        saveSampleData: isSimulating,
                         flowVersionIdToRun,
                         execute: flow.status === FlowStatus.ENABLED,
                     },


### PR DESCRIPTION
## What does this PR do?

When testing e.g. a Slack trigger, we would use the last **published** version of the flow if it existed

### Explain How the Feature Works

When simulating / testing a trigger, always use the last flow version

<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
