### PR TITLE
fix(release pieces): strip semver major only

### DIFF
--- a/packages/cli/src/lib/utils/workspace-utils.ts
+++ b/packages/cli/src/lib/utils/workspace-utils.ts
@@ -57,7 +57,7 @@ export function resolveWorkspaceDependencies(
 }
 
 export function isExactVersion(version: string): boolean {
-  return /^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)
+  return /^\d+(\.\d+){0,2}(-[\w.]+)?$/.test(version)
 }
 
 export function stripSemverRanges(


### PR DESCRIPTION
The isExactVersion regex only accepted X.Y.Z format, causing prepare-pieces-for-publish to fail on deps like @types/node: "^24" where stripping the caret yields just "24". Relax the regex to accept X, X.Y, and X.Y.Z formats.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
