### PR TITLE
feat(mcp): resolve dynamic dropdown options in ap_get_piece_props

### DIFF
--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -51,6 +51,8 @@ Get the detailed input property schema for a specific piece action or trigger. R
 | `pieceName` | string | Yes | Piece name (e.g., `@activepieces/piece-slack`) |
 | `actionOrTriggerName` | string | Yes | Action or trigger name (e.g., `send_channel_message`) |
 | `type` | string | Yes | `action` or `trigger` |
+| `auth` | string | No | Connection externalId. When provided, dynamic dropdowns return actual options (e.g., Slack channels, Google Sheets). |
+| `flowId` | string | No | Flow ID for resolving dependent dropdowns that need step context. |
 
 ### ap_validate_step_config
 

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -1,21 +1,32 @@
+import { PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
 import {
+    EngineResponse,
+    EngineResponseStatus,
+    FlowVersion,
     isNil,
     McpServer,
     McpToolDefinition,
+    SampleDataFileType,
+    WorkerJobType,
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
+import { flowService } from '../../flows/flow/flow.service'
+import { sampleDataService } from '../../flows/step-run/sample-data.service'
+import { getPiecePackageWithoutArchive } from '../../pieces/metadata/piece-metadata-service'
+import { projectService } from '../../project/project-service'
+import { userInteractionWatcher } from '../../workers/user-interaction-watcher'
 import { mcpUtils } from './mcp-utils'
 
 export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
         title: 'ap_get_piece_props',
-        description: 'Get the input property schema for a piece action or trigger. Returns field names, types, required/optional, defaults, and options.',
+        description: 'Get the input property schema for a piece action or trigger. Returns field names, types, required/optional, defaults, and options. Pass auth to resolve dynamic dropdown values.',
         inputSchema: getPiecePropsInput.shape,
         annotations: { readOnlyHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
-                const { pieceName, actionOrTriggerName, type } = getPiecePropsInput.parse(args)
+                const { pieceName, actionOrTriggerName, type, auth, flowId } = getPiecePropsInput.parse(args)
 
                 const lookup = await mcpUtils.lookupPieceComponent({
                     pieceName,
@@ -32,6 +43,20 @@ export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 const label = type === 'action' ? 'Action' : 'Trigger'
                 const props = mcpUtils.buildPropSummaries(component.props)
                 const requiresAuth = component.requireAuth && !isNil(piece.auth)
+
+                if (auth) {
+                    await resolveDropdownOptions({
+                        props,
+                        componentProps: component.props,
+                        pieceName: normalized,
+                        pieceVersion: piece.version,
+                        actionOrTriggerName,
+                        auth,
+                        flowId,
+                        projectId: mcp.projectId,
+                        log,
+                    })
+                }
 
                 const result = {
                     piece: normalized,
@@ -57,4 +82,85 @@ const getPiecePropsInput = z.object({
     pieceName: z.string().describe('The piece name (e.g. "@activepieces/piece-slack"). Use ap_list_pieces to get valid values.'),
     actionOrTriggerName: z.string().describe('The action or trigger name (e.g. "send_channel_message"). Use ap_list_pieces with includeActions=true or includeTriggers=true to get valid values.'),
     type: z.enum(['action', 'trigger']).describe('Whether to look up an action or a trigger.'),
+    auth: z.string().optional().describe('Connection externalId from ap_list_connections. When provided, dynamic dropdowns return actual options instead of a placeholder note.'),
+    flowId: z.string().optional().describe('Flow ID for resolving dependent dropdowns that need step context. Optional — most dropdowns work without it.'),
 })
+
+const DROPDOWN_TYPES = new Set([PropertyType.DROPDOWN, PropertyType.MULTI_SELECT_DROPDOWN])
+
+async function resolveDropdownOptions({ props, componentProps, pieceName, pieceVersion, actionOrTriggerName, auth, flowId, projectId, log }: ResolveDropdownParams): Promise<void> {
+    const project = await projectService(log).getOneOrThrow(projectId)
+    const piecePackage = await getPiecePackageWithoutArchive(log, project.platformId, { pieceName, pieceVersion })
+
+    let flowVersion: FlowVersion | undefined
+    let sampleData: Record<string, unknown> = {}
+    if (flowId) {
+        const flow = await flowService(log).getOnePopulated({ id: flowId, projectId })
+        if (flow) {
+            flowVersion = flow.version
+            sampleData = await sampleDataService(log).getSampleDataForFlow(projectId, flow.version, SampleDataFileType.OUTPUT)
+        }
+    }
+
+    const input: Record<string, unknown> = { auth: `{{connections['${auth}']}}` }
+
+    const dropdownProps = props.filter(prop => {
+        const propDef = componentProps[prop.name]
+        return DROPDOWN_TYPES.has(prop.type) && !isNil(propDef) && 'refreshers' in propDef
+    })
+
+    await Promise.all(dropdownProps.map(async (prop) => {
+        try {
+            const result = await withTimeout(
+                userInteractionWatcher.submitAndWaitForResponse<EngineResponse<{
+                    options: Array<{ label: string, value: unknown }>
+                    disabled?: boolean
+                }>>({
+                    jobType: WorkerJobType.EXECUTE_PROPERTY,
+                    platformId: project.platformId,
+                    projectId,
+                    flowVersion,
+                    propertyName: prop.name,
+                    actionOrTriggerName,
+                    input,
+                    sampleData,
+                    searchValue: undefined,
+                    piece: piecePackage,
+                }, log),
+                DROPDOWN_TIMEOUT_MS,
+            )
+
+            if (result.status === EngineResponseStatus.OK && result.response?.options && Array.isArray(result.response.options)) {
+                prop.options = result.response.options.map((o: { label: string, value: unknown }) => ({ label: o.label, value: o.value }))
+                prop.note = undefined
+            }
+        }
+        catch (err) {
+            log.debug({ err, propertyName: prop.name }, 'Failed to resolve dropdown options, keeping placeholder note')
+        }
+    }))
+}
+
+const DROPDOWN_TIMEOUT_MS = 15_000
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>
+    return Promise.race([
+        promise.finally(() => clearTimeout(timer)),
+        new Promise<never>((_resolve, reject) => {
+            timer = setTimeout(() => reject(new Error(`Dropdown resolution timed out after ${ms}ms`)), ms)
+        }),
+    ])
+}
+
+type ResolveDropdownParams = {
+    props: Array<{ name: string, type: PropertyType, options?: unknown, note?: string | undefined }>
+    componentProps: PiecePropertyMap
+    pieceName: string
+    pieceVersion: string
+    actionOrTriggerName: string
+    auth: string
+    flowId: string | undefined
+    projectId: string
+    log: FastifyBaseLogger
+}

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -87,6 +87,7 @@ const getPiecePropsInput = z.object({
 })
 
 const DROPDOWN_TYPES = new Set([PropertyType.DROPDOWN, PropertyType.MULTI_SELECT_DROPDOWN])
+const DROPDOWN_TIMEOUT_MS = 15_000
 
 async function resolveDropdownOptions({ props, componentProps, pieceName, pieceVersion, actionOrTriggerName, auth, flowId, projectId, log }: ResolveDropdownParams): Promise<void> {
     const project = await projectService(log).getOneOrThrow(projectId)
@@ -111,8 +112,8 @@ async function resolveDropdownOptions({ props, componentProps, pieceName, pieceV
 
     await Promise.all(dropdownProps.map(async (prop) => {
         try {
-            const result = await withTimeout(
-                userInteractionWatcher.submitAndWaitForResponse<EngineResponse<{
+            const result = await withTimeout({
+                promise: userInteractionWatcher.submitAndWaitForResponse<EngineResponse<{
                     options: Array<{ label: string, value: unknown }>
                     disabled?: boolean
                 }>>({
@@ -127,8 +128,8 @@ async function resolveDropdownOptions({ props, componentProps, pieceName, pieceV
                     searchValue: undefined,
                     piece: piecePackage,
                 }, log),
-                DROPDOWN_TIMEOUT_MS,
-            )
+                ms: DROPDOWN_TIMEOUT_MS,
+            })
 
             if (result.status === EngineResponseStatus.OK && result.response?.options && Array.isArray(result.response.options)) {
                 prop.options = result.response.options.map((o: { label: string, value: unknown }) => ({ label: o.label, value: o.value }))
@@ -141,9 +142,7 @@ async function resolveDropdownOptions({ props, componentProps, pieceName, pieceV
     }))
 }
 
-const DROPDOWN_TIMEOUT_MS = 15_000
-
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+function withTimeout<T>({ promise, ms }: { promise: Promise<T>, ms: number }): Promise<T> {
     let timer: ReturnType<typeof setTimeout>
     return Promise.race([
         promise.finally(() => clearTimeout(timer)),

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -140,7 +140,7 @@ type DiagnosisResult = {
 
 type PropSummary = {
     name: string
-    type: string
+    type: PropertyType
     required: boolean
     displayName: string
     description?: string

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -54,6 +54,7 @@ beforeAll(async () => {
                 props: {
                     to: { type: 'SHORT_TEXT', displayName: 'To', required: true },
                     subject: { type: 'SHORT_TEXT', displayName: 'Subject', required: true },
+                    folder: { type: 'DROPDOWN', displayName: 'Folder', required: false, refreshers: [] },
                 },
             },
         },
@@ -494,5 +495,109 @@ describe('MCP Tools integration', () => {
         expect(text(result)).toContain('Empty Branches')
         expect(text(result)).toContain('My Router')
         expect(text(result)).toContain('empty branch')
+    })
+
+    it('22. ap_get_piece_props — without auth returns note for dropdown fields', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-gmail',
+            actionOrTriggerName: 'send_email',
+            type: 'action',
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('folder')
+        expect(text(result)).toContain('DROPDOWN')
+        expect(text(result)).toContain('Dynamic dropdown')
+    })
+
+    it('23. ap_get_piece_props — with auth attempts dropdown resolution and falls back gracefully', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-gmail',
+            actionOrTriggerName: 'send_email',
+            type: 'action',
+            auth: 'fake-connection-id',
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('folder')
+        expect(text(result)).toContain('DROPDOWN')
+        expect(text(result)).toContain('to')
+        expect(text(result)).toContain('subject')
+    })
+
+    it('24. ap_get_piece_props — with auth on piece with no dropdowns returns clean schema', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-gmail',
+            actionOrTriggerName: 'new_email',
+            type: 'trigger',
+            auth: 'fake-connection-id',
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).not.toContain('DROPDOWN')
+        expect(text(result)).not.toContain('Dynamic dropdown')
+    })
+
+    it('25. ap_get_piece_props — with auth and invalid piece returns error before resolution', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-nonexistent',
+            actionOrTriggerName: 'fake_action',
+            type: 'action',
+            auth: 'some-connection',
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('not found')
+    })
+
+    it('26. ap_get_piece_props — with auth and invalid action returns error with available list', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-gmail',
+            actionOrTriggerName: 'nonexistent_action',
+            type: 'action',
+            auth: 'some-connection',
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('not found')
+        expect(text(result)).toContain('send_email')
+    })
+
+    it('27. ap_get_piece_props — static dropdowns always return options regardless of auth', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const withAuth = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-gmail',
+            actionOrTriggerName: 'send_email',
+            type: 'action',
+            auth: 'fake-connection',
+        })
+
+        const withoutAuth = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-gmail',
+            actionOrTriggerName: 'send_email',
+            type: 'action',
+        })
+
+        expect(text(withAuth)).toContain('to')
+        expect(text(withAuth)).toContain('subject')
+        expect(text(withoutAuth)).toContain('to')
+        expect(text(withoutAuth)).toContain('subject')
     })
 })


### PR DESCRIPTION
## Summary

Enhance `ap_get_piece_props` to optionally resolve dynamic dropdown values (Slack channels, Google Sheets spreadsheets, etc.) when an `auth` connection is provided. No new tool — keeps tool count at 33.

**Without auth** (current behavior): dropdowns show `"note": "Dynamic dropdown — configure in UI"`
**With auth**: attempts to resolve actual options via the worker job system. Falls back gracefully to the note if resolution times out.

### Implementation
- Add optional `auth` and `flowId` params to `ap_get_piece_props`
- Resolve all dropdowns in **parallel** via `Promise.all`
- **15s per-property timeout** with graceful fallback — tool always returns fast
- Timer cleanup via `.finally()` to prevent leaks
- `PropSummary.type` narrowed from `string` to `PropertyType`

## Test plan

Tested 13 scenarios across Slack, Google Sheets, Schedule, Webhook, and AI pieces:

- [x] Slack `send_channel_message` with valid auth → fallback (dev sandbox cold-start > 15s), tool fast
- [x] Slack `send_channel_message` without auth → note shown (no resolution attempted)
- [x] Slack `send_direct_message` with valid auth → fallback, fast
- [x] Slack `new_mention` trigger with auth → 3 MULTI_SELECT_DROPDOWNs all fallback, fast
- [x] Slack with invalid auth ID → fallback, no crash
- [x] Google Sheets `find_rows` with auth → 3 dropdowns all fallback, fast
- [x] Google Sheets `insert_row` with auth + flowId → fallback on dropdowns, DYNAMIC shows note
- [x] AI `run_agent` without auth → no dropdowns, clean schema
- [x] Webhook `catch_webhook` with random auth → STATIC_DROPDOWN returns full options (no resolution needed)
- [x] Slack `listUsers` with auth → no dropdowns, just checkboxes
- [x] Slack fake action with auth → error before resolution starts
- [x] Schedule `every_x_minutes` with auth → STATIC_DROPDOWN returns full options
- [x] Slack `new-message-in-channel` trigger with auth → dropdown fallback, fast
- [x] TypeScript build passes
- [x] Lint passes