### PR TITLE
fix: subflow e2e tests stale internalApiUrl

### DIFF
--- a/packages/server/worker/src/lib/config/configs.ts
+++ b/packages/server/worker/src/lib/config/configs.ts
@@ -6,7 +6,7 @@ const env = from(environmentMigrations.migrate())
 function getApiUrl(): string {
     const containerType = system.get(WorkerSystemProp.CONTAINER_TYPE) ?? 'WORKER_AND_APP'
     if (containerType === 'WORKER_AND_APP') {
-        const port = system.get(WorkerSystemProp.PORT)
+        const port = process.env[WorkerSystemProp.PORT] ?? system.get(WorkerSystemProp.PORT)
         return `http://127.0.0.1:${port}/api/`
     }
     const frontendUrl = system.getOrThrow(WorkerSystemProp.FRONTEND_URL).replace(/\/+$/, '')
@@ -16,7 +16,7 @@ function getApiUrl(): string {
 function getSocketUrl(): { url: string, path: string } {
     const containerType = system.get(WorkerSystemProp.CONTAINER_TYPE) ?? 'WORKER_AND_APP'
     if (containerType === 'WORKER_AND_APP') {
-        const port = system.get(WorkerSystemProp.PORT)
+        const port = process.env[WorkerSystemProp.PORT] ?? system.get(WorkerSystemProp.PORT)
         return { url: `http://127.0.0.1:${port}`, path: '/api/socket.io' }
     }
     const frontendUrl = system.getOrThrow(WorkerSystemProp.FRONTEND_URL).replace(/\/+$/, '')


### PR DESCRIPTION
## Summary
- Fix subflow e2e tests failing because `getApiUrl()` / `getSocketUrl()` read `AP_PORT` from a stale env snapshot instead of live `process.env`
- The worker config snapshots env vars at module import time, before the test harness assigns the dynamic port, causing the engine to connect to port 3000 instead of the actual server port

## Test plan
- [x] All 6 tests in `execute-flow-e2e.test.ts` pass (including the 3 subflow tests that were failing)
- [x] Lint passes with no errors