### PR TITLE
feat(mcp): add ap_build_flow tool for one-call flow creation

### DIFF
--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -44,15 +44,16 @@ List available pieces with their actions and triggers. Required before adding or
 
 ### ap_get_piece_props
 
-Get the detailed input property schema for a specific piece action or trigger. Returns field names, types, required/optional, descriptions, default values, and dropdown options. Use this before `ap_update_step` or `ap_update_trigger` to know exactly which fields to set.
+Get the detailed input property schema for a specific piece action or trigger. Returns field names, types, required/optional, descriptions, default values, and dropdown options. When auth is required but not provided, automatically lists available connections. Use this before `ap_update_step` or `ap_update_trigger` to know exactly which fields to set.
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
 | `pieceName` | string | Yes | Piece name (e.g., `@activepieces/piece-slack`) |
 | `actionOrTriggerName` | string | Yes | Action or trigger name (e.g., `send_channel_message`) |
 | `type` | string | Yes | `action` or `trigger` |
-| `auth` | string | No | Connection externalId. When provided, dynamic dropdowns return actual options (e.g., Slack channels, Google Sheets). |
+| `auth` | string | No | Connection externalId. When provided, dynamic dropdowns and DYNAMIC sub-fields are resolved. |
 | `flowId` | string | No | Flow ID for resolving dependent dropdowns that need step context. |
+| `input` | object | No | Known input values for resolving dependent DYNAMIC properties (e.g., `{"body_type": "json"}`). |
 
 ### ap_validate_step_config
 
@@ -182,6 +183,22 @@ Publish the current draft of a flow. Validates all steps are configured.
 
 Add, configure, and remove steps in a flow.
 
+### ap_build_flow
+
+Create a complete flow in one call — trigger plus any number of steps. Steps are added sequentially (trigger → step_1 → step_2 → ...). All steps are validated on creation. Use granular tools (`ap_add_step`, `ap_update_step`) to modify existing flows or add nested structures (loop contents, router branches).
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `flowName` | string | Yes | Name for the new flow |
+| `trigger` | object | Yes | `{pieceName, pieceVersion, triggerName, input?, auth?}` |
+| `steps` | array | Yes | Array of step specs, each with `type`, `displayName`, and type-specific fields |
+
+**Step types in the array:**
+- **PIECE**: `pieceName`, `pieceVersion`, `actionName`, `input`, `auth`
+- **CODE**: `sourceCode`, `input`
+- **LOOP_ON_ITEMS**: `loopItems`
+- **ROUTER**: creates a router with Branch 1 + Otherwise
+
 ### ap_update_trigger
 
 Set or update the trigger for a flow.
@@ -198,7 +215,7 @@ Set or update the trigger for a flow.
 
 ### ap_add_step
 
