### PR TITLE
fix(subflows): use internal resume URL only for internal callbacks

### DIFF
--- a/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
+++ b/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
@@ -126,7 +126,8 @@ export const callFlow = createAction({
       body: {
         data: payload,
         callbackUrl: context.propsValue.waitForResponse ?  context.generateResumeUrl({
-          queryParams: {}
+          queryParams: {},
+          visibility: 'internal'
         }) : undefined,
       },
     });

--- a/packages/pieces/framework/src/lib/context/index.ts
+++ b/packages/pieces/framework/src/lib/context/index.ts
@@ -206,7 +206,8 @@ type BaseActionContext<
   run: RunContext;
   generateResumeUrl: (params: {
     queryParams: Record<string, string>,
-    sync?: boolean
+    sync?: boolean,
+    visibility?: 'public' | 'internal'
   }) => string;
 };
 

--- a/packages/server/engine/src/lib/handler/piece-executor.ts
+++ b/packages/server/engine/src/lib/handler/piece-executor.ts
@@ -149,7 +149,9 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
                 const visibility = params.visibility ?? 'public'
                 const baseApiUrl =
                     visibility === 'internal'
-                        ? (constants.internalApiUrl ?? constants.publicApiUrl)
+                const baseApiUrl =
+                    visibility === 'internal'
+                        ? constants.internalApiUrl
                         : constants.publicApiUrl
 
                 const path = `v1/flow-runs/${constants.flowRunId}/requests/${executionState.pauseRequestId}${params.sync ? '/sync' : ''}`

--- a/packages/server/engine/src/lib/handler/piece-executor.ts
+++ b/packages/server/engine/src/lib/handler/piece-executor.ts
@@ -149,8 +149,6 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
                 const visibility = params.visibility ?? 'public'
                 const baseApiUrl =
                     visibility === 'internal'
-                const baseApiUrl =
-                    visibility === 'internal'
                         ? constants.internalApiUrl
                         : constants.publicApiUrl
 

--- a/packages/server/engine/src/lib/handler/piece-executor.ts
+++ b/packages/server/engine/src/lib/handler/piece-executor.ts
@@ -146,8 +146,23 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
                 externalId: constants.externalProjectId,
             },
             generateResumeUrl: (params) => {
-                const url = new URL(`${constants.publicApiUrl}v1/flow-runs/${constants.flowRunId}/requests/${executionState.pauseRequestId}${params.sync ? '/sync' : ''}`)
-                url.search = new URLSearchParams(params.queryParams).toString()
+                const visibility = params.visibility ?? 'public'
+                const baseApiUrl =
+                    visibility === 'internal'
+                        ? (constants.internalApiUrl ?? constants.publicApiUrl)
+                        : constants.publicApiUrl
+
+                const path = `v1/flow-runs/${constants.flowRunId}/requests/${executionState.pauseRequestId}${params.sync ? '/sync' : ''}`
+                const url = new URL(`${baseApiUrl}${path}`)
+
+                if (params.queryParams) {
+                    for (const [key, value] of Object.entries(params.queryParams)) {
+                        if (value !== undefined && value !== null) {
+                            url.searchParams.set(key, String(value))
+                        }
+                    }
+                }
+
                 return url.toString()
             },
         }


### PR DESCRIPTION
## What does this PR do?

This PR keeps `generateResumeUrl()` public by default, and adds an optional `visibility` parameter so internal-only callback paths can explicitly request an internal URL.

It then updates the sub-flow `callFlow` action to use `visibility: 'internal'` for its internal callback URL when `waitForResponse` is enabled.

### Explain How the Feature Works

`generateResumeUrl()` now accepts:

- `visibility: 'public'` (default)
- `visibility: 'internal'`

Existing approval and externally shared resume links continue using the public URL by default.

The sub-flow callback path is the internal-only caller that now opts into `visibility: 'internal'`, so it can resume within containerised/self-hosted deployments where internal and public URLs differ.

### Relevant User Scenarios

- Sub-flows using **Wait for Response** in self-hosted/containerised deployments
- Internal callback flows where the public URL is not reachable from inside the container
- Approval links and other externally shared resume URLs continue to work unchanged because the default remains public

Fixes #12386