### PR TITLE
fix: update Node.js version check to require v22+ in setup-dev.js

### DIFF
--- a/tools/setup-dev.js
+++ b/tools/setup-dev.js
@@ -4,8 +4,10 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 
 // Check Node.js version
+// Note: Node 18 and v20 are no longer supported. Node v22+ is required because
+// zstdCompress/zstdDecompress from node:zlib are only available from Node v22.15.0+
 const nodeVersion = execSync('node --version').toString().trim();
-const requiredVersions = ['v18','v20'];
+const requiredVersions = ['v22', 'v24'];
 
 // Check operating system
 const os = process.platform;
@@ -14,7 +16,7 @@ console.log(`Running on ${os} operating system.`)
 if (requiredVersions.some(version=>nodeVersion.startsWith(version))) {
   console.log(`Node.js version is compatible ${nodeVersion}.`);
 } else {
-  console.log(`Node.js version is not compatible. Required version: ${requiredVersions.toString()}`);
+  console.log(`Node.js version is not compatible. Required version: ${requiredVersions.toString()}. Node v18 and v20 are no longer supported due to missing zstd compression support in node:zlib (requires Node v22.15.0+).`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

Fixes #12290

The dev setup script `tools/setup-dev.js` was accepting Node v18 and v20, but the API server crashes at runtime due to missing `zstd` compression support.

## Root cause

`file-compressor.ts` calls `promisify(zstdCompress)` and `promisify(zstdDecompress)` from `node:zlib`. These APIs are only available from **Node v22.15.0+** (see [Node.js docs](https://nodejs.org/docs/latest-v22.x/api/zlib.html#class-zlibzstdcompress)).

With Node 18 or v20, startup crashes with:
```
TypeError [ERR_INVALID_ARG_TYPE]: The 'original' argument must be of type function. Received undefined
```

## Changes

- Updated `requiredVersions` from `['v18', 'v20']` to `['v22', 'v24']`
- Added a clearer error message explaining why Node 18/20 are no longer supported
- Added a comment documenting the reason for the version requirement

## Testing

Verified that setup correctly fails early with a helpful message when running on Node 18 or v20.