### PR TITLE
fix: guard major queries behind feature flags

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",

--- a/packages/web/AGENTS.md
+++ b/packages/web/AGENTS.md
@@ -79,6 +79,24 @@ You are working in the Activepieces web application (`packages/web`).
 - **Transforming data for rendering** — Calculate it inline during render instead.
 - **Passing data upward to a parent** — Lift state up or use a shared store.
 
+## Query Feature Guards
+
+When a server endpoint is gated by `platformMustHaveFeatureEnabled` (returns HTTP 402 `FEATURE_DISABLED` when the plan lacks the feature), the corresponding `useQuery` hook **must** include `enabled: platform.plan.<flag>` so the request never fires when the feature is off. Without this, the global `QueryCache.onError` handler in `app.tsx` shows a misleading "Failed to load data" error dialog.
+
+**Pattern** (see `secret-managers-hooks.ts`):
+```ts
+const { platform } = platformHooks.useCurrentPlatform();
+return useQuery({
+  queryKey: [...],
+  queryFn: ...,
+  enabled: platform.plan.someFeatureEnabled,
+});
+```
+
+- `platformHooks.useCurrentPlatform()` returns instantly from cache (loaded by `InitialDataGuard`), safe to call in any hook.
+- If the query already has an `enabled` condition, combine them: `enabled: !!existing && platform.plan.<flag>`.
+- For pages with plan-gated content, also wrap with `LockedFeatureGuard` so users see an upgrade prompt instead of a broken/empty page.
+
 ## Guidelines
 
 - Read existing code before making changes to understand patterns

--- a/packages/web/src/app/app.tsx
+++ b/packages/web/src/app/app.tsx
@@ -59,7 +59,10 @@ const queryClient = new QueryClient({
           description: t(
             'Something went wrong while loading your data. Your data is safe — please try again by refreshing the page.',
           ),
-          error: api.isError(error) ? error.response?.data : error,
+          error: {
+            queryKey: query.queryKey,
+            details: api.isError(error) ? error.response?.data : String(error),
+          },
         });
       }
     },

--- a/packages/web/src/app/routes/impact/index.tsx
+++ b/packages/web/src/app/routes/impact/index.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useEffectOnce } from 'react-use';
 import { toast } from 'sonner';
 
