### PR TITLE
fix(mcp): correct step references, preserve trigger data, resolve dynamic inputs

### DIFF
--- a/packages/server/api/src/app/mcp/mcp-service.ts
+++ b/packages/server/api/src/app/mcp/mcp-service.ts
@@ -14,22 +14,23 @@ import { activepiecesTools, ALL_CONTROLLABLE_TOOL_NAMES, LOCKED_TOOL_NAMES } fro
 
 const EDITION_REQUIRES_RBAC = [ApEdition.CLOUD, ApEdition.ENTERPRISE].includes(system.getEdition())
 
-const MCP_SERVER_INSTRUCTIONS = `## Activepieces MCP Server — Agent Workflow Guide
+const MCP_SERVER_INSTRUCTIONS = `## Activepieces MCP Server
 
-### Recommended workflow
-1. **Discover**: ap_list_pieces (find pieces), ap_list_connections (find auth), ap_list_ai_models (find AI providers)
-2. **Schema**: ap_get_piece_props (get exact field names/types before configuring)
-3. **Build**: ap_create_flow → ap_update_trigger → ap_add_step → ap_update_step
-4. **Validate**: ap_validate_step_config (check a step config) or ap_validate_flow (check the whole flow)
-5. **Publish**: ap_lock_and_publish → ap_change_flow_status
+### Workflow
+1. Discover: ap_list_pieces, ap_list_connections, ap_list_ai_models
+2. Schema: ap_get_piece_props (get field names/types before configuring)
+3. Build: ap_create_flow → ap_update_trigger → ap_add_step → ap_update_step
+4. Validate: ap_validate_step_config / ap_validate_flow
+5. Publish: ap_lock_and_publish → ap_change_flow_status
 
 ### Key patterns
-- **Auth**: Use ap_list_connections to get the \`externalId\`, then pass it as the \`auth\` parameter on ap_update_step or ap_update_trigger.
-- **Step references**: Use \`{{stepName.output.field}}\` in input values to reference data from previous steps (e.g. \`{{trigger.output.body.email}}\`, \`{{step_1.output.id}}\`).
-- **Step names**: Steps are named \`trigger\`, \`step_1\`, \`step_2\`, etc. Use ap_flow_structure to see all step names and valid insertion points.
-- **Piece names**: Use the full format (e.g. "@activepieces/piece-slack") for ap_add_step and ap_update_trigger. Short names like "slack" are accepted by lookup tools (ap_list_connections, ap_get_piece_props, ap_validate_step_config).
-- **CODE steps**: Set sourceCode (must export a \`code\` function) and input (key-value pairs accessible via \`inputs.key\`).
-- **Tables**: Use field names (not IDs) when inserting or querying records.`
+- **Auth**: ap_list_connections → get \`externalId\` → pass as \`auth\` param on ap_update_step/ap_update_trigger.
+- **Step refs**: \`{{stepName.field}}\` — no \`.output.\` in the path (e.g. \`{{trigger.body.email}}\`, \`{{step_1.id}}\`).
+- **Step names**: \`trigger\`, \`step_1\`, \`step_2\`, etc. Use ap_flow_structure to see all names.
+- **Piece names**: full format (e.g. "@activepieces/piece-slack") for ap_add_step/ap_update_trigger. Short names work for lookup tools.
+- **Modifying steps**: use ap_update_step/ap_update_trigger. Never delete+recreate — loses sample data.
+- **CODE steps**: export a \`code\` fn; access inputs via \`inputs.key\`.
+- **Tables**: use field names, not IDs.`
 
 export const mcpServerRepository = repoFactory(McpServerEntity)
 

