### PR TITLE
fix(worker): fix sandbox memory leaks and add REUSE_SANDBOX override

### DIFF
--- a/packages/server/worker/src/lib/execute/sandbox-manager.ts
+++ b/packages/server/worker/src/lib/execute/sandbox-manager.ts
@@ -6,9 +6,9 @@ import { Sandbox } from '../sandbox/types'
 import { createSandboxForJob } from './create-sandbox-for-job'
 
 function canReuseSandbox(): boolean {
-    const workerGroupId = system.get(WorkerSystemProp.WORKER_GROUP_ID)
-    if (!isNil(workerGroupId)) {
-        return system.get(WorkerSystemProp.REUSE_SANDBOX) === 'true'
+    const reuseSandbox = system.get(WorkerSystemProp.REUSE_SANDBOX)
+    if (!isNil(reuseSandbox)) {
+        return reuseSandbox === 'true'
     }
     const settings = workerSettings.getSettings()
     if (settings.ENVIRONMENT === ApEnvironment.DEVELOPMENT) {

--- a/packages/server/worker/src/lib/sandbox/sandbox.ts
+++ b/packages/server/worker/src/lib/sandbox/sandbox.ts
@@ -135,35 +135,37 @@ export function createSandbox(
         execute: async (operationType: EngineOperationType, operation: EngineOperation, executeOptions: SandboxOptions) => {
             let killedByTimeout = false
             let timeout: NodeJS.Timeout | null = null
+            const executeSocket = connectedSocket
+            const executeProcess = childProcess
             const operationPromise = new Promise<SandboxResult>((resolve, reject) => {
-                assertNotNullOrUndefined(childProcess, 'Sandbox process should not be null')
-                assertNotNullOrUndefined(connectedSocket, 'Connected socket should not be null')
+                assertNotNullOrUndefined(executeProcess, 'Sandbox process should not be null')
+                assertNotNullOrUndefined(executeSocket, 'Connected socket should not be null')
 
                 let stdError = ''
                 let stdOut = ''
 
-                createNotifyServer<WorkerNotifyContract>(connectedSocket!, {
+                createNotifyServer<WorkerNotifyContract>(executeSocket, {
                     stdout: (input: EngineStdout) => {
-                        stdOut += input.message 
+                        stdOut += input.message
                     },
                     stderr: (input: EngineStderr) => {
-                        stdError += input.message 
+                        stdError += input.message
                     },
                 })
 
                 timeout = setTimeout(async () => {
                     killedByTimeout = true
                     log.debug({ sandboxId }, 'Killing sandbox by timeout')
-                    if (!isNil(childProcess)) {
-                        await killProcess(childProcess, log)
+                    if (!isNil(executeProcess)) {
+                        await killProcess(executeProcess, log)
                     }
                 }, executeOptions.timeoutInSeconds * 1000)
 
-                childProcess.on('error', (error) => {
+                executeProcess.on('error', (error) => {
                     log.error({ sandboxId, error: String(error) }, 'Sandbox process error')
                 })
 
-                childProcess.on('exit', (code, signal) => {
+                executeProcess.on('exit', (code, signal) => {
                     handleProcessExit(log, {
                         sandboxId,
                         operationType,
@@ -178,7 +180,7 @@ export function createSandbox(
 
                 log.debug({ sandboxId, operationType }, '[Sandbox] Executing operation via RPC')
                 const operationTimeoutMs = (executeOptions.timeoutInSeconds + 5) * 1000
-                const client = createRpcClient<EngineContract>(connectedSocket!, operationTimeoutMs)
+                const client = createRpcClient<EngineContract>(executeSocket, operationTimeoutMs)
                 client.executeOperation({ operationType, operation }).then((engineResponse: EngineResponse<unknown>) => {
                     resolve({ ...engineResponse, logs: buildLogs(stdOut, stdError) })
                 }).catch((error: unknown) => {
@@ -199,9 +201,9 @@ export function createSandbox(
                 if (!isNil(timeout)) {
                     clearTimeout(timeout)
                 }
-                connectedSocket?.removeAllListeners('rpc-notify')
-                childProcess?.removeAllListeners('exit')
-                childProcess?.removeAllListeners('error')
+                executeSocket?.removeAllListeners('rpc-notify')
+                executeProcess?.removeAllListeners('exit')
+                executeProcess?.removeAllListeners('error')
             }
         },
         isReady,

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -95,6 +95,13 @@ async function startPollingWorkers(apiClient: WorkerToApiContract): Promise<void
     polling = true
 
     const generation = connectionGeneration
+
+    if (sandboxManagers.length > 0) {
+        logger.info({ count: sandboxManagers.length }, 'Shutting down old sandbox managers before creating new ones')
+        await Promise.all(sandboxManagers.map((sm) => sm.shutdown(logger)))
+        sandboxManagers = []
+    }
+
     const rawConcurrency = Number(system.get(WorkerSystemProp.WORKER_CONCURRENCY) ?? '1')
     const concurrency = Number.isInteger(rawConcurrency) && rawConcurrency > 0 ? rawConcurrency : 1
     if (!Number.isInteger(rawConcurrency) || rawConcurrency < 1) {


### PR DESCRIPTION
## Summary
- Shut down old sandbox managers on socket reconnect to prevent leaked engine processes
- Capture socket/process refs at execute time so cleanup targets the correct objects
- Make `AP_REUSE_SANDBOX` a top-level override for all workers (not just group workers)

## Test plan
- [ ] Deploy to staging and verify no leaked engine child processes after socket reconnections
- [ ] Set `AP_REUSE_SANDBOX=false` and confirm engine process is killed after each execution
- [ ] Set `AP_REUSE_SANDBOX=true` and confirm engine process is reused across executions
- [ ] Monitor memory usage over time — should not grow unboundedly