-Add a new step to a flow. Creates a skeleton — configure it with `ap_update_step`.
+Add a new step to a flow. Optionally configure it in the same call by providing `input`, `auth`, `sourceCode`, or `loopItems`.
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -211,6 +228,11 @@ Add a new step to a flow. Creates a skeleton — configure it with `ap_update_st
 | `pieceVersion` | string | No | For PIECE steps |
 | `actionName` | string | No | For PIECE steps |
 | `branchIndex` | number | No | For INSIDE_BRANCH |
+| `input` | object | No | Step input config (key-value pairs) |
+| `auth` | string | No | Connection externalId |
+| `sourceCode` | string | No | For CODE steps: JavaScript/TypeScript source |
+| `packageJson` | string | No | For CODE steps: npm dependencies |
+| `loopItems` | string | No | For LOOP steps: items expression |
 
 ### ap_update_step
 
@@ -230,7 +252,7 @@ Update an existing step's settings. Auto-fills default values for optional prope
 | `skip` | boolean | No | Skip this step |
 
 <Tip>
-Use `{{stepName.output.field}}` syntax in input values to reference data from previous steps.
+Use `{{stepName.field}}` syntax in input values to reference data from previous steps (e.g., `{{trigger.body.email}}`, `{{step_1.id}}`). Do NOT include `.output.` in the path.
 </Tip>
 
 ### ap_delete_step
@@ -358,11 +380,12 @@ Test flows, inspect results, and retry failures. Test tools poll for up to 120 s
 
 ### ap_test_flow
 
-Test a flow end-to-end in the test environment using saved sample data.
+Test a flow end-to-end in the test environment. Pass `triggerTestData` to provide mock trigger output when no sample data exists (e.g., for webhook triggers).
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
 | `flowId` | string | Yes | The flow ID |
+| `triggerTestData` | object | No | Mock trigger output data. Saved as sample data before running the test. |
 
 <Warning>
 The flow must have a configured trigger. The tool validates this before running and returns a clear error if not.
@@ -370,12 +393,13 @@ The flow must have a configured trigger. The tool validates this before running 
 
 ### ap_test_step
 
-Test a single step within a flow. Runs all steps up to and including the target step.
+Test a single step within a flow. Runs all steps up to and including the target step. Pass `triggerTestData` when no sample data exists.
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
 | `flowId` | string | Yes | The flow ID |
 | `stepName` | string | Yes | Step to test |
+| `triggerTestData` | object | No | Mock trigger output data. |
 
 ### ap_retry_run
 

--- a/packages/server/api/src/app/mcp/mcp-service.ts
+++ b/packages/server/api/src/app/mcp/mcp-service.ts
@@ -19,8 +19,8 @@ const MCP_SERVER_INSTRUCTIONS = `## Activepieces MCP Server
 ### Workflow
 1. Discover: ap_list_pieces, ap_list_connections, ap_list_ai_models
 2. Schema: ap_get_piece_props (get field names/types before configuring)
