### PR TITLE
fix: strip CORS headers from webhook response.headers to prevent duplicates

### DIFF
--- a/packages/server/api/src/app/webhooks/webhook-controller.ts
+++ b/packages/server/api/src/app/webhooks/webhook-controller.ts
@@ -1,4 +1,3 @@
-
 import {
     RAW_PAYLOAD_HEADER,
     WebhookUrlParams,
@@ -13,6 +12,21 @@ import { convertRequest, extractHeaderFromRequest } from './webhook-request-conv
 import { WebhookFlowVersionToRun, webhookService } from './webhook.service'
 
 const tracer = trace.getTracer('webhook-controller')
+
+const CORS_HEADERS = new Set([
+    'access-control-allow-origin',
+    'access-control-allow-headers',
+    'access-control-allow-methods',
+    'access-control-allow-credentials',
+    'access-control-expose-headers',
+    'access-control-max-age',
+])
+
+function filterCorsHeaders(headers: Record<string, string>): Record<string, string> {
+    return Object.fromEntries(
+        Object.entries(headers ?? {}).filter(([key]) => !CORS_HEADERS.has(key.toLowerCase())),
+    )
+}
 
 export const webhookController: FastifyPluginAsyncZod = async (app) => {
 
@@ -37,7 +51,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
                         saveSampleData: await triggerSourceService(request.log).existsByFlowId({
                             flowId: request.params.flowId,
                             simulate: true,
-                        },
+                            },
                         ),
                         execute: true,
                         ...extractRawPayload(request),
@@ -46,7 +60,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
                     span.setAttribute('webhook.response.status', response.status)
                     await reply
                         .status(response.status)
-                        .headers(response.headers)
+                        .headers(filterCorsHeaders(response.headers))
                         .send(response.body)
                 }
                 finally {
@@ -76,7 +90,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
                         saveSampleData: await triggerSourceService(request.log).existsByFlowId({
                             flowId: request.params.flowId,
                             simulate: true,
-                        },
+                            },
                         ),
                         flowVersionToRun: WebhookFlowVersionToRun.LOCKED_FALL_BACK_TO_LATEST,
                         execute: true,
@@ -86,7 +100,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
                     span.setAttribute('webhook.response.status', response.status)
                     await reply
                         .status(response.status)
-                        .headers(response.headers)
+                        .headers(filterCorsHeaders(response.headers))
                         .send(response.body)
                 }
                 finally {
@@ -112,7 +126,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
         })
         await reply
             .status(response.status)
-            .headers(response.headers)
+            .headers(filterCorsHeaders(response.headers))
             .send(response.body)
     })
 
@@ -129,7 +143,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
         })
         await reply
             .status(response.status)
-            .headers(response.headers)
+            .headers(filterCorsHeaders(response.headers))
             .send(response.body)
     })
 
@@ -146,7 +160,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
         })
         await reply
             .status(response.status)
-            .headers(response.headers)
+            .headers(filterCorsHeaders(response.headers))
             .send(response.body)
     })
 


### PR DESCRIPTION
Calling a webhook's `/sync` endpoint from a browser via `fetch()` fails with:

> The 'Access-Control-Allow-Origin' header contains multiple values '*, *', but only one is allowed.

The response contains two separate `Access-Control-Allow-Origin` headers. The global Fastify CORS plugin sets one, and the webhook controller sets another by forwarding `response.headers` from the flow execution directly to the reply — which may include CORS headers if the flow itself made HTTP requests that returned them.

Fastify's `.headers()` appends rather than replaces, so you end up with both. Browsers concatenate duplicate headers as `*, *` and reject the response even though the server returns 200.

Reproduction (self-hosted, no CORS headers in nginx):

```
curl -sI -X POST \
  'https://<host>/api/v1/webhooks/<flow-id>/sync' \
  -H 'Origin: https://your-frontend.app'
```

Response:
```
access-control-allow-origin: *       <- global CORS plugin
access-control-expose-headers: *
Access-Control-Allow-Origin: *       <- forwarded from response.headers
Access-Control-Allow-Methods: GET, POST, OPTIONS
```

The fix adds a `filterCorsHeaders` helper that strips all CORS-related headers from the flow's response before passing them to `reply.headers()`. CORS is already handled globally by the plugin — the webhook controller does not need to forward them.