### PR TITLE
fix: prevent trigger badge from overlapping step name text

### DIFF
--- a/packages/web/src/app/builder/flow-canvas/nodes/step-node/index.tsx
+++ b/packages/web/src/app/builder/flow-canvas/nodes/step-node/index.tsx
@@ -130,7 +130,7 @@ const ApStepCanvasNode = React.memo(
         }}
         onContextMenu={(e) => handleContextMenu(e)}
         className={cn(
-          'transition-all border-box rounded-md border border-solid border-border relative overflow-show  group',
+          'transition-all border-box rounded-md border border-solid border-border relative overflow-visible  group',
           {
             'border-primary': isSelected,
             'bg-background': !isDragging,

--- a/packages/web/src/app/builder/flow-canvas/nodes/step-node/trigger-widget.tsx
+++ b/packages/web/src/app/builder/flow-canvas/nodes/step-node/trigger-widget.tsx
@@ -7,7 +7,7 @@ const TriggerWidget = ({ isSelected }: { isSelected: boolean }) => {
   return (
     <div
       className={cn(
-        'flex items-center absolute transition-all  -translate-y-[26px] -translate-x-[1px]  border-border border border-1   justify-center gap-1 rounded-t-md bg-background text-muted-foreground text-xs py-1 px-2 ',
+        'flex items-center absolute transition-all  -translate-y-[26px] -translate-x-[1px]  border-border border border-1   justify-center gap-1 rounded-t-md bg-background text-muted-foreground text-xs py-1 px-2 z-10 ',
         {
           'border-primary text-primary ': isSelected,
           'group-hover:border-ring ': !isSelected,


### PR DESCRIPTION
## Problem

The "Trigger" badge on the flow canvas overlaps the step name text and logo, making the step name partially hidden behind the badge.

![Screenshot](https://github.com/user-attachments/assets/1d77b7bb-1e2c-4c95-8748-6910a9ec7f58)

## Root Cause

Two issues:

1. **Missing z-index on TriggerWidget** — The badge is absolutely positioned above the step card via `-translate-y-[26px]`, but without a z-index, step card content can visually overlap it.

2. **Invalid Tailwind class** — The step node container uses `overflow-show` which is not a valid Tailwind utility. This means overflow behavior falls back to the browser default (`visible`), but the intent should be explicit.

## Solution

- Added `z-10` to the TriggerWidget component so it always renders above the step card content
- Replaced invalid `overflow-show` with `overflow-visible` on the step node container to explicitly allow the badge (positioned outside the card bounds) to remain visible

## Testing

- Verified the trigger badge no longer overlaps with step name text
- The badge correctly sits above the card border in the tab-like position
- No visual regression on non-trigger step nodes

Fixes #12354