+import LockedFeatureGuard from '@/app/components/locked-feature-guard';
 import { PageHeader } from '@/components/custom/page-header';
 import { Button } from '@/components/ui/button';
 import {
@@ -27,6 +28,7 @@ import {
   RefreshAnalyticsContext,
 } from '@/features/platform-admin';
 import { projectCollectionUtils } from '@/features/projects';
+import { platformHooks } from '@/hooks/platform-hooks';
 import { cn, DASHBOARD_CONTENT_PADDING_X } from '@/lib/utils';
 
 import { ProjectSelect } from './components/project-select';
@@ -39,6 +41,7 @@ const REPORT_TTL_MS = 1000 * 60 * 60 * 24;
 type TabValue = 'analytics' | 'details';
 
 export default function ImpactPage() {
+  const { platform } = platformHooks.useCurrentPlatform();
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedProjectId = searchParams.get('projectId') || undefined;
   const selectedTimePeriod =
@@ -94,127 +97,137 @@ export default function ImpactPage() {
   const report = isLoading ? undefined : data ?? undefined;
 
   return (
-    <div className="flex flex-col gap-4 w-full">
-      <PageHeader
-        showSidebarToggle={true}
-        title={
-          <div className="flex items-center gap-1.5">
-            <span className="text-sm font-medium">{t('Impact')}</span>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info className="h-4 w-4 text-muted-foreground cursor-help" />
-              </TooltipTrigger>
-              <TooltipContent>
-                {t('View impact analytics and metrics for the active flows.')}
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        }
-        rightContent={
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-2 px-3 py-1.5 border border-dashed rounded-md text-sm text-muted-foreground">
-              <span>
-                {t('Updated')} {dayjs(data?.updated).format('MMM DD, hh:mm A')}{' '}
-                — {t('Refreshes daily')}
-              </span>
+    <LockedFeatureGuard
+      featureKey="ANALYTICS"
+      locked={!platform.plan.analyticsEnabled}
+      lockTitle={t('Unlock Impact Analytics')}
+      lockDescription={t(
+        'View impact analytics and metrics for the active flows across your platform',
+      )}
+    >
+      <div className="flex flex-col gap-4 w-full">
+        <PageHeader
+          showSidebarToggle={true}
+          title={
+            <div className="flex items-center gap-1.5">
+              <span className="text-sm font-medium">{t('Impact')}</span>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6"
-                    onClick={() =>
-                      refreshAnalytics(undefined, {
-                        onSuccess: () =>
-                          toast.success(t('Data refreshed successfully')),
-                      })
-                    }
-                    disabled={isRefreshing}
-                  >
-                    <RefreshCcw
-                      className={`h-3.5 w-3.5 ${
-                        isRefreshing ? 'animate-spin' : ''
-                      }`}
-                    />
-                  </Button>
+                  <Info className="h-4 w-4 text-muted-foreground cursor-help" />
                 </TooltipTrigger>
-                <TooltipContent>{t('Refresh analytics')}</TooltipContent>
+                <TooltipContent>
+                  {t('View impact analytics and metrics for the active flows.')}
+                </TooltipContent>
               </Tooltip>
             </div>
+          }
+          rightContent={
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2 px-3 py-1.5 border border-dashed rounded-md text-sm text-muted-foreground">
+                <span>
+                  {t('Updated')}{' '}
+                  {dayjs(data?.updated).format('MMM DD, hh:mm A')} —{' '}
+                  {t('Refreshes daily')}
+                </span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      onClick={() =>
+                        refreshAnalytics(undefined, {
+                          onSuccess: () =>
+                            toast.success(t('Data refreshed successfully')),
+                        })
+                      }
+                      disabled={isRefreshing}
+                    >
+                      <RefreshCcw
+                        className={`h-3.5 w-3.5 ${
+                          isRefreshing ? 'animate-spin' : ''
+                        }`}
+                      />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('Refresh analytics')}</TooltipContent>
+                </Tooltip>
+              </div>
 
-            <Select
-              value={selectedTimePeriod}
-              onValueChange={handleTimePeriodChange}
-            >
-              <SelectTrigger className="w-auto gap-2 h-8">
-                <Calendar className="h-4 w-4" />
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent side="bottom" align="end">
-                <SelectItem value={AnalyticsTimePeriod.LAST_WEEK}>
-                  {t('Last 7 days')}
-                </SelectItem>
-                <SelectItem value={AnalyticsTimePeriod.LAST_MONTH}>
-                  {t('Last 30 days')}
-                </SelectItem>
-                <SelectItem value={AnalyticsTimePeriod.LAST_THREE_MONTHS}>
-                  {t('Last 3 months')}
-                </SelectItem>
-                <SelectItem value={AnalyticsTimePeriod.LAST_SIX_MONTHS}>
-                  {t('Last 6 months')}
-                </SelectItem>
-                <SelectItem value={AnalyticsTimePeriod.LAST_YEAR}>
-                  {t('Last year')}
-                </SelectItem>
-              </SelectContent>
-            </Select>
+              <Select
+                value={selectedTimePeriod}
+                onValueChange={handleTimePeriodChange}
+              >
+                <SelectTrigger className="w-auto gap-2 h-8">
+                  <Calendar className="h-4 w-4" />
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent side="bottom" align="end">
+                  <SelectItem value={AnalyticsTimePeriod.LAST_WEEK}>
+                    {t('Last 7 days')}
+                  </SelectItem>
+                  <SelectItem value={AnalyticsTimePeriod.LAST_MONTH}>
+                    {t('Last 30 days')}
+                  </SelectItem>
+                  <SelectItem value={AnalyticsTimePeriod.LAST_THREE_MONTHS}>
+                    {t('Last 3 months')}
+                  </SelectItem>
+                  <SelectItem value={AnalyticsTimePeriod.LAST_SIX_MONTHS}>
+                    {t('Last 6 months')}
+                  </SelectItem>
+                  <SelectItem value={AnalyticsTimePeriod.LAST_YEAR}>
+                    {t('Last year')}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
 
-            <ProjectSelect
-              projects={projects ?? []}
-              selectedProjectId={selectedProjectId}
-              onProjectChange={handleProjectChange}
-            />
-          </div>
-        }
-        className="min-w-full"
-      />
+              <ProjectSelect
+                projects={projects ?? []}
+                selectedProjectId={selectedProjectId}
+                onProjectChange={handleProjectChange}
+              />
+            </div>
+          }
+          className="min-w-full"
+        />
 
-      <Tabs
-        value={activeTab}
-        onValueChange={handleTabChange}
-        className="w-full "
-      >
-        <TabsList
-          variant="outline"
-          className={cn('border-b w-full', DASHBOARD_CONTENT_PADDING_X)}
+        <Tabs
+          value={activeTab}
+          onValueChange={handleTabChange}
+          className="w-full "
         >
-          <TabsTrigger variant="outline" value="analytics">
-            <LineChart className="w-4 h-4 mr-2" />
-            {t('Analytics')}
-          </TabsTrigger>
-          <TabsTrigger variant="outline" value="details">
-            <List className="w-4 h-4 mr-2" />
-            {t('Details')}
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="analytics">
-          <div
-            className={cn('flex flex-col gap-6', DASHBOARD_CONTENT_PADDING_X)}
+          <TabsList
+            variant="outline"
+            className={cn('border-b w-full', DASHBOARD_CONTENT_PADDING_X)}
           >
-            <Summary report={report ?? undefined} />
-            <Trends report={report ?? undefined} />
-          </div>
-        </TabsContent>
+            <TabsTrigger variant="outline" value="analytics">
+              <LineChart className="w-4 h-4 mr-2" />
+              {t('Analytics')}
+            </TabsTrigger>
+            <TabsTrigger variant="outline" value="details">
+              <List className="w-4 h-4 mr-2" />
+              {t('Details')}
+            </TabsTrigger>
+          </TabsList>
 
-        <TabsContent value="details">
-          <FlowsDetails
-            report={report}
-            isLoading={isLoading}
-            projects={projects}
-          />
-        </TabsContent>
-      </Tabs>
-    </div>
+          <TabsContent value="analytics">
+            <div
+              className={cn('flex flex-col gap-6', DASHBOARD_CONTENT_PADDING_X)}
+            >
+              <Summary report={report ?? undefined} />
+              <Trends report={report ?? undefined} />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="details">
+            <FlowsDetails
+              report={report}
+              isLoading={isLoading}
+              projects={projects}
+            />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </LockedFeatureGuard>
   );
 }

--- a/packages/web/src/app/routes/leaderboard/index.tsx
+++ b/packages/web/src/app/routes/leaderboard/index.tsx
@@ -21,6 +21,7 @@ import { useContext, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { userApi } from '@/api/user-api';
+import LockedFeatureGuard from '@/app/components/locked-feature-guard';
 import { PageHeader } from '@/components/custom/page-header';
 import { SearchInput } from '@/components/custom/search-input';
 import { Button } from '@/components/ui/button';
@@ -48,6 +49,7 @@ import {
   RefreshAnalyticsProvider,
 } from '@/features/platform-admin';
 import { projectCollectionUtils } from '@/features/projects';
+import { platformHooks } from '@/hooks/platform-hooks';
 import { downloadFile } from '@/lib/dom-utils';
 import { formatUtils } from '@/lib/format-utils';
 import { cn, DASHBOARD_CONTENT_PADDING_X } from '@/lib/utils';
@@ -97,6 +99,7 @@ function applyTimeSavedFilter<T extends { minutesSaved: number }>(
 }
 
 export default function LeaderboardPage() {
+  const { platform } = platformHooks.useCurrentPlatform();
   const [timePeriod, setTimePeriod] = useState<AnalyticsTimePeriod>(
     AnalyticsTimePeriod.LAST_WEEK,
   );
@@ -337,194 +340,208 @@ export default function LeaderboardPage() {
   };
 
   return (
-    <RefreshAnalyticsProvider>
-      <div className="flex flex-col gap-2 w-full">
-        <PageHeader
-          showSidebarToggle={true}
-          title={
-            <div className="flex items-center gap-1.5">
-              <span className="text-sm font-medium">{t('Leaderboard')}</span>
+    <LockedFeatureGuard
+      featureKey="ANALYTICS"
+      locked={!platform.plan.analyticsEnabled}
+      lockTitle={t('Unlock Leaderboard')}
+      lockDescription={t(
+        'See top performers by flows created and time saved across your platform',
+      )}
+    >
+      <RefreshAnalyticsProvider>
+        <div className="flex flex-col gap-2 w-full">
+          <PageHeader
+            showSidebarToggle={true}
+            title={
+              <div className="flex items-center gap-1.5">
+                <span className="text-sm font-medium">{t('Leaderboard')}</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t('See top performers by flows created and time saved')}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            }
+            rightContent={
+              <div className="flex items-center gap-3">
+                <div className="flex items-center gap-2 px-3 py-1.5 border border-dashed rounded-md text-sm text-muted-foreground">
+                  <span>
+                    {t('Updated')}{' '}
+                    {dayjs(analyticsData?.cachedAt).format('MMM DD, hh:mm A')}
+                    {' — '}
+                    {t('Refreshes daily')}
+                  </span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6"
+                        onClick={() =>
+                          refreshAnalytics(undefined, {
+                            onSuccess: () =>
+                              toast.success(t('Data refreshed successfully')),
+                          })
+                        }
+                        disabled={isRefreshing}
+                      >
+                        <RefreshCcw
+                          className={`h-3.5 w-3.5 ${
+                            isRefreshing ? 'animate-spin' : ''
+                          }`}
+                        />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('Refresh analytics')}</TooltipContent>
+                  </Tooltip>
+                </div>
+
+                <Select
+                  value={timePeriod}
+                  onValueChange={(value) =>
+                    setTimePeriod(value as AnalyticsTimePeriod)
+                  }
+                >
+                  <SelectTrigger className="w-auto gap-2 h-8">
+                    <Calendar className="h-4 w-4" />
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent side="bottom" align="end">
+                    <SelectItem value={AnalyticsTimePeriod.LAST_WEEK}>
+                      {t('Last 7 days')}
+                    </SelectItem>
+                    <SelectItem value={AnalyticsTimePeriod.LAST_MONTH}>
+                      {t('Last 30 days')}
+                    </SelectItem>
+                    <SelectItem value={AnalyticsTimePeriod.LAST_THREE_MONTHS}>
+                      {t('Last 3 months')}
+                    </SelectItem>
+                    <SelectItem value={AnalyticsTimePeriod.LAST_SIX_MONTHS}>
+                      {t('Last 6 months')}
+                    </SelectItem>
+                    <SelectItem value={AnalyticsTimePeriod.LAST_YEAR}>
+                      {t('Last year')}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            }
+            className="min-w-full"
+          />
+
+          <Tabs
+            defaultValue="creators"
+            className="w-full mt-2"
+            onValueChange={handleTabChange}
+          >
+            <TabsList
+              variant="outline"
+              className={cn('border-b w-full', DASHBOARD_CONTENT_PADDING_X)}
+            >
+              <TabsTrigger variant="outline" value="creators">
+                <Users className="w-4 h-4 mr-1.5" />
+                {t('People')}
+              </TabsTrigger>
+              <TabsTrigger variant="outline" value="projects">
+                <LayoutGrid className="w-4 h-4 mr-1.5" />
+                {t('Projects')}
+              </TabsTrigger>
+            </TabsList>
+
+            <div
+              className={cn(
+                'flex items-center justify-between mt-4 mb-4',
+                DASHBOARD_CONTENT_PADDING_X,
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <SearchInput
+                  value={searchQuery}
+                  onChange={setSearchQuery}
+                  placeholder={
+                    activeTab === 'creators'
+                      ? t('Search users')
+                      : t('Search projects')
+                  }
+                  className="w-[200px]"
+                />
+                <Popover
+                  open={timeSavedPopoverOpen}
+                  onOpenChange={handleTimeSavedPopoverOpen}
+                >
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="gap-2 font-normal border-dashed"
+                    >
+                      <Clock className="h-4 w-4" />
+                      <span>{t('Time Saved')}</span>
+                      {timeSavedLabel && (
+                        <span className="rounded bg-accent px-1.5 py-0.5 text-xs font-medium">
+                          {timeSavedLabel}
+                        </span>
+                      )}
+                      <ChevronDown className="h-4 w-4 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[200px] p-4" align="start">
+                    <TimeSavedFilterContent
+                      draftMin={draftTimeSavedMin}
+                      onMinChange={setDraftTimeSavedMin}
+                      unitMin={draftTimeUnitMin}
+                      onCycleUnitMin={cycleDraftTimeUnitMin}
+                      draftMax={draftTimeSavedMax}
+                      onMaxChange={setDraftTimeSavedMax}
+                      unitMax={draftTimeUnitMax}
+                      onCycleUnitMax={cycleDraftTimeUnitMax}
+                      onApply={handleApplyFilter}
+                    />
+                  </PopoverContent>
+                </Popover>
+                {hasActiveFilters && (
+                  <Button variant="ghost" size="sm" onClick={clearAllFilters}>
+                    <X className="h-4 w-4" />
+                    {t('Clear')}
+                  </Button>
+                )}
+              </div>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleDownload}
+                    disabled={isDownloadDisabled}
+                  >
+                    <Download className="h-4 w-4 mr-2" />
+                    {t('Download')}
+                  </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  {t('See top performers by flows created and time saved')}
+                  {t('Download leaderboard data')}
                 </TooltipContent>
               </Tooltip>
             </div>
-          }
-          rightContent={
-            <div className="flex items-center gap-3">
-              <div className="flex items-center gap-2 px-3 py-1.5 border border-dashed rounded-md text-sm text-muted-foreground">
-                <span>
-                  {t('Updated')}{' '}
-                  {dayjs(analyticsData?.cachedAt).format('MMM DD, hh:mm A')}
-                  {' — '}
-                  {t('Refreshes daily')}
-                </span>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6"
-                      onClick={() =>
-                        refreshAnalytics(undefined, {
-                          onSuccess: () =>
-                            toast.success(t('Data refreshed successfully')),
-                        })
-                      }
-                      disabled={isRefreshing}
-                    >
-                      <RefreshCcw
-                        className={`h-3.5 w-3.5 ${
-                          isRefreshing ? 'animate-spin' : ''
-                        }`}
-                      />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t('Refresh analytics')}</TooltipContent>
-                </Tooltip>
-              </div>
 
-              <Select
-                value={timePeriod}
-                onValueChange={(value) =>
-                  setTimePeriod(value as AnalyticsTimePeriod)
-                }
-              >
-                <SelectTrigger className="w-auto gap-2 h-8">
-                  <Calendar className="h-4 w-4" />
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent side="bottom" align="end">
-                  <SelectItem value={AnalyticsTimePeriod.LAST_WEEK}>
-                    {t('Last 7 days')}
-                  </SelectItem>
-                  <SelectItem value={AnalyticsTimePeriod.LAST_MONTH}>
-                    {t('Last 30 days')}
-                  </SelectItem>
-                  <SelectItem value={AnalyticsTimePeriod.LAST_THREE_MONTHS}>
-                    {t('Last 3 months')}
-                  </SelectItem>
-                  <SelectItem value={AnalyticsTimePeriod.LAST_SIX_MONTHS}>
-                    {t('Last 6 months')}
-                  </SelectItem>
-                  <SelectItem value={AnalyticsTimePeriod.LAST_YEAR}>
-                    {t('Last year')}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          }
-          className="min-w-full"
-        />
-
-        <Tabs
-          defaultValue="creators"
-          className="w-full mt-2"
-          onValueChange={handleTabChange}
-        >
-          <TabsList
-            variant="outline"
-            className={cn('border-b w-full', DASHBOARD_CONTENT_PADDING_X)}
-          >
-            <TabsTrigger variant="outline" value="creators">
-              <Users className="w-4 h-4 mr-1.5" />
-              {t('People')}
-            </TabsTrigger>
-            <TabsTrigger variant="outline" value="projects">
-              <LayoutGrid className="w-4 h-4 mr-1.5" />
-              {t('Projects')}
-            </TabsTrigger>
-          </TabsList>
-
-          <div
-            className={cn(
-              'flex items-center justify-between mt-4 mb-4',
-              DASHBOARD_CONTENT_PADDING_X,
-            )}
-          >
-            <div className="flex items-center gap-2">
-              <SearchInput
-                value={searchQuery}
-                onChange={setSearchQuery}
-                placeholder={
-                  activeTab === 'creators'
-                    ? t('Search users')
-                    : t('Search projects')
-                }
-                className="w-[200px]"
+            <TabsContent value="creators">
+              <UsersLeaderboard
+                data={filteredPeopleData}
+                isLoading={isLoading}
               />
-              <Popover
-                open={timeSavedPopoverOpen}
-                onOpenChange={handleTimeSavedPopoverOpen}
-              >
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="gap-2 font-normal border-dashed"
-                  >
-                    <Clock className="h-4 w-4" />
-                    <span>{t('Time Saved')}</span>
-                    {timeSavedLabel && (
-                      <span className="rounded bg-accent px-1.5 py-0.5 text-xs font-medium">
-                        {timeSavedLabel}
-                      </span>
-                    )}
-                    <ChevronDown className="h-4 w-4 opacity-50" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[200px] p-4" align="start">
-                  <TimeSavedFilterContent
-                    draftMin={draftTimeSavedMin}
-                    onMinChange={setDraftTimeSavedMin}
-                    unitMin={draftTimeUnitMin}
-                    onCycleUnitMin={cycleDraftTimeUnitMin}
-                    draftMax={draftTimeSavedMax}
-                    onMaxChange={setDraftTimeSavedMax}
-                    unitMax={draftTimeUnitMax}
-                    onCycleUnitMax={cycleDraftTimeUnitMax}
-                    onApply={handleApplyFilter}
-                  />
-                </PopoverContent>
-              </Popover>
-              {hasActiveFilters && (
-                <Button variant="ghost" size="sm" onClick={clearAllFilters}>
-                  <X className="h-4 w-4" />
-                  {t('Clear')}
-                </Button>
-              )}
-            </div>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleDownload}
-                  disabled={isDownloadDisabled}
-                >
-                  <Download className="h-4 w-4 mr-2" />
-                  {t('Download')}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{t('Download leaderboard data')}</TooltipContent>
-            </Tooltip>
-          </div>
+            </TabsContent>
 
-          <TabsContent value="creators">
-            <UsersLeaderboard data={filteredPeopleData} isLoading={isLoading} />
-          </TabsContent>
-
-          <TabsContent value="projects">
-            <ProjectsLeaderboard
-              data={filteredProjectsData}
-              isLoading={isLoading}
-            />
-          </TabsContent>
-        </Tabs>
-      </div>
-    </RefreshAnalyticsProvider>
+            <TabsContent value="projects">
+              <ProjectsLeaderboard
+                data={filteredProjectsData}
+                isLoading={isLoading}
+              />
+            </TabsContent>
+          </Tabs>
+        </div>
+      </RefreshAnalyticsProvider>
+    </LockedFeatureGuard>
   );
 }

