### PR TITLE
feat(mcp): auto-discover auth connections in ap_get_piece_props

### DIFF
--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -165,12 +165,11 @@ async function discoverAvailableConnections({ pieceName, projectId, log }: {
             cursorRequest: null,
             scope: undefined,
             displayName: undefined,
-            status: undefined,
+            status: [AppConnectionStatus.ACTIVE],
             limit: 10,
             externalIds: undefined,
         })
         const active = connections.data
-            .filter(c => c.status === AppConnectionStatus.ACTIVE)
             .map(c => ({ externalId: c.externalId, displayName: c.displayName }))
         if (active.length > 0) {
             return { message: 'Pass one as the auth param.', connections: active }

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -1,5 +1,6 @@
 import { PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
 import {
+    AppConnectionStatus,
     EngineResponse,
     EngineResponseStatus,
     FlowVersion,
@@ -12,6 +13,7 @@ import {
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
+import { appConnectionService } from '../../app-connection/app-connection-service/app-connection-service'
 import { flowService } from '../../flows/flow/flow.service'
 import { sampleDataService } from '../../flows/step-run/sample-data.service'
 import { getPiecePackageWithoutArchive } from '../../pieces/metadata/piece-metadata-service'
@@ -45,6 +47,11 @@ export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                 const props = mcpUtils.buildPropSummaries(component.props)
                 const requiresAuth = component.requireAuth && !isNil(piece.auth)
 
+                let authHint: AuthHint | undefined
+                if (requiresAuth && !auth) {
+                    authHint = await discoverAvailableConnections({ pieceName: normalized, projectId: mcp.projectId, log })
+                }
+
                 await resolvePropertyOptions({
                     props,
                     componentProps: component.props,
@@ -64,6 +71,7 @@ export const apGetPiecePropsTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                     displayName: component.displayName,
                     description: component.description,
                     requiresAuth,
+                    ...(authHint && { authHint }),
                     props,
                 }
 
@@ -143,6 +151,38 @@ async function resolvePropertyOptions({ props, componentProps, pieceName, pieceV
     }))
 }
 
+async function discoverAvailableConnections({ pieceName, projectId, log }: {
+    pieceName: string
+    projectId: string
+    log: FastifyBaseLogger
+}): Promise<AuthHint> {
+    try {
+        const project = await projectService(log).getOneOrThrow(projectId)
+        const connections = await appConnectionService(log).list({
+            projectId,
+            platformId: project.platformId,
+            pieceName,
+            cursorRequest: null,
+            scope: undefined,
+            displayName: undefined,
+            status: undefined,
+            limit: 10,
+            externalIds: undefined,
+        })
+        const active = connections.data
+            .filter(c => c.status === AppConnectionStatus.ACTIVE)
+            .map(c => ({ externalId: c.externalId, displayName: c.displayName }))
+        if (active.length > 0) {
+            return { message: 'Pass one as the auth param.', connections: active }
+        }
+        return { message: 'No connections found. Set up in UI or use ap_setup_guide.', connections: [] }
+    }
+    catch (err) {
+        log.debug({ err, pieceName }, 'Failed to discover connections')
+        return { message: 'Use ap_list_connections to find connections.', connections: [] }
+    }
+}
+
 function withTimeout<T>({ promise, ms }: { promise: Promise<T>, ms: number }): Promise<T> {
     let timer: ReturnType<typeof setTimeout>
     return Promise.race([
@@ -175,4 +215,9 @@ type ResolvePropertyOptionsParams = {
     providedInput: Record<string, unknown>
     projectId: string
     log: FastifyBaseLogger
+}
+
+type AuthHint = {
+    message: string
+    connections: Array<{ externalId: string, displayName: string }>
 }


### PR DESCRIPTION
## Summary
When a piece requires auth and no `auth` param is provided, `ap_get_piece_props` now auto-appends an `authHint` with available connections. Agents can read the `externalId` directly without a separate `ap_list_connections` call.

```json
"authHint": {
  "message": "Pass one as the auth param.",
  "connections": [{"externalId": "abc", "displayName": "My Slack"}]
}
```

Zero overhead when auth is not required or already provided.

## Test plan
- [x] `npm run lint-dev` — 0 errors
- [x] Integration tests — 45/45 pass
- [x] MCP live: Slack (requiresAuth) without auth — authHint with connections list
- [x] MCP live: HTTP (no auth required) — no authHint, no overhead