### PR TITLE
fix(netsuite): oauth signature generation

### DIFF
--- a/packages/pieces/community/netsuite/package.json
+++ b/packages/pieces/community/netsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-netsuite",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/netsuite/src/lib/common/oauth.ts
+++ b/packages/pieces/community/netsuite/src/lib/common/oauth.ts
@@ -3,6 +3,15 @@ import { createHmac } from 'crypto';
 const SIGN_METHOD = 'HMAC-SHA256';
 const OAUTH_VERSION = '1.0';
 
+// OAuth 1.0 (RFC 5849 §3.6) requires RFC 3986 percent-encoding, which encodes
+// '!', '*', "'", '(', ')' — characters that encodeURIComponent leaves unencoded.
+function oauthEncode(str: string): string {
+  return encodeURIComponent(str).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+}
+
 function generateNonce(): string {
   const length = 11;
   const possible =
@@ -53,19 +62,19 @@ function generateSignature(
   // Sort parameters by key, then by value (OAuth 1.0 spec)
   const sortedKeys = Object.keys(allParams).sort();
   const paramPairs = sortedKeys.map(
-    (key) => `${encodeURIComponent(key)}=${encodeURIComponent(allParams[key])}`
+    (key) => `${oauthEncode(key)}=${oauthEncode(allParams[key])}`
   );
   const paramString = paramPairs.join('&');
 
   const signatureBaseString = [
     httpMethod.toUpperCase(),
-    encodeURIComponent(baseUrl),
-    encodeURIComponent(paramString),
+    oauthEncode(baseUrl),
+    oauthEncode(paramString),
   ].join('&');
 
   const signingKey = [
-    encodeURIComponent(consumerSecret),
-    encodeURIComponent(tokenSecret),
+    oauthEncode(consumerSecret),
+    oauthEncode(tokenSecret),
   ].join('&');
 
   const hmac = createHmac('sha256', signingKey);

--- a/packages/pieces/community/netsuite/src/lib/common/oauth.ts
+++ b/packages/pieces/community/netsuite/src/lib/common/oauth.ts
@@ -54,12 +54,16 @@ function generateSignature(
     });
   }
 
-  // Sort parameters by key, then by value (OAuth 1.0 spec)
-  const sortedKeys = Object.keys(allParams).sort();
-  const paramPairs = sortedKeys.map(
-    (key) => `${oauthEncode(key)}=${oauthEncode(allParams[key])}`
+  // RFC 5849 §3.4.1.3: encode keys/values first, then sort the encoded pairs.
+  // Sorting on raw strings would differ from sorting on encoded strings when
+  // param names contain characters whose encoded form changes byte order (e.g. '{' → '%7B').
+  const encodedPairs = Object.entries(allParams).map(
+    ([key, value]) => [oauthEncode(key), oauthEncode(value)] as const
   );
-  const paramString = paramPairs.join('&');
+  encodedPairs.sort(([ka, va], [kb, vb]) =>
+    ka < kb ? -1 : ka > kb ? 1 : va < vb ? -1 : va > vb ? 1 : 0
+  );
+  const paramString = encodedPairs.map(([k, v]) => `${k}=${v}`).join('&');
 
   const signatureBaseString = [
     httpMethod.toUpperCase(),

--- a/packages/pieces/community/netsuite/src/lib/common/oauth.ts
+++ b/packages/pieces/community/netsuite/src/lib/common/oauth.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto';
+import { createHmac, randomBytes } from 'crypto';
 
 const SIGN_METHOD = 'HMAC-SHA256';
 const OAUTH_VERSION = '1.0';
@@ -13,13 +13,8 @@ function oauthEncode(str: string): string {
 }
 
 function generateNonce(): string {
-  const length = 11;
-  const possible =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  return Array.from(
-    { length },
-    () => possible[Math.floor(Math.random() * possible.length)]
-  ).join('');
+  // Use CSPRNG instead of Math.random() for unpredictable nonces.
+  return randomBytes(16).toString('hex');
 }
 
 function generateSignature(

--- a/packages/pieces/community/netsuite/src/lib/common/oauth.ts
+++ b/packages/pieces/community/netsuite/src/lib/common/oauth.ts
@@ -80,7 +80,7 @@ function generateSignature(
   hmac.update(signatureBaseString);
   const signature = hmac.digest('base64');
 
-  return encodeURIComponent(signature);
+  return oauthEncode(signature);
 }
 
 export function createOAuthHeader(


### PR DESCRIPTION
## What does this PR do?

This fixes a few bugs and edge cases in OAuth 1.0 signature generation that can result in a 401 error.

### Special characters in URL
There are some endpoints with special characters eg `/!transform`. This was previously not properly percent encoded with `encodeURIComponent`. Fix by explicitly handling those characters.

### Params sorting
The OAuth 1.0 spec needs params to be encoded before sorting, we currently sort then encode. This can cause signature mismatches.

### Nonce generation
The previous implementation with `Math.random` isn't cryptographically secure. I've not encountered any issues or collisions but it's safer to harden the implementation.
