### PR TITLE
feat: add EngageBay CRM piece (#12194)

### DIFF
--- a/packages/pieces/community/engagebay/.eslintrc.json
+++ b/packages/pieces/community/engagebay/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/engagebay/package.json
+++ b/packages/pieces/community/engagebay/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-engagebay",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/engagebay/src/index.ts
+++ b/packages/pieces/community/engagebay/src/index.ts
@@ -1,0 +1,29 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { engagebayAuth } from './lib/auth';
+import { createContactAction } from './lib/actions/create-contact';
+import { updateContactAction } from './lib/actions/update-contact';
+import { getContactsAction } from './lib/actions/get-contacts';
+import { searchContactsAction } from './lib/actions/search-contacts';
+import { createContactGroupAction } from './lib/actions/create-contact-group';
+import { getContactGroupsAction } from './lib/actions/get-contact-groups';
+
+export const engagebay = createPiece({
+  displayName: 'EngageBay',
+  description:
+    'All-in-one CRM and marketing automation platform.',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/engagebay.png',
+  categories: [PieceCategory.SALES_AND_CRM, PieceCategory.MARKETING],
+  auth: engagebayAuth,
+  authors: ['tarai-dl'],
+  actions: [
+    createContactAction,
+    updateContactAction,
+    getContactsAction,
+    searchContactsAction,
+    createContactGroupAction,
+    getContactGroupsAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/engagebay/src/lib/actions/create-contact-group.ts
+++ b/packages/pieces/community/engagebay/src/lib/actions/create-contact-group.ts
@@ -1,0 +1,27 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { engagebayAuth } from '../auth';
+import { engagebayRequest } from '../common/client';
+
+export const createContactGroupAction = createAction({
+  auth: engagebayAuth,
+  name: 'create_contact_group',
+  displayName: 'Create Contact Group',
+  description: 'Create a new contact group in EngageBay.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Group Name',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { name } = context.propsValue;
+
+    return await engagebayRequest({
+      apiKey: context.auth,
+      method: HttpMethod.POST,
+      path: '/api/core/groups',
+      body: { name },
+    });
+  },
+});

--- a/packages/pieces/community/engagebay/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/engagebay/src/lib/actions/create-contact.ts
@@ -1,0 +1,52 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { engagebayAuth } from '../auth';
+import { engagebayRequest } from '../common/client';
+
+export const createContactAction = createAction({
+  auth: engagebayAuth,
+  name: 'create_contact',
+  displayName: 'Create Contact',
+  description: 'Create a new contact in EngageBay.',
+  props: {
+    first_name: Property.ShortText({
+      displayName: 'First Name',
+      required: true,
+    }),
+    last_name: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: true,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      required: false,
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { first_name, last_name, email, phone, company } = context.propsValue;
+
+    const properties: { name: string; value: string }[] = [
+      { name: 'first_name', value: first_name },
+      { name: 'email', value: email },
+    ];
+
+    if (last_name) properties.push({ name: 'last_name', value: last_name });
+    if (phone) properties.push({ name: 'phone', value: phone });
+    if (company) properties.push({ name: 'company', value: company });
+
+    return await engagebayRequest({
+      apiKey: context.auth,
+      method: HttpMethod.POST,
+      path: '/api/panel/users/contacts',
+      body: { properties },
+    });
+  },
+});

--- a/packages/pieces/community/engagebay/src/lib/actions/get-contact-groups.ts
+++ b/packages/pieces/community/engagebay/src/lib/actions/get-contact-groups.ts
@@ -1,0 +1,17 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { engagebayAuth } from '../auth';
+import { engagebayRequest } from '../common/client';
+
+export const getContactGroupsAction = createAction({
+  auth: engagebayAuth,
+  name: 'get_contact_groups',
+  displayName: 'Get Contact Groups',
+  description: 'Get a list of contact groups from EngageBay.',
+  props: {},
+  async run(context) {
+    return await engagebayRequest({
+      apiKey: context.auth,
+      path: '/api/core/groups',
+    });
+  },
+});

--- a/packages/pieces/community/engagebay/src/lib/actions/get-contacts.ts
+++ b/packages/pieces/community/engagebay/src/lib/actions/get-contacts.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { engagebayAuth } from '../auth';
+import { engagebayRequest } from '../common/client';
+
+export const getContactsAction = createAction({
+  auth: engagebayAuth,
+  name: 'get_contacts',
+  displayName: 'Get Contacts',
+  description: 'Get a list of contacts from EngageBay.',
+  props: {
+    page: Property.Number({
+      displayName: 'Page',
+      description: 'Page number for pagination.',
+      required: false,
+      defaultValue: 0,
+    }),
+    size: Property.Number({
+      displayName: 'Page Size',
+      description: 'Number of contacts per page.',
+      required: false,
+      defaultValue: 20,
+    }),
+  },
+  async run(context) {
+    const { page, size } = context.propsValue;
+
+    return await engagebayRequest({
+      apiKey: context.auth,
+      path: '/api/panel/users/contacts',
+      queryParams: {
+        page: String(page ?? 0),
+        size: String(size ?? 20),
+      },
+    });
+  },
+});

--- a/packages/pieces/community/engagebay/src/lib/actions/search-contacts.ts
+++ b/packages/pieces/community/engagebay/src/lib/actions/search-contacts.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { engagebayAuth } from '../auth';
+import { engagebayRequest } from '../common/client';
+
+export const searchContactsAction = createAction({
+  auth: engagebayAuth,
+  name: 'search_contacts',
+  displayName: 'Search Contacts',
+  description: 'Search contacts by keyword in EngageBay.',
+  props: {
+    keyword: Property.ShortText({
+      displayName: 'Search Keyword',
+      description: 'Search by name, email, or phone.',
+      required: true,
+    }),
+    page: Property.Number({
+      displayName: 'Page',
+      description: 'Page number for pagination.',
+      required: false,
+      defaultValue: 0,
+    }),
+    size: Property.Number({
+      displayName: 'Page Size',
+      description: 'Number of contacts per page.',
+      required: false,
+      defaultValue: 20,
+    }),
+  },
+  async run(context) {
+    const { keyword, page, size } = context.propsValue;
+
+    return await engagebayRequest({
+      apiKey: context.auth,
+      method: HttpMethod.POST,
+      path: '/api/panel/users/search',
+      body: {
+        search: keyword,
+        page: page ?? 0,
+        size: size ?? 20,
+      },
+    });
+  },
+});

--- a/packages/pieces/community/engagebay/src/lib/actions/update-contact.ts
+++ b/packages/pieces/community/engagebay/src/lib/actions/update-contact.ts
@@ -1,0 +1,55 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { engagebayAuth } from '../auth';
+import { engagebayRequest } from '../common/client';
+
+export const updateContactAction = createAction({
+  auth: engagebayAuth,
+  name: 'update_contact',
+  displayName: 'Update Contact',
+  description: 'Update an existing contact in EngageBay.',
+  props: {
+    contact_id: Property.ShortText({
+      displayName: 'Contact ID',
+      required: true,
+    }),
+    first_name: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+    }),
+    last_name: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      required: false,
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { contact_id, first_name, last_name, email, phone, company } = context.propsValue;
+
+    const properties: { name: string; value: string }[] = [];
+
+    if (first_name) properties.push({ name: 'first_name', value: first_name });
+    if (last_name) properties.push({ name: 'last_name', value: last_name });
+    if (email) properties.push({ name: 'email', value: email });
+    if (phone) properties.push({ name: 'phone', value: phone });
+    if (company) properties.push({ name: 'company', value: company });
+
+    return await engagebayRequest({
+      apiKey: context.auth,
+      method: HttpMethod.PUT,
+      path: '/api/panel/users/contacts',
+      body: { id: contact_id, properties },
+    });
+  },
+});

--- a/packages/pieces/community/engagebay/src/lib/auth.ts
+++ b/packages/pieces/community/engagebay/src/lib/auth.ts
@@ -1,0 +1,22 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { engagebayRequest } from './common/client';
+
+export const engagebayAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your EngageBay REST API key.',
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await engagebayRequest({
+        apiKey: auth,
+        path: '/api/core/groups',
+      });
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error: 'Invalid API key or unable to reach the EngageBay API.',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/engagebay/src/lib/common/client.ts
+++ b/packages/pieces/community/engagebay/src/lib/common/client.ts
@@ -1,0 +1,32 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const ENGAGEBAY_API_BASE_URL = 'https://api.engagebay.com';
+
+type EngagebayRequestParams = {
+  apiKey: string;
+  path: string;
+  method?: HttpMethod;
+  body?: Record<string, unknown>;
+  queryParams?: Record<string, string>;
+};
+
+export async function engagebayRequest<TResponse>({
+  apiKey,
+  path,
+  method = HttpMethod.GET,
+  body,
+  queryParams,
+}: EngagebayRequestParams): Promise<TResponse> {
+  const response = await httpClient.sendRequest<TResponse>({
+    method,
+    url: `${ENGAGEBAY_API_BASE_URL}${path}`,
+    headers: {
+      Authorization: apiKey,
+      'Content-Type': 'application/json',
+    },
+    body,
+    queryParams,
+  });
+
+  return response.body;
+}

--- a/packages/pieces/community/engagebay/tsconfig.json
+++ b/packages/pieces/community/engagebay/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/engagebay/tsconfig.lib.json
+++ b/packages/pieces/community/engagebay/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -399,6 +399,9 @@
       "@activepieces/piece-emailoctopus": [
         "packages/pieces/community/emailoctopus/src/index.ts"
       ],
+      "@activepieces/piece-engagebay": [
+        "packages/pieces/community/engagebay/src/index.ts"
+      ],
       "@activepieces/piece-eth-name-service": [
         "packages/pieces/community/eth-name-service/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Adds a new Activepieces piece for [EngageBay](https://www.engagebay.com/), an all-in-one CRM and marketing automation platform.

### Actions
- **Create Contact** — Create a new contact
- **Update Contact** — Update an existing contact by ID
- **Get Contacts** — List contacts with pagination
- **Search Contacts** — Search contacts by keyword
- **Create Contact Group** — Create a new contact group
- **Get Contact Groups** — List all contact groups

### Auth
- API key authentication via `Authorization` header

### Reference
- API docs: https://api.engagebay.com/
- Fixes #12194

## Checklist
- [x] App file with auth
- [x] Actions
- [x] index.ts export