### PR TITLE
feat(pieces): add OAuth2 authentication to Fathom piece

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2443,7 +2443,7 @@
     },
     "packages/pieces/community/fathom": {
       "name": "@activepieces/piece-fathom",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/fathom/package.json
+++ b/packages/pieces/community/fathom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-fathom",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/fathom/src/index.ts
+++ b/packages/pieces/community/fathom/src/index.ts
@@ -1,4 +1,4 @@
-import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { createPiece } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import { getRecordingSummary } from './lib/actions/get-recording-summary';
 import { getRecordingTranscript } from './lib/actions/get-recording-transcript';
@@ -6,12 +6,9 @@ import { listMeetings } from './lib/actions/list-meetings';
 import { findTeam } from './lib/actions/find-team';
 import { findTeamMember } from './lib/actions/find-team-member';
 import { newRecording } from './lib/triggers/new-recording';
+import { fathomAuth } from './lib/common/auth';
 
-export const fathomAuth = PieceAuth.SecretText({
-  displayName: 'API Key',
-  description: 'Enter your Fathom API key',
-  required: true
-});
+export { fathomAuth };
 
 export const fathom = createPiece({
   displayName: 'Fathom',

--- a/packages/pieces/community/fathom/src/lib/actions/find-team-member.ts
+++ b/packages/pieces/community/fathom/src/lib/actions/find-team-member.ts
@@ -1,6 +1,5 @@
-import { fathomAuth } from '../..';
+import { fathomAuth, getFathomClient } from '../common/auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { Fathom } from 'fathom-typescript';
 import { ListTeamMembersRequest } from 'fathom-typescript/dist/esm/sdk/models/operations';
 
 export const findTeamMember = createAction({
@@ -21,9 +20,7 @@ export const findTeamMember = createAction({
     })
   },
   async run({ auth, propsValue }) {
-    const fathom = new Fathom({
-      security: { apiKeyAuth: auth.secret_text }
-    });
+    const fathom = getFathomClient(auth);
 
     const params: Partial<ListTeamMembersRequest> = {};
 

--- a/packages/pieces/community/fathom/src/lib/actions/find-team.ts
+++ b/packages/pieces/community/fathom/src/lib/actions/find-team.ts
@@ -1,6 +1,5 @@
-import { fathomAuth } from '../..';
+import { fathomAuth, getFathomClient } from '../common/auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { Fathom } from 'fathom-typescript';
 import { ListTeamsRequest } from 'fathom-typescript/dist/esm/sdk/models/operations';
 
 export const findTeam = createAction({
@@ -16,9 +15,7 @@ export const findTeam = createAction({
     }),
   },
   async run({ auth, propsValue }) {
-    const fathom = new Fathom({
-      security: { apiKeyAuth: auth.secret_text },
-    });
+    const fathom = getFathomClient(auth);
 
     const params: Partial<ListTeamsRequest> = {};
     if (propsValue.cursor) {

--- a/packages/pieces/community/fathom/src/lib/actions/get-recording-summary.ts
+++ b/packages/pieces/community/fathom/src/lib/actions/get-recording-summary.ts
@@ -1,11 +1,10 @@
-import { fathomAuth } from '../..';
+import { fathomAuth, getFathomClient } from '../common/auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { Fathom } from 'fathom-typescript';
 
 export const getRecordingSummary = createAction({
   name: 'getRecordingSummary',
   displayName: 'Get Recording Summary',
-  description: 'Get the AI-generated summary of a meeting recording',
+  description: 'Get the AI-generated summary of a meeting recording. Note: This action requires API Key authentication and is not available when using OAuth2.',
   auth: fathomAuth,
   props: {
     recording_id: Property.Dropdown({
@@ -24,9 +23,7 @@ export const getRecordingSummary = createAction({
         }
 
         try {
-          const fathom = new Fathom({
-            security: { apiKeyAuth: auth.secret_text },
-          });
+          const fathom = getFathomClient(auth);
 
           const meetingsIterator = await fathom.listMeetings();
 
@@ -51,7 +48,7 @@ export const getRecordingSummary = createAction({
           return {
             disabled: true,
             options: [],
-            placeholder: 'Failed to load meetings. Please check your API key.'
+            placeholder: 'Failed to load meetings. Please check your connection.'
           };
         }
       }
@@ -63,9 +60,7 @@ export const getRecordingSummary = createAction({
     }),
   },
   async run({ auth, propsValue }) {
-    const fathom = new Fathom({
-      security: { apiKeyAuth: auth.secret_text },
-    });
+    const fathom = getFathomClient(auth);
 
     const request = {
       recordingId: propsValue.recording_id,

--- a/packages/pieces/community/fathom/src/lib/actions/get-recording-transcript.ts
+++ b/packages/pieces/community/fathom/src/lib/actions/get-recording-transcript.ts
@@ -1,12 +1,11 @@
-import { fathomAuth } from '../..';
+import { fathomAuth, getFathomClient } from '../common/auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { Fathom } from 'fathom-typescript';
 import { GetRecordingTranscriptRequest } from 'fathom-typescript/dist/esm/sdk/models/operations';
 
 export const getRecordingTranscript = createAction({
   name: 'getRecordingTranscript',
   displayName: 'Get Recording Transcript',
-  description: 'Get the AI-generated transcript of a meeting recording',
+  description: 'Get the AI-generated transcript of a meeting recording. Note: This action requires API Key authentication and is not available when using OAuth2.',
   auth: fathomAuth,
   props: {
     recording_id: Property.Dropdown({
@@ -25,9 +24,7 @@ export const getRecordingTranscript = createAction({
         }
 
         try {
-          const fathom = new Fathom({
-            security: { apiKeyAuth: auth.secret_text },
-          });
+          const fathom = getFathomClient(auth);
 
           const meetingsIterator = await fathom.listMeetings();
 
@@ -52,7 +49,7 @@ export const getRecordingTranscript = createAction({
           return {
             disabled: true,
             options: [],
-            placeholder: 'Failed to load meetings. Please check your API key.'
+            placeholder: 'Failed to load meetings. Please check your connection.'
           };
         }
       }
@@ -64,9 +61,7 @@ export const getRecordingTranscript = createAction({
     }),
   },
   async run({ auth, propsValue }) {
-    const fathom = new Fathom({
-      security: { apiKeyAuth: auth.secret_text },
-    });
+    const fathom = getFathomClient(auth);
 
     const request = {
       recordingId: propsValue.recording_id,

--- a/packages/pieces/community/fathom/src/lib/actions/list-meetings.ts
+++ b/packages/pieces/community/fathom/src/lib/actions/list-meetings.ts
@@ -1,6 +1,5 @@
-import { fathomAuth } from '../..';
+import { fathomAuth, getFathomClient } from '../common/auth';
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { Fathom } from 'fathom-typescript';
 import { ListMeetingsRequest } from 'fathom-typescript/dist/esm/sdk/models/operations';
 
 export const listMeetings = createAction({
@@ -83,9 +82,7 @@ export const listMeetings = createAction({
     }),
   },
   async run({ auth, propsValue }) {
-    const fathom = new Fathom({
-      security: { apiKeyAuth: auth.secret_text },
-    });
+    const fathom = getFathomClient(auth);
 
     const request: Partial<ListMeetingsRequest> = {};
 

--- a/packages/pieces/community/fathom/src/lib/common/auth.ts
+++ b/packages/pieces/community/fathom/src/lib/common/auth.ts
@@ -1,0 +1,29 @@
+import { PieceAuth, AppConnectionValueForAuthProperty } from '@activepieces/pieces-framework';
+import { AppConnectionType } from '@activepieces/shared';
+import { Fathom } from 'fathom-typescript';
+
+const fathomOAuth2Auth = PieceAuth.OAuth2({
+  displayName: 'Sign in with Fathom',
+  description: 'Connect your Fathom account using OAuth2.',
+  authUrl: 'https://fathom.video/external/v1/oauth2/authorize',
+  tokenUrl: 'https://fathom.video/external/v1/oauth2/token',
+  required: true,
+  scope: ['public_api'],
+});
+
+const fathomApiKeyAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Enter your Fathom API key',
+  required: true,
+});
+
+export const fathomAuth = [fathomOAuth2Auth, fathomApiKeyAuth];
+
+export function getFathomClient(auth: FathomAuthValue): Fathom {
+  if (auth.type === AppConnectionType.SECRET_TEXT) {
+    return new Fathom({ security: { apiKeyAuth: auth.secret_text } });
+  }
+  return new Fathom({ security: { bearerAuth: auth.access_token } });
+}
+
+export type FathomAuthValue = AppConnectionValueForAuthProperty<typeof fathomAuth>;

--- a/packages/pieces/community/fathom/src/lib/triggers/new-recording.ts
+++ b/packages/pieces/community/fathom/src/lib/triggers/new-recording.ts
@@ -1,10 +1,9 @@
-import { fathomAuth } from '../..';
+import { fathomAuth, getFathomClient } from '../common/auth';
 import {
   createTrigger,
   TriggerStrategy,
   Property
 } from '@activepieces/pieces-framework';
-import { Fathom } from 'fathom-typescript';
 import { CreateWebhookRequest } from 'fathom-typescript/dist/esm/sdk/models/operations';
 
 interface WebhookInformation {
@@ -78,9 +77,7 @@ export const newRecording = createTrigger({
   },
   type: TriggerStrategy.WEBHOOK,
   async onEnable(context) {
-    const fathom = new Fathom({
-      security: { apiKeyAuth: context.auth.secret_text }
-    });
+    const fathom = getFathomClient(context.auth);
 
     const webhookParams: CreateWebhookRequest = {
       destinationUrl: context.webhookUrl,
@@ -105,17 +102,13 @@ export const newRecording = createTrigger({
     );
 
     if (webhookInfo?.webhookId) {
-      const fathom = new Fathom({
-        security: { apiKeyAuth: context.auth.secret_text }
-      });
+      const fathom = getFathomClient(context.auth);
 
       await fathom.deleteWebhook({ id: webhookInfo.webhookId });
     }
   },
   async test(context) {
-    const fathom = new Fathom({
-      security: { apiKeyAuth: context.auth.secret_text }
-    });
+    const fathom = getFathomClient(context.auth);
 
     const params = {
       includeTranscript: context.propsValue.include_transcript || false,


### PR DESCRIPTION
## What does this PR do?

Adds OAuth2 authentication to the Fathom piece as the default connection method, while keeping the existing API Key (SecretText) auth for backward compatibility. This was requested directly by the Fathom team so they can list Activepieces on their integration hub.

### Explain How the Feature Works

- Users now see two connection options when setting up Fathom: **"Sign in with Fathom"** (OAuth2, default) and **"API Key"** (existing method).
- OAuth2 uses Fathom's authorization flow with the `public_api` scope. The platform handles token exchange and refresh automatically.
- A shared `getFathomClient(auth)` helper detects the connection type at runtime and initializes the Fathom SDK with either `bearerAuth` (OAuth2) or `apiKeyAuth` (API Key) accordingly.
- All 5 existing actions and the webhook trigger work with both auth methods.
- The `Get Recording Summary` and `Get Recording Transcript` actions include a note that they require API Key auth, as Fathom's API restricts these endpoints for OAuth-connected apps (users can use the `List Meetings` action with the "Include Summary" / "Include Transcript" flags as an alternative).
- Existing API Key connections are **not affected** — the `SECRET_TEXT` auth type is preserved.

### Relevant User Scenarios

- **Integration hub listing**: Fathom requires OAuth2 for partner integrations to be listed on their integration hub, enabling shared GTM and discovery by mutual customers.
- **Better end-user UX**: Users can connect their Fathom account with a single click instead of manually generating and pasting an API key.
- **Self-hosted / existing users**: Users who already have API Key connections continue to work without re-authenticating.

Fixes # (issue)
