### PR TITLE
feat(mcp): filter MARKDOWN props + combine add/update step

### DIFF
--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -1,3 +1,4 @@
+import { PropertyType } from '@activepieces/pieces-framework'
 import {
     BranchExecutionType,
     FlowActionType,
@@ -15,6 +16,7 @@ import {
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
+import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { projectService } from '../../project/project-service'
 import { mcpUtils } from './mcp-utils'
 
@@ -28,13 +30,18 @@ const addStepInput = z.object({
     pieceName: z.string().optional(),
     pieceVersion: z.string().optional(),
     actionName: z.string().optional(),
+    input: z.record(z.string(), z.unknown()).optional(),
+    auth: z.string().optional(),
+    sourceCode: z.string().optional(),
+    packageJson: z.string().optional(),
+    loopItems: z.string().optional(),
 })
 
 export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
         title: 'ap_add_step',
         permission: Permission.WRITE_FLOW,
-        description: 'Add a new step to a flow (skeleton only — configure with ap_update_step afterwards). Prefer PIECE over CODE.',
+        description: 'Add a new step to a flow. Optionally configure it in the same call by providing input/auth/sourceCode. Prefer PIECE over CODE.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             parentStepName: z.string().describe('The step name to insert after/into (e.g. "trigger", "step_1"). Use ap_flow_structure to get valid values.'),
@@ -45,10 +52,15 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
             pieceName: z.string().optional().describe('For PIECE steps: the piece name (e.g. "@activepieces/piece-gmail"). Use ap_list_pieces to get valid values.'),
             pieceVersion: z.string().optional().describe('For PIECE steps: the piece version (e.g. "~0.1.0"). Use ap_list_pieces to get valid values.'),
             actionName: z.string().optional().describe('For PIECE steps: the action name within the piece. Use ap_list_pieces with includeActions=true to get valid values.'),
+            input: z.record(z.string(), z.unknown()).optional().describe(`For PIECE/CODE steps: input config (key-value pairs). ${mcpUtils.STEP_REFERENCE_HINT}`),
+            auth: z.string().optional().describe('Connection externalId from ap_list_connections. Auto-wrapped as {{connections[\'externalId\']}}.'),
+            sourceCode: z.string().optional().describe('For CODE steps: JavaScript/TypeScript source. Must export a `code` function.'),
+            packageJson: z.string().optional().describe('For CODE steps: package.json as JSON string. Defaults to "{}".'),
+            loopItems: z.string().optional().describe('For LOOP steps: expression for items to iterate (e.g. "{{step_1.items}}").'),
         },
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
-            const { flowId, parentStepName, stepLocationRelativeToParent, branchIndex, stepType, displayName, pieceName, pieceVersion, actionName } = addStepInput.parse(args)
+            const { flowId, parentStepName, stepLocationRelativeToParent, branchIndex, stepType, displayName, pieceName, pieceVersion, actionName, input, auth, sourceCode, packageJson, loopItems } = addStepInput.parse(args)
 
             const [flow, project] = await Promise.all([
                 flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
@@ -60,6 +72,17 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
 
             const stepName = flowStructureUtil.findUnusedName(flow.version.trigger)
 
+            if (auth !== undefined && auth.includes('\'')) {
+                return {
+                    content: [{ type: 'text', text: '❌ auth value must not contain single quotes. Use the exact externalId from ap_list_connections.' }],
+                }
+            }
+
+            const resolvedInput = {
+                ...(input ?? {}),
+                ...(auth !== undefined && { auth: `{{connections['${auth}']}}` }),
+            }
+
             let skeletonAction: Record<string, unknown>
             switch (stepType) {
                 case FlowActionType.CODE:
@@ -69,13 +92,16 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                         displayName,
                         valid: false,
                         settings: {
-                            sourceCode: { code: 'export const code = async (inputs) => { return {} }', packageJson: '{}' },
-                            input: {},
+                            sourceCode: {
+                                code: sourceCode ?? 'export const code = async (inputs) => { return {} }',
+                                packageJson: packageJson ?? '{}',
+                            },
+                            input: input ?? {},
                             errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
                         },
                     }
                     break
-                case FlowActionType.PIECE:
+                case FlowActionType.PIECE: {
                     if (!pieceName || !pieceVersion) {
                         return {
                             content: [{
@@ -84,21 +110,26 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                             }],
                         }
                     }
+                    const pieceSettings: Record<string, unknown> = {
+                        pieceName,
+                        pieceVersion,
+                        actionName: actionName ?? '',
+                        input: resolvedInput,
+                        propertySettings: {},
+                        errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
+                    }
+                    if (input !== undefined) {
+                        await fillDefaultsForMissingOptionalProps({ settings: pieceSettings, platformId: project.platformId, log })
+                    }
                     skeletonAction = {
                         type: FlowActionType.PIECE,
                         name: stepName,
                         displayName,
                         valid: false,
-                        settings: {
-                            pieceName,
-                            pieceVersion,
-                            actionName: actionName ?? '',
-                            input: {},
-                            propertySettings: {},
-                            errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
-                        },
+                        settings: pieceSettings,
                     }
                     break
+                }
                 case FlowActionType.LOOP_ON_ITEMS:
                     skeletonAction = {
                         type: FlowActionType.LOOP_ON_ITEMS,
@@ -106,7 +137,7 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                         displayName,
                         valid: false,
                         settings: {
-                            items: '',
+                            items: loopItems ?? '',
                         },
                     }
                     break
@@ -156,13 +187,32 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
             }
 
             try {
-                await flowService(log).update({
+                const updatedFlow = await flowService(log).update({
                     id: flow.id,
                     projectId: mcp.projectId,
                     userId: null,
                     platformId: project.platformId,
                     operation,
                 })
+
+                const hasConfig = input !== undefined || sourceCode !== undefined || loopItems !== undefined
+                const addedStep = flowStructureUtil.getStep(stepName, updatedFlow.version.trigger)
+                if (hasConfig && addedStep && !addedStep.valid) {
+                    return {
+                        content: [{
+                            type: 'text',
+                            text: `⚠️ Step "${displayName}" (${stepName}) added but still invalid. Use ap_get_piece_props to check required fields, then ap_update_step to fix.`,
+                        }],
+                    }
+                }
+                if (hasConfig) {
+                    return {
+                        content: [{
+                            type: 'text',
+                            text: `✅ Step "${displayName}" (${stepName}) added and configured.`,
+                        }],
+                    }
+                }
                 return {
                     content: [{
                         type: 'text',
@@ -174,5 +224,41 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                 return mcpUtils.mcpToolError('Step add failed', err)
             }
         },
+    }
+}
+
+async function fillDefaultsForMissingOptionalProps({ settings, platformId, log }: {
+    settings: Record<string, unknown>
+    platformId: string
+    log: FastifyBaseLogger
+}): Promise<void> {
+    const pieceName = settings.pieceName
+    const pieceVersion = settings.pieceVersion
+    const actionName = settings.actionName
+    if (typeof pieceName !== 'string' || typeof pieceVersion !== 'string' || typeof actionName !== 'string') {
+        return
+    }
+    try {
+        const piece = await pieceMetadataService(log).getOrThrow({ platformId, name: pieceName, version: pieceVersion })
+        const action = piece.actions[actionName]
+        if (isNil(action)) {
+            return
+        }
+        const defaults: Record<string, unknown> = {}
+        for (const [propName, prop] of Object.entries(action.props)) {
+            if (prop.type === PropertyType.ARRAY && !prop.required) {
+                defaults[propName] = []
+            }
+            else if (prop.type === PropertyType.DYNAMIC && !prop.required) {
+                defaults[propName] = {}
+            }
+            else if (prop.type === PropertyType.CHECKBOX && !prop.required) {
+                defaults[propName] = prop.defaultValue ?? false
+            }
+        }
+        settings.input = { ...defaults, ...(typeof settings.input === 'object' && settings.input !== null ? settings.input : {}) }
+    }
+    catch (err) {
+        log.warn({ err, pieceName, actionName }, 'fillDefaultsForMissingOptionalProps: failed, skipping defaults')
     }
 }

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -93,7 +93,7 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                                 code: sourceCode ?? 'export const code = async (inputs) => { return {} }',
                                 packageJson: packageJson ?? '{}',
                             },
-                            input: input ?? {},
+                            input: resolvedInput,
                             errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
                         },
                     }
@@ -192,7 +192,7 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                     operation,
                 })
 