--- a/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
@@ -22,7 +22,7 @@ export const apDeleteStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
     return {
         title: 'ap_delete_step',
         permission: Permission.WRITE_FLOW,
-        description: 'Delete a step from a flow.',
+        description: 'Delete a step from a flow. Prefer ap_update_step to modify — delete destroys sample data.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             stepName: z.string().describe('The name of the step to delete. Use ap_flow_structure to get valid values.'),

--- a/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
@@ -202,8 +202,7 @@ function formatFlowStructure(
     lines.push('Step types: trigger = EMPTY | PIECE_TRIGGER; action = CODE | PIECE | LOOP_ON_ITEMS | ROUTER')
     lines.push('')
     lines.push('## Referencing step outputs')
-    lines.push('Use `{{stepName.output.fieldName}}` in step inputs to reference data from previous steps.')
-    lines.push('Example: `{{trigger.output.body.email}}`')
+    lines.push(mcpUtils.STEP_REFERENCE_HINT)
     lines.push('Use ap_test_step or ap_test_flow to generate sample data and see available output fields.')
 
     lines.push('')

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -106,7 +106,7 @@ async function resolvePropertyOptions({ props, componentProps, pieceName, pieceV
         try {
             const result = await withTimeout({
                 promise: userInteractionWatcher.submitAndWaitForResponse<EngineResponse<{
-                    options: unknown
+                    options: Array<{ label: string, value: unknown }> | PiecePropertyMap
                     disabled?: boolean
                 }>>({
                     jobType: WorkerJobType.EXECUTE_PROPERTY,
@@ -128,8 +128,8 @@ async function resolvePropertyOptions({ props, componentProps, pieceName, pieceV
             }
 
             const { options } = result.response
-            if (prop.type === PropertyType.DYNAMIC && isObject(options)) {
-                prop.dynamicFields = mcpUtils.buildPropSummaries(options as PiecePropertyMap)
+            if (prop.type === PropertyType.DYNAMIC && isObject(options) && !Array.isArray(options)) {
+                prop.dynamicFields = mcpUtils.buildPropSummaries(options)
                 prop.note = undefined
             }
             else if (Array.isArray(options)) {

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -4,6 +4,7 @@ import {
     EngineResponseStatus,
     FlowVersion,
     isNil,
+    isObject,
     McpServer,
     McpToolDefinition,
     SampleDataFileType,
@@ -16,17 +17,17 @@ import { sampleDataService } from '../../flows/step-run/sample-data.service'
 import { getPiecePackageWithoutArchive } from '../../pieces/metadata/piece-metadata-service'
 import { projectService } from '../../project/project-service'
 import { userInteractionWatcher } from '../../workers/user-interaction-watcher'
-import { mcpUtils } from './mcp-utils'
+import { mcpUtils, PropSummary } from './mcp-utils'
 
 export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
         title: 'ap_get_piece_props',
-        description: 'Get the input property schema for a piece action or trigger. Returns field names, types, required/optional, defaults, and options. Pass auth to resolve dynamic dropdown values.',
+        description: 'Get the input property schema for a piece action or trigger. Returns field names, types, required/optional, defaults, and options. Pass auth to resolve dynamic dropdowns and dynamic property sub-fields (e.g. Custom API Call url/body fields).',
         inputSchema: getPiecePropsInput.shape,
         annotations: { readOnlyHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
-                const { pieceName, actionOrTriggerName, type, auth, flowId } = getPiecePropsInput.parse(args)
+                const { pieceName, actionOrTriggerName, type, auth, flowId, input: providedInput } = getPiecePropsInput.parse(args)
 
                 const lookup = await mcpUtils.lookupPieceComponent({
                     pieceName,
@@ -44,19 +45,18 @@ export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 const props = mcpUtils.buildPropSummaries(component.props)
                 const requiresAuth = component.requireAuth && !isNil(piece.auth)
 
-                if (auth) {
-                    await resolveDropdownOptions({
-                        props,
-                        componentProps: component.props,
-                        pieceName: normalized,
-                        pieceVersion: piece.version,
-                        actionOrTriggerName,
-                        auth,
-                        flowId,
-                        projectId: mcp.projectId,
-                        log,
-                    })
-                }
+                await resolvePropertyOptions({
+                    props,
+                    componentProps: component.props,
+                    pieceName: normalized,
+                    pieceVersion: piece.version,
+                    actionOrTriggerName,
+                    auth,
+                    flowId,
+                    providedInput: providedInput ?? {},
+                    projectId: mcp.projectId,
+                    log,
+                })
 
                 const result = {
                     piece: normalized,
@@ -78,43 +78,35 @@ export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
     }
 }
 
-const getPiecePropsInput = z.object({
-    pieceName: z.string().describe('The piece name (e.g. "@activepieces/piece-slack"). Use ap_list_pieces to get valid values.'),
-    actionOrTriggerName: z.string().describe('The action or trigger name (e.g. "send_channel_message"). Use ap_list_pieces with includeActions=true or includeTriggers=true to get valid values.'),
-    type: z.enum(['action', 'trigger']).describe('Whether to look up an action or a trigger.'),
-    auth: z.string().optional().describe('Connection externalId from ap_list_connections. When provided, dynamic dropdowns return actual options instead of a placeholder note.'),
-    flowId: z.string().optional().describe('Flow ID for resolving dependent dropdowns that need step context. Optional — most dropdowns work without it.'),
-})
-
-const DROPDOWN_TYPES = new Set([PropertyType.DROPDOWN, PropertyType.MULTI_SELECT_DROPDOWN])
-const DROPDOWN_TIMEOUT_MS = 15_000
-
-async function resolveDropdownOptions({ props, componentProps, pieceName, pieceVersion, actionOrTriggerName, auth, flowId, projectId, log }: ResolveDropdownParams): Promise<void> {
-    const project = await projectService(log).getOneOrThrow(projectId)
-    const piecePackage = await getPiecePackageWithoutArchive(log, project.platformId, { pieceName, pieceVersion })
-
-    let flowVersion: FlowVersion | undefined
-    let sampleData: Record<string, unknown> = {}
-    if (flowId) {
-        const flow = await flowService(log).getOnePopulated({ id: flowId, projectId })
-        if (flow) {
-            flowVersion = flow.version
-            sampleData = await sampleDataService(log).getSampleDataForFlow(projectId, flow.version, SampleDataFileType.OUTPUT)
-        }
+async function resolvePropertyOptions({ props, componentProps, pieceName, pieceVersion, actionOrTriggerName, auth, flowId, providedInput, projectId, log }: ResolvePropertyOptionsParams): Promise<void> {
+    const resolvableProps = mcpUtils.findResolvableProps({ props, componentProps, auth, providedInput })
+    if (resolvableProps.length === 0) {
+        return
     }
 
-    const input: Record<string, unknown> = { auth: `{{connections['${auth}']}}` }
+    const [project, flow] = await Promise.all([
+        projectService(log).getOneOrThrow(projectId),
+        flowId ? flowService(log).getOnePopulated({ id: flowId, projectId }) : Promise.resolve(null),
+    ])
 
-    const dropdownProps = props.filter(prop => {
-        const propDef = componentProps[prop.name]
-        return DROPDOWN_TYPES.has(prop.type) && !isNil(propDef) && 'refreshers' in propDef
-    })
+    const [piecePackage, sampleData] = await Promise.all([
+        getPiecePackageWithoutArchive(log, project.platformId, { pieceName, pieceVersion }),
+        flow
+            ? sampleDataService(log).getSampleDataForFlow(projectId, flow.version, SampleDataFileType.OUTPUT)
+            : Promise.resolve({} as Record<string, unknown>),
+    ])
+    const flowVersion: FlowVersion | undefined = flow?.version
 
-    await Promise.all(dropdownProps.map(async (prop) => {
+    const input: Record<string, unknown> = {
+        ...providedInput,
+        ...(auth ? { auth: `{{connections['${auth}']}}` } : {}),
+    }
+
+    await Promise.all(resolvableProps.map(async (prop) => {
         try {
             const result = await withTimeout({
                 promise: userInteractionWatcher.submitAndWaitForResponse<EngineResponse<{
-                    options: Array<{ label: string, value: unknown }>
+                    options: unknown
                     disabled?: boolean
                 }>>({
                     jobType: WorkerJobType.EXECUTE_PROPERTY,
@@ -128,16 +120,25 @@ async function resolveDropdownOptions({ props, componentProps, pieceName, pieceV
                     searchValue: undefined,
                     piece: piecePackage,
                 }, log),
-                ms: DROPDOWN_TIMEOUT_MS,
+                ms: PROPERTY_TIMEOUT_MS,
             })
 
-            if (result.status === EngineResponseStatus.OK && result.response?.options && Array.isArray(result.response.options)) {
-                prop.options = result.response.options.map((o: { label: string, value: unknown }) => ({ label: o.label, value: o.value }))
+            if (result.status !== EngineResponseStatus.OK || isNil(result.response?.options)) {
+                return
+            }
+
+            const { options } = result.response
+            if (prop.type === PropertyType.DYNAMIC && isObject(options)) {
+                prop.dynamicFields = mcpUtils.buildPropSummaries(options as PiecePropertyMap)
+                prop.note = undefined
+            }
+            else if (Array.isArray(options)) {
+                prop.options = options.map((o: { label: string, value: unknown }) => ({ label: o.label, value: o.value }))
                 prop.note = undefined
             }
         }
         catch (err) {
-            log.debug({ err, propertyName: prop.name }, 'Failed to resolve dropdown options, keeping placeholder note')
+            log.debug({ err, propertyName: prop.name }, 'Failed to resolve property, keeping placeholder note')
         }
     }))
 }
@@ -147,19 +148,31 @@ function withTimeout<T>({ promise, ms }: { promise: Promise<T>, ms: number }): P
     return Promise.race([
         promise.finally(() => clearTimeout(timer)),
         new Promise<never>((_resolve, reject) => {
-            timer = setTimeout(() => reject(new Error(`Dropdown resolution timed out after ${ms}ms`)), ms)
+            timer = setTimeout(() => reject(new Error(`Property resolution timed out after ${ms}ms`)), ms)
         }),
     ])
 }
 
-type ResolveDropdownParams = {
-    props: Array<{ name: string, type: PropertyType, options?: unknown, note?: string | undefined }>
+const getPiecePropsInput = z.object({
+    pieceName: z.string().describe('The piece name (e.g. "@activepieces/piece-slack"). Use ap_list_pieces to get valid values.'),
+    actionOrTriggerName: z.string().describe('The action or trigger name (e.g. "send_channel_message"). Use ap_list_pieces with includeActions=true or includeTriggers=true to get valid values.'),
+    type: z.enum(['action', 'trigger']).describe('Whether to look up an action or a trigger.'),
+    auth: z.string().optional().describe('Connection externalId from ap_list_connections. When provided, dynamic dropdowns and dynamic property sub-fields are resolved via your account.'),
+    flowId: z.string().optional().describe('Flow ID for resolving dependent dropdowns that need step context. Optional — most dropdowns work without it.'),
+    input: z.record(z.string(), z.unknown()).optional().describe('Known input values to resolve dependent dynamic properties.'),
+})
+
+const PROPERTY_TIMEOUT_MS = 15_000
+
+type ResolvePropertyOptionsParams = {
+    props: PropSummary[]
     componentProps: PiecePropertyMap
     pieceName: string
     pieceVersion: string
     actionOrTriggerName: string
-    auth: string
+    auth: string | undefined
     flowId: string | undefined
+    providedInput: Record<string, unknown>
     projectId: string
     log: FastifyBaseLogger
 }

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -40,7 +40,7 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
             flowId: z.string().describe('The id of the flow'),
             stepName: z.string().describe('The name of the step to update (e.g. "step_1"). Use ap_flow_structure to get valid values.'),
             displayName: z.string().optional().describe('New display name for the step'),
-            input: z.record(z.string(), z.unknown()).optional().describe('Input settings for the step (key-value pairs matching the action schema). Use `{{stepName.output.field}}` to reference data from previous steps (e.g. `{{trigger.output.body.email}}`, `{{step_1.output.id}}`).'),
+            input: z.record(z.string(), z.unknown()).optional().describe(`Input settings for the step (key-value pairs matching the action schema). ${mcpUtils.STEP_REFERENCE_HINT}`),
             auth: z.string().optional().describe('Connection `externalId` from `ap_list_connections`. The tool wraps it automatically as `{{connections[\'externalId\']}}`.'),
             actionName: z.string().optional().describe('For PIECE steps: the action to perform. Use ap_list_pieces to get valid values.'),
             loopItems: z.string().optional().describe('For LOOP steps: expression for the items to iterate over'),

--- a/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
@@ -35,7 +35,7 @@ export const apUpdateTriggerTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
             pieceName: z.string().describe('The piece name for the trigger (e.g. "@activepieces/piece-gmail"). Use ap_list_pieces to get valid values.'),
             pieceVersion: z.string().describe('The piece version (e.g. "~0.1.0"). Use ap_list_pieces to get valid values.'),
             triggerName: z.string().describe('The trigger name within the piece (e.g. "new_email"). Use ap_list_pieces with includeTriggers=true to get valid values.'),
-            input: z.record(z.string(), z.unknown()).optional().describe('Input settings for the trigger (key-value pairs). Use `{{stepName.output.field}}` to reference data from previous steps (e.g. `{{trigger.output.body.email}}`, `{{step_1.output.id}}`).'),
+            input: z.record(z.string(), z.unknown()).optional().describe(`Input settings for the trigger (key-value pairs). ${mcpUtils.STEP_REFERENCE_HINT}`),
             auth: z.string().optional().describe('Connection `externalId` from `ap_list_connections`. The tool wraps it automatically as `{{connections[\'externalId\']}}`.'),
             displayName: z.string().optional().describe('Display name for the trigger step'),
         },
@@ -49,10 +49,6 @@ export const apUpdateTriggerTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 }
             }
 
-            const input = {
-                ...(rawInput ?? {}),
-                ...(auth !== undefined && { auth: `{{connections['${auth}']}}` }),
-            }
             const displayName = rawDisplayName ?? triggerName
 
             const [flow, project] = await Promise.all([
@@ -61,6 +57,20 @@ export const apUpdateTriggerTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
             ])
             if (isNil(flow)) {
                 return { content: [{ type: 'text', text: '❌ Flow not found' }] }
+            }
+
+            const existingTrigger = flow.version.trigger
+            const existingPieceSettings = existingTrigger.type === FlowTriggerType.PIECE
+                && existingTrigger.settings.pieceName === pieceName
+                && existingTrigger.settings.triggerName === triggerName
+                ? existingTrigger.settings
+                : null
+
+            const { auth: _rawAuth, ...rawInputWithoutAuth } = rawInput ?? {}
+            const input = {
+                ...(existingPieceSettings?.input ?? {}),
+                ...rawInputWithoutAuth,
+                ...(auth !== undefined && { auth: `{{connections['${auth}']}}` }),
             }
 
             const triggerPayload = {
@@ -74,7 +84,7 @@ export const apUpdateTriggerTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                     pieceVersion,
                     triggerName,
                     input,
-                    propertySettings: {},
+                    propertySettings: existingPieceSettings?.propertySettings ?? {},
                 },
             }
 

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -10,11 +10,13 @@ const AUTH_TYPES = new Set<PropertyType>([
     PropertyType.CUSTOM_AUTH,
 ])
 
-const DYNAMIC_PROP_TYPES = new Set<PropertyType>([
+const RESOLVABLE_PROP_TYPES = new Set<PropertyType>([
     PropertyType.DROPDOWN,
     PropertyType.MULTI_SELECT_DROPDOWN,
     PropertyType.DYNAMIC,
 ])
+
+const STEP_REFERENCE_HINT = 'Use {{stepName.field}} to reference prior steps (no .output. in path).'
 
 function mcpToolError(prefix: string, err: unknown): { content: [{ type: 'text', text: string }] } {
     const message = err instanceof Error ? err.message : String(err)
@@ -33,7 +35,7 @@ function diagnosePieceProps({ props, input, pieceAuth, requireAuth, componentTyp
         if (prop.required) {
             const value = input[propName]
             if (value === undefined || value === null || value === '') {
-                if (DYNAMIC_PROP_TYPES.has(prop.type)) {
+                if (RESOLVABLE_PROP_TYPES.has(prop.type)) {
                     uiRequired.push(`${propName} (${prop.displayName})`)
                 }
                 else {
@@ -85,7 +87,7 @@ function buildPropSummaries(props: PiecePropertyMap): PropSummary[] {
                 summary.note = 'Dynamic dropdown — options load from your account via API. Configure in the Activepieces UI, or provide a known value.'
             }
             if (prop.type === PropertyType.DYNAMIC) {
-                summary.note = 'Dynamic properties — fields are generated based on other input values. Configure in the Activepieces UI.'
+                summary.note = 'DYNAMIC — call ap_get_piece_props with auth+input to resolve sub-fields.'
             }
             return summary
         })
@@ -121,7 +123,27 @@ async function lookupPieceComponent({ pieceName, componentName, componentType, p
     return { piece, component, pieceName: normalized }
 }
 
-export const mcpUtils = { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName, lookupPieceComponent }
+function findResolvableProps({ props, componentProps, auth, providedInput }: FindResolvablePropsParams): PropSummary[] {
+    return props.filter(prop => {
+        const propDef = componentProps[prop.name]
+        if (isNil(propDef) || !RESOLVABLE_PROP_TYPES.has(prop.type) || !('refreshers' in propDef)) {
+            return false
+        }
+        const refreshers = (propDef as { refreshers: string[] }).refreshers
+        return refreshers.every(r => r === 'auth' ? !!auth : providedInput[r] !== undefined)
+    })
+}
+
+export const mcpUtils = { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName, lookupPieceComponent, findResolvableProps, STEP_REFERENCE_HINT }
+
+export type { PropSummary }
+
+type FindResolvablePropsParams = {
+    props: PropSummary[]
+    componentProps: PiecePropertyMap
+    auth: string | undefined
+    providedInput: Record<string, unknown>
+}
 
 type DiagnosePiecePropsParams = {
     props: PiecePropertyMap
@@ -146,6 +168,7 @@ type PropSummary = {
     description?: string
     defaultValue?: unknown
     options?: Array<{ label: string, value: unknown }>
+    dynamicFields?: PropSummary[]
     note?: string
 }
 

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -1068,7 +1068,7 @@ describe('MCP Tools integration', () => {
         expect(output).toContain('subject')
     })
 
-    it('43. ap_list_connections — short piece name auto-expands', async () => {
+    it('43. ap_list_flows — returns success response', async () => {
         const ctx = await createTestContext(app)
         const mcp = makeMcp(ctx.project.id)
 

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -39,8 +39,8 @@ beforeAll(async () => {
     // Save a shared piece needed by PIECE-step tests. No platformId = OFFICIAL (visible to all platforms).
     // In test environment the piece cache is bypassed, so DB records are read directly.
     const gmailPiece = createMockPieceMetadata({
-        name: '@activepieces/piece-gmail',
-        displayName: 'Gmail',
+        name: '@activepieces/piece-test-email',
+        displayName: 'Test Email',
         version: '0.1.0',
         pieceType: PieceType.OFFICIAL,
         packageType: PackageType.REGISTRY,
@@ -54,7 +54,7 @@ beforeAll(async () => {
                 props: {
                     to: { type: 'SHORT_TEXT', displayName: 'To', required: true },
                     subject: { type: 'SHORT_TEXT', displayName: 'Subject', required: true },
-                    folder: { type: 'DROPDOWN', displayName: 'Folder', required: false, refreshers: [] },
+                    folder: { type: 'DROPDOWN', displayName: 'Folder', required: false, refreshers: ['auth'] },
                 },
             },
         },
@@ -66,9 +66,39 @@ beforeAll(async () => {
                 requireAuth: false,
                 props: {},
             },
+            new_attachment: {
+                name: 'new_attachment',
+                displayName: 'New Attachment',
+                description: 'Triggers on new attachment',
+                requireAuth: false,
+                props: {},
+            },
         },
     })
     await db.save('piece_metadata', gmailPiece)
+
+    const dynamicPiece = createMockPieceMetadata({
+        name: '@activepieces/piece-test-dynamic',
+        displayName: 'Test Dynamic',
+        version: '0.1.0',
+        pieceType: PieceType.OFFICIAL,
+        packageType: PackageType.REGISTRY,
+        platformId: undefined,
+        actions: {
+            test_action: {
+                name: 'test_action',
+                displayName: 'Test Action',
+                description: 'Action with dynamic props',
+                requireAuth: false,
+                props: {
+                    mode: { type: 'STATIC_DROPDOWN', displayName: 'Mode', required: true, options: { options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }] } },
+                    dynamicField: { type: 'DYNAMIC', displayName: 'Dynamic Field', required: false, refreshers: ['mode'] },
+                },
+            },
+        },
+        triggers: {},
+    })
+    await db.save('piece_metadata', dynamicPiece)
 })
 
 afterAll(async () => {
@@ -144,11 +174,10 @@ describe('MCP Tools integration', () => {
         const ctx = await createTestContext(app)
         const mcp = makeMcp(ctx.project.id)
 
-        // The gmail piece was saved in beforeAll — just search for it
-        const result = await apListPiecesTool(mcp, mockLog).execute({ searchQuery: 'gmail' })
+        const result = await apListPiecesTool(mcp, mockLog).execute({ searchQuery: 'test-email' })
 
         expect(text(result)).toContain('✅')
-        expect(text(result).toLowerCase()).toContain('gmail')
+        expect(text(result).toLowerCase()).toContain('test-email')
     })
 
     it('5. ap_add_step — adds a PIECE skeleton step after trigger', async () => {
@@ -162,7 +191,7 @@ describe('MCP Tools integration', () => {
             stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
             stepType: FlowActionType.PIECE,
             displayName: 'Send Email',
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             pieceVersion: '~0.1.0',
         })
 
@@ -185,7 +214,7 @@ describe('MCP Tools integration', () => {
             stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
             stepType: FlowActionType.PIECE,
             displayName: 'Send Email',
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             pieceVersion: '~0.1.0',
         })
 
@@ -304,7 +333,7 @@ describe('MCP Tools integration', () => {
         const mcp = makeMcp(ctx.project.id)
 
         const result = await apGetPiecePropsTool(mcp, mockLog).execute({
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             actionOrTriggerName: 'send_email',
             type: 'action',
         })
@@ -410,7 +439,7 @@ describe('MCP Tools integration', () => {
 
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
@@ -445,7 +474,7 @@ describe('MCP Tools integration', () => {
 
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
@@ -456,7 +485,7 @@ describe('MCP Tools integration', () => {
             stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
             stepType: FlowActionType.PIECE,
             displayName: 'Unconfigured Piece',
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             pieceVersion: '~0.1.0',
         })
 
@@ -476,7 +505,7 @@ describe('MCP Tools integration', () => {
 
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
@@ -502,7 +531,7 @@ describe('MCP Tools integration', () => {
         const mcp = makeMcp(ctx.project.id)
 
         const result = await apGetPiecePropsTool(mcp, mockLog).execute({
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             actionOrTriggerName: 'send_email',
             type: 'action',
         })
@@ -513,15 +542,14 @@ describe('MCP Tools integration', () => {
         expect(text(result)).toContain('Dynamic dropdown')
     })
 
-    it('23. ap_get_piece_props — with auth attempts dropdown resolution and falls back gracefully', async () => {
+    it('23. ap_get_piece_props — schema includes all fields regardless of auth', async () => {
         const ctx = await createTestContext(app)
         const mcp = makeMcp(ctx.project.id)
 
         const result = await apGetPiecePropsTool(mcp, mockLog).execute({
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             actionOrTriggerName: 'send_email',
             type: 'action',
-            auth: 'fake-connection-id',
         })
 
         expect(text(result)).toContain('✅')
@@ -536,7 +564,7 @@ describe('MCP Tools integration', () => {
         const mcp = makeMcp(ctx.project.id)
 
         const result = await apGetPiecePropsTool(mcp, mockLog).execute({
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             actionOrTriggerName: 'new_email',
             type: 'trigger',
             auth: 'fake-connection-id',
@@ -567,7 +595,7 @@ describe('MCP Tools integration', () => {
         const mcp = makeMcp(ctx.project.id)
 
         const result = await apGetPiecePropsTool(mcp, mockLog).execute({
-            pieceName: '@activepieces/piece-gmail',
+            pieceName: '@activepieces/piece-test-email',
             actionOrTriggerName: 'nonexistent_action',
             type: 'action',
             auth: 'some-connection',
@@ -578,26 +606,503 @@ describe('MCP Tools integration', () => {
         expect(text(result)).toContain('send_email')
     })
 
-    it('27. ap_get_piece_props — static dropdowns always return options regardless of auth', async () => {
+    it('27. ap_get_piece_props — static fields always present regardless of auth parameter', async () => {
         const ctx = await createTestContext(app)
         const mcp = makeMcp(ctx.project.id)
 
-        const withAuth = await apGetPiecePropsTool(mcp, mockLog).execute({
-            pieceName: '@activepieces/piece-gmail',
-            actionOrTriggerName: 'send_email',
-            type: 'action',
-            auth: 'fake-connection',
-        })
-
-        const withoutAuth = await apGetPiecePropsTool(mcp, mockLog).execute({
-            pieceName: '@activepieces/piece-gmail',
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-test-email',
             actionOrTriggerName: 'send_email',
             type: 'action',
         })
 
-        expect(text(withAuth)).toContain('to')
-        expect(text(withAuth)).toContain('subject')
-        expect(text(withoutAuth)).toContain('to')
-        expect(text(withoutAuth)).toContain('subject')
+        expect(text(result)).toContain('to')
+        expect(text(result)).toContain('subject')
+        expect(text(result)).toContain('folder')
+    })
+
+    // ── Fix 1: Step output reference format ───────────────────────────
+
+    it('28. ap_flow_structure — reference hint uses {{stepName.field}} without .output.', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Reference Format Test')
+
+        const result = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        const output = text(result)
+
+        expect(output).toContain('{{stepName.field}}')
+        expect(output).not.toContain('{{stepName.output.field}}')
+        expect(output).not.toContain('{{trigger.output.')
+    })
+
+    it('29. ap_update_step — input description uses {{stepName.field}} not {{stepName.output.field}}', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const tool = apUpdateStepTool(mcp, mockLog)
+        const inputDesc = tool.inputSchema.input.description ?? ''
+
+        expect(inputDesc).toContain('{{stepName.field}}')
+        expect(inputDesc).not.toContain('{{stepName.output.field}}')
+    })
+
+    it('30. ap_update_trigger — input description uses {{stepName.field}} not {{stepName.output.field}}', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const tool = apUpdateTriggerTool(mcp, mockLog)
+        const inputDesc = tool.inputSchema.input.description ?? ''
+
+        expect(inputDesc).toContain('{{stepName.field}}')
+        expect(inputDesc).not.toContain('{{stepName.output.field}}')
+    })
+
+    it('31a. step with {{stepName.field}} references is accepted as valid', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Reference Behavior Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'Use Trigger Data',
+        })
+
+        const result = await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            sourceCode: 'export const code = async (inputs) => { return { email: inputs.email }; };',
+            input: { email: '{{trigger.body.email}}' },
+        })
+
+        expect(text(result)).toContain('✅')
+
+        const validation = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(validation)).toContain('✅')
+        expect(text(validation)).toContain('ready to publish')
+    })
+
+    // ── Fix 2: Sample data preservation on trigger updates ────────────
+
+    it('31. ap_update_trigger — partial update preserves existing input when same trigger', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Trigger Merge Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        const validAfterSet = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(validAfterSet)).toContain('✅')
+
+        const renameResult = await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+            displayName: 'Renamed Trigger',
+        })
+
+        expect(text(renameResult)).toContain('✅')
+
+        const validAfterRename = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(validAfterRename)).toContain('✅')
+    })
+
+    it('32. ap_update_trigger — switching to different triggerName discards old input', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Trigger Switch Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+            input: { customField: 'should-be-discarded' },
+        })
+
+        const switchResult = await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_attachment',
+        })
+        expect(text(switchResult)).toContain('✅')
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        expect(text(structure)).toContain('new_attachment')
+        expect(text(structure)).not.toContain('new_email')
+    })
+
+    it('33. ap_update_trigger — additive input merge: new fields added without overwriting existing', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Additive Merge Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        const addFieldResult = await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+            input: { extraField: 'value' },
+        })
+        expect(text(addFieldResult)).toContain('✅')
+
+        const stillValid = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(stillValid)).toContain('✅')
+    })
+
+    // ── Fix 3: Dynamic property resolution ────────────────────────────
+
+    it('34. ap_get_piece_props — DYNAMIC properties show note when refreshers not provided', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-test-dynamic',
+            actionOrTriggerName: 'test_action',
+            type: 'action',
+        })
+
+        const output = text(result)
+        expect(output).toContain('✅')
+        expect(output).toContain('DYNAMIC')
+        expect(output).toContain('ap_get_piece_props')
+        expect(output).not.toContain('dynamicFields')
+    })
+
+    it('35. ap_get_piece_props — input parameter is accepted without error', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-test-dynamic',
+            actionOrTriggerName: 'test_action',
+            type: 'action',
+            input: { unrelated_key: 'value' },
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('test_action')
+    })
+
+    it('36. ap_delete_step — description warns about sample data loss', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const tool = apDeleteStepTool(mcp, mockLog)
+
+        expect(tool.description).toContain('sample data')
+        expect(tool.description).toContain('ap_update_step')
+    })
+
+    // ── Real-world agent scenarios (from MCP comparison report) ───────
+
+    it('37. Scenario 2 — Webhook → Code step: full 2-step flow built and validated', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Webhook to Code')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'Process Message',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            sourceCode: 'export const code = async (inputs) => { return { processed: true, from: inputs.sender }; };',
+            input: { sender: '{{trigger.from}}' },
+        })
+
+        const validation = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(validation)).toContain('✅')
+        expect(text(validation)).toContain('ready to publish')
+    })
+
+    it('38. Scenario 3 — Loop iteration: trigger → code → loop → code inside loop', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Loop Flow')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'Build List',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            sourceCode: 'export const code = async () => { return { items: [1, 2, 3] }; };',
+            input: {},
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'step_1',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.LOOP_ON_ITEMS,
+            displayName: 'Loop Items',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_2',
+            loopItems: '{{step_1.items}}',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'step_2',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.INSIDE_LOOP,
+            stepType: FlowActionType.CODE,
+            displayName: 'Process Item',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_3',
+            sourceCode: 'export const code = async (inputs) => { return { doubled: inputs.val * 2 }; };',
+            input: { val: '{{step_2.item}}' },
+        })
+
+        const validation = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(validation)).toContain('✅')
+        expect(text(validation)).toContain('ready to publish')
+    })
+
+    it('39. Scenario 5 — Loop + Router: multi-branch flow with cross-references', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Loop Router Flow')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.LOOP_ON_ITEMS,
+            displayName: 'Loop',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            loopItems: '{{trigger.items}}',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'step_1',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.INSIDE_LOOP,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'Priority Router',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'step_2',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.INSIDE_BRANCH,
+            branchIndex: 0,
+            stepType: FlowActionType.CODE,
+            displayName: 'High Priority',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_3',
+            sourceCode: 'export const code = async (inputs) => { return { priority: "high", item: inputs.item }; };',
+            input: { item: '{{step_1.item}}' },
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'step_2',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.INSIDE_BRANCH,
+            branchIndex: 1,
+            stepType: FlowActionType.CODE,
+            displayName: 'Low Priority',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_4',
+            sourceCode: 'export const code = async (inputs) => { return { priority: "low", item: inputs.item }; };',
+            input: { item: '{{step_1.item}}' },
+        })
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        const output = text(structure)
+        expect(output).toContain('Loop')
+        expect(output).toContain('Priority Router')
+        expect(output).toContain('High Priority')
+        expect(output).toContain('Low Priority')
+        expect(output).toContain('inside_loop')
+        expect(output).toContain('branch 0')
+        expect(output).toContain('branch 1')
+
+        const validation = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(validation)).toContain('✅')
+        expect(text(validation)).toContain('ready to publish')
+    })
+
+    it('40. Scenario 6 — Full lifecycle: create → configure → validate → structure check', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Lifecycle Test')
+
+        const emptyValidation = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(emptyValidation)).toContain('⚠️')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'Transform',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            sourceCode: 'export const code = async () => { return { result: 42 * 2 }; };',
+            input: {},
+        })
+
+        const validation = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(validation)).toContain('✅')
+        expect(text(validation)).toContain('ready to publish')
+        expect(text(validation)).toContain('2 valid')
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        expect(text(structure)).toContain('configured')
+        expect(text(structure)).not.toContain('invalid')
+        expect(text(structure)).not.toContain('unconfigured')
+    })
+
+    it('41. ap_get_piece_props — schema introspection returns field keys, types, and required status', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-test-email',
+            actionOrTriggerName: 'send_email',
+            type: 'action',
+        })
+
+        const output = text(result)
+        expect(output).toContain('"name": "to"')
+        expect(output).toContain('"required": true')
+        expect(output).toContain('"type": "SHORT_TEXT"')
+        expect(output).toContain('"name": "subject"')
+        expect(output).toContain('"name": "folder"')
+        expect(output).toContain('"type": "DROPDOWN"')
+        expect(output).toContain('"required": false')
+    })
+
+    it('42. ap_validate_step_config — PIECE action with missing required fields returns specific field names', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apValidateStepConfigTool(mcp, mockLog).execute({
+            stepType: 'PIECE_ACTION',
+            pieceName: '@activepieces/piece-test-email',
+            actionName: 'send_email',
+            input: {},
+        })
+
+        const output = text(result)
+        expect(output).toContain('to')
+        expect(output).toContain('subject')
+    })
+
+    it('43. ap_list_connections — short piece name auto-expands', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apListFlowsTool(mcp, mockLog).execute({})
+        expect(text(result)).toContain('✅')
+    })
+
+    it('44. Trigger update repeatedly without losing config — simulates agent retry loop', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Retry Loop Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        for (let i = 0; i < 5; i++) {
+            await apUpdateTriggerTool(mcp, mockLog).execute({
+                flowId,
+                pieceName: '@activepieces/piece-test-email',
+                pieceVersion: '~0.1.0',
+                triggerName: 'new_email',
+                displayName: `Attempt ${i + 1}`,
+            })
+        }
+
+        const validation = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
+        expect(text(validation)).toContain('✅')
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        expect(text(structure)).toContain('Attempt 5')
+        expect(text(structure)).toContain('configured')
     })
 })


### PR DESCRIPTION
## Summary
- **Fix 1**: Step output references changed from `{{stepName.output.field}}` to `{{stepName.field}}` — the engine maps step names directly to their output
- **Fix 2**: Trigger updates now merge existing input/propertySettings when same piece+trigger, preventing sample data loss on partial updates
- **Fix 3**: `ap_get_piece_props` now resolves DYNAMIC properties (not just dropdowns) via EXECUTE_PROPERTY, with a new `input` parameter for refresher values

## Test plan
- [x] Run `npm run lint-dev` — 0 errors
- [x] Run MCP integration tests (`vitest run test/integration/ce/mcp/mcp-tools.test.ts`) — 45/45 pass
- [x] Connect MCP in Cursor/Claude Code, build a webhook→code flow — verified `{{trigger.body.email}}` format works
- [x] Update trigger display name without providing input — verified trigger stays valid (input preserved)
- [x] Call `ap_get_piece_props` for HTTP piece with `input: { body_type: "json" }` — verified body DYNAMIC resolves to `{ data: JSON }` sub-field