### PR TITLE
fix: remove lastUpdatedDate from diff computation

### DIFF
--- a/packages/server/api/src/app/ee/projects/project-release/project-state/diff/flow-diff.service.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-state/diff/flow-diff.service.ts
@@ -123,8 +123,9 @@ async function normalize(flowVersion: FlowVersion): Promise<FlowVersion> {
     return flowStructureUtil.transferFlow(flowUpgradable, (step) => {
         const clonedStep: Step = JSON.parse(JSON.stringify(step))
         clonedStep.settings.sampleData = DEFAULT_SAMPLE_DATA_SETTINGS
+        clonedStep.lastUpdatedDate = ''
         const authExists = clonedStep?.settings?.input?.auth
-        
+
         if ([FlowActionType.PIECE, FlowTriggerType.PIECE].includes(step.type)) {
             clonedStep.settings.pieceVersion = ''
             if (authExists) {


### PR DESCRIPTION
## What does this PR do?

The newly introduced `lastUpdatedDate` must be removed from the normalised version when computing a diff - otherwise all flows in the project are included in the diff, causing timeouts after a certain number of flows

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