-                const hasConfig = input !== undefined || sourceCode !== undefined || loopItems !== undefined
+                const hasConfig = input !== undefined || auth !== undefined || sourceCode !== undefined || loopItems !== undefined
                 const addedStep = flowStructureUtil.getStep(stepName, updatedFlow.version.trigger)
                 if (hasConfig && addedStep && !addedStep.valid) {
                     return {

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -1,4 +1,3 @@
-import { PropertyType } from '@activepieces/pieces-framework'
 import {
     BranchExecutionType,
     FlowActionType,
@@ -16,7 +15,6 @@ import {
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
-import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { projectService } from '../../project/project-service'
 import { mcpUtils } from './mcp-utils'
 
@@ -72,10 +70,9 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
 
             const stepName = flowStructureUtil.findUnusedName(flow.version.trigger)
 
-            if (auth !== undefined && auth.includes('\'')) {
-                return {
-                    content: [{ type: 'text', text: '❌ auth value must not contain single quotes. Use the exact externalId from ap_list_connections.' }],
-                }
+            const authError = mcpUtils.validateAuth(auth)
+            if (authError) {
+                return authError
             }
 
             const resolvedInput = {
@@ -119,7 +116,7 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                         errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
                     }
                     if (input !== undefined) {
-                        await fillDefaultsForMissingOptionalProps({ settings: pieceSettings, platformId: project.platformId, log })
+                        await mcpUtils.fillDefaultsForMissingOptionalProps({ settings: pieceSettings, platformId: project.platformId, log })
                     }
                     skeletonAction = {
                         type: FlowActionType.PIECE,
@@ -224,41 +221,5 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                 return mcpUtils.mcpToolError('Step add failed', err)
             }
         },
-    }
-}
-
-async function fillDefaultsForMissingOptionalProps({ settings, platformId, log }: {
-    settings: Record<string, unknown>
-    platformId: string
-    log: FastifyBaseLogger
-}): Promise<void> {
-    const pieceName = settings.pieceName
-    const pieceVersion = settings.pieceVersion
-    const actionName = settings.actionName
-    if (typeof pieceName !== 'string' || typeof pieceVersion !== 'string' || typeof actionName !== 'string') {
-        return
-    }
-    try {
-        const piece = await pieceMetadataService(log).getOrThrow({ platformId, name: pieceName, version: pieceVersion })
-        const action = piece.actions[actionName]
-        if (isNil(action)) {
-            return
-        }
-        const defaults: Record<string, unknown> = {}
-        for (const [propName, prop] of Object.entries(action.props)) {
-            if (prop.type === PropertyType.ARRAY && !prop.required) {
-                defaults[propName] = []
-            }
-            else if (prop.type === PropertyType.DYNAMIC && !prop.required) {
-                defaults[propName] = {}
-            }
-            else if (prop.type === PropertyType.CHECKBOX && !prop.required) {
-                defaults[propName] = prop.defaultValue ?? false
-            }
-        }
-        settings.input = { ...defaults, ...(typeof settings.input === 'object' && settings.input !== null ? settings.input : {}) }
-    }
-    catch (err) {
-        log.warn({ err, pieceName, actionName }, 'fillDefaultsForMissingOptionalProps: failed, skipping defaults')
     }
 }

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -1,4 +1,3 @@
-import { PropertyType } from '@activepieces/pieces-framework'
 import {
     FlowActionType,
     FlowOperationRequest,
@@ -14,7 +13,6 @@ import {
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
-import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { projectService } from '../../project/project-service'
 import { mcpUtils } from './mcp-utils'
 
@@ -74,10 +72,9 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 }
             }
 
-            if (auth !== undefined && auth.includes('\'')) {
-                return {
-                    content: [{ type: 'text', text: '❌ auth value must not contain single quotes. Use the exact externalId from ap_list_connections.' }],
-                }
+            const authError = mcpUtils.validateAuth(auth)
+            if (authError) {
+                return authError
             }
 
             const currentSettings = step.settings as Record<string, unknown>
@@ -122,7 +119,7 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
             }
 
             if (step.type === FlowActionType.PIECE && input !== undefined) {
-                await fillDefaultsForMissingOptionalProps({
+                await mcpUtils.fillDefaultsForMissingOptionalProps({
                     settings: updatedSettings,
                     platformId: project.platformId,
                     log,
@@ -208,45 +205,5 @@ async function diagnoseMissingInputs({ settings, platformId, log }: {
     catch (err) {
         log.warn({ err, pieceName, actionName }, 'diagnoseMissingInputs: failed to fetch piece metadata')
         return null
-    }
-}
-
-async function fillDefaultsForMissingOptionalProps({ settings, platformId, log }: {
-    settings: Record<string, unknown>
-    platformId: string
-    log: FastifyBaseLogger
-}): Promise<void> {
-    const pieceName = settings.pieceName
-    const pieceVersion = settings.pieceVersion
-    const actionName = settings.actionName
-    if (typeof pieceName !== 'string' || typeof pieceVersion !== 'string' || typeof actionName !== 'string') {
-        return
-    }
-    try {
-        const piece = await pieceMetadataService(log).getOrThrow({
-            platformId,
-            name: pieceName,
-            version: pieceVersion,
-        })
-        const action = piece.actions[actionName]
-        if (isNil(action)) {
-            return
-        }
-        const defaults: Record<string, unknown> = {}
-        for (const [propName, prop] of Object.entries(action.props)) {
-            if (prop.type === PropertyType.ARRAY && !prop.required) {
-                defaults[propName] = []
-            }
-            else if (prop.type === PropertyType.DYNAMIC && !prop.required) {
-                defaults[propName] = {}
-            }
-            else if (prop.type === PropertyType.CHECKBOX && !prop.required) {
-                defaults[propName] = prop.defaultValue ?? false
-            }
-        }
-        settings.input = { ...defaults, ...(typeof settings.input === 'object' && settings.input !== null ? settings.input : {}) }
-    }
-    catch (err) {
-        log.warn({ err, pieceName, actionName }, 'fillDefaultsForMissingOptionalProps: failed to fetch piece metadata, skipping defaults')
     }
 }

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -13,6 +13,7 @@ import {
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
+import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { projectService } from '../../project/project-service'
 import { mcpUtils } from './mcp-utils'
 

--- a/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
@@ -43,10 +43,9 @@ export const apUpdateTriggerTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
         execute: async (args) => {
             const { flowId, pieceName, pieceVersion, triggerName, input: rawInput, auth, displayName: rawDisplayName } = updateTriggerInput.parse(args)
 
-            if (auth !== undefined && auth.includes('\'')) {
-                return {
-                    content: [{ type: 'text', text: '❌ auth value must not contain single quotes. Use the exact externalId from ap_list_connections.' }],
-                }
+            const authError = mcpUtils.validateAuth(auth)
+            if (authError) {
+                return authError
             }
 
             const displayName = rawDisplayName ?? triggerName

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -136,8 +136,8 @@ function findResolvableProps({ props, componentProps, auth, providedInput }: Fin
 }
 
 function validateAuth(auth: string | undefined): { content: [{ type: 'text', text: string }] } | null {
-    if (auth !== undefined && auth.includes('\'')) {
-        return { content: [{ type: 'text', text: '❌ auth value must not contain single quotes. Use the exact externalId from ap_list_connections.' }] }
+    if (auth !== undefined && /['{}\[\]]/.test(auth)) {
+        return { content: [{ type: 'text', text: '❌ auth must be a plain externalId with no special characters. Use the exact value from ap_list_connections.' }] }
     }
     return null
 }

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -3,7 +3,7 @@ import { isNil } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 
-const HIDDEN_PROP_TYPES = new Set<PropertyType>([
+const NON_INPUT_PROP_TYPES = new Set<PropertyType>([
     PropertyType.OAUTH2,
     PropertyType.SECRET_TEXT,
     PropertyType.BASIC_AUTH,
@@ -29,7 +29,7 @@ function diagnosePieceProps({ props, input, pieceAuth, requireAuth, componentTyp
     const uiRequired: string[] = []
     const allProps: string[] = []
     for (const [propName, prop] of Object.entries(props)) {
-        if (HIDDEN_PROP_TYPES.has(prop.type)) {
+        if (NON_INPUT_PROP_TYPES.has(prop.type)) {
             continue
         }
         allProps.push(`${propName} (${prop.type}${prop.required ? ', required' : ''})`)
@@ -67,7 +67,7 @@ function diagnosePieceProps({ props, input, pieceAuth, requireAuth, componentTyp
 
 function buildPropSummaries(props: PiecePropertyMap): PropSummary[] {
     return Object.entries(props)
-        .filter(([, prop]) => !HIDDEN_PROP_TYPES.has(prop.type))
+        .filter(([, prop]) => !NON_INPUT_PROP_TYPES.has(prop.type))
         .map(([name, prop]) => {
             const summary: PropSummary = {
                 name,
@@ -135,7 +135,50 @@ function findResolvableProps({ props, componentProps, auth, providedInput }: Fin
     })
 }
 
-export const mcpUtils = { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName, lookupPieceComponent, findResolvableProps, STEP_REFERENCE_HINT }
+function validateAuth(auth: string | undefined): { content: [{ type: 'text', text: string }] } | null {
+    if (auth !== undefined && auth.includes('\'')) {
+        return { content: [{ type: 'text', text: '❌ auth value must not contain single quotes. Use the exact externalId from ap_list_connections.' }] }
+    }
+    return null
+}
+
+async function fillDefaultsForMissingOptionalProps({ settings, platformId, log }: {
+    settings: Record<string, unknown>
+    platformId: string
+    log: FastifyBaseLogger
+}): Promise<void> {
+    const pieceName = settings.pieceName
+    const pieceVersion = settings.pieceVersion
+    const actionName = settings.actionName
+    if (typeof pieceName !== 'string' || typeof pieceVersion !== 'string' || typeof actionName !== 'string') {
+        return
+    }
+    try {
+        const piece = await pieceMetadataService(log).getOrThrow({ platformId, name: pieceName, version: pieceVersion })
+        const action = piece.actions[actionName]
+        if (isNil(action)) {
+            return
+        }
+        const defaults: Record<string, unknown> = {}
+        for (const [propName, prop] of Object.entries(action.props)) {
+            if (prop.type === PropertyType.ARRAY && !prop.required) {
+                defaults[propName] = []
+            }
+            else if (prop.type === PropertyType.DYNAMIC && !prop.required) {
+                defaults[propName] = {}
+            }
+            else if (prop.type === PropertyType.CHECKBOX && !prop.required) {
+                defaults[propName] = prop.defaultValue ?? false
+            }
+        }
+        settings.input = { ...defaults, ...(typeof settings.input === 'object' && settings.input !== null ? settings.input : {}) }
+    }
+    catch (err) {
+        log.warn({ err, pieceName, actionName }, 'fillDefaultsForMissingOptionalProps: failed, skipping defaults')
+    }
+}
+
+export const mcpUtils = { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName, lookupPieceComponent, findResolvableProps, validateAuth, fillDefaultsForMissingOptionalProps, STEP_REFERENCE_HINT }
 
 export type { PropSummary }
 

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -3,11 +3,12 @@ import { isNil } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 
-const AUTH_TYPES = new Set<PropertyType>([
+const HIDDEN_PROP_TYPES = new Set<PropertyType>([
     PropertyType.OAUTH2,
     PropertyType.SECRET_TEXT,
     PropertyType.BASIC_AUTH,
     PropertyType.CUSTOM_AUTH,
+    PropertyType.MARKDOWN,
 ])
 
 const RESOLVABLE_PROP_TYPES = new Set<PropertyType>([
@@ -28,7 +29,7 @@ function diagnosePieceProps({ props, input, pieceAuth, requireAuth, componentTyp
     const uiRequired: string[] = []
     const allProps: string[] = []
     for (const [propName, prop] of Object.entries(props)) {
-        if (AUTH_TYPES.has(prop.type)) {
+        if (HIDDEN_PROP_TYPES.has(prop.type)) {
             continue
         }
         allProps.push(`${propName} (${prop.type}${prop.required ? ', required' : ''})`)
@@ -66,7 +67,7 @@ function diagnosePieceProps({ props, input, pieceAuth, requireAuth, componentTyp
 
 function buildPropSummaries(props: PiecePropertyMap): PropSummary[] {
     return Object.entries(props)
-        .filter(([, prop]) => !AUTH_TYPES.has(prop.type))
+        .filter(([, prop]) => !HIDDEN_PROP_TYPES.has(prop.type))
         .map(([name, prop]) => {
             const summary: PropSummary = {
                 name,


### PR DESCRIPTION
## Summary
Two quick-win MCP enhancements for better agent ergonomics:

1. **Filter MARKDOWN props** from `ap_get_piece_props` — MARKDOWN properties are UI-only display elements that waste tokens. Webhook schema drops from 5 props to 2 (60% reduction).

2. **Combine ap_add_step + ap_update_step** — `ap_add_step` now accepts optional `input`, `auth`, `sourceCode`, `packageJson`, `loopItems`. When provided, the step is added AND configured in one call. Building a 5-step flow drops from 12 calls to 7 (42% fewer).

Both changes are backward compatible.

## Test plan
- [x] `npm run lint-dev` — 0 errors
- [x] Integration tests — 45/45 pass
- [x] MCP live: `ap_get_piece_props` for webhook — no MARKDOWN props (5→2 props)
- [x] MCP live: `ap_add_step` with `input` + `sourceCode` — step configured in one call
- [x] MCP live: `ap_add_step` without config — backward compatible skeleton
- [x] MCP live: Built 6-step flow in 7 calls (was 12), all valid
- [x] MCP live: Router flow with branches configured in one call each