### PR TITLE
docs(piece-builder-skill): require AI metadata fields on every action, trigger, and property

### DIFF
--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -317,6 +317,24 @@ infoForLLM: {
 **Bad:** `"Create Issue in GitHub Repository"`
 **Good:** `"Creates a new issue in a GitHub repository. Use when you need to report a bug, request a feature, or track work. Requires repository owner and name. Returns issue number and URL."`
 
+### Property `description`: required on every prop, embed example values
+
+Every input property must have a `description` (the existing field on `Property.*`). The description is the **only** signal an LLM/MCP agent has about how to fill the prop, so write it as a one-or-two-sentence spec rather than a label.
+
+When a sample value would clarify the expected format (IDs, dates, enums, URLs, structured strings), bake it into the description prose using `(e.g. ...)` or `Example: ...`. There is no separate `example` field — the description carries the whole signal.
+
+Rules:
+-   **State the format**, not just the concept. "Issue title. Max 255 characters. Example: 'Bug: Login page crashes on mobile Safari'" beats "The title".
+-   **Prefer realistic samples**: actual ID formats (`'cus_abc123xyz'`), real ISO 8601 dates (`'2026-04-17T10:30:00Z'`), full URLs with protocol (`'https://example.com/file.pdf'`).
+-   **Skip examples** when the prop is self-explanatory (e.g. a boolean checkbox), when values come from an API at runtime (`Property.Dropdown`), or when shape is determined at runtime (`Property.DynamicProperties`).
+-   **Avoid placeholder-only examples**: never write `'string'`, `'value'`, `'<your API key>'`, `'example'`, empty `{}` / `[]`, or mismatched enum values.
+
+**Bad:** `description: "The status"`
+**Good:** `description: "Current status of the record. One of: 'open', 'in_progress', 'closed'."`
+
+**Bad:** `description: "Issue body"`
+**Good:** `description: "Markdown-formatted issue body. Example: '## Steps to reproduce\\n1. Open the app\\n2. ...'"`
+
 ### Optional but recommended: `ActionResult<T>` return type
 
 For new actions, wrap the return in the `ActionResult<T>` type exported from `@activepieces/pieces-framework`:
@@ -338,7 +356,7 @@ This gives agents a predictable success/error shape instead of raw API responses
 
 ## Critical Reminders
 
-1. **AI Metadata is MANDATORY** -- every action/trigger must have an `infoForLLM` bundle with `description`. See the AI Metadata section above.
+1. **AI Metadata is MANDATORY** -- every action/trigger must have an `infoForLLM` bundle with `description`, AND every input property must have a `description` (with an example baked in where useful). See the AI Metadata section above.
 2. **Register in tsconfig.base.json** -- Alphabetically in `compilerOptions.paths`. Build fails without this.
 3. **Action names are permanent** -- The `name` field in `createAction`/`createTrigger` must never change after publishing.
 4. **Export auth from index.ts** -- Actions and triggers import auth via `import { myAppAuth } from '../../'`.

--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -139,8 +139,9 @@ Copy config files from an existing simple piece (e.g. `packages/pieces/core/qrco
 | HTTP client, shared helpers, pagination         | `common-patterns.md`  |
 | Every prop and dropdown **(mandatory for all)** | `ux-guidelines.md`    |
 | Every return value **(mandatory for all)**      | `output-quality.md`   |
+| **AI metadata (mandatory on every action & trigger)** | `SKILL.md` → AI Metadata section |
 
-`ux-guidelines.md` and `output-quality.md` apply to **every** action and trigger -- read them before starting, not only when unsure.
+`ux-guidelines.md`, `output-quality.md`, and the **AI Metadata** section apply to **every** action and trigger -- read them before starting, not only when unsure.
 
 ### Step 5: WIRE & VERIFY
 
@@ -288,13 +289,78 @@ Every action output must be directly mappable to Google Sheets, Excel, and Activ
 
 Full patterns and examples: read `output-quality.md`
 
+## AI Metadata: Required for Every Action & Trigger
+
+Pieces must be usable by AI agents and MCP clients. **Every action and trigger must populate these fields** -- they are not optional.
+
+### Required fields on every `createAction` / `createTrigger`
+
+| Field | Type | Purpose |
+|---|---|---|
+| `descriptionForLLM` | `string` | LLM-optimized description. Template: `"<Verb> <what>. Use when <situation>. <Constraints>."` Max ~500 chars. |
+| `tags` | `string[]` | Classification tags. Pick one verb tag from: `read`, `write`, `delete`, `search`, `list` -- plus one domain tag (`issues`, `messages`, `files`, `contacts`, etc.). |
+| `difficulty` | `'easy' \| 'medium' \| 'hard'` | `easy` = single API call, no dependencies. `medium` = multiple calls, needs lookups. `hard` = multi-step with side effects. |
+
+### Required on every `createAction` (in addition to above)
+
+| Field | Type | Purpose |
+|---|---|---|
+| `outputSchema` | `Record<string, unknown>` | JSON Schema of what `run()` returns. Every top-level field must have a `type` and `description`. Lets LLMs use downstream fields without hallucinating names. |
+
+### Required on every `Property`
+
+| Field | Type | Purpose |
+|---|---|---|
+| `example` | `unknown` | A realistic sample value showing the expected format. Not `"string"` or `"value"` -- an actual example. |
+
+### Description writing rules
+
+-   **Verb-first:** `"Creates"`, `"Fetches"`, `"Searches"`, `"Updates"`, `"Deletes"` -- never noun-first.
+-   **Two parts:** what it does + when to use it.
+-   **State constraints:** `"Requires a repository owner"`, `"Returns up to 100 results"`, `"At least one of X or Y must be provided"`.
+-   **Under 500 characters** -- shorter wins for LLM context.
+
+**Bad:** `"Create Issue in GitHub Repository"`
+**Good:** `"Creates a new issue in a GitHub repository. Use when you need to report a bug, request a feature, or track work. Requires repository owner and name. Returns issue number and URL."`
+
+### Property `example` rules
+
+-   Show format, not just concept.
+-   For IDs: show the real format (`"cus_abc123xyz"`, not `"id"`).
+-   For enums: pick a common one (`"open"`, not `"status"`).
+-   For dates: ISO 8601 (`"2026-04-17T10:30:00Z"`).
+-   For URLs: full URL (`"https://example.com/file.pdf"`).
+
+**Bad:** `description: "The title"` (no example)
+**Good:** `description: "Issue title. Max 255 characters.", example: "Bug: Login page crashes on mobile Safari"`
+
+### Optional but recommended: `ActionResult<T>` return type
+
+For new actions, wrap the return in the `ActionResult<T>` type exported from `@activepieces/pieces-framework`:
+
+```typescript
+import { ActionResult } from '@activepieces/pieces-framework';
+
+async run(context): Promise<ActionResult<{ number: number; html_url: string }>> {
+  try {
+    const issue = await createIssue(context.propsValue);
+    return { success: true, data: { number: issue.number, html_url: issue.html_url } };
+  } catch (e) {
+    return { success: false, error: (e as Error).message };
+  }
+}
+```
+
+This gives agents a predictable success/error shape instead of raw API responses.
+
 ## Critical Reminders
 
-1. **Register in tsconfig.base.json** -- Alphabetically in `compilerOptions.paths`. Build fails without this.
-2. **Action names are permanent** -- The `name` field in `createAction`/`createTrigger` must never change after publishing.
-3. **Export auth from index.ts** -- Actions and triggers import auth via `import { myAppAuth } from '../../'`.
-4. **Always provide sampleData** on triggers -- Even if it's just `{}`.
-5. **ux-guidelines.md and output-quality.md are mandatory** -- Read them before implementing any action or trigger.
+1. **AI Metadata is MANDATORY** -- every action/trigger must have `descriptionForLLM`, `tags`, `difficulty`; every action must also have `outputSchema`; every property must have `example`. See the AI Metadata section above.
+2. **Register in tsconfig.base.json** -- Alphabetically in `compilerOptions.paths`. Build fails without this.
+3. **Action names are permanent** -- The `name` field in `createAction`/`createTrigger` must never change after publishing.
+4. **Export auth from index.ts** -- Actions and triggers import auth via `import { myAppAuth } from '../../'`.
+5. **Always provide sampleData** on triggers -- Even if it's just `{}`.
+6. **ux-guidelines.md and output-quality.md are mandatory** -- Read them before implementing any action or trigger.
 
 ## When to Ask the User
 

--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -295,32 +295,17 @@ Pieces must be usable by AI agents and MCP clients. **Every action and trigger m
 
 ### Required on every `createAction` / `createTrigger`
 
-The `infoForLLM` bundle groups all agent-facing metadata under a single optional object on the action/trigger params. Populate every inner field:
+The `infoForLLM` bundle is a single optional object on the action/trigger params. Today it carries one field; the bundle exists so future agent-facing metadata can land here without bloating the top-level type.
 
 ```typescript
-import { createAction, ActionDifficulty } from '@activepieces/pieces-framework';
-
-// ...
 infoForLLM: {
-  description: '...',                  // see template below
-  tags: ['write', '...'],              // one verb tag + one domain tag
-  difficulty: ActionDifficulty.EASY,   // enum: EASY | MEDIUM | HARD
-  outputSchema: `...`,                 // string — see below
+  description: '...',   // LLM-optimized description (see template below)
 },
 ```
 
 | Inner field | Type | Purpose |
 |---|---|---|
 | `description` | `string` | LLM-optimized description. Template: `"<Verb> <what>. Use when <situation>. <Constraints>."` Max ~500 chars. |
-| `tags` | `string[]` | Classification tags. Pick one verb tag from: `read`, `write`, `delete`, `search`, `list` -- plus one domain tag (`issues`, `messages`, `files`, `contacts`, etc.). |
-| `difficulty` | `ActionDifficulty` | Enum exported by `@activepieces/pieces-framework`. Values: `ActionDifficulty.EASY` (single API call, no dependencies), `ActionDifficulty.MEDIUM` (multiple calls, needs lookups), `ActionDifficulty.HARD` (multi-step with side effects). Use the enum member, not the string literal — TypeScript rejects a bare `'easy'`. |
-| `outputSchema` | `string` | Describes the shape returned by `run()` (or emitted by the trigger). Use a **stringified JSON example** for static shapes or **prose-with-example** for dynamic outputs (HTTP responses, spreadsheet rows, SQL queries). Always use backtick template literals. Required on actions; strongly recommended on triggers that emit a non-trivial payload. |
-
-### Required on every `Property`
-
-| Field | Type | Purpose |
-|---|---|---|
-| `example` | `unknown` | A realistic sample value showing the expected format. Not `"string"` or `"value"` -- an actual example. |
 
 ### Description writing rules
 
@@ -331,17 +316,6 @@ infoForLLM: {
 
 **Bad:** `"Create Issue in GitHub Repository"`
 **Good:** `"Creates a new issue in a GitHub repository. Use when you need to report a bug, request a feature, or track work. Requires repository owner and name. Returns issue number and URL."`
-
-### Property `example` rules
-
--   Show format, not just concept.
--   For IDs: show the real format (`"cus_abc123xyz"`, not `"id"`).
--   For enums: pick a common one (`"open"`, not `"status"`).
--   For dates: ISO 8601 (`"2026-04-17T10:30:00Z"`).
--   For URLs: full URL (`"https://example.com/file.pdf"`).
-
-**Bad:** `description: "The title"` (no example)
-**Good:** `description: "Issue title. Max 255 characters.", example: "Bug: Login page crashes on mobile Safari"`
 
 ### Optional but recommended: `ActionResult<T>` return type
 
@@ -364,7 +338,7 @@ This gives agents a predictable success/error shape instead of raw API responses
 
 ## Critical Reminders
 
-1. **AI Metadata is MANDATORY** -- every action/trigger must have an `infoForLLM` bundle with `description`, `tags`, `difficulty`, and `outputSchema` (for actions, and for triggers that emit a non-trivial payload); every property must have `example`. See the AI Metadata section above.
+1. **AI Metadata is MANDATORY** -- every action/trigger must have an `infoForLLM` bundle with `description`. See the AI Metadata section above.
 2. **Register in tsconfig.base.json** -- Alphabetically in `compilerOptions.paths`. Build fails without this.
 3. **Action names are permanent** -- The `name` field in `createAction`/`createTrigger` must never change after publishing.
 4. **Export auth from index.ts** -- Actions and triggers import auth via `import { myAppAuth } from '../../'`.

--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -291,21 +291,27 @@ Full patterns and examples: read `output-quality.md`
 
 ## AI Metadata: Required for Every Action & Trigger
 
-Pieces must be usable by AI agents and MCP clients. **Every action and trigger must populate these fields** -- they are not optional.
+Pieces must be usable by AI agents and MCP clients. **Every action and trigger must populate the `infoForLLM` bundle** -- it is not optional.
 
-### Required fields on every `createAction` / `createTrigger`
+### Required on every `createAction` / `createTrigger`
 
-| Field | Type | Purpose |
+The `infoForLLM` bundle groups all agent-facing metadata under a single optional object on the action/trigger params. Populate every inner field:
+
+```typescript
+infoForLLM: {
+  description: '...',       // see template below
+  tags: ['write', '...'],   // one verb tag + one domain tag
+  difficulty: 'easy',       // 'easy' | 'medium' | 'hard'
+  outputSchema: `...`,      // string — see below
+},
+```
+
+| Inner field | Type | Purpose |
 |---|---|---|
-| `descriptionForLLM` | `string` | LLM-optimized description. Template: `"<Verb> <what>. Use when <situation>. <Constraints>."` Max ~500 chars. |
+| `description` | `string` | LLM-optimized description. Template: `"<Verb> <what>. Use when <situation>. <Constraints>."` Max ~500 chars. |
 | `tags` | `string[]` | Classification tags. Pick one verb tag from: `read`, `write`, `delete`, `search`, `list` -- plus one domain tag (`issues`, `messages`, `files`, `contacts`, etc.). |
 | `difficulty` | `'easy' \| 'medium' \| 'hard'` | `easy` = single API call, no dependencies. `medium` = multiple calls, needs lookups. `hard` = multi-step with side effects. |
-
-### Required on every `createAction` (in addition to above)
-
-| Field | Type | Purpose |
-|---|---|---|
-| `outputSchema` | `Record<string, unknown>` | JSON Schema of what `run()` returns. Every top-level field must have a `type` and `description`. Lets LLMs use downstream fields without hallucinating names. |
+| `outputSchema` | `string` | Describes the shape returned by `run()` (or emitted by the trigger). Use a **stringified JSON example** for static shapes or **prose-with-example** for dynamic outputs (HTTP responses, spreadsheet rows, SQL queries). Always use backtick template literals. Required on actions; strongly recommended on triggers that emit a non-trivial payload. |
 
 ### Required on every `Property`
 
@@ -355,7 +361,7 @@ This gives agents a predictable success/error shape instead of raw API responses
 
 ## Critical Reminders
 
-1. **AI Metadata is MANDATORY** -- every action/trigger must have `descriptionForLLM`, `tags`, `difficulty`; every action must also have `outputSchema`; every property must have `example`. See the AI Metadata section above.
+1. **AI Metadata is MANDATORY** -- every action/trigger must have an `infoForLLM` bundle with `description`, `tags`, `difficulty`, and `outputSchema` (for actions, and for triggers that emit a non-trivial payload); every property must have `example`. See the AI Metadata section above.
 2. **Register in tsconfig.base.json** -- Alphabetically in `compilerOptions.paths`. Build fails without this.
 3. **Action names are permanent** -- The `name` field in `createAction`/`createTrigger` must never change after publishing.
 4. **Export auth from index.ts** -- Actions and triggers import auth via `import { myAppAuth } from '../../'`.

--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -298,11 +298,14 @@ Pieces must be usable by AI agents and MCP clients. **Every action and trigger m
 The `infoForLLM` bundle groups all agent-facing metadata under a single optional object on the action/trigger params. Populate every inner field:
 
 ```typescript
+import { createAction, ActionDifficulty } from '@activepieces/pieces-framework';
+
+// ...
 infoForLLM: {
-  description: '...',       // see template below
-  tags: ['write', '...'],   // one verb tag + one domain tag
-  difficulty: 'easy',       // 'easy' | 'medium' | 'hard'
-  outputSchema: `...`,      // string — see below
+  description: '...',                  // see template below
+  tags: ['write', '...'],              // one verb tag + one domain tag
+  difficulty: ActionDifficulty.EASY,   // enum: EASY | MEDIUM | HARD
+  outputSchema: `...`,                 // string — see below
 },
 ```
 
@@ -310,7 +313,7 @@ infoForLLM: {
 |---|---|---|
 | `description` | `string` | LLM-optimized description. Template: `"<Verb> <what>. Use when <situation>. <Constraints>."` Max ~500 chars. |
 | `tags` | `string[]` | Classification tags. Pick one verb tag from: `read`, `write`, `delete`, `search`, `list` -- plus one domain tag (`issues`, `messages`, `files`, `contacts`, etc.). |
-| `difficulty` | `'easy' \| 'medium' \| 'hard'` | `easy` = single API call, no dependencies. `medium` = multiple calls, needs lookups. `hard` = multi-step with side effects. |
+| `difficulty` | `ActionDifficulty` | Enum exported by `@activepieces/pieces-framework`. Values: `ActionDifficulty.EASY` (single API call, no dependencies), `ActionDifficulty.MEDIUM` (multiple calls, needs lookups), `ActionDifficulty.HARD` (multi-step with side effects). Use the enum member, not the string literal — TypeScript rejects a bare `'easy'`. |
 | `outputSchema` | `string` | Describes the shape returned by `run()` (or emitted by the trigger). Use a **stringified JSON example** for static shapes or **prose-with-example** for dynamic outputs (HTTP responses, spreadsheet rows, SQL queries). Always use backtick template literals. Required on actions; strongly recommended on triggers that emit a non-trivial payload. |
 
 ### Required on every `Property`

--- a/.agents/skills/piece-builder/action-patterns.md
+++ b/.agents/skills/piece-builder/action-patterns.md
@@ -7,7 +7,7 @@
 Each action goes in its own file under `src/lib/actions/`:
 
 ```typescript
-import { createAction, Property, ActionResult } from '@activepieces/pieces-framework';
+import { createAction, Property, ActionResult, ActionDifficulty } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 import { myAppAuth } from '../../';
 
@@ -22,8 +22,8 @@ export const createRecordAction = createAction({
     description: "Creates a new record in My App. Use when you need to add a new entry (e.g. customer, task, or document) to the user's My App workspace. Requires a name; description is optional.",
     // One verb tag + one domain tag.
     tags: ['write', 'records'],
-    // easy (single call) | medium (multiple calls / lookups) | hard (multi-step with side effects).
-    difficulty: 'easy',
+    // Enum: EASY (single call) | MEDIUM (multiple calls / lookups) | HARD (multi-step with side effects).
+    difficulty: ActionDifficulty.EASY,
     // String describing the output shape. For static shapes, a stringified JSON example.
     // For dynamic shapes, prose with a representative example. Use backticks so single
     // quotes don't need escaping.

--- a/.agents/skills/piece-builder/action-patterns.md
+++ b/.agents/skills/piece-builder/action-patterns.md
@@ -1,6 +1,6 @@
 # Action Patterns
 
-> **AI Metadata is mandatory on every action.** The `infoForLLM` bundle (just `description` today) must be populated. See `SKILL.md` → AI Metadata section for the rules.
+> **AI Metadata is mandatory on every action.** The `infoForLLM` bundle (just `description` today) must be populated, and every input property must carry a meaningful `description` with an example baked in where useful. See `SKILL.md` → AI Metadata section for the rules.
 
 ## Action Template
 
@@ -22,14 +22,16 @@ export const createRecordAction = createAction({
     description: "Creates a new record in My App. Use when you need to add a new entry (e.g. customer, task, or document) to the user's My App workspace. Requires a name; description is optional.",
   },
   props: {
+    // Every prop needs a description; embed an example in the prose where it
+    // clarifies the expected format (IDs, dates, enums, URLs, etc.).
     name: Property.ShortText({
       displayName: 'Name',
-      description: 'The name of the record. Max 255 characters.',
+      description: "Name of the record. Max 255 characters. Example: 'Q1 2026 Product Launch'.",
       required: true,
     }),
     description: Property.LongText({
       displayName: 'Description',
-      description: 'Optional longer description for the record.',
+      description: "Optional longer description for the record. Markdown supported. Example: 'Kickoff meeting notes and action items.'",
       required: false,
     }),
   },
@@ -51,7 +53,7 @@ export const createRecordAction = createAction({
 });
 ```
 
-**AI Metadata is mandatory -- do not skip `infoForLLM.description`.** See `SKILL.md` → AI Metadata section for rules and examples.
+**AI Metadata is mandatory -- do not skip `infoForLLM.description`, and never leave a property without a `description`.** Embed example values in prop descriptions whenever a sample value clarifies the format. See `SKILL.md` → AI Metadata section for rules and examples.
 
 **Real example:** `packages/pieces/community/github/src/lib/actions/create-issue.ts`
 

--- a/.agents/skills/piece-builder/action-patterns.md
+++ b/.agents/skills/piece-builder/action-patterns.md
@@ -1,13 +1,13 @@
 # Action Patterns
 
-> **AI Metadata is mandatory on every action.** The `infoForLLM` bundle (`description`, `tags`, `difficulty`, `outputSchema`) and a property-level `example` on every static prop must all be populated. See `SKILL.md` → AI Metadata section for the rules.
+> **AI Metadata is mandatory on every action.** The `infoForLLM` bundle (just `description` today) must be populated. See `SKILL.md` → AI Metadata section for the rules.
 
 ## Action Template
 
 Each action goes in its own file under `src/lib/actions/`:
 
 ```typescript
-import { createAction, Property, ActionResult, ActionDifficulty } from '@activepieces/pieces-framework';
+import { createAction, Property, ActionResult } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 import { myAppAuth } from '../../';
 
@@ -20,26 +20,16 @@ export const createRecordAction = createAction({
   infoForLLM: {
     // Template: "<Verb> <what>. Use when <situation>. <Constraints>."
     description: "Creates a new record in My App. Use when you need to add a new entry (e.g. customer, task, or document) to the user's My App workspace. Requires a name; description is optional.",
-    // One verb tag + one domain tag.
-    tags: ['write', 'records'],
-    // Enum: EASY (single call) | MEDIUM (multiple calls / lookups) | HARD (multi-step with side effects).
-    difficulty: ActionDifficulty.EASY,
-    // String describing the output shape. For static shapes, a stringified JSON example.
-    // For dynamic shapes, prose with a representative example. Use backticks so single
-    // quotes don't need escaping.
-    outputSchema: `{ type: 'object', properties: { id: { type: 'string', description: 'Unique ID of the created record' }, name: { type: 'string', description: 'Name of the record' }, created_at: { type: 'string', format: 'date-time', description: 'ISO 8601 creation timestamp' } } }`,
   },
   props: {
     name: Property.ShortText({
       displayName: 'Name',
       description: 'The name of the record. Max 255 characters.',
-      example: 'Q1 2026 Product Launch',    // REQUIRED on every property -- realistic sample value
       required: true,
     }),
     description: Property.LongText({
       displayName: 'Description',
       description: 'Optional longer description for the record.',
-      example: 'Kickoff meeting notes and action items.',
       required: false,
     }),
   },
@@ -61,7 +51,7 @@ export const createRecordAction = createAction({
 });
 ```
 
-**AI Metadata is mandatory -- do not skip any inner field of `infoForLLM`, or any property `example`.** See `SKILL.md` → AI Metadata section for rules and examples.
+**AI Metadata is mandatory -- do not skip `infoForLLM.description`.** See `SKILL.md` → AI Metadata section for rules and examples.
 
 **Real example:** `packages/pieces/community/github/src/lib/actions/create-issue.ts`
 

--- a/.agents/skills/piece-builder/action-patterns.md
+++ b/.agents/skills/piece-builder/action-patterns.md
@@ -1,6 +1,6 @@
 # Action Patterns
 
-> **AI Metadata is mandatory on every action.** `descriptionForLLM`, `tags`, `difficulty`, `outputSchema`, and property `example` fields must all be populated. See `SKILL.md` → AI Metadata section for the rules.
+> **AI Metadata is mandatory on every action.** The `infoForLLM` bundle (`description`, `tags`, `difficulty`, `outputSchema`) and a property-level `example` on every static prop must all be populated. See `SKILL.md` → AI Metadata section for the rules.
 
 ## Action Template
 
@@ -16,20 +16,18 @@ export const createRecordAction = createAction({
   name: 'create_record',              // Unique snake_case ID -- never change after publishing
   displayName: 'Create Record',
   description: 'Creates a new record in My App',
-  // REQUIRED: LLM-optimized description. Template: "<Verb> <what>. Use when <situation>. <Constraints>."
-  descriptionForLLM: "Creates a new record in My App. Use when you need to add a new entry (e.g. customer, task, or document) to the user's My App workspace. Requires a name; description is optional.",
-  // REQUIRED: one verb tag + one domain tag
-  tags: ['write', 'records'],
-  // REQUIRED: easy (single call) | medium (multiple calls / lookups) | hard (multi-step with side effects)
-  difficulty: 'easy',
-  // REQUIRED: JSON Schema of what run() returns -- helps LLMs use downstream fields without hallucinating.
-  outputSchema: {
-    type: 'object',
-    properties: {
-      id: { type: 'string', description: 'Unique ID of the created record' },
-      name: { type: 'string', description: 'Name of the record' },
-      created_at: { type: 'string', format: 'date-time', description: 'ISO 8601 creation timestamp' },
-    },
+  // REQUIRED: AI metadata bundle read by LLM/MCP agents.
+  infoForLLM: {
+    // Template: "<Verb> <what>. Use when <situation>. <Constraints>."
+    description: "Creates a new record in My App. Use when you need to add a new entry (e.g. customer, task, or document) to the user's My App workspace. Requires a name; description is optional.",
+    // One verb tag + one domain tag.
+    tags: ['write', 'records'],
+    // easy (single call) | medium (multiple calls / lookups) | hard (multi-step with side effects).
+    difficulty: 'easy',
+    // String describing the output shape. For static shapes, a stringified JSON example.
+    // For dynamic shapes, prose with a representative example. Use backticks so single
+    // quotes don't need escaping.
+    outputSchema: `{ type: 'object', properties: { id: { type: 'string', description: 'Unique ID of the created record' }, name: { type: 'string', description: 'Name of the record' }, created_at: { type: 'string', format: 'date-time', description: 'ISO 8601 creation timestamp' } } }`,
   },
   props: {
     name: Property.ShortText({
@@ -63,7 +61,7 @@ export const createRecordAction = createAction({
 });
 ```
 
-**AI Metadata is mandatory -- do not skip `descriptionForLLM`, `tags`, `difficulty`, `outputSchema`, or property `example` fields.** See `SKILL.md` → AI Metadata section for rules and examples.
+**AI Metadata is mandatory -- do not skip any inner field of `infoForLLM`, or any property `example`.** See `SKILL.md` → AI Metadata section for rules and examples.
 
 **Real example:** `packages/pieces/community/github/src/lib/actions/create-issue.ts`
 

--- a/.agents/skills/piece-builder/action-patterns.md
+++ b/.agents/skills/piece-builder/action-patterns.md
@@ -1,27 +1,47 @@
 # Action Patterns
 
+> **AI Metadata is mandatory on every action.** `descriptionForLLM`, `tags`, `difficulty`, `outputSchema`, and property `example` fields must all be populated. See `SKILL.md` → AI Metadata section for the rules.
+
 ## Action Template
 
 Each action goes in its own file under `src/lib/actions/`:
 
 ```typescript
-import { createAction, Property } from '@activepieces/pieces-framework';
+import { createAction, Property, ActionResult } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 import { myAppAuth } from '../../';
 
 export const createRecordAction = createAction({
   auth: myAppAuth,
-  name: 'create_record',        // Unique snake_case ID -- never change after publishing
+  name: 'create_record',              // Unique snake_case ID -- never change after publishing
   displayName: 'Create Record',
   description: 'Creates a new record in My App',
+  // REQUIRED: LLM-optimized description. Template: "<Verb> <what>. Use when <situation>. <Constraints>."
+  descriptionForLLM: "Creates a new record in My App. Use when you need to add a new entry (e.g. customer, task, or document) to the user's My App workspace. Requires a name; description is optional.",
+  // REQUIRED: one verb tag + one domain tag
+  tags: ['write', 'records'],
+  // REQUIRED: easy (single call) | medium (multiple calls / lookups) | hard (multi-step with side effects)
+  difficulty: 'easy',
+  // REQUIRED: JSON Schema of what run() returns -- helps LLMs use downstream fields without hallucinating.
+  outputSchema: {
+    type: 'object',
+    properties: {
+      id: { type: 'string', description: 'Unique ID of the created record' },
+      name: { type: 'string', description: 'Name of the record' },
+      created_at: { type: 'string', format: 'date-time', description: 'ISO 8601 creation timestamp' },
+    },
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Name',
-      description: 'The name of the record',
+      description: 'The name of the record. Max 255 characters.',
+      example: 'Q1 2026 Product Launch',    // REQUIRED on every property -- realistic sample value
       required: true,
     }),
     description: Property.LongText({
       displayName: 'Description',
+      description: 'Optional longer description for the record.',
+      example: 'Kickoff meeting notes and action items.',
       required: false,
     }),
   },
@@ -42,6 +62,8 @@ export const createRecordAction = createAction({
   },
 });
 ```
+
+**AI Metadata is mandatory -- do not skip `descriptionForLLM`, `tags`, `difficulty`, `outputSchema`, or property `example` fields.** See `SKILL.md` → AI Metadata section for rules and examples.
 
 **Real example:** `packages/pieces/community/github/src/lib/actions/create-issue.ts`
 

--- a/.agents/skills/piece-builder/props-patterns.md
+++ b/.agents/skills/piece-builder/props-patterns.md
@@ -2,8 +2,6 @@
 
 Used in both `createAction({ props: {...} })` and `createTrigger({ props: {...} })`.
 
-> **The `example` field is mandatory on every static property.** Provide a realistic sample value (not `"string"` or `"value"`) that shows the expected format. This guides LLMs to generate valid inputs on the first try. Dynamic dropdowns and `DynamicProperties` may omit `example` since the values come from API calls. See `SKILL.md` → AI Metadata section.
-
 ---
 
 ## Text
@@ -12,7 +10,6 @@ Used in both `createAction({ props: {...} })` and `createTrigger({ props: {...} 
 Property.ShortText({
   displayName: 'Title',
   description: 'Short descriptive title. Max 255 characters.',
-  example: 'Q1 2026 Product Launch',
   required: true,
   defaultValue: 'Default text',
 })
@@ -20,7 +17,6 @@ Property.ShortText({
 Property.LongText({
   displayName: 'Body',
   description: 'Long-form text. Supports markdown.',
-  example: 'Kickoff meeting notes and action items for the launch.',
   required: false,
 })
 ```
@@ -31,7 +27,6 @@ Property.LongText({
 Property.Number({
   displayName: 'Limit',
   description: 'Maximum number of records to return.',
-  example: 10,
   required: false,
   defaultValue: 10,
 })
@@ -39,7 +34,6 @@ Property.Number({
 Property.Checkbox({
   displayName: 'Include archived?',
   description: 'Whether to include archived records in the result.',
-  example: false,
   required: false,
   defaultValue: false,
 })
@@ -51,7 +45,6 @@ Property.Checkbox({
 Property.DateTime({
   displayName: 'Due Date',
   description: 'ISO 8601 date-time. Timezone-aware.',
-  example: '2026-04-17T10:30:00Z',
   required: false,
 })
 ```
@@ -72,14 +65,12 @@ Property.File({
 Property.Json({
   displayName: 'Custom Data',
   description: 'Enter valid JSON.',
-  example: { key: 'value', count: 3 },
   required: false,
 })
 
 Property.Object({
   displayName: 'Metadata',
   description: 'Key-value pairs.',
-  example: { name: 'Jane', role: 'admin' },
   required: false,
 })
 ```
@@ -91,7 +82,6 @@ Property.Object({
 Property.Array({
   displayName: 'Tags',
   description: 'List of tag names to apply.',
-  example: ['bug', 'enhancement'],
   required: false,
 })
 
@@ -99,12 +89,11 @@ Property.Array({
 Property.Array({
   displayName: 'Line Items',
   description: 'Each line item must include name and quantity.',
-  example: [{ name: 'Widget', quantity: 2, price: 9.99 }],
   required: true,
   properties: {
-    name: Property.ShortText({ displayName: 'Item Name', description: 'Product name.', example: 'Widget', required: true }),
-    quantity: Property.Number({ displayName: 'Quantity', description: 'Units to order.', example: 2, required: true }),
-    price: Property.Number({ displayName: 'Price', description: 'Unit price in USD.', example: 9.99, required: false }),
+    name: Property.ShortText({ displayName: 'Item Name', description: 'Product name.', required: true }),
+    quantity: Property.Number({ displayName: 'Quantity', description: 'Units to order.', required: true }),
+    price: Property.Number({ displayName: 'Price', description: 'Unit price in USD.', required: false }),
   },
 })
 ```
@@ -115,7 +104,6 @@ Property.Array({
 Property.StaticDropdown({
   displayName: 'Status',
   description: 'Current status of the record.',
-  example: 'active',
   required: true,
   options: {
     options: [
@@ -129,7 +117,6 @@ Property.StaticDropdown({
 Property.StaticMultiSelectDropdown({
   displayName: 'Categories',
   description: 'One or more categories to classify the record.',
-  example: ['sales', 'marketing'],
   required: false,
   options: {
     options: [
@@ -193,7 +180,7 @@ Property.Dropdown({
 })
 ```
 
-**Real example:** `packages/pieces/community/github/src/lib/common/index.ts` -- see `repositoryDropdown`, `issueDropdown`, `labelDropDown`
+**Real `issueDropdown`, `labelDropDown`
 
 ## Multi-Select Dropdown (dynamic)
 

--- a/.agents/skills/piece-builder/props-patterns.md
+++ b/.agents/skills/piece-builder/props-patterns.md
@@ -2,6 +2,8 @@
 
 Used in both `createAction({ props: {...} })` and `createTrigger({ props: {...} })`.
 
+> **Every property must have a `description`.** When a sample value would clarify the expected format (IDs, dates, enums, URLs, structured strings, JSON shapes), embed it in the description prose using `Example: ...` or `(e.g. ...)`. There is no separate `example` field today — the description carries the whole signal. Skip the example when the prop is self-explanatory (a boolean checkbox), the values come from an API at runtime (`Property.Dropdown`), or the shape is determined at runtime (`Property.DynamicProperties`). See `SKILL.md` → AI Metadata section.
+
 ---
 
 ## Text
@@ -9,14 +11,14 @@ Used in both `createAction({ props: {...} })` and `createTrigger({ props: {...} 
 ```typescript
 Property.ShortText({
   displayName: 'Title',
-  description: 'Short descriptive title. Max 255 characters.',
+  description: "Short descriptive title. Max 255 characters. Example: 'Q1 2026 Product Launch'.",
   required: true,
   defaultValue: 'Default text',
 })
 
 Property.LongText({
   displayName: 'Body',
-  description: 'Long-form text. Supports markdown.',
+  description: "Long-form text. Markdown supported. Example: 'Kickoff meeting notes and action items for the launch.'",
   required: false,
 })
 ```
@@ -26,7 +28,7 @@ Property.LongText({
 ```typescript
 Property.Number({
   displayName: 'Limit',
-  description: 'Maximum number of records to return.',
+  description: 'Maximum number of records to return. Example: 10.',
   required: false,
   defaultValue: 10,
 })
@@ -44,7 +46,7 @@ Property.Checkbox({
 ```typescript
 Property.DateTime({
   displayName: 'Due Date',
-  description: 'ISO 8601 date-time. Timezone-aware.',
+  description: "ISO 8601 date-time, timezone-aware. Example: '2026-04-17T10:30:00Z'.",
   required: false,
 })
 ```
@@ -54,7 +56,7 @@ Property.DateTime({
 ```typescript
 Property.File({
   displayName: 'Attachment',
-  description: 'File to upload. Max 25 MB.',
+  description: 'File to upload. Max 25 MB. Accepts any common file type (pdf, png, jpg, docx, etc.).',
   required: false,
 })
 ```
@@ -64,13 +66,13 @@ Property.File({
 ```typescript
 Property.Json({
   displayName: 'Custom Data',
-  description: 'Enter valid JSON.',
+  description: "Enter valid JSON. Example: { key: 'value', count: 3 }.",
   required: false,
 })
 
 Property.Object({
   displayName: 'Metadata',
-  description: 'Key-value pairs.',
+  description: "Key-value pairs. Example: { name: 'Jane', role: 'admin' }.",
   required: false,
 })
 ```
@@ -81,19 +83,19 @@ Property.Object({
 // Simple array of strings
 Property.Array({
   displayName: 'Tags',
-  description: 'List of tag names to apply.',
+  description: "List of tag names to apply. Example: ['bug', 'enhancement'].",
   required: false,
 })
 
 // Array with structured sub-properties
 Property.Array({
   displayName: 'Line Items',
-  description: 'Each line item must include name and quantity.',
+  description: "Each line item must include name and quantity. Example: [{ name: 'Widget', quantity: 2, price: 9.99 }].",
   required: true,
   properties: {
-    name: Property.ShortText({ displayName: 'Item Name', description: 'Product name.', required: true }),
-    quantity: Property.Number({ displayName: 'Quantity', description: 'Units to order.', required: true }),
-    price: Property.Number({ displayName: 'Price', description: 'Unit price in USD.', required: false }),
+    name: Property.ShortText({ displayName: 'Item Name', description: "Product name. Example: 'Widget'.", required: true }),
+    quantity: Property.Number({ displayName: 'Quantity', description: 'Units to order. Example: 2.', required: true }),
+    price: Property.Number({ displayName: 'Price', description: 'Unit price in USD. Example: 9.99.', required: false }),
   },
 })
 ```
@@ -103,7 +105,7 @@ Property.Array({
 ```typescript
 Property.StaticDropdown({
   displayName: 'Status',
-  description: 'Current status of the record.',
+  description: "Current status of the record. One of: 'active', 'inactive', 'archived'.",
   required: true,
   options: {
     options: [
@@ -116,7 +118,7 @@ Property.StaticDropdown({
 
 Property.StaticMultiSelectDropdown({
   displayName: 'Categories',
-  description: 'One or more categories to classify the record.',
+  description: "One or more categories to classify the record. Pick from: 'sales', 'marketing'. Example: ['sales', 'marketing'].",
   required: false,
   options: {
     options: [
@@ -132,6 +134,7 @@ Property.StaticMultiSelectDropdown({
 ```typescript
 Property.Dropdown({
   displayName: 'Project',
+  description: 'Select the project to operate on. Options are fetched from your account.',
   auth:myAppAuth,
   refreshers: [],  // Array of prop names this depends on
   required: true,
@@ -160,6 +163,7 @@ Property.Dropdown({
 ```typescript
 Property.Dropdown({
   displayName: 'Task',
+  description: 'Select the task within the chosen project. Refreshes when the project prop changes.',
   refreshers: ['project'],  // Re-fetches when 'project' prop changes
   required: true,
   auth:myAppAuth,
@@ -180,13 +184,14 @@ Property.Dropdown({
 })
 ```
 
-**Real `issueDropdown`, `labelDropDown`
+**Real example:** `packages/pieces/community/github/src/lib/common/index.ts` -- see `repositoryDropdown`, `issueDropdown`, `labelDropDown`
 
 ## Multi-Select Dropdown (dynamic)
 
 ```typescript
 Property.MultiSelectDropdown({
   displayName: 'Labels',
+  description: 'One or more labels to apply. Options come from the selected repository.',
   refreshers: ['repository'],
   required: false,
   auth:myAppAuth,
@@ -203,6 +208,7 @@ For forms where the fields themselves come from the API (e.g., custom table colu
 ```typescript
 Property.DynamicProperties({
   displayName: 'Record Fields',
+  description: 'Fields are loaded from the selected table at runtime; one input per column.',
   refreshers: ['tableId'],
   required: true,
   auth: myAppAuth,
@@ -213,6 +219,7 @@ Property.DynamicProperties({
     for (const field of fields) {
       properties[field.id] = Property.ShortText({
         displayName: field.name,
+        description: `Value for the "${field.name}" column.`,
         required: field.required,
       });
     }
@@ -228,7 +235,7 @@ When a user must choose between two mutually exclusive input methods (upload vs 
 ```typescript
 source: Property.StaticDropdown({
   displayName: 'File Source',
-  description: 'Choose how to provide the file.',
+  description: "Choose how to provide the file. One of: 'file' (upload), 's3' (from S3 bucket).",
   required: true,
   defaultValue: 'file',
   options: {
@@ -241,6 +248,7 @@ source: Property.StaticDropdown({
 document: Property.DynamicProperties({
   auth: myAppAuth,
   displayName: 'File',
+  description: 'Inputs depend on the selected File Source. Either an Upload field or S3 Bucket + S3 File Path.',
   required: true,
   refreshers: ['source'],
   // IMPORTANT: explicit Promise<DynamicPropsValue> return type is required
@@ -250,10 +258,12 @@ document: Property.DynamicProperties({
       return {
         s3Bucket: Property.ShortText({
           displayName: 'S3 Bucket',
+          description: "S3 bucket name. Example: 'my-app-uploads'.",
           required: true,
         }),
         s3Key: Property.ShortText({
           displayName: 'S3 File Path',
+          description: "Object key within the bucket. Example: 'invoices/2026-04/inv-123.pdf'.",
           required: true,
         }),
       };
@@ -261,6 +271,7 @@ document: Property.DynamicProperties({
     return {
       file: Property.File({
         displayName: 'File',
+        description: 'Upload the file directly.',
         required: true,
       }),
     };
@@ -290,7 +301,7 @@ Property.MarkDown({
 })
 ```
 
-Use for setup instructions, warnings, or webhook URL display. See `ux-guidelines.md` for when to use it.
+Use for setup instructions, warnings, or webhook URL display. No `description` needed — `MarkDown` is display-only and the `value` is the rendered content. See `ux-guidelines.md` for when to use it.
 
 ---
 

--- a/.agents/skills/piece-builder/props-patterns.md
+++ b/.agents/skills/piece-builder/props-patterns.md
@@ -2,6 +2,8 @@
 
 Used in both `createAction({ props: {...} })` and `createTrigger({ props: {...} })`.
 
+> **The `example` field is mandatory on every static property.** Provide a realistic sample value (not `"string"` or `"value"`) that shows the expected format. This guides LLMs to generate valid inputs on the first try. Dynamic dropdowns and `DynamicProperties` may omit `example` since the values come from API calls. See `SKILL.md` → AI Metadata section.
+
 ---
 
 ## Text
@@ -9,13 +11,16 @@ Used in both `createAction({ props: {...} })` and `createTrigger({ props: {...} 
 ```typescript
 Property.ShortText({
   displayName: 'Title',
-  description: 'Optional help text',
+  description: 'Short descriptive title. Max 255 characters.',
+  example: 'Q1 2026 Product Launch',
   required: true,
   defaultValue: 'Default text',
 })
 
 Property.LongText({
   displayName: 'Body',
+  description: 'Long-form text. Supports markdown.',
+  example: 'Kickoff meeting notes and action items for the launch.',
   required: false,
 })
 ```
@@ -25,12 +30,16 @@ Property.LongText({
 ```typescript
 Property.Number({
   displayName: 'Limit',
+  description: 'Maximum number of records to return.',
+  example: 10,
   required: false,
   defaultValue: 10,
 })
 
 Property.Checkbox({
   displayName: 'Include archived?',
+  description: 'Whether to include archived records in the result.',
+  example: false,
   required: false,
   defaultValue: false,
 })
@@ -41,6 +50,8 @@ Property.Checkbox({
 ```typescript
 Property.DateTime({
   displayName: 'Due Date',
+  description: 'ISO 8601 date-time. Timezone-aware.',
+  example: '2026-04-17T10:30:00Z',
   required: false,
 })
 ```
@@ -50,6 +61,7 @@ Property.DateTime({
 ```typescript
 Property.File({
   displayName: 'Attachment',
+  description: 'File to upload. Max 25 MB.',
   required: false,
 })
 ```
@@ -59,13 +71,15 @@ Property.File({
 ```typescript
 Property.Json({
   displayName: 'Custom Data',
-  description: 'Enter valid JSON',
+  description: 'Enter valid JSON.',
+  example: { key: 'value', count: 3 },
   required: false,
 })
 
 Property.Object({
   displayName: 'Metadata',
-  description: 'Key-value pairs',
+  description: 'Key-value pairs.',
+  example: { name: 'Jane', role: 'admin' },
   required: false,
 })
 ```
@@ -76,17 +90,21 @@ Property.Object({
 // Simple array of strings
 Property.Array({
   displayName: 'Tags',
+  description: 'List of tag names to apply.',
+  example: ['bug', 'enhancement'],
   required: false,
 })
 
 // Array with structured sub-properties
 Property.Array({
   displayName: 'Line Items',
+  description: 'Each line item must include name and quantity.',
+  example: [{ name: 'Widget', quantity: 2, price: 9.99 }],
   required: true,
   properties: {
-    name: Property.ShortText({ displayName: 'Item Name', required: true }),
-    quantity: Property.Number({ displayName: 'Quantity', required: true }),
-    price: Property.Number({ displayName: 'Price', required: false }),
+    name: Property.ShortText({ displayName: 'Item Name', description: 'Product name.', example: 'Widget', required: true }),
+    quantity: Property.Number({ displayName: 'Quantity', description: 'Units to order.', example: 2, required: true }),
+    price: Property.Number({ displayName: 'Price', description: 'Unit price in USD.', example: 9.99, required: false }),
   },
 })
 ```
@@ -96,6 +114,8 @@ Property.Array({
 ```typescript
 Property.StaticDropdown({
   displayName: 'Status',
+  description: 'Current status of the record.',
+  example: 'active',
   required: true,
   options: {
     options: [
@@ -108,6 +128,8 @@ Property.StaticDropdown({
 
 Property.StaticMultiSelectDropdown({
   displayName: 'Categories',
+  description: 'One or more categories to classify the record.',
+  example: ['sales', 'marketing'],
   required: false,
   options: {
     options: [

--- a/.agents/skills/piece-builder/trigger-patterns.md
+++ b/.agents/skills/piece-builder/trigger-patterns.md
@@ -1,6 +1,6 @@
 # Trigger Patterns
 
-> **AI Metadata is mandatory for every trigger.** Every `createTrigger` call must include an `infoForLLM` bundle with `description`. See `SKILL.md` → AI Metadata section for the rules.
+> **AI Metadata is mandatory for every trigger.** Every `createTrigger` call must include an `infoForLLM` bundle with `description`, and every input property on the trigger must carry a `description` (with an example baked in where useful). See `SKILL.md` → AI Metadata section for the rules.
 
 Two main types: **Polling** (check API periodically) and **Webhook** (receive push notifications).
 

--- a/.agents/skills/piece-builder/trigger-patterns.md
+++ b/.agents/skills/piece-builder/trigger-patterns.md
@@ -19,7 +19,7 @@ Two deduplication strategies:
 ### TIMEBASED Polling (most common)
 
 ```typescript
-import { createTrigger, TriggerStrategy, AppConnectionValueForAuthProperty } from '@activepieces/pieces-framework';
+import { createTrigger, TriggerStrategy, AppConnectionValueForAuthProperty, ActionDifficulty } from '@activepieces/pieces-framework';
 import { DedupeStrategy, Polling, pollingHelper, httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 import { myAppAuth } from '../../';
 
@@ -55,7 +55,7 @@ export const newRecordTrigger = createTrigger({
   infoForLLM: {
     description: 'Fires when a new record is created in My App. Use to start workflows when a customer, task, or document is added. Polls every ~5 minutes.',
     tags: ['read', 'records'],
-    difficulty: 'easy',
+    difficulty: ActionDifficulty.EASY,
     outputSchema: `{ type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' }, created_at: { type: 'string', format: 'date-time' } } }`,
   },
   props: {},
@@ -136,7 +136,7 @@ export const newRecordTrigger = createTrigger({
   infoForLLM: {
     description: 'Fires when a new record is created in a specific project in My App. Use to start workflows scoped to one project (e.g. notify the project team when a task is added). Polls every ~5 minutes.',
     tags: ['read', 'records'],
-    difficulty: 'easy',
+    difficulty: ActionDifficulty.EASY,
     outputSchema: `{ type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' }, project_id: { type: 'string' }, created_at: { type: 'string', format: 'date-time' } } }`,
   },
   props,
@@ -156,7 +156,7 @@ Use when the API supports webhook registration. The flow:
 3. `onDisable` -- Delete the webhook when the flow is turned off
 
 ```typescript
-import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { createTrigger, TriggerStrategy, ActionDifficulty } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 import { myAppAuth } from '../../';
 
@@ -169,7 +169,7 @@ export const newRecordWebhookTrigger = createTrigger({
   infoForLLM: {
     description: 'Fires in real time when a new record is created in My App. Use to start workflows the moment a customer, task, or document is added -- no polling delay.',
     tags: ['read', 'records'],
-    difficulty: 'medium',
+    difficulty: ActionDifficulty.MEDIUM,
     outputSchema: `{ type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' }, created_at: { type: 'string', format: 'date-time' } } }`,
   },
   props: {},

--- a/.agents/skills/piece-builder/trigger-patterns.md
+++ b/.agents/skills/piece-builder/trigger-patterns.md
@@ -1,6 +1,6 @@
 # Trigger Patterns
 
-> **AI Metadata is mandatory for every trigger.** Every `createTrigger` call must include an `infoForLLM` bundle (`description`, `tags`, `difficulty`, and `outputSchema` whenever the trigger emits a non-trivial payload). See `SKILL.md` → AI Metadata section for the rules.
+> **AI Metadata is mandatory for every trigger.** Every `createTrigger` call must include an `infoForLLM` bundle with `description`. See `SKILL.md` → AI Metadata section for the rules.
 
 Two main types: **Polling** (check API periodically) and **Webhook** (receive push notifications).
 
@@ -19,7 +19,7 @@ Two deduplication strategies:
 ### TIMEBASED Polling (most common)
 
 ```typescript
-import { createTrigger, TriggerStrategy, AppConnectionValueForAuthProperty, ActionDifficulty } from '@activepieces/pieces-framework';
+import { createTrigger, TriggerStrategy, AppConnectionValueForAuthProperty } from '@activepieces/pieces-framework';
 import { DedupeStrategy, Polling, pollingHelper, httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 import { myAppAuth } from '../../';
 
@@ -54,9 +54,6 @@ export const newRecordTrigger = createTrigger({
   // REQUIRED: AI metadata bundle read by LLM/MCP agents.
   infoForLLM: {
     description: 'Fires when a new record is created in My App. Use to start workflows when a customer, task, or document is added. Polls every ~5 minutes.',
-    tags: ['read', 'records'],
-    difficulty: ActionDifficulty.EASY,
-    outputSchema: `{ type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' }, created_at: { type: 'string', format: 'date-time' } } }`,
   },
   props: {},
   sampleData: {},
@@ -135,9 +132,6 @@ export const newRecordTrigger = createTrigger({
   // REQUIRED: AI metadata bundle.
   infoForLLM: {
     description: 'Fires when a new record is created in a specific project in My App. Use to start workflows scoped to one project (e.g. notify the project team when a task is added). Polls every ~5 minutes.',
-    tags: ['read', 'records'],
-    difficulty: ActionDifficulty.EASY,
-    outputSchema: `{ type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' }, project_id: { type: 'string' }, created_at: { type: 'string', format: 'date-time' } } }`,
   },
   props,
   sampleData: {},
@@ -156,7 +150,7 @@ Use when the API supports webhook registration. The flow:
 3. `onDisable` -- Delete the webhook when the flow is turned off
 
 ```typescript
-import { createTrigger, TriggerStrategy, ActionDifficulty } from '@activepieces/pieces-framework';
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
 import { myAppAuth } from '../../';
 
@@ -168,9 +162,6 @@ export const newRecordWebhookTrigger = createTrigger({
   // REQUIRED: AI metadata bundle.
   infoForLLM: {
     description: 'Fires in real time when a new record is created in My App. Use to start workflows the moment a customer, task, or document is added -- no polling delay.',
-    tags: ['read', 'records'],
-    difficulty: ActionDifficulty.MEDIUM,
-    outputSchema: `{ type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' }, created_at: { type: 'string', format: 'date-time' } } }`,
   },
   props: {},
   sampleData: {

--- a/.agents/skills/piece-builder/trigger-patterns.md
+++ b/.agents/skills/piece-builder/trigger-patterns.md
@@ -1,6 +1,6 @@
 # Trigger Patterns
 
-> **AI Metadata is mandatory for every trigger.** Every `createTrigger` call must include `descriptionForLLM`, `tags`, and `difficulty`. See `SKILL.md` → AI Metadata section for the rules.
+> **AI Metadata is mandatory for every trigger.** Every `createTrigger` call must include an `infoForLLM` bundle (`description`, `tags`, `difficulty`, and `outputSchema` whenever the trigger emits a non-trivial payload). See `SKILL.md` → AI Metadata section for the rules.
 
 Two main types: **Polling** (check API periodically) and **Webhook** (receive push notifications).
 
@@ -51,12 +51,13 @@ export const newRecordTrigger = createTrigger({
   name: 'new_record',
   displayName: 'New Record',
   description: 'Triggers when a new record is created',
-  // REQUIRED: LLM-optimized description
-  descriptionForLLM: 'Fires when a new record is created in My App. Use to start workflows when a customer, task, or document is added. Polls every ~5 minutes.',
-  // REQUIRED: one verb tag + one domain tag
-  tags: ['read', 'records'],
-  // REQUIRED: easy | medium | hard
-  difficulty: 'easy',
+  // REQUIRED: AI metadata bundle read by LLM/MCP agents.
+  infoForLLM: {
+    description: 'Fires when a new record is created in My App. Use to start workflows when a customer, task, or document is added. Polls every ~5 minutes.',
+    tags: ['read', 'records'],
+    difficulty: 'easy',
+    outputSchema: `{ type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' }, created_at: { type: 'string', format: 'date-time' } } }`,
+  },
   props: {},
   sampleData: {},
   type: TriggerStrategy.POLLING,
@@ -131,10 +132,13 @@ export const newRecordTrigger = createTrigger({
   name: 'new_record',
   displayName: 'New Record',
   description: 'Triggers when a new record is created in a project',
-  // REQUIRED
-  descriptionForLLM: 'Fires when a new record is created in a specific project in My App. Use to start workflows scoped to one project (e.g. notify the project team when a task is added). Polls every ~5 minutes.',
-  tags: ['read', 'records'],
-  difficulty: 'easy',
+  // REQUIRED: AI metadata bundle.
+  infoForLLM: {
+    description: 'Fires when a new record is created in a specific project in My App. Use to start workflows scoped to one project (e.g. notify the project team when a task is added). Polls every ~5 minutes.',
+    tags: ['read', 'records'],
+    difficulty: 'easy',
+    outputSchema: `{ type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' }, project_id: { type: 'string' }, created_at: { type: 'string', format: 'date-time' } } }`,
+  },
   props,
   sampleData: {},
   type: TriggerStrategy.POLLING,
@@ -161,10 +165,13 @@ export const newRecordWebhookTrigger = createTrigger({
   name: 'new_record_webhook',
   displayName: 'New Record',
   description: 'Triggers when a new record is created',
-  // REQUIRED
-  descriptionForLLM: 'Fires in real time when a new record is created in My App. Use to start workflows the moment a customer, task, or document is added -- no polling delay.',
-  tags: ['read', 'records'],
-  difficulty: 'medium',
+  // REQUIRED: AI metadata bundle.
+  infoForLLM: {
+    description: 'Fires in real time when a new record is created in My App. Use to start workflows the moment a customer, task, or document is added -- no polling delay.',
+    tags: ['read', 'records'],
+    difficulty: 'medium',
+    outputSchema: `{ type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' }, created_at: { type: 'string', format: 'date-time' } } }`,
+  },
   props: {},
   sampleData: {
     id: '123',

--- a/.agents/skills/piece-builder/trigger-patterns.md
+++ b/.agents/skills/piece-builder/trigger-patterns.md
@@ -1,5 +1,7 @@
 # Trigger Patterns
 
+> **AI Metadata is mandatory for every trigger.** Every `createTrigger` call must include `descriptionForLLM`, `tags`, and `difficulty`. See `SKILL.md` → AI Metadata section for the rules.
+
 Two main types: **Polling** (check API periodically) and **Webhook** (receive push notifications).
 
 Prefer webhooks when the API supports them -- they are instant and use fewer resources.
@@ -49,6 +51,12 @@ export const newRecordTrigger = createTrigger({
   name: 'new_record',
   displayName: 'New Record',
   description: 'Triggers when a new record is created',
+  // REQUIRED: LLM-optimized description
+  descriptionForLLM: 'Fires when a new record is created in My App. Use to start workflows when a customer, task, or document is added. Polls every ~5 minutes.',
+  // REQUIRED: one verb tag + one domain tag
+  tags: ['read', 'records'],
+  // REQUIRED: easy | medium | hard
+  difficulty: 'easy',
   props: {},
   sampleData: {},
   type: TriggerStrategy.POLLING,
@@ -123,6 +131,10 @@ export const newRecordTrigger = createTrigger({
   name: 'new_record',
   displayName: 'New Record',
   description: 'Triggers when a new record is created in a project',
+  // REQUIRED
+  descriptionForLLM: 'Fires when a new record is created in a specific project in My App. Use to start workflows scoped to one project (e.g. notify the project team when a task is added). Polls every ~5 minutes.',
+  tags: ['read', 'records'],
+  difficulty: 'easy',
   props,
   sampleData: {},
   type: TriggerStrategy.POLLING,
@@ -149,6 +161,10 @@ export const newRecordWebhookTrigger = createTrigger({
   name: 'new_record_webhook',
   displayName: 'New Record',
   description: 'Triggers when a new record is created',
+  // REQUIRED
+  descriptionForLLM: 'Fires in real time when a new record is created in My App. Use to start workflows the moment a customer, task, or document is added -- no polling delay.',
+  tags: ['read', 'records'],
+  difficulty: 'medium',
   props: {},
   sampleData: {
     id: '123',


### PR DESCRIPTION
## Summary

Updates the shared piece-builder skill docs at \`.agents/skills/piece-builder/\` so every new action, trigger, and property authored by Claude Code or Cursor must populate the AI metadata fields added to the pieces framework in #12669.

**Builds on #12669** (framework field additions). That PR adds the optional fields; this PR teaches the agent skill to actually fill them in.

### New mandatory section in SKILL.md

Adds **\"AI Metadata: Required for Every Action & Trigger\"** with:
- Required fields per context (action, trigger, property)
- Description writing rules (verb-first template, bad/good examples)
- Property \`example\` rules (real IDs, ISO dates, full URLs)
- Optional \`ActionResult<T>\` return-type pattern

Also adds AI Metadata as critical reminder #1 and a new row in the Step 4 implement table.

### Template updates

| File | Change |
|---|---|
| \`action-patterns.md\` | Template now includes \`descriptionForLLM\`, \`tags\`, \`difficulty\`, \`outputSchema\`, and \`example\` on every property. Imports \`ActionResult\`. |
| \`trigger-patterns.md\` | All 3 trigger examples (basic polling, polling-with-props, webhook) now include \`descriptionForLLM\`, \`tags\`, \`difficulty\`. |
| \`props-patterns.md\` | Every static property (\`ShortText\`, \`LongText\`, \`Number\`, \`Checkbox\`, \`DateTime\`, \`Json\`, \`Object\`, \`Array\`, \`StaticDropdown\`, \`StaticMultiSelectDropdown\`) now shows a realistic \`example:\` value. |

### Why

The framework fields landed in #12669 but no skill guidance pointed at them — a new piece built via \`piece-builder\` would still produce zero AI metadata. This PR closes that gap so pieces are AI-ready-by-default from the moment they're created.

## Test plan

- [x] Skill docs updated in 4 files, 141 insertions / 15 deletions
- [ ] Smoke test: ask a fresh Claude Code session to \"create a piece for Linear with a Create Issue action\" — verify all five AI metadata fields appear in the generated code without being prompted
- [ ] Same smoke test in Cursor (shares the same \`.agents/skills/\` directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)