### PR TITLE
fix: validate key in storage get/delete to prevent confusing errors

### DIFF
--- a/packages/server/engine/src/lib/services/storage.service.ts
+++ b/packages/server/engine/src/lib/services/storage.service.ts
@@ -6,6 +6,9 @@ import { utils } from '../utils'
 export const createStorageService = ({ engineToken, apiUrl }: CreateStorageServiceParams): StorageService => {
     return {
         async get(key: string): Promise<StoreEntry | null> {
+            if (isNil(key) || key.length === 0) {
+                throw new StorageInvalidKeyError(key)
+            }
             const url = buildUrl(apiUrl, key)
 
             const { data: storeEntry, error: storeEntryError } = await utils.tryCatchAndThrowOnEngineError((async () => {
@@ -70,6 +73,9 @@ export const createStorageService = ({ engineToken, apiUrl }: CreateStorageServi
         },
 
         async delete(request: DeleteStoreEntryRequest): Promise<null> {
+            if (isNil(request.key) || request.key.length === 0) {
+                throw new StorageInvalidKeyError(request.key)
+            }
             const url = buildUrl(apiUrl, request.key)
 
             const { data: storeEntry, error: storeEntryError } = await utils.tryCatchAndThrowOnEngineError((async () => {


### PR DESCRIPTION
## Summary
- Adds early key validation in `StorageService.get()` and `StorageService.delete()` to throw a clear `StorageInvalidKeyError` when the key is undefined or empty
- Prevents a confusing Fastify querystring validation error that occurs when `buildUrl` silently omits the `key` param for falsy values

## Test plan
- [x] `npx turbo run build --filter=@activepieces/engine` compiles successfully
- [x] `npm run lint-dev` passes with no new errors
- [x] All existing tests pass