### PR TITLE
fix(pieces/amazon-textract): clarify that direct file upload only sup…

### DIFF
--- a/packages/pieces/community/amazon-textract/package.json
+++ b/packages/pieces/community/amazon-textract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-textract",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document.ts
@@ -16,7 +16,7 @@ export const analyzeDocument = createAction({
   name: 'analyze-document',
   displayName: 'Analyze Document',
   description:
-    'Extract text, forms (key-value pairs), tables, and signatures from a document. Supports JPEG, PNG, PDF, and TIFF. For multi-page PDFs, use Start Document Analysis instead.',
+    'Extract text, forms (key-value pairs), tables, and signatures from a document. Supports JPEG and PNG via direct upload; PDF and TIFF via S3 only. For multi-page PDFs, use Start Document Analysis instead.',
   props: {
     source: Property.StaticDropdown({
       displayName: 'Document Source',

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document.ts
@@ -53,7 +53,7 @@ export const analyzeDocument = createAction({
         return {
           file: Property.File({
             displayName: 'File',
-            description: 'The document to analyze. Supported formats: JPEG, PNG, PDF (single page), TIFF. Maximum 10 MB.',
+            description: 'The document to analyze. Only JPEG and PNG are supported for direct upload (max 5 MB). For PDF or TIFF files, use the "From S3 bucket" option instead.',
             required: true,
           }),
         };

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-expense.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-expense.ts
@@ -50,7 +50,7 @@ export const analyzeExpense = createAction({
         return {
           file: Property.File({
             displayName: 'File',
-            description: 'The receipt or invoice to analyze. Supported formats: JPEG, PNG, PDF (single page), TIFF. Maximum 10 MB.',
+            description: 'The receipt or invoice to analyze. Only JPEG and PNG are supported for direct upload (max 5 MB). For PDF or TIFF files, use the "From S3 bucket" option instead.',
             required: true,
           }),
         };

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-id.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-id.ts
@@ -42,7 +42,7 @@ export const analyzeId = createAction({
             }),
             s3Key: Property.ShortText({
               displayName: 'S3 File Path',
-              description: 'The path to the file in your S3 bucket (e.g. "id-documents/passport.jpg").',
+              description: 'The path to the image in your S3 bucket (e.g. "id-documents/passport.jpg"). Only JPEG and PNG are supported — PDF and TIFF are not accepted by this action.',
               required: true,
             }),
           };
@@ -50,7 +50,7 @@ export const analyzeId = createAction({
         return {
           file: Property.File({
             displayName: 'File',
-            description: 'The ID document to analyze. Only JPEG and PNG are supported for direct upload (max 5 MB). For PDF or TIFF files, use the "From S3 bucket" option instead.',
+            description: 'The ID document to analyze. Only JPEG and PNG are supported (max 5 MB). PDF and TIFF are not supported by this action.',
             required: true,
           }),
         };

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-id.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-id.ts
@@ -50,7 +50,7 @@ export const analyzeId = createAction({
         return {
           file: Property.File({
             displayName: 'File',
-            description: 'The ID document to analyze. Supported formats: JPEG, PNG, PDF (single page), TIFF. Maximum 10 MB.',
+            description: 'The ID document to analyze. Only JPEG and PNG are supported for direct upload (max 5 MB). For PDF or TIFF files, use the "From S3 bucket" option instead.',
             required: true,
           }),
         };

--- a/packages/pieces/community/amazon-textract/src/lib/actions/detect-document-text.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/detect-document-text.ts
@@ -51,7 +51,7 @@ export const detectDocumentText = createAction({
         return {
           file: Property.File({
             displayName: 'File',
-            description: 'The document to read. Supported formats: JPEG, PNG, PDF (single page), TIFF. Maximum 10 MB.',
+            description: 'The document to read. Only JPEG and PNG are supported for direct upload (max 5 MB). For PDF or TIFF files, use the "From S3 bucket" option instead.',
             required: true,
           }),
         };

--- a/packages/pieces/community/amazon-textract/src/lib/actions/detect-document-text.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/detect-document-text.ts
@@ -13,7 +13,7 @@ export const detectDocumentText = createAction({
   name: 'detect-document-text',
   displayName: 'Detect Document Text',
   description:
-    'Extract plain text from a document. Faster and cheaper than Analyze Document — use this when you only need the text content without forms or tables. Supports JPEG, PNG, PDF (single page), and TIFF.',
+    'Extract plain text from a document. Faster and cheaper than Analyze Document — use this when you only need the text content without forms or tables. Supports JPEG and PNG via direct upload; PDF and TIFF via S3 only.',
   props: {
     source: Property.StaticDropdown({
       displayName: 'Document Source',


### PR DESCRIPTION
…ports JPEG and PNG

AWS Textract only accepts JPEG and PNG when sending file bytes directly. PDF and TIFF require an S3 reference. Updated the file upload description on all four document actions to prevent the 'document format not supported' error customers were hitting when uploading PDFs.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
