### PR TITLE
feat(snowflake): improve UX and add 5 polling triggers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6276,7 +6276,7 @@
     },
     "packages/pieces/community/snowflake": {
       "name": "@activepieces/piece-snowflake",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/snowflake/package.json
+++ b/packages/pieces/community/snowflake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-snowflake",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/snowflake/src/index.ts
+++ b/packages/pieces/community/snowflake/src/index.ts
@@ -1,8 +1,4 @@
-import {
-  createPiece,
-  PieceAuth,
-  Property,
-} from '@activepieces/pieces-framework';
+import { createPiece } from '@activepieces/pieces-framework';
 import { runMultipleQueries } from './lib/actions/run-multiple-queries';
 import { runQuery } from './lib/actions/run-query';
 import { PieceCategory } from '@activepieces/shared';
@@ -19,6 +15,11 @@ import { executeStoredProcedureAction } from './lib/actions/execute-stored-proce
 import { createDynamicTableAction } from './lib/actions/create-dynamic-table';
 import { loadDataFromStageAction } from './lib/actions/load-data-from-stage';
 import { snowflakeAuth } from './lib/auth';
+import { newColumnTrigger } from './lib/triggers/new-column';
+import { newTableTrigger } from './lib/triggers/new-table';
+import { newViewTrigger } from './lib/triggers/new-view';
+import { newRowTrigger } from './lib/triggers/new-row';
+import { newOrUpdatedRowTrigger } from './lib/triggers/new-or-updated-row';
 
 export const snowflake = createPiece({
   displayName: 'Snowflake',
@@ -50,5 +51,11 @@ export const snowflake = createPiece({
     createDynamicTableAction,
     loadDataFromStageAction,
   ],
-  triggers: [],
+  triggers: [
+    newRowTrigger,
+    newOrUpdatedRowTrigger,
+    newColumnTrigger,
+    newTableTrigger,
+    newViewTrigger,
+  ],
 });

--- a/packages/pieces/community/snowflake/src/lib/actions/create-dynamic-table.ts
+++ b/packages/pieces/community/snowflake/src/lib/actions/create-dynamic-table.ts
@@ -22,26 +22,21 @@ export const createDynamicTableAction = createAction({
     table_name: Property.ShortText({
       displayName: 'Dynamic Table Name',
       description:
-        'The name for the new dynamic table (e.g. `DAILY_SALES_SUMMARY`).',
+        'The name for the new dynamic table (e.g. `DAILY_SALES_SUMMARY`). Only letters, digits, underscores, and `$` are allowed.',
       required: true,
     }),
     target_lag: Property.ShortText({
-      displayName: 'Target Lag',
+      displayName: 'Refresh Interval',
       description:
-        'How fresh the dynamic table data should be. Accepts time expressions like `1 minute`, `5 minutes`, `1 hour`, or `DOWNSTREAM` to refresh when downstream objects are refreshed.',
+        'How up-to-date the dynamic table data should be (called **Target Lag** in Snowflake). Examples: `1 minute`, `5 minutes`, `1 hour`. Use `DOWNSTREAM` to only refresh when a downstream object explicitly requests it.',
       required: true,
       defaultValue: '1 hour',
     }),
-    warehouse: Property.ShortText({
-      displayName: 'Warehouse',
-      description:
-        'The name of the virtual warehouse to use when refreshing the dynamic table. Uses the auth warehouse if left empty.',
-      required: false,
-    }),
+    warehouse: snowflakeCommonProps.warehouse,
     query: Property.LongText({
       displayName: 'Source Query',
       description:
-        'The SELECT statement that defines the dynamic table content. ' +
+        'The SELECT statement that defines the content of the dynamic table. ' +
         'Example: `SELECT user_id, SUM(amount) AS total FROM orders GROUP BY user_id`',
       required: true,
     }),

--- a/packages/pieces/community/snowflake/src/lib/actions/load-data-from-stage.ts
+++ b/packages/pieces/community/snowflake/src/lib/actions/load-data-from-stage.ts
@@ -22,14 +22,16 @@ export const loadDataFromStageAction = createAction({
     stage_path: Property.ShortText({
       displayName: 'Stage Path',
       description:
-        'The stage path to load from. For internal stages use `@stage_name` or `@schema.stage_name/path/`. ' +
-        'For external (S3/GCS/Azure) stages use `@schema.stage_name/prefix/`. ' +
-        'Example: `@my_stage/data/`',
+        'Path to the Snowflake stage (a staging area that holds files before loading). ' +
+        'For **internal stages**: use `@stage_name` or `@schema.stage_name/folder/`. ' +
+        'For **external stages** (S3, GCS, Azure): use `@schema.stage_name/prefix/`. ' +
+        'Example: `@my_stage/data/`. ' +
+        'You can find your stage names under **Data → Databases → [your database] → Stages**.',
       required: true,
     }),
     file_format_type: Property.StaticDropdown({
       displayName: 'File Format',
-      description: 'The format of the files in the stage.',
+      description: 'The file format of the data files in the stage.',
       required: true,
       defaultValue: 'CSV',
       options: {
@@ -46,26 +48,26 @@ export const loadDataFromStageAction = createAction({
     file_pattern: Property.ShortText({
       displayName: 'File Pattern',
       description:
-        'Optional regex pattern to filter files in the stage (e.g. `.*\\.csv` to load only CSV files).',
+        'Optional regular expression to load only files whose names match the pattern (e.g. `.*\\.csv` loads only `.csv` files, `sales_2024.*` loads files that start with `sales_2024`). Leave empty to load all files in the stage path.',
       required: false,
     }),
     skip_header: Property.Number({
       displayName: 'Skip Header Rows',
       description:
-        'Number of header rows to skip at the top of each CSV file (CSV only). Defaults to 0.',
+        'Number of rows to skip at the top of each CSV file (e.g. `1` to skip a column-header row). Only applies to CSV files. Defaults to 0.',
       required: false,
       defaultValue: 0,
     }),
     error_on_column_count_mismatch: Property.Checkbox({
-      displayName: 'Error on Column Count Mismatch',
+      displayName: 'Fail on Column Count Mismatch',
       description:
-        'If enabled, COPY fails when the number of columns in the file does not match the table.',
+        'When enabled, the load fails if the number of columns in a file does not match the number of columns in the target table. Disable to allow files with fewer columns.',
       required: false,
       defaultValue: true,
     }),
     on_error: Property.StaticDropdown({
       displayName: 'On Error',
-      description: 'What to do when a row fails to load.',
+      description: 'What to do when a row fails validation during loading.',
       required: false,
       defaultValue: 'ABORT_STATEMENT',
       options: {

--- a/packages/pieces/community/snowflake/src/lib/actions/run-multiple-queries.ts
+++ b/packages/pieces/community/snowflake/src/lib/actions/run-multiple-queries.ts
@@ -12,43 +12,40 @@ const DEFAULT_QUERY_TIMEOUT = 30000;
 export const runMultipleQueries = createAction({
   name: 'runMultipleQueries',
   displayName: 'Run Multiple Queries',
-  description: 'Run Multiple Queries',
+  description:
+    'Execute multiple SQL statements in sequence against your Snowflake database. Optionally wrap them in a transaction so all changes are rolled back if any statement fails.',
   auth: snowflakeAuth,
   props: {
     sqlTexts: Property.Array({
-      displayName: 'SQL queries',
+      displayName: 'SQL Queries',
       description:
-        'Array of SQL queries to execute in order, in the same transaction. Use :1, :2… placeholders to use binding parameters. ' +
-        'Avoid using "?" to avoid unexpected behaviors when having multiple queries.',
+        'List of SQL statements to run in order. Use `:1`, `:2`… placeholders to reference shared **Parameters** values. Avoid `?` placeholders when running multiple queries — use numbered placeholders instead to prevent unexpected behaviour.',
       required: true,
     }),
     binds: Property.Array({
       displayName: 'Parameters',
       description:
-        'Binding parameters shared across all queries to prevent SQL injection attacks. ' +
-        'Use :1, :2, etc. to reference parameters in order. ' +
-        'Avoid using "?" to avoid unexpected behaviors when having multiple queries. ' +
-        'Unused parameters are allowed.',
+        'Values shared across all queries for the numbered placeholders (`:1`, `:2`…). Provide them in order. Unused parameters are allowed.',
       required: false,
     }),
     useTransaction: Property.Checkbox({
       displayName: 'Use Transaction',
       description:
-        'When enabled, all queries will be executed in a single transaction. If any query fails, all changes will be rolled back.',
+        'When enabled, all queries run inside a single transaction. If any query fails, every preceding change in this batch is rolled back automatically.',
       required: false,
       defaultValue: false,
     }),
     timeout: Property.Number({
-      displayName: 'Query timeout (ms)',
+      displayName: 'Query Timeout (ms)',
       description:
-        'An integer indicating the maximum number of milliseconds to wait for a query to complete before timing out.',
+        'Maximum time in milliseconds to wait for each query to complete before cancelling it. Defaults to 30 000 ms (30 seconds).',
       required: false,
       defaultValue: DEFAULT_QUERY_TIMEOUT,
     }),
     application: Property.ShortText({
-      displayName: 'Application name',
+      displayName: 'Application Name',
       description:
-        'A string indicating the name of the client application connecting to the server.',
+        'An optional label sent to Snowflake to identify this client. Visible in query history under **Monitoring → Query History → Client Application**.',
       required: false,
       defaultValue: DEFAULT_APPLICATION_NAME,
     }),

--- a/packages/pieces/community/snowflake/src/lib/actions/run-query.ts
+++ b/packages/pieces/community/snowflake/src/lib/actions/run-query.ts
@@ -15,31 +15,33 @@ const DEFAULT_QUERY_TIMEOUT = 30000;
 export const runQuery = createAction({
   name: 'runQuery',
   displayName: 'Run Query',
-  description: 'Run Query',
+  description:
+    'Execute a SQL query against your Snowflake database and return the results as rows.',
   auth: snowflakeAuth,
   props: {
-    sqlText: Property.ShortText({
-      displayName: 'SQL query',
-      description: 'Use :1, :2… or ? placeholders to use binding parameters.',
+    sqlText: Property.LongText({
+      displayName: 'SQL Query',
+      description:
+        'The SQL statement to execute. Use `:1`, `:2`… or `?` as placeholders for the **Parameters** values below to safely pass dynamic values without SQL injection risk.',
       required: true,
     }),
     binds: Property.Array({
       displayName: 'Parameters',
       description:
-        'Binding parameters for the SQL query (to prevent SQL injection attacks)',
+        'Values to bind to the placeholders (`:1`, `:2`…, or `?`) in the SQL query. Provide them in the same order they appear in the query. Using parameters is the safe way to pass dynamic values — never concatenate user input directly into the SQL.',
       required: false,
     }),
     timeout: Property.Number({
-      displayName: 'Query timeout (ms)',
+      displayName: 'Query Timeout (ms)',
       description:
-        'An integer indicating the maximum number of milliseconds to wait for a query to complete before timing out.',
+        'Maximum time in milliseconds to wait for the query to complete before cancelling it. Defaults to 30 000 ms (30 seconds).',
       required: false,
       defaultValue: DEFAULT_QUERY_TIMEOUT,
     }),
     application: Property.ShortText({
-      displayName: 'Application name',
+      displayName: 'Application Name',
       description:
-        'A string indicating the name of the client application connecting to the server.',
+        'An optional label sent to Snowflake to identify this client. Visible in query history under **Monitoring → Query History → Client Application**. Useful for auditing which automation triggered a query.',
       required: false,
       defaultValue: DEFAULT_APPLICATION_NAME,
     }),

--- a/packages/pieces/community/snowflake/src/lib/actions/search-rows.ts
+++ b/packages/pieces/community/snowflake/src/lib/actions/search-rows.ts
@@ -20,17 +20,17 @@ export const searchRowsAction = createAction({
     schema: snowflakeCommonProps.schema,
     table: snowflakeCommonProps.table,
     where_clause: Property.ShortText({
-      displayName: 'WHERE Condition',
+      displayName: 'Filter Condition',
       description:
-        "Optional SQL condition to filter results (e.g. `status = 'active' AND age > 18`). " +
+        "Optional SQL WHERE condition to narrow down results (e.g. `status = 'active' AND age > 18`). " +
         'Leave empty to return all rows (subject to the row limit). ' +
         '**Security note:** this value is embedded directly in SQL. Only use static values or data from trusted, internal steps — never pass unvalidated end-user input here.',
       required: false,
     }),
     order_by: Property.ShortText({
-      displayName: 'ORDER BY',
+      displayName: 'Sort By',
       description:
-        'Optional column(s) to sort by (e.g. `created_at DESC` or `name ASC, age DESC`). ' +
+        'Optional column(s) to sort results by (SQL ORDER BY clause). Examples: `created_at DESC` sorts newest first; `name ASC, age DESC` sorts by name then age. ' +
         '**Security note:** this value is embedded directly in SQL. Only use static values or data from trusted, internal steps — never pass unvalidated end-user input here.',
       required: false,
     }),

--- a/packages/pieces/community/snowflake/src/lib/common/index.ts
+++ b/packages/pieces/community/snowflake/src/lib/common/index.ts
@@ -149,6 +149,8 @@ export const snowflakeCommonProps = {
   database: Property.Dropdown({
     auth: snowflakeAuth,
     displayName: 'Database',
+    description:
+      'Select the Snowflake database to use. Databases are listed under **Data → Databases** in the Snowflake console.',
     refreshers: [],
     required: true,
     options: async ({ auth }) => {
@@ -179,6 +181,8 @@ export const snowflakeCommonProps = {
   schema: Property.Dropdown({
     auth: snowflakeAuth,
     displayName: 'Schema',
+    description:
+      'Select the schema within the chosen database. Schemas are listed under **Data → Databases → [your database]** in the Snowflake console.',
     refreshers: ['database'],
     required: true,
     options: async ({ auth, database }) => {
@@ -193,7 +197,7 @@ export const snowflakeCommonProps = {
         return {
           disabled: true,
           options: [],
-          placeholder: 'Please select database first',
+          placeholder: 'Please select a database first',
         };
       }
 
@@ -220,6 +224,7 @@ export const snowflakeCommonProps = {
   table: Property.Dropdown({
     auth: snowflakeAuth,
     displayName: 'Table',
+    description: 'Select the table to work with.',
     refreshers: ['database', 'schema'],
     required: true,
     options: async ({ auth, database, schema }) => {
@@ -234,14 +239,14 @@ export const snowflakeCommonProps = {
         return {
           disabled: true,
           options: [],
-          placeholder: 'Please select database first',
+          placeholder: 'Please select a database first',
         };
       }
       if (!schema) {
         return {
           disabled: true,
           options: [],
-          placeholder: 'Please select schema first',
+          placeholder: 'Please select a schema first',
         };
       }
 
@@ -265,9 +270,42 @@ export const snowflakeCommonProps = {
       };
     },
   }),
+  warehouse: Property.Dropdown({
+    auth: snowflakeAuth,
+    displayName: 'Warehouse',
+    description:
+      'Select the virtual warehouse to use for this operation. Warehouses are listed under **Admin → Warehouses** in the Snowflake console. Leave empty to use the warehouse set in your connection.',
+    refreshers: [],
+    required: false,
+    options: async ({ auth }) => {
+      if (!auth) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Please connect your account first',
+        };
+      }
+
+      const connection = configureConnection(auth as SnowflakeAuthValue);
+      await connect(connection);
+      const response = await execute(connection, 'SHOW WAREHOUSES', []);
+      await destroy(connection);
+
+      return {
+        disabled: false,
+        options: response
+          ? response.map((wh: Record<string, unknown>) => ({
+              label: wh['name'] as string,
+              value: wh['name'] as string,
+            }))
+          : [],
+      };
+    },
+  }),
   table_column_values: Property.DynamicProperties({
     auth: snowflakeAuth,
-    displayName: 'Rows',
+    displayName: 'Row Data',
+    description: 'Enter the value for each column in the new row.',
     required: true,
     refreshers: ['database', 'schema', 'table'],
     props: async ({ auth, table }) => {

--- a/packages/pieces/community/snowflake/src/lib/triggers/new-column.ts
+++ b/packages/pieces/community/snowflake/src/lib/triggers/new-column.ts
@@ -1,0 +1,106 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  AppConnectionValueForAuthProperty,
+} from '@activepieces/pieces-framework';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import { snowflakeAuth } from '../auth';
+import {
+  configureConnection,
+  connect,
+  destroy,
+  execute,
+  snowflakeCommonProps,
+  SnowflakeAuthValue,
+} from '../common';
+
+type NewColumnProps = {
+  database: string;
+  schema: string;
+  table: string;
+};
+
+const props = {
+  database: snowflakeCommonProps.database,
+  schema: snowflakeCommonProps.schema,
+  table: snowflakeCommonProps.table,
+};
+
+const polling: Polling<
+  AppConnectionValueForAuthProperty<typeof snowflakeAuth>,
+  NewColumnProps
+> = {
+  strategy: DedupeStrategy.LAST_ITEM,
+  items: async ({ auth, propsValue }) => {
+    const { table } = propsValue;
+    if (!table) return [];
+
+    const connection = configureConnection(auth as SnowflakeAuthValue);
+    await connect(connection);
+    try {
+      const result = await execute(connection, `DESCRIBE TABLE ${table}`, []);
+
+      if (!result) return [];
+
+      // Columns are returned in ordinal-position order (lowest first).
+      // New columns are always appended at the end → highest index = newest.
+      // Reverse so that LAST_ITEM deduplication stores the newest column's id
+      // and emits only columns added after that position on subsequent polls.
+      return (result as Record<string, unknown>[])
+        .map((col, index) => ({
+          id: index + 1,
+          data: {
+            column_name: col['name'],
+            data_type: col['type'],
+            nullable: col['null?'],
+            default_value: col['default'],
+            primary_key: col['primary key'],
+            unique_key: col['unique key'],
+            comment: col['comment'],
+            position: index + 1,
+            table,
+          },
+        }))
+        .reverse();
+    } finally {
+      await destroy(connection);
+    }
+  },
+};
+
+export const newColumnTrigger = createTrigger({
+  auth: snowflakeAuth,
+  name: 'new_column',
+  displayName: 'New Column',
+  description:
+    'Triggers when a new column is added to the selected table. Checked by polling every few minutes.',
+  props,
+  sampleData: {
+    column_name: 'EMAIL',
+    data_type: 'VARCHAR(256)',
+    nullable: 'Y',
+    default_value: null,
+    primary_key: 'N',
+    unique_key: 'N',
+    comment: '',
+    position: 5,
+    table: 'MY_DATABASE.PUBLIC.CUSTOMERS',
+  },
+  type: TriggerStrategy.POLLING,
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+});

--- a/packages/pieces/community/snowflake/src/lib/triggers/new-or-updated-row.ts
+++ b/packages/pieces/community/snowflake/src/lib/triggers/new-or-updated-row.ts
@@ -1,0 +1,127 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+  AppConnectionValueForAuthProperty,
+} from '@activepieces/pieces-framework';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import { snowflakeAuth } from '../auth';
+import {
+  configureConnection,
+  connect,
+  destroy,
+  execute,
+  getTableColumnOptions,
+  snowflakeCommonProps,
+  SnowflakeAuthValue,
+} from '../common';
+
+type NewOrUpdatedRowProps = {
+  database: string;
+  schema: string;
+  table: string;
+  updated_at_column: string;
+};
+
+const props = {
+  database: snowflakeCommonProps.database,
+  schema: snowflakeCommonProps.schema,
+  table: snowflakeCommonProps.table,
+  updated_at_column: Property.Dropdown({
+    auth: snowflakeAuth,
+    displayName: 'Updated At Column',
+    description:
+      'Select the column that stores when each row was last modified (e.g. `UPDATED_AT`, `LAST_MODIFIED_TIME`). ' +
+      'Both new rows and rows updated after the last check will fire the trigger. ' +
+      'The column must be updated by your application or a DEFAULT clause every time a row changes.',
+    refreshers: ['table'],
+    required: true,
+    options: async ({ auth, table }) => {
+      if (!auth) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Please connect your account first',
+        };
+      }
+      if (!table) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Please select a table first',
+        };
+      }
+      return getTableColumnOptions(auth as SnowflakeAuthValue, table as string);
+    },
+  }),
+};
+
+function toEpochMs(value: unknown): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'string') return new Date(value).getTime();
+  return 0;
+}
+
+const polling: Polling<
+  AppConnectionValueForAuthProperty<typeof snowflakeAuth>,
+  NewOrUpdatedRowProps
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue }) => {
+    const { table, updated_at_column } = propsValue;
+    if (!table || !updated_at_column) return [];
+
+    const connection = configureConnection(auth as SnowflakeAuthValue);
+    await connect(connection);
+    try {
+      // Fetch the 100 most-recently modified rows. pollingHelper keeps only
+      // rows whose timestamp exceeds the last stored watermark.
+      const result = await execute(
+        connection,
+        `SELECT * FROM ${table} ORDER BY ${updated_at_column} DESC LIMIT 100`,
+        []
+      );
+
+      if (!result) return [];
+
+      return (result as Record<string, unknown>[]).map((row) => ({
+        epochMilliSeconds: toEpochMs(row[updated_at_column]),
+        data: row,
+      }));
+    } finally {
+      await destroy(connection);
+    }
+  },
+};
+
+export const newOrUpdatedRowTrigger = createTrigger({
+  auth: snowflakeAuth,
+  name: 'new_or_updated_row',
+  displayName: 'New or Updated Row',
+  description:
+    'Triggers when a row is inserted or updated in the selected table. Uses an "updated at" timestamp column you choose — any row whose timestamp is newer than the last check will fire the trigger.',
+  props,
+  sampleData: {
+    ID: 1001,
+    NAME: 'Jane Doe',
+    EMAIL: 'jane.doe@example.com',
+    UPDATED_AT: '2024-01-15T10:30:00.000Z',
+  },
+  type: TriggerStrategy.POLLING,
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+});

--- a/packages/pieces/community/snowflake/src/lib/triggers/new-row.ts
+++ b/packages/pieces/community/snowflake/src/lib/triggers/new-row.ts
@@ -1,0 +1,126 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+  AppConnectionValueForAuthProperty,
+} from '@activepieces/pieces-framework';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import { snowflakeAuth } from '../auth';
+import {
+  configureConnection,
+  connect,
+  destroy,
+  execute,
+  getTableColumnOptions,
+  snowflakeCommonProps,
+  SnowflakeAuthValue,
+} from '../common';
+
+type NewRowProps = {
+  database: string;
+  schema: string;
+  table: string;
+  created_at_column: string;
+};
+
+const props = {
+  database: snowflakeCommonProps.database,
+  schema: snowflakeCommonProps.schema,
+  table: snowflakeCommonProps.table,
+  created_at_column: Property.Dropdown({
+    auth: snowflakeAuth,
+    displayName: 'Created At Column',
+    description:
+      'Select the column that stores when each row was inserted (e.g. `CREATED_AT`, `INSERT_TIME`). ' +
+      'Only rows with a timestamp in this column newer than the last check will fire the trigger.',
+    refreshers: ['table'],
+    required: true,
+    options: async ({ auth, table }) => {
+      if (!auth) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Please connect your account first',
+        };
+      }
+      if (!table) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Please select a table first',
+        };
+      }
+      return getTableColumnOptions(auth as SnowflakeAuthValue, table as string);
+    },
+  }),
+};
+
+function toEpochMs(value: unknown): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'string') return new Date(value).getTime();
+  return 0;
+}
+
+const polling: Polling<
+  AppConnectionValueForAuthProperty<typeof snowflakeAuth>,
+  NewRowProps
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue }) => {
+    const { table, created_at_column } = propsValue;
+    if (!table || !created_at_column) return [];
+
+    const connection = configureConnection(auth as SnowflakeAuthValue);
+    await connect(connection);
+    try {
+      // Fetch the 100 most-recently inserted rows. pollingHelper keeps only
+      // rows whose timestamp exceeds the last stored watermark.
+      const result = await execute(
+        connection,
+        `SELECT * FROM ${table} ORDER BY ${created_at_column} DESC LIMIT 100`,
+        []
+      );
+
+      if (!result) return [];
+
+      return (result as Record<string, unknown>[]).map((row) => ({
+        epochMilliSeconds: toEpochMs(row[created_at_column]),
+        data: row,
+      }));
+    } finally {
+      await destroy(connection);
+    }
+  },
+};
+
+export const newRowTrigger = createTrigger({
+  auth: snowflakeAuth,
+  name: 'new_row',
+  displayName: 'New Row',
+  description:
+    'Triggers when a new row is inserted into the selected table. Uses a timestamp column you choose to detect rows added since the last check.',
+  props,
+  sampleData: {
+    ID: 1001,
+    NAME: 'Jane Doe',
+    EMAIL: 'jane.doe@example.com',
+    CREATED_AT: '2024-01-15T10:30:00.000Z',
+  },
+  type: TriggerStrategy.POLLING,
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+});

--- a/packages/pieces/community/snowflake/src/lib/triggers/new-table.ts
+++ b/packages/pieces/community/snowflake/src/lib/triggers/new-table.ts
@@ -1,0 +1,108 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  AppConnectionValueForAuthProperty,
+} from '@activepieces/pieces-framework';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import { snowflakeAuth } from '../auth';
+import {
+  configureConnection,
+  connect,
+  destroy,
+  execute,
+  snowflakeCommonProps,
+  SnowflakeAuthValue,
+} from '../common';
+
+type NewTableProps = {
+  database: string;
+  schema: string;
+};
+
+const props = {
+  database: snowflakeCommonProps.database,
+  schema: snowflakeCommonProps.schema,
+};
+
+function toEpochMs(value: unknown): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'string') return new Date(value).getTime();
+  return 0;
+}
+
+const polling: Polling<
+  AppConnectionValueForAuthProperty<typeof snowflakeAuth>,
+  NewTableProps
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue }) => {
+    const { database, schema } = propsValue;
+    if (!database || !schema) return [];
+
+    const connection = configureConnection(auth as SnowflakeAuthValue);
+    await connect(connection);
+    try {
+      const result = await execute(
+        connection,
+        `SHOW TABLES IN SCHEMA ${database}.${schema}`,
+        []
+      );
+
+      if (!result) return [];
+
+      return (result as Record<string, unknown>[]).map((table) => ({
+        epochMilliSeconds: toEpochMs(table['created_on']),
+        data: {
+          table_name: table['name'],
+          database_name: table['database_name'],
+          schema_name: table['schema_name'],
+          kind: table['kind'],
+          rows: table['rows'],
+          bytes: table['bytes'],
+          owner: table['owner'],
+          comment: table['comment'],
+          created_on: table['created_on'],
+        },
+      }));
+    } finally {
+      await destroy(connection);
+    }
+  },
+};
+
+export const newTableTrigger = createTrigger({
+  auth: snowflakeAuth,
+  name: 'new_table',
+  displayName: 'New Table',
+  description:
+    'Triggers when a new table is created in the selected schema. Checked by polling every few minutes.',
+  props,
+  sampleData: {
+    table_name: 'ORDERS',
+    database_name: 'MY_DATABASE',
+    schema_name: 'PUBLIC',
+    kind: 'TABLE',
+    rows: 0,
+    bytes: 0,
+    owner: 'SYSADMIN',
+    comment: '',
+    created_on: '2024-01-15T10:30:00.000Z',
+  },
+  type: TriggerStrategy.POLLING,
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+});

--- a/packages/pieces/community/snowflake/src/lib/triggers/new-view.ts
+++ b/packages/pieces/community/snowflake/src/lib/triggers/new-view.ts
@@ -1,0 +1,108 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  AppConnectionValueForAuthProperty,
+} from '@activepieces/pieces-framework';
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+} from '@activepieces/pieces-common';
+import { snowflakeAuth } from '../auth';
+import {
+  configureConnection,
+  connect,
+  destroy,
+  execute,
+  snowflakeCommonProps,
+  SnowflakeAuthValue,
+} from '../common';
+
+type NewViewProps = {
+  database: string;
+  schema: string;
+};
+
+const props = {
+  database: snowflakeCommonProps.database,
+  schema: snowflakeCommonProps.schema,
+};
+
+function toEpochMs(value: unknown): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'string') return new Date(value).getTime();
+  return 0;
+}
+
+const polling: Polling<
+  AppConnectionValueForAuthProperty<typeof snowflakeAuth>,
+  NewViewProps
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue }) => {
+    const { database, schema } = propsValue;
+    if (!database || !schema) return [];
+
+    const connection = configureConnection(auth as SnowflakeAuthValue);
+    await connect(connection);
+    try {
+      const result = await execute(
+        connection,
+        `SHOW VIEWS IN SCHEMA ${database}.${schema}`,
+        []
+      );
+
+      if (!result) return [];
+
+      return (result as Record<string, unknown>[]).map((view) => ({
+        epochMilliSeconds: toEpochMs(view['created_on']),
+        data: {
+          view_name: view['name'],
+          database_name: view['database_name'],
+          schema_name: view['schema_name'],
+          owner: view['owner'],
+          comment: view['comment'],
+          text: view['text'],
+          is_secure: view['is_secure'],
+          is_materialized: view['is_materialized'],
+          created_on: view['created_on'],
+        },
+      }));
+    } finally {
+      await destroy(connection);
+    }
+  },
+};
+
+export const newViewTrigger = createTrigger({
+  auth: snowflakeAuth,
+  name: 'new_view',
+  displayName: 'New View',
+  description:
+    'Triggers when a new view is created in the selected schema. Checked by polling every few minutes.',
+  props,
+  sampleData: {
+    view_name: 'ACTIVE_CUSTOMERS',
+    database_name: 'MY_DATABASE',
+    schema_name: 'PUBLIC',
+    owner: 'SYSADMIN',
+    comment: '',
+    text: "CREATE VIEW ACTIVE_CUSTOMERS AS SELECT * FROM CUSTOMERS WHERE STATUS = 'ACTIVE'",
+    is_secure: 'N',
+    is_materialized: 'N',
+    created_on: '2024-01-15T10:30:00.000Z',
+  },
+  type: TriggerStrategy.POLLING,
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+});


### PR DESCRIPTION
- Improve prop descriptions, display names, and placeholders across all actions per UX guidelines (plain language, no jargon)
- Change SQL query field from ShortText to LongText in run-query
- Add warehouse dynamic dropdown to common props; use it in create-dynamic-table instead of a text input
- Rename 'Target Lag' → 'Refresh Interval' and 'ORDER BY' → 'Sort By'
- Add 5 polling triggers: New Row, New or Updated Row, New Column, New Table, New View

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
