### PR TITLE
fix(web): fix MCP project selector search and add type filter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8065,7 +8065,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.55.3",
+      "version": "0.57.0",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",

--- a/packages/web/src/app/routes/mcp-authorize/index.tsx
+++ b/packages/web/src/app/routes/mcp-authorize/index.tsx
@@ -33,6 +33,10 @@ function McpAuthorizePage() {
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const debouncedSetSearchValue = useDebouncedCallback(setSearchValue, 300);
   const isLoggedIn = authenticationSession.isLoggedIn();
+  const projectTypeOptions = [
+    { value: ProjectType.TEAM, label: t('Team') },
+    { value: ProjectType.PERSONAL, label: t('Personal') },
+  ];
 
   const { data: projectsPage, isLoading: projectsLoading } = useQuery({
     queryKey: ['mcp-authorize-projects', searchValue, selectedTypes],
@@ -115,7 +119,7 @@ function McpAuthorizePage() {
               <MultiSelectFilter
                 label={t('Type')}
                 icon={<FolderKanban className="size-4" />}
-                options={PROJECT_TYPE_OPTIONS}
+                options={projectTypeOptions}
                 selectedValues={selectedTypes}
                 onChange={setSelectedTypes}
               />
@@ -185,10 +189,5 @@ function decodeJwtClientName(token: string | null): string {
     return t('Unknown app');
   }
 }
-
-const PROJECT_TYPE_OPTIONS = [
-  { value: ProjectType.TEAM, label: 'Team' },
-  { value: ProjectType.PERSONAL, label: 'Personal' },
-];
 
 export { McpAuthorizePage };

--- a/packages/web/src/app/routes/mcp-authorize/index.tsx
+++ b/packages/web/src/app/routes/mcp-authorize/index.tsx
@@ -2,7 +2,7 @@ import { ProjectType, ProjectWithLimits, SeekPage } from '@activepieces/shared';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { jwtDecode } from 'jwt-decode';
-import { Blocks, Shield } from 'lucide-react';
+import { Blocks, FolderKanban, Shield } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Navigate, useSearchParams } from 'react-router-dom';
 import { useDebouncedCallback } from 'use-debounce';
@@ -18,6 +18,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { MultiSelectFilter } from '@/features/automations/components/multi-select-filter';
 import { api } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
 
@@ -29,17 +30,17 @@ function McpAuthorizePage() {
     string | undefined
   >(undefined);
   const [searchValue, setSearchValue] = useState('');
+  const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const debouncedSetSearchValue = useDebouncedCallback(setSearchValue, 300);
   const isLoggedIn = authenticationSession.isLoggedIn();
 
   const { data: projectsPage, isLoading: projectsLoading } = useQuery({
-    queryKey: ['mcp-authorize-projects', searchValue],
+    queryKey: ['mcp-authorize-projects', searchValue, selectedTypes],
     queryFn: () =>
       api.get<SeekPage<ProjectWithLimits>>('/v1/projects', {
-        params: {
-          limit: 1000,
-          ...(searchValue && { displayName: searchValue }),
-        },
+        limit: 1000,
+        ...(searchValue && { displayName: searchValue }),
+        ...(selectedTypes.length > 0 && { types: selectedTypes }),
       }),
     enabled: isLoggedIn && !!authRequestId,
   });
@@ -52,11 +53,13 @@ function McpAuthorizePage() {
     },
   });
 
-  const projects = projectsPage?.data ?? [];
-  const projectsMap = useMemo(
-    () => new Map(projects.map((p) => [p.id, p])),
-    [projectsPage?.data],
-  );
+  const { projectsMap, options } = useMemo(() => {
+    const list = projectsPage?.data ?? [];
+    return {
+      projectsMap: new Map(list.map((p) => [p.id, p])),
+      options: list.map((p) => ({ value: p.id, label: p.displayName })),
+    };
+  }, [projectsPage?.data]);
 
   if (!authRequestId) {
     return <Navigate to="/404" replace />;
@@ -105,12 +108,20 @@ function McpAuthorizePage() {
           </div>
 
           <div className="flex flex-col gap-2">
-            <label className="text-sm font-medium">{t('Select Project')}</label>
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">
+                {t('Select Project')}
+              </label>
+              <MultiSelectFilter
+                label={t('Type')}
+                icon={<FolderKanban className="size-4" />}
+                options={PROJECT_TYPE_OPTIONS}
+                selectedValues={selectedTypes}
+                onChange={setSelectedTypes}
+              />
+            </div>
             <SearchableSelect<string>
-              options={projects.map((project) => ({
-                value: project.id,
-                label: project.displayName,
-              }))}
+              options={options}
               onChange={(value) => setSelectedProjectId(value ?? undefined)}
               value={selectedProjectId}
               placeholder={t('Search projects...')}
@@ -121,14 +132,14 @@ function McpAuthorizePage() {
                 const project = projectsMap.get(String(value));
                 if (!project) return null;
                 return (
-                  <span className="flex w-full items-center justify-between gap-2">
+                  <div className="flex w-full items-center justify-between gap-2">
                     <span className="truncate">{project.displayName}</span>
                     <Badge variant="outline" className="shrink-0 text-[10px]">
                       {project.type === ProjectType.PERSONAL
                         ? t('Personal')
                         : t('Team')}
                     </Badge>
-                  </span>
+                  </div>
                 );
               }}
             />
@@ -174,5 +185,10 @@ function decodeJwtClientName(token: string | null): string {
     return t('Unknown app');
   }
 }
+
+const PROJECT_TYPE_OPTIONS = [
+  { value: ProjectType.TEAM, label: 'Team' },
+  { value: ProjectType.PERSONAL, label: 'Personal' },
+];
 
 export { McpAuthorizePage };


### PR DESCRIPTION
## Summary
- Fixed `api.get` call that wrapped query params in an extra `params` key, causing both `displayName` search and `limit` to be silently ignored by the backend
- Added project type filter using the existing `MultiSelectFilter` component (same pattern used in automations, connections, and flow runs pages)
- Consolidated `projectsMap` and `options` into a single `useMemo` for correct dependencies

## Test plan
- [x] Open `/mcp-authorize` page with a valid auth request
- [x] Verify search filters projects by name
- [x] Click "Type" filter button and select "Team" — verify only team projects show
- [x] Select a project and click Authorize — verify it works