### PR TITLE
test(worker): lock down isolate sandbox mount bindings

### DIFF
--- a/packages/server/worker/src/lib/config/configs.ts
+++ b/packages/server/worker/src/lib/config/configs.ts
@@ -1,7 +1,9 @@
 import { environmentMigrations } from '@activepieces/server-utils'
 import { from } from 'env-var'
 
-const env = from(environmentMigrations.migrate())
+function env() {
+    return from(environmentMigrations.migrate())
+}
 
 function getApiUrl(): string {
     const containerType = system.get(WorkerSystemProp.CONTAINER_TYPE) ?? 'WORKER_AND_APP'
@@ -48,16 +50,16 @@ const defaultValues: Partial<Record<WorkerSystemProp, string>> = {
 
 export const system = {
     get(prop: WorkerSystemProp): string | undefined {
-        return env.get(prop).asString() ?? defaultValues[prop]
+        return env().get(prop).asString() ?? defaultValues[prop]
     },
     getOrThrow(prop: WorkerSystemProp): string {
-        return env.get(prop).required().asString()
+        return env().get(prop).required().asString()
     },
     getBoolean(prop: WorkerSystemProp): boolean | undefined {
-        return env.get(prop).asBoolStrict()
+        return env().get(prop).asBoolStrict()
     },
     getList(prop: WorkerSystemProp): string[] {
-        const value = env.get(prop).asString() ?? defaultValues[prop]
+        const value = env().get(prop).asString() ?? defaultValues[prop]
         return value ? value.split(',').map(s => s.trim()).filter(Boolean) : []
     },
 }

--- a/packages/server/worker/src/lib/sandbox/isolate.ts
+++ b/packages/server/worker/src/lib/sandbox/isolate.ts
@@ -63,14 +63,6 @@ export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDire
                 assertMountInsideRoot(mount)
             }
 
-            await execPromise(`${isolateBinaryPath} --box-id=${boxId} --cleanup`)
-            await execPromise(`${isolateBinaryPath} --box-id=${boxId} --init`)
-
-            const sandboxRootfs = `/var/local/lib/isolate/${boxId}/root`
-            for (const mount of mounts) {
-                await mkdir(`${sandboxRootfs}${mount.sandboxPath}`, { recursive: true })
-            }
-
             const engineSandboxPath = path.join('/root/common', path.basename(enginePath))
             const sandboxEnv = {
                 ...env,
@@ -78,6 +70,14 @@ export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDire
                 SANDBOX_ID: sandboxId,
             }
             assertSandboxEnv(sandboxEnv)
+
+            await execPromise(`${isolateBinaryPath} --box-id=${boxId} --cleanup`)
+            await execPromise(`${isolateBinaryPath} --box-id=${boxId} --init`)
+
+            const sandboxRootfs = `/var/local/lib/isolate/${boxId}/root`
+            for (const mount of mounts) {
+                await mkdir(`${sandboxRootfs}${mount.sandboxPath}`, { recursive: true })
+            }
 
             const envArgs = Object.entries(sandboxEnv)
                 .map(([key, value]) => `--env=${key}=${value}`)

--- a/packages/server/worker/src/lib/sandbox/isolate.ts
+++ b/packages/server/worker/src/lib/sandbox/isolate.ts
@@ -3,15 +3,52 @@ import { mkdir } from 'fs/promises'
 import path from 'path'
 import { arch } from 'process'
 import { execPromise } from '../utils/exec'
-import { CreateSandboxProcessParams, SandboxLogger, SandboxProcessMaker } from './types'
+import { CreateSandboxProcessParams, SandboxLogger, SandboxMount, SandboxProcessMaker } from './types'
 
-const getIsolateExecutableName = (): string => {
+export function getIsolateExecutableName(nodeArch: NodeJS.Architecture = arch): string {
     const defaultName = 'isolate'
-    const executableNameMap: Partial<Record<typeof arch, string>> = {
+    const executableNameMap: Partial<Record<NodeJS.Architecture, string>> = {
         arm: 'isolate-arm',
         arm64: 'isolate-arm',
     }
-    return executableNameMap[arch] ?? defaultName
+    return executableNameMap[nodeArch] ?? defaultName
+}
+
+function assertMountInsideRoot(mount: SandboxMount): void {
+    const normalized = path.posix.normalize(mount.sandboxPath)
+    if (!normalized.startsWith('/root/') && normalized !== '/root') {
+        throw new Error(`Refusing to mount outside sandbox rootfs: sandboxPath="${mount.sandboxPath}"`)
+    }
+}
+
+const ENV_KEY_RE = /^[A-Z_][A-Z0-9_]*$/
+const FORBIDDEN_VALUE_CHARS = /[\n\r\0]/
+const REQUIRED_SANDBOX_ENV_KEYS: readonly string[] = [
+    'HOME',
+    'NODE_PATH',
+    'AP_EXECUTION_MODE',
+    'AP_SANDBOX_WS_PORT',
+    'AP_BASE_CODE_DIRECTORY',
+    'SANDBOX_ID',
+]
+
+function assertSandboxEnv(env: Record<string, string>): void {
+    for (const [key, value] of Object.entries(env)) {
+        if (!ENV_KEY_RE.test(key)) {
+            throw new Error(`Invalid sandbox env key: "${key}" — must match ${ENV_KEY_RE}`)
+        }
+        if (typeof value !== 'string') {
+            throw new Error(`Invalid sandbox env value for "${key}": expected string, got ${typeof value}`)
+        }
+        if (FORBIDDEN_VALUE_CHARS.test(value)) {
+            throw new Error(`Invalid sandbox env value for "${key}": must not contain newlines or NUL bytes`)
+        }
+    }
+    for (const key of REQUIRED_SANDBOX_ENV_KEYS) {
+        if (typeof env[key] !== 'string' || env[key].length === 0) {
+            throw new Error(`Required sandbox env "${key}" is missing or empty`)
+        }
+    }
 }
 
 const isolateBinaryPath = path.resolve(process.cwd(), 'packages/server/api/src/assets', getIsolateExecutableName())
@@ -22,22 +59,25 @@ export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDire
         create: async (params: CreateSandboxProcessParams) => {
             const { sandboxId, mounts, env } = params
 
+            for (const mount of mounts) {
+                assertMountInsideRoot(mount)
+            }
+
             await execPromise(`${isolateBinaryPath} --box-id=${boxId} --cleanup`)
             await execPromise(`${isolateBinaryPath} --box-id=${boxId} --init`)
 
-            // Pre-create mount point directories in the sandbox rootfs (isolate doesn't create them)
             const sandboxRootfs = `/var/local/lib/isolate/${boxId}/root`
             for (const mount of mounts) {
                 await mkdir(`${sandboxRootfs}${mount.sandboxPath}`, { recursive: true })
             }
 
-            // Engine runs at /root/common/<filename> inside the sandbox (common dir is mounted there)
             const engineSandboxPath = path.join('/root/common', path.basename(enginePath))
             const sandboxEnv = {
                 ...env,
                 AP_BASE_CODE_DIRECTORY: '/root/codes',
                 SANDBOX_ID: sandboxId,
             }
+            assertSandboxEnv(sandboxEnv)
 
             const envArgs = Object.entries(sandboxEnv)
                 .map(([key, value]) => `--env=${key}=${value}`)

--- a/packages/server/worker/src/lib/sandbox/sandbox.ts
+++ b/packages/server/worker/src/lib/sandbox/sandbox.ts
@@ -8,7 +8,14 @@ import { getGlobalCachePathLatestVersion, getGlobalCodeCachePath } from '../cach
 import { Sandbox, SandboxInitOptions, SandboxLogger, SandboxMount, SandboxOptions, SandboxProcessMaker, SandboxResult } from './types'
 
 function assertSafePathSegment(value: string, field: string): void {
-    if (value.length === 0 || value.includes('..') || value.includes('/') || value.includes('\\') || value.includes('\0')) {
+    const isUnsafe = value.length === 0
+        || value === '.'
+        || value === '..'
+        || value.includes('..')
+        || value.includes('/')
+        || value.includes('\\')
+        || value.includes('\0')
+    if (isUnsafe) {
         throw new ActivepiecesError({
             code: ErrorCode.VALIDATION,
             params: { message: `Invalid ${field}: "${value}" — path segment contains disallowed characters` },

--- a/packages/server/worker/src/lib/sandbox/sandbox.ts
+++ b/packages/server/worker/src/lib/sandbox/sandbox.ts
@@ -7,6 +7,25 @@ import treeKill from 'tree-kill'
 import { getGlobalCachePathLatestVersion, getGlobalCodeCachePath } from '../cache/cache-paths'
 import { Sandbox, SandboxInitOptions, SandboxLogger, SandboxMount, SandboxOptions, SandboxProcessMaker, SandboxResult } from './types'
 
+function assertSafePathSegment(value: string, field: string): void {
+    if (value.length === 0 || value.includes('..') || value.includes('/') || value.includes('\\') || value.includes('\0')) {
+        throw new ActivepiecesError({
+            code: ErrorCode.VALIDATION,
+            params: { message: `Invalid ${field}: "${value}" — path segment contains disallowed characters` },
+        })
+    }
+}
+
+function assertSandboxPathUnderRoot(mount: SandboxMount): void {
+    const normalized = path.posix.normalize(mount.sandboxPath)
+    if (!normalized.startsWith('/root/') && normalized !== '/root') {
+        throw new ActivepiecesError({
+            code: ErrorCode.VALIDATION,
+            params: { message: `Mount sandboxPath "${mount.sandboxPath}" must be under /root/` },
+        })
+    }
+}
+
 function buildCodeMount({ flowVersionId, reusable }: { flowVersionId: string | undefined, reusable: boolean }): SandboxMount | null {
     const codeCachePath = getGlobalCodeCachePath()
     if (reusable) {
@@ -17,6 +36,7 @@ function buildCodeMount({ flowVersionId, reusable }: { flowVersionId: string | u
         }
     }
     if (!isNil(flowVersionId)) {
+        assertSafePathSegment(flowVersionId, 'flowVersionId')
         return {
             hostPath: path.join(codeCachePath, flowVersionId),
             sandboxPath: `/root/codes/${flowVersionId}`,
@@ -111,6 +131,7 @@ export function createSandbox(
             const codeMount = buildCodeMount({ flowVersionId, reusable: options.reusable })
             const customPieceMounts: SandboxMount[] = []
             if (platformId) {
+                assertSafePathSegment(platformId, 'platformId')
                 const customPiecesHostPath = path.resolve(getGlobalCachePathLatestVersion(), 'custom_pieces', platformId)
                 customPieceMounts.push({
                     hostPath: customPiecesHostPath,
@@ -119,10 +140,20 @@ export function createSandbox(
                 })
             }
 
+            const allMounts: SandboxMount[] = [
+                ...(options.baseMounts ?? []),
+                ...(codeMount ? [codeMount] : []),
+                ...mounts,
+                ...customPieceMounts,
+            ]
+            for (const mount of allMounts) {
+                assertSandboxPathUnderRoot(mount)
+            }
+
             childProcess = await processMaker.create({
                 sandboxId,
                 command: options.command ?? [],
-                mounts: [...(options.baseMounts ?? []), ...(codeMount ? [codeMount] : []), ...mounts, ...customPieceMounts],
+                mounts: allMounts,
                 env: {
                     ...options.env,
                     AP_SANDBOX_WS_PORT: String(port),

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -340,7 +340,7 @@ function sleep(ms: number): Promise<void> {
 
 
 function startHealthServer(): ReturnType<typeof createServer> {
-    const port = Number(system.get(WorkerSystemProp.PORT))
+    const port = Number(process.env[WorkerSystemProp.PORT] ?? system.get(WorkerSystemProp.PORT))
     const healthPaths = new Set(['/worker/health', '/v1/health'])
     const server = createServer((req, res) => {
         if (req.method === 'GET' && req.url && healthPaths.has(req.url)) {

--- a/packages/server/worker/test/lib/execute/create-sandbox-for-job.test.ts
+++ b/packages/server/worker/test/lib/execute/create-sandbox-for-job.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ApEnvironment, ExecutionMode } from '@activepieces/shared'
+
+const { getSettingsMock, createSandboxMock, isolateProcessMock, simpleProcessMock, getGlobalCacheCommonPathMock, getGlobalCodeCachePathMock, getEnginePathMock } = vi.hoisted(() => ({
+    getSettingsMock: vi.fn(),
+    createSandboxMock: vi.fn(),
+    isolateProcessMock: vi.fn(() => ({ create: vi.fn() })),
+    simpleProcessMock: vi.fn(() => ({ create: vi.fn() })),
+    getGlobalCacheCommonPathMock: vi.fn(() => '/tmp/cache/common'),
+    getGlobalCodeCachePathMock: vi.fn(() => '/tmp/cache/codes'),
+    getEnginePathMock: vi.fn(() => '/tmp/cache/common/main.js'),
+}))
+
+vi.mock('../../../src/lib/config/worker-settings', () => ({
+    workerSettings: {
+        getSettings: (...args: unknown[]) => getSettingsMock(...args),
+    },
+}))
+
+vi.mock('../../../src/lib/sandbox/sandbox', () => ({
+    createSandbox: createSandboxMock,
+}))
+
+vi.mock('../../../src/lib/sandbox/isolate', () => ({
+    isolateProcess: isolateProcessMock,
+}))
+
+vi.mock('../../../src/lib/sandbox/fork', () => ({
+    simpleProcess: simpleProcessMock,
+}))
+
+vi.mock('../../../src/lib/cache/cache-paths', () => ({
+    getGlobalCacheCommonPath: getGlobalCacheCommonPathMock,
+    getGlobalCodeCachePath: getGlobalCodeCachePathMock,
+    getEnginePath: getEnginePathMock,
+}))
+
+import { createSandboxForJob } from '../../../src/lib/execute/create-sandbox-for-job'
+
+type Settings = {
+    PUBLIC_URL: string
+    TRIGGER_TIMEOUT_SECONDS: number
+    TRIGGER_HOOKS_TIMEOUT_SECONDS: number
+    PAUSED_FLOW_TIMEOUT_DAYS: number
+    EXECUTION_MODE: string
+    FLOW_TIMEOUT_SECONDS: number
+    LOG_LEVEL: string
+    LOG_PRETTY: string
+    ENVIRONMENT: string
+    APP_WEBHOOK_SECRETS: string
+    MAX_FLOW_RUN_LOG_SIZE_MB: number
+    MAX_FILE_SIZE_MB: number
+    SANDBOX_MEMORY_LIMIT: string
+    SANDBOX_PROPAGATED_ENV_VARS: string[]
+    DEV_PIECES: string[]
+    OTEL_ENABLED: boolean
+    FILE_STORAGE_LOCATION: string
+    S3_USE_SIGNED_URLS: string
+    EVENT_DESTINATION_TIMEOUT_SECONDS: number
+    EDITION: string
+    SSRF_PROTECTION_ENABLED: boolean
+    SSRF_ALLOW_LIST: string[]
+}
+
+function buildSettings(overrides: Partial<Settings> = {}): Settings {
+    const base: Settings = {
+        PUBLIC_URL: 'http://localhost:3000',
+        TRIGGER_TIMEOUT_SECONDS: 60,
+        TRIGGER_HOOKS_TIMEOUT_SECONDS: 60,
+        PAUSED_FLOW_TIMEOUT_DAYS: 30,
+        EXECUTION_MODE: ExecutionMode.SANDBOX_PROCESS,
+        FLOW_TIMEOUT_SECONDS: 600,
+        LOG_LEVEL: 'info',
+        LOG_PRETTY: 'false',
+        ENVIRONMENT: ApEnvironment.PRODUCTION,
+        APP_WEBHOOK_SECRETS: '{}',
+        MAX_FLOW_RUN_LOG_SIZE_MB: 10,
+        MAX_FILE_SIZE_MB: 10,
+        SANDBOX_MEMORY_LIMIT: '1048576',
+        SANDBOX_PROPAGATED_ENV_VARS: [],
+        DEV_PIECES: [],
+        OTEL_ENABLED: false,
+        FILE_STORAGE_LOCATION: '/tmp',
+        S3_USE_SIGNED_URLS: 'false',
+        EVENT_DESTINATION_TIMEOUT_SECONDS: 30,
+        EDITION: 'community',
+        SSRF_PROTECTION_ENABLED: false,
+        SSRF_ALLOW_LIST: [],
+    }
+    return { ...base, ...overrides }
+}
+
+const log = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() } as never
+const apiClient = {} as never
+
+describe('createSandboxForJob', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        createSandboxMock.mockReturnValue({ id: 'sb', start: vi.fn(), execute: vi.fn(), shutdown: vi.fn(), isReady: vi.fn() })
+    })
+
+    describe('baseMounts', () => {
+        it('contains exactly /root/common → getGlobalCacheCommonPath()', () => {
+            getSettingsMock.mockReturnValue(buildSettings())
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+
+            const options = createSandboxMock.mock.calls[0][2]
+            expect(options.baseMounts).toEqual([
+                { hostPath: '/tmp/cache/common', sandboxPath: '/root/common' },
+            ])
+        })
+
+        it('never leaks host / or /etc into baseMounts', () => {
+            getSettingsMock.mockReturnValue(buildSettings())
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+
+            const options = createSandboxMock.mock.calls[0][2]
+            for (const mount of options.baseMounts) {
+                expect(mount.hostPath).not.toBe('/')
+                expect(mount.hostPath).not.toBe('/etc')
+                expect(mount.sandboxPath.startsWith('/root/') || mount.sandboxPath === '/root').toBe(true)
+            }
+        })
+    })
+
+    describe('processMaker selection', () => {
+        it.each([
+            [ExecutionMode.SANDBOX_PROCESS, 'isolate'],
+            [ExecutionMode.SANDBOX_CODE_AND_PROCESS, 'isolate'],
+        ])('uses isolateProcess for %s', (executionMode) => {
+            getSettingsMock.mockReturnValue(buildSettings({ EXECUTION_MODE: executionMode }))
+            createSandboxForJob({ log, apiClient, boxId: 7, reusable: false })
+
+            expect(isolateProcessMock).toHaveBeenCalledTimes(1)
+            expect(simpleProcessMock).not.toHaveBeenCalled()
+            expect(isolateProcessMock).toHaveBeenCalledWith(log, '/tmp/cache/common/main.js', '/tmp/cache/codes', 7)
+        })
+
+        it.each([
+            [ExecutionMode.UNSANDBOXED, 'simple'],
+            [ExecutionMode.SANDBOX_CODE_ONLY, 'simple'],
+        ])('uses simpleProcess for %s', (executionMode) => {
+            getSettingsMock.mockReturnValue(buildSettings({ EXECUTION_MODE: executionMode }))
+            createSandboxForJob({ log, apiClient, boxId: 3, reusable: false })
+
+            expect(simpleProcessMock).toHaveBeenCalledTimes(1)
+            expect(isolateProcessMock).not.toHaveBeenCalled()
+            expect(simpleProcessMock).toHaveBeenCalledWith('/tmp/cache/common/main.js', '/tmp/cache/codes')
+        })
+    })
+
+    describe('buildSandboxEnv', () => {
+        it('emits all required keys including NODE_PATH', () => {
+            getSettingsMock.mockReturnValue(buildSettings({
+                EXECUTION_MODE: ExecutionMode.SANDBOX_PROCESS,
+                MAX_FLOW_RUN_LOG_SIZE_MB: 25,
+                MAX_FILE_SIZE_MB: 50,
+                SSRF_PROTECTION_ENABLED: true,
+            }))
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+
+            const env = createSandboxMock.mock.calls[0][2].env
+            expect(env).toMatchObject({
+                HOME: '/tmp/',
+                AP_EXECUTION_MODE: ExecutionMode.SANDBOX_PROCESS,
+                AP_MAX_FLOW_RUN_LOG_SIZE_MB: '25',
+                AP_MAX_FILE_SIZE_MB: '50',
+                NODE_PATH: '/usr/src/node_modules',
+                AP_SSRF_PROTECTION_ENABLED: 'true',
+            })
+        })
+
+        it('omits AP_DEV_PIECES when DEV_PIECES is empty', () => {
+            getSettingsMock.mockReturnValue(buildSettings({ DEV_PIECES: [] }))
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+
+            const env = createSandboxMock.mock.calls[0][2].env
+            expect(env.AP_DEV_PIECES).toBeUndefined()
+        })
+
+        it('joins DEV_PIECES with comma', () => {
+            getSettingsMock.mockReturnValue(buildSettings({ DEV_PIECES: ['a', 'b', 'c'] }))
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+
+            const env = createSandboxMock.mock.calls[0][2].env
+            expect(env.AP_DEV_PIECES).toBe('a,b,c')
+        })
+
+        it('only propagates env vars that exist in process.env (no undefined leak)', () => {
+            const originalProcessEnv = { ...process.env }
+            try {
+                process.env.PROPAGATED_YES = 'forwarded'
+                delete process.env.PROPAGATED_NO
+                getSettingsMock.mockReturnValue(buildSettings({
+                    SANDBOX_PROPAGATED_ENV_VARS: ['PROPAGATED_YES', 'PROPAGATED_NO'],
+                }))
+                createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+
+                const env = createSandboxMock.mock.calls[0][2].env
+                expect(env.PROPAGATED_YES).toBe('forwarded')
+                expect('PROPAGATED_NO' in env).toBe(false)
+            }
+            finally {
+                process.env = originalProcessEnv
+            }
+        })
+    })
+
+    describe('parseMemoryLimit', () => {
+        it('converts KB string to MB', () => {
+            getSettingsMock.mockReturnValue(buildSettings({ SANDBOX_MEMORY_LIMIT: '524288' }))
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+
+            expect(createSandboxMock.mock.calls[0][2].memoryLimitMb).toBe(512)
+        })
+
+        it('defaults to 1024 MB on invalid input', () => {
+            getSettingsMock.mockReturnValue(buildSettings({ SANDBOX_MEMORY_LIMIT: 'not-a-number' }))
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+
+            expect(createSandboxMock.mock.calls[0][2].memoryLimitMb).toBe(1024)
+        })
+    })
+
+    it('forwards reusable flag into createSandbox options', () => {
+        getSettingsMock.mockReturnValue(buildSettings())
+        createSandboxForJob({ log, apiClient, boxId: 1, reusable: true })
+
+        expect(createSandboxMock.mock.calls[0][2].reusable).toBe(true)
+    })
+})

--- a/packages/server/worker/test/lib/sandbox/fork.test.ts
+++ b/packages/server/worker/test/lib/sandbox/fork.test.ts
@@ -24,7 +24,7 @@ describe('simpleProcess', () => {
             mounts: [],
             env: { CUSTOM_VAR: 'hello', AP_SANDBOX_WS_PORT: '9999' },
             resourceLimits: {
-                memoryBytes: 512 * 1024 * 1024,
+                memoryLimitMb: 512,
                 cpuMsPerSec: 1000,
                 timeLimitSeconds: 300,
             },
@@ -32,9 +32,9 @@ describe('simpleProcess', () => {
         children.push(child)
 
         const msg = await new Promise<{ env: Record<string, string>, execArgv: string[] }>((resolve, reject) => {
-            child.on('message', (m) => resolve(m as any))
+            child.on('message', (m) => resolve(m as { env: Record<string, string>, execArgv: string[] }))
             child.on('error', reject)
-            setTimeout(() => reject(new Error('timeout waiting for child message')), 5000)
+            setTimeout(() => reject(new Error('timeout waiting for child message')), 10000)
         })
 
         expect(msg.execArgv).toContain('--no-node-snapshot')
@@ -44,9 +44,9 @@ describe('simpleProcess', () => {
         expect(msg.env.SANDBOX_ID).toBe('sb-fork-1')
         expect(msg.env.CUSTOM_VAR).toBe('hello')
         expect(msg.env.AP_SANDBOX_WS_PORT).toBe('9999')
-    })
+    }, 15000)
 
-    it('calculates memoryLimitMb correctly from non-round bytes', async () => {
+    it('passes through integer memoryLimitMb to --max-old-space-size', async () => {
         const maker = simpleProcess(fixturePath, '/code')
 
         const child = await maker.create({
@@ -55,7 +55,7 @@ describe('simpleProcess', () => {
             mounts: [],
             env: {},
             resourceLimits: {
-                memoryBytes: 300 * 1024 * 1024 + 500000,
+                memoryLimitMb: 300,
                 cpuMsPerSec: 1000,
                 timeLimitSeconds: 60,
             },
@@ -63,12 +63,11 @@ describe('simpleProcess', () => {
         children.push(child)
 
         const msg = await new Promise<{ env: Record<string, string>, execArgv: string[] }>((resolve, reject) => {
-            child.on('message', (m) => resolve(m as any))
+            child.on('message', (m) => resolve(m as { env: Record<string, string>, execArgv: string[] }))
             child.on('error', reject)
-            setTimeout(() => reject(new Error('timeout waiting for child message')), 5000)
+            setTimeout(() => reject(new Error('timeout waiting for child message')), 10000)
         })
 
-        // Math.floor((300 * 1024 * 1024 + 500000) / (1024 * 1024)) = 300
         expect(msg.execArgv).toContain('--max-old-space-size=300')
-    })
+    }, 15000)
 })

--- a/packages/server/worker/test/lib/sandbox/isolate.test.ts
+++ b/packages/server/worker/test/lib/sandbox/isolate.test.ts
@@ -1,0 +1,303 @@
+import { EventEmitter } from 'node:events'
+import path from 'path'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { spawnMock, mkdirMock, execPromiseMock } = vi.hoisted(() => ({
+    spawnMock: vi.fn(),
+    mkdirMock: vi.fn(),
+    execPromiseMock: vi.fn(),
+}))
+
+vi.mock('child_process', () => ({
+    spawn: spawnMock,
+}))
+
+vi.mock('fs/promises', () => ({
+    mkdir: mkdirMock,
+}))
+
+vi.mock('../../../src/lib/utils/exec', () => ({
+    execPromise: execPromiseMock,
+}))
+
+import { isolateProcess, getIsolateExecutableName } from '../../../src/lib/sandbox/isolate'
+import { SandboxLogger, SandboxMount } from '../../../src/lib/sandbox/types'
+
+function createMockLogger(): SandboxLogger {
+    return {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+    }
+}
+
+function createMockChild() {
+    const child = new EventEmitter() as EventEmitter & { stdout: null, stderr: null }
+    child.stdout = null
+    child.stderr = null
+    return child
+}
+
+const BASE_ENV: Record<string, string> = {
+    HOME: '/tmp/',
+    NODE_PATH: '/usr/src/node_modules',
+    AP_EXECUTION_MODE: 'SANDBOX_PROCESS',
+    AP_SANDBOX_WS_PORT: '12345',
+}
+
+const etcDir = path.resolve(process.cwd(), 'packages/server/api/src/assets/etc')
+
+async function callCreate({
+    mounts = [],
+    env = BASE_ENV,
+    boxId = 7,
+    enginePath = '/host/cache/common/main.js',
+    sandboxId = 'sb-abc',
+}: {
+    mounts?: SandboxMount[]
+    env?: Record<string, string>
+    boxId?: number
+    enginePath?: string
+    sandboxId?: string
+} = {}) {
+    const maker = isolateProcess(createMockLogger(), enginePath, '/host/cache/codes', boxId)
+    return maker.create({
+        sandboxId,
+        command: [],
+        mounts,
+        env,
+        resourceLimits: { memoryLimitMb: 256, cpuMsPerSec: 1000, timeLimitSeconds: 60 },
+    })
+}
+
+describe('isolateProcess', () => {
+    beforeEach(() => {
+        spawnMock.mockReset()
+        mkdirMock.mockReset()
+        execPromiseMock.mockReset()
+        spawnMock.mockImplementation(() => createMockChild())
+        mkdirMock.mockResolvedValue(undefined)
+        execPromiseMock.mockResolvedValue({ stdout: '', stderr: '' })
+    })
+
+    describe('pre-spawn', () => {
+        it('runs isolate --cleanup then --init before spawning', async () => {
+            await callCreate({ boxId: 3 })
+
+            expect(execPromiseMock).toHaveBeenCalledTimes(2)
+            expect(execPromiseMock.mock.calls[0][0]).toMatch(/--box-id=3 --cleanup$/)
+            expect(execPromiseMock.mock.calls[1][0]).toMatch(/--box-id=3 --init$/)
+            expect(execPromiseMock.mock.invocationCallOrder[0]).toBeLessThan(spawnMock.mock.invocationCallOrder[0])
+        })
+
+        it('pre-creates a sandbox rootfs directory for each mount', async () => {
+            const mounts: SandboxMount[] = [
+                { hostPath: '/host/common', sandboxPath: '/root/common' },
+                { hostPath: '/host/codes/fv-1', sandboxPath: '/root/codes/fv-1', optional: true },
+            ]
+            await callCreate({ mounts, boxId: 9 })
+
+            expect(mkdirMock).toHaveBeenCalledWith('/var/local/lib/isolate/9/root/root/common', { recursive: true })
+            expect(mkdirMock).toHaveBeenCalledWith('/var/local/lib/isolate/9/root/root/codes/fv-1', { recursive: true })
+            expect(mkdirMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('refuses to mkdir or spawn when a mount sandboxPath escapes /root/', async () => {
+            const mounts: SandboxMount[] = [{ hostPath: '/host/evil', sandboxPath: '/root/../etc' }]
+
+            await expect(callCreate({ mounts })).rejects.toThrow(/outside sandbox rootfs/)
+            expect(mkdirMock).not.toHaveBeenCalled()
+            expect(spawnMock).not.toHaveBeenCalled()
+        })
+
+        it('refuses absolute paths outside /root/', async () => {
+            const mounts: SandboxMount[] = [{ hostPath: '/host/evil', sandboxPath: '/etc/passwd' }]
+            await expect(callCreate({ mounts })).rejects.toThrow(/outside sandbox rootfs/)
+            expect(spawnMock).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('argv', () => {
+        it('emits all static --dir flags in the expected order', async () => {
+            await callCreate()
+
+            const args: string[] = spawnMock.mock.calls[0][1]
+            expect(args.slice(0, 4)).toEqual([
+                '--dir=/usr/bin/',
+                '--dir=/usr/local/',
+                `--dir=/etc/=${etcDir}`,
+                '--dir=/usr/src/node_modules/',
+            ])
+        })
+
+        it('never drops the /etc mount (binds to the bundled etcDir)', async () => {
+            await callCreate()
+            const args: string[] = spawnMock.mock.calls[0][1]
+            const etcMount = args.find((a) => a.startsWith('--dir=/etc/='))
+            expect(etcMount).toBe(`--dir=/etc/=${etcDir}`)
+            expect(args.some((a) => a === '--dir=/etc/' || a === '--dir=/etc')).toBe(false)
+        })
+
+        it('renders dynamic mounts as --dir=<sandbox>=<host>', async () => {
+            const mounts: SandboxMount[] = [
+                { hostPath: '/host/common', sandboxPath: '/root/common' },
+                { hostPath: '/host/codes/fv-1', sandboxPath: '/root/codes/fv-1' },
+            ]
+            await callCreate({ mounts })
+
+            const args: string[] = spawnMock.mock.calls[0][1]
+            expect(args).toContain('--dir=/root/common=/host/common')
+            expect(args).toContain('--dir=/root/codes/fv-1=/host/codes/fv-1')
+        })
+
+        it('appends :maybe suffix on optional mounts', async () => {
+            const mounts: SandboxMount[] = [
+                { hostPath: '/host/custom', sandboxPath: '/root/custom_pieces', optional: true },
+            ]
+            await callCreate({ mounts })
+
+            const args: string[] = spawnMock.mock.calls[0][1]
+            expect(args).toContain('--dir=/root/custom_pieces=/host/custom:maybe')
+        })
+
+        it('emits exactly one --dir per mount, no duplicates', async () => {
+            const mounts: SandboxMount[] = [
+                { hostPath: '/host/a', sandboxPath: '/root/a' },
+                { hostPath: '/host/b', sandboxPath: '/root/b', optional: true },
+            ]
+            await callCreate({ mounts })
+
+            const args: string[] = spawnMock.mock.calls[0][1]
+            const dynamicDirs = args.filter((a) => a.startsWith('--dir=/root/'))
+            expect(dynamicDirs).toEqual([
+                '--dir=/root/a=/host/a',
+                '--dir=/root/b=/host/b:maybe',
+            ])
+        })
+
+        it('includes --box-id, --chdir=/root, --processes, --share-net', async () => {
+            await callCreate({ boxId: 42 })
+            const args: string[] = spawnMock.mock.calls[0][1]
+            expect(args).toContain('--box-id=42')
+            expect(args).toContain('--chdir=/root')
+            expect(args).toContain('--processes')
+            expect(args).toContain('--share-net')
+        })
+
+        it('runs node with engine path at /root/common/<basename>', async () => {
+            await callCreate({ enginePath: '/any/where/engine-main.js' })
+            const args: string[] = spawnMock.mock.calls[0][1]
+            expect(args[args.length - 2]).toBe(process.execPath)
+            expect(args[args.length - 1]).toBe('/root/common/engine-main.js')
+            expect(args[args.length - 3]).toBe('--')
+            expect(args[args.length - 4]).toBe('--run')
+        })
+
+        it('spawns with shell: false', async () => {
+            await callCreate()
+            expect(spawnMock.mock.calls[0][2]).toEqual({ shell: false })
+        })
+    })
+
+    describe('env', () => {
+        it('injects AP_BASE_CODE_DIRECTORY=/root/codes and SANDBOX_ID=<sandboxId>', async () => {
+            await callCreate({ sandboxId: 'sb-xyz' })
+            const args: string[] = spawnMock.mock.calls[0][1]
+            expect(args).toContain('--env=AP_BASE_CODE_DIRECTORY=/root/codes')
+            expect(args).toContain('--env=SANDBOX_ID=sb-xyz')
+        })
+
+        it('forwards every caller-provided env entry as --env=K=V', async () => {
+            await callCreate({
+                env: {
+                    ...BASE_ENV,
+                    MY_SECRET: 'hunter2',
+                },
+            })
+            const args: string[] = spawnMock.mock.calls[0][1]
+            expect(args).toContain('--env=MY_SECRET=hunter2')
+            expect(args).toContain('--env=HOME=/tmp/')
+            expect(args).toContain('--env=NODE_PATH=/usr/src/node_modules')
+            expect(args).toContain('--env=AP_EXECUTION_MODE=SANDBOX_PROCESS')
+        })
+
+        it('does not allow caller-supplied env to override injected AP_BASE_CODE_DIRECTORY or SANDBOX_ID', async () => {
+            await callCreate({
+                sandboxId: 'sb-xyz',
+                env: {
+                    ...BASE_ENV,
+                    AP_BASE_CODE_DIRECTORY: '/etc',
+                    SANDBOX_ID: 'spoofed',
+                },
+            })
+            const args: string[] = spawnMock.mock.calls[0][1]
+            const baseCodeDirArgs = args.filter((a) => a.startsWith('--env=AP_BASE_CODE_DIRECTORY='))
+            const sandboxIdArgs = args.filter((a) => a.startsWith('--env=SANDBOX_ID='))
+            expect(baseCodeDirArgs).toEqual(['--env=AP_BASE_CODE_DIRECTORY=/root/codes'])
+            expect(sandboxIdArgs).toEqual(['--env=SANDBOX_ID=sb-xyz'])
+        })
+
+        it.each([
+            'HOME',
+            'NODE_PATH',
+            'AP_EXECUTION_MODE',
+            'AP_SANDBOX_WS_PORT',
+        ])('throws when required env "%s" is missing', async (missingKey) => {
+            const env = { ...BASE_ENV } as Record<string, string>
+            delete env[missingKey]
+            await expect(callCreate({ env })).rejects.toThrow(/Required sandbox env/)
+            expect(spawnMock).not.toHaveBeenCalled()
+        })
+
+        it.each([
+            'HOME',
+            'NODE_PATH',
+            'AP_EXECUTION_MODE',
+        ])('throws when required env "%s" is empty string', async (key) => {
+            const env = { ...BASE_ENV, [key]: '' }
+            await expect(callCreate({ env })).rejects.toThrow(/Required sandbox env/)
+            expect(spawnMock).not.toHaveBeenCalled()
+        })
+
+        it.each([
+            ['lowercase', 'home'],
+            ['starts with digit', '9HOME'],
+            ['contains hyphen', 'MY-VAR'],
+            ['contains space', 'MY VAR'],
+            ['contains equals', 'MY=VAR'],
+        ])('rejects malformed env key (%s)', async (_label, badKey) => {
+            const env = { ...BASE_ENV, [badKey]: 'v' }
+            await expect(callCreate({ env })).rejects.toThrow(/Invalid sandbox env key/)
+            expect(spawnMock).not.toHaveBeenCalled()
+        })
+
+        it.each([
+            ['newline', 'line1\nline2'],
+            ['carriage return', 'line1\rline2'],
+            ['NUL', 'value\0withNull'],
+        ])('rejects env values containing %s', async (_label, badValue) => {
+            const env = { ...BASE_ENV, MY_VAR: badValue }
+            await expect(callCreate({ env })).rejects.toThrow(/must not contain newlines or NUL bytes/)
+            expect(spawnMock).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('getIsolateExecutableName', () => {
+        it('returns isolate-arm on arm', () => {
+            expect(getIsolateExecutableName('arm')).toBe('isolate-arm')
+        })
+
+        it('returns isolate-arm on arm64', () => {
+            expect(getIsolateExecutableName('arm64')).toBe('isolate-arm')
+        })
+
+        it('returns isolate on x64', () => {
+            expect(getIsolateExecutableName('x64')).toBe('isolate')
+        })
+
+        it('falls back to isolate for unknown archs', () => {
+            expect(getIsolateExecutableName('ppc64' as NodeJS.Architecture)).toBe('isolate')
+        })
+    })
+})

--- a/packages/server/worker/test/lib/sandbox/isolate.test.ts
+++ b/packages/server/worker/test/lib/sandbox/isolate.test.ts
@@ -247,6 +247,8 @@ describe('isolateProcess', () => {
             const env = { ...BASE_ENV } as Record<string, string>
             delete env[missingKey]
             await expect(callCreate({ env })).rejects.toThrow(/Required sandbox env/)
+            expect(execPromiseMock).not.toHaveBeenCalled()
+            expect(mkdirMock).not.toHaveBeenCalled()
             expect(spawnMock).not.toHaveBeenCalled()
         })
 
@@ -257,6 +259,7 @@ describe('isolateProcess', () => {
         ])('throws when required env "%s" is empty string', async (key) => {
             const env = { ...BASE_ENV, [key]: '' }
             await expect(callCreate({ env })).rejects.toThrow(/Required sandbox env/)
+            expect(execPromiseMock).not.toHaveBeenCalled()
             expect(spawnMock).not.toHaveBeenCalled()
         })
 
@@ -269,6 +272,7 @@ describe('isolateProcess', () => {
         ])('rejects malformed env key (%s)', async (_label, badKey) => {
             const env = { ...BASE_ENV, [badKey]: 'v' }
             await expect(callCreate({ env })).rejects.toThrow(/Invalid sandbox env key/)
+            expect(execPromiseMock).not.toHaveBeenCalled()
             expect(spawnMock).not.toHaveBeenCalled()
         })
 
@@ -279,6 +283,7 @@ describe('isolateProcess', () => {
         ])('rejects env values containing %s', async (_label, badValue) => {
             const env = { ...BASE_ENV, MY_VAR: badValue }
             await expect(callCreate({ env })).rejects.toThrow(/must not contain newlines or NUL bytes/)
+            expect(execPromiseMock).not.toHaveBeenCalled()
             expect(spawnMock).not.toHaveBeenCalled()
         })
     })

--- a/packages/server/worker/test/lib/sandbox/sandbox.test.ts
+++ b/packages/server/worker/test/lib/sandbox/sandbox.test.ts
@@ -206,28 +206,33 @@ describe('createSandbox', () => {
         })
 
         it.each([
-            ['..', 'flowVersionId'],
-            ['../etc', 'flowVersionId'],
-            ['a/b', 'flowVersionId'],
-            ['fv\\1', 'flowVersionId'],
-            ['fv\0null', 'flowVersionId'],
+            ['.'],
+            ['..'],
+            ['../etc'],
+            ['a/b'],
+            ['fv\\1'],
+            ['fv\0null'],
+            [''],
         ])('rejects path traversal in flowVersionId: %s', async (flowVersionId) => {
             const log = createMockLogger()
             const workerHandlers = createMockWorkerHandlers()
             testPM = createTestProcessMaker()
             sandbox = createSandbox(log, 'sb-fv-trav', defaultOptions, testPM.maker, workerHandlers)
 
-            await expect(sandbox.start({ flowVersionId, platformId: '', mounts: [] })).rejects.toThrow()
+            let caughtErr: unknown
             try {
                 await sandbox.start({ flowVersionId, platformId: '', mounts: [] })
             }
             catch (err) {
-                expect((err as ActivepiecesError).error.code).toBe(ErrorCode.VALIDATION)
+                caughtErr = err
             }
+            expect(caughtErr).toBeDefined()
+            expect((caughtErr as ActivepiecesError).error.code).toBe(ErrorCode.VALIDATION)
             expect(testPM.maker.create).not.toHaveBeenCalled()
         })
 
         it.each([
+            ['.'],
             ['..'],
             ['../other'],
             ['plat/sub'],
@@ -239,13 +244,15 @@ describe('createSandbox', () => {
             testPM = createTestProcessMaker()
             sandbox = createSandbox(log, 'sb-plat-trav', defaultOptions, testPM.maker, workerHandlers)
 
-            await expect(sandbox.start({ flowVersionId: 'fv-1', platformId, mounts: [] })).rejects.toThrow()
+            let caughtErr: unknown
             try {
                 await sandbox.start({ flowVersionId: 'fv-1', platformId, mounts: [] })
             }
             catch (err) {
-                expect((err as ActivepiecesError).error.code).toBe(ErrorCode.VALIDATION)
+                caughtErr = err
             }
+            expect(caughtErr).toBeDefined()
+            expect((caughtErr as ActivepiecesError).error.code).toBe(ErrorCode.VALIDATION)
             expect(testPM.maker.create).not.toHaveBeenCalled()
         })
 

--- a/packages/server/worker/test/lib/sandbox/sandbox.test.ts
+++ b/packages/server/worker/test/lib/sandbox/sandbox.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { io as ioClient, type Socket as ClientSocket } from 'socket.io-client'
 import { ActivepiecesError, EngineResponseStatus, ErrorCode, WorkerContract } from '@activepieces/shared'
 import { createSandbox } from '../../../src/lib/sandbox/sandbox'
-import { Sandbox, SandboxLogger, SandboxProcessMaker } from '../../../src/lib/sandbox/types'
+import { Sandbox, SandboxLogger, SandboxMount, SandboxProcessMaker } from '../../../src/lib/sandbox/types'
 
 const { treeKillMock } = vi.hoisted(() => ({
     treeKillMock: vi.fn((_pid: number, _signal: string, cb: (err?: Error) => void) => cb()),
@@ -186,6 +186,142 @@ describe('createSandbox', () => {
             const createCall = (testPM.maker.create as ReturnType<typeof vi.fn>).mock.calls[0][0]
             const codeMount = createCall.mounts.find((m: { sandboxPath: string }) => m.sandboxPath.startsWith('/root/codes'))
             expect(codeMount).toBeUndefined()
+        })
+
+        it('resolves custom_pieces hostPath to cache/custom_pieces/<platformId>', async () => {
+            const log = createMockLogger()
+            const workerHandlers = createMockWorkerHandlers()
+            testPM = createTestProcessMaker()
+            sandbox = createSandbox(log, 'sb-plat', defaultOptions, testPM.maker, workerHandlers)
+
+            await sandbox.start({ flowVersionId: 'fv-1', platformId: 'plat-xyz', mounts: [] })
+
+            const createCall = (testPM.maker.create as ReturnType<typeof vi.fn>).mock.calls[0][0]
+            const customPieceMount = createCall.mounts.find((m: SandboxMount) => m.sandboxPath === '/root/custom_pieces')
+            expect(customPieceMount).toEqual({
+                hostPath: '/tmp/test-cache/custom_pieces/plat-xyz',
+                sandboxPath: '/root/custom_pieces',
+                optional: true,
+            })
+        })
+
+        it.each([
+            ['..', 'flowVersionId'],
+            ['../etc', 'flowVersionId'],
+            ['a/b', 'flowVersionId'],
+            ['fv\\1', 'flowVersionId'],
+            ['fv\0null', 'flowVersionId'],
+        ])('rejects path traversal in flowVersionId: %s', async (flowVersionId) => {
+            const log = createMockLogger()
+            const workerHandlers = createMockWorkerHandlers()
+            testPM = createTestProcessMaker()
+            sandbox = createSandbox(log, 'sb-fv-trav', defaultOptions, testPM.maker, workerHandlers)
+
+            await expect(sandbox.start({ flowVersionId, platformId: '', mounts: [] })).rejects.toThrow()
+            try {
+                await sandbox.start({ flowVersionId, platformId: '', mounts: [] })
+            }
+            catch (err) {
+                expect((err as ActivepiecesError).error.code).toBe(ErrorCode.VALIDATION)
+            }
+            expect(testPM.maker.create).not.toHaveBeenCalled()
+        })
+
+        it.each([
+            ['..'],
+            ['../other'],
+            ['plat/sub'],
+            ['plat\\x'],
+            ['plat\0null'],
+        ])('rejects path traversal in platformId: %s', async (platformId) => {
+            const log = createMockLogger()
+            const workerHandlers = createMockWorkerHandlers()
+            testPM = createTestProcessMaker()
+            sandbox = createSandbox(log, 'sb-plat-trav', defaultOptions, testPM.maker, workerHandlers)
+
+            await expect(sandbox.start({ flowVersionId: 'fv-1', platformId, mounts: [] })).rejects.toThrow()
+            try {
+                await sandbox.start({ flowVersionId: 'fv-1', platformId, mounts: [] })
+            }
+            catch (err) {
+                expect((err as ActivepiecesError).error.code).toBe(ErrorCode.VALIDATION)
+            }
+            expect(testPM.maker.create).not.toHaveBeenCalled()
+        })
+
+        it('rejects caller-supplied mount whose sandboxPath escapes /root/', async () => {
+            const log = createMockLogger()
+            const workerHandlers = createMockWorkerHandlers()
+            testPM = createTestProcessMaker()
+            sandbox = createSandbox(log, 'sb-escape', defaultOptions, testPM.maker, workerHandlers)
+
+            const maliciousMount: SandboxMount = { hostPath: '/host/evil', sandboxPath: '/root/../etc' }
+
+            await expect(
+                sandbox.start({ flowVersionId: 'fv-1', platformId: '', mounts: [maliciousMount] }),
+            ).rejects.toThrow()
+            expect(testPM.maker.create).not.toHaveBeenCalled()
+        })
+
+        it('rejects baseMount whose sandboxPath escapes /root/', async () => {
+            const log = createMockLogger()
+            const workerHandlers = createMockWorkerHandlers()
+            testPM = createTestProcessMaker()
+            const baseMounts: SandboxMount[] = [{ hostPath: '/host/secret', sandboxPath: '/etc/passwd-evil' }]
+            sandbox = createSandbox(log, 'sb-base-escape', { ...defaultOptions, baseMounts }, testPM.maker, workerHandlers)
+
+            await expect(
+                sandbox.start({ flowVersionId: 'fv-1', platformId: '', mounts: [] }),
+            ).rejects.toThrow()
+            expect(testPM.maker.create).not.toHaveBeenCalled()
+        })
+
+        it('composes mounts in order: baseMounts, codeMount, callerMounts, customPieceMounts', async () => {
+            const log = createMockLogger()
+            const workerHandlers = createMockWorkerHandlers()
+            testPM = createTestProcessMaker()
+            const baseMounts: SandboxMount[] = [{ hostPath: '/host/common', sandboxPath: '/root/common' }]
+            sandbox = createSandbox(log, 'sb-order', { ...defaultOptions, baseMounts }, testPM.maker, workerHandlers)
+
+            const callerMount: SandboxMount = { hostPath: '/host/x', sandboxPath: '/root/x' }
+            await sandbox.start({ flowVersionId: 'fv-1', platformId: 'plat-1', mounts: [callerMount] })
+
+            const createCall = (testPM.maker.create as ReturnType<typeof vi.fn>).mock.calls[0][0]
+            expect(createCall.mounts).toEqual([
+                { hostPath: '/host/common', sandboxPath: '/root/common' },
+                { hostPath: '/tmp/test-cache/codes/fv-1', sandboxPath: '/root/codes/fv-1', optional: true },
+                { hostPath: '/host/x', sandboxPath: '/root/x' },
+                { hostPath: '/tmp/test-cache/custom_pieces/plat-1', sandboxPath: '/root/custom_pieces', optional: true },
+            ])
+        })
+
+        it('never exposes host /etc, /root, or / as a sandbox mount', async () => {
+            const log = createMockLogger()
+            const workerHandlers = createMockWorkerHandlers()
+            testPM = createTestProcessMaker()
+            sandbox = createSandbox(log, 'sb-no-host-leak', defaultOptions, testPM.maker, workerHandlers)
+
+            await sandbox.start(startOptions)
+
+            const createCall = (testPM.maker.create as ReturnType<typeof vi.fn>).mock.calls[0][0]
+            for (const mount of createCall.mounts as SandboxMount[]) {
+                expect(mount.hostPath).not.toBe('/')
+                expect(mount.hostPath).not.toBe('/etc')
+                expect(mount.hostPath).not.toBe('/root')
+                expect(mount.hostPath).not.toMatch(/^\/home(\/|$)/)
+            }
+        })
+
+        it('does not inject AP_CUSTOM_PIECES_PATHS when platformId is undefined', async () => {
+            const log = createMockLogger()
+            const workerHandlers = createMockWorkerHandlers()
+            testPM = createTestProcessMaker()
+            sandbox = createSandbox(log, 'sb-no-plat-env', defaultOptions, testPM.maker, workerHandlers)
+
+            await sandbox.start({ flowVersionId: 'fv-1', platformId: '', mounts: [] })
+
+            const createCall = (testPM.maker.create as ReturnType<typeof vi.fn>).mock.calls[0][0]
+            expect(createCall.env.AP_CUSTOM_PIECES_PATHS).toBeUndefined()
         })
 
         it('is idempotent when already connected', async () => {

--- a/packages/server/worker/test/lib/worker-settings-override.test.ts
+++ b/packages/server/worker/test/lib/worker-settings-override.test.ts
@@ -113,6 +113,7 @@ describe('worker settings override', () => {
         await worker.stop()
         delete process.env.AP_EXECUTION_MODE
         delete process.env.AP_WORKER_GROUP_ID
+        delete process.env.AP_REUSE_SANDBOX
         await new Promise<void>((resolve) => {
             ioServer.close(() => resolve())
         })
@@ -190,6 +191,7 @@ describe('worker settings override', () => {
     it('worker group + SANDBOX_PROCESS passes validation', async () => {
         process.env.AP_WORKER_GROUP_ID = 'group-1'
         process.env.AP_EXECUTION_MODE = ExecutionMode.SANDBOX_PROCESS
+        process.env.AP_REUSE_SANDBOX = 'false'
         const serverSettings = buildWorkerSettingsResponse()
         await connectAndWaitForSettings(serverSettings)
 
@@ -201,6 +203,7 @@ describe('worker settings override', () => {
     it('worker group + SANDBOX_CODE_AND_PROCESS passes validation', async () => {
         process.env.AP_WORKER_GROUP_ID = 'group-1'
         process.env.AP_EXECUTION_MODE = ExecutionMode.SANDBOX_CODE_AND_PROCESS
+        process.env.AP_REUSE_SANDBOX = 'false'
         const serverSettings = buildWorkerSettingsResponse()
         await connectAndWaitForSettings(serverSettings)
 
@@ -229,6 +232,7 @@ describe('worker settings override', () => {
 
     it('worker group + no local override, server sends SANDBOX_PROCESS → passes', async () => {
         process.env.AP_WORKER_GROUP_ID = 'group-1'
+        process.env.AP_REUSE_SANDBOX = 'false'
         const serverSettings = buildWorkerSettingsResponse({ EXECUTION_MODE: ExecutionMode.SANDBOX_PROCESS })
         await connectAndWaitForSettings(serverSettings)
 

--- a/packages/server/worker/test/piece-installer.test.ts
+++ b/packages/server/worker/test/piece-installer.test.ts
@@ -151,7 +151,7 @@ describe('pieceInstaller', () => {
         const piece = makePiece('@activepieces/piece-cached')
         const pieceDir = pieceDirPath(piece)
 
-        await mkdir(pieceDir, { recursive: true })
+        await mkdir(join(pieceDir, 'node_modules'), { recursive: true })
         await writeFile(join(pieceDir, 'ready'), 'true')
 
         const installer = pieceInstaller(fakeLog, fakeApiClient)


### PR DESCRIPTION
## Summary

Locks down the worker's isolate sandbox mount bindings with tests and minimal validation guards, motivated by a cross-tenant data leak via invalid mount bindings.

- **Guards added** — reject traversal in `flowVersionId` / `platformId`, reject mounts whose `sandboxPath` escapes `/root/`, hard-assert env keys (regex) and values (no `\n`/`\r`/`\0`), require critical sandbox env keys.
- **165 tests passing** — 34 new in `isolate.test.ts` (argv snapshot, escape rejection, env asserts, arch mapping), 13 new in `create-sandbox-for-job.test.ts` (baseMounts, processMaker selection, env build), extended `sandbox.test.ts` mount-binding coverage.
- **Fixes pre-existing test failures** — fork test (`memoryBytes` → `memoryLimitMb`), piece-installer test (create `node_modules/` for install-skip path), worker-settings-override (set `AP_REUSE_SANDBOX` where worker-group validation requires it), health endpoint test (read `AP_PORT` from `process.env` at runtime), configs snapshot (make `env()` lazy so runtime `process.env` mutations are visible).

## Test plan

- [x] `npx vitest run` on `packages/server/worker` — 165/165 pass
- [x] `npm run lint-dev` — 0 errors
- [ ] Manually verify: spawn isolate locally with a malicious `flowVersionId`/`platformId` and confirm `ErrorCode.VALIDATION` is thrown before any mount is bound