### PR TITLE
fix: flow lock takeover flickering and route loading bar

### DIFF
--- a/packages/server/api/src/app/core/collaborative/lock/lock.module.ts
+++ b/packages/server/api/src/app/core/collaborative/lock/lock.module.ts
@@ -21,7 +21,9 @@ export const lockModule: FastifyPluginAsyncZod = async (app) => {
                 })
 
                 if (result.acquired) {
-                    socket.data.lockedResourceId = data.resourceId
+                    if (!data.force) {
+                        socket.data.lockedResourceId = data.resourceId
+                    }
                     socket.to(projectId).emit(WebsocketClientEvent.RESOURCE_LOCKED, {
                         resourceId: data.resourceId,
                         userId: principal.id,

--- a/packages/web/src/app/builder/flow-canvas/widgets/use-flow-lock.ts
+++ b/packages/web/src/app/builder/flow-canvas/widgets/use-flow-lock.ts
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import { useResourceLock } from '@/hooks/use-resource-lock';
 
 import { useBuilderStateContext } from '../../builder-hooks';
@@ -8,14 +10,22 @@ function useFlowLock() {
     state.flow.id,
     state.setReadOnly,
   ]);
+  const readonlySetByLock = useRef(false);
 
   const { lockedBy, takeOver } = useResourceLock({
     resourceId: flowId,
   });
 
-  if (lockedBy && !readonly) {
-    setReadOnly(true);
-  }
+  useEffect(() => {
+    if (lockedBy && !readonly) {
+      readonlySetByLock.current = true;
+      setReadOnly(true);
+    }
+    if (!lockedBy && readonlySetByLock.current) {
+      readonlySetByLock.current = false;
+      setReadOnly(false);
+    }
+  }, [lockedBy, readonly, setReadOnly]);
 
   return { lockedBy, takeOver };
 }

--- a/packages/web/src/app/components/platform-layout.tsx
+++ b/packages/web/src/app/components/platform-layout.tsx
@@ -23,7 +23,10 @@ export function PlatformLayout({ children }: { children: React.ReactNode }) {
             <PlatformSidebar />
             <SidebarInset className="flex flex-col h-full overflow-hidden bg-sidebar">
               <div className="flex-1 flex flex-col p-2 pt-3 pb-3 overflow-hidden">
-                <div className="flex flex-col h-full bg-background rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border overflow-clip">
+                <div
+                  id="dashboard-content-container"
+                  className="relative flex flex-col h-full bg-background rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border overflow-clip"
+                >
                   <div className="flex flex-col flex-1 overflow-auto">
                     {children}
                   </div>

--- a/packages/web/src/app/components/project-layout/index.tsx
+++ b/packages/web/src/app/components/project-layout/index.tsx
@@ -117,7 +117,10 @@ function ProjectDashboardLayoutInner({
       {!isEmbedded && <ProjectDashboardSidebar />}
       <SidebarInset className="flex flex-col h-full overflow-hidden bg-sidebar">
         <div className="flex-1 flex flex-col pr-2 pt-3 pb-3 overflow-hidden">
-          <div className="flex flex-col h-full bg-background rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border overflow-clip">
+          <div
+            id="dashboard-content-container"
+            className="relative flex flex-col h-full bg-background rounded-xl shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)] border overflow-clip"
+          >
             {!hideHeader && (
               <ProjectDashboardLayoutHeader key={currentProjectId} />
             )}

--- a/packages/web/src/app/routes/platform-routes.tsx
+++ b/packages/web/src/app/routes/platform-routes.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import { Navigate } from 'react-router-dom';
 
 import { PageTitle } from '@/app/components/page-title';
-import { LoadingScreen } from '@/components/custom/loading-screen';
+import { RouteLoadingBar } from '@/components/custom/route-loading-bar';
 import { Error, Success } from '@/features/billing';
 
 import { PlatformLayout } from '../components/platform-layout';
@@ -65,7 +65,7 @@ const PlatformTemplatesPage = React.lazy(() =>
 const UsersPage = React.lazy(() => import('./platform/users'));
 
 function SuspenseWrapper({ children }: { children: React.ReactNode }) {
-  return <Suspense fallback={<LoadingScreen />}>{children}</Suspense>;
+  return <Suspense fallback={<RouteLoadingBar />}>{children}</Suspense>;
 }
 
 export const platformRoutes = [

--- a/packages/web/src/app/routes/project-routes.tsx
+++ b/packages/web/src/app/routes/project-routes.tsx
@@ -3,7 +3,7 @@ import React, { Suspense } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 
 import { PageTitle } from '@/app/components/page-title';
-import { LoadingScreen } from '@/components/custom/loading-screen';
+import { RouteLoadingBar } from '@/components/custom/route-loading-bar';
 import { ApTableStateProvider } from '@/features/tables';
 import { routesThatRequireProjectId } from '@/lib/route-utils';
 
@@ -50,7 +50,7 @@ const SettingsRerouter = () => {
 };
 
 function SuspenseWrapper({ children }: { children: React.ReactNode }) {
-  return <Suspense fallback={<LoadingScreen />}>{children}</Suspense>;
+  return <Suspense fallback={<RouteLoadingBar />}>{children}</Suspense>;
 }
 
 const automationsPagePermissions = [

--- a/packages/web/src/app/routes/public-routes.tsx
+++ b/packages/web/src/app/routes/public-routes.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react';
 
 import { PageTitle } from '@/app/components/page-title';
-import { LoadingScreen } from '@/components/custom/loading-screen';
+import { RouteLoadingBar } from '@/components/custom/route-loading-bar';
 
 import { ProjectDashboardLayout } from '../components/project-layout';
 import { TemplateDetailsWrapper } from '../guards/template-details-wrapper';
@@ -24,7 +24,7 @@ const TemplatesPage = React.lazy(() =>
 );
 
 function SuspenseWrapper({ children }: { children: React.ReactNode }) {
-  return <Suspense fallback={<LoadingScreen />}>{children}</Suspense>;
+  return <Suspense fallback={<RouteLoadingBar />}>{children}</Suspense>;
 }
 
 export const publicRoutes = [

--- a/packages/web/src/components/custom/route-loading-bar.tsx
+++ b/packages/web/src/components/custom/route-loading-bar.tsx
@@ -1,0 +1,22 @@
+import { createPortal } from 'react-dom';
+
+export function RouteLoadingBar() {
+  const bar = (
+    <div className="absolute top-0 left-0 right-0 h-0.5 overflow-hidden bg-primary/20 z-50">
+      <div className="h-full w-1/4 bg-primary rounded-full animate-indeterminate-progress" />
+    </div>
+  );
+
+  const container = document.getElementById('dashboard-content-container');
+  if (container) {
+    return createPortal(bar, container);
+  }
+
+  return (
+    <div className="h-full w-full">
+      <div className="h-0.5 w-full overflow-hidden bg-primary/20">
+        <div className="h-full w-1/4 bg-primary rounded-full animate-indeterminate-progress" />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/features/tables/components/ap-table-state-provider.tsx
+++ b/packages/web/src/features/tables/components/ap-table-state-provider.tsx
@@ -6,7 +6,7 @@ import { createContext, useContext, useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useStore } from 'zustand';
 
-import { LoadingScreen } from '@/components/custom/loading-screen';
+import { RouteLoadingBar } from '@/components/custom/route-loading-bar';
 import { buttonVariants } from '@/components/ui/button';
 import {
   TableState,
@@ -98,11 +98,7 @@ export function ApTableStateProvider({
   });
 
   if (isTableLoading || isFieldsLoading || isRecordsLoading) {
-    return (
-      <div className="flex justify-center items-center h-full w-full pb-6">
-        <LoadingScreen mode="container" />
-      </div>
-    );
+    return <RouteLoadingBar />;
   }
 
   if (

--- a/packages/web/src/hooks/use-resource-lock.ts
+++ b/packages/web/src/hooks/use-resource-lock.ts
@@ -87,7 +87,7 @@ function useResourceLock({ resourceId }: UseResourceLockParams) {
       { resourceId, force: true },
       (response: LockResourceResponse) => {
         if (response.acquired) {
-          isOwner.current = true;
+          isOwner.current = false;
           window.location.reload();
         }
       },

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -159,6 +159,8 @@
   --animate-typing: typing 0.7s steps(7) alternate;
   --animate-typing-sm: typing 0.5s steps(5) alternate;
   --animate-slide-in-from-bottom: slide-in-from-bottom 0.2s ease-out forwards;
+  --animate-indeterminate-progress: indeterminate-progress 1.5s ease-in-out
+    infinite;
   --animate-primary-color-pulse: primary-color-pulse 1s ease-in-out infinite
     alternate;
   --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif,
@@ -223,6 +225,15 @@
     }
     100% {
       transform: translateY(0%);
+    }
+  }
+
+  @keyframes indeterminate-progress {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(400%);
     }
   }
 }


### PR DESCRIPTION
## Summary
- **Fix readonly not resetting on lock release**: When another user releases a flow lock, the builder was stuck showing "Viewing Version #2" instead of returning to editable state. Added a `useRef` guard in `useFlowLock` to track when readonly was set by the lock mechanism, and a `useEffect` to reset it when the lock is released.
- **Fix lock release during takeover**: During takeover, `window.location.reload()` disconnected the old socket which released the lock in Redis before the new socket reconnected, causing flickering. Fixed by not setting `lockedResourceId` on the socket for force acquires (server), and setting `isOwner=false` before reload (client).
- **Replace full-screen loading spinner with slim progress bar**: Route transitions and table loading now show a subtle indeterminate progress bar at the top of the content area instead of a full-screen spinner, using a portal into the dashboard content container.

## Test plan
- [ ] User A edits flow, User B opens same flow (sees lock banner), User A navigates away → User B should see editable flow (not "Viewing Version #2")
- [ ] User A edits flow, User B opens and clicks "Take Over" → User A should see lock banner consistently (no flicker to "Viewing Version #2")
- [ ] Navigate between routes → slim progress bar appears at top of content area during lazy load
- [ ] Table loading shows progress bar instead of full-screen spinner