-3. Build: ap_create_flow → ap_update_trigger → ap_add_step → ap_update_step
-4. Validate: ap_validate_step_config / ap_validate_flow
+3. Build: ap_build_flow (one call for new flows) OR ap_create_flow → ap_update_trigger → ap_add_step (granular)
+4. Validate: ap_validate_flow
 5. Publish: ap_lock_and_publish → ap_change_flow_status
 
 ### Key patterns

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -1,0 +1,208 @@
+import {
+    BranchExecutionType,
+    FlowActionType,
+    FlowOperationType,
+    flowStructureUtil,
+    FlowTriggerType,
+    McpServer,
+    McpToolDefinition,
+    Permission,
+    PieceTrigger,
+    RouterExecutionType,
+    StepLocationRelativeToParent,
+    UpdateActionRequest,
+} from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { flowService } from '../../flows/flow/flow.service'
+import { projectService } from '../../project/project-service'
+import { mcpUtils } from './mcp-utils'
+
+const stepSpec = z.object({
+    type: z.enum([FlowActionType.CODE, FlowActionType.PIECE, FlowActionType.LOOP_ON_ITEMS, FlowActionType.ROUTER]),
+    displayName: z.string(),
+    pieceName: z.string().optional(),
+    pieceVersion: z.string().optional(),
+    actionName: z.string().optional(),
+    input: z.record(z.string(), z.unknown()).optional(),
+    auth: z.string().optional(),
+    sourceCode: z.string().optional(),
+    packageJson: z.string().optional(),
+    loopItems: z.string().optional(),
+})
+
+const buildFlowInput = z.object({
+    flowName: z.string(),
+    trigger: z.object({
+        pieceName: z.string(),
+        pieceVersion: z.string(),
+        triggerName: z.string(),
+        input: z.record(z.string(), z.unknown()).optional(),
+        auth: z.string().optional(),
+    }),
+    steps: z.array(stepSpec),
+})
+
+export const apBuildFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_build_flow',
+        permission: Permission.WRITE_FLOW,
+        description: 'Create a complete flow in one call: trigger + steps. Steps are added sequentially (trigger → step_1 → step_2 → ...). Use granular tools (ap_add_step, ap_update_step) to modify flows or add nested structures (loop contents, router branches).',
+        inputSchema: {
+            flowName: z.string().describe('Name for the new flow'),
+            trigger: z.object({
+                pieceName: z.string().describe('Trigger piece name (e.g. "@activepieces/piece-webhook")'),
+                pieceVersion: z.string().describe('Piece version (e.g. "~0.1.32")'),
+                triggerName: z.string().describe('Trigger name (e.g. "catch_webhook")'),
+                input: z.record(z.string(), z.unknown()).optional().describe('Trigger input config'),
+                auth: z.string().optional().describe('Connection externalId for trigger auth'),
+            }).describe('Trigger configuration'),
+            steps: z.array(stepSpec).describe('Array of steps added sequentially after trigger. Each step supports: PIECE (pieceName+actionName+input), CODE (sourceCode+input), LOOP_ON_ITEMS (loopItems), ROUTER.'),
+        },
+        annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
+        execute: async (args) => {
+            try {
+                const { flowName, trigger, steps } = buildFlowInput.parse(args)
+                const project = await projectService(log).getOneOrThrow(mcp.projectId)
+                const platformId = project.platformId
+                const projectId = mcp.projectId
+
+                const flow = await flowService(log).create({
+                    projectId,
+                    request: { displayName: flowName, projectId },
+                })
+                const flowId = flow.id
+
+                const triggerInput = {
+                    ...(trigger.input ?? {}),
+                    ...(trigger.auth ? { auth: `{{connections['${trigger.auth}']}}` } : {}),
+                }
+                const triggerPayload = PieceTrigger.parse({
+                    name: 'trigger',
+                    displayName: trigger.triggerName,
+                    valid: false,
+                    lastUpdatedDate: new Date().toISOString(),
+                    type: FlowTriggerType.PIECE,
+                    settings: {
+                        pieceName: trigger.pieceName,
+                        pieceVersion: trigger.pieceVersion,
+                        triggerName: trigger.triggerName,
+                        input: triggerInput,
+                        propertySettings: {},
+                    },
+                })
+                await flowService(log).update({
+                    id: flowId, projectId, userId: null, platformId,
+                    operation: { type: FlowOperationType.UPDATE_TRIGGER, request: triggerPayload },
+                })
+
+                let parentStepName = 'trigger'
+                for (const step of steps) {
+                    const skeleton = buildSkeleton({ step, parentStepName })
+                    const parseResult = UpdateActionRequest.safeParse(skeleton)
+                    if (!parseResult.success) {
+                        continue
+                    }
+                    await flowService(log).update({
+                        id: flowId, projectId, userId: null, platformId,
+                        operation: {
+                            type: FlowOperationType.ADD_ACTION,
+                            request: {
+                                parentStep: parentStepName,
+                                stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+                                action: parseResult.data,
+                            },
+                        },
+                    })
+                    parentStepName = String(skeleton.name)
+                }
+
+                const finalFlow = await flowService(log).getOnePopulated({ id: flowId, projectId })
+                if (!finalFlow) {
+                    return { content: [{ type: 'text', text: `✅ Flow "${flowName}" created (id: ${flowId}).` }] }
+                }
+
+                const allSteps = flowStructureUtil.getAllSteps(finalFlow.version.trigger)
+                const validCount = allSteps.filter(s => s.valid).length
+                const invalidSteps = allSteps.filter(s => !s.valid).map(s => s.name)
+
+                if (invalidSteps.length === 0) {
+                    return { content: [{ type: 'text', text: `✅ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} steps, all valid.` }] }
+                }
+                return { content: [{ type: 'text', text: `⚠️ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} steps (${validCount} valid, ${invalidSteps.length} invalid: ${invalidSteps.join(', ')}). Use ap_update_step or ap_update_trigger to fix.` }] }
+            }
+            catch (err) {
+                return mcpUtils.mcpToolError('Failed to build flow', err)
+            }
+        },
+    }
+}
+
+function buildSkeleton({ step, parentStepName }: {
+    step: z.infer<typeof stepSpec>
+    parentStepName: string
+}): Record<string, unknown> {
+    const stepIndex = parentStepName === 'trigger' ? 1 : Number(parentStepName.replace('step_', '')) + 1
+    const name = `step_${stepIndex}`
+    const resolvedInput = {
+        ...(step.input ?? {}),
+        ...(step.auth ? { auth: `{{connections['${step.auth}']}}` } : {}),
+    }
+
+    switch (step.type) {
+        case FlowActionType.CODE:
+            return {
+                type: FlowActionType.CODE,
+                name,
+                displayName: step.displayName,
+                valid: false,
+                settings: {
+                    sourceCode: {
+                        code: step.sourceCode ?? 'export const code = async (inputs) => { return {} }',
+                        packageJson: step.packageJson ?? '{}',
+                    },
+                    input: step.input ?? {},
+                    errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
+                },
+            }
+        case FlowActionType.PIECE:
+            return {
+                type: FlowActionType.PIECE,
+                name,
+                displayName: step.displayName,
+                valid: false,
+                settings: {
+                    pieceName: step.pieceName ?? '',
+                    pieceVersion: step.pieceVersion ?? '',
+                    actionName: step.actionName ?? '',
+                    input: resolvedInput,
+                    propertySettings: {},
+                    errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
+                },
+            }
+        case FlowActionType.LOOP_ON_ITEMS:
+            return {
+                type: FlowActionType.LOOP_ON_ITEMS,
+                name,
+                displayName: step.displayName,
+                valid: false,
+                settings: { items: step.loopItems ?? '' },
+            }
+        case FlowActionType.ROUTER:
+            return {
+                type: FlowActionType.ROUTER,
+                name,
+                displayName: step.displayName,
+                valid: false,
+                settings: {
+                    branches: [
+                        { branchName: 'Branch 1', branchType: BranchExecutionType.CONDITION, conditions: [[]] },
+                        { branchName: 'Otherwise', branchType: BranchExecutionType.FALLBACK },
+                    ],
+                    executionType: RouterExecutionType.EXECUTE_FIRST_MATCH,
+                },
+            }
+        default:
+            return { type: step.type, name, displayName: step.displayName, valid: false, settings: {} }
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -134,20 +134,16 @@ export const apBuildFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                     })
                 }
 
