### PR TITLE
fix: provision user invitations across platforms during signup

### DIFF
--- a/packages/server/api/src/app/authentication/authentication.service.ts
+++ b/packages/server/api/src/app/authentication/authentication.service.ts
@@ -26,12 +26,29 @@ export const authenticationService = (log: FastifyBaseLogger) => ({
             })
         }
         if (isNil(platformId)) {
+            const hasInvitations = await userInvitationsService(log).hasAnyAcceptedInvitationsForEmail({ email: params.email })
+            const isFederatedProvider = params.provider === UserIdentityProvider.GOOGLE || params.provider === UserIdentityProvider.JWT || params.provider === UserIdentityProvider.SAML
             const userIdentity = await userIdentityService(log).create({
                 ...params,
-                verified: params.provider === UserIdentityProvider.GOOGLE || params.provider === UserIdentityProvider.JWT || params.provider === UserIdentityProvider.SAML,
+                verified: hasInvitations || isFederatedProvider,
             })
             const response = await createUserAndPlatform(userIdentity, log)
             await userInvitationsService(log).provisionUserInvitation({ email: params.email })
+            const preferredPlatformId = await getPreferredPlatformId(userIdentity.id, log)
+            if (!isNil(preferredPlatformId)) {
+                const user = await userService(log).getOneByIdentityAndPlatform({
+                    identityId: userIdentity.id,
+                    platformId: preferredPlatformId,
+                })
+                if (!isNil(user)) {
+                    log.info({ email: params.email, provider: params.provider, preferredPlatformId }, 'User signed up with invitation, returning preferred platform token')
+                    return authenticationUtils(log).getProjectAndToken({
+                        userId: user.id,
+                        platformId: preferredPlatformId,
+                        projectId: null,
+                    })
+                }
+            }
             log.info({ email: params.email, provider: params.provider }, 'User signed up and platform created')
             return response
         }
