### PR TITLE
fix(pieces): fall back to newest compatible version when latest requires newer release

### DIFF
--- a/packages/server/api/src/app/pieces/metadata/piece-cache.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-cache.ts
@@ -32,7 +32,7 @@ export type PieceMetadataRefreshMessage =
     | { type: PieceMetadataRefreshType.BULK_SYNC }
 
 const CACHE_KEY = {
-    list: (locale: LocalesEnum): string => `list:${locale}`,
+    list: (locale: LocalesEnum, release: string): string => `list:${locale}:${release}`,
     piece: (name: string, version: string, platformId: string | undefined): string => `piece:${name}:${version}:${platformId ?? 'OFFICIAL'}`,
     registry: (): string => 'registry',
 }
@@ -54,10 +54,11 @@ export const pieceCache = (log: FastifyBaseLogger) => {
 
         async getList(params: GetListParams): Promise<PieceMetadataSchema[]> {
             const { platformId, locale = LocalesEnum.ENGLISH } = params
-            const cacheKey = CACHE_KEY.list(locale)
+            const currentRelease = await apVersionUtil.getCurrentRelease()
+            const cacheKey = CACHE_KEY.list(locale, currentRelease)
 
             const cachedPieces = await getCachedOrFetch(cacheKey, async () => {
-                const latestPieces = await fetchLatestPiecesFromDB()
+                const latestPieces = await fetchLatestCompatiblePiecesFromDB(currentRelease)
                 return translatePieces(latestPieces, locale)
             })
 
@@ -66,7 +67,6 @@ export const pieceCache = (log: FastifyBaseLogger) => {
                 pieceTranslation.translatePiece<PieceMetadataSchema>({ piece, locale, mutate: true }),
             )
 
-            const currentRelease = await apVersionUtil.getCurrentRelease()
             const devPieceNames = new Set(translatedDevPieces.map((p) => p.name))
             const filteredPieces = [...cachedPieces.filter((p) => !devPieceNames.has(p.name)), ...translatedDevPieces]
                 .filter((piece) => filterPieceBasedOnType(platformId, piece))
@@ -137,13 +137,14 @@ function translatePieces(pieces: PieceMetadataSchema[], locale: LocalesEnum): Pi
     })
 }
 
