### PR TITLE
feat(mcp): load up to 1000 projects and use searchable select

### DIFF
--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -1426,5 +1426,7 @@
   "Embedding model for knowledge base: {model}": "Embedding model for knowledge base: {model}",
   "This provider does not support knowledge base embeddings.": "This provider does not support knowledge base embeddings.",
   "Knowledge base requires a provider that supports embeddings, such as OpenAI or Google.": "Knowledge base requires a provider that supports embeddings, such as OpenAI or Google.",
-  "The selected provider does not support embeddings. Switch to a provider like OpenAI or Google for knowledge base to work.": "The selected provider does not support embeddings. Switch to a provider like OpenAI or Google for knowledge base to work."
+  "The selected provider does not support embeddings. Switch to a provider like OpenAI or Google for knowledge base to work.": "The selected provider does not support embeddings. Switch to a provider like OpenAI or Google for knowledge base to work.",
+  "Personal": "Personal",
+  "Team": "Team"
 }

--- a/packages/web/src/app/routes/mcp-authorize/index.tsx
+++ b/packages/web/src/app/routes/mcp-authorize/index.tsx
@@ -1,4 +1,4 @@
-import { ProjectWithLimits, SeekPage } from '@activepieces/shared';
+import { ProjectType, ProjectWithLimits, SeekPage } from '@activepieces/shared';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { jwtDecode } from 'jwt-decode';
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { Navigate, useSearchParams } from 'react-router-dom';
 
 import { FullLogo } from '@/components/custom/full-logo';
+import { SearchableSelect } from '@/components/custom/searchable-select';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -15,13 +16,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { api } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
 
@@ -29,14 +24,17 @@ function McpAuthorizePage() {
   const [searchParams] = useSearchParams();
   const authRequestId = searchParams.get('authRequestId');
   const clientName = decodeJwtClientName(authRequestId);
-  const [selectedProjectId, setSelectedProjectId] = useState<string>('');
+  const [selectedProjectId, setSelectedProjectId] = useState<
+    string | undefined
+  >(undefined);
+  const [projectTypeFilter, setProjectTypeFilter] = useState<string>('all');
   const isLoggedIn = authenticationSession.isLoggedIn();
 
   const { data: projectsPage, isLoading: projectsLoading } = useQuery({
     queryKey: ['mcp-authorize-projects'],
     queryFn: () =>
       api.get<SeekPage<ProjectWithLimits>>('/v1/projects', {
-        params: { limit: 100 },
+        params: { limit: 1000 },
       }),
     enabled: isLoggedIn && !!authRequestId,
   });
@@ -60,6 +58,10 @@ function McpAuthorizePage() {
   }
 
   const projects = projectsPage?.data ?? [];
+  const filteredProjects =
+    projectTypeFilter === 'all'
+      ? projects
+      : projects.filter((p) => p.type === projectTypeFilter);
 
   const handleAuthorize = () => {
     if (!selectedProjectId) return;
@@ -99,28 +101,40 @@ function McpAuthorizePage() {
 
           <div className="flex flex-col gap-2">
             <label className="text-sm font-medium">{t('Select Project')}</label>
-            <Select
-              value={selectedProjectId}
-              onValueChange={setSelectedProjectId}
-              disabled={projectsLoading}
+            <Tabs
+              value={projectTypeFilter}
+              onValueChange={(value) => {
+                setProjectTypeFilter(value);
+                setSelectedProjectId(undefined);
+              }}
             >
-              <SelectTrigger>
-                <SelectValue
-                  placeholder={
-                    projectsLoading
-                      ? t('Loading projects...')
-                      : t('Choose a project')
-                  }
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {projects.map((project) => (
-                  <SelectItem key={project.id} value={project.id}>
-                    {project.displayName}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              <TabsList className="w-full">
+                <TabsTrigger value="all" className="flex-1">
+                  {t('All')}
+                </TabsTrigger>
+                <TabsTrigger value={ProjectType.PERSONAL} className="flex-1">
+                  {t('Personal')}
+                </TabsTrigger>
+                <TabsTrigger value={ProjectType.TEAM} className="flex-1">
+                  {t('Team')}
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <SearchableSelect<string>
+              options={filteredProjects.map((project) => ({
+                value: project.id,
+                label: project.displayName,
+              }))}
+              onChange={(value) => setSelectedProjectId(value ?? undefined)}
+              value={selectedProjectId}
+              placeholder={
+                projectsLoading
+                  ? t('Loading projects...')
+                  : t('Search projects...')
+              }
+              disabled={projectsLoading}
+              loading={projectsLoading}
+            />
           </div>
 
           {approveMutation.isError && (


### PR DESCRIPTION
## What does this PR do?

MCP project selector only loads the first 100 projects

### Explain How the Feature Works

- load 1000 projects
- use searchable select
- add team vs personal project toggle

⚠️ I was not able to test it locally
🔮 Ideally the search should be done server side - the hard 1000 projects limit won't scale

<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
