### PR TITLE
fix(docs): correct 1Password secret manager link

### DIFF
--- a/docs/admin-guide/guides/secret-managers/overview.mdx
+++ b/docs/admin-guide/guides/secret-managers/overview.mdx
@@ -20,7 +20,7 @@ Secret Managers allow you to integrate external secret management systems with A
 - **[HashiCorp Vault](./hashicorp)** - Enterprise-grade secrets management
 - **[CyberArk Conjur](./cyberark-conjur)** - Centralized secrets management with host-based authentication
 - **[AWS Secrets Manager](./aws)** - Managed secrets storage on AWS
-- **[1Password](./1password)** - Consumer and team password manager with Secrets Automation
+- **[1Password](./onepassword)** - Consumer and team password manager with Secrets Automation
 
 ## How to Connect
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a broken relative link in the secret managers overview documentation.

The 1Password entry currently points to `./1password`, but the actual provider page in this repository is `onepassword.mdx`. Updating the link makes the provider entry resolve correctly from the overview page.

## Why is this needed?

Users browsing the Secret Managers overview should be able to open the 1Password setup page directly, just like the other provider links in the same list.
