### PR TITLE
fix(web): add loadSubsetOptions to major query meta

### DIFF
--- a/packages/web/src/app/routes/platform/setup/templates/index.tsx
+++ b/packages/web/src/app/routes/platform/setup/templates/index.tsx
@@ -40,7 +40,7 @@ const PlatformTemplatesPage = () => {
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['templates', searchParams.toString()],
     staleTime: 0,
-    meta: { showErrorDialog: true },
+    meta: { showErrorDialog: true, loadSubsetOptions: {} },
     queryFn: () => {
       return templatesApi.list({
         type: TemplateType.CUSTOM,

--- a/packages/web/src/features/agents/hooks/agent-hooks.ts
+++ b/packages/web/src/features/agents/hooks/agent-hooks.ts
@@ -21,7 +21,7 @@ export const agentQueries = {
           projectId: projectId!,
         });
       },
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
   },
 };

--- a/packages/web/src/features/automations/hooks/use-automations-data.ts
+++ b/packages/web/src/features/automations/hooks/use-automations-data.ts
@@ -48,7 +48,7 @@ export function useAutomationsData(
     queryFn: () => foldersApi.list(),
     staleTime: STALE_TIME,
     refetchOnMount: 'always',
-    meta: { showErrorDialog: true },
+    meta: { showErrorDialog: true, loadSubsetOptions: {} },
   });
 
   const folderIds = foldersQuery.data?.map((f) => f.id).join(',') ?? '';
@@ -108,7 +108,7 @@ export function useAutomationsData(
     enabled: !!foldersQuery.data && foldersQuery.data.length > 0,
     staleTime: STALE_TIME,
     refetchOnMount: 'always',
-    meta: { showErrorDialog: true },
+    meta: { showErrorDialog: true, loadSubsetOptions: {} },
   });
 
   const skipFlows =
