### PR TITLE
fix(ui): prevent personal project disappearing when currentUserId is null

### DIFF
--- a/packages/web/src/features/projects/stores/project-collection.ts
+++ b/packages/web/src/features/projects/stores/project-collection.ts
@@ -151,8 +151,18 @@ export const projectCollectionUtils = {
   useAll: () => {
     const currentUserId = authenticationSession.getCurrentUserId();
     return useLiveSuspenseQuery(
-      (q) =>
-        q
+      (q) => {
+        const base = q
+          .from({ project: projectCollection })
+          .orderBy(({ project }) => project.type, 'asc')
+          .orderBy(({ project }) => project.created, 'asc')
+          .select(({ project }) => ({ ...project }));
+
+        if (isNil(currentUserId)) {
+          return base;
+        }
+
+        return q
           .from({ project: projectCollection })
           .where(({ project }) =>
             or(
@@ -162,7 +172,8 @@ export const projectCollectionUtils = {
           )
           .orderBy(({ project }) => project.type, 'asc')
           .orderBy(({ project }) => project.created, 'asc')
-          .select(({ project }) => ({ ...project })),
+          .select(({ project }) => ({ ...project }));
+      },
       [currentUserId],
     );
   },


### PR DESCRIPTION
## Summary

- `@tanstack/react-db`'s `eq()` uses SQL-like NULL semantics: `eq(field, null)` returns `null` (unknown), and `or(false, null)` also returns `null`, which the predicate engine treats as `false` — silently excluding personal projects from the sidebar
- This manifested after navigating from the platform admin page back to the project dashboard, where `currentUserId` could be `null`/`undefined` at query evaluation time
- Fix: guard with `isNil(currentUserId)` and return the unfiltered base query in that case, preserving admin isolation when a valid `userId` is present

## Test plan

- [ ] Log in as a regular user → personal project appears in sidebar
- [ ] Navigate to platform admin page, then back to the project dashboard → personal project still appears in sidebar
- [ ] Log in as a platform admin → only your own personal project and team projects appear (not other users' personal projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)