### PR TITLE
fix: bump version to 0.82.0 to fix dev pieces not showing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.81.3",
+  "version": "0.82.0",
   "rcVersion": "0.82.0-rc.0",
   "packageManager": "bun@1.3.3",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps root `package.json` version from `0.81.3` → `0.82.0`

## Root Cause

After `f51199d6e0` (introduce waitpoint), `MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION` in `packages/pieces/framework/src/lib/context/versioning.ts` was bumped from `'0.73.0'` to `'0.82.0'`.

The `Piece` class constructor enforces this as a floor — any piece with a declared `minimumSupportedRelease` lower than this constant gets it silently overridden to `'0.82.0'` at runtime. This affects all dev pieces loaded via `require()` (including google-sheets which declares `'0.71.4'`).

Since the server version was `0.81.3`, `isSupportedRelease('0.81.3', { minimumSupportedRelease: '0.82.0' })` returned `false`, filtering out every dev piece from the API response.

## Test plan

- Set `AP_DEV_PIECES=google-sheets` and start the dev server
- Verify google-sheets appears in the piece selector