### PR TITLE
feat(mcp): add schema introspection, CODE step support, and fix record empty fields

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",

--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -34,13 +34,25 @@ List available pieces with their actions and triggers. Required before adding or
 | `includeActions` | boolean | No | Include action details |
 | `includeTriggers` | boolean | No | Include trigger details |
 
+### ap_get_piece_props
+
+Get the detailed input property schema for a specific piece action or trigger. Returns field names, types, required/optional, descriptions, default values, and dropdown options. Use this before `ap_update_step` or `ap_update_trigger` to know exactly which fields to set.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pieceName` | string | Yes | Piece name (e.g., `@activepieces/piece-slack`) |
+| `actionOrTriggerName` | string | Yes | Action or trigger name (e.g., `send_channel_message`) |
+| `type` | string | Yes | `action` or `trigger` |
+
 ### ap_list_connections
 
 List OAuth/app connections in the project. Required before adding steps that need authentication.
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
-| — | — | — | No inputs required |
+| `pieceName` | string | No | Filter by piece name. Short names like `slack` or `google-sheets` are auto-expanded. |
+| `displayName` | string | No | Filter by connection display name (partial match) |
+| `status` | array | No | Filter by status: `ACTIVE`, `MISSING`, or `ERROR` |
 
 ### ap_list_ai_models
 
@@ -186,6 +198,8 @@ Update an existing step's settings. Auto-fills default values for optional prope
 | `auth` | string | No | Connection externalId |
 | `actionName` | string | No | For PIECE steps |
 | `loopItems` | string | No | For LOOP steps |
+| `sourceCode` | string | No | For CODE steps: JavaScript/TypeScript source code |
+| `packageJson` | string | No | For CODE steps: npm dependencies as JSON string |
 | `skip` | boolean | No | Skip this step |
 
 <Tip>

--- a/packages/server/api/src/app/mcp/oauth/client/mcp-oauth-register.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/client/mcp-oauth-register.controller.ts
@@ -19,6 +19,12 @@ export const mcpOAuthRegisterController: FastifyPluginAsyncZod = async (app) => 
     })
 }
 
+function isPrivateUseScheme(protocol: string): boolean {
+    const scheme = protocol.replace(/:$/, '')
+    return /^[a-z][a-z0-9+\-.]*\.[a-z][a-z0-9+\-.]*$/.test(scheme)
+        || ['cursor', 'vscode', 'vscode-insiders', 'windsurf', 'claude'].includes(scheme)
+}
+
 const RegisterRequest = {
     config: { security: securityAccess.public() },
     schema: {
@@ -26,8 +32,8 @@ const RegisterRequest = {
         body: z.object({
             redirect_uris: z.array(z.string().url().refine((uri) => {
                 const scheme = new URL(uri).protocol
-                return scheme === 'http:' || scheme === 'https:'
-            }, { message: 'Only http and https redirect URIs are allowed' })).min(1),
+                return scheme === 'http:' || scheme === 'https:' || isPrivateUseScheme(scheme)
+            }, { message: 'Only http, https, or private-use URI schemes (RFC 8252) are allowed' })).min(1),
             client_name: z.string().max(255).optional(),
             grant_types: z.array(z.string()).optional(),
             response_types: z.array(z.string()).optional(),

--- a/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
@@ -10,6 +10,25 @@ import { mcpOAuthTokenService } from './token/mcp-oauth-token.service'
 
 export const mcpOAuthHttpController: FastifyPluginAsyncZod = async (app) => {
 
+    app.addContentTypeParser(
+        'application/json',
+        { parseAs: 'string' },
+        (_req, body: string, done) => {
+            if (body == null || body.trim() === '') {
+                return done(null, {})
+            }
+
+            try {
+                done(null, JSON.parse(body))
+            }
+            catch (err) {
+                const error: Error & { statusCode?: number } = err instanceof Error ? err : new Error('JSON parsing failed')
+                error.statusCode = 400
+                done(error, undefined)
+            }
+        },
+    )
+
     app.get('/', McpEndpointConfig, async (_req, reply) => {
         return reply.status(405).send({
             error: 'Method Not Allowed',

--- a/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
@@ -13,7 +13,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const addBranchInput = z.object({
     flowId: z.string(),
@@ -98,7 +98,7 @@ export const apAddBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                 }
             }
             catch (err) {
-                return mcpToolError('Add branch failed', err)
+                return mcpUtils.mcpToolError('Add branch failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -16,7 +16,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const addStepInput = z.object({
     flowId: z.string(),
@@ -171,7 +171,7 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                 }
             }
             catch (err) {
-                return mcpToolError('Step add failed', err)
+                return mcpUtils.mcpToolError('Step add failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-change-flow-status.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-change-flow-status.ts
@@ -11,7 +11,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const changeFlowStatusInput = z.object({
     flowId: z.string(),
@@ -67,7 +67,7 @@ export const apChangeFlowStatusTool = (mcp: McpServer, log: FastifyBaseLogger): 
                 }
             }
             catch (err) {
-                return mcpToolError('Status change failed', err)
+                return mcpUtils.mcpToolError('Status change failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
@@ -2,7 +2,7 @@ import { McpServer, McpToolDefinition, Permission } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 export const apCreateFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
@@ -31,7 +31,7 @@ export const apCreateFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                return mcpToolError('Flow creation failed', err)
+                return mcpUtils.mcpToolError('Flow creation failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-create-table.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-create-table.ts
@@ -3,7 +3,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { fieldService } from '../../tables/field/field.service'
 import { tableService } from '../../tables/table/table.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 import { fieldTypeSchema, formatFieldInfo } from './table-utils'
 
 const createTableInput = z.object({
@@ -65,7 +65,7 @@ export const apCreateTableTool = (mcp: McpServer, log: FastifyBaseLogger): McpTo
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_create_table failed')
-                return mcpToolError('Failed to create table', err)
+                return mcpUtils.mcpToolError('Failed to create table', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-delete-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-branch.ts
@@ -12,7 +12,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const deleteBranchInput = z.object({
     flowId: z.string(),
@@ -91,7 +91,7 @@ export const apDeleteBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
                 }
             }
             catch (err) {
-                return mcpToolError('Delete branch failed', err)
+                return mcpUtils.mcpToolError('Delete branch failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-delete-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-records.ts
@@ -2,7 +2,7 @@ import { McpServer, McpToolDefinition, Permission } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { recordService } from '../../tables/record/record.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const deleteRecordsInput = z.object({
     recordIds: z.array(z.string()).describe('Array of record IDs to delete. Use ap_find_records to find them.'),
@@ -37,7 +37,7 @@ export const apDeleteRecordsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_delete_records failed')
-                return mcpToolError('Failed to delete records', err)
+                return mcpUtils.mcpToolError('Failed to delete records', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
@@ -11,7 +11,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const deleteStepInput = z.object({
     flowId: z.string(),
@@ -69,7 +69,7 @@ export const apDeleteStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                return mcpToolError('Step delete failed', err)
+                return mcpUtils.mcpToolError('Step delete failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-delete-table.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-table.ts
@@ -2,7 +2,7 @@ import { McpServer, McpToolDefinition, Permission } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { tableService } from '../../tables/table/table.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const deleteTableInput = z.object({
     tableId: z.string().describe('The ID of the table to delete. Use ap_list_tables to find it.'),
@@ -38,7 +38,7 @@ export const apDeleteTableTool = (mcp: McpServer, log: FastifyBaseLogger): McpTo
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_delete_table failed')
-                return mcpToolError('Failed to delete table', err)
+                return mcpUtils.mcpToolError('Failed to delete table', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-find-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-find-records.ts
@@ -2,7 +2,7 @@ import { FilterOperator, McpServer, McpToolDefinition, Permission } from '@activ
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { recordService } from '../../tables/record/record.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 import { formatPopulatedRecord, resolveFieldNamesForTable } from './table-utils'
 
 const OPERATOR_VALUES = [
@@ -90,7 +90,7 @@ export const apFindRecordsTool = (mcp: McpServer, log: FastifyBaseLogger): McpTo
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_find_records failed')
-                return mcpToolError('Failed to find records', err)
+                return mcpUtils.mcpToolError('Failed to find records', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
@@ -15,7 +15,7 @@ import type { Step } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 type StepInfo = {
     name: string
@@ -245,7 +245,7 @@ export const apFlowStructureTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 return { content: [{ type: 'text', text }] }
             }
             catch (err) {
-                return mcpToolError('Failed to get flow structure', err)
+                return mcpUtils.mcpToolError('Failed to get flow structure', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -6,13 +6,7 @@ import {
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
-import { buildPropSummaries, mcpToolError } from './mcp-utils'
-
-const getPiecePropsInput = z.object({
-    pieceName: z.string().describe('The piece name (e.g. "@activepieces/piece-slack"). Use ap_list_pieces to get valid values.'),
-    actionOrTriggerName: z.string().describe('The action or trigger name (e.g. "send_channel_message"). Use ap_list_pieces with includeActions=true or includeTriggers=true to get valid values.'),
-    type: z.enum(['action', 'trigger']).describe('Whether to look up an action or a trigger.'),
-})
+import { mcpUtils } from './mcp-utils'
 
 export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
@@ -45,7 +39,7 @@ export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                     }
                 }
 
-                const props = buildPropSummaries(component.props)
+                const props = mcpUtils.buildPropSummaries(component.props)
                 const requiresAuth = component.requireAuth && !isNil(piece.auth)
 
                 const result = {
@@ -62,8 +56,14 @@ export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 }
             }
             catch (err) {
-                return mcpToolError('Failed to get piece props', err)
+                return mcpUtils.mcpToolError('Failed to get piece props', err)
             }
         },
     }
 }
+
+const getPiecePropsInput = z.object({
+    pieceName: z.string().describe('The piece name (e.g. "@activepieces/piece-slack"). Use ap_list_pieces to get valid values.'),
+    actionOrTriggerName: z.string().describe('The action or trigger name (e.g. "send_channel_message"). Use ap_list_pieces with includeActions=true or includeTriggers=true to get valid values.'),
+    type: z.enum(['action', 'trigger']).describe('Whether to look up an action or a trigger.'),
+})

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -1,0 +1,69 @@
+import {
+    isNil,
+    McpServer,
+    McpToolDefinition,
+} from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
+import { buildPropSummaries, mcpToolError } from './mcp-utils'
+
+const getPiecePropsInput = z.object({
+    pieceName: z.string().describe('The piece name (e.g. "@activepieces/piece-slack"). Use ap_list_pieces to get valid values.'),
+    actionOrTriggerName: z.string().describe('The action or trigger name (e.g. "send_channel_message"). Use ap_list_pieces with includeActions=true or includeTriggers=true to get valid values.'),
+    type: z.enum(['action', 'trigger']).describe('Whether to look up an action or a trigger.'),
+})
+
+export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_get_piece_props',
+        description: 'Get the detailed input property schema for a specific piece action or trigger. Returns field names, types, required/optional, descriptions, default values, and dropdown options. Use this before ap_update_step or ap_update_trigger to know exactly which fields to set and what values are accepted.',
+        inputSchema: getPiecePropsInput.shape,
+        annotations: { readOnlyHint: true, openWorldHint: false },
+        execute: async (args) => {
+            try {
+                const { pieceName, actionOrTriggerName, type } = getPiecePropsInput.parse(args)
+
+                const piece = await pieceMetadataService(log).get({
+                    name: pieceName,
+                    projectId: mcp.projectId,
+                })
+
+                if (isNil(piece)) {
+                    return { content: [{ type: 'text', text: `❌ Piece "${pieceName}" not found. Use ap_list_pieces to get valid piece names.` }] }
+                }
+
+                const componentMap = type === 'action' ? piece.actions : piece.triggers
+                const label = type === 'action' ? 'Action' : 'Trigger'
+                const component = componentMap[actionOrTriggerName]
+                if (isNil(component)) {
+                    return {
+                        content: [{
+                            type: 'text',
+                            text: `❌ ${label} "${actionOrTriggerName}" not found in "${pieceName}". Available: ${Object.keys(componentMap).join(', ')}`,
+                        }],
+                    }
+                }
+
+                const props = buildPropSummaries(component.props)
+                const requiresAuth = component.requireAuth && !isNil(piece.auth)
+
+                const result = {
+                    piece: pieceName,
+                    name: component.name,
+                    displayName: component.displayName,
+                    description: component.description,
+                    requiresAuth,
+                    props,
+                }
+
+                return {
+                    content: [{ type: 'text', text: `✅ ${label} schema for "${pieceName}/${actionOrTriggerName}":\n${JSON.stringify(result, null, 2)}` }],
+                }
+            }
+            catch (err) {
+                return mcpToolError('Failed to get piece props', err)
+            }
+        },
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/ap-get-run.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-run.ts
@@ -3,7 +3,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowRunService } from '../../flows/flow-run/flow-run-service'
 import { formatRunResult } from './flow-run-utils'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const getRunInput = z.object({
     flowRunId: z.string().describe('The ID of the flow run. Use ap_list_runs to find it.'),
@@ -34,7 +34,7 @@ export const apGetRunTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDef
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_get_run failed')
-                return mcpToolError('Failed to get run', err)
+                return mcpUtils.mcpToolError('Failed to get run', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-insert-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-insert-records.ts
@@ -2,7 +2,7 @@ import { McpServer, McpToolDefinition, Permission } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { recordService } from '../../tables/record/record.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 import { resolveFieldNamesForTable } from './table-utils'
 
 const insertRecordsInput = z.object({
@@ -50,7 +50,7 @@ export const apInsertRecordsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_insert_records failed')
-                return mcpToolError('Failed to insert records', err)
+                return mcpUtils.mcpToolError('Failed to insert records', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-list-ai-models.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-ai-models.ts
@@ -3,7 +3,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { aiProviderService } from '../../ai/ai-provider-service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const providerSchema = z.enum(Object.values(AIProviderName) as [AIProviderName, ...AIProviderName[]])
 
@@ -69,7 +69,7 @@ export const apListAiModelsTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_list_ai_models failed')
-                return mcpToolError('Failed to list AI models', err)
+                return mcpUtils.mcpToolError('Failed to list AI models', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
@@ -8,7 +8,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { appConnectionService } from '../../app-connection/app-connection-service/app-connection-service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpToolError, normalizePieceName } from './mcp-utils'
 
 const statusEnum = z.enum(Object.values(AppConnectionStatus) as [AppConnectionStatus, ...AppConnectionStatus[]])
 
@@ -17,7 +17,7 @@ const listConnectionsSchema = z.object({
         .string()
         .optional()
         .describe(
-            'Filter by piece/app name (exact match). Examples: "google_drive", "slack", "notion". Use when you need connections for a specific integration.',
+            'Filter by piece name. Short names like "slack" or "google-drive" are auto-expanded to full format (e.g. "@activepieces/piece-slack"). You can also pass the full name directly.',
         ),
     displayName: z
         .string()
@@ -56,7 +56,7 @@ export const apListConnectionsTool = (mcp: McpServer, log: FastifyBaseLogger): M
                     scope: undefined,
                     displayName: params.displayName,
                     status: params.status,
-                    pieceName: params.pieceName,
+                    pieceName: normalizePieceName(params.pieceName),
                     limit: 200,
                     externalIds: undefined,
                 })

--- a/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
@@ -8,7 +8,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { appConnectionService } from '../../app-connection/app-connection-service/app-connection-service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError, normalizePieceName } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const statusEnum = z.enum(Object.values(AppConnectionStatus) as [AppConnectionStatus, ...AppConnectionStatus[]])
 
@@ -56,7 +56,7 @@ export const apListConnectionsTool = (mcp: McpServer, log: FastifyBaseLogger): M
                     scope: undefined,
                     displayName: params.displayName,
                     status: params.status,
-                    pieceName: normalizePieceName(params.pieceName),
+                    pieceName: mcpUtils.normalizePieceName(params.pieceName),
                     limit: 200,
                     externalIds: undefined,
                 })
@@ -69,7 +69,7 @@ export const apListConnectionsTool = (mcp: McpServer, log: FastifyBaseLogger): M
                 }
             }
             catch (err) {
-                return mcpToolError('Failed to list connections', err)
+                return mcpUtils.mcpToolError('Failed to list connections', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
@@ -1,7 +1,7 @@
 import { FlowTriggerType, isNil, McpServer, McpToolDefinition, Permission, PopulatedFlow } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { flowService } from '../../flows/flow/flow.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 export const apListFlowsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
@@ -26,7 +26,7 @@ export const apListFlowsTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                 }
             }
             catch (err) {
-                return mcpToolError('Failed to list flows', err)
+                return mcpUtils.mcpToolError('Failed to list flows', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
@@ -1,4 +1,3 @@
-import { PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
 import {
     LocalesEnum,
     McpServer,
@@ -9,7 +8,7 @@ import {
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
-import { AUTH_PROP_TYPES, mcpToolError } from './mcp-utils'
+import { buildPropSummaries, mcpToolError } from './mcp-utils'
 
 const listPiecesSchema = z.object({
     categories: z.array(z.enum(Object.values(PieceCategory) as [string, ...string[]])).optional(),
@@ -81,7 +80,7 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                                 displayName: a.displayName,
                                 description: a.description,
                                 requireAuth: a.requireAuth,
-                                ...summarizeProps(a.props),
+                                inputProps: buildPropSummaries(a.props),
                             }))
                         }
                         if (params.includeTriggers) {
@@ -90,7 +89,7 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                                 displayName: t.displayName,
                                 description: t.description,
                                 requireAuth: t.requireAuth,
-                                ...summarizeProps(t.props),
+                                inputProps: buildPropSummaries(t.props),
                             }))
                         }
                     }
@@ -109,38 +108,4 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
             }
         },
     }
-}
-
-function summarizeProps(props: PiecePropertyMap): { inputProps: PropSummary[] } {
-    const entries = Object.entries(props)
-        .filter(([, prop]) => !AUTH_PROP_TYPES.has(prop.type))
-        .map(([name, prop]) => {
-            const summary: PropSummary = {
-                name,
-                type: prop.type,
-                required: prop.required ?? false,
-                displayName: prop.displayName ?? name,
-            }
-            if (prop.description) {
-                summary.description = prop.description
-            }
-            if (prop.defaultValue !== undefined) {
-                summary.defaultValue = prop.defaultValue
-            }
-            if ((prop.type === PropertyType.STATIC_DROPDOWN || prop.type === PropertyType.STATIC_MULTI_SELECT_DROPDOWN) && 'options' in prop && prop.options?.options) {
-                summary.options = prop.options.options.map((o: { label: string }) => o.label)
-            }
-            return summary
-        })
-    return { inputProps: entries }
-}
-
-type PropSummary = {
-    name: string
-    type: string
-    required: boolean
-    displayName: string
-    description?: string
-    defaultValue?: unknown
-    options?: string[]
 }

--- a/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
@@ -8,7 +8,7 @@ import {
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
-import { buildPropSummaries, mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const listPiecesSchema = z.object({
     categories: z.array(z.enum(Object.values(PieceCategory) as [string, ...string[]])).optional(),
@@ -80,7 +80,7 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                                 displayName: a.displayName,
                                 description: a.description,
                                 requireAuth: a.requireAuth,
-                                inputProps: buildPropSummaries(a.props),
+                                inputProps: mcpUtils.buildPropSummaries(a.props),
                             }))
                         }
                         if (params.includeTriggers) {
@@ -89,7 +89,7 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                                 displayName: t.displayName,
                                 description: t.description,
                                 requireAuth: t.requireAuth,
-                                inputProps: buildPropSummaries(t.props),
+                                inputProps: mcpUtils.buildPropSummaries(t.props),
                             }))
                         }
                     }
@@ -104,7 +104,7 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                return mcpToolError('Failed to list pieces', err)
+                return mcpUtils.mcpToolError('Failed to list pieces', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
@@ -3,7 +3,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowRunService } from '../../flows/flow-run/flow-run-service'
 import { formatRunSummary } from './flow-run-utils'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const runStatusValues = Object.values(FlowRunStatus) as [FlowRunStatus, ...FlowRunStatus[]]
 
@@ -46,7 +46,7 @@ export const apListRunsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolD
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_list_runs failed')
-                return mcpToolError('Failed to list runs', err)
+                return mcpUtils.mcpToolError('Failed to list runs', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-list-tables.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-tables.ts
@@ -2,7 +2,7 @@ import { McpServer, McpToolDefinition, Permission } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { fieldService } from '../../tables/field/field.service'
 import { tableService } from '../../tables/table/table.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 import { formatFieldInfo } from './table-utils'
 
 export const apListTablesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
@@ -54,7 +54,7 @@ export const apListTablesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_list_tables failed')
-                return mcpToolError('Failed to list tables', err)
+                return mcpUtils.mcpToolError('Failed to list tables', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-lock-and-publish.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-lock-and-publish.ts
@@ -12,7 +12,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const lockAndPublishInput = z.object({
     flowId: z.string(),
@@ -68,7 +68,7 @@ export const apLockAndPublishTool = (mcp: McpServer, log: FastifyBaseLogger): Mc
                 }
             }
             catch (err) {
-                return mcpToolError('Publish failed', err)
+                return mcpUtils.mcpToolError('Publish failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-manage-fields.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-manage-fields.ts
@@ -2,7 +2,7 @@ import { FieldType, isNil, McpServer, McpToolDefinition, Permission } from '@act
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { fieldService } from '../../tables/field/field.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 import { fieldTypeSchema, formatFieldInfo } from './table-utils'
 
 const manageFieldsInput = z.object({
@@ -83,7 +83,7 @@ export const apManageFieldsTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_manage_fields failed')
-                return mcpToolError('Field operation failed', err)
+                return mcpUtils.mcpToolError('Field operation failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-manage-notes.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-manage-notes.ts
@@ -12,7 +12,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const manageNotesInput = z.object({
     flowId: z.string(),
@@ -138,7 +138,7 @@ export const apManageNotesTool = (mcp: McpServer, log: FastifyBaseLogger): McpTo
                 return { content: [{ type: 'text', text: messages[op] }] }
             }
             catch (err) {
-                return mcpToolError('Note operation failed', err)
+                return mcpUtils.mcpToolError('Note operation failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-rename-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-rename-flow.ts
@@ -10,7 +10,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const renameFlowInput = z.object({
     flowId: z.string(),
@@ -56,7 +56,7 @@ export const apRenameFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                return mcpToolError('Flow rename failed', err)
+                return mcpUtils.mcpToolError('Flow rename failed', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-retry-run.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-retry-run.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { flowRunService } from '../../flows/flow-run/flow-run-service'
 import { formatRunResult, pollForRunCompletion } from './flow-run-utils'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const retryStrategyValues = Object.values(FlowRetryStrategy) as [FlowRetryStrategy, ...FlowRetryStrategy[]]
 
@@ -62,7 +62,7 @@ export const apRetryRunTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolD
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_retry_run failed')
-                return mcpToolError('Failed to retry run', err)
+                return mcpUtils.mcpToolError('Failed to retry run', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { aiProviderService } from '../../ai/ai-provider-service'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { projectService } from '../../project/project-service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const setupGuideInput = z.object({
     topic: z.enum(['connection', 'ai_provider']).describe('What to get setup instructions for'),
@@ -29,7 +29,7 @@ export const apSetupGuideTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_setup_guide failed')
-                return mcpToolError('Failed to generate setup guide', err)
+                return mcpUtils.mcpToolError('Failed to generate setup guide', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-test-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-test-flow.ts
@@ -2,7 +2,7 @@ import { McpServer, McpToolDefinition, Permission } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { executeFlowTest } from './flow-run-utils'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const testFlowInput = z.object({
     flowId: z.string().describe('The ID of the flow to test. Use ap_list_flows to find it.'),
@@ -22,7 +22,7 @@ export const apTestFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolD
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_test_flow failed')
-                return mcpToolError('Failed to test flow', err)
+                return mcpUtils.mcpToolError('Failed to test flow', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-test-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-test-step.ts
@@ -2,7 +2,7 @@ import { McpServer, McpToolDefinition, Permission } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { executeFlowTest } from './flow-run-utils'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const testStepInput = z.object({
     flowId: z.string().describe('The ID of the flow containing the step. Use ap_list_flows to find it.'),
@@ -23,7 +23,7 @@ export const apTestStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolD
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_test_step failed')
-                return mcpToolError('Failed to test step', err)
+                return mcpUtils.mcpToolError('Failed to test step', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-update-record.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-record.ts
@@ -2,7 +2,7 @@ import { McpServer, McpToolDefinition, Permission } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { recordService } from '../../tables/record/record.service'
-import { mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 import { formatPopulatedRecord, resolveFieldNamesForTable } from './table-utils'
 
 const updateRecordInput = z.object({
@@ -52,7 +52,7 @@ export const apUpdateRecordTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_update_record failed')
-                return mcpToolError('Failed to update record', err)
+                return mcpUtils.mcpToolError('Failed to update record', err)
             }
         },
     }

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -16,7 +16,7 @@ import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { projectService } from '../../project/project-service'
-import { diagnosePieceProps, mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const updateStepInput = z.object({
     flowId: z.string(),
@@ -180,7 +180,7 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
             catch (err) {
-                return mcpToolError('Step update failed', err)
+                return mcpUtils.mcpToolError('Step update failed', err)
             }
         },
     }
@@ -202,7 +202,7 @@ async function diagnoseMissingInputs({ settings, platformId, log }: {
             return `Action "${actionName}" not found in piece "${pieceName}". Use ap_list_pieces with includeActions=true to get valid action names.`
         }
         const input = settings.input ?? {}
-        const { parts } = diagnosePieceProps({ props: action.props, input, pieceAuth: piece.auth, requireAuth: action.requireAuth, componentType: 'action' })
+        const { parts } = mcpUtils.diagnosePieceProps({ props: action.props, input, pieceAuth: piece.auth, requireAuth: action.requireAuth, componentType: 'action' })
         return parts.join(' ')
     }
     catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -27,6 +27,8 @@ const updateStepInput = z.object({
     actionName: z.string().optional(),
     loopItems: z.string().optional(),
     skip: z.boolean().optional(),
+    sourceCode: z.string().optional(),
+    packageJson: z.string().optional(),
 })
 
 export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
@@ -43,10 +45,12 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
             actionName: z.string().optional().describe('For PIECE steps: the action to perform. Use ap_list_pieces to get valid values.'),
             loopItems: z.string().optional().describe('For LOOP steps: expression for the items to iterate over'),
             skip: z.boolean().optional().describe('Whether to skip this step during execution'),
+            sourceCode: z.string().optional().describe('For CODE steps only: the JavaScript/TypeScript source code. Must export a `run` function: `export const run = async (inputs) => { ... }`.'),
+            packageJson: z.string().optional().describe('For CODE steps only: package.json content as a JSON string for npm dependencies. Defaults to "{}".'),
         },
         annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
-            const { flowId, stepName, displayName, input, auth, actionName, loopItems, skip } = updateStepInput.parse(args)
+            const { flowId, stepName, displayName, input, auth, actionName, loopItems, skip, sourceCode, packageJson } = updateStepInput.parse(args)
 
             const [flow, project] = await Promise.all([
                 flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
@@ -102,6 +106,20 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                     return { content: [{ type: 'text', text: `❌ loopItems can only be set on LOOP_ON_ITEMS steps, but "${stepName}" is type ${step.type}.` }] }
                 }
             }
+            if (sourceCode !== undefined || packageJson !== undefined) {
+                if (step.type !== FlowActionType.CODE) {
+                    const param = sourceCode !== undefined ? 'sourceCode' : 'packageJson'
+                    return { content: [{ type: 'text', text: `❌ ${param} can only be set on CODE steps, but "${stepName}" is type ${step.type}.` }] }
+                }
+                const existing = currentSettings.sourceCode
+                const isObj = typeof existing === 'object' && existing !== null
+                const existingCode = isObj && 'code' in existing ? String(existing.code) : ''
+                const existingPkg = isObj && 'packageJson' in existing ? String(existing.packageJson) : '{}'
+                updatedSettings.sourceCode = {
+                    code: sourceCode ?? existingCode,
+                    packageJson: packageJson ?? existingPkg,
+                }
+            }
 
             if (step.type === FlowActionType.PIECE && input !== undefined) {
                 await fillDefaultsForMissingOptionalProps({
@@ -115,7 +133,7 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 type: step.type,
                 name: step.name,
                 displayName: displayName ?? step.displayName,
-                valid: step.valid,
+                valid: true,
                 settings: updatedSettings,
                 ...(skip !== undefined && { skip }),
             }

--- a/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
@@ -13,7 +13,7 @@ import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { projectService } from '../../project/project-service'
-import { diagnosePieceProps, mcpToolError } from './mcp-utils'
+import { mcpUtils } from './mcp-utils'
 
 const updateTriggerInput = z.object({
     flowId: z.string(),
@@ -115,7 +115,7 @@ export const apUpdateTriggerTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 }
             }
             catch (err) {
-                return mcpToolError('Trigger update failed', err)
+                return mcpUtils.mcpToolError('Trigger update failed', err)
             }
         },
     }
@@ -135,7 +135,7 @@ async function diagnoseMissingTriggerInputs({ pieceName, pieceVersion, triggerNa
         if (isNil(trigger)) {
             return `Trigger "${triggerName}" not found in piece "${pieceName}". Use ap_list_pieces with includeTriggers=true to get valid trigger names.`
         }
-        const { parts, missing, uiRequired, hasAuth } = diagnosePieceProps({ props: trigger.props, input, pieceAuth: piece.auth, requireAuth: trigger.requireAuth, componentType: 'trigger' })
+        const { parts, missing, uiRequired, hasAuth } = mcpUtils.diagnosePieceProps({ props: trigger.props, input, pieceAuth: piece.auth, requireAuth: trigger.requireAuth, componentType: 'trigger' })
         if (missing.length === 0 && uiRequired.length === 0 && !hasAuth) {
             return 'All inputs are provided but the trigger may need sample data. Ask the user to send a test event or configure the trigger in the Activepieces UI.'
         }

--- a/packages/server/api/src/app/mcp/tools/index.ts
+++ b/packages/server/api/src/app/mcp/tools/index.ts
@@ -11,6 +11,7 @@ import { apDeleteStepTool } from './ap-delete-step'
 import { apDeleteTableTool } from './ap-delete-table'
 import { apFindRecordsTool } from './ap-find-records'
 import { apFlowStructureTool } from './ap-flow-structure'
+import { apGetPiecePropsTool } from './ap-get-piece-props'
 import { apGetRunTool } from './ap-get-run'
 import { apInsertRecordsTool } from './ap-insert-records'
 import { apListAiModelsTool } from './ap-list-ai-models'
@@ -35,6 +36,7 @@ export const LOCKED_TOOL_NAMES: string[] = [
     'ap_list_flows',
     'ap_flow_structure',
     'ap_list_pieces',
+    'ap_get_piece_props',
     'ap_list_connections',
     'ap_list_ai_models',
     'ap_list_tables',
@@ -76,6 +78,7 @@ export const activepiecesTools = (mcp: McpServer, log: FastifyBaseLogger): McpTo
     apListFlowsTool(mcp, log),
     apFlowStructureTool(mcp, log),
     apListPiecesTool(mcp, log),
+    apGetPiecePropsTool(mcp, log),
     apListConnectionsTool(mcp, log),
     apUpdateTriggerTool(mcp, log),
     apAddStepTool(mcp, log),

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -96,11 +96,12 @@ function normalizePieceName(pieceName: string | undefined): string | undefined {
     if (pieceName.startsWith('@')) {
         return pieceName
     }
-    const normalized = pieceName.replace(/_/g, '-')
+    const stripped = pieceName.startsWith('piece-') ? pieceName.slice('piece-'.length) : pieceName
+    const normalized = stripped.replace(/_/g, '-')
     return `@activepieces/piece-${normalized}`
 }
 
-export { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName }
+export const mcpUtils = { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName }
 
 type DiagnosePiecePropsParams = {
     props: PiecePropertyMap

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -100,7 +100,7 @@ function normalizePieceName(pieceName: string | undefined): string | undefined {
     return `@activepieces/piece-${normalized}`
 }
 
-export { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName, AUTH_TYPES as AUTH_PROP_TYPES }
+export { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName }
 
 type DiagnosePiecePropsParams = {
     props: PiecePropertyMap

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -1,4 +1,5 @@
 import { PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
+import { isNil } from '@activepieces/shared'
 
 const AUTH_TYPES = new Set<PropertyType>([
     PropertyType.OAUTH2,
@@ -59,7 +60,47 @@ function diagnosePieceProps({ props, input, pieceAuth, requireAuth, componentTyp
     return { parts, missing, uiRequired, hasAuth }
 }
 
-export { mcpToolError, diagnosePieceProps, AUTH_TYPES as AUTH_PROP_TYPES }
+function buildPropSummaries(props: PiecePropertyMap): PropSummary[] {
+    return Object.entries(props)
+        .filter(([, prop]) => !AUTH_TYPES.has(prop.type))
+        .map(([name, prop]) => {
+            const summary: PropSummary = {
+                name,
+                type: prop.type,
+                required: prop.required ?? false,
+                displayName: prop.displayName ?? name,
+            }
+            if (prop.description) {
+                summary.description = prop.description
+            }
+            if (prop.defaultValue !== undefined) {
+                summary.defaultValue = prop.defaultValue
+            }
+            if ((prop.type === PropertyType.STATIC_DROPDOWN || prop.type === PropertyType.STATIC_MULTI_SELECT_DROPDOWN) && 'options' in prop && prop.options?.options) {
+                summary.options = prop.options.options.map((o: { label: string, value: unknown }) => ({ label: o.label, value: o.value }))
+            }
+            if (prop.type === PropertyType.DROPDOWN || prop.type === PropertyType.MULTI_SELECT_DROPDOWN) {
+                summary.note = 'Dynamic dropdown — options load from your account via API. Configure in the Activepieces UI, or provide a known value.'
+            }
+            if (prop.type === PropertyType.DYNAMIC) {
+                summary.note = 'Dynamic properties — fields are generated based on other input values. Configure in the Activepieces UI.'
+            }
+            return summary
+        })
+}
+
+function normalizePieceName(pieceName: string | undefined): string | undefined {
+    if (isNil(pieceName)) {
+        return undefined
+    }
+    if (pieceName.startsWith('@')) {
+        return pieceName
+    }
+    const normalized = pieceName.replace(/_/g, '-')
+    return `@activepieces/piece-${normalized}`
+}
+
+export { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName, AUTH_TYPES as AUTH_PROP_TYPES }
 
 type DiagnosePiecePropsParams = {
     props: PiecePropertyMap
@@ -74,4 +115,15 @@ type DiagnosisResult = {
     missing: string[]
     uiRequired: string[]
     hasAuth: boolean
+}
+
+type PropSummary = {
+    name: string
+    type: string
+    required: boolean
+    displayName: string
+    description?: string
+    defaultValue?: unknown
+    options?: Array<{ label: string, value: unknown }>
+    note?: string
 }

--- a/packages/server/api/src/app/tables/record/record.service.ts
+++ b/packages/server/api/src/app/tables/record/record.service.ts
@@ -465,17 +465,28 @@ function formatRecords(records: RecordSchema[], fields: Field[]): PopulatedRecor
         return acc
     }, {} as Record<string, string>)
     return records.map((record) => {
+        const cells = record.cells.reduce<PopulatedRecord['cells']>((acc, cell) => {
+            acc[cell.fieldId] = {
+                fieldName: fieldsNamesMap[cell.fieldId],
+                value: cell.value,
+                updated: cell.updated,
+                created: cell.created,
+            }
+            return acc
+        }, {})
+        for (const field of fields) {
+            if (!(field.id in cells)) {
+                cells[field.id] = {
+                    fieldName: field.name,
+                    value: null,
+                    updated: record.updated,
+                    created: record.created,
+                }
+            }
+        }
         return {
             ...record,
-            cells: record.cells.reduce<PopulatedRecord['cells']>((acc, cell) => {
-                acc[cell.fieldId] = {
-                    fieldName: fieldsNamesMap[cell.fieldId],
-                    value: cell.value,
-                    updated: cell.updated,
-                    created: cell.created,
-                }
-                return acc
-            }, {}),
+            cells,
         }
     })
 }

--- a/packages/server/api/src/app/tables/record/record.service.ts
+++ b/packages/server/api/src/app/tables/record/record.service.ts
@@ -109,9 +109,19 @@ export const recordService = {
                 recordId: In(records.map((record) => record.id)),
             },
         })
-        records.map((record) => {
-            record.cells = cells.filter((cell) => cell.recordId === record.id)
-        })
+        const cellsByRecordId = new Map<string, typeof cells>()
+        for (const cell of cells) {
+            const group = cellsByRecordId.get(cell.recordId)
+            if (group) {
+                group.push(cell)
+            }
+            else {
+                cellsByRecordId.set(cell.recordId, [cell])
+            }
+        }
+        for (const record of records) {
+            record.cells = cellsByRecordId.get(record.id) ?? []
+        }
         const filteredOutRecords = records.filter((record) => {
             if (!filters || filters.length === 0) {
                 return true

--- a/packages/web/src/app/components/project-settings/mcp-server/index.tsx
+++ b/packages/web/src/app/components/project-settings/mcp-server/index.tsx
@@ -69,7 +69,7 @@ export const McpServerSettings = () => {
             </TabsList>
 
             <TabsContent value="connection" className="mt-4 pb-6" tabIndex={-1}>
-              <McpCredentials mcpServer={mcpServer} />
+              <McpCredentials />
             </TabsContent>
 
             <TabsContent

--- a/packages/web/src/app/components/project-settings/mcp-server/mcp-credentials.tsx
+++ b/packages/web/src/app/components/project-settings/mcp-server/mcp-credentials.tsx
@@ -1,31 +1,11 @@
-import { ApFlagId, Permission, PopulatedMcpServer } from '@activepieces/shared';
+import { ApFlagId, PopulatedMcpServer } from '@activepieces/shared';
 import { t } from 'i18next';
-import { Eye, EyeOff, RefreshCw } from 'lucide-react';
-import { useState } from 'react';
 
-import { ButtonWithTooltip } from '@/components/custom/button-with-tooltip';
 import { CopyButton } from '@/components/custom/clipboard/copy-button';
 import { CollapsibleJson } from '@/components/custom/collapsible-json';
-import { useAuthorization } from '@/hooks/authorization-hooks';
 import { flagsHooks } from '@/hooks/flags-hooks';
-import { authenticationSession } from '@/lib/authentication-session';
 
-import { mcpHooks } from './utils/mcp-hooks';
-
-function maskToken(tokenValue: string): string {
-  if (tokenValue.length <= 8) return '••••••••';
-  return '••••••••' + tokenValue.slice(-4);
-}
-
-export function McpCredentials({ mcpServer }: McpCredentialsProps) {
-  const [showToken, setShowToken] = useState(false);
-  const toggleTokenVisibility = () => setShowToken(!showToken);
-  const currentProjectId = authenticationSession.getProjectId();
-
-  const { checkAccess } = useAuthorization();
-  const { mutate: rotateToken, isPending: isRotating } =
-    mcpHooks.useRotateMcpToken(currentProjectId!);
-
+export function McpCredentials(_props: McpCredentialsProps) {
   const { data: publicUrl } = flagsHooks.useFlag<string>(ApFlagId.PUBLIC_URL);
   const serverUrl = `${(publicUrl ?? '').replace(/\/$/, '')}/mcp`;
 
@@ -33,9 +13,6 @@ export function McpCredentials({ mcpServer }: McpCredentialsProps) {
     mcpServers: {
       activepieces: {
         url: serverUrl,
-        headers: {
-          Authorization: `Bearer ${mcpServer?.token ?? ''}`,
-        },
       },
     },
   };
@@ -46,7 +23,7 @@ export function McpCredentials({ mcpServer }: McpCredentialsProps) {
         <label className="text-sm font-medium">{t('Server URL')}</label>
         <p className="text-xs text-muted-foreground">
           {t(
-            'Use this URL to connect from Claude.ai, Cursor, Windsurf, or any MCP-compatible client.',
+            'Use this URL to connect from Cursor, Windsurf, Claude Desktop, or any MCP-compatible client. Authentication is handled via OAuth.',
           )}
         </p>
         <div className="flex items-center gap-2">
@@ -54,51 +31,6 @@ export function McpCredentials({ mcpServer }: McpCredentialsProps) {
             {serverUrl}
           </div>
           <CopyButton textToCopy={serverUrl} />
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <label className="text-sm font-medium">{t('Bearer Token')}</label>
-        <p className="text-xs text-muted-foreground">
-          {t('For clients that do not support OAuth (Cursor, Windsurf, etc.).')}
-        </p>
-        <div className="flex items-center gap-2">
-          <div className="bg-muted/50 rounded-md px-3 py-2 text-sm flex-1 overflow-x-auto">
-            {showToken ? mcpServer?.token : maskToken(mcpServer?.token ?? '')}
-          </div>
-          <ButtonWithTooltip
-            className="h-9 w-9"
-            tooltip={
-              showToken ? t('Hide sensitive data') : t('Show sensitive data')
-            }
-            onClick={toggleTokenVisibility}
-            variant="outline"
-            icon={
-              showToken ? (
-                <EyeOff className="h-4 w-4" />
-              ) : (
-                <Eye className="h-4 w-4" />
-              )
-            }
-          />
-          <ButtonWithTooltip
-            tooltip={t(
-              'Create a new token. The current one will stop working.',
-            )}
-            onClick={() => rotateToken()}
-            variant="outline"
-            className="h-9 w-9"
-            disabled={isRotating || !mcpServer?.status}
-            hasPermission={checkAccess(Permission.WRITE_MCP)}
-            icon={
-              isRotating ? (
-                <RefreshCw className="h-4 w-4 animate-spin" />
-              ) : (
-                <RefreshCw className="h-4 w-4" />
-              )
-            }
-          />
-          <CopyButton textToCopy={mcpServer?.token ?? ''} />
         </div>
       </div>
 

--- a/packages/web/src/app/components/project-settings/mcp-server/mcp-credentials.tsx
+++ b/packages/web/src/app/components/project-settings/mcp-server/mcp-credentials.tsx
@@ -1,11 +1,11 @@
-import { ApFlagId, PopulatedMcpServer } from '@activepieces/shared';
+import { ApFlagId } from '@activepieces/shared';
 import { t } from 'i18next';
 
 import { CopyButton } from '@/components/custom/clipboard/copy-button';
 import { CollapsibleJson } from '@/components/custom/collapsible-json';
 import { flagsHooks } from '@/hooks/flags-hooks';
 
-export function McpCredentials(_props: McpCredentialsProps) {
+export function McpCredentials() {
   const { data: publicUrl } = flagsHooks.useFlag<string>(ApFlagId.PUBLIC_URL);
   const serverUrl = `${(publicUrl ?? '').replace(/\/$/, '')}/mcp`;
 
@@ -45,7 +45,3 @@ export function McpCredentials(_props: McpCredentialsProps) {
     </div>
   );
 }
-
-type McpCredentialsProps = {
-  mcpServer: PopulatedMcpServer;
-};

--- a/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
+++ b/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
@@ -28,6 +28,11 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
           'List pieces with actions and triggers — required before adding or updating steps',
       },
       {
+        name: 'ap_get_piece_props',
+        description:
+          'Get detailed property schema for a specific piece action or trigger',
+      },
+      {
         name: 'ap_list_connections',
         description:
           'List OAuth/app connections in the project — required before adding steps that need auth',

--- a/packages/web/src/app/routes/mcp-authorize/index.tsx
+++ b/packages/web/src/app/routes/mcp-authorize/index.tsx
@@ -2,7 +2,7 @@ import { ProjectType, ProjectWithLimits, SeekPage } from '@activepieces/shared';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { jwtDecode } from 'jwt-decode';
-import { Blocks, FolderKanban, Shield } from 'lucide-react';
+import { CheckCircle, FolderKanban, Lock, Plug, Workflow } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Navigate, useSearchParams } from 'react-router-dom';
 import { useDebouncedCallback } from 'use-debounce';
@@ -18,6 +18,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
 import { MultiSelectFilter } from '@/features/automations/components/multi-select-filter';
 import { api } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
@@ -31,6 +32,7 @@ function McpAuthorizePage() {
   >(undefined);
   const [searchValue, setSearchValue] = useState('');
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+  const [authorized, setAuthorized] = useState(false);
   const debouncedSetSearchValue = useDebouncedCallback(setSearchValue, 300);
   const isLoggedIn = authenticationSession.isLoggedIn();
   const projectTypeOptions = [
@@ -54,6 +56,7 @@ function McpAuthorizePage() {
       api.post<{ redirectUrl: string }>('/v1/mcp-oauth/approve', body),
     onSuccess: (data) => {
       window.location.href = data.redirectUrl;
+      setAuthorized(true);
     },
   });
 
@@ -83,33 +86,64 @@ function McpAuthorizePage() {
     });
   };
 
+  if (authorized) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center px-4">
+        <FullLogo />
+        <Card className="mt-4 w-full max-w-md rounded-sm drop-shadow-xl">
+          <CardContent className="flex flex-col items-center gap-5 pt-8 pb-8">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-success-100">
+              <CheckCircle className="h-7 w-7 text-success" />
+            </div>
+            <div className="flex flex-col items-center gap-2 text-center">
+              <CardTitle className="text-2xl">{t('Connected')}</CardTitle>
+              <CardDescription>
+                <span className="font-medium text-foreground">
+                  {clientName}
+                </span>{' '}
+                {t('is now connected to your project.')}
+              </CardDescription>
+            </div>
+            <Separator />
+            <p className="text-sm text-muted-foreground">
+              {t('You can close this tab and return to the application.')}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
-    <div className="mx-auto flex h-screen flex-col items-center justify-center gap-4 px-4">
+    <div className="flex h-screen flex-col items-center justify-center px-4">
       <FullLogo />
-      <Card className="w-full max-w-md rounded-sm drop-shadow-xl">
-        <CardHeader className="text-center pb-2">
-          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-            <Shield className="h-6 w-6 text-primary" />
+      <Card className="mt-4 w-full max-w-md rounded-sm drop-shadow-xl">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+            <Plug className="h-5 w-5 text-primary" />
           </div>
-          <CardTitle className="text-xl">
+          <CardTitle className="text-2xl">
             {t('Authorize Application')}
           </CardTitle>
-          <CardDescription className="pt-1">
+          <CardDescription>
             <span className="font-semibold text-foreground">{clientName}</span>{' '}
-            {t('wants to access your Activepieces account')}
+            {t('wants to connect to your Activepieces account')}
           </CardDescription>
         </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <div className="rounded-md border bg-muted/30 p-3">
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Blocks className="h-4 w-4 shrink-0" />
-              <span>
-                {t(
-                  'This will allow the app to execute automations and access tools in your selected project.',
-                )}
-              </span>
-            </div>
+
+        <CardContent className="flex flex-col gap-5">
+          <div className="flex flex-col gap-3">
+            <PermissionItem
+              icon={<Workflow className="h-4 w-4 text-primary" />}
+              text={t('Build, test, and manage automations')}
+            />
+            <PermissionItem
+              icon={<Lock className="h-4 w-4 text-primary" />}
+              text={t('Use connections and execute flows')}
+            />
           </div>
+
+          <Separator />
 
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
@@ -150,12 +184,12 @@ function McpAuthorizePage() {
           </div>
 
           {approveMutation.isError && (
-            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+            <div className="rounded-md border border-destructive/50 bg-destructive-100 p-3 text-sm text-destructive">
               {t('Authorization failed. Please try again.')}
             </div>
           )}
 
-          <div className="flex gap-3 pt-2">
+          <div className="flex gap-3">
             <Button
               type="button"
               variant="outline"
@@ -176,6 +210,23 @@ function McpAuthorizePage() {
           </div>
         </CardContent>
       </Card>
+    </div>
+  );
+}
+
+function PermissionItem({
+  icon,
+  text,
+}: {
+  icon: React.ReactNode;
+  text: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border bg-accent/50 px-3 py-2.5 text-sm">
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10">
+        {icon}
+      </div>
+      <span>{text}</span>
     </div>
   );
 }

--- a/packages/web/vite.config.mts
+++ b/packages/web/vite.config.mts
@@ -35,7 +35,27 @@ export default defineConfig(({ command, mode }) => {
           changeOrigin: true,
           rewrite: (p: string) => p,
         },
-        '/.well-known/oauth-authorization-server': {
+        '/.well-known': {
+          target: 'http://127.0.0.1:3000',
+          secure: false,
+          changeOrigin: true,
+        },
+        '/register': {
+          target: 'http://127.0.0.1:3000',
+          secure: false,
+          changeOrigin: true,
+        },
+        '/authorize': {
+          target: 'http://127.0.0.1:3000',
+          secure: false,
+          changeOrigin: true,
+        },
+        '/token': {
+          target: 'http://127.0.0.1:3000',
+          secure: false,
+          changeOrigin: true,
+        },
+        '/revoke': {
           target: 'http://127.0.0.1:3000',
           secure: false,
           changeOrigin: true,


### PR DESCRIPTION
## Summary

- **Add `ap_get_piece_props` tool** — returns detailed field schemas (names, types, required, defaults, enums) for any piece action or trigger, enabling AI agents to configure steps without guessing
- **Add CODE step support to `ap_update_step`** — new `sourceCode` and `packageJson` params write to `settings.sourceCode` instead of `settings.input`
- **Fix CODE step validity bug** — `valid: step.valid` carried stale `false` state; changed to `valid: true` so server-side schema validation determines validity
- **Add `normalizePieceName`** — `ap_list_connections` now accepts short names like `"slack"` or `"google_sheets"` (auto-expanded to `@activepieces/piece-slack`)
- **Fix `ap_find_records` empty fields** — newly added table fields now appear as `(empty)` in query results instead of being omitted
- **OAuth improvements** — support private-use URI schemes (Cursor, VS Code, etc.), add JSON body parser for MCP HTTP endpoint, remove bearer token UI in favor of OAuth-only, improve authorize page design

## Test plan

All 6 benchmark scenarios from the MCP comparison report were tested end-to-end:

- [x] Scenario 1: Schedule → Sheets → Router → Slack (4/4 configured)
- [x] Scenario 2: Webhook → Slack DM (2/2 configured)
- [x] Scenario 3: Schedule → Sheets → Loop → Slack per row (4/4 configured)
- [x] Scenario 4: Slack mention → AI agent → Reply (3/3 configured — was 0/3 before)
- [x] Scenario 5: Hourly → Sheets → Loop → Router → 2 Slack channels (6/6 configured)
- [x] Scenario 6: Full lifecycle with CODE step — build, publish, enable, disable
- [x] Tables CRUD: 8/8 operations passed, including empty fields fix verification
- [x] Connection filter: short names (`slack`, `google_sheets`, `google-sheets`) all resolve correctly
- [x] Schema introspection: `ap_get_piece_props` returns full field schemas for schedule, webhook, slack, sheets pieces