### PR TITLE
fix: validate Buffer in step-file upload path to prevent 500 errors

### DIFF
--- a/packages/server/api/src/app/file/s3-helper.ts
+++ b/packages/server/api/src/app/file/s3-helper.ts
@@ -28,6 +28,9 @@ export const s3Helper = (log: FastifyBaseLogger) => ({
         }
     },
     async uploadFile(s3Key: string, data: Buffer): Promise<string> {
+        if (!Buffer.isBuffer(data)) {
+            throw new Error(`Expected Buffer for S3 upload, received ${typeof data}`)
+        }
         log.info({
             s3Key,
         }, 'uploading file to s3')

--- a/packages/server/api/src/app/file/step-file/step-file.controller.ts
+++ b/packages/server/api/src/app/file/step-file/step-file.controller.ts
@@ -85,17 +85,6 @@ async function getFileByToken(token: string, log: FastifyBaseLogger): Promise<Om
     }
 }
 
-const SignedFileRequest = {
-    config: {
-        security: securityAccess.public(),
-    },
-    schema: {
-        querystring: z.object({
-            token: z.string(),
-        }),
-    },
-}
-
 function extractBufferOrUndefined(value: unknown): Buffer | undefined {
     if (value === undefined || value === null) {
         return undefined
@@ -113,6 +102,17 @@ function extractBufferOrUndefined(value: unknown): Buffer | undefined {
         code: ErrorCode.VALIDATION,
         params: { message: 'File data must be a Buffer' },
     })
+}
+
+const SignedFileRequest = {
+    config: {
+        security: securityAccess.public(),
+    },
+    schema: {
+        querystring: z.object({
+            token: z.string(),
+        }),
+    },
 }
 
 const UpsertStepFileRequest = {

--- a/packages/server/api/src/app/file/step-file/step-file.controller.ts
+++ b/packages/server/api/src/app/file/step-file/step-file.controller.ts
@@ -52,7 +52,7 @@ export const stepFileController: FastifyPluginAsyncZod = async (app) => {
             fileName: request.body.fileName,
             flowId: request.body.flowId,
             stepName: request.body.stepName,
-            data: request.body.file?.data as Buffer | undefined,
+            data: extractBufferOrUndefined(request.body.file?.data),
             platformId,
             projectId: request.principal.projectId,
             contentLength: request.body.contentLength,
@@ -94,6 +94,25 @@ const SignedFileRequest = {
             token: z.string(),
         }),
     },
