### PR TITLE
docs: update MCP overview with quick-start guide and OAuth setup

### DIFF
--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -4,66 +4,66 @@ icon: "plug"
 description: "Connect AI assistants to Activepieces using the Model Context Protocol (MCP)"
 ---
 
-Activepieces includes a built-in MCP server that allows AI assistants (Claude, GPT, etc.) to interact with your automation platform. AI agents can build flows, manage tables, test automations, and more — all through natural language.
+Activepieces includes a built-in [MCP](https://modelcontextprotocol.io/) server that lets AI assistants build flows, manage tables, test automations, and more — all through natural language.
 
-## What is MCP?
+## Quick Start
 
-The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standard that lets AI assistants connect to external tools and data sources. Activepieces implements an MCP server that exposes 33 tools for managing your automation workflows.
-
-## Enable the MCP Server
+### 1. Get Your Server URL
 
 1. Go to **Settings** → **MCP Server**
 2. Toggle the server **on**
-3. Copy the **server URL** and **token**
+3. Copy the **Server URL**
 
-## Connect Your AI Assistant
+### 2. Connect Your Client
 
-The MCP server uses the **Streamable HTTP** transport. Configure your AI client with:
-
-- **URL**: `https://your-instance.com/api/v1/projects/{projectId}/mcp-server/http`
-- **Authentication**: Bearer token (or `?token=` query parameter)
-
-<Tip>
-The token can be rotated at any time from the MCP Server settings page.
-</Tip>
-
-### Claude Desktop
-
-Add this to your Claude Desktop config (`claude_desktop_config.json`):
+Add the URL to your MCP client config. Authentication is handled via OAuth — your client will open a browser to authenticate on first use.
 
 ```json
 {
   "mcpServers": {
     "activepieces": {
-      "url": "https://your-instance.com/api/v1/projects/{projectId}/mcp-server/http?token={your-token}"
+      "url": "https://your-instance.com/mcp"
     }
   }
 }
 ```
 
-### Cursor / Other MCP Clients
+| Client | Config Location |
+|--------|----------------|
+| Cursor | `.cursor/mcp.json` |
+| Claude Desktop | `claude_desktop_config.json` |
+| Windsurf | MCP settings in editor preferences |
+| Claude.ai | **Organization Settings** → **Connectors** → **Add** → **Custom connector** |
 
-Use the Streamable HTTP URL with your token as a Bearer token in the Authorization header.
+### 3. Start Building
+
+Once connected, ask your AI assistant things like:
+
+- *"Create a flow that sends a Slack message when a new row is added to Google Sheets"*
+- *"Check my flow for any issues before publishing"*
+- *"Create a Contacts table and add 3 records"*
+- *"Show me the last failed run and what went wrong"*
+- *"What Slack triggers are available?"*
 
 ## Tool Categories
 
 Tools are organized into categories. **Discovery tools** are always available. Other categories can be enabled or disabled per-project in the MCP Server settings.
 
-| Category | Tools | Description |
-|----------|-------|-------------|
-| [Discovery](#discovery) | 10 | Read-only tools for exploring flows, pieces, tables, runs, and AI models |
-| [Flow Management](#flow-management) | 4 | Create, rename, publish, and enable/disable flows |
-| [Flow Building](#flow-building) | 4 | Add, update, and delete steps and triggers |
-| [Router & Branching](#router-branching) | 2 | Add and delete conditional branches |
-| [Annotations](#annotations) | 1 | Manage canvas notes |
-| [Tables](#tables) | 6 | Full CRUD for tables, fields, and records |
-| [Testing & Runs](#testing-runs) | 3 | Test flows, inspect results, retry failures |
+| Category | Description |
+|----------|-------------|
+| Discovery | Read-only tools for exploring flows, pieces, connections, tables, runs, and validation |
+| Flow Management | Create, rename, publish, and enable/disable flows |
+| Flow Building | Add, update, and delete steps and triggers |
+| Router & Branching | Add and delete conditional branches |
+| Annotations | Manage canvas notes |
+| Tables | Full CRUD for tables, fields, and records |
+| Testing & Runs | Test flows, inspect results, retry failures |
 
-See the [Tools Reference](/mcp/tools) for the complete catalog with input schemas and examples.
+See the [Tools Reference](/mcp/tools) for the complete catalog with input schemas.
 
 ## Security
 
-- **Credentials are never exposed** — connection secrets, API keys, and OAuth tokens are never returned by any MCP tool
+- **OAuth authentication** — secure, token-based authentication handled automatically by your MCP client
+- **Credentials are never exposed** — connection secrets, API keys, and OAuth tokens are never returned by any tool
 - **Project-scoped** — all operations are scoped to the authenticated project
-- **Sensitive setup** — the `ap_setup_guide` tool returns instructions for the user to configure connections and AI providers in the UI, rather than handling secrets through MCP
-- **Token rotation** — the MCP token can be rotated at any time without affecting existing connections or flows
+- **Sensitive setup** — `ap_setup_guide` returns instructions for the user to configure connections in the UI, rather than handling secrets through MCP

--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -30,8 +30,8 @@ Add the URL to your MCP client config. Authentication is handled via OAuth — y
 
 | Client | Config Location |
 |--------|----------------|
-| Cursor | `.cursor/mcp.json` |
-| Claude Desktop | `claude_desktop_config.json` |
+| Cursor | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global) |
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows) |
 | Windsurf | MCP settings in editor preferences |
 | Claude.ai | **Organization Settings** → **Connectors** → **Add** → **Custom connector** |
 


### PR DESCRIPTION
## Summary

Rewrites the MCP overview docs to be a proper quick-start guide:

- **3-step quick start**: get URL → connect → start building
- **Client setup table**: single JSON config shown once + where each client stores it (Cursor, Claude Desktop, Windsurf, Claude.ai)
- **Example prompts**: 5 concrete examples covering flow building, validation, tables, debugging, and discovery
- **OAuth auth**: updated from stale bearer token references to current OAuth flow
- **Removed stale content**: hardcoded tool count (goes stale), "What is MCP?" section (unnecessary for target audience), duplicate example tables, token rotation references

## What changed

| Before | After |
|--------|-------|
| Bearer token auth | OAuth |
| URL: `/api/v1/projects/{id}/mcp-server/http?token=` | URL: `/mcp` |
| 4 identical JSON tabs (one per client) | 1 JSON block + client location table |
| "What is MCP?" + "What Can You Do?" + "Start Building" (3 overlapping sections) | Single "Start Building" with 5 examples |
| Tool count "33" hardcoded | Removed (goes stale) |
| Discovery: 10 tools | Removed counts from table |

## Test plan

- [x] Docs render correctly in Mintlify preview
- [x] All links valid
- [x] JSON config examples are correct for current OAuth flow