### PR TITLE
fix(pieces/amazon-textract): clarify single-page limit and multi-page…

### DIFF
--- a/packages/pieces/community/amazon-textract/package.json
+++ b/packages/pieces/community/amazon-textract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-textract",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document.ts
@@ -45,7 +45,7 @@ export const analyzeDocument = createAction({
             }),
             s3Key: Property.ShortText({
               displayName: 'S3 File Path',
-              description: 'The path to the file in your S3 bucket (e.g. "documents/invoice.pdf").',
+              description: 'The path to the file in your S3 bucket (e.g. "documents/invoice.pdf"). PDF and TIFF are supported for single-page documents only. For multi-page PDFs, use the Start Document Analysis action instead.',
               required: true,
             }),
           };

--- a/packages/pieces/community/amazon-textract/src/lib/common.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/common.ts
@@ -501,7 +501,7 @@ export function formatTextractError(error: unknown): string {
     case 'InvalidS3ObjectException':
       return 'The specified S3 object could not be read. Check the bucket name, key, and permissions.';
     case 'UnsupportedDocumentException':
-      return 'The document format is not supported. Use JPEG, PNG, PDF, or TIFF.';
+      return 'The document format or page count is not supported. Synchronous analysis supports JPEG, PNG, and single-page PDF or TIFF via S3. For multi-page PDFs, use the Start Document Analysis action.';
     case 'DocumentTooLargeException':
       return 'The document exceeds the maximum allowed size. Use S3 for large documents.';
     case 'BadDocumentException':


### PR DESCRIPTION
… error message

Synchronous AnalyzeDocument only supports single-page PDFs via S3. Update the S3 file path description and UnsupportedDocumentException error message to guide users to Start Document Analysis for multi-page PDFs.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
