### PR TITLE
feat(mcp): add ap_validate_step_config preflight validation tool

### DIFF
--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -44,6 +44,23 @@ Get the detailed input property schema for a specific piece action or trigger. R
 | `actionOrTriggerName` | string | Yes | Action or trigger name (e.g., `send_channel_message`) |
 | `type` | string | Yes | `action` or `trigger` |
 
+### ap_validate_step_config
+
+Validate a step configuration before applying it. Returns field-level errors without modifying any flow.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `stepType` | string | Yes | `PIECE_ACTION`, `PIECE_TRIGGER`, `CODE`, `LOOP_ON_ITEMS`, or `ROUTER` |
+| `pieceName` | string | No | For PIECE types: piece name (short names like `slack` accepted) |
+| `actionName` | string | No | For PIECE_ACTION: action name |
+| `triggerName` | string | No | For PIECE_TRIGGER: trigger name |
+| `input` | object | No | For PIECE types: input config to validate |
+| `auth` | string | No | For PIECE types: any non-empty string indicates auth is provided |
+| `sourceCode` | string | No | For CODE: JavaScript/TypeScript source code |
+| `packageJson` | string | No | For CODE: package.json as JSON string |
+| `loopItems` | string | No | For LOOP_ON_ITEMS: items expression |
+| `settings` | object | No | For ROUTER: raw router settings |
+
 ### ap_list_connections
 
 List OAuth/app connections in the project. Required before adding steps that need authentication.

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -5,7 +5,6 @@ import {
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
-import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { mcpUtils } from './mcp-utils'
 
 export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
@@ -18,32 +17,24 @@ export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
             try {
                 const { pieceName, actionOrTriggerName, type } = getPiecePropsInput.parse(args)
 
-                const piece = await pieceMetadataService(log).get({
-                    name: pieceName,
+                const lookup = await mcpUtils.lookupPieceComponent({
+                    pieceName,
+                    componentName: actionOrTriggerName,
+                    componentType: type,
                     projectId: mcp.projectId,
+                    log,
                 })
-
-                if (isNil(piece)) {
-                    return { content: [{ type: 'text', text: `❌ Piece "${pieceName}" not found. Use ap_list_pieces to get valid piece names.` }] }
+                if (lookup.error) {
+                    return lookup.error
                 }
 
-                const componentMap = type === 'action' ? piece.actions : piece.triggers
+                const { piece, component, pieceName: normalized } = lookup
                 const label = type === 'action' ? 'Action' : 'Trigger'
-                const component = componentMap[actionOrTriggerName]
-                if (isNil(component)) {
-                    return {
-                        content: [{
-                            type: 'text',
-                            text: `❌ ${label} "${actionOrTriggerName}" not found in "${pieceName}". Available: ${Object.keys(componentMap).join(', ')}`,
-                        }],
-                    }
-                }
-
                 const props = mcpUtils.buildPropSummaries(component.props)
                 const requiresAuth = component.requireAuth && !isNil(piece.auth)
 
                 const result = {
-                    piece: pieceName,
+                    piece: normalized,
                     name: component.name,
                     displayName: component.displayName,
                     description: component.description,
@@ -52,7 +43,7 @@ export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 }
 
                 return {
-                    content: [{ type: 'text', text: `✅ ${label} schema for "${pieceName}/${actionOrTriggerName}":\n${JSON.stringify(result, null, 2)}` }],
+                    content: [{ type: 'text', text: `✅ ${label} schema for "${normalized}/${actionOrTriggerName}":\n${JSON.stringify(result, null, 2)}` }],
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
@@ -27,7 +27,7 @@ export const apValidateStepConfigTool = (mcp: McpServer, log: FastifyBaseLogger)
                             const missing = !params.pieceName ? 'pieceName' : (componentType === 'action' ? 'actionName' : 'triggerName')
                             return { content: [{ type: 'text', text: `❌ ${missing} is required for ${componentType} validation.` }] }
                         }
-                        return validatePieceComponent({ pieceName: params.pieceName, componentName, componentType, input: params.input ?? {}, auth: params.auth, projectId: mcp.projectId, log })
+                        return await validatePieceComponent({ pieceName: params.pieceName, componentName, componentType, input: params.input ?? {}, auth: params.auth, projectId: mcp.projectId, log })
                     }
                     case 'CODE':
                         return validateWithSchema({ schema: codeValidator, data: { sourceCode: { code: params.sourceCode ?? '', packageJson: params.packageJson ?? '{}' }, input: {} }, label: 'CODE' })

--- a/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
@@ -30,11 +30,11 @@ export const apValidateStepConfigTool = (mcp: McpServer, log: FastifyBaseLogger)
                         return validatePieceComponent({ pieceName: params.pieceName, componentName, componentType, input: params.input ?? {}, auth: params.auth, projectId: mcp.projectId, log })
                     }
                     case 'CODE':
-                        return validateWithSchema(codeValidator, { sourceCode: { code: params.sourceCode ?? '', packageJson: params.packageJson ?? '{}' }, input: {} }, 'CODE')
+                        return validateWithSchema({ schema: codeValidator, data: { sourceCode: { code: params.sourceCode ?? '', packageJson: params.packageJson ?? '{}' }, input: {} }, label: 'CODE' })
                     case 'LOOP_ON_ITEMS':
-                        return validateWithSchema(loopValidator, { items: params.loopItems ?? '' }, 'LOOP_ON_ITEMS')
+                        return validateWithSchema({ schema: loopValidator, data: { items: params.loopItems ?? '' }, label: 'LOOP_ON_ITEMS' })
                     case 'ROUTER':
-                        return validateWithSchema(RouterActionSettingsWithValidation, params.settings ?? {}, 'ROUTER')
+                        return validateWithSchema({ schema: RouterActionSettingsWithValidation, data: params.settings ?? {}, label: 'ROUTER' })
                 }
             }
             catch (err) {
@@ -84,13 +84,16 @@ async function validatePieceComponent({ pieceName, componentName, componentType,
     })
 
     if (diagnosis.missing.length === 0) {
-        return { content: [{ type: 'text', text: `✅ Valid configuration for ${componentType.toUpperCase()} "${normalized}/${componentName}".` }] }
+        const uiHint = diagnosis.uiRequired.length > 0
+            ? `\nNote: these fields require configuration in the Activepieces UI: ${diagnosis.uiRequired.join(', ')}.`
+            : ''
+        return { content: [{ type: 'text', text: `✅ Valid configuration for ${componentType.toUpperCase()} "${normalized}/${componentName}".${uiHint}` }] }
     }
 
     return { content: [{ type: 'text', text: `⚠️ Invalid configuration:\n${diagnosis.parts.join('\n')}` }] }
 }
 
-function validateWithSchema(schema: z.ZodType, data: unknown, label: string): McpResult {
+function validateWithSchema({ schema, data, label }: { schema: z.ZodType, data: unknown, label: string }): McpResult {
     const result = schema.safeParse(data)
     if (result.success) {
         return { content: [{ type: 'text', text: `✅ Valid ${label} configuration.` }] }
@@ -104,7 +107,7 @@ const codeValidator = z.object({
         code: z.string().min(1),
         packageJson: z.string().min(1),
     })),
-    input: z.record(z.string(), z.any()),
+    input: z.record(z.string(), z.unknown()),
 })
 
 const loopValidator = z.object({

--- a/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
@@ -1,0 +1,124 @@
+import {
+    McpServer,
+    McpToolDefinition,
+    RouterActionSettingsWithValidation,
+    SourceCode,
+} from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { mcpUtils } from './mcp-utils'
+
+export const apValidateStepConfigTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_validate_step_config',
+        description: 'Validate a step configuration before applying it. Returns field-level errors without modifying any flow. Use this to check your config is correct before calling ap_update_step or ap_update_trigger.',
+        inputSchema: validateStepConfigInput.shape,
+        annotations: { readOnlyHint: true, openWorldHint: false },
+        execute: async (args) => {
+            try {
+                const params = validateStepConfigInput.parse(args)
+
+                switch (params.stepType) {
+                    case 'PIECE_ACTION':
+                    case 'PIECE_TRIGGER': {
+                        const componentType = params.stepType === 'PIECE_ACTION' ? 'action' : 'trigger'
+                        const componentName = componentType === 'action' ? params.actionName : params.triggerName
+                        if (!params.pieceName || !componentName) {
+                            const missing = !params.pieceName ? 'pieceName' : (componentType === 'action' ? 'actionName' : 'triggerName')
+                            return { content: [{ type: 'text', text: `❌ ${missing} is required for ${componentType} validation.` }] }
+                        }
+                        return validatePieceComponent({ pieceName: params.pieceName, componentName, componentType, input: params.input ?? {}, auth: params.auth, projectId: mcp.projectId, log })
+                    }
+                    case 'CODE':
+                        return validateWithSchema(codeValidator, { sourceCode: { code: params.sourceCode ?? '', packageJson: params.packageJson ?? '{}' }, input: {} }, 'CODE')
+                    case 'LOOP_ON_ITEMS':
+                        return validateWithSchema(loopValidator, { items: params.loopItems ?? '' }, 'LOOP_ON_ITEMS')
+                    case 'ROUTER':
+                        return validateWithSchema(RouterActionSettingsWithValidation, params.settings ?? {}, 'ROUTER')
+                }
+            }
+            catch (err) {
+                return mcpUtils.mcpToolError('Validation failed', err)
+            }
+        },
+    }
+}
+
+const validateStepConfigInput = z.object({
+    stepType: z.enum(['PIECE_ACTION', 'PIECE_TRIGGER', 'CODE', 'LOOP_ON_ITEMS', 'ROUTER'])
+        .describe('The type of step to validate.'),
+    pieceName: z.string().optional()
+        .describe('For PIECE_ACTION/PIECE_TRIGGER: piece name (e.g. "slack" or "@activepieces/piece-slack").'),
+    actionName: z.string().optional()
+        .describe('For PIECE_ACTION: action name (e.g. "send_channel_message").'),
+    triggerName: z.string().optional()
+        .describe('For PIECE_TRIGGER: trigger name (e.g. "new_mention").'),
+    input: z.record(z.string(), z.unknown()).optional()
+        .describe('For PIECE_ACTION/PIECE_TRIGGER: the input config to validate (key-value pairs).'),
+    auth: z.string().optional()
+        .describe('For PIECE steps requiring auth: any non-empty string indicates auth is provided.'),
+    sourceCode: z.string().optional()
+        .describe('For CODE: the JavaScript/TypeScript source code.'),
+    packageJson: z.string().optional()
+        .describe('For CODE: package.json content as JSON string.'),
+    loopItems: z.string().optional()
+        .describe('For LOOP_ON_ITEMS: expression for items to iterate over.'),
+    settings: z.record(z.string(), z.unknown()).optional()
+        .describe('For ROUTER: raw router settings including branches and executionType.'),
+})
+
+async function validatePieceComponent({ pieceName, componentName, componentType, input, auth, projectId, log }: ValidatePieceParams): Promise<McpResult> {
+    const lookup = await mcpUtils.lookupPieceComponent({ pieceName, componentName, componentType, projectId, log })
+    if (lookup.error) {
+        return lookup.error
+    }
+
+    const { component, pieceName: normalized } = lookup
+    const inputWithAuth = auth ? { ...input, auth } : input
+    const diagnosis = mcpUtils.diagnosePieceProps({
+        props: component.props,
+        input: inputWithAuth,
+        pieceAuth: lookup.piece.auth,
+        requireAuth: component.requireAuth,
+        componentType,
+    })
+
+    if (diagnosis.missing.length === 0) {
+        return { content: [{ type: 'text', text: `✅ Valid configuration for ${componentType.toUpperCase()} "${normalized}/${componentName}".` }] }
+    }
+
+    return { content: [{ type: 'text', text: `⚠️ Invalid configuration:\n${diagnosis.parts.join('\n')}` }] }
+}
+
+function validateWithSchema(schema: z.ZodType, data: unknown, label: string): McpResult {
+    const result = schema.safeParse(data)
+    if (result.success) {
+        return { content: [{ type: 'text', text: `✅ Valid ${label} configuration.` }] }
+    }
+    const errors = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`)
+    return { content: [{ type: 'text', text: `⚠️ Invalid ${label} configuration:\n${errors.join('\n')}` }] }
+}
+
+const codeValidator = z.object({
+    sourceCode: SourceCode.and(z.object({
+        code: z.string().min(1),
+        packageJson: z.string().min(1),
+    })),
+    input: z.record(z.string(), z.any()),
+})
+
+const loopValidator = z.object({
+    items: z.string().min(1),
+})
+
+type McpResult = { content: [{ type: 'text', text: string }] }
+
+type ValidatePieceParams = {
+    pieceName: string
+    componentName: string
+    componentType: 'action' | 'trigger'
+    input: Record<string, unknown>
+    auth: string | undefined
+    projectId: string
+    log: FastifyBaseLogger
+}

--- a/packages/server/api/src/app/mcp/tools/index.ts
+++ b/packages/server/api/src/app/mcp/tools/index.ts
@@ -31,12 +31,14 @@ import { apTestStepTool } from './ap-test-step'
 import { apUpdateRecordTool } from './ap-update-record'
 import { apUpdateStepTool } from './ap-update-step'
 import { apUpdateTriggerTool } from './ap-update-trigger'
+import { apValidateStepConfigTool } from './ap-validate-step-config'
 
 export const LOCKED_TOOL_NAMES: string[] = [
     'ap_list_flows',
     'ap_flow_structure',
     'ap_list_pieces',
     'ap_get_piece_props',
+    'ap_validate_step_config',
     'ap_list_connections',
     'ap_list_ai_models',
     'ap_list_tables',
@@ -79,6 +81,7 @@ export const activepiecesTools = (mcp: McpServer, log: FastifyBaseLogger): McpTo
     apFlowStructureTool(mcp, log),
     apListPiecesTool(mcp, log),
     apGetPiecePropsTool(mcp, log),
+    apValidateStepConfigTool(mcp, log),
     apListConnectionsTool(mcp, log),
     apUpdateTriggerTool(mcp, log),
     apAddStepTool(mcp, log),

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -1,5 +1,7 @@
-import { PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
+import { PieceMetadataModel, PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
 import { isNil } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 
 const AUTH_TYPES = new Set<PropertyType>([
     PropertyType.OAUTH2,
@@ -101,7 +103,25 @@ function normalizePieceName(pieceName: string | undefined): string | undefined {
     return `@activepieces/piece-${normalized}`
 }
 
-export const mcpUtils = { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName }
+async function lookupPieceComponent({ pieceName, componentName, componentType, projectId, log }: LookupPieceComponentParams): Promise<LookupPieceComponentResult> {
+    const normalized = normalizePieceName(pieceName)
+    if (isNil(normalized)) {
+        return { error: mcpToolError('Validation failed', new Error('pieceName is required')) }
+    }
+    const piece = await pieceMetadataService(log).get({ name: normalized, projectId })
+    if (isNil(piece)) {
+        return { error: { content: [{ type: 'text', text: `❌ Piece "${normalized}" not found. Use ap_list_pieces to get valid piece names.` }] } }
+    }
+    const componentMap = componentType === 'action' ? piece.actions : piece.triggers
+    const label = componentType === 'action' ? 'Action' : 'Trigger'
+    const component = componentMap[componentName]
+    if (isNil(component)) {
+        return { error: { content: [{ type: 'text', text: `❌ ${label} "${componentName}" not found in "${normalized}". Available: ${Object.keys(componentMap).join(', ')}` }] } }
+    }
+    return { piece, component, pieceName: normalized }
+}
+
+export const mcpUtils = { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName, lookupPieceComponent }
 
 type DiagnosePiecePropsParams = {
     props: PiecePropertyMap
@@ -128,3 +148,15 @@ type PropSummary = {
     options?: Array<{ label: string, value: unknown }>
     note?: string
 }
+
+type LookupPieceComponentParams = {
+    pieceName: string
+    componentName: string
+    componentType: 'action' | 'trigger'
+    projectId: string
+    log: FastifyBaseLogger
+}
+
+type LookupPieceComponentResult =
+    | { piece: PieceMetadataModel, component: { props: PiecePropertyMap, requireAuth: boolean, name: string, displayName: string, description: string }, pieceName: string, error?: never }
+    | { error: { content: [{ type: 'text', text: string }] }, piece?: never, component?: never, pieceName?: never }

--- a/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
+++ b/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
@@ -33,6 +33,11 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
           'Get detailed property schema for a specific piece action or trigger',
       },
       {
+        name: 'ap_validate_step_config',
+        description:
+          'Validate step configuration before applying — returns field-level errors without modifying any flow',
+      },
+      {
         name: 'ap_list_connections',
         description:
           'List OAuth/app connections in the project — required before adding steps that need auth',


### PR DESCRIPTION
## Summary

- Add **`ap_validate_step_config`** — a read-only MCP tool that validates step configurations before writing them to a flow, reducing the guess-and-retry loop for AI agents
- Supports all 5 step types: `PIECE_ACTION`, `PIECE_TRIGGER`, `CODE`, `LOOP_ON_ITEMS`, `ROUTER`
- Returns field-level errors matching what `ap_update_step` produces, without mutating any flow
- Extract **`lookupPieceComponent`** into `mcpUtils` to eliminate duplicated piece fetch + component lookup code across `ap-get-piece-props` and the new tool

## Test plan

- [x] PIECE_ACTION with empty input → returns missing fields + auth requirement
- [x] PIECE_ACTION with correct input + auth → returns valid
- [x] PIECE_TRIGGER with correct input + auth → returns valid
- [x] CODE with valid sourceCode → returns valid
- [x] CODE with no sourceCode → returns invalid with "code: Too small"
- [x] LOOP_ON_ITEMS with expression → returns valid
- [x] LOOP_ON_ITEMS with no items → returns invalid
- [x] Short piece names (`slack`) auto-expand via normalizePieceName
- [x] Invalid piece/action names return clear error with available options
- [x] TypeScript build passes
- [x] Lint passes