### PR TITLE
feat(mcp): add server instructions and slim tool descriptions by 45%

### DIFF
--- a/packages/server/api/src/app/mcp/mcp-service.ts
+++ b/packages/server/api/src/app/mcp/mcp-service.ts
@@ -27,7 +27,7 @@ const MCP_SERVER_INSTRUCTIONS = `## Activepieces MCP Server — Agent Workflow G
 - **Auth**: Use ap_list_connections to get the \`externalId\`, then pass it as the \`auth\` parameter on ap_update_step or ap_update_trigger.
 - **Step references**: Use \`{{stepName.output.field}}\` in input values to reference data from previous steps (e.g. \`{{trigger.output.body.email}}\`, \`{{step_1.output.id}}\`).
 - **Step names**: Steps are named \`trigger\`, \`step_1\`, \`step_2\`, etc. Use ap_flow_structure to see all step names and valid insertion points.
-- **Piece names**: Short names like "slack" or "google-sheets" are auto-expanded to full format (e.g. "@activepieces/piece-slack").
+- **Piece names**: Use the full format (e.g. "@activepieces/piece-slack") for ap_add_step and ap_update_trigger. Short names like "slack" are accepted by lookup tools (ap_list_connections, ap_get_piece_props, ap_validate_step_config).
 - **CODE steps**: Set sourceCode (must export a \`run\` function) and input (key-value pairs accessible via \`inputs.key\`).
 - **Tables**: Use field names (not IDs) when inserting or querying records.`
 

--- a/packages/server/api/src/app/mcp/mcp-service.ts
+++ b/packages/server/api/src/app/mcp/mcp-service.ts
@@ -14,6 +14,23 @@ import { activepiecesTools, ALL_CONTROLLABLE_TOOL_NAMES, LOCKED_TOOL_NAMES } fro
 
 const EDITION_REQUIRES_RBAC = [ApEdition.CLOUD, ApEdition.ENTERPRISE].includes(system.getEdition())
 
+const MCP_SERVER_INSTRUCTIONS = `## Activepieces MCP Server — Agent Workflow Guide
+
+### Recommended workflow
+1. **Discover**: ap_list_pieces (find pieces), ap_list_connections (find auth), ap_list_ai_models (find AI providers)
+2. **Schema**: ap_get_piece_props (get exact field names/types before configuring)
+3. **Build**: ap_create_flow → ap_update_trigger → ap_add_step → ap_update_step
+4. **Validate**: ap_validate_step_config (check a step config) or ap_validate_flow (check the whole flow)
+5. **Publish**: ap_lock_and_publish → ap_change_flow_status
+
+### Key patterns
+- **Auth**: Use ap_list_connections to get the \`externalId\`, then pass it as the \`auth\` parameter on ap_update_step or ap_update_trigger.
+- **Step references**: Use \`{{stepName.output.field}}\` in input values to reference data from previous steps (e.g. \`{{trigger.output.body.email}}\`, \`{{step_1.output.id}}\`).
+- **Step names**: Steps are named \`trigger\`, \`step_1\`, \`step_2\`, etc. Use ap_flow_structure to see all step names and valid insertion points.
+- **Piece names**: Short names like "slack" or "google-sheets" are auto-expanded to full format (e.g. "@activepieces/piece-slack").
+- **CODE steps**: Set sourceCode (must export a \`run\` function) and input (key-value pairs accessible via \`inputs.key\`).
+- **Tables**: Use field names (not IDs) when inserting or querying records.`
+
 export const mcpServerRepository = repoFactory(McpServerEntity)
 
 export const mcpServerService = (log: FastifyBaseLogger) => {
@@ -78,6 +95,8 @@ export const mcpServerService = (log: FastifyBaseLogger) => {
                         sizes: ['192x192'],
                     },
                 ],
