### PR TITLE
feat(mcp): add triggerTestData param for flow testing

### DIFF
--- a/packages/server/api/src/app/mcp/tools/ap-test-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-test-flow.ts
@@ -6,19 +6,20 @@ import { mcpUtils } from './mcp-utils'
 
 const testFlowInput = z.object({
     flowId: z.string().describe('The ID of the flow to test. Use ap_list_flows to find it.'),
+    triggerTestData: z.record(z.string(), z.unknown()).optional().describe('Mock trigger output data. Saved as sample data before running the test. Useful when the trigger has no prior test data.'),
 })
 
 export const apTestFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
         title: 'ap_test_flow',
         permission: Permission.WRITE_FLOW,
-        description: 'Test a flow end-to-end in the test environment. Requires a configured trigger. Waits up to 120s.',
+        description: 'Test a flow end-to-end in the test environment. Requires a configured trigger. Waits up to 120s. Pass triggerTestData to provide mock trigger output when no sample data exists.',
         inputSchema: testFlowInput.shape,
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             try {
-                const { flowId } = testFlowInput.parse(args)
-                return await executeFlowTest({ flowId, projectId: mcp.projectId, log })
+                const { flowId, triggerTestData } = testFlowInput.parse(args)
+                return await executeFlowTest({ flowId, projectId: mcp.projectId, triggerTestData, log })
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_test_flow failed')

--- a/packages/server/api/src/app/mcp/tools/ap-test-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-test-step.ts
@@ -7,19 +7,20 @@ import { mcpUtils } from './mcp-utils'
 const testStepInput = z.object({
     flowId: z.string().describe('The ID of the flow containing the step. Use ap_list_flows to find it.'),
     stepName: z.string().describe('The name of the step to test (e.g., "step_1"). Use ap_flow_structure to find it.'),
+    triggerTestData: z.record(z.string(), z.unknown()).optional().describe('Mock trigger output data. Saved as sample data before running the test. Useful when the trigger has no prior test data.'),
 })
 
 export const apTestStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
         title: 'ap_test_step',
         permission: Permission.WRITE_FLOW,
-        description: 'Test a single step within a flow. Runs all steps up to and including the specified step using saved sample data. The flow must have a configured trigger.',
+        description: 'Test a single step within a flow. Runs all steps up to and including the specified step. The flow must have a configured trigger. Pass triggerTestData when no sample data exists.',
         inputSchema: testStepInput.shape,
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             try {
-                const { flowId, stepName } = testStepInput.parse(args)
-                return await executeFlowTest({ flowId, projectId: mcp.projectId, stepName, log })
+                const { flowId, stepName, triggerTestData } = testStepInput.parse(args)
+                return await executeFlowTest({ flowId, projectId: mcp.projectId, stepName, triggerTestData, log })
             }
             catch (err) {
                 log.error({ err, projectId: mcp.projectId }, 'ap_test_step failed')

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -1,15 +1,18 @@
-import { FlowRun, FlowRunStatus, flowStructureUtil, isFlowRunStateTerminal, isNil, RunEnvironment, StepOutputStatus } from '@activepieces/shared'
+import { FlowOperationType, FlowRun, FlowRunStatus, flowStructureUtil, isFlowRunStateTerminal, isNil, RunEnvironment, SampleDataFileType, StepOutputStatus } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { flowService } from '../../flows/flow/flow.service'
 import { flowRunService } from '../../flows/flow-run/flow-run-service'
+import { sampleDataService } from '../../flows/step-run/sample-data.service'
+import { projectService } from '../../project/project-service'
 
 const POLL_INTERVAL_MS = 2000
 const MAX_WAIT_MS = 120_000
 
-export async function executeFlowTest({ flowId, projectId, stepName, log }: {
+export async function executeFlowTest({ flowId, projectId, stepName, triggerTestData, log }: {
     flowId: string
     projectId: string
     stepName?: string
+    triggerTestData?: Record<string, unknown>
     log: FastifyBaseLogger
 }): Promise<{ content: [{ type: 'text', text: string }] }> {
     const flow = await flowService(log).getOnePopulated({ id: flowId, projectId })
@@ -36,6 +39,27 @@ export async function executeFlowTest({ flowId, projectId, stepName, log }: {
         if (invalidSteps.length > 0) {
             warning = `⚠️ These steps are not fully configured: ${invalidSteps.join(', ')}. Results may be incomplete.\n\n`
         }
+    }
+
+    if (triggerTestData) {
+        const project = await projectService(log).getOneOrThrow(projectId)
+        const sampleDataSettings = await sampleDataService(log).saveSampleDataFileIdsInStep({
+            projectId,
+            flowVersionId: flow.version.id,
+            stepName: flow.version.trigger.name,
+            payload: triggerTestData,
+            type: SampleDataFileType.OUTPUT,
+        })
+        await flowService(log).update({
+            id: flow.id,
+            projectId,
+            userId: null,
+            platformId: project.platformId,
+            operation: {
+                type: FlowOperationType.UPDATE_SAMPLE_DATA_INFO,
+                request: { stepName: flow.version.trigger.name, sampleDataSettings },
+            },
+        })
     }
 
     const flowRun = await flowRunService(log).test({

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -15,7 +15,7 @@ export async function executeFlowTest({ flowId, projectId, stepName, triggerTest
     triggerTestData?: Record<string, unknown>
     log: FastifyBaseLogger
 }): Promise<{ content: [{ type: 'text', text: string }] }> {
-    const flow = await flowService(log).getOnePopulated({ id: flowId, projectId })
+    let flow = await flowService(log).getOnePopulated({ id: flowId, projectId })
     if (isNil(flow)) {
         return { content: [{ type: 'text', text: '❌ Flow not found' }] }
     }
@@ -50,7 +50,7 @@ export async function executeFlowTest({ flowId, projectId, stepName, triggerTest
             payload: triggerTestData,
             type: SampleDataFileType.OUTPUT,
         })
-        await flowService(log).update({
+        const updatedFlow = await flowService(log).update({
             id: flow.id,
             projectId,
             userId: null,
@@ -60,6 +60,7 @@ export async function executeFlowTest({ flowId, projectId, stepName, triggerTest
                 request: { stepName: flow.version.trigger.name, sampleDataSettings },
             },
         })
+        flow = updatedFlow
     }
 
     const flowRun = await flowRunService(log).test({


### PR DESCRIPTION
## Summary
`ap_test_flow` and `ap_test_step` now accept optional `triggerTestData`. When provided, saves it as trigger sample data before running the test — unblocking E2E testing for flows that have no prior test data (e.g. webhook triggers).

Works for any trigger type, not just webhooks. Backward compatible — zero overhead when not provided.

## Test plan
- [x] `npm run lint-dev` — 0 errors
- [x] Integration tests — 45/45 pass
- [x] `ap_test_flow` without triggerTestData — same behavior as before