### PR TITLE
fix(mcp): correct CODE step export name from run to code

### DIFF
--- a/packages/server/api/src/app/mcp/mcp-service.ts
+++ b/packages/server/api/src/app/mcp/mcp-service.ts
@@ -28,7 +28,7 @@ const MCP_SERVER_INSTRUCTIONS = `## Activepieces MCP Server — Agent Workflow G
 - **Step references**: Use \`{{stepName.output.field}}\` in input values to reference data from previous steps (e.g. \`{{trigger.output.body.email}}\`, \`{{step_1.output.id}}\`).
 - **Step names**: Steps are named \`trigger\`, \`step_1\`, \`step_2\`, etc. Use ap_flow_structure to see all step names and valid insertion points.
 - **Piece names**: Use the full format (e.g. "@activepieces/piece-slack") for ap_add_step and ap_update_trigger. Short names like "slack" are accepted by lookup tools (ap_list_connections, ap_get_piece_props, ap_validate_step_config).
-- **CODE steps**: Set sourceCode (must export a \`run\` function) and input (key-value pairs accessible via \`inputs.key\`).
+- **CODE steps**: Set sourceCode (must export a \`code\` function) and input (key-value pairs accessible via \`inputs.key\`).
 - **Tables**: Use field names (not IDs) when inserting or querying records.`
 
 export const mcpServerRepository = repoFactory(McpServerEntity)

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -69,7 +69,7 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                         displayName,
                         valid: false,
                         settings: {
-                            sourceCode: { code: 'export const run = async (inputs) => { return {} }', packageJson: '{}' },
+                            sourceCode: { code: 'export const code = async (inputs) => { return {} }', packageJson: '{}' },
                             input: {},
                             errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
                         },

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -45,7 +45,7 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
             actionName: z.string().optional().describe('For PIECE steps: the action to perform. Use ap_list_pieces to get valid values.'),
             loopItems: z.string().optional().describe('For LOOP steps: expression for the items to iterate over'),
             skip: z.boolean().optional().describe('Whether to skip this step during execution'),
-            sourceCode: z.string().optional().describe('For CODE steps only: the JavaScript/TypeScript source code. Must export a `run` function: `export const run = async (inputs) => { ... }`.'),
+            sourceCode: z.string().optional().describe('For CODE steps only: the JavaScript/TypeScript source code. Must export a `code` function: `export const code = async (inputs) => { ... }`.'),
             packageJson: z.string().optional().describe('For CODE steps only: package.json content as a JSON string for npm dependencies. Defaults to "{}".'),
         },
         annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -335,7 +335,7 @@ describe('MCP Tools integration', () => {
 
         const result = await apValidateStepConfigTool(mcp, mockLog).execute({
             stepType: 'CODE',
-            sourceCode: 'export const run = async () => { return true; };',
+            sourceCode: 'export const code = async () => { return true; };',
         })
 
         expect(text(result)).toContain('✅')
@@ -426,7 +426,7 @@ describe('MCP Tools integration', () => {
         await apUpdateStepTool(mcp, mockLog).execute({
             flowId,
             stepName: 'step_1',
-            sourceCode: 'export const run = async () => { return { ok: true }; };',
+            sourceCode: 'export const code = async () => { return { ok: true }; };',
             input: {},
         })
 


### PR DESCRIPTION
## Summary
- Fixed typo in MCP docs/tools: CODE steps must export a `code` function, not `run`. The engine (`code-sandbox-common.ts`) calls `.code()` and the worker's `code-builder.ts` uses `exports.code`.
- Updated server instructions, tool descriptions, skeleton template, and tests.

## Test plan
- [x] `npm run lint-dev` passes (0 errors)
- [ ] Existing MCP integration tests pass with corrected export name