+            }, {
+                instructions: MCP_SERVER_INSTRUCTIONS,
             })
             const enabledFlows = mcp.flows.filter((flow) => flow.status === FlowStatus.ENABLED)
             for (const flow of enabledFlows) {

--- a/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
@@ -26,7 +26,7 @@ export const apAddBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
     return {
         title: 'ap_add_branch',
         permission: Permission.WRITE_FLOW,
-        description: 'Add a new conditional branch to a router (ROUTER) step. The branch is inserted before the fallback branch. Use ap_flow_structure to get the router step name.',
+        description: 'Add a conditional branch to a router step. Inserted before the fallback branch.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             routerStepName: z.string().describe('The name of the ROUTER step to add a branch to. Use ap_flow_structure to get valid values.'),

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -34,7 +34,7 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
     return {
         title: 'ap_add_step',
         permission: Permission.WRITE_FLOW,
-        description: 'Add a new step to a flow (skeleton only - configure it afterwards with ap_update_step or ap_update_trigger). IMPORTANT: Always search for an existing piece using ap_list_pieces before choosing stepType=CODE. CODE steps should only be used as a last resort when no suitable piece action exists. Use ap_flow_structure to get valid parentStepName and insert locations. Use ap_list_pieces to get pieceName, pieceVersion, and actionName for PIECE steps.',
+        description: 'Add a new step to a flow (skeleton only — configure with ap_update_step afterwards). Prefer PIECE over CODE.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             parentStepName: z.string().describe('The step name to insert after/into (e.g. "trigger", "step_1"). Use ap_flow_structure to get valid values.'),

--- a/packages/server/api/src/app/mcp/tools/ap-change-flow-status.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-change-flow-status.ts
@@ -22,7 +22,7 @@ export const apChangeFlowStatusTool = (mcp: McpServer, log: FastifyBaseLogger): 
     return {
         title: 'ap_change_flow_status',
         permission: Permission.UPDATE_FLOW_STATUS,
-        description: 'Enable or disable a flow. The flow must be published first (use ap_lock_and_publish). Use ap_list_flows to get flow IDs.',
+        description: 'Enable or disable a published flow.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             status: z.enum([FlowStatus.ENABLED, FlowStatus.DISABLED]).describe('The new status: ENABLED to activate the flow, DISABLED to pause it'),

--- a/packages/server/api/src/app/mcp/tools/ap-create-table.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-create-table.ts
@@ -19,7 +19,7 @@ export const apCreateTableTool = (mcp: McpServer, log: FastifyBaseLogger): McpTo
     return {
         title: 'ap_create_table',
         permission: Permission.WRITE_TABLE,
-        description: 'Create a new table with an initial set of fields. Field types: TEXT, NUMBER, DATE, STATIC_DROPDOWN (requires options). The new table will be empty — use ap_insert_records to add data.',
+        description: 'Create a new table with an initial set of fields. Types: TEXT, NUMBER, DATE, STATIC_DROPDOWN.',
         inputSchema: createTableInput.shape,
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-delete-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-branch.ts
@@ -24,7 +24,7 @@ export const apDeleteBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
     return {
         title: 'ap_delete_branch',
         permission: Permission.WRITE_FLOW,
-        description: 'Delete a branch from a router (ROUTER) step. Cannot delete the last (fallback) branch. Use ap_flow_structure to get branch indices.',
+        description: 'Delete a branch from a router step. Cannot delete the fallback branch.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             routerStepName: z.string().describe('The name of the ROUTER step. Use ap_flow_structure to get valid values.'),

--- a/packages/server/api/src/app/mcp/tools/ap-delete-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-records.ts
@@ -12,7 +12,7 @@ export const apDeleteRecordsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
     return {
         title: 'ap_delete_records',
         permission: Permission.WRITE_TABLE,
-        description: 'Permanently delete one or more records from a table by their IDs. This action cannot be undone. Use ap_find_records to get record IDs.',
+        description: 'Permanently delete one or more records by their IDs.',
         inputSchema: deleteRecordsInput.shape,
         annotations: { destructiveHint: true, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
@@ -22,7 +22,7 @@ export const apDeleteStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
     return {
         title: 'ap_delete_step',
         permission: Permission.WRITE_FLOW,
-        description: 'Delete a step from a flow. Use ap_flow_structure to get valid step names.',
+        description: 'Delete a step from a flow.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             stepName: z.string().describe('The name of the step to delete. Use ap_flow_structure to get valid values.'),

--- a/packages/server/api/src/app/mcp/tools/ap-delete-table.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-table.ts
@@ -12,7 +12,7 @@ export const apDeleteTableTool = (mcp: McpServer, log: FastifyBaseLogger): McpTo
     return {
         title: 'ap_delete_table',
         permission: Permission.WRITE_TABLE,
-        description: 'Permanently delete a table and all its records and fields. This action cannot be undone. Use ap_list_tables to find the table ID.',
+        description: 'Permanently delete a table and all its data.',
         inputSchema: deleteTableInput.shape,
         annotations: { destructiveHint: true, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-find-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-find-records.ts
@@ -33,7 +33,7 @@ export const apFindRecordsTool = (mcp: McpServer, log: FastifyBaseLogger): McpTo
     return {
         title: 'ap_find_records',
         permission: Permission.READ_TABLE,
-        description: 'Query records from a table with optional filtering. Use ap_list_tables first to discover table IDs and field names. Supports operators: eq, neq, gt, gte, lt, lte, co (contains), exists, not_exists. Use field names (not IDs) in filters.',
+        description: 'Query records from a table with optional filtering. Operators: eq, neq, gt, gte, lt, lte, co, exists, not_exists.',
         inputSchema: findRecordsInput.shape,
         annotations: { readOnlyHint: true, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -10,7 +10,7 @@ import { mcpUtils } from './mcp-utils'
 export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
         title: 'ap_get_piece_props',
-        description: 'Get the detailed input property schema for a specific piece action or trigger. Returns field names, types, required/optional, descriptions, default values, and dropdown options. Use this before ap_update_step or ap_update_trigger to know exactly which fields to set and what values are accepted.',
+        description: 'Get the input property schema for a piece action or trigger. Returns field names, types, required/optional, defaults, and options.',
         inputSchema: getPiecePropsInput.shape,
         annotations: { readOnlyHint: true, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-get-run.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-run.ts
@@ -13,7 +13,7 @@ export const apGetRunTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDef
     return {
         title: 'ap_get_run',
         permission: Permission.READ_RUN,
-        description: 'Get detailed results of a flow run including step-by-step outputs, errors, and durations. Use ap_list_runs or ap_test_flow to get run IDs.',
+        description: 'Get detailed results of a flow run including step-by-step outputs, errors, and durations.',
         inputSchema: getRunInput.shape,
         annotations: { readOnlyHint: true, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-insert-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-insert-records.ts
@@ -14,7 +14,7 @@ export const apInsertRecordsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
     return {
         title: 'ap_insert_records',
         permission: Permission.WRITE_TABLE,
-        description: 'Insert one or more records into a table. Each record is an object mapping field names to string values. Use ap_list_tables to discover field names. Max 50 records per call.',
+        description: 'Insert one or more records into a table. Max 50 records per call.',
         inputSchema: insertRecordsInput.shape,
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
@@ -38,7 +38,7 @@ export const apListConnectionsTool = (mcp: McpServer, log: FastifyBaseLogger): M
         title: 'ap_list_connections',
         permission: Permission.READ_APP_CONNECTION,
         description:
-            'List OAuth/app connections available to the current project. Use this to discover available connections before adding steps that require auth (e.g. Google Drive, Slack). Filter by pieceName to find connections for a specific app, or by displayName to find a named connection. Use the `externalId` (not `id`) with the `auth` parameter of `ap_update_step`/`ap_update_trigger`. If no connection exists for the required piece, use ap_setup_guide to help the user create one.',
+            'List OAuth/app connections in the project. Returns externalId needed for the auth parameter on steps.',
         inputSchema: {
             pieceName: listConnectionsSchema.shape.pieceName,
             displayName: listConnectionsSchema.shape.displayName,

--- a/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
@@ -23,7 +23,7 @@ const listPiecesSchema = z.object({
 export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
         title: 'ap_list_pieces',
-        description: 'List available integration pieces (pieceName, pieceVersion, actions count, triggers count). IMPORTANT: Always search for a suitable piece before resorting to a CODE step — this should be the first tool you call when building or modifying a flow. Use includeActions=true to get action names, descriptions, and required input fields. Use includeTriggers=true to get trigger names, descriptions, and required input fields. Use suggestionType=ACTION or TRIGGER to filter pieces that only have relevant actions or triggers. Use specific searchQuery terms (e.g. "gmail" not "email send") for best results.',
+        description: 'List available pieces with their actions and triggers. Use includeActions/includeTriggers for details.',
         inputSchema: {
             categories: listPiecesSchema.shape.categories,
             tags: listPiecesSchema.shape.tags,

--- a/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
@@ -17,7 +17,7 @@ export const apListRunsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolD
     return {
         title: 'ap_list_runs',
         permission: Permission.READ_RUN,
-        description: 'List recent flow runs with optional filters. Returns run ID, status, environment, timestamps, and failed step info. Does not include step outputs — use ap_get_run for full details.',
+        description: 'List recent flow runs with optional filters. Returns run ID, status, timestamps, and failed step info.',
         inputSchema: listRunsInput.shape,
         annotations: { readOnlyHint: true, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-manage-fields.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-manage-fields.ts
@@ -18,7 +18,7 @@ export const apManageFieldsTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
     return {
         title: 'ap_manage_fields',
         permission: Permission.WRITE_TABLE,
-        description: 'Add, rename, or delete fields (columns) on a table. Use ap_list_tables to see existing fields and their IDs. Max 100 fields per table.',
+        description: 'Add, rename, or delete fields on a table. Max 100 fields per table.',
         inputSchema: manageFieldsInput.shape,
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-rename-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-rename-flow.ts
@@ -21,7 +21,7 @@ export const apRenameFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
     return {
         title: 'ap_rename_flow',
         permission: Permission.WRITE_FLOW,
-        description: 'Rename a flow. Use ap_list_flows to get valid flow IDs.',
+        description: 'Rename a flow.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow to rename'),
             displayName: z.string().describe('The new display name for the flow'),

--- a/packages/server/api/src/app/mcp/tools/ap-retry-run.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-retry-run.ts
@@ -17,7 +17,7 @@ export const apRetryRunTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolD
     return {
         title: 'ap_retry_run',
         permission: Permission.WRITE_RUN,
-        description: 'Retry a failed flow run. Use FROM_FAILED_STEP to resume from the failure point, or ON_LATEST_VERSION to re-run with the current published version. Only works on failed runs.',
+        description: 'Retry a failed flow run. FROM_FAILED_STEP resumes at failure point, ON_LATEST_VERSION re-runs entirely.',
         inputSchema: retryRunInput.shape,
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
@@ -15,7 +15,7 @@ const setupGuideInput = z.object({
 export const apSetupGuideTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
         title: 'ap_setup_guide',
-        description: 'Get step-by-step instructions for setting up connections or AI providers. Use this when a piece needs authentication or when no AI providers are configured. Returns instructions for the user to follow in the UI — sensitive credentials are never handled through MCP.',
+        description: 'Get setup instructions for connections or AI providers. Returns steps for the user to follow in the UI.',
         inputSchema: setupGuideInput.shape,
         annotations: { readOnlyHint: true, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-test-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-test-flow.ts
@@ -12,7 +12,7 @@ export const apTestFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolD
     return {
         title: 'ap_test_flow',
         permission: Permission.WRITE_FLOW,
-        description: 'Test a flow by running it in the test environment using saved sample/trigger data. The flow must have a configured trigger. Waits up to 120s for completion and returns step-by-step results.',
+        description: 'Test a flow end-to-end in the test environment. Requires a configured trigger. Waits up to 120s.',
         inputSchema: testFlowInput.shape,
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-update-record.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-record.ts
@@ -15,7 +15,7 @@ export const apUpdateRecordTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
     return {
         title: 'ap_update_record',
         permission: Permission.WRITE_TABLE,
-        description: 'Update specific cells in a record. Pass field names and new values — only specified fields are updated, others remain unchanged. Use ap_find_records to get record IDs.',
+        description: 'Update specific cells in a record. Only specified fields are changed.',
         inputSchema: updateRecordInput.shape,
         annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -35,7 +35,7 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
     return {
         title: 'ap_update_step',
         permission: Permission.WRITE_FLOW,
-        description: 'Update an existing step\'s settings in a flow. Use ap_flow_structure to get step names. Use ap_list_pieces to get valid pieceName, pieceVersion, actionName. If you are about to configure a CODE step, first verify with ap_list_pieces that no existing piece can accomplish the task. Provide only the fields you want to change.',
+        description: 'Update an existing step\'s settings. Provide only the fields you want to change.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             stepName: z.string().describe('The name of the step to update (e.g. "step_1"). Use ap_flow_structure to get valid values.'),

--- a/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
@@ -29,7 +29,7 @@ export const apUpdateTriggerTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
     return {
         title: 'ap_update_trigger',
         permission: Permission.WRITE_FLOW,
-        description: 'Set or update the trigger for a flow. Use ap_list_pieces to get valid pieceName, pieceVersion, and triggerName. Use ap_list_connections to get the connection externalId for auth.',
+        description: 'Set or update the trigger for a flow.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             pieceName: z.string().describe('The piece name for the trigger (e.g. "@activepieces/piece-gmail"). Use ap_list_pieces to get valid values.'),


### PR DESCRIPTION
## Summary

- Add **MCP server instructions** sent once at initialization — contains the agent workflow guide, auth patterns, step reference syntax, piece naming conventions, CODE step usage, and tables guidance
- **Slim 20+ tool descriptions** by removing cross-references and inline guidance that now lives in server instructions
- Average description: **177 → 100 chars (45% reduction)**, ~2,600 chars saved per request across 33 tools

### Before
Tool descriptions were bloated with repeated cross-references:
> "Update an existing step's settings in a flow. Use ap_flow_structure to get step names. Use ap_list_pieces to get valid pieceName, pieceVersion, actionName. If you are about to configure a CODE step, first verify with ap_list_pieces that no existing piece can accomplish the task. Provide only the fields you want to change."

### After
Descriptions answer only "what does this tool do?":
> "Update an existing step's settings. Provide only the fields you want to change."

The "how to use the system" guidance is in server instructions (sent once).

## Test plan

- [x] Server instructions appear in MCP initialization response
- [x] All tools still work with slimmed descriptions
- [x] Stress-tested: complex 6-step nested flow (loop + router + CODE + PIECE), template reference validation, adversarial inputs, unicode/emoji, wrong types, empty configs
- [x] TypeScript build passes
- [x] Lint passes