### PR TITLE
fix(web): replace global MAJOR_QUERY_PREFIXES with meta-based opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@
 
 ## Query Error Handling
 
-- **Global error dialog for major queries** — `app.tsx` has a `QueryCache.onError` handler that shows an error dialog for queries whose first query key is in the `MAJOR_QUERY_PREFIXES` set. When adding a new `useQuery` that fetches primary page data (e.g. table rows, list data), add its query key prefix to `MAJOR_QUERY_PREFIXES` in `packages/web/src/app/app.tsx`.
-- **Do NOT add** prefixes for minor/auxiliary queries (feature flags, piece metadata, single-item fetches, filter options, user details). These should fail silently.
-- Rule of thumb: if the query failure would leave the user staring at an empty table or blank page with no explanation, its prefix belongs in `MAJOR_QUERY_PREFIXES`.
+- **Global error dialog via `meta`** — `app.tsx` has a `QueryCache.onError` handler that shows an error dialog when `query.meta?.showErrorDialog` is truthy. When adding a new `useQuery` that fetches primary page data (e.g. table rows, list data), add `meta: { showErrorDialog: true }` to the query options.
+- **Do NOT add** `showErrorDialog` to minor/auxiliary queries (feature flags, piece metadata, single-item fetches, filter options, user details). These should fail silently.
+- Rule of thumb: if the query failure would leave the user staring at an empty table or blank page with no explanation, it should have `meta: { showErrorDialog: true }`.
 
 ## Git Push
 

--- a/packages/web/AGENTS.md
+++ b/packages/web/AGENTS.md
@@ -81,7 +81,7 @@ You are working in the Activepieces web application (`packages/web`).
 
 ## Query Feature Guards
 
