### PR TITLE
fix: consolidate oncall paging into reportFlowStatus

### DIFF
--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -18,9 +18,7 @@ import {
     WorkerJobType,
     WorkerToApiContract,
 } from '@activepieces/shared'
-import { FastifyBaseLogger } from 'fastify'
 import { flowCache } from '../../cache/flow/flow-cache'
-import { system, WorkerSystemProp } from '../../config/configs'
 import { workerSettings } from '../../config/worker-settings'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../types'
 import { provisionFlowPieces } from '../utils/flow-helpers'
@@ -132,7 +130,7 @@ async function buildFlowOperation(
     }
 
     if (data.executionType === ExecutionType.RESUME) {
-        const executionState = await fetchExecutionState(ctx.apiClient, data, ctx.log)
+        const executionState = await fetchExecutionState(ctx.apiClient, data)
         if (Object.keys(executionState.steps).length === 0) {
             ctx.log.error({ runId: data.runId, executionType: data.executionType }, 'RESUME operation has empty execution state — this is a bug that would cause an infinite loop')
             throw new ActivepiecesError({
@@ -160,33 +158,22 @@ async function buildFlowOperation(
     }
 }
 
-async function fetchExecutionState(apiClient: WorkerToApiContract, data: ExecuteFlowJobData, log: FastifyBaseLogger): Promise<ExecutionState> {
-    try {
-        if (isNil(data.logsFileId)) {
-            throw new ActivepiecesError({
-                code: ErrorCode.RESUME_LOGS_FILE_MISSING,
-                params: { runId: data.runId },
-            }, 'logsFileId is missing for RESUME operation')
-        }
-        const buffer = await apiClient.getPayloadFile({ fileId: data.logsFileId, projectId: data.projectId })
-        const parsed = JSON.parse(buffer.toString('utf-8'))
-        if (isNil(parsed.executionState)) {
-            throw new ActivepiecesError({
-                code: ErrorCode.EXECUTION_STATE_MISSING,
-                params: { logsFileId: data.logsFileId },
-            }, 'executionState is missing in logs file')
-        }
-        return parsed.executionState
-    }
-    catch (error) {
-        const code = error instanceof ActivepiecesError ? error.error.code : ErrorCode.EXECUTION_STATE_MISSING
-        onCallService(log, workerSettings.getSettings().PAGE_ONCALL_WEBHOOK).page({
-            code,
-            message: inspect(error),
+async function fetchExecutionState(apiClient: WorkerToApiContract, data: ExecuteFlowJobData): Promise<ExecutionState> {
+    if (isNil(data.logsFileId)) {
+        throw new ActivepiecesError({
+            code: ErrorCode.RESUME_LOGS_FILE_MISSING,
             params: { runId: data.runId },
-        }).catch((e) => log.error({ runId: data.runId, error: inspect(e) }, 'Failed to send on-call notification for execution state fetch failure'))
-        throw error
+        }, 'logsFileId is missing for RESUME operation')
     }
+    const buffer = await apiClient.getPayloadFile({ fileId: data.logsFileId, projectId: data.projectId })
+    const parsed = JSON.parse(buffer.toString('utf-8'))
+    if (isNil(parsed.executionState)) {
+        throw new ActivepiecesError({
+            code: ErrorCode.EXECUTION_STATE_MISSING,
+            params: { logsFileId: data.logsFileId },
+        }, 'executionState is missing in logs file')
+    }
+    return parsed.executionState
 }
 
 async function reportFlowStatus(
@@ -204,15 +191,11 @@ async function reportFlowStatus(
         finishTime: new Date().toISOString(),
     })
 
-    if (status === FlowRunStatus.INTERNAL_ERROR && isDedicatedWorker()) {
+    if (status === FlowRunStatus.INTERNAL_ERROR) {
         onCallService(ctx.log, workerSettings.getSettings().PAGE_ONCALL_WEBHOOK).page({
             code: ErrorCode.ENGINE_OPERATION_FAILURE,
-            message: `Flow run ${data.runId} ended with INTERNAL_ERROR on dedicated worker`,
+            message: `Flow run ${data.runId} ended with INTERNAL_ERROR`,
             params: { runId: data.runId, flowId: data.flowId, projectId: data.projectId },
         }).catch((e) => ctx.log.error({ runId: data.runId, error: inspect(e) }, 'Failed to send on-call page for INTERNAL_ERROR'))
     }
-}
-
-function isDedicatedWorker(): boolean {
-    return !isNil(system.get(WorkerSystemProp.WORKER_GROUP_ID))
 }

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -18,7 +18,6 @@ import {
     WorkerJobType,
     WorkerToApiContract,
 } from '@activepieces/shared'
-import { FastifyBaseLogger } from 'fastify'
 import { flowCache } from '../../cache/flow/flow-cache'
 import { system, WorkerSystemProp } from '../../config/configs'
 import { workerSettings } from '../../config/worker-settings'
@@ -132,7 +131,7 @@ async function buildFlowOperation(
     }
 
     if (data.executionType === ExecutionType.RESUME) {
-        const executionState = await fetchExecutionState({ apiClient: ctx.apiClient, data, log: ctx.log })
+        const executionState = await fetchExecutionState({ apiClient: ctx.apiClient, data })
         if (Object.keys(executionState.steps).length === 0) {
             ctx.log.error({ runId: data.runId, executionType: data.executionType }, 'RESUME operation has empty execution state — this is a bug that would cause an infinite loop')
             throw new ActivepiecesError({
@@ -160,7 +159,7 @@ async function buildFlowOperation(
     }
 }
 
-async function fetchExecutionState({ apiClient, data, log }: { apiClient: WorkerToApiContract, data: ExecuteFlowJobData, log: FastifyBaseLogger }): Promise<ExecutionState> {
+async function fetchExecutionState({ apiClient, data }: { apiClient: WorkerToApiContract, data: ExecuteFlowJobData }): Promise<ExecutionState> {
     if (isNil(data.logsFileId)) {
         throw new ActivepiecesError({
             code: ErrorCode.RESUME_LOGS_FILE_MISSING,
@@ -170,13 +169,6 @@ async function fetchExecutionState({ apiClient, data, log }: { apiClient: Worker
     const buffer = await apiClient.getPayloadFile({ fileId: data.logsFileId, projectId: data.projectId })
     const parsed = JSON.parse(buffer.toString('utf-8'))
     if (isNil(parsed.executionState)) {
-        if (!isDedicatedWorker()) {
-            onCallService(log, workerSettings.getSettings().PAGE_ONCALL_WEBHOOK).page({
-                code: ErrorCode.EXECUTION_STATE_MISSING,
-                message: `Flow run ${data.runId} has missing execution state in logs file ${data.logsFileId}`,
-                params: { runId: data.runId, logsFileId: data.logsFileId },
-            }).catch((e) => log.error({ runId: data.runId, error: inspect(e) }, 'Failed to send on-call page for EXECUTION_STATE_MISSING'))
-        }
         throw new ActivepiecesError({
             code: ErrorCode.EXECUTION_STATE_MISSING,
             params: { logsFileId: data.logsFileId },

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -18,7 +18,9 @@ import {
     WorkerJobType,
     WorkerToApiContract,
 } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
 import { flowCache } from '../../cache/flow/flow-cache'
+import { system, WorkerSystemProp } from '../../config/configs'
 import { workerSettings } from '../../config/worker-settings'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../types'
 import { provisionFlowPieces } from '../utils/flow-helpers'
@@ -130,7 +132,7 @@ async function buildFlowOperation(
     }
 
     if (data.executionType === ExecutionType.RESUME) {
-        const executionState = await fetchExecutionState(ctx.apiClient, data)
+        const executionState = await fetchExecutionState({ apiClient: ctx.apiClient, data, log: ctx.log })
         if (Object.keys(executionState.steps).length === 0) {
             ctx.log.error({ runId: data.runId, executionType: data.executionType }, 'RESUME operation has empty execution state — this is a bug that would cause an infinite loop')
             throw new ActivepiecesError({
@@ -158,7 +160,7 @@ async function buildFlowOperation(
     }
 }
 
-async function fetchExecutionState(apiClient: WorkerToApiContract, data: ExecuteFlowJobData): Promise<ExecutionState> {
+async function fetchExecutionState({ apiClient, data, log }: { apiClient: WorkerToApiContract, data: ExecuteFlowJobData, log: FastifyBaseLogger }): Promise<ExecutionState> {
     if (isNil(data.logsFileId)) {
         throw new ActivepiecesError({
             code: ErrorCode.RESUME_LOGS_FILE_MISSING,
@@ -168,6 +170,13 @@ async function fetchExecutionState(apiClient: WorkerToApiContract, data: Execute
     const buffer = await apiClient.getPayloadFile({ fileId: data.logsFileId, projectId: data.projectId })
     const parsed = JSON.parse(buffer.toString('utf-8'))
     if (isNil(parsed.executionState)) {
+        if (!isDedicatedWorker()) {
+            onCallService(log, workerSettings.getSettings().PAGE_ONCALL_WEBHOOK).page({
+                code: ErrorCode.EXECUTION_STATE_MISSING,
+                message: `Flow run ${data.runId} has missing execution state in logs file ${data.logsFileId}`,
+                params: { runId: data.runId, logsFileId: data.logsFileId },
+            }).catch((e) => log.error({ runId: data.runId, error: inspect(e) }, 'Failed to send on-call page for EXECUTION_STATE_MISSING'))
+        }
         throw new ActivepiecesError({
             code: ErrorCode.EXECUTION_STATE_MISSING,
             params: { logsFileId: data.logsFileId },
@@ -191,11 +200,15 @@ async function reportFlowStatus(
         finishTime: new Date().toISOString(),
     })
 
-    if (status === FlowRunStatus.INTERNAL_ERROR) {
+    if (status === FlowRunStatus.INTERNAL_ERROR && isDedicatedWorker()) {
         onCallService(ctx.log, workerSettings.getSettings().PAGE_ONCALL_WEBHOOK).page({
             code: ErrorCode.ENGINE_OPERATION_FAILURE,
             message: `Flow run ${data.runId} ended with INTERNAL_ERROR`,
             params: { runId: data.runId, flowId: data.flowId, projectId: data.projectId },
         }).catch((e) => ctx.log.error({ runId: data.runId, error: inspect(e) }, 'Failed to send on-call page for INTERNAL_ERROR'))
     }
+}
+
+function isDedicatedWorker(): boolean {
+    return !isNil(system.get(WorkerSystemProp.WORKER_GROUP_ID))
 }


### PR DESCRIPTION
## Summary

Follow-up to #12599. Addresses the double-page issue flagged in review.

- Remove the oncall page from `fetchExecutionState` — it was duplicating pages because `fetchExecutionState` errors propagate to the outer catch which calls `reportFlowStatus(INTERNAL_ERROR)`.
- `reportFlowStatus` is now the **single** oncall page path for all `INTERNAL_ERROR` cases.
- `fetchExecutionState` is now a pure function with no side effects.
- Removed the dedicated-worker-only guard — all `INTERNAL_ERROR` cases page oncall (the webhook is a no-op when `PAGE_ONCALL_WEBHOOK` is not configured).

## Test plan

- [ ] Trigger a RESUME flow that fails to fetch execution state — verify exactly 1 oncall page (not 2)
- [ ] Trigger a flow that fails with INTERNAL_ERROR — verify oncall page fires
- [ ] Verify no page fires when `PAGE_ONCALL_WEBHOOK` is not set