### PR TITLE
feat(mcp): add ap_validate_flow for flow-level preflight validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -475,7 +475,7 @@
     },
     "packages/pieces/community/ai": {
       "name": "@activepieces/piece-ai",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -553,7 +553,7 @@
     },
     "packages/pieces/community/airtable": {
       "name": "@activepieces/piece-airtable",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -586,7 +586,7 @@
     },
     "packages/pieces/community/algolia": {
       "name": "@activepieces/piece-algolia",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -620,7 +620,7 @@
     },
     "packages/pieces/community/amazon-bedrock": {
       "name": "@activepieces/piece-amazon-bedrock",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -635,7 +635,7 @@
     },
     "packages/pieces/community/amazon-s3": {
       "name": "@activepieces/piece-amazon-s3",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -698,7 +698,7 @@
     },
     "packages/pieces/community/amazon-textract": {
       "name": "@activepieces/piece-amazon-textract",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -749,7 +749,7 @@
     },
     "packages/pieces/community/apify": {
       "name": "@activepieces/piece-apify",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -873,7 +873,7 @@
     },
     "packages/pieces/community/attio": {
       "name": "@activepieces/piece-attio",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -1003,7 +1003,7 @@
     },
     "packages/pieces/community/baserow": {
       "name": "@activepieces/piece-baserow",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -1116,7 +1116,7 @@
     },
     "packages/pieces/community/bland-ai": {
       "name": "@activepieces/piece-bland-ai",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -1270,7 +1270,7 @@
     },
     "packages/pieces/community/buttondown": {
       "name": "@activepieces/piece-buttondown",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -1332,7 +1332,7 @@
     },
     "packages/pieces/community/canny": {
       "name": "@activepieces/piece-canny",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -1362,7 +1362,7 @@
     },
     "packages/pieces/community/carbone": {
       "name": "@activepieces/piece-carbone",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -1528,7 +1528,7 @@
     },
     "packages/pieces/community/chatwoot": {
       "name": "@activepieces/piece-chatwoot",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -1752,7 +1752,7 @@
     },
     "packages/pieces/community/cohere": {
       "name": "@activepieces/piece-cohere",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -1872,7 +1872,7 @@
     },
     "packages/pieces/community/coralogix": {
       "name": "@activepieces/piece-coralogix",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2206,7 +2206,7 @@
     },
     "packages/pieces/community/dropbox": {
       "name": "@activepieces/piece-dropbox",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2231,7 +2231,7 @@
     },
     "packages/pieces/community/dub": {
       "name": "@activepieces/piece-dub",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2298,7 +2298,7 @@
     },
     "packages/pieces/community/eden-ai": {
       "name": "@activepieces/piece-eden-ai",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2309,7 +2309,7 @@
     },
     "packages/pieces/community/elastic-email": {
       "name": "@activepieces/piece-elastic-email",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2331,7 +2331,7 @@
     },
     "packages/pieces/community/emailit": {
       "name": "@activepieces/piece-emailit",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2351,7 +2351,7 @@
     },
     "packages/pieces/community/enrichlayer": {
       "name": "@activepieces/piece-enrichlayer",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2381,7 +2381,7 @@
     },
     "packages/pieces/community/everhour": {
       "name": "@activepieces/piece-everhour",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2431,7 +2431,7 @@
     },
     "packages/pieces/community/famulor": {
       "name": "@activepieces/piece-famulor",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2454,7 +2454,7 @@
     },
     "packages/pieces/community/fathom-analytics": {
       "name": "@activepieces/piece-fathom-analytics",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2797,7 +2797,7 @@
     },
     "packages/pieces/community/getresponse": {
       "name": "@activepieces/piece-getresponse",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2841,7 +2841,7 @@
     },
     "packages/pieces/community/gitea": {
       "name": "@activepieces/piece-gitea",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2851,7 +2851,7 @@
     },
     "packages/pieces/community/github": {
       "name": "@activepieces/piece-github",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2883,7 +2883,7 @@
     },
     "packages/pieces/community/glide": {
       "name": "@activepieces/piece-glide",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2893,7 +2893,7 @@
     },
     "packages/pieces/community/gmail": {
       "name": "@activepieces/piece-gmail",
-      "version": "0.11.6",
+      "version": "0.11.7",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2914,7 +2914,7 @@
     },
     "packages/pieces/community/goodmem": {
       "name": "@activepieces/piece-goodmem",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2924,7 +2924,7 @@
     },
     "packages/pieces/community/google-bigquery": {
       "name": "@activepieces/piece-google-bigquery",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2985,7 +2985,7 @@
     },
     "packages/pieces/community/google-drive": {
       "name": "@activepieces/piece-google-drive",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3016,7 +3016,7 @@
     },
     "packages/pieces/community/google-gemini": {
       "name": "@activepieces/piece-google-gemini",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3058,7 +3058,7 @@
     },
     "packages/pieces/community/google-search-console": {
       "name": "@activepieces/piece-google-search-console",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3110,7 +3110,7 @@
     },
     "packages/pieces/community/google-vertexai": {
       "name": "@activepieces/piece-google-vertexai",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3156,7 +3156,7 @@
     },
     "packages/pieces/community/granola": {
       "name": "@activepieces/piece-granola",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3302,7 +3302,7 @@
     },
     "packages/pieces/community/hedy": {
       "name": "@activepieces/piece-hedy",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3324,7 +3324,7 @@
     },
     "packages/pieces/community/heygen": {
       "name": "@activepieces/piece-heygen",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3544,7 +3544,7 @@
     },
     "packages/pieces/community/intercom": {
       "name": "@activepieces/piece-intercom",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3557,7 +3557,7 @@
     },
     "packages/pieces/community/intruder": {
       "name": "@activepieces/piece-intruder",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3604,7 +3604,7 @@
     },
     "packages/pieces/community/jira-data-center": {
       "name": "@activepieces/piece-jira-data-center",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3638,7 +3638,7 @@
     },
     "packages/pieces/community/json": {
       "name": "@activepieces/piece-json",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3727,7 +3727,7 @@
     },
     "packages/pieces/community/klaviyo": {
       "name": "@activepieces/piece-klaviyo",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3738,7 +3738,7 @@
     },
     "packages/pieces/community/klenty": {
       "name": "@activepieces/piece-klenty",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3758,7 +3758,7 @@
     },
     "packages/pieces/community/knock": {
       "name": "@activepieces/piece-knock",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3845,7 +3845,7 @@
     },
     "packages/pieces/community/lemon-squeezy": {
       "name": "@activepieces/piece-lemon-squeezy",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3911,7 +3911,7 @@
     },
     "packages/pieces/community/linear": {
       "name": "@activepieces/piece-linear",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3977,7 +3977,7 @@
     },
     "packages/pieces/community/lobstermail": {
       "name": "@activepieces/piece-lobstermail",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4038,7 +4038,7 @@
     },
     "packages/pieces/community/loops": {
       "name": "@activepieces/piece-loops",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4156,7 +4156,7 @@
     },
     "packages/pieces/community/mailgun": {
       "name": "@activepieces/piece-mailgun",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4350,7 +4350,7 @@
     },
     "packages/pieces/community/microsoft-365-people": {
       "name": "@activepieces/piece-microsoft-365-people",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4363,7 +4363,7 @@
     },
     "packages/pieces/community/microsoft-365-planner": {
       "name": "@activepieces/piece-microsoft-365-planner",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4376,7 +4376,7 @@
     },
     "packages/pieces/community/microsoft-copilot": {
       "name": "@activepieces/piece-microsoft-copilot",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4388,7 +4388,7 @@
     },
     "packages/pieces/community/microsoft-dynamics-365-business-central": {
       "name": "@activepieces/piece-microsoft-dynamics-365-business-central",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4399,7 +4399,7 @@
     },
     "packages/pieces/community/microsoft-dynamics-crm": {
       "name": "@activepieces/piece-microsoft-dynamics-crm",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4409,7 +4409,7 @@
     },
     "packages/pieces/community/microsoft-excel-365": {
       "name": "@activepieces/piece-microsoft-excel-365",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4422,7 +4422,7 @@
     },
     "packages/pieces/community/microsoft-onedrive": {
       "name": "@activepieces/piece-microsoft-onedrive",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4439,7 +4439,7 @@
     },
     "packages/pieces/community/microsoft-onenote": {
       "name": "@activepieces/piece-microsoft-onenote",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4451,7 +4451,7 @@
     },
     "packages/pieces/community/microsoft-outlook": {
       "name": "@activepieces/piece-microsoft-outlook",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4464,7 +4464,7 @@
     },
     "packages/pieces/community/microsoft-outlook-calendar": {
       "name": "@activepieces/piece-microsoft-outlook-calendar",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4475,7 +4475,7 @@
     },
     "packages/pieces/community/microsoft-power-bi": {
       "name": "@activepieces/piece-microsoft-power-bi",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4485,7 +4485,7 @@
     },
     "packages/pieces/community/microsoft-sharepoint": {
       "name": "@activepieces/piece-microsoft-sharepoint",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4498,7 +4498,7 @@
     },
     "packages/pieces/community/microsoft-teams": {
       "name": "@activepieces/piece-microsoft-teams",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4511,7 +4511,7 @@
     },
     "packages/pieces/community/microsoft-todo": {
       "name": "@activepieces/piece-microsoft-todo",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4586,7 +4586,7 @@
     },
     "packages/pieces/community/modelslab": {
       "name": "@activepieces/piece-modelslab",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4998,7 +4998,7 @@
     },
     "packages/pieces/community/oracle-database": {
       "name": "@activepieces/piece-oracle-database",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5033,7 +5033,7 @@
     },
     "packages/pieces/community/outseta": {
       "name": "@activepieces/piece-outseta",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5043,7 +5043,7 @@
     },
     "packages/pieces/community/paddle": {
       "name": "@activepieces/piece-paddle",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5053,7 +5053,7 @@
     },
     "packages/pieces/community/pagerduty": {
       "name": "@activepieces/piece-pagerduty",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5150,7 +5150,7 @@
     },
     "packages/pieces/community/pdfcrowd": {
       "name": "@activepieces/piece-pdfcrowd",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5266,7 +5266,7 @@
     },
     "packages/pieces/community/pipedrive": {
       "name": "@activepieces/piece-pipedrive",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5300,7 +5300,7 @@
     },
     "packages/pieces/community/pocketbase": {
       "name": "@activepieces/piece-pocketbase",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5367,7 +5367,7 @@
     },
     "packages/pieces/community/postiz": {
       "name": "@activepieces/piece-postiz",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5408,7 +5408,7 @@
     },
     "packages/pieces/community/productboard": {
       "name": "@activepieces/piece-productboard",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5418,7 +5418,7 @@
     },
     "packages/pieces/community/promotekit": {
       "name": "@activepieces/piece-promotekit",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5617,7 +5617,7 @@
     },
     "packages/pieces/community/recurly": {
       "name": "@activepieces/piece-recurly",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5648,7 +5648,7 @@
     },
     "packages/pieces/community/reply-io": {
       "name": "@activepieces/piece-reply-io",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5718,7 +5718,7 @@
     },
     "packages/pieces/community/returning-ai": {
       "name": "@activepieces/piece-returning-ai",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5810,7 +5810,7 @@
     },
     "packages/pieces/community/salesforce": {
       "name": "@activepieces/piece-salesforce",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5832,7 +5832,7 @@
     },
     "packages/pieces/community/sardis": {
       "name": "@activepieces/piece-sardis",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5842,7 +5842,7 @@
     },
     "packages/pieces/community/savvycal": {
       "name": "@activepieces/piece-savvycal",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5905,7 +5905,7 @@
     },
     "packages/pieces/community/send-it": {
       "name": "@activepieces/piece-send-it",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5935,7 +5935,7 @@
     },
     "packages/pieces/community/sendgrid": {
       "name": "@activepieces/piece-sendgrid",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5982,7 +5982,7 @@
     },
     "packages/pieces/community/senja": {
       "name": "@activepieces/piece-senja",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6160,7 +6160,7 @@
     },
     "packages/pieces/community/slack": {
       "name": "@activepieces/piece-slack",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6194,7 +6194,7 @@
     },
     "packages/pieces/community/smartlead": {
       "name": "@activepieces/piece-smartlead",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6245,7 +6245,7 @@
     },
     "packages/pieces/community/snowflake": {
       "name": "@activepieces/piece-snowflake",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6360,7 +6360,7 @@
     },
     "packages/pieces/community/strale": {
       "name": "@activepieces/piece-strale",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6423,7 +6423,7 @@
     },
     "packages/pieces/community/surveytale": {
       "name": "@activepieces/piece-surveytale",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6483,7 +6483,7 @@
     },
     "packages/pieces/community/tally": {
       "name": "@activepieces/piece-tally",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6493,7 +6493,7 @@
     },
     "packages/pieces/community/tapfiliate": {
       "name": "@activepieces/piece-tapfiliate",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6534,7 +6534,7 @@
     },
     "packages/pieces/community/teable": {
       "name": "@activepieces/piece-teable",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6711,7 +6711,7 @@
     },
     "packages/pieces/community/trello": {
       "name": "@activepieces/piece-trello",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6733,7 +6733,7 @@
     },
     "packages/pieces/community/twenty": {
       "name": "@activepieces/piece-twenty",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6802,7 +6802,7 @@
     },
     "packages/pieces/community/typefully": {
       "name": "@activepieces/piece-typefully",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6812,7 +6812,7 @@
     },
     "packages/pieces/community/umami": {
       "name": "@activepieces/piece-umami",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6873,7 +6873,7 @@
     },
     "packages/pieces/community/vapi": {
       "name": "@activepieces/piece-vapi",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6894,7 +6894,7 @@
     },
     "packages/pieces/community/vercel": {
       "name": "@activepieces/piece-vercel",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7057,7 +7057,7 @@
     },
     "packages/pieces/community/webex": {
       "name": "@activepieces/piece-webex",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7149,7 +7149,7 @@
     },
     "packages/pieces/community/whatsscale": {
       "name": "@activepieces/piece-whatsscale",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7222,7 +7222,7 @@
     },
     "packages/pieces/community/workday": {
       "name": "@activepieces/piece-workday",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7323,7 +7323,7 @@
     },
     "packages/pieces/community/zendesk": {
       "name": "@activepieces/piece-zendesk",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7455,7 +7455,7 @@
     },
     "packages/pieces/community/zoom": {
       "name": "@activepieces/piece-zoom",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -8,7 +8,7 @@ Activepieces includes a built-in MCP server that allows AI assistants (Claude, G
 
 ## What is MCP?
 
-The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standard that lets AI assistants connect to external tools and data sources. Activepieces implements an MCP server that exposes 30 tools for managing your automation workflows.
+The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standard that lets AI assistants connect to external tools and data sources. Activepieces implements an MCP server that exposes 33 tools for managing your automation workflows.
 
 ## Enable the MCP Server
 

--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -24,6 +24,14 @@ Get the structure of a flow: step tree, configuration status, and valid insert l
 |-------|------|----------|-------------|
 | `flowId` | string | Yes | The flow ID |
 
+### ap_validate_flow
+
+Validate a flow for structural issues without publishing. Checks step validity, template references, and empty branches.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `flowId` | string | Yes | The flow ID |
+
 ### ap_list_pieces
 
 List available pieces with their actions and triggers. Required before adding or updating steps.

--- a/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
@@ -87,7 +87,7 @@ function validateFlow({ trigger }: { trigger: Step }): ValidationResult {
         }
 
         if (step.type === FlowActionType.ROUTER) {
-            const children = 'children' in step ? (step.children as (unknown | null)[]) : []
+            const children = 'children' in step ? (step.children as unknown[]) : []
             const branches = 'settings' in step && typeof step.settings === 'object' && step.settings !== null && 'branches' in step.settings
                 ? (step.settings.branches as { branchName?: string }[])
                 : []

--- a/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
@@ -74,9 +74,12 @@ function validateFlow({ trigger }: { trigger: Step }): ValidationResult {
         }
 
         const strings = collectStringValues({ step })
+        const seenRefs = new Set<string>()
         for (const str of strings) {
             const refs = extractReferencedStepNames({ value: str })
             for (const ref of refs) {
+                if (seenRefs.has(ref)) continue
+                seenRefs.add(ref)
                 if (!allStepNames.has(ref)) {
                     issues.push({ category: 'template_reference', stepName: step.name, message: `"${step.displayName}" references "{{${ref}...}}" which does not exist in the flow.` })
                 }
@@ -87,10 +90,8 @@ function validateFlow({ trigger }: { trigger: Step }): ValidationResult {
         }
 
         if (step.type === FlowActionType.ROUTER) {
-            const children = 'children' in step ? (step.children as unknown[]) : []
-            const branches = 'settings' in step && typeof step.settings === 'object' && step.settings !== null && 'branches' in step.settings
-                ? (step.settings.branches as { branchName?: string }[])
-                : []
+            const { children, settings } = step
+            const branches = settings.branches ?? []
             for (let i = 0; i < children.length; i++) {
                 if (isNil(children[i])) {
                     const branchName = branches[i]?.branchName ?? `Branch ${i}`
@@ -174,7 +175,8 @@ const CATEGORY_LABELS: Record<ValidationIssue['category'], string> = {
 
 function formatValidationResult({ result, flowDisplayName }: { result: ValidationResult, flowDisplayName: string }): string {
     if (result.issues.length === 0) {
-        return `✅ Flow "${flowDisplayName}" is ready to publish (${result.totalSteps} steps, all valid).`
+        const skippedNote = result.skippedSteps > 0 ? `, ${result.skippedSteps} skipped` : ''
+        return `✅ Flow "${flowDisplayName}" is ready to publish (${result.totalSteps} steps, ${result.validSteps} valid${skippedNote}).`
     }
 
     const grouped = new Map<ValidationIssue['category'], ValidationIssue[]>()

--- a/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
@@ -1,0 +1,217 @@
+import {
+    FlowActionType,
+    flowStructureUtil,
+    FlowTriggerType,
+    isNil,
+    McpServer,
+    McpToolDefinition,
+    Permission,
+    Step,
+} from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { flowService } from '../../flows/flow/flow.service'
+import { mcpUtils } from './mcp-utils'
+
+export const apValidateFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_validate_flow',
+        permission: Permission.READ_FLOW,
+        description: 'Validate a flow for structural issues without publishing. Checks step validity, template references, and empty branches. Returns a detailed report with all issues found. Use this before ap_lock_and_publish to catch problems early.',
+        inputSchema: validateFlowInput.shape,
+        annotations: { readOnlyHint: true, openWorldHint: false },
+        execute: async (args) => {
+            try {
+                const { flowId } = validateFlowInput.parse(args)
+
+                const flow = await flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId })
+                if (isNil(flow)) {
+                    return { content: [{ type: 'text', text: '❌ Flow not found.' }] }
+                }
+
+                const result = validateFlow({ trigger: flow.version.trigger })
+                return { content: [{ type: 'text', text: formatValidationResult({ result, flowDisplayName: flow.version.displayName }) }] }
+            }
+            catch (err) {
+                return mcpUtils.mcpToolError('Flow validation failed', err)
+            }
+        },
+    }
+}
+
+const validateFlowInput = z.object({
+    flowId: z.string().describe('The id of the flow to validate. Use ap_list_flows to find it.'),
+})
+
+function validateFlow({ trigger }: { trigger: Step }): ValidationResult {
+    const allSteps = flowStructureUtil.getAllSteps(trigger)
+    const allStepNames = new Set(allSteps.map(s => s.name))
+    const issues: ValidationIssue[] = []
+
+    if (trigger.type === FlowTriggerType.EMPTY) {
+        issues.push({ category: 'step_validity', stepName: 'trigger', message: 'Trigger is not configured (use ap_update_trigger).' })
+    }
+
+    const seenSteps = new Set<string>()
+    let validCount = 0
+    let invalidCount = 0
+    let skippedCount = 0
+
+    for (const step of allSteps) {
+        const isSkipped = 'skip' in step && step.skip === true
+
+        if (isSkipped) {
+            skippedCount++
+        }
+        else if (step.valid) {
+            validCount++
+        }
+        else {
+            invalidCount++
+            if (!flowStructureUtil.isTrigger(step.type)) {
+                issues.push({ category: 'step_validity', stepName: step.name, message: `"${step.displayName}" is invalid (use ap_update_step to fix).` })
+            }
+        }
+
+        const strings = collectStringValues({ step })
+        for (const str of strings) {
+            const refs = extractReferencedStepNames({ value: str })
+            for (const ref of refs) {
+                if (!allStepNames.has(ref)) {
+                    issues.push({ category: 'template_reference', stepName: step.name, message: `"${step.displayName}" references "{{${ref}...}}" which does not exist in the flow.` })
+                }
+                else if (!seenSteps.has(ref)) {
+                    issues.push({ category: 'template_reference', stepName: step.name, message: `"${step.displayName}" references "{{${ref}...}}" which comes AFTER it in execution order.` })
+                }
+            }
+        }
+
+        if (step.type === FlowActionType.ROUTER) {
+            const children = 'children' in step ? (step.children as (unknown | null)[]) : []
+            const branches = 'settings' in step && typeof step.settings === 'object' && step.settings !== null && 'branches' in step.settings
+                ? (step.settings.branches as { branchName?: string }[])
+                : []
+            for (let i = 0; i < children.length; i++) {
+                if (isNil(children[i])) {
+                    const branchName = branches[i]?.branchName ?? `Branch ${i}`
+                    issues.push({ category: 'empty_branch', stepName: step.name, message: `"${step.displayName}" has empty branch: "${branchName}".` })
+                }
+            }
+        }
+
+        seenSteps.add(step.name)
+    }
+
+    return { totalSteps: allSteps.length, validSteps: validCount, invalidSteps: invalidCount, skippedSteps: skippedCount, issues }
+}
+
+function collectStringValues({ step }: { step: Step }): string[] {
+    const result: string[] = []
+
+    if ('settings' in step && typeof step.settings === 'object' && step.settings !== null) {
+        const settings = step.settings as Record<string, unknown>
+
+        if ('input' in settings && typeof settings.input === 'object' && settings.input !== null) {
+            walkValues(settings.input, (val) => {
+                if (typeof val === 'string') result.push(val)
+            })
+        }
+
+        if ('items' in settings && typeof settings.items === 'string') {
+            result.push(settings.items)
+        }
+
+        if ('branches' in settings && Array.isArray(settings.branches)) {
+            for (const branch of settings.branches) {
+                if (typeof branch === 'object' && branch !== null && 'conditions' in branch && Array.isArray(branch.conditions)) {
+                    for (const group of branch.conditions) {
+                        if (!Array.isArray(group)) continue
+                        for (const cond of group) {
+                            if (typeof cond === 'object' && cond !== null) {
+                                if ('firstValue' in cond && typeof cond.firstValue === 'string') result.push(cond.firstValue)
+                                if ('secondValue' in cond && typeof cond.secondValue === 'string') result.push(cond.secondValue)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return result
+}
+
+function walkValues(obj: unknown, fn: (val: unknown) => void): void {
+    if (obj === null || obj === undefined) return
+    fn(obj)
+    if (Array.isArray(obj)) {
+        for (const item of obj) walkValues(item, fn)
+    }
+    else if (typeof obj === 'object') {
+        for (const val of Object.values(obj)) walkValues(val, fn)
+    }
+}
+
+function extractReferencedStepNames({ value }: { value: string }): string[] {
+    const regex = /\{\{(\w+)/g
+    const names = new Set<string>()
+    let match
+    while ((match = regex.exec(value)) !== null) {
+        const name = match[1]
+        if (name !== 'connections') {
+            names.add(name)
+        }
+    }
+    return [...names]
+}
+
+const CATEGORY_ORDER: ValidationIssue['category'][] = ['step_validity', 'template_reference', 'empty_branch']
+const CATEGORY_LABELS: Record<ValidationIssue['category'], string> = {
+    step_validity: 'Step Validity',
+    template_reference: 'Template References',
+    empty_branch: 'Empty Branches',
+}
+
+function formatValidationResult({ result, flowDisplayName }: { result: ValidationResult, flowDisplayName: string }): string {
+    if (result.issues.length === 0) {
+        return `✅ Flow "${flowDisplayName}" is ready to publish (${result.totalSteps} steps, all valid).`
+    }
+
+    const grouped = new Map<ValidationIssue['category'], ValidationIssue[]>()
+    for (const issue of result.issues) {
+        const list = grouped.get(issue.category) ?? []
+        list.push(issue)
+        grouped.set(issue.category, list)
+    }
+
+    const lines: string[] = []
+    lines.push(`⚠️ Flow "${flowDisplayName}" has ${result.issues.length} issue(s):`)
+    lines.push('')
+
+    for (const category of CATEGORY_ORDER) {
+        const issues = grouped.get(category)
+        if (issues && issues.length > 0) {
+            lines.push(`${CATEGORY_LABELS[category]}:`)
+            for (const issue of issues) lines.push(`- ${issue.stepName}: ${issue.message}`)
+            lines.push('')
+        }
+    }
+
+    lines.push(`Summary: ${result.totalSteps} total, ${result.validSteps} valid, ${result.invalidSteps} invalid, ${result.skippedSteps} skipped`)
+
+    return lines.join('\n')
+}
+
+type ValidationIssue = {
+    category: 'step_validity' | 'template_reference' | 'empty_branch'
+    stepName: string
+    message: string
+}
+
+type ValidationResult = {
+    totalSteps: number
+    validSteps: number
+    invalidSteps: number
+    skippedSteps: number
+    issues: ValidationIssue[]
+}

--- a/packages/server/api/src/app/mcp/tools/index.ts
+++ b/packages/server/api/src/app/mcp/tools/index.ts
@@ -31,11 +31,13 @@ import { apTestStepTool } from './ap-test-step'
 import { apUpdateRecordTool } from './ap-update-record'
 import { apUpdateStepTool } from './ap-update-step'
 import { apUpdateTriggerTool } from './ap-update-trigger'
+import { apValidateFlowTool } from './ap-validate-flow'
 import { apValidateStepConfigTool } from './ap-validate-step-config'
 
 export const LOCKED_TOOL_NAMES: string[] = [
     'ap_list_flows',
     'ap_flow_structure',
+    'ap_validate_flow',
     'ap_list_pieces',
     'ap_get_piece_props',
     'ap_validate_step_config',
@@ -79,6 +81,7 @@ export const activepiecesTools = (mcp: McpServer, log: FastifyBaseLogger): McpTo
     apRenameFlowTool(mcp, log),
     apListFlowsTool(mcp, log),
     apFlowStructureTool(mcp, log),
+    apValidateFlowTool(mcp, log),
     apListPiecesTool(mcp, log),
     apGetPiecePropsTool(mcp, log),
     apValidateStepConfigTool(mcp, log),

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -45,6 +45,27 @@ beforeAll(async () => {
         pieceType: PieceType.OFFICIAL,
         packageType: PackageType.REGISTRY,
         platformId: undefined,
+        actions: {
+            send_email: {
+                name: 'send_email',
+                displayName: 'Send Email',
+                description: 'Send an email',
+                requireAuth: true,
+                props: {
+                    to: { type: 'SHORT_TEXT', displayName: 'To', required: true },
+                    subject: { type: 'SHORT_TEXT', displayName: 'Subject', required: true },
+                },
+            },
+        },
+        triggers: {
+            new_email: {
+                name: 'new_email',
+                displayName: 'New Email',
+                description: 'Triggers on new email',
+                requireAuth: false,
+                props: {},
+            },
+        },
     })
     await db.save('piece_metadata', gmailPiece)
 })
@@ -288,7 +309,9 @@ describe('MCP Tools integration', () => {
         })
 
         expect(text(result)).toContain('✅')
-        expect(text(result)).toContain('schema')
+        expect(text(result)).toContain('send_email')
+        expect(text(result)).toContain('to')
+        expect(text(result)).toContain('subject')
     })
 
     it('12. ap_get_piece_props — returns error for non-existent piece', async () => {
@@ -408,7 +431,10 @@ describe('MCP Tools integration', () => {
 
         const result = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
 
+        expect(text(result)).toContain('✅')
         expect(text(result)).toContain('ready to publish')
+        expect(text(result)).not.toContain('⚠️')
+        expect(text(result)).not.toContain('issue')
     })
 
     it('20. ap_validate_flow — flow with invalid step lists it', async () => {
@@ -436,8 +462,10 @@ describe('MCP Tools integration', () => {
         const result = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
 
         expect(text(result)).toContain('⚠️')
-        expect(text(result)).toContain('invalid')
+        expect(text(result)).toContain('Step Validity')
         expect(text(result)).toContain('Unconfigured Piece')
+        expect(text(result)).toContain('invalid')
+        expect(text(result)).toContain('1 invalid')
     })
 
     it('21. ap_validate_flow — detects empty router branches', async () => {
@@ -462,6 +490,9 @@ describe('MCP Tools integration', () => {
 
         const result = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
 
+        expect(text(result)).toContain('⚠️')
+        expect(text(result)).toContain('Empty Branches')
+        expect(text(result)).toContain('My Router')
         expect(text(result)).toContain('empty branch')
     })
 })

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -24,6 +24,10 @@ import { apDeleteStepTool } from '../../../../src/app/mcp/tools/ap-delete-step'
 import { apLockAndPublishTool } from '../../../../src/app/mcp/tools/ap-lock-and-publish'
 import { apAddBranchTool } from '../../../../src/app/mcp/tools/ap-add-branch'
 import { apDeleteBranchTool } from '../../../../src/app/mcp/tools/ap-delete-branch'
+import { apGetPiecePropsTool } from '../../../../src/app/mcp/tools/ap-get-piece-props'
+import { apValidateStepConfigTool } from '../../../../src/app/mcp/tools/ap-validate-step-config'
+import { apValidateFlowTool } from '../../../../src/app/mcp/tools/ap-validate-flow'
+import { apUpdateTriggerTool } from '../../../../src/app/mcp/tools/ap-update-trigger'
 
 let app: FastifyInstance
 let mockLog: FastifyBaseLogger
@@ -271,5 +275,193 @@ describe('MCP Tools integration', () => {
             branchIndex: 1,
         })
         expect(text(errorResult)).toContain('❌')
+    })
+
+    it('11. ap_get_piece_props — returns field schemas for a piece action', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-gmail',
+            actionOrTriggerName: 'send_email',
+            type: 'action',
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('schema')
+    })
+
+    it('12. ap_get_piece_props — returns error for non-existent piece', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-nonexistent',
+            actionOrTriggerName: 'fake_action',
+            type: 'action',
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('not found')
+    })
+
+    it('13. ap_validate_step_config — CODE with valid source returns valid', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apValidateStepConfigTool(mcp, mockLog).execute({
+            stepType: 'CODE',
+            sourceCode: 'export const run = async () => { return true; };',
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('Valid CODE')
+    })
+
+    it('14. ap_validate_step_config — CODE with empty source returns invalid', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apValidateStepConfigTool(mcp, mockLog).execute({
+            stepType: 'CODE',
+        })
+
+        expect(text(result)).toContain('⚠️')
+        expect(text(result)).toContain('Invalid CODE')
+    })
+
+    it('15. ap_validate_step_config — LOOP with items returns valid', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apValidateStepConfigTool(mcp, mockLog).execute({
+            stepType: 'LOOP_ON_ITEMS',
+            loopItems: '{{step_1.output}}',
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('Valid LOOP')
+    })
+
+    it('16. ap_validate_step_config — LOOP without items returns invalid', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apValidateStepConfigTool(mcp, mockLog).execute({
+            stepType: 'LOOP_ON_ITEMS',
+        })
+
+        expect(text(result)).toContain('⚠️')
+        expect(text(result)).toContain('Invalid LOOP')
+    })
+
+    it('17. ap_validate_step_config — PIECE_ACTION missing pieceName returns error', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apValidateStepConfigTool(mcp, mockLog).execute({
+            stepType: 'PIECE_ACTION',
+            actionName: 'send_email',
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('pieceName')
+    })
+
+    it('18. ap_validate_flow — new flow with empty trigger has issues', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Validate Flow Test')
+
+        const result = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+
+        expect(text(result)).toContain('⚠️')
+        expect(text(result)).toContain('not configured')
+    })
+
+    it('19. ap_validate_flow — flow with configured trigger and valid CODE step is ready', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Valid Flow Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-gmail',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'My Code',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            sourceCode: 'export const run = async () => { return { ok: true }; };',
+            input: {},
+        })
+
+        const result = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+
+        expect(text(result)).toContain('ready to publish')
+    })
+
+    it('20. ap_validate_flow — flow with invalid step lists it', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Invalid Step Flow')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-gmail',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.PIECE,
+            displayName: 'Unconfigured Piece',
+            pieceName: '@activepieces/piece-gmail',
+            pieceVersion: '~0.1.0',
+        })
+
+        const result = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+
+        expect(text(result)).toContain('⚠️')
+        expect(text(result)).toContain('invalid')
+        expect(text(result)).toContain('Unconfigured Piece')
+    })
+
+    it('21. ap_validate_flow — detects empty router branches', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Router Validate Flow')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-gmail',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        const result = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+
+        expect(text(result)).toContain('empty branch')
     })
 })

--- a/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
+++ b/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
@@ -23,6 +23,11 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
           'Get the structure of a flow: step tree, configuration status, and valid insert locations',
       },
       {
+        name: 'ap_validate_flow',
+        description:
+          'Validate a flow for structural issues without publishing — checks step validity, template references, and empty branches',
+      },
+      {
         name: 'ap_list_pieces',
         description:
           'List pieces with actions and triggers — required before adding or updating steps',


### PR DESCRIPTION
## Summary

- Add **`ap_validate_flow`** — a read-only MCP tool that validates an entire flow for structural issues without publishing
- Three levels of validation:
  1. **Step validity** — lists all invalid/unconfigured steps (same check as `ap_lock_and_publish` but without publishing)
  2. **Template references** — detects `{{stepName}}` references to nonexistent steps or forward references to steps that come later in execution order
  3. **Empty branches** — flags router branches with no steps
- Add **11 integration tests** covering `ap_get_piece_props`, `ap_validate_step_config`, and `ap_validate_flow`
- Update tool count in docs (30 → 33)

## Test plan

Tested via MCP against live flows:

- [x] Empty trigger flow → flags "not configured"
- [x] Published valid flow (CODE step) → "ready to publish (2 steps, all valid)"
- [x] Complex flow with empty router fallback → flags "Otherwise" empty branch
- [x] Nonexistent flow ID → "Flow not found"
- [x] Forward reference (step_1 refs step_2) → "comes AFTER it in execution order"
- [x] Nonexistent step reference → "does not exist in the flow"
- [x] Valid reference ({{trigger.output}}) → correctly NOT flagged
- [x] Multi-category: empty trigger + empty router branches → 3 issues across 2 categories
- [x] TypeScript build passes
- [x] Lint passes
- [x] 11 new integration tests added