### PR TITLE
feat: add Billsby subscription billing piece (#12193)

### DIFF
--- a/packages/pieces/community/billsby/.eslintrc.json
+++ b/packages/pieces/community/billsby/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/billsby/package.json
+++ b/packages/pieces/community/billsby/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-billsby",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/billsby/src/index.ts
+++ b/packages/pieces/community/billsby/src/index.ts
@@ -1,0 +1,23 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { billsbyAuth } from './lib/auth';
+import { createCustomerAction } from './lib/actions/create-customer';
+import { getCustomerAction } from './lib/actions/get-customer';
+import { createSubscriptionAction } from './lib/actions/create-subscription';
+
+export const billsby = createPiece({
+  displayName: 'Billsby',
+  description:
+    'Subscription billing and recurring payments platform.',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/billsby.png',
+  categories: [PieceCategory.COMMERCE],
+  auth: billsbyAuth,
+  authors: ['tarai-dl'],
+  actions: [
+    createCustomerAction,
+    getCustomerAction,
+    createSubscriptionAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/billsby/src/lib/actions/create-customer.ts
+++ b/packages/pieces/community/billsby/src/lib/actions/create-customer.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { billsbyAuth, BillsbyAuthType } from '../auth';
+import { billsbyRequest } from '../common/client';
+
+export const createCustomerAction = createAction({
+  auth: billsbyAuth,
+  name: 'create_customer',
+  displayName: 'Create Customer',
+  description: 'Create a new customer in Billsby.',
+  props: {
+    first_name: Property.ShortText({
+      displayName: 'First Name',
+      required: true,
+    }),
+    last_name: Property.ShortText({
+      displayName: 'Last Name',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: true,
+    }),
+    company_name: Property.ShortText({
+      displayName: 'Company Name',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { first_name, last_name, email, company_name, phone } = context.propsValue;
+
+    return await billsbyRequest({
+      auth: context.auth as BillsbyAuthType,
+      method: HttpMethod.POST,
+      path: '/customers',
+      body: {
+        firstName: first_name,
+        lastName: last_name,
+        email,
+        ...(company_name ? { companyName: company_name } : {}),
+        ...(phone ? { phone } : {}),
+      },
+    });
+  },
+});

--- a/packages/pieces/community/billsby/src/lib/actions/create-subscription.ts
+++ b/packages/pieces/community/billsby/src/lib/actions/create-subscription.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { billsbyAuth, BillsbyAuthType } from '../auth';
+import { billsbyRequest } from '../common/client';
+
+export const createSubscriptionAction = createAction({
+  auth: billsbyAuth,
+  name: 'create_subscription',
+  displayName: 'Create Subscription',
+  description: 'Create a new subscription for a customer in Billsby.',
+  props: {
+    customer_id: Property.ShortText({
+      displayName: 'Customer ID',
+      description: 'The unique ID of the customer.',
+      required: true,
+    }),
+    plan_code: Property.ShortText({
+      displayName: 'Plan Code',
+      description: 'The code of the plan to subscribe to.',
+      required: true,
+    }),
+    quantity: Property.Number({
+      displayName: 'Quantity',
+      description: 'Number of units to subscribe.',
+      required: false,
+      defaultValue: 1,
+    }),
+  },
+  async run(context) {
+    const { customer_id, plan_code, quantity } = context.propsValue;
+
+    return await billsbyRequest({
+      auth: context.auth as BillsbyAuthType,
+      method: HttpMethod.POST,
+      path: '/subscriptions',
+      body: {
+        customerUniqueId: customer_id,
+        planCode: plan_code,
+        ...(quantity ? { quantity } : {}),
+      },
+    });
+  },
+});

--- a/packages/pieces/community/billsby/src/lib/actions/get-customer.ts
+++ b/packages/pieces/community/billsby/src/lib/actions/get-customer.ts
@@ -1,0 +1,24 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { billsbyAuth, BillsbyAuthType } from '../auth';
+import { billsbyRequest } from '../common/client';
+
+export const getCustomerAction = createAction({
+  auth: billsbyAuth,
+  name: 'get_customer',
+  displayName: 'Get Customer',
+  description: 'Get a customer by ID from Billsby.',
+  props: {
+    customer_id: Property.ShortText({
+      displayName: 'Customer ID',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { customer_id } = context.propsValue;
+
+    return await billsbyRequest({
+      auth: context.auth as BillsbyAuthType,
+      path: `/customers/${customer_id}`,
+    });
+  },
+});

--- a/packages/pieces/community/billsby/src/lib/auth.ts
+++ b/packages/pieces/community/billsby/src/lib/auth.ts
@@ -1,0 +1,39 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import { billsbyRequest } from './common/client';
+
+export const billsbyAuth = PieceAuth.CustomAuth({
+  description: 'Authenticate with your Billsby account.',
+  required: true,
+  props: {
+    company_domain: Property.ShortText({
+      displayName: 'Company Domain',
+      description: 'Your Billsby company subdomain (e.g. mycompany).',
+      required: true,
+    }),
+    api_key: PieceAuth.SecretText({
+      displayName: 'API Key',
+      description: 'Your Billsby API key.',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      await billsbyRequest({
+        auth,
+        path: '/customers',
+        queryParams: { page: '1', pageSize: '1' },
+      });
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error: 'Invalid API key or company domain.',
+      };
+    }
+  },
+});
+
+export type BillsbyAuthType = {
+  company_domain: string;
+  api_key: string;
+};

--- a/packages/pieces/community/billsby/src/lib/common/client.ts
+++ b/packages/pieces/community/billsby/src/lib/common/client.ts
@@ -1,0 +1,33 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import type { BillsbyAuthType } from '../auth';
+
+type BillsbyRequestParams = {
+  auth: BillsbyAuthType;
+  path: string;
+  method?: HttpMethod;
+  body?: Record<string, unknown>;
+  queryParams?: Record<string, string>;
+};
+
+export async function billsbyRequest<TResponse>({
+  auth,
+  path,
+  method = HttpMethod.GET,
+  body,
+  queryParams,
+}: BillsbyRequestParams): Promise<TResponse> {
+  const baseUrl = `https://public.billsby.com/api/v1/rest/core/${auth.company_domain}`;
+
+  const response = await httpClient.sendRequest<TResponse>({
+    method,
+    url: `${baseUrl}${path}`,
+    headers: {
+      ApiKey: auth.api_key,
+      'Content-Type': 'application/json',
+    },
+    body,
+    queryParams,
+  });
+
+  return response.body;
+}

--- a/packages/pieces/community/billsby/tsconfig.json
+++ b/packages/pieces/community/billsby/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/billsby/tsconfig.lib.json
+++ b/packages/pieces/community/billsby/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -146,6 +146,9 @@
       "@activepieces/piece-bettermode": [
         "packages/pieces/community/bettermode/src/index.ts"
       ],
+      "@activepieces/piece-billsby": [
+        "packages/pieces/community/billsby/src/index.ts"
+      ],
       "@activepieces/piece-bigcommerce": [
         "packages/pieces/community/bigcommerce/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Adds a new Activepieces piece for [Billsby](https://www.billsby.com/), a subscription billing and recurring payments platform.

### Actions
- **Create Customer** — Create a new customer
- **Get Customer** — Get a customer by ID
- **Create Subscription** — Create a new subscription for a customer

### Auth
- Custom auth with Company Domain + API Key
- API base URL: `https://public.billsby.com/api/v1/rest/core/{company_domain}`

### Reference
- API docs: https://support.billsby.com/reference
- Fixes #12193

## Checklist
- [x] App file with auth
- [x] Actions
- [x] index.ts export