### PR TITLE
fix: allow webhook validation during disabled flow enablement

### DIFF
--- a/packages/server/api/src/app/webhooks/webhook-handshake.ts
+++ b/packages/server/api/src/app/webhooks/webhook-handshake.ts
@@ -51,11 +51,21 @@ export const webhookHandshake = {
 export function isHandshakeRequest(params: IsHandshakeRequestParams): boolean {
     const { payload, handshakeConfiguration } = params
 
-    if (isNil(handshakeConfiguration) || isNil(handshakeConfiguration.strategy) || isNil(handshakeConfiguration.paramName)) {
+    if (isNil(handshakeConfiguration) || isNil(handshakeConfiguration.strategy)) {
         return false
     }
 
-    const { strategy, paramName } = handshakeConfiguration
+    const { strategy } = handshakeConfiguration
+
+    if (strategy === WebhookHandshakeStrategy.NONE) {
+        return payload.method.toUpperCase() === 'HEAD'
+    }
+
+    if (isNil(handshakeConfiguration.paramName)) {
+        return false
+    }
+
+    const { paramName } = handshakeConfiguration
 
     switch (strategy) {
         case WebhookHandshakeStrategy.HEADER_PRESENT:

--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -84,7 +84,8 @@ export const webhookService = {
                     }
                 }
                 const { flow } = flowExecutionResult
-                if (flow.status === FlowStatus.DISABLED && !saveSampleData) {
+                const handshakeConfiguration = flowExecutionResult.handshakeConfiguration ?? null
+                if (flow.status === FlowStatus.DISABLED && !saveSampleData && isNil(handshakeConfiguration)) {
                     pinoLogger.warn({ flowId }, 'Webhook received for disabled flow')
                     span.setAttribute('webhook.triggerSourceFound', false)
                     return {
@@ -100,10 +101,11 @@ export const webhookService = {
                 span.setAttribute('webhook.projectId', flow.projectId)
                 const flowVersionIdToRun = await webhookService.getFlowVersionIdToRun(flowVersionToRun, flow)
                 span.setAttribute('webhook.flowVersionId', flowVersionIdToRun)
+                const resolvedPayload = payload ?? await data(flow.projectId)
 
                 const response = await webhookHandshake.handleHandshakeRequest({
-                    payload: (payload ?? await data(flow.projectId)) as TriggerPayload,
-                    handshakeConfiguration: flowExecutionResult.handshakeConfiguration ?? null,
+                    payload: resolvedPayload as TriggerPayload,
+                    handshakeConfiguration,
                     flowId: flow.id,
                     flowVersionId: flowVersionIdToRun,
                     projectId: flow.projectId,
@@ -123,9 +125,19 @@ export const webhookService = {
                     }
                 }
 
-                pinoLogger.info('Adding webhook job to queue')
+                if (flow.status === FlowStatus.DISABLED && !saveSampleData) {
+                    pinoLogger.warn({ flowId }, 'Webhook received for disabled flow')
+                    span.setAttribute('webhook.triggerSourceFound', false)
+                    return {
+                        status: StatusCodes.NOT_FOUND,
+                        body: {},
+                        headers: {
+                            [webhookHeader]: webhookRequestId,
+                        },
+                    }
+                }
 
-                const resolvedPayload = payload ?? await data(flow.projectId)
+                pinoLogger.info('Adding webhook job to queue')
 
                 const payloadSize = payloadOffloader.getPayloadSizeInBytes(resolvedPayload)
                 if (payloadSize > MAX_PAYLOAD_SIZE_BYTES) {

--- a/packages/server/api/test/integration/ce/webhooks/webhook.test.ts
+++ b/packages/server/api/test/integration/ce/webhooks/webhook.test.ts
@@ -1,19 +1,33 @@
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
-import { FlowStatus, PrincipalType } from '@activepieces/shared'
+import {
+    apId,
+    EngineResponseStatus,
+    FlowStatus,
+    PrincipalType,
+    TriggerHookType,
+    WebhookHandshakeStrategy,
+} from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
+import * as flowExecutionCacheModule from '../../../../src/app/flows/flow/flow-execution-cache'
+import { userInteractionWatcher } from '../../../../src/app/workers/user-interaction-watcher'
 import { generateMockToken } from '../../../helpers/auth'
 import { db } from '../../../helpers/db'
 import { createMockFlow, createMockFlowVersion, mockAndSaveBasicSetup } from '../../../helpers/mocks'
 
 let app: FastifyInstance | null = null
 const MOCK_FLOW_ID = '8hfKOpm3kY1yAi1ApYOa1'
+
 beforeAll(async () => {
     app = await setupTestEnvironment()
 })
 
 afterAll(async () => {
     await teardownTestEnvironment()
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
 })
 describe('Webhook Service', () => {
     it('should accept webhook for enabled flow', async () => {
@@ -96,6 +110,72 @@ describe('Webhook Service', () => {
             },
         })
         expect(response?.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+
+    it('should accept handshake validation for disabled flows using NONE strategy', async () => {
+        const { mockProject, mockPlatform, mockOwner, mockFlow } = await setupDisabledWebhookFlow({
+            handshakeConfiguration: {
+                strategy: WebhookHandshakeStrategy.NONE,
+            },
+        })
+        const handshakeSpy = mockHandshakeResponse()
+        const mockToken = await generateMockToken({
+            type: PrincipalType.USER,
+            platform: {
+                id: mockPlatform.id,
+            },
+            id: mockOwner.id,
+        })
+
+        const response = await app?.inject({
+            method: 'HEAD',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: {
+                authorization: `Bearer ${mockToken}`,
+            },
+        })
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        expect(handshakeSpy).toHaveBeenCalledWith(expect.objectContaining({
+            hookType: TriggerHookType.HANDSHAKE,
+            flowId: mockFlow.id,
+            projectId: mockProject.id,
+        }), expect.anything())
+    })
+
+    it('should accept handshake validation for disabled flows when a body marker is present', async () => {
+        const { mockProject, mockPlatform, mockOwner, mockFlow } = await setupDisabledWebhookFlow({
+            handshakeConfiguration: {
+                strategy: WebhookHandshakeStrategy.BODY_PARAM_PRESENT,
+                paramName: 'challenge',
+            },
+        })
+        const handshakeSpy = mockHandshakeResponse()
+        const mockToken = await generateMockToken({
+            type: PrincipalType.USER,
+            platform: {
+                id: mockPlatform.id,
+            },
+            id: mockOwner.id,
+        })
+
+        const response = await app?.inject({
+            method: 'POST',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: {
+                authorization: `Bearer ${mockToken}`,
+            },
+            body: {
+                challenge: '123',
+            },
+        })
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        expect(handshakeSpy).toHaveBeenCalledWith(expect.objectContaining({
+            hookType: TriggerHookType.HANDSHAKE,
+            flowId: mockFlow.id,
+            projectId: mockProject.id,
+        }), expect.anything())
     })
 
     it('should pass query parameters in webhook payload', async () => {
@@ -414,3 +494,66 @@ describe('Webhook Service', () => {
         expect(response?.statusCode).toBe(StatusCodes.OK)
     })
 })
+
+async function setupDisabledWebhookFlow({
+    handshakeConfiguration,
+}: SetupDisabledWebhookFlowParams): Promise<SetupDisabledWebhookFlowResult> {
+    const { mockProject, mockPlatform, mockOwner } = await mockAndSaveBasicSetup()
+    const mockFlow = createMockFlow({
+        projectId: mockProject.id,
+        status: FlowStatus.DISABLED,
+        publishedVersionId: apId(),
+    })
+    vi.spyOn(flowExecutionCacheModule, 'flowExecutionCache').mockReturnValue({
+        get: async () => ({
+            exists: true,
+            flow: mockFlow,
+            platformId: mockPlatform.id,
+            handshakeConfiguration,
+        }),
+        invalidate: async () => undefined,
+    })
+
+    return {
+        mockProject,
+        mockPlatform,
+        mockOwner,
+        mockFlow,
+    }
+}
+
+function mockHandshakeResponse() {
+    return vi.spyOn(userInteractionWatcher, 'submitAndWaitForResponse').mockResolvedValue({
+        status: EngineResponseStatus.OK,
+        response: {
+            response: {
+                status: StatusCodes.OK,
+                body: {},
+                headers: {},
+            },
+        },
+        error: undefined,
+    })
+}
+
+type SetupDisabledWebhookFlowParams = {
+    handshakeConfiguration: {
+        strategy: WebhookHandshakeStrategy
+        paramName?: string
+    }
+}
+
+type SetupDisabledWebhookFlowResult = {
+    mockProject: {
+        id: string
+    }
+    mockPlatform: {
+        id: string
+    }
+    mockOwner: {
+        id: string
+    }
+    mockFlow: {
+        id: string
+    }
+}

--- a/packages/server/api/test/unit/app/webhooks/webhook-handshake.test.ts
+++ b/packages/server/api/test/unit/app/webhooks/webhook-handshake.test.ts
@@ -1,11 +1,11 @@
 import { WebhookHandshakeStrategy } from '@activepieces/shared'
 import { isHandshakeRequest } from '../../../../src/app/webhooks/webhook-handshake'
 
-const makePayload = (overrides: { headers?: Record<string, string>, queryParams?: Record<string, string>, body?: unknown } = {}) => ({
+const makePayload = (overrides: { headers?: Record<string, string>, queryParams?: Record<string, string>, body?: unknown, method?: string } = {}) => ({
     headers: overrides.headers ?? {},
     queryParams: overrides.queryParams ?? {},
     body: overrides.body ?? {},
-    method: 'POST',
+    method: overrides.method ?? 'POST',
 })
 
 describe('isHandshakeRequest', () => {
@@ -81,6 +81,28 @@ describe('isHandshakeRequest', () => {
         })
     })
 
+    describe('NONE strategy', () => {
+        it('should return true for HEAD requests', () => {
+            const result = isHandshakeRequest({
+                payload: makePayload({ method: 'HEAD' }),
+                handshakeConfiguration: {
+                    strategy: WebhookHandshakeStrategy.NONE,
+                },
+            })
+            expect(result).toBe(true)
+        })
+
+        it('should return false for POST requests', () => {
+            const result = isHandshakeRequest({
+                payload: makePayload(),
+                handshakeConfiguration: {
+                    strategy: WebhookHandshakeStrategy.NONE,
+                },
+            })
+            expect(result).toBe(false)
+        })
+    })
+
     it('should return false when config is null', () => {
         const result = isHandshakeRequest({
             payload: makePayload(),
@@ -92,8 +114,9 @@ describe('isHandshakeRequest', () => {
     it('should return false when strategy is null', () => {
         const result = isHandshakeRequest({
             payload: makePayload(),
+            // @ts-expect-error testing invalid handshake configuration
             handshakeConfiguration: {
-                strategy: null as unknown as WebhookHandshakeStrategy,
+                strategy: null,
                 paramName: 'test',
             },
         })
@@ -103,9 +126,10 @@ describe('isHandshakeRequest', () => {
     it('should return false when paramName is null', () => {
         const result = isHandshakeRequest({
             payload: makePayload(),
+            // @ts-expect-error testing invalid handshake configuration
             handshakeConfiguration: {
                 strategy: WebhookHandshakeStrategy.HEADER_PRESENT,
-                paramName: null as unknown as string,
+                paramName: null,
             },
         })
         expect(result).toBe(false)


### PR DESCRIPTION
## What does this PR do?

Fixes webhook registration for triggers that validate their callback URL while the flow is still disabled during enablement.

Third-party services can now complete webhook validation successfully instead of getting a 404 during the enable flow path.

### Explain How the Feature Works

The webhook service now checks handshake requests before applying the disabled-flow 404 response for flows that have handshake configuration.

`WebhookHandshakeStrategy.NONE` is treated as a `HEAD` validation request, which covers validator-style webhook registration flows like Trello without changing normal disabled-flow webhook behavior.

Disabled flows without handshake configuration still return 404 as before.

### Relevant User Scenarios

- A user enables a flow backed by a webhook trigger that validates the callback URL during registration.
- Trello and similar services can register webhooks successfully even though the flow is still disabled while `onEnable` runs.
- Normal webhook requests to disabled flows still fail as expected when there is no handshake validation.

## Verification

- `npx vitest run --config packages/server/api/vitest.config.ts packages/server/api/test/unit/app/webhooks/webhook-handshake.test.ts packages/server/api/test/integration/ce/webhooks/webhook.test.ts`
- `npm run lint-dev`

Fixes issue #12436 