### PR TITLE
feat(mcp): slim down ap_list_pieces response

### DIFF
--- a/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
@@ -50,7 +50,14 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                 if (!params.includeActions && !params.includeTriggers) {
                     const totalCount = pieces.length
                     const LIST_CAP = 50
-                    const capped = pieces.slice(0, LIST_CAP)
+                    const capped = pieces.slice(0, LIST_CAP).map(p => ({
+                        name: p.name,
+                        displayName: p.displayName,
+                        version: p.version,
+                        description: p.description,
+                        actions: p.actions,
+                        triggers: p.triggers,
+                    }))
                     const hint = totalCount > LIST_CAP ? ` (showing ${LIST_CAP} of ${totalCount} — use searchQuery to narrow results)` : ''
                     return {
                         content: [{ type: 'text', text: `✅ Successfully listed pieces${hint}:\n${JSON.stringify(capped)}` }],
@@ -80,7 +87,6 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                                 displayName: a.displayName,
                                 description: a.description,
                                 requireAuth: a.requireAuth,
-                                inputProps: mcpUtils.buildPropSummaries(a.props),
                             }))
                         }
                         if (params.includeTriggers) {
@@ -89,7 +95,6 @@ export const apListPiecesTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                                 displayName: t.displayName,
                                 description: t.description,
                                 requireAuth: t.requireAuth,
-                                inputProps: mcpUtils.buildPropSummaries(t.props),
                             }))
                         }
                     }


### PR DESCRIPTION
## Summary
Reduces `ap_list_pieces` response size by stripping fields agents don't need:

- **Basic list**: returns only `name`, `displayName`, `version`, `description`, action/trigger counts. Previously dumped full PieceBase with auth schemas, i18n records, authors, logoUrl.
- **Enriched list** (includeActions/includeTriggers): returns action/trigger names and descriptions only. Previously included full inputProps summaries — agents should use ap_get_piece_props for field details.

## Test plan
- [x] npm run lint-dev — 0 errors
- [x] Integration tests — 45/45 pass
- [x] MCP live: ap_list_pieces search "webhook" — returns slim JSON with counts
- [x] MCP live: ap_list_pieces with includeActions — returns action names without inputProps