@@ -59,7 +76,7 @@ export const authenticationService = (log: FastifyBaseLogger) => ({
     },
     async signInWithPassword(params: SignInWithPasswordParams): Promise<AuthenticationResponse> {
         const identity = await userIdentityService(log).verifyIdentityPassword(params)
-        const platformId = isNil(params.predefinedPlatformId) ? await getPersonalPlatformIdForIdentity(identity.id, log) : params.predefinedPlatformId
+        const platformId = isNil(params.predefinedPlatformId) ? await getPreferredPlatformId(identity.id, log) : params.predefinedPlatformId
         if (isNil(platformId)) {
             throw new ActivepiecesError({
                 code: ErrorCode.AUTHENTICATION,
@@ -89,7 +106,7 @@ export const authenticationService = (log: FastifyBaseLogger) => ({
         })
     },
     async federatedAuthn(params: FederatedAuthnParams): Promise<AuthenticationResponse> {
-        const platformId = isNil(params.predefinedPlatformId) ? await getPersonalPlatformIdForFederatedAuthn(params.email, log) : params.predefinedPlatformId
+        const platformId = isNil(params.predefinedPlatformId) ? await getPreferredPlatformIdForFederatedAuthn(params.email, log) : params.predefinedPlatformId
         const userIdentity = await userIdentityService(log).getIdentityByEmail(params.email)
 
         if (isNil(platformId)) {
@@ -212,11 +229,13 @@ async function createUserAndPlatform(userIdentity: UserIdentity, log: FastifyBas
 
     switch (cloudEdition) {
         case ApEdition.CLOUD:
-            await otpService(log).createAndSend({
-                platformId: platform.id,
-                email: userIdentity.email,
-                type: OtpType.EMAIL_VERIFICATION,
-            })
+            if (!userIdentity.verified) {
+                await otpService(log).createAndSend({
+                    platformId: platform.id,
+                    email: userIdentity.email,
+                    type: OtpType.EMAIL_VERIFICATION,
+                })
+            }
             break
         case ApEdition.COMMUNITY:
         case ApEdition.ENTERPRISE:
@@ -242,20 +261,21 @@ async function createUserAndPlatform(userIdentity: UserIdentity, log: FastifyBas
     })
 }
 
-async function getPersonalPlatformIdForFederatedAuthn(email: string, log: FastifyBaseLogger): Promise<string | null> {
+async function getPreferredPlatformIdForFederatedAuthn(email: string, log: FastifyBaseLogger): Promise<string | null> {
     const identity = await userIdentityService(log).getIdentityByEmail(email)
     if (isNil(identity)) {
         return null
     }
-    return getPersonalPlatformIdForIdentity(identity.id, log)
+    return getPreferredPlatformId(identity.id, log)
 }
 
-async function getPersonalPlatformIdForIdentity(identityId: string, log: FastifyBaseLogger): Promise<string | null> {
+async function getPreferredPlatformId(identityId: string, log: FastifyBaseLogger): Promise<string | null> {
     const edition = system.getEdition()
     if (edition === ApEdition.CLOUD) {
         const platforms = await platformService(log).listPlatformsForIdentityWithAtleastProject({ identityId })
-        const platform = platforms.find((platform) => !platformUtils.isCustomerOnDedicatedDomain(platform))
-        return platform?.id ?? null
+        const nonDedicated = platforms.filter((p) => !platformUtils.isCustomerOnDedicatedDomain(p))
+        const licensed = nonDedicated.find((p) => !isNil(p.plan.licenseKey))
+        return licensed?.id ?? nonDedicated[0]?.id ?? null
     }
     return null
 }

--- a/packages/server/api/src/app/authentication/authentication.service.ts
+++ b/packages/server/api/src/app/authentication/authentication.service.ts
@@ -14,29 +14,31 @@ import { userIdentityService } from './user-identity/user-identity-service'
 
 export const authenticationService = (log: FastifyBaseLogger) => ({
     async signUp(params: SignUpParams): Promise<AuthenticationResponse> {
-        if (!isNil(params.platformId)) {
+        const platformId = params.platformId
+        if (!isNil(platformId)) {
             await authenticationUtils(log).assertEmailAuthIsEnabled({
-                platformId: params.platformId,
+                platformId,
                 provider: params.provider,
             })
             await authenticationUtils(log).assertDomainIsAllowed({
                 email: params.email,
-                platformId: params.platformId,
+                platformId,
             })
         }
-        if (isNil(params.platformId)) {
+        if (isNil(platformId)) {
             const userIdentity = await userIdentityService(log).create({
                 ...params,
                 verified: params.provider === UserIdentityProvider.GOOGLE || params.provider === UserIdentityProvider.JWT || params.provider === UserIdentityProvider.SAML,
             })
             const response = await createUserAndPlatform(userIdentity, log)
+            await userInvitationsService(log).provisionUserInvitation({ email: params.email })
             log.info({ email: params.email, provider: params.provider }, 'User signed up and platform created')
             return response
         }
 
         await authenticationUtils(log).assertUserIsInvitedToPlatformOrProject({
             email: params.email,
-            platformId: params.platformId,
+            platformId,
         })
         const userIdentity = await userIdentityService(log).create({
             ...params,
@@ -44,17 +46,14 @@ export const authenticationService = (log: FastifyBaseLogger) => ({
         })
         const user = await userService(log).getOrCreateWithProject({
             identity: userIdentity,
-            platformId: params.platformId,
+            platformId,
         })
-        await userInvitationsService(log).provisionUserInvitation({
-            email: params.email,
-            user,
-        })
+        await userInvitationsService(log).provisionUserInvitation({ email: params.email })
 
-        log.info({ email: params.email, platformId: params.platformId }, 'User signed up to existing platform')
+        log.info({ email: params.email, platformId }, 'User signed up to existing platform')
         return authenticationUtils(log).getProjectAndToken({
             userId: user.id,
-            platformId: params.platformId,
+            platformId,
             projectId: null,
         })
     },
@@ -128,10 +127,7 @@ export const authenticationService = (log: FastifyBaseLogger) => ({
             identity: userIdentity,
             platformId,
         })
-        await userInvitationsService(log).provisionUserInvitation({
-            email: params.email,
-            user,
-        })
+        await userInvitationsService(log).provisionUserInvitation({ email: params.email })
         return authenticationUtils(log).getProjectAndToken({
             userId: user.id,
             platformId,

--- a/packages/server/api/src/app/user-invitations/user-invitation.module.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.module.ts
@@ -83,11 +83,11 @@ const invitationController: FastifyPluginAsyncZod = async (app) => {
 
     app.post('/accept', AcceptUserInvitationRequestParams, async (request, reply) => {
         const invitation = await userInvitationsService(request.log).getOneByInvitationTokenOrThrow(request.body.invitationToken)
-        const result = await userInvitationsService(request.log).accept({
+        await userInvitationsService(request.log).accept({
             invitationId: invitation.id,
             platformId: invitation.platformId,
         })
-        await reply.status(StatusCodes.OK).send(result)
+        await reply.status(StatusCodes.OK).send(invitation)
     })
 
     app.delete('/:id', DeleteInvitationRequestParams, async (request, reply) => {

--- a/packages/server/api/src/app/user-invitations/user-invitation.module.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.module.ts
@@ -83,11 +83,11 @@ const invitationController: FastifyPluginAsyncZod = async (app) => {
 
     app.post('/accept', AcceptUserInvitationRequestParams, async (request, reply) => {
         const invitation = await userInvitationsService(request.log).getOneByInvitationTokenOrThrow(request.body.invitationToken)
-        await userInvitationsService(request.log).accept({
+        const result = await userInvitationsService(request.log).accept({
             invitationId: invitation.id,
             platformId: invitation.platformId,
         })
-        await reply.status(StatusCodes.OK).send(invitation)
+        await reply.status(StatusCodes.OK).send(result)
     })
 
     app.delete('/:id', DeleteInvitationRequestParams, async (request, reply) => {

--- a/packages/server/api/src/app/user-invitations/user-invitation.service.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.service.ts
@@ -192,23 +192,18 @@ export const userInvitationsService = (log: FastifyBaseLogger) => ({
         }
         return invitation
     },
-    async accept({ invitationId, platformId }: AcceptParams): Promise<{ registered: boolean }> {
+    async accept({ invitationId, platformId }: AcceptParams): Promise<void> {
         const invitation = await this.getOneOrThrow({ id: invitationId, platformId })
         await repo().update(invitation.id, {
             status: InvitationStatus.ACCEPTED,
         })
         const identity = await userIdentityService(log).getIdentityByEmail(invitation.email)
         if (isNil(identity)) {
-            return {
-                registered: false,
-            }
+            return
         }
         await this.provisionUserInvitation({
             email: invitation.email,
         })
-        return {
-            registered: true,
-        }
     },
     async hasAnyAcceptedInvitationsForEmail({ email }: { email: string }): Promise<boolean> {
         const count = await repo().createQueryBuilder('user_invitation')

--- a/packages/server/api/src/app/user-invitations/user-invitation.service.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.service.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, apId, assertEqual, assertNotNullOrUndefined, ErrorCode, InvitationStatus, InvitationType, isNil, PlatformRole, SeekPage, spreadIfDefined, User, UserInvitation, UserInvitationWithLink } from '@activepieces/shared'
+import { ActivepiecesError, apId, assertEqual, assertNotNullOrUndefined, ErrorCode, InvitationStatus, InvitationType, isNil, PlatformRole, SeekPage, spreadIfDefined, UserInvitation, UserInvitationWithLink } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { IsNull } from 'typeorm'
 import { userIdentityService } from '../authentication/user-identity/user-identity-service'
@@ -38,7 +38,7 @@ export const userInvitationsService = (log: FastifyBaseLogger) => ({
         }
         return invitation
     },
-    async provisionUserInvitation({ user, email }: ProvisionUserInvitationParams): Promise<void> {
+    async provisionUserInvitation({ email }: ProvisionUserInvitationParams): Promise<void> {
         const invitations = await repo().createQueryBuilder('user_invitation')
             .where('LOWER("user_invitation"."email") = :email', { email: email.toLowerCase().trim() })
             .andWhere({
@@ -46,9 +46,18 @@ export const userInvitationsService = (log: FastifyBaseLogger) => ({
             })
             .getMany()
 
+        if (invitations.length === 0) return
+
+        const identity = await userIdentityService(log).getIdentityByEmail(email)
+        if (isNil(identity)) return
+
         log.info({ count: invitations.length }, '[provisionUserInvitation] list invitations')
         for (const invitation of invitations) {
             log.info({ invitation }, '[provisionUserInvitation] provision')
+            const user = await userService(log).getOrCreateWithProject({
+                identity,
+                platformId: invitation.platformId,
+            })
             switch (invitation.type) {
                 case InvitationType.PLATFORM: {
                     assertNotNullOrUndefined(invitation.platformRole, 'platformRole')
@@ -194,13 +203,8 @@ export const userInvitationsService = (log: FastifyBaseLogger) => ({
                 registered: false,
             }
         }
-        const user = await userService(log).getOrCreateWithProject({
-            identity,
-            platformId: invitation.platformId,
-        })
         await this.provisionUserInvitation({
             email: invitation.email,
-            user,
         })
         return {
             registered: true,
@@ -273,7 +277,6 @@ type HasAnyAcceptedInvitationsParams = {
     platformId: string
 }
 type ProvisionUserInvitationParams = {
-    user: User
     email: string
 }
 

--- a/packages/server/api/src/app/user-invitations/user-invitation.service.ts
+++ b/packages/server/api/src/app/user-invitations/user-invitation.service.ts
@@ -210,6 +210,13 @@ export const userInvitationsService = (log: FastifyBaseLogger) => ({
             registered: true,
         }
     },
+    async hasAnyAcceptedInvitationsForEmail({ email }: { email: string }): Promise<boolean> {
+        const count = await repo().createQueryBuilder('user_invitation')
+            .where('LOWER("user_invitation"."email") = :email', { email: email.toLowerCase().trim() })
+            .andWhere({ status: InvitationStatus.ACCEPTED })
+            .getCount()
+        return count > 0
+    },
     async hasAnyAcceptedInvitations({
         email,
         platformId,

--- a/packages/server/api/test/integration/cloud/authn/cloud-authn.test.ts
+++ b/packages/server/api/test/integration/cloud/authn/cloud-authn.test.ts
@@ -319,6 +319,54 @@ describe('Authentication API', () => {
             expect(responseBody?.verified).toBe(true)
         })
 
+        it('should join enterprise platform when signing up with accepted invitation on cloud (no custom domain)', async () => {
+            // arrange - enterprise platform exists
+            const { mockPlatform, mockUser } = await createMockPlatformAndDomain({
+                platform: { emailAuthEnabled: true },
+                plan: { projectRolesEnabled: true },
+            })
+
+            const mockProject = createMockProject({
+                ownerId: mockUser.id,
+                platformId: mockPlatform.id,
+            })
+            await db.save('project', mockProject)
+
+            const invitedEmail = faker.internet.email()
+
+            // ACCEPTED invitation (user clicked invite link)
+            const mockUserInvitation = createMockUserInvitation({
+                platformId: mockPlatform.id,
+                email: invitedEmail,
+                platformRole: PlatformRole.MEMBER,
+                type: InvitationType.PLATFORM,
+                status: InvitationStatus.ACCEPTED,
+                created: dayjs().toISOString(),
+            })
+            await db.save('user_invitation', mockUserInvitation)
+
+            const mockSignUpRequest = createMockSignUpRequest({ email: invitedEmail })
+
+            // act - sign up WITHOUT Host header (cloud.activepieces.com, no custom domain)
+            const response = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/sign-up',
+                body: mockSignUpRequest,
+            })
+
+            const responseBody = response?.json()
+
+            // assert - user should be on enterprise platform
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(responseBody?.platformId).toBe(mockPlatform.id)
+
+            // Invitation should be provisioned (deleted after processing)
+            const remainingInvitation = await databaseConnection()
+                .getRepository('user_invitation')
+                .findOneBy({ id: mockUserInvitation.id })
+            expect(remainingInvitation).toBeNull()
+        })
+
         it('fails to sign up invited user platform if no project exist', async () => {
             // arrange
             const { mockCustomDomain } = await createMockPlatformAndDomain({

--- a/packages/server/api/test/integration/cloud/authn/cloud-authn.test.ts
+++ b/packages/server/api/test/integration/cloud/authn/cloud-authn.test.ts
@@ -323,7 +323,7 @@ describe('Authentication API', () => {
             // arrange - enterprise platform exists
             const { mockPlatform, mockUser } = await createMockPlatformAndDomain({
                 platform: { emailAuthEnabled: true },
-                plan: { projectRolesEnabled: true },
+                plan: { projectRolesEnabled: true, licenseKey: 'test-key' },
             })
 
             const mockProject = createMockProject({
@@ -365,6 +365,10 @@ describe('Authentication API', () => {
                 .getRepository('user_invitation')
                 .findOneBy({ id: mockUserInvitation.id })
             expect(remainingInvitation).toBeNull()
+
+            // A personal platform was also created for the user
+            const allPlatforms = await databaseConnection().getRepository('platform').find()
+            expect(allPlatforms.length).toBe(2)
         })
 
         it('fails to sign up invited user platform if no project exist', async () => {


### PR DESCRIPTION
Cloud signup with an accepted invitation would create a new platform instead of provisioning the user on the invited enterprise org.

- Change provisionUserInvitation to accept { email } and create user records on each invited platform via getOrCreateWithProject
- Call provisionUserInvitation as safety net in create-platform branch
- Fix accept endpoint to return { registered } instead of raw invitation
- Add integration test for signup with accepted invitation

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