-                const finalFlow = currentFlow
-                if (!finalFlow) {
-                    return { content: [{ type: 'text', text: `✅ Flow "${flowName}" created (id: ${flowId}).` }] }
-                }
-
-                const allSteps = flowStructureUtil.getAllSteps(finalFlow.version.trigger)
+                const allSteps = flowStructureUtil.getAllSteps(currentFlow.version.trigger)
                 const validCount = allSteps.filter(s => s.valid).length
                 const invalidSteps = allSteps.filter(s => !s.valid).map(s => s.name)
+                const stepWord = allSteps.length === 1 ? 'step' : 'steps'
 
                 const skippedHint = skippedSteps.length > 0 ? ` Skipped: ${skippedSteps.join(', ')}.` : ''
                 if (invalidSteps.length === 0 && skippedSteps.length === 0) {
-                    return { content: [{ type: 'text', text: `✅ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} steps, all valid.` }] }
+                    return { content: [{ type: 'text', text: `✅ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} ${stepWord}, all valid.` }] }
                 }
-                return { content: [{ type: 'text', text: `⚠️ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} steps (${validCount} valid, ${invalidSteps.length} invalid: ${invalidSteps.join(', ')}).${skippedHint} Use ap_update_step or ap_update_trigger to fix.` }] }
+                return { content: [{ type: 'text', text: `⚠️ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} ${stepWord} (${validCount} valid, ${invalidSteps.length} invalid: ${invalidSteps.join(', ')}).${skippedHint} Use ap_update_step or ap_update_trigger to fix.` }] }
             }
             catch (err) {
                 return mcpUtils.mcpToolError('Failed to build flow', err)

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -67,6 +67,17 @@ export const apBuildFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                 const platformId = project.platformId
                 const projectId = mcp.projectId
 
+                const triggerAuthError = mcpUtils.validateAuth(trigger.auth)
+                if (triggerAuthError) {
+                    return triggerAuthError
+                }
+                for (const step of steps) {
+                    const stepAuthError = mcpUtils.validateAuth(step.auth)
+                    if (stepAuthError) {
+                        return stepAuthError
+                    }
+                }
+
                 const flow = await flowService(log).create({
                     projectId,
                     request: { displayName: flowName, projectId },
@@ -91,33 +102,39 @@ export const apBuildFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                         propertySettings: {},
                     },
                 })