-When a server endpoint is gated by `platformMustHaveFeatureEnabled` (returns HTTP 402 `FEATURE_DISABLED` when the plan lacks the feature), the corresponding `useQuery` hook **must** include `enabled: platform.plan.<flag>` so the request never fires when the feature is off. Without this, the global `QueryCache.onError` handler in `app.tsx` shows a misleading "Failed to load data" error dialog.
+When a server endpoint is gated by `platformMustHaveFeatureEnabled` (returns HTTP 402 `FEATURE_DISABLED` when the plan lacks the feature), the corresponding `useQuery` hook **must** include `enabled: platform.plan.<flag>` so the request never fires when the feature is off. Without this, queries with `meta: { showErrorDialog: true }` will trigger a misleading "Failed to load data" error dialog via the global `QueryCache.onError` handler in `app.tsx`.
 
 **Pattern** (see `secret-managers-hooks.ts`):
 ```ts

--- a/packages/web/src/app/app.tsx
+++ b/packages/web/src/app/app.tsx
@@ -24,35 +24,10 @@ import { EmbeddingFontLoader } from './components/embedding-font-loader';
 import { InitialDataGuard } from './components/initial-data-guard';
 import { ApRouter } from './guards';
 
-const MAJOR_QUERY_PREFIXES = new Set([
-  'audit-logs',
-  'project-releases',
-  'users',
-  'platform-invitations',
-  'app-connections',
-  'globalConnections',
-  'project-members',
-  'user-invitations',
-  'secret-managers',
-  'pieces-table',
-  'templates',
-  'flow-run-table',
-  'trigger-status-report',
-  'flows',
-  'folders',
-  'all-folder-contents',
-  'root-flows',
-  'root-tables',
-  'tables',
-  'user-leaderboard',
-  'project-leaderboard',
-]);
-
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error, query) => {
-      const prefix = query.queryKey[0];
-      if (typeof prefix === 'string' && MAJOR_QUERY_PREFIXES.has(prefix)) {
+      if (query.meta?.showErrorDialog) {
         const { openDialog } = useApErrorDialogStore.getState();
         openDialog({
           title: t('Failed to load data'),

--- a/packages/web/src/app/routes/platform/setup/templates/index.tsx
+++ b/packages/web/src/app/routes/platform/setup/templates/index.tsx
@@ -40,6 +40,7 @@ const PlatformTemplatesPage = () => {
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['templates', searchParams.toString()],
     staleTime: 0,
+    meta: { showErrorDialog: true },
     queryFn: () => {
       return templatesApi.list({
         type: TemplateType.CUSTOM,

--- a/packages/web/src/features/agents/hooks/agent-hooks.ts
+++ b/packages/web/src/features/agents/hooks/agent-hooks.ts
@@ -21,6 +21,7 @@ export const agentQueries = {
           projectId: projectId!,
         });
       },
+      meta: { showErrorDialog: true },
     });
   },
 };

--- a/packages/web/src/features/automations/hooks/use-automations-data.ts
+++ b/packages/web/src/features/automations/hooks/use-automations-data.ts
@@ -48,6 +48,7 @@ export function useAutomationsData(
     queryFn: () => foldersApi.list(),
     staleTime: STALE_TIME,
     refetchOnMount: 'always',
+    meta: { showErrorDialog: true },
   });
 
   const folderIds = foldersQuery.data?.map((f) => f.id).join(',') ?? '';
@@ -107,6 +108,7 @@ export function useAutomationsData(
     enabled: !!foldersQuery.data && foldersQuery.data.length > 0,
     staleTime: STALE_TIME,
     refetchOnMount: 'always',
+    meta: { showErrorDialog: true },
   });
 
   const skipFlows =
@@ -135,6 +137,7 @@ export function useAutomationsData(
     enabled: !skipFlows,
     staleTime: STALE_TIME,
     refetchOnMount: 'always',
+    meta: { showErrorDialog: true },
   });
 
   const rootTablesQuery = useQuery({
@@ -150,6 +153,7 @@ export function useAutomationsData(
     enabled: !skipTables,
     staleTime: STALE_TIME,
     refetchOnMount: 'always',
+    meta: { showErrorDialog: true },
   });
 
   const toggleFolder = useCallback((folderId: string) => {

--- a/packages/web/src/features/connections/hooks/app-connections-hooks.ts
+++ b/packages/web/src/features/connections/hooks/app-connections-hooks.ts
@@ -280,6 +280,7 @@ export const appConnectionsQueries = {
   }: UseConnectionsProps) => {
     return useQuery({
       queryKey: ['app-connections', ...extraKeys],
+      meta: { showErrorDialog: true },
       queryFn: async () => {
         const connections = await appConnectionsApi.list(request);
         if (pieceAuth) {

--- a/packages/web/src/features/connections/hooks/global-connections-hooks.ts
+++ b/packages/web/src/features/connections/hooks/global-connections-hooks.ts
@@ -42,6 +42,7 @@ export const globalConnectionsQueries = {
       staleTime,
       gcTime,
       enabled: platform.plan.globalConnectionsEnabled,
+      meta: { showErrorDialog: true },
       queryFn: () => {
         return globalConnectionsApi.list(request);
       },

--- a/packages/web/src/features/flow-runs/components/runs-table/index.tsx
+++ b/packages/web/src/features/flow-runs/components/runs-table/index.tsx
@@ -74,6 +74,7 @@ export const RunsTable = () => {
     queryKey: ['flow-run-table', searchParams.toString(), projectId],
     staleTime: 0,
     gcTime: 0,
+    meta: { showErrorDialog: true },
     queryFn: () => {
       const status = searchParams.getAll('status') as FlowRunStatus[];
       const flowId = searchParams.getAll('flowId');

--- a/packages/web/src/features/flows/api/trigger-run-api.ts
+++ b/packages/web/src/features/flows/api/trigger-run-api.ts
@@ -14,6 +14,7 @@ export const triggerRunHooks = {
     return useQuery({
       queryKey: ['trigger-status-report'],
       queryFn: triggerRunApi.getStatusReport,
+      meta: { showErrorDialog: true },
     });
   },
 };

--- a/packages/web/src/features/folders/hooks/folders-hooks.ts
+++ b/packages/web/src/features/folders/hooks/folders-hooks.ts
@@ -10,6 +10,7 @@ export const foldersHooks = {
     const folderQuery = useQuery({
       queryKey: ['folders', authenticationSession.getProjectId()],
       queryFn: () => foldersApi.list(),
+      meta: { showErrorDialog: true },
     });
     return {
       folders: folderQuery.data,

--- a/packages/web/src/features/members/hooks/project-members-hooks.ts
+++ b/packages/web/src/features/members/hooks/project-members-hooks.ts
@@ -17,6 +17,7 @@ export const projectMembersHooks = {
     const { platform } = platformHooks.useCurrentPlatform();
     const query = useQuery<ProjectMemberWithUser[]>({
       queryKey: ['project-members', authenticationSession.getProjectId()],
+      meta: { showErrorDialog: true },
       queryFn: async () => {
         const projectId = authenticationSession.getProjectId();
         assertNotNullOrUndefined(projectId, 'Project ID is null');

--- a/packages/web/src/features/members/hooks/user-invitations-hooks.ts
+++ b/packages/web/src/features/members/hooks/user-invitations-hooks.ts
@@ -19,6 +19,7 @@ export const userInvitationsHooks = {
       },
       queryKey: [userInvitationsQueryKey],
       staleTime: 0,
+      meta: { showErrorDialog: true },
     });
     return {
       invitations: query.data,

--- a/packages/web/src/features/pieces/hooks/pieces-hooks.ts
+++ b/packages/web/src/features/pieces/hooks/pieces-hooks.ts
@@ -152,6 +152,7 @@ export const piecesHooks = {
           locale: i18n.language as LocalesEnum,
         }),
       staleTime: searchQuery ? 0 : Infinity,
+      meta: isTableQuery ? { showErrorDialog: true } : undefined,
     });
     return {
       pieces: query.data,

--- a/packages/web/src/features/platform-admin/hooks/analytics-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/analytics-hooks.ts
@@ -31,6 +31,7 @@ export const platformAnalyticsHooks = {
       queryKey: userLeaderboardQueryKey(timePeriod),
       queryFn: () => analyticsApi.getUserLeaderboard(timePeriod),
       enabled: platform.plan.analyticsEnabled,
+      meta: { showErrorDialog: true },
     });
 
     return {
@@ -47,6 +48,7 @@ export const platformAnalyticsHooks = {
       queryKey: projectLeaderboardQueryKey(timePeriod),
       queryFn: () => analyticsApi.getProjectLeaderboard(timePeriod),
       enabled: platform.plan.analyticsEnabled,
+      meta: { showErrorDialog: true },
     });
 
     return {

--- a/packages/web/src/features/platform-admin/hooks/audit-log-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/audit-log-hooks.ts
@@ -22,6 +22,7 @@ export const auditLogQueries = {
       staleTime: 0,
       gcTime: 0,
       enabled: platform.plan.auditLogEnabled,
+      meta: { showErrorDialog: true },
       queryFn: async () => {
         const cursor = searchParams.get(CURSOR_QUERY_PARAM);
         const limit = searchParams.get(LIMIT_QUERY_PARAM);

--- a/packages/web/src/features/platform-admin/hooks/platform-user-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/platform-user-hooks.ts
@@ -22,6 +22,7 @@ export const platformUserHooks = {
   useUsers: () => {
     return useQuery<SeekPage<UserWithMetaInformation>, Error>({
       queryKey: platformUserKeys.users,
+      meta: { showErrorDialog: true },
       queryFn: async () => {
         const results = await platformUserApi.list({
           limit: 2000,
@@ -44,6 +45,7 @@ export const platformUserHooks = {
       },
       queryKey: platformUserKeys.invitations,
       staleTime: 0,
+      meta: { showErrorDialog: true },
     });
   },
 };

--- a/packages/web/src/features/project-releases/hooks/project-release-hooks.ts
+++ b/packages/web/src/features/project-releases/hooks/project-release-hooks.ts
@@ -19,6 +19,7 @@ export const projectReleaseQueries = {
         projectReleaseApi.list({
           projectId: authenticationSession.getProjectId()!,
         }),
+      meta: { showErrorDialog: true },
     }),
   useProjectRelease: (releaseId: string, enabled: boolean) =>
     useQuery({

--- a/packages/web/src/features/secret-managers/hooks/secret-managers-hooks.ts
+++ b/packages/web/src/features/secret-managers/hooks/secret-managers-hooks.ts
@@ -32,6 +32,7 @@ export const secretManagersHooks = {
         return result.data;
       },
       enabled: platform.plan.secretManagersEnabled,
+      meta: { showErrorDialog: true },
     });
   },
   useCreateSecretManagerConnection: ({

--- a/packages/web/src/features/tables/hooks/table-hooks.ts
+++ b/packages/web/src/features/tables/hooks/table-hooks.ts
@@ -50,6 +50,7 @@ export const tableHooks = {
             : undefined,
           name: searchParams.get('name') ?? undefined,
         }),
+      meta: { showErrorDialog: true },
     });
   },
   useCreateTable: (folderId: string) => {

--- a/packages/web/src/features/templates/hooks/templates-hook.ts
+++ b/packages/web/src/features/templates/hooks/templates-hook.ts
@@ -36,6 +36,7 @@ export const templatesHooks = {
         return result.data;
       },
       staleTime: 5 * 60 * 1000,
+      meta: { showErrorDialog: true },
     });
   },
 
@@ -58,6 +59,7 @@ export const templatesHooks = {
         return templates.data;
       },
       staleTime: 5 * 60 * 1000,
+      meta: { showErrorDialog: true },
     });
 
     const setSearch = (newSearch: string) => {

--- a/packages/web/src/hooks/platform-user-hooks.ts
+++ b/packages/web/src/hooks/platform-user-hooks.ts
@@ -7,6 +7,7 @@ export const platformUserHooks = {
   useUsers: () => {
     return useQuery<SeekPage<UserWithMetaInformation>, Error>({
       queryKey: ['users'],
+      meta: { showErrorDialog: true },
       queryFn: async () => {
         const results = await platformUserApi.list({
           limit: 2000,


### PR DESCRIPTION
## Summary
- Removes the global `MAJOR_QUERY_PREFIXES` set (21 entries) from `app.tsx`
- Switches `QueryCache.onError` to check `query.meta?.showErrorDialog` instead
- Adds `meta: { showErrorDialog: true }` to each core table query that was previously in the set
- Updates `CLAUDE.md` and `packages/web/CLAUDE.md` docs to reflect the new pattern

## Test plan
- [ ] Trigger a query failure on flows page → error dialog should appear
- [ ] Trigger a failure on a minor query (e.g. feature flag check) → no dialog
- [ ] Verify all major data table pages still show the error dialog on fetch failure