-async function fetchLatestPiecesFromDB(): Promise<PieceMetadataSchema[]> {
+async function fetchLatestCompatiblePiecesFromDB(currentRelease: string): Promise<PieceMetadataSchema[]> {
     const allKeys = await repo()
         .createQueryBuilder('pm')
-        .select(['pm."id"', 'pm."name"', 'pm."version"', 'pm."platformId"'])
+        .select(['pm."id"', 'pm."name"', 'pm."version"', 'pm."platformId"', 'pm."minimumSupportedRelease"', 'pm."maximumSupportedRelease"'])
         .getRawMany<PieceKey>()
 
-    const latestIds = pickLatestVersionIds(allKeys)
+    const compatibleKeys = allKeys.filter((piece) => isSupportedRelease(currentRelease, piece))
+    const latestIds = pickLatestVersionIds(compatibleKeys)
     return latestIds.length > 0 ? repo().find({ where: { id: In(latestIds) } }) : []
 }
 
@@ -206,13 +207,13 @@ function handleRefreshMessage(message: PieceMetadataRefreshMessage): void {
     switch (message.type) {
         case PieceMetadataRefreshType.CREATE:
             cache.set(CACHE_KEY.piece(message.piece.name, message.piece.version, message.piece.platformId), message.piece)
-            invalidateAggregateCaches()
+            void invalidateAggregateCaches()
             break
         case PieceMetadataRefreshType.DELETE:
             for (const piece of message.pieces) {
                 cache.delete(CACHE_KEY.piece(piece.name, piece.version, undefined))
             }
-            invalidateAggregateCaches()
+            void invalidateAggregateCaches()
             break
         case PieceMetadataRefreshType.UPDATE_USAGE: {
             const { piece } = message
@@ -224,15 +225,16 @@ function handleRefreshMessage(message: PieceMetadataRefreshMessage): void {
             break
         }
         case PieceMetadataRefreshType.BULK_SYNC:
-            invalidateAggregateCaches()
+            void invalidateAggregateCaches()
             break
     }
 }
 
-function invalidateAggregateCaches(): void {
+async function invalidateAggregateCaches(): Promise<void> {
     invalidateKey(CACHE_KEY.registry())
+    const currentRelease = await apVersionUtil.getCurrentRelease()
     for (const locale of Object.values(LocalesEnum)) {
-        invalidateKey(CACHE_KEY.list(locale as LocalesEnum))
+        invalidateKey(CACHE_KEY.list(locale as LocalesEnum, currentRelease))
     }
 }
 
@@ -274,4 +276,6 @@ type PieceKey = {
     name: string
     version: string
     platformId: string | null
+    minimumSupportedRelease?: string
+    maximumSupportedRelease?: string
 }

--- a/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
@@ -26,6 +26,7 @@ import { EntityManager, IsNull } from 'typeorm'
 import { repoFactory } from '../../core/db/repo-factory'
 import { enterpriseFilteringUtils } from '../../ee/pieces/filters/piece-filtering-utils'
 import { pubsub } from '../../helper/pubsub'
+import { apVersionUtil } from '../../helper/system/system-props'
 import { pieceTagService } from '../tags/pieces/piece-tag.service'
 import { PIECE_METADATA_REFRESH_CHANNEL, pieceCache, PieceMetadataRefreshMessage, PieceMetadataRefreshType } from './piece-cache'
 import { PieceMetadataEntity, PieceMetadataSchema } from './piece-metadata-entity'
@@ -318,7 +319,8 @@ const findExactVersion = async (
 ): Promise<{ name: string, version: string, platformId: string | undefined } | undefined> => {
     const { name, version, platformId } = params
     const versionToSearch = findNextExcludedVersion(version)
-    const registry = await pieceCache(log).getRegistry({ release: undefined, platformId })
+    const currentRelease = await apVersionUtil.getCurrentRelease()
+    const registry = await pieceCache(log).getRegistry({ release: currentRelease, platformId })
     const matchingRegistryEntries = registry.filter((entry) => {
         if (entry.name !== name) {
             return false

--- a/packages/server/api/test/integration/ce/pieces/piece-metadata.test.ts
+++ b/packages/server/api/test/integration/ce/pieces/piece-metadata.test.ts
@@ -204,6 +204,89 @@ describe('Piece Metadata CE API', () => {
         })
     })
 
+    describe('release-compatibility fallback', () => {
+        it('GET /v1/pieces/:scope/:name falls back to the newest compatible version when latest requires a newer release', async () => {
+            const compatible = createMockPieceMetadata({
+                name: '@activepieces/piece-release-test',
+                pieceType: PieceType.OFFICIAL,
+                packageType: PackageType.REGISTRY,
+                version: '0.1.32',
+                minimumSupportedRelease: '0.0.0',
+                maximumSupportedRelease: '99999.99999.9999',
+            })
+            const incompatible = createMockPieceMetadata({
+                name: '@activepieces/piece-release-test',
+                pieceType: PieceType.OFFICIAL,
+                packageType: PackageType.REGISTRY,
+                version: '0.1.33',
+                minimumSupportedRelease: '99.0.0',
+                maximumSupportedRelease: '99999.99999.9999',
+            })
+            await db.save('piece_metadata', [compatible, incompatible])
+            await pieceCache(mockLog).setup()
+
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get('/v1/pieces/@activepieces/piece-release-test')
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(response?.json().version).toBe('0.1.32')
+        })
+
+        it('GET /v1/pieces returns the newest compatible version in list when latest is incompatible', async () => {
+            const compatible = createMockPieceMetadata({
+                name: 'list-release-test-piece',
+                pieceType: PieceType.OFFICIAL,
+                packageType: PackageType.REGISTRY,
+                version: '0.1.32',
+                minimumSupportedRelease: '0.0.0',
+                maximumSupportedRelease: '99999.99999.9999',
+            })
+            const incompatible = createMockPieceMetadata({
+                name: 'list-release-test-piece',
+                pieceType: PieceType.OFFICIAL,
+                packageType: PackageType.REGISTRY,
+                version: '0.1.33',
+                minimumSupportedRelease: '99.0.0',
+                maximumSupportedRelease: '99999.99999.9999',
+            })
+            await db.save('piece_metadata', [compatible, incompatible])
+            await pieceCache(mockLog).setup()
+
+            const testToken = await generateMockToken({
+                type: PrincipalType.UNKNOWN,
+                id: apId(),
+            })
+            const response = await app?.inject({
+                method: 'GET',
+                url: '/api/v1/pieces',
+                headers: { authorization: `Bearer ${testToken}` },
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const entry = response?.json().find((p: { name: string }) => p.name === 'list-release-test-piece')
+            expect(entry).toBeDefined()
+            expect(entry.version).toBe('0.1.32')
+        })
+
+        it('GET /v1/pieces/:scope/:name returns 404 when all versions are incompatible', async () => {
+            const incompatible = createMockPieceMetadata({
+                name: '@activepieces/piece-all-incompatible',
+                pieceType: PieceType.OFFICIAL,
+                packageType: PackageType.REGISTRY,
+                version: '0.1.33',
+                minimumSupportedRelease: '99.0.0',
+                maximumSupportedRelease: '99999.99999.9999',
+            })
+            await db.save('piece_metadata', incompatible)
+            await pieceCache(mockLog).setup()
+
+            const ctx = await createTestContext(app!)
+            const response = await ctx.get('/v1/pieces/@activepieces/piece-all-incompatible')
+
+            expect(response?.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+    })
+
     describe('pieceMetadataService.get() — custom pieces', () => {
         it('should return undefined for custom piece when platformId is not provided', async () => {
             const platformId = apId()


### PR DESCRIPTION
## Summary

When a platform running AP `0.81.3` requested `/v1/pieces/@activepieces/piece-webhook`, the API returned webhook `0.1.33` (`minimumSupportedRelease: 0.82.0`) instead of the older compatible `0.1.32`. The same bug made pieces disappear from `/v1/pieces` entirely when their newest version was incompatible.

## Root cause

Two spots ignored the current release:

1. `findExactVersion` in `piece-metadata-service.ts:321` called `getRegistry({ release: undefined })` then sorted DESC and picked the top. No compatibility filter → incompatible versions always won.
2. `fetchLatestPiecesFromDB` in `piece-cache.ts` picked the newest version per piece DB-wide, then filtered by release *afterwards* — an incompatible latest dropped the piece entirely instead of degrading to an older compatible one.

## Fix

- Pass `apVersionUtil.getCurrentRelease()` to `getRegistry` in `findExactVersion`.
- Rename `fetchLatestPiecesFromDB` → `fetchLatestCompatiblePiecesFromDB(release)`; filter by `isSupportedRelease` *before* picking the latest per piece.
- Include release in the list cache key so different releases don't share state.

## Test plan

- [x] `npx vitest run test/integration/ce/pieces/piece-metadata.test.ts` — 12/12 pass
- [x] `npm run lint-dev` — 0 errors

Added 3 integration tests that would have caught the webhook regression:
- `GET /v1/pieces/:scope/:name` falls back to newest compatible version when latest is incompatible
- `GET /v1/pieces` list returns the newest compatible version when latest is incompatible
- `GET /v1/pieces/:scope/:name` returns 404 when *all* versions are incompatible