@@ -137,7 +137,7 @@ export function useAutomationsData(
     enabled: !skipFlows,
     staleTime: STALE_TIME,
     refetchOnMount: 'always',
-    meta: { showErrorDialog: true },
+    meta: { showErrorDialog: true, loadSubsetOptions: {} },
   });
 
   const rootTablesQuery = useQuery({
@@ -153,7 +153,7 @@ export function useAutomationsData(
     enabled: !skipTables,
     staleTime: STALE_TIME,
     refetchOnMount: 'always',
-    meta: { showErrorDialog: true },
+    meta: { showErrorDialog: true, loadSubsetOptions: {} },
   });
 
   const toggleFolder = useCallback((folderId: string) => {

--- a/packages/web/src/features/connections/hooks/app-connections-hooks.ts
+++ b/packages/web/src/features/connections/hooks/app-connections-hooks.ts
@@ -280,7 +280,7 @@ export const appConnectionsQueries = {
   }: UseConnectionsProps) => {
     return useQuery({
       queryKey: ['app-connections', ...extraKeys],
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
       queryFn: async () => {
         const connections = await appConnectionsApi.list(request);
         if (pieceAuth) {

--- a/packages/web/src/features/connections/hooks/global-connections-hooks.ts
+++ b/packages/web/src/features/connections/hooks/global-connections-hooks.ts
@@ -42,7 +42,7 @@ export const globalConnectionsQueries = {
       staleTime,
       gcTime,
       enabled: platform.plan.globalConnectionsEnabled,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
       queryFn: () => {
         return globalConnectionsApi.list(request);
       },

--- a/packages/web/src/features/flow-runs/components/runs-table/index.tsx
+++ b/packages/web/src/features/flow-runs/components/runs-table/index.tsx
@@ -74,7 +74,7 @@ export const RunsTable = () => {
     queryKey: ['flow-run-table', searchParams.toString(), projectId],
     staleTime: 0,
     gcTime: 0,
-    meta: { showErrorDialog: true },
+    meta: { showErrorDialog: true, loadSubsetOptions: {} },
     queryFn: () => {
       const status = searchParams.getAll('status') as FlowRunStatus[];
       const flowId = searchParams.getAll('flowId');

--- a/packages/web/src/features/flows/api/trigger-run-api.ts
+++ b/packages/web/src/features/flows/api/trigger-run-api.ts
@@ -14,7 +14,7 @@ export const triggerRunHooks = {
     return useQuery({
       queryKey: ['trigger-status-report'],
       queryFn: triggerRunApi.getStatusReport,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
   },
 };

--- a/packages/web/src/features/folders/hooks/folders-hooks.ts
+++ b/packages/web/src/features/folders/hooks/folders-hooks.ts
@@ -10,7 +10,7 @@ export const foldersHooks = {
     const folderQuery = useQuery({
       queryKey: ['folders', authenticationSession.getProjectId()],
       queryFn: () => foldersApi.list(),
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
     return {
       folders: folderQuery.data,

--- a/packages/web/src/features/members/hooks/project-members-hooks.ts
+++ b/packages/web/src/features/members/hooks/project-members-hooks.ts
@@ -17,7 +17,7 @@ export const projectMembersHooks = {
     const { platform } = platformHooks.useCurrentPlatform();
     const query = useQuery<ProjectMemberWithUser[]>({
       queryKey: ['project-members', authenticationSession.getProjectId()],
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
       queryFn: async () => {
         const projectId = authenticationSession.getProjectId();
         assertNotNullOrUndefined(projectId, 'Project ID is null');

--- a/packages/web/src/features/members/hooks/user-invitations-hooks.ts
+++ b/packages/web/src/features/members/hooks/user-invitations-hooks.ts
@@ -19,7 +19,7 @@ export const userInvitationsHooks = {
       },
       queryKey: [userInvitationsQueryKey],
       staleTime: 0,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
     return {
       invitations: query.data,

--- a/packages/web/src/features/pieces/hooks/pieces-hooks.ts
+++ b/packages/web/src/features/pieces/hooks/pieces-hooks.ts
@@ -152,7 +152,9 @@ export const piecesHooks = {
           locale: i18n.language as LocalesEnum,
         }),
       staleTime: searchQuery ? 0 : Infinity,
-      meta: isTableQuery ? { showErrorDialog: true } : undefined,
+      meta: isTableQuery
+        ? { showErrorDialog: true, loadSubsetOptions: {} }
+        : undefined,
     });
     return {
       pieces: query.data,

--- a/packages/web/src/features/platform-admin/hooks/analytics-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/analytics-hooks.ts
@@ -31,7 +31,7 @@ export const platformAnalyticsHooks = {
       queryKey: userLeaderboardQueryKey(timePeriod),
       queryFn: () => analyticsApi.getUserLeaderboard(timePeriod),
       enabled: platform.plan.analyticsEnabled,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
 
     return {
@@ -48,7 +48,7 @@ export const platformAnalyticsHooks = {
       queryKey: projectLeaderboardQueryKey(timePeriod),
       queryFn: () => analyticsApi.getProjectLeaderboard(timePeriod),
       enabled: platform.plan.analyticsEnabled,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
 
     return {

--- a/packages/web/src/features/platform-admin/hooks/audit-log-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/audit-log-hooks.ts
@@ -22,7 +22,7 @@ export const auditLogQueries = {
       staleTime: 0,
       gcTime: 0,
       enabled: platform.plan.auditLogEnabled,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
       queryFn: async () => {
         const cursor = searchParams.get(CURSOR_QUERY_PARAM);
         const limit = searchParams.get(LIMIT_QUERY_PARAM);

--- a/packages/web/src/features/platform-admin/hooks/platform-user-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/platform-user-hooks.ts
@@ -22,7 +22,7 @@ export const platformUserHooks = {
   useUsers: () => {
     return useQuery<SeekPage<UserWithMetaInformation>, Error>({
       queryKey: platformUserKeys.users,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
       queryFn: async () => {
         const results = await platformUserApi.list({
           limit: 2000,
@@ -45,7 +45,7 @@ export const platformUserHooks = {
       },
       queryKey: platformUserKeys.invitations,
       staleTime: 0,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
   },
 };

--- a/packages/web/src/features/project-releases/hooks/project-release-hooks.ts
+++ b/packages/web/src/features/project-releases/hooks/project-release-hooks.ts
@@ -19,7 +19,7 @@ export const projectReleaseQueries = {
         projectReleaseApi.list({
           projectId: authenticationSession.getProjectId()!,
         }),
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     }),
   useProjectRelease: (releaseId: string, enabled: boolean) =>
     useQuery({

--- a/packages/web/src/features/secret-managers/hooks/secret-managers-hooks.ts
+++ b/packages/web/src/features/secret-managers/hooks/secret-managers-hooks.ts
@@ -32,7 +32,7 @@ export const secretManagersHooks = {
         return result.data;
       },
       enabled: platform.plan.secretManagersEnabled,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
   },
   useCreateSecretManagerConnection: ({

--- a/packages/web/src/features/tables/hooks/table-hooks.ts
+++ b/packages/web/src/features/tables/hooks/table-hooks.ts
@@ -50,7 +50,7 @@ export const tableHooks = {
             : undefined,
           name: searchParams.get('name') ?? undefined,
         }),
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
   },
   useCreateTable: (folderId: string) => {

--- a/packages/web/src/features/templates/hooks/templates-hook.ts
+++ b/packages/web/src/features/templates/hooks/templates-hook.ts
@@ -36,7 +36,7 @@ export const templatesHooks = {
         return result.data;
       },
       staleTime: 5 * 60 * 1000,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
   },
 
@@ -59,7 +59,7 @@ export const templatesHooks = {
         return templates.data;
       },
       staleTime: 5 * 60 * 1000,
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });
 
     const setSearch = (newSearch: string) => {

--- a/packages/web/src/hooks/platform-user-hooks.ts
+++ b/packages/web/src/hooks/platform-user-hooks.ts
@@ -7,7 +7,7 @@ export const platformUserHooks = {
   useUsers: () => {
     return useQuery<SeekPage<UserWithMetaInformation>, Error>({
       queryKey: ['users'],
-      meta: { showErrorDialog: true },
+      meta: { showErrorDialog: true, loadSubsetOptions: {} },
       queryFn: async () => {
         const results = await platformUserApi.list({
           limit: 2000,

--- a/packages/web/src/query-meta.d.ts
+++ b/packages/web/src/query-meta.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare module '@tanstack/query-db-collection' {
+  interface QueryCollectionMeta {
+    showErrorDialog?: boolean;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `loadSubsetOptions: {}` to all major query `meta` objects for consistency with `query-db-collection` integration
- Adds `query-meta.d.ts` module augmentation to declare `showErrorDialog` on `QueryCollectionMeta`

## Test plan
- [ ] Verify all pages with major queries load correctly
- [ ] Verify error dialogs still appear on query failures