### PR TITLE
test: unskip sync webhook + subflow wait-for-response E2E test

### DIFF
--- a/packages/server/api/test/integration/ce/flows/flow-run/execute-flow-e2e.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow-run/execute-flow-e2e.test.ts
@@ -838,10 +838,7 @@ describe('Execute Flow E2E', () => {
         )
     }, 180_000)
 
-    // TODO: Re-enable once callFlow's waitpoint-based resume properly relays the sync webhook response.
-    // Skipped because callFlow was migrated from pause()/generateResumeUrl() to createWaitpoint()/waitForWaitpoint(),
-    // and the resumed engine's sendFlowResponse doesn't reach the original engineResponseWatcher listener.
-    it.skip('executes webhook → call subflow (wait-for-response) → return webhook response', async () => {
+    it('executes webhook → call subflow (wait-for-response) → return webhook response', async () => {
         const { parentFlow } = await setupSubflowWithWebhookResponseFixtures()
 
         // Hit the real /sync route so workerHandlerId + httpRequestId are wired up,


### PR DESCRIPTION
The httpRequestId correlation fix in resume-service ensures the engine's sendFlowResponse reaches the correct engineResponseWatcher listener.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
