### PR TITLE
fix(pieces): fix classify-text failing on multi-word categories

### DIFF
--- a/packages/pieces/community/ai/src/lib/actions/utility/classify-text.ts
+++ b/packages/pieces/community/ai/src/lib/actions/utility/classify-text.ts
@@ -37,21 +37,33 @@ export const classifyText = createAction({
       runId: context.run.id,
     });
 
+    const numberedCategories = categories
+      .map((cat, i) => `${i + 1}. ${cat}`)
+      .join('\n');
+
     const response = await generateText({
       model,
-      prompt: `As a text classifier, your task is to assign one of the following categories to the provided text: ${categories.join(
-        ', '
-      )}. Please respond with only the selected category as a single word, and nothing else.
-      Text to classify: "${context.propsValue.text}"`,
+      prompt: `As a text classifier, your task is to assign one of the following categories to the provided text.
+
+Categories:
+${numberedCategories}
+
+Respond with ONLY the exact category text — nothing else, no numbering, no quotes, no explanation.
+
+Text to classify: "${context.propsValue.text}"`,
     });
     const result = response.text.trim();
 
-    if (!categories.includes(result)) {
+    const matched = categories.find(
+      (cat) => cat.toLowerCase() === result.toLowerCase()
+    );
+
+    if (!matched) {
       throw new Error(
-        'Unable to classify the text into the provided categories.'
+        `Unable to classify the text into the provided categories. The model responded with "${result}", which did not match any of: ${categories.join(', ')}.`
       );
     }
 
-    return result;
+    return matched;
   },
 });


### PR DESCRIPTION
## Summary

Fixes #12439

The **Classify Text** action always fails with multi-word categories because the prompt tells the model to respond with "a single word", and the match logic uses strict case-sensitive exact matching.

- Rewrote the prompt to list categories clearly (numbered) and ask for the exact category text
- Changed matching to case-insensitive comparison for robustness
- Improved error message to include the model's actual response for easier debugging

## Test plan

- [ ] Create a flow with a Classify Text step using multi-word categories (e.g. "Likely a customer", "General inquiry", "Spam")
- [ ] Verify classification succeeds and returns the correct category
- [ ] Verify single-word categories still work as before
- [ ] Verify the error message is helpful when classification fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)