### PR TITLE
fix(server): reduce RUNS_METADATA queue attempts from 5 to 2

### DIFF
--- a/packages/server/api/src/app/workers/job/runs-metadata-queue-factory.ts
+++ b/packages/server/api/src/app/workers/job/runs-metadata-queue-factory.ts
@@ -20,7 +20,7 @@ export const runsMetadataQueueFactory = ({
                 connection: await createRedisConnection(),
                 telemetry: config.isOtelEnabled ? new BullMQOtel(QueueName.RUNS_METADATA) : undefined,
                 defaultJobOptions: {
-                    attempts: 2,
+                    attempts: 1,
                     backoff: {
                         type: 'exponential',
                         delay: apDayjsDuration(8, 'minute').asMilliseconds(),


### PR DESCRIPTION
## Summary

- Reduces `attempts` in the `RUNS_METADATA` BullMQ queue from 5 → 2 (1 retry on real failure)
- BullMQ stall recovery (`maxStalledCount`) is tracked via a separate Redis field (`stc`) and **does not consume `attempts` slots** — the original value of 5 was inflated under a false assumption that stalls eat into retries

## Background

Stalled jobs and failure retries are completely independent in BullMQ:

| Mechanism | Config option | Tracks |
|-----------|--------------|--------|
| Failure retries | `attempts` | Re-runs when a job throws |
| Stall recovery | `maxStalledCount` (worker option) | Rescues locked-but-not-heartbeating jobs |

The `RUNS_METADATA` worker applies BullMQ's default `maxStalledCount: 1`, which is separate from these attempts.

## Test plan

- [ ] Deploy and verify `RUNS_METADATA` jobs still retry once on transient DB/network errors
- [ ] Confirm stalled jobs are still recovered independently via stall check timer