### PR TITLE
fix(ui): restore project filter so admins don't see other users' personal projects

### DIFF
--- a/packages/web/src/features/projects/stores/project-collection.ts
+++ b/packages/web/src/features/projects/stores/project-collection.ts
@@ -149,14 +149,21 @@ export const projectCollectionUtils = {
     };
   },
   useAll: () => {
+    const currentUserId = authenticationSession.getCurrentUserId();
     return useLiveSuspenseQuery(
       (q) =>
         q
           .from({ project: projectCollection })
+          .where(({ project }) =>
+            or(
+              eq(project.type, ProjectType.TEAM),
+              eq(project.ownerId, currentUserId),
+            ),
+          )
           .orderBy(({ project }) => project.type, 'asc')
           .orderBy(({ project }) => project.created, 'asc')
           .select(({ project }) => ({ ...project })),
-      [],
+      [currentUserId],
     );
   },
   useAllPlatformProjects: (filters?: {


### PR DESCRIPTION
## Summary

- Restores the `WHERE` clause in `projectCollectionUtils.useAll()` that was accidentally dropped in the sleek UI refactor (`f7d683b`)
- Without the filter, all projects synced to the local TanStack DB store are returned — admins were seeing every user's personal project in the sidebar and other project selectors
- The fix re-applies the original filter: show only `TEAM` projects **or** personal projects owned by the current user

## Test plan

- [ ] Log in as a platform admin
- [ ] Open the sidebar project switcher — should show your own personal project + team projects only, **not** other users' personal projects
- [ ] Verify non-admin users see no change in their project list