### PR TITLE
fix: n+1 queries in project releases

### DIFF
--- a/packages/server/api/src/app/ee/projects/project-release/project-state/project-state.service.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-state/project-state.service.ts
@@ -3,10 +3,11 @@ import { FastifyBaseLogger } from 'fastify'
 import { appConnectionService } from '../../../../app-connection/app-connection-service/app-connection-service'
 import { fileService } from '../../../../file/file.service'
 import { flowRepo } from '../../../../flows/flow/flow.repo'
-import { flowService } from '../../../../flows/flow/flow.service'
+import { flowVersionService } from '../../../../flows/flow-version/flow-version.service'
 import { flowMigrations } from '../../../../flows/flow-version/migrations'
 import { fieldService } from '../../../../tables/field/field.service'
 import { tableService } from '../../../../tables/table/table.service'
+import { triggerSourceService } from '../../../../trigger/trigger-source/trigger-source-service'
 import { projectStateHelper } from './project-state-helper'
 
 export const projectStateService = (log: FastifyBaseLogger) => ({
@@ -174,25 +175,35 @@ export const projectStateService = (log: FastifyBaseLogger) => ({
                 projectId,
             },
         })
-        const allPopulatedFlows = await Promise.all(flows.map(async (flow) => {
-            return flowService(log).getOnePopulatedOrThrow({
-                id: flow.id,
+        const flowIds = flows.map((f) => f.id)
+
+        const [flowVersionMap, triggerSourceMap, connections, tables] = await Promise.all([
+            flowVersionService(log).getLatestVersionsByFlowIds(flowIds, projectId),
+            triggerSourceService(log).getByFlowIds({ flowIds, projectId }),
+            appConnectionService(log).getManyConnectionStates({ projectId }),
+            tableService.list({
+                folderId: undefined,
                 projectId,
+                cursor: undefined,
+                limit: 1000,
+                name: undefined,
+                externalIds: undefined,
+            }),
+        ])
+
+        const allPopulatedFlows: PopulatedFlow[] = flows
+            .filter((flow) => flowVersionMap.has(flow.id))
+            .map((flow) => {
+                const triggerSource = triggerSourceMap.get(flow.id)
+                return {
+                    ...flow,
+                    version: flowVersionMap.get(flow.id)!,
+                    triggerSource: triggerSource ? {
+                        schedule: triggerSource.schedule,
+                    } : undefined,
+                }
             })
-        }))
 
-        const connections: ConnectionState[] = await appConnectionService(log).getManyConnectionStates({
-            projectId,
-        })
-
-        const tables = await tableService.list({
-            folderId: undefined,
-            projectId,
-            cursor: undefined,
-            limit: 1000,
-            name: undefined,
-            externalIds: undefined,
-        })
         const populatedTables = await Promise.all(tables.data.map(async (table) => {
             const fields = await fieldService.getAll({
                 projectId,

--- a/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
@@ -192,6 +192,26 @@ export const flowVersionService = (log: FastifyBaseLogger) => ({
         })
     },
 
+    async getLatestVersionsByFlowIds(flowIds: FlowId[], projectId?: ProjectId): Promise<Map<FlowId, FlowVersion>> {
+        if (flowIds.length === 0) {
+            return new Map()
+        }
+        const latestVersions = await flowVersionRepo()
+            .createQueryBuilder('fv')
+            .where('fv.flowId IN (:...flowIds)', { flowIds })
+            .distinctOn(['fv.flowId'])
+            .orderBy('fv.flowId')
+            .addOrderBy('fv.created', 'DESC')
+            .getMany()
+        const migratedEntries = await Promise.all(
+            latestVersions.map(async (version) => {
+                const migrated = await flowVersionMigrationService(log).migrate(version, projectId)
+                return [version.flowId, migrated] as const
+            }),
+        )
+        return new Map(migratedEntries)
+    },
+
     async getLatestLockedVersionOrThrow(flowId: FlowId): Promise<FlowVersion> {
         const lockedVersion = await this.getLatestVersion(flowId, FlowVersionState.LOCKED)
         if (isNil(lockedVersion)) {

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
@@ -1,5 +1,6 @@
-import { ActivepiecesError, apId, ErrorCode, FlowVersion, isNil, PopulatedTriggerSource, TemplateTelemetryEventType, TriggerSource } from '@activepieces/shared'
+import { ActivepiecesError, apId, ErrorCode, FlowId, FlowVersion, isNil, PopulatedTriggerSource, TemplateTelemetryEventType, TriggerSource } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
+import { In } from 'typeorm'
 import { repoFactory } from '../../core/db/repo-factory'
 import { flowVersionService } from '../../flows/flow-version/flow-version.service'
 import { templateTelemetryService } from '../../template/template-telemetry/template-telemetry.service'
@@ -79,6 +80,23 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
                     ...(projectId ? { projectId } : {}),
                 },
             })
+        },
+        async getByFlowIds(params: GetByFlowIdsParams): Promise<Map<FlowId, TriggerSource>> {
+            const { flowIds, projectId } = params
+            if (flowIds.length === 0) {
+                return new Map()
+            }
+            const triggerSources = await triggerSourceRepo().find({
+                where: {
+                    flowId: In(flowIds),
+                    projectId,
+                },
+            })
+            const result = new Map<FlowId, TriggerSource>()
+            for (const ts of triggerSources) {
+                result.set(ts.flowId, ts)
+            }
+            return result
         },
         async getByFlowIdPopulated(params: GetByFlowIdParams): Promise<PopulatedTriggerSource | null> {
             const { flowId, simulate } = params
@@ -171,6 +189,11 @@ type GetByFlowIdParams = {
     flowId: string
     projectId?: string
     simulate: boolean
+}
+
+type GetByFlowIdsParams = {
+    flowIds: FlowId[]
+    projectId: string
 }
 
 type GetFlowIdParamsWithProjectId = {


### PR DESCRIPTION
## What does this PR do?

Trying to perform a project release (git) times out - presumably because:
- of N+1 queries in the endpoint
- there is a large number of flows in the project to migrate to the latest schema

Hopefully fixing the N+1 and parallelising the queries will be sufficient

⚠️ Could not test locally

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
