### PR TITLE
feat(flodesk): add Flodesk email marketing piece (#12170)

### DIFF
--- a/packages/pieces/community/flodesk/package.json
+++ b/packages/pieces/community/flodesk/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-flodesk",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/flodesk/src/index.ts
+++ b/packages/pieces/community/flodesk/src/index.ts
@@ -1,0 +1,27 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createOrUpdateSubscriber } from './lib/actions/create-or-update-subscriber';
+import { addSubscriberToSegments } from './lib/actions/add-subscriber-to-segments';
+import { findSubscriber } from './lib/actions/find-subscriber';
+
+export const flodeskAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Enter your Flodesk API key (Bearer token)',
+  required: true,
+});
+
+export const flodesk = createPiece({
+  displayName: 'Flodesk',
+  description: 'Email marketing platform for creators with beautiful templates',
+  auth: flodeskAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/flodesk.png',
+  categories: [PieceCategory.MARKETING],
+  authors: ['tarai-dl'],
+  actions: [
+    createOrUpdateSubscriber,
+    addSubscriberToSegments,
+    findSubscriber,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/flodesk/src/lib/actions/add-subscriber-to-segments.ts
+++ b/packages/pieces/community/flodesk/src/lib/actions/add-subscriber-to-segments.ts
@@ -1,0 +1,42 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { flodeskAuth } from '../..';
+
+const BASE_URL = 'https://api.flodesk.com/v1';
+
+export const addSubscriberToSegments = createAction({
+  auth: flodeskAuth,
+  name: 'add_subscriber_to_segments',
+  displayName: 'Add Subscriber To Segments',
+  description:
+    'Add a subscriber to one or more segments in Flodesk. [See the documentation](https://developers.flodesk.com/#tag/subscriber/operation/addSubscriberToSegments)',
+  props: {
+    subscriber_id: Property.ShortText({
+      displayName: 'Subscriber ID',
+      description: 'The ID of the subscriber to add to segments',
+      required: true,
+    }),
+    segment_ids: Property.Array({
+      displayName: 'Segment IDs',
+      description: 'Array of segment IDs to add the subscriber to',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { subscriber_id, segment_ids } = propsValue;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/subscribers/${subscriber_id}/segments`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        segment_ids,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flodesk/src/lib/actions/create-or-update-subscriber.ts
+++ b/packages/pieces/community/flodesk/src/lib/actions/create-or-update-subscriber.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { flodeskAuth } from '../..';
+
+const BASE_URL = 'https://api.flodesk.com/v1';
+
+export const createOrUpdateSubscriber = createAction({
+  auth: flodeskAuth,
+  name: 'create_or_update_subscriber',
+  displayName: 'Create or Update Subscriber',
+  description:
+    'Creates a new subscriber or updates an existing one in Flodesk. [See the documentation](https://developers.flodesk.com/#tag/subscriber/operation/createOrUpdateSubscriber)',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'The subscriber email address',
+      required: true,
+    }),
+    first_name: Property.ShortText({
+      displayName: 'First Name',
+      description: 'The subscriber first name',
+      required: false,
+    }),
+    last_name: Property.ShortText({
+      displayName: 'Last Name',
+      description: 'The subscriber last name',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { email, first_name, last_name } = propsValue;
+
+    const body: Record<string, unknown> = { email };
+    if (first_name) body['first_name'] = first_name;
+    if (last_name) body['last_name'] = last_name;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/subscribers`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flodesk/src/lib/actions/find-subscriber.ts
+++ b/packages/pieces/community/flodesk/src/lib/actions/find-subscriber.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { flodeskAuth } from '../..';
+
+const BASE_URL = 'https://api.flodesk.com/v1';
+
+export const findSubscriber = createAction({
+  auth: flodeskAuth,
+  name: 'find_subscriber',
+  displayName: 'Find Subscriber By Email',
+  description:
+    'Find a subscriber by email address in Flodesk. [See the documentation](https://developers.flodesk.com/#tag/subscriber/operation/retrieveSubscriber)',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Email address of the subscriber to find',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { email } = propsValue;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${BASE_URL}/subscribers`,
+      headers: {
+        Authorization: `Bearer ${auth}`,
+      },
+      queryParams: {
+        email,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flodesk/tsconfig.json
+++ b/packages/pieces/community/flodesk/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/flodesk/tsconfig.lib.json
+++ b/packages/pieces/community/flodesk/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new Activepieces piece for [Flodesk](https://flodesk.com/), an email marketing platform for creators known for beautiful templates.

### Actions (3)
- `create_or_update_subscriber` — Create or update a subscriber in Flodesk
- `add_subscriber_to_segments` — Add a subscriber to one or more segments
- `find_subscriber` — Find a subscriber by email address

### Auth
- API Key (Bearer token)

### Reference
- [Pipedream Flodesk components](https://github.com/PipedreamHQ/pipedream/tree/master/components/flodesk)
- [Flodesk API docs](https://developers.flodesk.com/)

Closes #12170