### PR TITLE
Add HOL skill-publish validate workflow (schema + safety + trust signals)

### DIFF
--- a/.github/workflows/validate-skill.yml
+++ b/.github/workflows/validate-skill.yml
@@ -4,16 +4,29 @@ on:
     paths:
       - 'SKILL.md'
       - 'skill.json'
+  workflow_run:
+    workflows: ['Validate Skill']
+    types: [requested]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   validate:
+    name: Validate skill definition
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashgraph-online/skill-publish@v1
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate skill
+        uses: hashgraph-online/skill-publish@v1
         with:
           mode: validate
           skill-dir: .


### PR DESCRIPTION
## Add HOL skill-publish validate workflow

This PR adds a GitHub Actions workflow that runs the skill-publish action in validate mode.

### What it does

- Validates skill.json and SKILL.md against registry schema
- Checks trust signals (repo integrity, manifest integrity, domain proof)
- Scans for malicious scripts with safety score
- Shows on-chain cost estimate before publishing

### After merge

The workflow runs on push to main/master and pull requests. Results show schema validity, trust signals, and safety score.

To publish to the registry later, you'll need an RB_API_KEY and credits.