### PR TITLE
fix: page oncall when dedicated worker hits INTERNAL_ERROR

### DIFF
--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -20,6 +20,7 @@ import {
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { flowCache } from '../../cache/flow/flow-cache'
+import { system, WorkerSystemProp } from '../../config/configs'
 import { workerSettings } from '../../config/worker-settings'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../types'
 import { provisionFlowPieces } from '../utils/flow-helpers'
@@ -202,4 +203,16 @@ async function reportFlowStatus(
         httpRequestId: data.httpRequestId ?? null,
         finishTime: new Date().toISOString(),
     })
+
+    if (status === FlowRunStatus.INTERNAL_ERROR && isDedicatedWorker()) {
+        onCallService(ctx.log, workerSettings.getSettings().PAGE_ONCALL_WEBHOOK).page({
+            code: ErrorCode.ENGINE_OPERATION_FAILURE,
+            message: `Flow run ${data.runId} ended with INTERNAL_ERROR on dedicated worker`,
+            params: { runId: data.runId, flowId: data.flowId, projectId: data.projectId },
+        }).catch((e) => ctx.log.error({ runId: data.runId, error: inspect(e) }, 'Failed to send on-call page for INTERNAL_ERROR'))
+    }
+}
+
+function isDedicatedWorker(): boolean {
+    return !isNil(system.get(WorkerSystemProp.WORKER_GROUP_ID))
 }


### PR DESCRIPTION
## Summary

- When a flow run ends with `INTERNAL_ERROR` on a **dedicated worker** (one with `AP_WORKER_GROUP_ID` set), page the oncall via `onCallService` so the team is alerted immediately.
- Shared workers are unaffected — only dedicated workers trigger the page.

## Changes

In `reportFlowStatus` (`execute-flow.ts`), after uploading the run log with `INTERNAL_ERROR` status, check if the worker is dedicated (`WORKER_GROUP_ID` is set) and fire an oncall page with the run ID, flow ID, and project ID.

## Test plan

- [ ] Deploy to staging with a dedicated worker and `PAGE_ONCALL_WEBHOOK` configured
- [ ] Trigger a flow that causes `INTERNAL_ERROR` — verify webhook receives the page
- [ ] Verify shared workers do NOT trigger the page on `INTERNAL_ERROR`