### PR TITLE
fix(oracle): surface thick-mode install logs in connection test error dialog

### DIFF
--- a/packages/pieces/community/oracle-database/package.json
+++ b/packages/pieces/community/oracle-database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-oracle-database",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/oracle-database/src/index.ts
+++ b/packages/pieces/community/oracle-database/src/index.ts
@@ -16,7 +16,7 @@ export const oracleDatabase = createPiece({
   minimumSupportedRelease: '0.36.1',
   logoUrl: 'https://cdn.activepieces.com/pieces/oracle-database.png',
   categories: [PieceCategory.DEVELOPER_TOOLS],
-  authors: ['Prabhukiran161', 'onyedikachi-david'],
+  authors: ['Prabhukiran161', 'onyedikachi-david', 'sanket-a11y'],
   actions: [
     insertRowAction,
     insertRowsAction,

--- a/packages/pieces/community/oracle-database/src/lib/common/auth.ts
+++ b/packages/pieces/community/oracle-database/src/lib/common/auth.ts
@@ -64,6 +64,7 @@ export const oracleDbAuth = PieceAuth.CustomAuth({
   validate: async ({ auth }) => {
     let connection: oracledb.Connection | undefined;
     const typedAuth = auth as StaticPropsValue<(typeof oracleDbAuth)['props']>;
+    const logs: string[] = [];
 
     try {
       let connectString: string | undefined;
@@ -77,6 +78,7 @@ export const oracleDbAuth = PieceAuth.CustomAuth({
           };
         }
         connectString = `${typedAuth.host}:${typedAuth.port}/${typedAuth.serviceName}`;
+        logs.push(`[oracle] Connection type: serviceName → ${connectString}`);
       } else {
         if (!typedAuth.connectionString) {
           return {
@@ -85,23 +87,26 @@ export const oracleDbAuth = PieceAuth.CustomAuth({
           };
         }
         connectString = typedAuth.connectionString;
+        logs.push(`[oracle] Connection type: connectionString → ${connectString}`);
       }
 
-      await ensureOracleClient(typedAuth.thickMode === true);
+      logs.push(`[oracle] Thick mode: ${typedAuth.thickMode === true}`);
+      await ensureOracleClient({ thickMode: typedAuth.thickMode === true, logs });
+      logs.push('[oracle] Oracle client ready. Opening connection...');
 
       connection = await oracledb.getConnection({
         user: typedAuth.user,
         password: typedAuth.password,
         connectString: connectString,
       });
-      console.log('Successfully connected to Oracle Database for authentication validation.');
-
+      logs.push('[oracle] Connection established successfully.');
+      console.log(logs.join('\n'));
       return { valid: true };
     } catch (e) {
-      console.error('Error occurred while validating Oracle Database connection:', (e as Error)?.message);
+      logs.push(`[oracle] Error: ${(e as Error)?.message ?? 'Unknown error'}`);
       return {
         valid: false,
-        error: (e as Error)?.message || 'Unknown connection error.',
+        error: `Connection failed. Debug log:\n${logs.join('\n')}`,
       };
     } finally {
       if (connection) {

--- a/packages/pieces/community/oracle-database/src/lib/common/auth.ts
+++ b/packages/pieces/community/oracle-database/src/lib/common/auth.ts
@@ -87,7 +87,7 @@ export const oracleDbAuth = PieceAuth.CustomAuth({
           };
         }
         connectString = typedAuth.connectionString;
-        logs.push(`[oracle] Connection type: connectionString → ${connectString}`);
+        logs.push(`[oracle] Connection type: connectionString → ${connectString.replace(/\/\/[^:]+:[^@]+@/, '//***:***@')}`);
       }
 
       logs.push(`[oracle] Thick mode: ${typedAuth.thickMode === true}`);

--- a/packages/pieces/community/oracle-database/src/lib/common/client.ts
+++ b/packages/pieces/community/oracle-database/src/lib/common/client.ts
@@ -2,10 +2,6 @@ import { OracleDbAuth } from './types';
 import oracledb from 'oracledb';
 import { ensureOracleClient } from './thick-mode';
 
-interface ExecuteManyResult {
-  rowsAffected?: number;
-}
-
 export class OracleDbClient {
   private readonly auth: OracleDbAuth;
   private connection: oracledb.Connection | undefined;
@@ -15,7 +11,7 @@ export class OracleDbClient {
   }
 
   private async connect(): Promise<void> {
-    await ensureOracleClient(this.auth.thickMode ?? false);
+    await ensureOracleClient({ thickMode: this.auth.thickMode ?? false, logs: [] });
 
     const connectString =
       this.auth.connectionType === 'serviceName'

--- a/packages/pieces/community/oracle-database/src/lib/common/thick-mode.ts
+++ b/packages/pieces/community/oracle-database/src/lib/common/thick-mode.ts
@@ -297,6 +297,7 @@ async function registerOracleLibs({ libDir, logs }: { libDir: string; logs: stri
 async function _initThickClient(logs: string[]): Promise<void> {
   // Flush any log lines captured at module load time (resolveOracleBaseDir)
   logs.push(...initLogs);
+  initLogs.length = 0;
 
   let libDir = getOracleClientLibDir();
 

--- a/packages/pieces/community/oracle-database/src/lib/common/thick-mode.ts
+++ b/packages/pieces/community/oracle-database/src/lib/common/thick-mode.ts
@@ -5,14 +5,28 @@ import os from 'os';
 import path from 'path';
 import { execSync } from 'child_process';
 
+// Collects log lines emitted during module initialisation so they can be
+// flushed into the caller's logs array when _initThickClient runs.
+const initLogs: string[] = [];
+
 // /opt/oracle if writable (system/Docker), otherwise ~/.oracle (local dev)
 function resolveOracleBaseDir(): string {
   const systemDir = '/opt/oracle';
   try {
+    if (!fs.existsSync(systemDir)) {
+      initLogs.push(`[oracle] ${systemDir} not found. Creating...`);
+      fs.mkdirSync(systemDir, { recursive: true });
+      initLogs.push(`[oracle] ${systemDir} created.`);
+    } else {
+      initLogs.push(`[oracle] ${systemDir} already exists.`);
+    }
     fs.accessSync(systemDir, fs.constants.W_OK);
+    initLogs.push(`[oracle] Using ${systemDir} as Oracle base dir.`);
     return systemDir;
-  } catch {
-    return path.join(os.homedir(), '.oracle');
+  } catch (err) {
+    const fallback = path.join(os.homedir(), '.oracle');
+    initLogs.push(`[oracle] Cannot use ${systemDir} (${(err as Error).message}). Falling back to ${fallback}.`);
+    return fallback;
   }
 }
 
@@ -51,25 +65,28 @@ function getOracleClientLibDir(): string | null {
 }
 
 // Downloads a file over HTTPS, following up to 10 redirects
-async function downloadFile(url: string, dest: string, redirectDepth = 0): Promise<void> {
+async function downloadFile({ url, dest, logs, redirectDepth = 0 }: { url: string; dest: string; logs: string[]; redirectDepth?: number }): Promise<void> {
   if (redirectDepth > 10) {
     throw new Error(`[oracle] Too many redirects downloading ${url}`);
   }
   return new Promise((resolve, reject) => {
+    logs.push(`[oracle] Downloading: ${url}`);
     console.log(`[oracle] Downloading: ${url}`);
     const file = fs.createWriteStream(dest);
 
     const req = https
       .get(url, (response) => {
         const { statusCode, headers } = response;
+        logs.push(`[oracle] HTTP ${statusCode} from ${url}`);
         console.log(`[oracle] HTTP ${statusCode} from ${url}`);
 
         if ([301, 302, 307, 308].includes(statusCode!)) {
+          logs.push(`[oracle] Redirecting to: ${headers.location}`);
           console.log(`[oracle] Redirecting to: ${headers.location}`);
           response.resume();
           file.close();
           fs.unlink(dest, () => {});
-          downloadFile(headers.location!, dest, redirectDepth + 1).then(resolve).catch(reject);
+          downloadFile({ url: headers.location!, dest, logs, redirectDepth: redirectDepth + 1 }).then(resolve).catch(reject);
           return;
         }
 
@@ -93,10 +110,12 @@ async function downloadFile(url: string, dest: string, redirectDepth = 0): Promi
 
         response.pipe(file);
         file.on('finish', () => {
+          logs.push(`[oracle] Download complete: ${dest}`);
           console.log(`\n[oracle] Download complete: ${dest}`);
           file.close(() => resolve());
         });
         file.on('error', (err) => {
+          logs.push(`[oracle] Write error: ${err.message}`);
           console.error(`[oracle] Write error:`, err.message);
           file.close();
           fs.unlink(dest, () => {});
@@ -104,6 +123,7 @@ async function downloadFile(url: string, dest: string, redirectDepth = 0): Promi
         });
       })
       .on('error', (err) => {
+        logs.push(`[oracle] Download error: ${err.message}`);
         console.error(`[oracle] Download error:`, err.message);
         file.close();
         fs.unlink(dest, () => {});
@@ -122,22 +142,29 @@ async function downloadFile(url: string, dest: string, redirectDepth = 0): Promi
  * Uses system patchelf if available, otherwise downloads the binary from
  * GitHub releases to ORACLE_BASE_DIR/bin/patchelf (no root required).
  */
-async function ensurePatchelf(): Promise<string> {
+async function ensurePatchelf({ logs }: { logs: string[] }): Promise<string> {
   // Use system patchelf if already installed (e.g. baked into Docker image)
   try {
+    logs.push('[oracle] Checking for system patchelf...');
     console.log('[oracle] Checking for system patchelf...');
     execSync('patchelf --version', { stdio: 'pipe' });
+    logs.push('[oracle] System patchelf found.');
     return 'patchelf';
   } catch {
+    logs.push('[oracle] System patchelf not found.');
     console.log('[oracle] System patchelf not found.');
   }
 
   // Use previously downloaded binary
-  if (fs.existsSync(PATCHELF_BIN)) return PATCHELF_BIN;
+  if (fs.existsSync(PATCHELF_BIN)) {
+    logs.push(`[oracle] Using cached patchelf at ${PATCHELF_BIN}.`);
+    return PATCHELF_BIN;
+  }
 
+  logs.push(`[oracle] Downloading patchelf ${PATCHELF_VERSION}...`);
   console.log(`[oracle] Downloading patchelf ${PATCHELF_VERSION}...`);
   const tarPath = path.join(os.tmpdir(), 'patchelf.tar.gz');
-  await downloadFile(PATCHELF_URL, tarPath);
+  await downloadFile({ url: PATCHELF_URL, dest: tarPath, logs });
 
   fs.mkdirSync(ORACLE_BASE_DIR, { recursive: true });
   // tarball has ./bin/patchelf; strip './' → extracts bin/patchelf into ORACLE_BASE_DIR
@@ -145,6 +172,7 @@ async function ensurePatchelf(): Promise<string> {
   fs.chmodSync(PATCHELF_BIN, 0o755);
   try { fs.unlinkSync(tarPath); } catch { /* ignore */ }
 
+  logs.push(`[oracle] patchelf downloaded to ${PATCHELF_BIN}.`);
   console.log(`[oracle] patchelf downloaded to ${PATCHELF_BIN}`);
   return PATCHELF_BIN;
 }
@@ -155,9 +183,12 @@ async function ensurePatchelf(): Promise<string> {
  * extracts libaio.so.1 directly into libDir (no root required).
  * Works together with the RPATH=$ORIGIN patchelf strategy.
  */
-async function ensureLibaio(libDir: string): Promise<void> {
+async function ensureLibaio({ libDir, logs }: { libDir: string; logs: string[] }): Promise<void> {
   // Already present in the Oracle lib dir (previously extracted)
-  if (fs.existsSync(path.join(libDir, 'libaio.so.1'))) return;
+  if (fs.existsSync(path.join(libDir, 'libaio.so.1'))) {
+    logs.push('[oracle] libaio.so.1 already present in lib dir.');
+    return;
+  }
 
   // Use system libaio if already installed
   const systemPaths = [
@@ -170,21 +201,25 @@ async function ensureLibaio(libDir: string): Promise<void> {
   ];
   const systemLib = systemPaths.find((p) => fs.existsSync(p));
   if (systemLib) {
-    console.log(`[oracle] libaio.so.1 found at ${systemLib}. Symlinking into libDir...`);
     const realLib = fs.realpathSync(systemLib);
+    logs.push(`[oracle] libaio.so.1 found at ${realLib}. Copying into lib dir...`);
+    console.log(`[oracle] libaio.so.1 found at ${systemLib}. Symlinking into libDir...`);
     console.log(`[oracle] Copying libaio.so.1 from ${realLib} into libDir...`);
     fs.copyFileSync(realLib, path.join(libDir, 'libaio.so.1'));
+    logs.push('[oracle] libaio.so.1 copied from system.');
     return;
   }
 
   // Download the Debian package and extract libaio.so.1
+  logs.push('[oracle] libaio.so.1 not found on system. Downloading Debian package...');
   console.log('[oracle] libaio.so.1 not found. Downloading Debian package...');
   const debPath = path.join(os.tmpdir(), 'libaio1.deb');
   const extractDir = path.join(os.tmpdir(), 'libaio1-extract');
 
-  await downloadFile(LIBAIO_DEB_URL, debPath);
+  await downloadFile({ url: LIBAIO_DEB_URL, dest: debPath, logs });
 
   // .deb is an ar archive — `ar` + `tar` works on all distros (not just Debian/Ubuntu)
+  logs.push('[oracle] Extracting libaio1.deb...');
   fs.mkdirSync(extractDir, { recursive: true });
   execSync(`ar x "${debPath}"`, { cwd: extractDir, stdio: 'pipe' });
   const dataFile = fs.readdirSync(extractDir).find((f) => f.startsWith('data.tar'));
@@ -206,6 +241,7 @@ async function ensureLibaio(libDir: string): Promise<void> {
   }
 
   fs.copyFileSync(extracted, path.join(libDir, 'libaio.so.1'));
+  logs.push('[oracle] libaio.so.1 extracted into Oracle lib dir.');
   console.log('[oracle] libaio.so.1 extracted into Oracle lib dir.');
 
   try { fs.rmSync(extractDir, { recursive: true }); } catch { /* ignore */ }
@@ -226,37 +262,49 @@ async function ensureLibaio(libDir: string): Promise<void> {
  * Strategy 2 — symlinks into /usr/local/lib (fallback, root only):
  *   Works in Docker containers running as root.
  */
-async function registerOracleLibs(libDir: string): Promise<void> {
+async function registerOracleLibs({ libDir, logs }: { libDir: string; logs: string[] }): Promise<void> {
   const libclntsh = `${libDir}/libclntsh.so`;
 
   try {
-    const patchelf = await ensurePatchelf();
+    logs.push('[oracle] Acquiring patchelf...');
+    const patchelf = await ensurePatchelf({ logs });
+    logs.push(`[oracle] Running: patchelf --set-rpath '$ORIGIN' libclntsh.so`);
     execSync(`"${patchelf}" --set-rpath '$ORIGIN' "${libclntsh}"`, { stdio: 'pipe' });
+    logs.push('[oracle] RPATH patched successfully.');
     console.log(`[oracle] Patched RPATH of libclntsh.so to $ORIGIN`);
     return;
   } catch (err) {
+    logs.push(`[oracle] patchelf strategy failed: ${(err as Error).message}. Trying symlink fallback...`);
     console.log(`[oracle] patchelf strategy failed: ${(err as Error).message}. Trying symlink fallback...`);
   }
 
   try {
     const libs = fs.readdirSync(libDir).filter((f) => f.endsWith('.so'));
+    logs.push(`[oracle] Symlinking ${libs.length} libs into /usr/local/lib and running ldconfig...`);
     for (const lib of libs) {
       execSync(`ln -sf "${libDir}/${lib}" /usr/local/lib/${lib}`, { stdio: 'pipe' });
     }
     execSync('ldconfig', { stdio: 'pipe' });
+    logs.push(`[oracle] Registered libs from ${libDir} via /usr/local/lib.`);
     console.log(`[oracle] Registered libs from ${libDir} via /usr/local/lib`);
   } catch {
+    logs.push(`[oracle] Could not register libs. Set LD_LIBRARY_PATH=${libDir} before starting the server.`);
     console.log(`[oracle] Could not register libs. Set LD_LIBRARY_PATH=${libDir} before starting the server.`);
   }
 }
 
 // Thick mode only — thin mode is oracledb's default, no initOracleClient() call needed.
-async function _initThickClient(): Promise<void> {
+async function _initThickClient(logs: string[]): Promise<void> {
+  // Flush any log lines captured at module load time (resolveOracleBaseDir)
+  logs.push(...initLogs);
+
   let libDir = getOracleClientLibDir();
 
   if (!libDir) {
+    logs.push('[oracle] Instant Client not found locally. Downloading automatically...');
     console.log('[oracle] Instant Client not found. Downloading automatically...');
-    await downloadFile(ORACLE_INSTANT_CLIENT_URL, ORACLE_TEMP_ZIP);
+    await downloadFile({ url: ORACLE_INSTANT_CLIENT_URL, dest: ORACLE_TEMP_ZIP, logs });
+    logs.push(`[oracle] Download complete. Extracting to ${ORACLE_BASE_DIR}...`);
 
     if (!fs.existsSync(ORACLE_BASE_DIR)) {
       fs.mkdirSync(ORACLE_BASE_DIR, { recursive: true });
@@ -274,10 +322,16 @@ async function _initThickClient(): Promise<void> {
         'Please install it manually at /opt/oracle/.'
       );
     }
+    logs.push(`[oracle] Instant Client extracted to ${libDir}.`);
+  } else {
+    logs.push(`[oracle] Instant Client already present at ${libDir}.`);
   }
 
-  await ensureLibaio(libDir);
-  await registerOracleLibs(libDir);
+  logs.push('[oracle] Ensuring libaio.so.1 is available...');
+  await ensureLibaio({ libDir, logs });
+  logs.push('[oracle] libaio.so.1 ready. Registering Oracle libs...');
+  await registerOracleLibs({ libDir, logs });
+  logs.push('[oracle] Oracle libs registered. Calling initOracleClient...');
 
   try {
     oracledb.initOracleClient({ libDir });
@@ -295,6 +349,7 @@ async function _initThickClient(): Promise<void> {
     throw err;
   }
 
+  logs.push(`[oracle] Instant Client loaded from ${libDir}. Thick mode active.`);
   console.log(`[oracle] Instant Client loaded from ${libDir}. Thick mode active.`);
 }
 
@@ -312,18 +367,26 @@ async function _initThickClient(): Promise<void> {
  * Promise-based singleton for thick mode — concurrent callers all await the same Promise
  * so initOracleClient is never called twice (prevents NJS-090).
  */
-export const ensureOracleClient: (thickMode: boolean) => Promise<void> = (() => {
+export const ensureOracleClient: (params: { thickMode: boolean; logs: string[] }) => Promise<void> = (() => {
   let thickInitPromise: Promise<void> | null = null;
-  return (thickMode: boolean): Promise<void> => {
-    if (!thickMode) return Promise.resolve();
+  return ({ thickMode, logs }: { thickMode: boolean; logs: string[] }): Promise<void> => {
+    if (!thickMode) {
+      logs.push('[oracle] Thin mode selected; skipping Instant Client setup.');
+      return Promise.resolve();
+    }
     // Already in thick mode (initOracleClient was called successfully earlier)
-    if (!oracledb.thin) return Promise.resolve();
+    if (!oracledb.thin) {
+      logs.push('[oracle] Thick mode already active (Instant Client previously loaded).');
+      return Promise.resolve();
+    }
     if (!thickInitPromise) {
       // Clear on failure so the next call can retry (e.g. transient network error)
-      thickInitPromise = _initThickClient().catch((err) => {
+      thickInitPromise = _initThickClient(logs).catch((err) => {
         thickInitPromise = null;
         throw err;
       });
+    } else {
+      logs.push('[oracle] Thick mode initialisation already in progress; waiting...');
     }
     return thickInitPromise;
   };


### PR DESCRIPTION

## Summary

- **Surfaces thick-mode install diagnostics in the UI**: every step of the Oracle Instant Client setup (base dir resolution, file downloads, patchelf, libaio, RPATH patching, `initOracleClient`) is now captured in a `logs` string array and included verbatim in the connection-test error message — visible immediately in the AP UI without needing server log access or an image upgrade
- **Threaded `logs` through the full call chain**: `ensureOracleClient` → `_initThickClient` → `downloadFile`, `ensurePatchelf`, `ensureLibaio`, `registerOracleLibs`; module-load logs from `resolveOracleBaseDir` are buffered in `initLogs` and flushed at the start of `_initThickClient`
- **Auto-creates `/opt/oracle`** on first run if the process has permission (Docker/root), so containers use the system path instead of falling back to `~/.oracle`


Fixes # (issue)