+}
+
+function extractBufferOrUndefined(value: unknown): Buffer | undefined {
+    if (value === undefined || value === null) {
+        return undefined
+    }
+    if (Buffer.isBuffer(value)) {
+        return value
+    }
+    if (typeof value === 'string') {
+        return Buffer.from(value, 'utf-8')
+    }
+    if (value instanceof Uint8Array) {
+        return Buffer.from(value)
+    }
+    throw new ActivepiecesError({
+        code: ErrorCode.VALIDATION,
+        params: { message: 'File data must be a Buffer' },
+    })
 }
 
 const UpsertStepFileRequest = {

--- a/packages/server/engine/src/lib/services/step-files.service.ts
+++ b/packages/server/engine/src/lib/services/step-files.service.ts
@@ -16,7 +16,7 @@ export function createFilesService({ stepName, flowId, engineToken, apiUrl }: Cr
         write: async ({ fileName, data }: { fileName: string, data: Buffer }): Promise<string> => {
             if (!Buffer.isBuffer(data)) {
                 throw new Error(
-                    `Expected file data to be a Buffer, but received ${typeof data === 'object' ? ((data as unknown as { constructor?: { name?: string } })?.constructor?.name ?? 'Object') : typeof data}`,
+                    `Expected file data to be a Buffer, but received ${typeof data === 'object' ? Object.prototype.toString.call(data) : typeof data}`,
                 )
             }
             validateFileSize(data, maxFileSizeMb)

--- a/packages/server/engine/src/lib/services/step-files.service.ts
+++ b/packages/server/engine/src/lib/services/step-files.service.ts
@@ -16,7 +16,7 @@ export function createFilesService({ stepName, flowId, engineToken, apiUrl }: Cr
         write: async ({ fileName, data }: { fileName: string, data: Buffer }): Promise<string> => {
             if (!Buffer.isBuffer(data)) {
                 throw new Error(
-                    `Expected file data to be a Buffer, but received ${typeof data === 'object' ? (data as Record<string, unknown>)?.constructor?.name ?? 'Object' : typeof data}`,
+                    `Expected file data to be a Buffer, but received ${typeof data === 'object' ? ((data as unknown as { constructor?: { name?: string } })?.constructor?.name ?? 'Object') : typeof data}`,
                 )
             }
             validateFileSize(data, maxFileSizeMb)

--- a/packages/server/engine/src/lib/services/step-files.service.ts
+++ b/packages/server/engine/src/lib/services/step-files.service.ts
@@ -14,6 +14,11 @@ export function createFilesService({ stepName, flowId, engineToken, apiUrl }: Cr
 
     return {
         write: async ({ fileName, data }: { fileName: string, data: Buffer }): Promise<string> => {
+            if (!Buffer.isBuffer(data)) {
+                throw new Error(
+                    `Expected file data to be a Buffer, but received ${typeof data === 'object' ? (data as Record<string, unknown>)?.constructor?.name ?? 'Object' : typeof data}`,
+                )
+            }
             validateFileSize(data, maxFileSizeMb)
             const formData = createFormData({ fileName, data, stepName, flowId, useSignedUrl })
             const result = await uploadFileMetadata({ formData, engineToken, apiUrl })
@@ -89,7 +94,7 @@ async function uploadFileContent({ url, data }: { url: string, data: Buffer }): 
     if (!uploadResponse.ok) {
         throw new FileStoreError({
             status: uploadResponse.status,
-            body: uploadResponse.body,
+            body: await uploadResponse.text(),
         })
     }
 }

--- a/packages/server/engine/test/services/step-files.test.ts
+++ b/packages/server/engine/test/services/step-files.test.ts
@@ -20,7 +20,7 @@ describe('step-files service', () => {
         const files = createFilesService(SERVICE_PARAMS)
         await expect(
             files.write({ fileName: 'test.txt', data: {} as any }),
-        ).rejects.toThrow('Expected file data to be a Buffer, but received Object')
+        ).rejects.toThrow('Expected file data to be a Buffer, but received [object Object]')
     })
 
     it('throws when data is a string', async () => {

--- a/packages/server/engine/test/services/step-files.test.ts
+++ b/packages/server/engine/test/services/step-files.test.ts
@@ -1,0 +1,48 @@
+import { FileSizeError } from '@activepieces/shared'
+import { createFilesService } from '../../src/lib/services/step-files.service'
+
+const SERVICE_PARAMS = {
+    stepName: 'step_1',
+    flowId: 'flow-id',
+    engineToken: 'test-token',
+    apiUrl: 'http://localhost:3000/',
+}
+
+describe('step-files service', () => {
+
+    beforeEach(() => {
+        process.env.AP_MAX_FILE_SIZE_MB = '10'
+        process.env.AP_FILE_STORAGE_LOCATION = 'DB'
+        process.env.AP_S3_USE_SIGNED_URLS = 'false'
+    })
+
+    it('throws when data is a plain Object', async () => {
+        const files = createFilesService(SERVICE_PARAMS)
+        await expect(
+            files.write({ fileName: 'test.txt', data: {} as any }),
+        ).rejects.toThrow('Expected file data to be a Buffer, but received Object')
+    })
+
+    it('throws when data is a string', async () => {
+        const files = createFilesService(SERVICE_PARAMS)
+        await expect(
+            files.write({ fileName: 'test.txt', data: 'hello' as any }),
+        ).rejects.toThrow('Expected file data to be a Buffer, but received string')
+    })
+
+    it('throws when data is undefined', async () => {
+        const files = createFilesService(SERVICE_PARAMS)
+        await expect(
+            files.write({ fileName: 'test.txt', data: undefined as any }),
+        ).rejects.toThrow('Expected file data to be a Buffer, but received undefined')
+    })
+
+    it('throws when file exceeds size limit', async () => {
+        process.env.AP_MAX_FILE_SIZE_MB = '1'
+        const files = createFilesService(SERVICE_PARAMS)
+        const twoMbBuffer = Buffer.alloc(2 * 1024 * 1024)
+        await expect(
+            files.write({ fileName: 'big.bin', data: twoMbBuffer }),
+        ).rejects.toThrow(FileSizeError)
+    })
+})


### PR DESCRIPTION
## Summary
- Adds early Buffer validation in the engine's `files.write()` to fail with a clear error message instead of crashing with `ERR_INVALID_ARG_TYPE`
- Removes unsafe `as Buffer` cast in `step-file.controller.ts`, replacing it with a proper `extractBufferOrUndefined` helper
- Adds defensive Buffer guard in `s3-helper.ts` `uploadFile`
- Fixes `uploadResponse.body` bug — was passing a ReadableStream instead of a string in the error handler

## Test plan
- [x] Engine unit tests: 4 new tests covering Object, string, undefined, and oversized Buffer inputs
- [x] `npm run lint-dev` passes (0 errors)
- [ ] Verify step-file integration tests pass in CI