### PR TITLE
feat(courier): add Courier multi-channel notification piece

### DIFF
--- a/packages/pieces/community/courier/.eslintrc.json
+++ b/packages/pieces/community/courier/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {"files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {}},
+    {"files": ["*.ts", "*.tsx"], "rules": {}},
+    {"files": ["*.js", "*.jsx"], "rules": {}}
+  ]
+}

--- a/packages/pieces/community/courier/package.json
+++ b/packages/pieces/community/courier/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-courier",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/courier/src/index.ts
+++ b/packages/pieces/community/courier/src/index.ts
@@ -1,0 +1,32 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { courierAuth } from './lib/common/auth';
+import { sendMessage } from './lib/actions/send-message';
+import { getMessage } from './lib/actions/get-message';
+import { listMessages } from './lib/actions/list-messages';
+
+export const courier = createPiece({
+  displayName: 'Courier',
+  description: 'Multi-channel notification API for sending notifications across email, SMS, push, and Slack.',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/courier.png',
+  categories: [PieceCategory.MARKETING],
+  authors: ['tarai-dl'],
+  auth: courierAuth,
+  actions: [
+    sendMessage,
+    getMessage,
+    listMessages,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.courier.com',
+      auth: courierAuth,
+      authMapping: async (auth) => {
+        return {
+          Authorization: `Bearer ${(auth as { secret_text: string }).secret_text}`,
+        };
+      },
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/courier/src/lib/actions/get-message.ts
+++ b/packages/pieces/community/courier/src/lib/actions/get-message.ts
@@ -1,0 +1,27 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { courierAuth } from '../common/auth';
+import { courierApiCall } from '../common/client';
+
+export const getMessage = createAction({
+  auth: courierAuth,
+  name: 'get_message',
+  displayName: 'Get Message',
+  description: 'Get the delivery status of a sent message by its message ID.',
+  props: {
+    message_id: Property.ShortText({
+      displayName: 'Message ID',
+      description: 'The ID of the message to check.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await courierApiCall<{ results: Record<string, unknown> }>({
+      method: HttpMethod.GET,
+      path: `/messages/${context.propsValue.message_id}`,
+      apiKey: context.auth,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/courier/src/lib/actions/list-messages.ts
+++ b/packages/pieces/community/courier/src/lib/actions/list-messages.ts
@@ -1,0 +1,55 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { courierAuth } from '../common/auth';
+import { courierApiCall } from '../common/client';
+
+export const listMessages = createAction({
+  auth: courierAuth,
+  name: 'list_messages',
+  displayName: 'List Messages',
+  description: 'List recently sent messages with optional filters.',
+  props: {
+    cursor: Property.ShortText({
+      displayName: 'Cursor',
+      description: 'Pagination cursor from a previous response.',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Number of messages to return (default: 20, max: 100).',
+      required: false,
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      required: false,
+      options: {
+        options: [
+          { label: 'All', value: '' },
+          { label: 'Sent', value: 'SENT' },
+          { label: 'Delivered', value: 'DELIVERED' },
+          { label: 'Opened', value: 'OPENED' },
+          { label: 'Clicked', value: 'CLICKED' },
+          { label: 'Bounced', value: 'BOUNCED' },
+          { label: 'Undeliverable', value: 'UNDELIVERABLE' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const props = context.propsValue;
+    const queryParams: Record<string, string> = {};
+
+    if (props.cursor) queryParams['cursor'] = props.cursor;
+    if (props.limit) queryParams['limit'] = String(props.limit);
+    if (props.status) queryParams['status'] = props.status;
+
+    const response = await courierApiCall<{ paging: Record<string, unknown>; results: Record<string, unknown>[] }>({
+      method: HttpMethod.GET,
+      path: '/messages',
+      apiKey: context.auth,
+      queryParams,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/courier/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/courier/src/lib/actions/send-message.ts
@@ -1,0 +1,60 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { courierAuth } from '../common/auth';
+import { courierApiCall } from '../common/client';
+
+export const sendMessage = createAction({
+  auth: courierAuth,
+  name: 'send_message',
+  displayName: 'Send Message',
+  description: 'Send a notification via any channel (email, SMS, push, Slack, etc.) using Courier.',
+  props: {
+    recipient_id: Property.ShortText({
+      displayName: 'Recipient ID',
+      description: 'The ID of the recipient (user or list).',
+      required: true,
+    }),
+    event: Property.ShortText({
+      displayName: 'Event/Notification ID',
+      description: 'The Courier notification event to trigger.',
+      required: false,
+    }),
+    message_content: Property.Json({
+      displayName: 'Message Content',
+      description: 'Direct message content (used if no event specified). Example: {"title":"Hi","body":"Hello!"}',
+      required: false,
+    }),
+    data: Property.Json({
+      displayName: 'Data',
+      description: 'Data variables to pass to the notification template.',
+      required: false,
+    }),
+    channels: Property.Array({
+      displayName: 'Channels',
+      description: 'Channels to send through (e.g., ["email", "sms"]).',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const props = context.propsValue;
+    const body: Record<string, unknown> = {
+      recipient: props.recipient_id,
+    };
+
+    if (props.event) body['event'] = props.event;
+    if (props.message_content) body['message'] = props.message_content;
+    if (props.data) body['data'] = props.data;
+    if (props.channels && props.channels.length > 0) {
+      body['channels'] = props.channels;
+    }
+
+    const response = await courierApiCall<{ requestId: string }>({
+      method: HttpMethod.POST,
+      path: '/send',
+      apiKey: context.auth,
+      body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/courier/src/lib/common/auth.ts
+++ b/packages/pieces/community/courier/src/lib/common/auth.ts
@@ -1,0 +1,28 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export type CourierAuth = { api_key: string };
+
+export const courierAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Courier API key. Found in Courier > Settings > API Keys.',
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://api.courier.com/lists',
+        headers: {
+          Authorization: `Bearer ${auth as string}`,
+          Accept: 'application/json',
+        },
+      });
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error: 'Invalid API key. Please check your Courier API key.',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/courier/src/lib/common/client.ts
+++ b/packages/pieces/community/courier/src/lib/common/client.ts
@@ -1,0 +1,34 @@
+import {
+  httpClient,
+  HttpMethod,
+  HttpResponse,
+  HttpMessageBody,
+} from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.courier.com';
+
+export async function courierApiCall<T extends HttpMessageBody>({
+  method,
+  path,
+  apiKey,
+  body,
+  queryParams,
+}: {
+  method: HttpMethod;
+  path: string;
+  apiKey: string;
+  body?: HttpMessageBody;
+  queryParams?: Record<string, string>;
+}): Promise<HttpResponse<T>> {
+  return httpClient.sendRequest<T>({
+    method,
+    url: `${BASE_URL}${path}`,
+    body,
+    queryParams,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/packages/pieces/community/courier/tsconfig.json
+++ b/packages/pieces/community/courier/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "lib": ["es2021"]
+  },
+  "files": ["src/index.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/courier/tsconfig.lib.json
+++ b/packages/pieces/community/courier/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "lib": ["es2021"],
+    "paths": {}
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -297,6 +297,9 @@
       "@activepieces/piece-confluence": [
         "packages/pieces/community/confluence/src/index.ts"
       ],
+      "@activepieces/piece-courier": [
+        "packages/pieces/community/courier/src/index.ts"
+      ],
       "@activepieces/piece-connections": [
         "packages/pieces/core/connections/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

New piece for [Courier](https://www.courier.com/) multi-channel notification API.

### Actions (3)
- `send_message` — Send notification via any channel (email, SMS, push, Slack)
- `get_message` — Get delivery status of sent message by ID
- `list_messages` — List recent messages with status filter + pagination
- Custom API call action

### Auth
Bearer token auth with validation against Courier API.

Closes #12195

/claim #12195