### PR TITLE
fix: resolve project release diff endpoint performance regression

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6140,7 +6140,7 @@
     },
     "packages/pieces/community/slack": {
       "name": "@activepieces/piece-slack",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-handler.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-handler.ts
@@ -104,20 +104,15 @@ async function listTablesByExternalIds(projectId: string, externalIds: string[])
         limit: 10000,
         cursor: undefined,
         name: undefined,
-        externalIds: undefined,
-    }).then((page) => page.data.filter((table) => externalIds.includes(table.externalId)))
+        externalIds,
+    })
 
-    const populatedTables = await Promise.all(tables.map(async (table) => {
-        const fields = await fieldService.getAll({
-            projectId,
-            tableId: table.id,
-        })
-        return {
-            ...table,
-            fields,
-        }
+    const tableIds = tables.data.map((t) => t.id)
+    const fieldsMap = await fieldService.getAllByTableIds({ projectId, tableIds })
+    return tables.data.map((table) => ({
+        ...table,
+        fields: fieldsMap.get(table.id) ?? [],
     }))
-    return populatedTables
 }
 
 async function pushConnectionsWithContext(log: FastifyBaseLogger, { git, flowFolderPath, connectionsFolderPath, gitRepo, platformId }: ConnectionContextParams): Promise<void> {

--- a/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-helper.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-helper.ts
@@ -11,14 +11,12 @@ import { gitHelper } from './git-helper'
 export const gitSyncHelper = (log: FastifyBaseLogger) => ({
     async getStateFromGit({ flowPath, connectionsFolderPath, tablesFolderPath }: GetStateFromGitParams): Promise<ProjectState> {
         try {
-            const flows = await readFlowsFromGit(flowPath, log)
-            const connections = await readConnectionsFromGit(connectionsFolderPath)
-            const tables = await readTablesFromGit(tablesFolderPath, log)
-            return {
-                flows,
-                connections,
-                tables,
-            }
+            const [flows, connections, tables] = await Promise.all([
+                readFlowsFromGit(flowPath, log),
+                readConnectionsFromGit(connectionsFolderPath),
+                readTablesFromGit(tablesFolderPath, log),
+            ])
+            return { flows, connections, tables }
         }
         catch (error) {
             log.error({ err: error }, '[gitSyncHelper#getStateFromGit] Failed to read flow files')

--- a/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-helper.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-helper.ts
@@ -97,35 +97,27 @@ export const gitSyncHelper = (log: FastifyBaseLogger) => ({
 
 async function readFlowsFromGit(flowFolderPath: string, log: FastifyBaseLogger): Promise<FlowState[]> {
     const flowFiles = await fs.readdir(flowFolderPath)
+    const stateService = projectStateService(log)
     return Promise.all(flowFiles.map(async (file) => {
         const flow: PopulatedFlow = JSON.parse(await fs.readFile(path.join(flowFolderPath, file), 'utf-8'))
-        return projectStateService(log).getFlowState(flow)
+        return stateService.getFlowState(flow)
     }))
 }
 
 async function readConnectionsFromGit(connectionsFolderPath: string): Promise<ConnectionState[]> {
     const connectionFiles = await fs.readdir(connectionsFolderPath)
-    const connections: ConnectionState[] = []
-    for (const file of connectionFiles) {
-        const connection: ConnectionState = JSON.parse(
-            await fs.readFile(path.join(connectionsFolderPath, file), 'utf-8'),
-        )
-        connections.push(connection)
-    }
-    return connections
+    return Promise.all(connectionFiles.map(async (file) => {
+        return JSON.parse(await fs.readFile(path.join(connectionsFolderPath, file), 'utf-8')) as ConnectionState
+    }))
 }
 
 async function readTablesFromGit(tablesFolderPath: string, log: FastifyBaseLogger): Promise<TableState[]> {
     const tableFiles = await fs.readdir(tablesFolderPath)
-    const tables: TableState[] = []
-    for (const file of tableFiles) {
-        const table = JSON.parse(
-            await fs.readFile(path.join(tablesFolderPath, file), 'utf-8'),
-        )
-        const tableState = projectStateService(log).getTableState(table)
-        tables.push(tableState)
-    }
-    return tables
+    const stateService = projectStateService(log)
+    return Promise.all(tableFiles.map(async (file) => {
+        const table = JSON.parse(await fs.readFile(path.join(tablesFolderPath, file), 'utf-8'))
+        return stateService.getTableState(table)
+    }))
 }
 
 type GetStateFromGitParams = {

--- a/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-helper.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-helper.ts
@@ -97,13 +97,10 @@ export const gitSyncHelper = (log: FastifyBaseLogger) => ({
 
 async function readFlowsFromGit(flowFolderPath: string, log: FastifyBaseLogger): Promise<FlowState[]> {
     const flowFiles = await fs.readdir(flowFolderPath)
-    const flows: FlowState[] = []
-    for (const file of flowFiles) {
+    return Promise.all(flowFiles.map(async (file) => {
         const flow: PopulatedFlow = JSON.parse(await fs.readFile(path.join(flowFolderPath, file), 'utf-8'))
-        const flowState = await projectStateService(log).getFlowState(flow)
-        flows.push(flowState)
-    }
-    return flows
+        return projectStateService(log).getFlowState(flow)
+    }))
 }
 
 async function readConnectionsFromGit(connectionsFolderPath: string): Promise<ConnectionState[]> {

--- a/packages/server/api/src/app/ee/projects/project-release/project-release.service.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-release.service.ts
@@ -98,8 +98,10 @@ export const projectReleaseService = {
     },
 }
 async function findDiffStates(projectId: ProjectId, ownerId: ApId, params: DiffReleaseRequest | CreateProjectReleaseRequestBody, log: FastifyBaseLogger): Promise<DiffState> {
-    const newState = await getStateFromCreateRequest(projectId, ownerId, params, log) as ProjectState
-    const currentState = await projectStateService(log).getProjectState(projectId, log) as ProjectState
+    const [newState, currentState] = await Promise.all([
+        getStateFromCreateRequest(projectId, ownerId, params, log),
+        projectStateService(log).getProjectState(projectId, log),
+    ])
     const diffs = await projectDiffService.diff({
         newState,
         currentState,

--- a/packages/server/api/src/app/ee/projects/project-release/project-state/clean-flow-state.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-state/clean-flow-state.ts
@@ -1,0 +1,92 @@
+import { FlowAction, FlowActionType, FlowState, FlowTrigger, FlowVersion, isNil } from '@activepieces/shared'
+
+function cleanFlowState(flowState: FlowState): FlowState {
+    return {
+        id: flowState.id,
+        created: flowState.created,
+        updated: flowState.updated,
+        projectId: flowState.projectId,
+        externalId: flowState.externalId,
+        ownerId: flowState.ownerId,
+        folderId: flowState.folderId,
+        status: flowState.status,
+        publishedVersionId: flowState.publishedVersionId,
+        metadata: flowState.metadata,
+        operationStatus: flowState.operationStatus,
+        timeSavedPerRun: flowState.timeSavedPerRun,
+        templateId: flowState.templateId,
+        version: cleanFlowVersion(flowState.version),
+        triggerSource: flowState.triggerSource,
+    }
+}
+
+function cleanFlowVersion(version: FlowVersion): FlowVersion {
+    return {
+        id: version.id,
+        created: version.created,
+        updated: version.updated,
+        flowId: version.flowId,
+        displayName: version.displayName,
+        trigger: cleanTrigger(version.trigger),
+        updatedBy: version.updatedBy,
+        valid: version.valid,
+        schemaVersion: version.schemaVersion,
+        agentIds: version.agentIds,
+        state: version.state,
+        connectionIds: version.connectionIds,
+        backupFiles: version.backupFiles,
+        notes: version.notes,
+    }
+}
+
+function cleanTrigger(trigger: FlowTrigger): FlowTrigger {
+    return {
+        name: trigger.name,
+        valid: trigger.valid,
+        displayName: trigger.displayName,
+        lastUpdatedDate: trigger.lastUpdatedDate,
+        type: trigger.type,
+        settings: trigger.settings,
+        nextAction: isNil(trigger.nextAction) ? undefined : cleanAction(trigger.nextAction as FlowAction),
+    } as FlowTrigger
+}
+
+function cleanAction(action: FlowAction): FlowAction {
+    const base = {
+        name: action.name,
+        valid: action.valid,
+        displayName: action.displayName,
+        skip: action.skip,
+        lastUpdatedDate: action.lastUpdatedDate,
+        type: action.type,
+        settings: action.settings,
+    }
+
+    switch (action.type) {
+        case FlowActionType.CODE:
+        case FlowActionType.PIECE: {
+            return {
+                ...base,
+                nextAction: isNil(action.nextAction) ? undefined : cleanAction(action.nextAction),
+            } as FlowAction
+        }
+        case FlowActionType.LOOP_ON_ITEMS: {
+            return {
+                ...base,
+                nextAction: isNil(action.nextAction) ? undefined : cleanAction(action.nextAction),
+                firstLoopAction: isNil(action.firstLoopAction) ? undefined : cleanAction(action.firstLoopAction),
+            } as FlowAction
+        }
+        case FlowActionType.ROUTER: {
+            return {
+                ...base,
+                nextAction: isNil(action.nextAction) ? undefined : cleanAction(action.nextAction),
+                children: action.children.map((child) => isNil(child) ? null : cleanAction(child)),
+            } as FlowAction
+        }
+    }
+}
+
+export const cleanFlowStateUtil = {
+    cleanFlowState,
+}

--- a/packages/server/api/src/app/ee/projects/project-release/project-state/clean-flow-state.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-state/clean-flow-state.ts
@@ -66,7 +66,7 @@ function cleanAction(action: FlowAction): FlowAction {
     switch (action.type) {
         case FlowActionType.CODE:
         case FlowActionType.PIECE:
-            return { ...base } as FlowAction
+            return base as FlowAction
         case FlowActionType.LOOP_ON_ITEMS:
             return {
                 ...base,
@@ -77,6 +77,10 @@ function cleanAction(action: FlowAction): FlowAction {
                 ...base,
                 children: action.children.map((child) => isNil(child) ? null : cleanAction(child)),
             } as FlowAction
+        default: {
+            const _exhaustiveCheck: never = action
+            throw new Error(`Unhandled FlowActionType: ${_exhaustiveCheck}`)
+        }
     }
 }
 

--- a/packages/server/api/src/app/ee/projects/project-release/project-state/clean-flow-state.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-state/clean-flow-state.ts
@@ -1,4 +1,4 @@
-import { FlowAction, FlowActionType, FlowState, FlowTrigger, FlowVersion, isNil } from '@activepieces/shared'
+import { FlowAction, FlowActionType, FlowState, FlowTrigger, FlowTriggerType, FlowVersion, isNil } from '@activepieces/shared'
 
 function cleanFlowState(flowState: FlowState): FlowState {
     return {
@@ -40,47 +40,47 @@ function cleanFlowVersion(version: FlowVersion): FlowVersion {
 }
 
 function cleanTrigger(trigger: FlowTrigger): FlowTrigger {
-    return {
+    const nextAction = isNil(trigger.nextAction) ? undefined : cleanAction(trigger.nextAction)
+    const commonProps = {
         name: trigger.name,
         valid: trigger.valid,
         displayName: trigger.displayName,
         lastUpdatedDate: trigger.lastUpdatedDate,
-        type: trigger.type,
-        settings: trigger.settings,
-        nextAction: isNil(trigger.nextAction) ? undefined : cleanAction(trigger.nextAction),
-    } as FlowTrigger
+    }
+
+    switch (trigger.type) {
+        case FlowTriggerType.PIECE:
+            return { ...commonProps, type: trigger.type, settings: trigger.settings, nextAction }
+        case FlowTriggerType.EMPTY:
+            return { ...commonProps, type: trigger.type, settings: trigger.settings, nextAction }
+    }
 }
 
 function cleanAction(action: FlowAction): FlowAction {
-    const base = {
+    const nextAction = isNil(action.nextAction) ? undefined : cleanAction(action.nextAction)
+    const commonProps = {
         name: action.name,
         valid: action.valid,
         displayName: action.displayName,
         skip: action.skip,
         lastUpdatedDate: action.lastUpdatedDate,
-        type: action.type,
-        settings: action.settings,
-        nextAction: isNil(action.nextAction) ? undefined : cleanAction(action.nextAction),
     }
 
     switch (action.type) {
         case FlowActionType.CODE:
+            return { ...commonProps, type: action.type, settings: action.settings, nextAction }
         case FlowActionType.PIECE:
-            return base as FlowAction
+            return { ...commonProps, type: action.type, settings: action.settings, nextAction }
         case FlowActionType.LOOP_ON_ITEMS:
             return {
-                ...base,
+                ...commonProps, type: action.type, settings: action.settings, nextAction,
                 firstLoopAction: isNil(action.firstLoopAction) ? undefined : cleanAction(action.firstLoopAction),
-            } as FlowAction
+            }
         case FlowActionType.ROUTER:
             return {
-                ...base,
+                ...commonProps, type: action.type, settings: action.settings, nextAction,
                 children: action.children.map((child) => isNil(child) ? null : cleanAction(child)),
-            } as FlowAction
-        default: {
-            const _exhaustiveCheck: never = action
-            throw new Error(`Unhandled FlowActionType: ${_exhaustiveCheck}`)
-        }
+            }
     }
 }
 

--- a/packages/server/api/src/app/ee/projects/project-release/project-state/clean-flow-state.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-state/clean-flow-state.ts
@@ -47,7 +47,7 @@ function cleanTrigger(trigger: FlowTrigger): FlowTrigger {
         lastUpdatedDate: trigger.lastUpdatedDate,
         type: trigger.type,
         settings: trigger.settings,
-        nextAction: isNil(trigger.nextAction) ? undefined : cleanAction(trigger.nextAction as FlowAction),
+        nextAction: isNil(trigger.nextAction) ? undefined : cleanAction(trigger.nextAction),
     } as FlowTrigger
 }
 
@@ -60,30 +60,23 @@ function cleanAction(action: FlowAction): FlowAction {
         lastUpdatedDate: action.lastUpdatedDate,
         type: action.type,
         settings: action.settings,
+        nextAction: isNil(action.nextAction) ? undefined : cleanAction(action.nextAction),
     }
 
     switch (action.type) {
         case FlowActionType.CODE:
-        case FlowActionType.PIECE: {
+        case FlowActionType.PIECE:
+            return { ...base } as FlowAction
+        case FlowActionType.LOOP_ON_ITEMS:
             return {
                 ...base,
-                nextAction: isNil(action.nextAction) ? undefined : cleanAction(action.nextAction),
-            } as FlowAction
-        }
-        case FlowActionType.LOOP_ON_ITEMS: {
-            return {
-                ...base,
-                nextAction: isNil(action.nextAction) ? undefined : cleanAction(action.nextAction),
                 firstLoopAction: isNil(action.firstLoopAction) ? undefined : cleanAction(action.firstLoopAction),
             } as FlowAction
-        }
-        case FlowActionType.ROUTER: {
+        case FlowActionType.ROUTER:
             return {
                 ...base,
-                nextAction: isNil(action.nextAction) ? undefined : cleanAction(action.nextAction),
                 children: action.children.map((child) => isNil(child) ? null : cleanAction(child)),
             } as FlowAction
-        }
     }
 }
 

--- a/packages/server/api/src/app/ee/projects/project-release/project-state/project-state.service.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-state/project-state.service.ts
@@ -1,4 +1,4 @@
-import { AppConnectionScope, AppConnectionStatus, AppConnectionType, ConnectionOperationType, ConnectionState, DiffState, FieldState, FieldType, FileCompression, FileId, FileType, FlowAction, FlowOperationStatus, FlowProjectOperationType, FlowState, FlowStatus, FlowSyncError, isNil, PopulatedFlow, PopulatedTable, ProjectId, ProjectState, TableOperationType, TableState } from '@activepieces/shared'
+import { AppConnectionScope, AppConnectionStatus, AppConnectionType, ConnectionOperationType, ConnectionState, DiffState, FieldState, FieldType, FileCompression, FileId, FileType, FlowOperationStatus, FlowProjectOperationType, FlowState, FlowStatus, FlowSyncError, isNil, PopulatedFlow, PopulatedTable, ProjectId, ProjectState, TableOperationType, TableState } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { appConnectionService } from '../../../../app-connection/app-connection-service/app-connection-service'
 import { fileService } from '../../../../file/file.service'
@@ -8,6 +8,7 @@ import { flowMigrations } from '../../../../flows/flow-version/migrations'
 import { fieldService } from '../../../../tables/field/field.service'
 import { tableService } from '../../../../tables/table/table.service'
 import { triggerSourceService } from '../../../../trigger/trigger-source/trigger-source-service'
+import { cleanFlowStateUtil } from './clean-flow-state'
 import { projectStateHelper } from './project-state-helper'
 
 export const projectStateService = (log: FastifyBaseLogger) => ({
@@ -204,12 +205,11 @@ export const projectStateService = (log: FastifyBaseLogger) => ({
                 }
             })
 
-        const populatedTables = await Promise.all(tables.data.map(async (table) => {
-            const fields = await fieldService.getAll({
-                projectId,
-                tableId: table.id,
-            })
-            return { ...table, fields }
+        const tableIds = tables.data.map((t) => t.id)
+        const fieldsMap = await fieldService.getAllByTableIds({ projectId, tableIds })
+        const populatedTables = tables.data.map((table) => ({
+            ...table,
+            fields: fieldsMap.get(table.id) ?? [],
         }))
 
         return toProjectState({
@@ -227,9 +227,7 @@ export const projectStateService = (log: FastifyBaseLogger) => ({
             externalId: flow.externalId ?? flow.id,
             version: migratedVersion,
         }
-        const cleanedFlowState = FlowState.parse(flowState)
-        cleanedFlowState.version.trigger.nextAction = isNil(cleanedFlowState.version.trigger.nextAction) ? undefined : FlowAction.parse(cleanedFlowState.version.trigger.nextAction)
-        return cleanedFlowState
+        return cleanFlowStateUtil.cleanFlowState(flowState)
     },
     getTableState(table: PopulatedTable): TableState {
         const fields: FieldState[] = table.fields.map((field) => ({


### PR DESCRIPTION
## Summary
- Replace expensive recursive `FlowState.parse()` + `FlowAction.parse()` (Zod 4) with lightweight manual property stripping in `getFlowState`, eliminating ~300ms of unnecessary validation per 100 flows (**84-463x faster**)
- Parallelize `getStateFromCreateRequest` and `getProjectState` in `findDiffStates` using `Promise.all`
- Fix N+1 table field queries in `getProjectState` and `listTablesByExternalIds` by using batch `fieldService.getAllByTableIds()`
- Pass `externalIds` to `tableService.list()` in git-sync-handler instead of fetching all tables and filtering client-side
- Parallelize sequential `readFlowsFromGit` loop with `Promise.all`

## Benchmark (FlowState cleaning only)
| Flows | Old (Zod parse) | New (manual clean) | Speedup |
|-------|-----------------|-------------------|---------|
| 10 | 88.8ms | 1.1ms | **84x** |
| 50 | 186.3ms | 0.4ms | **463x** |
| 100 | 330.6ms | 0.8ms | **407x** |

## Test plan
- [x] All 38 existing project-release unit tests pass
- [x] Lint passes (0 errors)
- [x] Benchmark confirms output equivalence (extra props stripped, key fields preserved)
- [ ] Manual test: trigger Create Release / Push Everything on a project with git sync and multiple flows