### PR TITLE
feat(moosend): add Moosend email marketing piece

### DIFF
--- a/packages/pieces/community/moosend/.eslintrc.json
+++ b/packages/pieces/community/moosend/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/moosend/package.json
+++ b/packages/pieces/community/moosend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-moosend",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/moosend/src/index.ts
+++ b/packages/pieces/community/moosend/src/index.ts
@@ -1,0 +1,34 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { moosendAuth } from './lib/common/auth';
+import { addSubscriber } from './lib/actions/add-subscriber';
+import { unsubscribeMember } from './lib/actions/unsubscribe-member';
+import { createCampaign } from './lib/actions/create-campaign';
+import { getCampaignStatistics } from './lib/actions/get-campaign-statistics';
+
+export const moosend = createPiece({
+  displayName: 'Moosend',
+  description: 'Email marketing platform for campaigns, subscriber management, and analytics.',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/moosend.png',
+  categories: [PieceCategory.MARKETING],
+  authors: ['tarai-dl'],
+  auth: moosendAuth,
+  actions: [
+    addSubscriber,
+    unsubscribeMember,
+    createCampaign,
+    getCampaignStatistics,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.moosend.com/v3',
+      auth: moosendAuth,
+      authMapping: async (auth) => {
+        return {
+          apikey: (auth as { secret_text: string }).secret_text,
+        };
+      },
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/moosend/src/lib/actions/add-subscriber.ts
+++ b/packages/pieces/community/moosend/src/lib/actions/add-subscriber.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { moosendAuth } from '../common/auth';
+import { moosendApiCall } from '../common/client';
+
+export const addSubscriber = createAction({
+  auth: moosendAuth,
+  name: 'add_subscriber',
+  displayName: 'Add Subscriber',
+  description: 'Add or update a subscriber on a Moosend mailing list.',
+  props: {
+    mailing_list_id: Property.ShortText({
+      displayName: 'Mailing List ID',
+      description: 'The ID of the mailing list.',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'The email address of the subscriber.',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Name',
+      description: 'The name of the subscriber.',
+      required: false,
+    }),
+    custom_fields: Property.Array({
+      displayName: 'Custom Fields',
+      description: 'Custom fields as [{"Name":"field","Value":"val"}].',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const props = context.propsValue;
+    const body: Record<string, unknown> = {
+      Email: props.email,
+    };
+    if (props.name) body['Name'] = props.name;
+    if (props.custom_fields && props.custom_fields.length > 0) {
+      body['CustomFields'] = props.custom_fields;
+    }
+
+    const response = await moosendApiCall<{ Context: Record<string, unknown> }>({
+      method: HttpMethod.POST,
+      path: `subscribers/${props.mailing_list_id}/subscribe.json`,
+      auth: context.auth,
+      body,
+    });
+
+    return response.body.Context;
+  },
+});

--- a/packages/pieces/community/moosend/src/lib/actions/create-campaign.ts
+++ b/packages/pieces/community/moosend/src/lib/actions/create-campaign.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { moosendAuth } from '../common/auth';
+import { moosendApiCall } from '../common/client';
+
+export const createCampaign = createAction({
+  auth: moosendAuth,
+  name: 'create_campaign',
+  displayName: 'Create Campaign',
+  description: 'Create a new email campaign in Moosend.',
+  props: {
+    mailing_list_id: Property.ShortText({
+      displayName: 'Mailing List ID',
+      description: 'The ID of the mailing list to send to.',
+      required: true,
+    }),
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'The subject line of the campaign.',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Campaign Name',
+      description: 'Internal name for the campaign.',
+      required: true,
+    }),
+    confirmation_email: Property.ShortText({
+      displayName: 'Confirmation Email',
+      description: 'Email to send confirmation to.',
+      required: true,
+    }),
+    web_location: Property.ShortText({
+      displayName: 'Web Version URL',
+      description: 'URL for the web version of the campaign.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const props = context.propsValue;
+    const body: Record<string, unknown> = {
+      MailingListID: props.mailing_list_id,
+      Subject: props.subject,
+      Name: props.name,
+      ConfirmationEmail: props.confirmation_email,
+    };
+    if (props.web_location) body['WebVersionLocation'] = props.web_location;
+
+    const response = await moosendApiCall<{ Context: { ID: string } }>({
+      method: HttpMethod.POST,
+      path: 'campaigns/create.json',
+      auth: context.auth,
+      body,
+    });
+
+    return response.body.Context;
+  },
+});

--- a/packages/pieces/community/moosend/src/lib/actions/get-campaign-statistics.ts
+++ b/packages/pieces/community/moosend/src/lib/actions/get-campaign-statistics.ts
@@ -1,0 +1,27 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { moosendAuth } from '../common/auth';
+import { moosendApiCall } from '../common/client';
+
+export const getCampaignStatistics = createAction({
+  auth: moosendAuth,
+  name: 'get_campaign_statistics',
+  displayName: 'Get Campaign Statistics',
+  description: 'Get performance statistics for a Moosend campaign.',
+  props: {
+    campaign_id: Property.ShortText({
+      displayName: 'Campaign ID',
+      description: 'The ID of the campaign.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await moosendApiCall<{ Context: Record<string, unknown> }>({
+      method: HttpMethod.GET,
+      path: `campaigns/${context.propsValue.campaign_id}/view.json`,
+      auth: context.auth,
+    });
+
+    return response.body.Context;
+  },
+});

--- a/packages/pieces/community/moosend/src/lib/actions/unsubscribe-member.ts
+++ b/packages/pieces/community/moosend/src/lib/actions/unsubscribe-member.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { moosendAuth } from '../common/auth';
+import { moosendApiCall } from '../common/client';
+
+export const unsubscribeMember = createAction({
+  auth: moosendAuth,
+  name: 'unsubscribe_member',
+  displayName: 'Unsubscribe Member',
+  description: 'Remove a subscriber from a Moosend mailing list.',
+  props: {
+    mailing_list_id: Property.ShortText({
+      displayName: 'Mailing List ID',
+      description: 'The ID of the mailing list.',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'The email address to unsubscribe.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await moosendApiCall<{ Context: Record<string, unknown> }>({
+      method: HttpMethod.POST,
+      path: `subscribers/${context.propsValue.mailing_list_id}/unsubscribe.json`,
+      auth: context.auth,
+      body: { Email: context.propsValue.email },
+    });
+
+    return response.body.Context;
+  },
+});

--- a/packages/pieces/community/moosend/src/lib/common/auth.ts
+++ b/packages/pieces/community/moosend/src/lib/common/auth.ts
@@ -1,0 +1,25 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export type MoosendAuth = { api_key: string };
+
+export const moosendAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Moosend API key. Found in Moosend > Settings > API Key.',
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://api.moosend.com/v3/lists.json`,
+        queryParams: { apikey: auth as string },
+      });
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error: 'Invalid API key. Please check your Moosend API key.',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/moosend/src/lib/common/client.ts
+++ b/packages/pieces/community/moosend/src/lib/common/client.ts
@@ -1,0 +1,41 @@
+import {
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+  HttpResponse,
+  HttpMessageBody,
+} from '@activepieces/pieces-common';
+import { MoosendAuth } from './auth';
+
+const BASE_URL = 'https://api.moosend.com/v3';
+
+export async function moosendApiCall<T extends HttpMessageBody>({
+  method,
+  path,
+  auth,
+  body,
+  queryParams,
+}: {
+  method: HttpMethod;
+  path: string;
+  auth: MoosendAuth;
+  body?: HttpMessageBody;
+  queryParams?: Record<string, string>;
+}): Promise<HttpResponse<T>> {
+  const request: HttpRequest = {
+    method,
+    url: `${BASE_URL}/${path}`,
+    body,
+    queryParams: {
+      apikey: auth.api_key,
+      ...queryParams,
+    },
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  };
+  return httpClient.sendRequest<T>(request);
+}
+
+export { BASE_URL };

--- a/packages/pieces/community/moosend/tsconfig.json
+++ b/packages/pieces/community/moosend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "lib": ["es2021"]
+  },
+  "files": ["src/index.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/moosend/tsconfig.lib.json
+++ b/packages/pieces/community/moosend/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "lib": ["es2021"],
+    "paths": {}
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -776,6 +776,9 @@
       "@activepieces/piece-mollie": [
         "packages/pieces/community/mollie/src/index.ts"
       ],
+      "@activepieces/piece-moosend": [
+        "packages/pieces/community/moosend/src/index.ts"
+      ],
       "@activepieces/piece-monday": [
         "packages/pieces/community/monday/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

New piece for [Moosend](https://moosend.com/) email marketing platform.

### Actions (4)
- `add_subscriber` — Add or update a subscriber on a mailing list
- `unsubscribe_member` — Remove a subscriber from a list
- `create_campaign` — Create a new email campaign
- `get_campaign_statistics` — Get campaign performance stats
- Custom API call action

### Auth
API key auth with validation against Moosend API.

Closes #12192

/claim #12192