--- a/packages/web/src/features/members/hooks/project-members-hooks.ts
+++ b/packages/web/src/features/members/hooks/project-members-hooks.ts
@@ -6,6 +6,7 @@ import {
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { flagsHooks } from '@/hooks/flags-hooks';
+import { platformHooks } from '@/hooks/platform-hooks';
 import { authenticationSession } from '@/lib/authentication-session';
 
 import { projectMembersApi } from '../api/project-members-api';
@@ -13,6 +14,7 @@ import { projectMembersApi } from '../api/project-members-api';
 export const projectMembersHooks = {
   useProjectMembers: () => {
     const { data } = flagsHooks.useFlag<boolean>(ApFlagId.SHOW_PROJECT_MEMBERS);
+    const { platform } = platformHooks.useCurrentPlatform();
     const query = useQuery<ProjectMemberWithUser[]>({
       queryKey: ['project-members', authenticationSession.getProjectId()],
       queryFn: async () => {
@@ -26,7 +28,7 @@ export const projectMembersHooks = {
         });
         return res.data;
       },
-      enabled: !!data,
+      enabled: !!data && platform.plan.projectRolesEnabled,
     });
     return {
       projectMembers: query.data,

--- a/packages/web/src/features/platform-admin/hooks/analytics-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/analytics-hooks.ts
@@ -8,6 +8,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useContext } from 'react';
 
 import { analyticsApi } from '@/features/platform-admin/api/analytics-api';
+import { platformHooks } from '@/hooks/platform-hooks';
 
 import { RefreshAnalyticsContext } from '../stores/refresh-analytics-context';
 
@@ -25,9 +26,11 @@ export const platformAnalyticsHooks = {
   useUsersLeaderboard: (
     timePeriod: AnalyticsTimePeriod,
   ): { data: UserLeaderboardItem[] | null; isLoading: boolean } => {
+    const { platform } = platformHooks.useCurrentPlatform();
     const { data, isLoading } = useQuery({
       queryKey: userLeaderboardQueryKey(timePeriod),
       queryFn: () => analyticsApi.getUserLeaderboard(timePeriod),
+      enabled: platform.plan.analyticsEnabled,
     });
 
     return {
@@ -39,9 +42,11 @@ export const platformAnalyticsHooks = {
   useProjectLeaderboard: (
     timePeriod: AnalyticsTimePeriod,
   ): { data: ProjectLeaderboardItem[] | null; isLoading: boolean } => {
+    const { platform } = platformHooks.useCurrentPlatform();
     const { data, isLoading } = useQuery({
       queryKey: projectLeaderboardQueryKey(timePeriod),
       queryFn: () => analyticsApi.getProjectLeaderboard(timePeriod),
+      enabled: platform.plan.analyticsEnabled,
     });
 
     return {
@@ -54,9 +59,11 @@ export const platformAnalyticsHooks = {
     data: PlatformAnalyticsReport | undefined;
     isLoading: boolean;
   } => {
+    const { platform } = platformHooks.useCurrentPlatform();
     const { data, isLoading } = useQuery({
       queryKey: analyticsQueryKey,
       queryFn: () => analyticsApi.get(),
+      enabled: platform.plan.analyticsEnabled,
     });
     return { data, isLoading };
   },
@@ -85,10 +92,12 @@ export const platformAnalyticsHooks = {
       [projectId],
     );
 
+    const { platform } = platformHooks.useCurrentPlatform();
     const { data, isLoading } = useQuery({
       queryKey: [...analyticsQueryKey, timePeriod],
       queryFn: () => analyticsApi.get(timePeriod),
       select: selectFilteredByProject,
+      enabled: platform.plan.analyticsEnabled,
     });
 
     return {

--- a/packages/web/src/features/platform-admin/hooks/audit-log-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/audit-log-hooks.ts
@@ -5,6 +5,7 @@ import {
   CURSOR_QUERY_PARAM,
   LIMIT_QUERY_PARAM,
 } from '@/components/custom/data-table';
+import { platformHooks } from '@/hooks/platform-hooks';
 
 import { auditEventsApi } from '../api/audit-events-api';
 
@@ -15,10 +16,12 @@ export const auditLogKeys = {
 export const auditLogQueries = {
   useAuditLogs: () => {
     const [searchParams] = useSearchParams();
+    const { platform } = platformHooks.useCurrentPlatform();
     return useQuery({
       queryKey: auditLogKeys.all(searchParams.toString()),
       staleTime: 0,
       gcTime: 0,
+      enabled: platform.plan.auditLogEnabled,
       queryFn: async () => {
         const cursor = searchParams.get(CURSOR_QUERY_PARAM);
         const limit = searchParams.get(LIMIT_QUERY_PARAM);


### PR DESCRIPTION
## Summary
- Guard major query hooks (`audit-logs`, `user-leaderboard`, `project-leaderboard`, `analytics`, `project-members`) behind platform plan feature flags (`enabled: platform.plan.*`) so they never fire when the feature is disabled — preventing false "Failed to load data" error dialogs from 402 responses
- Wrap the Impact and Leaderboard pages with `LockedFeatureGuard` so users without analytics see an upgrade prompt instead of a broken page
- Include the failing `queryKey` in the global error dialog's technical details for easier debugging

## Test plan
- [x] With `analyticsEnabled: false` in the platform plan, visit `/impact` and `/leaderboard` — should see the locked feature upgrade prompt, no error dialog
- [x] With `auditLogEnabled: false`, visit `/platform/security/audit-logs` — should see the locked feature prompt, no error dialog
- [x] With `projectRolesEnabled: false`, visit a page that loads project members — should not see an error dialog
- [x] With all features enabled, verify all pages load data normally with no regressions
- [x] Trigger a real query failure and confirm the error dialog now shows the `queryKey` in technical details