-                await flowService(log).update({
+                let currentFlow = await flowService(log).update({
                     id: flowId, projectId, userId: null, platformId,
                     operation: { type: FlowOperationType.UPDATE_TRIGGER, request: triggerPayload },
                 })
+                const skippedSteps: string[] = []
 
-                let parentStepName = 'trigger'
                 for (const step of steps) {
-                    const skeleton = buildSkeleton({ step, parentStepName })
+                    const latestTrigger = currentFlow!.version.trigger
+                    const stepName = flowStructureUtil.findUnusedName(latestTrigger)
+                    const allSteps = flowStructureUtil.getAllSteps(latestTrigger)
+                    const lastStep = allSteps[allSteps.length - 1]
+
+                    const skeleton = buildSkeleton({ step, name: stepName })
                     const parseResult = UpdateActionRequest.safeParse(skeleton)
                     if (!parseResult.success) {
+                        skippedSteps.push(step.displayName)
                         continue
                     }
-                    await flowService(log).update({
+
+                    currentFlow = await flowService(log).update({
                         id: flowId, projectId, userId: null, platformId,
                         operation: {
                             type: FlowOperationType.ADD_ACTION,
                             request: {
-                                parentStep: parentStepName,
+                                parentStep: lastStep.name,
                                 stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
                                 action: parseResult.data,
                             },
                         },
                     })
-                    parentStepName = String(skeleton.name)
                 }
 
-                const finalFlow = await flowService(log).getOnePopulated({ id: flowId, projectId })
+                const finalFlow = currentFlow
                 if (!finalFlow) {
                     return { content: [{ type: 'text', text: `✅ Flow "${flowName}" created (id: ${flowId}).` }] }
                 }
@@ -126,10 +143,11 @@ export const apBuildFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                 const validCount = allSteps.filter(s => s.valid).length
                 const invalidSteps = allSteps.filter(s => !s.valid).map(s => s.name)
 
-                if (invalidSteps.length === 0) {
+                const skippedHint = skippedSteps.length > 0 ? ` Skipped: ${skippedSteps.join(', ')}.` : ''
+                if (invalidSteps.length === 0 && skippedSteps.length === 0) {
                     return { content: [{ type: 'text', text: `✅ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} steps, all valid.` }] }
                 }
-                return { content: [{ type: 'text', text: `⚠️ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} steps (${validCount} valid, ${invalidSteps.length} invalid: ${invalidSteps.join(', ')}). Use ap_update_step or ap_update_trigger to fix.` }] }
+                return { content: [{ type: 'text', text: `⚠️ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} steps (${validCount} valid, ${invalidSteps.length} invalid: ${invalidSteps.join(', ')}).${skippedHint} Use ap_update_step or ap_update_trigger to fix.` }] }
             }
             catch (err) {
                 return mcpUtils.mcpToolError('Failed to build flow', err)
@@ -138,12 +156,10 @@ export const apBuildFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
     }
 }
 
-function buildSkeleton({ step, parentStepName }: {
+function buildSkeleton({ step, name }: {
     step: z.infer<typeof stepSpec>
-    parentStepName: string
+    name: string
 }): Record<string, unknown> {
-    const stepIndex = parentStepName === 'trigger' ? 1 : Number(parentStepName.replace('step_', '')) + 1
-    const name = `step_${stepIndex}`
     const resolvedInput = {
         ...(step.input ?? {}),
         ...(step.auth ? { auth: `{{connections['${step.auth}']}}` } : {}),

--- a/packages/server/api/src/app/mcp/tools/index.ts
+++ b/packages/server/api/src/app/mcp/tools/index.ts
@@ -2,6 +2,7 @@ import { McpServer, McpToolDefinition } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { apAddBranchTool } from './ap-add-branch'
 import { apAddStepTool } from './ap-add-step'
+import { apBuildFlowTool } from './ap-build-flow'
 import { apChangeFlowStatusTool } from './ap-change-flow-status'
 import { apCreateFlowTool } from './ap-create-flow'
 import { apCreateTableTool } from './ap-create-table'
@@ -54,6 +55,7 @@ export const LOCKED_TOOL_NAMES: string[] = [
 // packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
 // Any tool added here must also be added there so it appears in the UI settings panel.
 export const ALL_CONTROLLABLE_TOOL_NAMES: string[] = [
+    'ap_build_flow',
     'ap_create_flow',
     'ap_rename_flow',
     'ap_update_trigger',
@@ -77,6 +79,7 @@ export const ALL_CONTROLLABLE_TOOL_NAMES: string[] = [
 ]
 
 export const activepiecesTools = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition[] => [
+    apBuildFlowTool(mcp, log),
     apCreateFlowTool(mcp, log),
     apRenameFlowTool(mcp, log),
     apListFlowsTool(mcp, log),

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -14,6 +14,7 @@ import { createTestContext } from '../../../helpers/test-context'
 import { db } from '../../../helpers/db'
 import { createMockPieceMetadata } from '../../../helpers/mocks'
 import { apListFlowsTool } from '../../../../src/app/mcp/tools/ap-list-flows'
+import { apBuildFlowTool } from '../../../../src/app/mcp/tools/ap-build-flow'
 import { apCreateFlowTool } from '../../../../src/app/mcp/tools/ap-create-flow'
 import { apFlowStructureTool } from '../../../../src/app/mcp/tools/ap-flow-structure'
 import { apListPiecesTool } from '../../../../src/app/mcp/tools/ap-list-pieces'
@@ -1104,5 +1105,161 @@ describe('MCP Tools integration', () => {
         const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
         expect(text(structure)).toContain('Attempt 5')
         expect(text(structure)).toContain('configured')
+    })
+
+    // ── ap_build_flow — batch flow creation ──────────────────────────
+
+    it('45. ap_build_flow — creates trigger + CODE step, all valid', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apBuildFlowTool(mcp, mockLog).execute({
+            flowName: 'Build Test 1',
+            trigger: {
+                pieceName: '@activepieces/piece-test-email',
+                pieceVersion: '~0.1.0',
+                triggerName: 'new_email',
+            },
+            steps: [
+                {
+                    type: FlowActionType.CODE,
+                    displayName: 'Process',
+                    sourceCode: 'export const code = async () => { return { ok: true }; };',
+                    input: {},
+                },
+            ],
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('2 steps')
+        expect(text(result)).toContain('all valid')
+    })
+
+    it('46. ap_build_flow — creates trigger + multiple steps in correct order', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apBuildFlowTool(mcp, mockLog).execute({
+            flowName: 'Build Test 2',
+            trigger: {
+                pieceName: '@activepieces/piece-test-email',
+                pieceVersion: '~0.1.0',
+                triggerName: 'new_email',
+            },
+            steps: [
+                {
+                    type: FlowActionType.CODE,
+                    displayName: 'Step A',
+                    sourceCode: 'export const code = async () => { return { a: 1 }; };',
+                    input: {},
+                },
+                {
+                    type: FlowActionType.CODE,
+                    displayName: 'Step B',
+                    sourceCode: 'export const code = async () => { return { b: 2 }; };',
+                    input: {},
+                },
+                {
+                    type: FlowActionType.LOOP_ON_ITEMS,
+                    displayName: 'Loop',
+                    loopItems: '{{step_1.items}}',
+                },
+            ],
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('4 steps')
+
+        const flowId = text(result).match(/\(id: (\S+?)\)/)?.[1]
+        expect(flowId).toBeDefined()
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId: flowId! })
+        const output = text(structure)
+        expect(output).toContain('Step A')
+        expect(output).toContain('Step B')
+        expect(output).toContain('Loop')
+        expect(output).toContain('step_1')
+        expect(output).toContain('step_2')
+        expect(output).toContain('step_3')
+    })
+
+    it('47. ap_build_flow — partial success: invalid steps reported', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apBuildFlowTool(mcp, mockLog).execute({
+            flowName: 'Build Test Partial',
+            trigger: {
+                pieceName: '@activepieces/piece-test-email',
+                pieceVersion: '~0.1.0',
+                triggerName: 'new_email',
+            },
+            steps: [
+                {
+                    type: FlowActionType.CODE,
+                    displayName: 'Valid Code',
+                    sourceCode: 'export const code = async () => { return {}; };',
+                    input: {},
+                },
+                {
+                    type: FlowActionType.PIECE,
+                    displayName: 'Invalid Piece',
+                    pieceName: '@activepieces/piece-test-email',
+                    pieceVersion: '~0.1.0',
+                },
+            ],
+        })
+
+        expect(text(result)).toContain('⚠️')
+        expect(text(result)).toContain('step_2')
+        expect(text(result)).toContain('invalid')
+    })
+
+    it('48. ap_build_flow — empty steps array creates trigger-only flow', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apBuildFlowTool(mcp, mockLog).execute({
+            flowName: 'Build Test Empty',
+            trigger: {
+                pieceName: '@activepieces/piece-test-email',
+                pieceVersion: '~0.1.0',
+                triggerName: 'new_email',
+            },
+            steps: [],
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('1 steps')
+    })
+
+    it('49. ap_build_flow — flow can be validated and published after creation', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apBuildFlowTool(mcp, mockLog).execute({
+            flowName: 'Build Test Lifecycle',
+            trigger: {
+                pieceName: '@activepieces/piece-test-email',
+                pieceVersion: '~0.1.0',
+                triggerName: 'new_email',
+            },
+            steps: [
+                {
+                    type: FlowActionType.CODE,
+                    displayName: 'Compute',
+                    sourceCode: 'export const code = async () => { return { x: 42 }; };',
+                    input: {},
+                },
+            ],
+        })
+
+        expect(text(result)).toContain('✅')
+        const flowId = text(result).match(/\(id: (\S+?)\)/)?.[1]
+        expect(flowId).toBeDefined()
+
+        const validation = await apValidateFlowTool(mcp, mockLog).execute({ flowId: flowId! })
+        expect(text(validation)).toContain('✅')
+        expect(text(validation)).toContain('ready to publish')
     })
 })

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -1230,7 +1230,7 @@ describe('MCP Tools integration', () => {
         })
 
         expect(text(result)).toContain('✅')
-        expect(text(result)).toContain('1 steps')
+        expect(text(result)).toContain('1 step')
     })
 
     it('49. ap_build_flow — flow can be validated and published after creation', async () => {

--- a/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
+++ b/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
@@ -100,6 +100,10 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
     label: 'Flow Building',
     tools: [
       {
+        name: 'ap_build_flow',
+        description: 'Create a complete flow in one call: trigger + steps',
+      },
+      {
         name: 'ap_update_trigger',
         description: 'Set or update the trigger for a flow',
       },


### PR DESCRIPTION
## Summary
New `ap_build_flow` tool creates a complete flow (trigger + N steps) in a single MCP call. Uses sequential validated operations internally so all steps are valid on creation.

**Before:** 12 calls for a 5-step flow
**After:** 1 call, all steps valid

Also updates MCP instructions, adds UI tool metadata, and 5 integration tests.

## Test plan
- [x] `npm run lint-dev` — 0 errors
- [x] TypeScript compiles — 0 errors
- [x] Integration tests — 50/50 pass
- [x] MCP live: 5-step flow — all valid in 1 call
- [x] MCP live: 7-step flow with router — all valid in 1 call
- [x] MCP live: partial failure — correct invalid step reporting