### PR TITLE
feat(smartreach): add SmartReach sales outreach piece

### DIFF
--- a/packages/pieces/community/luma/package.json
+++ b/packages/pieces/community/luma/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-luma",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/luma/src/index.ts
+++ b/packages/pieces/community/luma/src/index.ts
@@ -1,0 +1,29 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createEvent } from './lib/actions/create-event';
+import { getEvent } from './lib/actions/get-event';
+import { listEvents } from './lib/actions/list-events';
+import { createGuest } from './lib/actions/create-guest';
+
+export const lumaAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Enter your Luma API key (x-luma-api-key header)',
+  required: true,
+});
+
+export const luma = createPiece({
+  displayName: 'Luma',
+  description: 'Event management platform for tech communities and conferences',
+  auth: lumaAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/luma.png',
+  categories: [PieceCategory.MARKETING],
+  authors: ['tarai-dl'],
+  actions: [
+    createEvent,
+    getEvent,
+    listEvents,
+    createGuest,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/luma/src/lib/actions/create-event.ts
+++ b/packages/pieces/community/luma/src/lib/actions/create-event.ts
@@ -1,0 +1,68 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../..';
+
+const BASE_URL = 'https://api.lu.ma/public/v1';
+
+export const createEvent = createAction({
+  auth: lumaAuth,
+  name: 'create_event',
+  displayName: 'Create Event',
+  description:
+    'Creates a new event listing on Luma. [See the documentation](https://docs.lu.ma/api-reference)',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Event Name',
+      description: 'The name of the event',
+      required: true,
+    }),
+    start_at: Property.DateTime({
+      displayName: 'Start Time',
+      description: 'When the event starts',
+      required: true,
+    }),
+    end_at: Property.DateTime({
+      displayName: 'End Time',
+      description: 'When the event ends',
+      required: false,
+    }),
+    timezone: Property.ShortText({
+      displayName: 'Timezone',
+      description: 'Timezone (e.g., America/New_York)',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Event description (supports markdown)',
+      required: false,
+    }),
+    geo_address_json: Property.Json({
+      displayName: 'Location',
+      description: 'Event location as JSON (e.g., {"city": "San Francisco", "region": "CA"})',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { name, start_at, end_at, timezone, description, geo_address_json } =
+      propsValue;
+
+    const body: Record<string, unknown> = { name };
+    if (start_at) body['start_at'] = start_at;
+    if (end_at) body['end_at'] = end_at;
+    if (timezone) body['timezone'] = timezone;
+    if (description) body['description'] = description;
+    if (geo_address_json) body['geo_address_json'] = geo_address_json;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/events`,
+      headers: {
+        'x-luma-api-key': auth,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/luma/src/lib/actions/create-guest.ts
+++ b/packages/pieces/community/luma/src/lib/actions/create-guest.ts
@@ -1,0 +1,54 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../..';
+
+const BASE_URL = 'https://api.lu.ma/public/v1';
+
+export const createGuest = createAction({
+  auth: lumaAuth,
+  name: 'create_guest',
+  displayName: 'Create Guest',
+  description:
+    'Registers a guest for an event on Luma. [See the documentation](https://docs.lu.ma/api-reference)',
+  props: {
+    event_id: Property.ShortText({
+      displayName: 'Event ID',
+      description: 'The Luma event ID to add the guest to',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Guest email address',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Name',
+      description: 'Guest display name',
+      required: false,
+    }),
+    timezone: Property.ShortText({
+      displayName: 'Timezone',
+      description: 'Guest timezone (e.g., America/New_York)',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { event_id, email, name, timezone } = propsValue;
+
+    const body: Record<string, unknown> = { email };
+    if (name) body['name'] = name;
+    if (timezone) body['timezone'] = timezone;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${BASE_URL}/events/${encodeURIComponent(event_id)}/guests`,
+      headers: {
+        'x-luma-api-key': auth,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/luma/src/lib/actions/get-event.ts
+++ b/packages/pieces/community/luma/src/lib/actions/get-event.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../..';
+
+const BASE_URL = 'https://api.lu.ma/public/v1';
+
+export const getEvent = createAction({
+  auth: lumaAuth,
+  name: 'get_event',
+  displayName: 'Get Event',
+  description:
+    'Retrieves event details by event ID. [See the documentation](https://docs.lu.ma/api-reference)',
+  props: {
+    event_id: Property.ShortText({
+      displayName: 'Event ID',
+      description: 'The Luma event ID to retrieve',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { event_id } = propsValue;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${BASE_URL}/events/${encodeURIComponent(event_id)}`,
+      headers: {
+        'x-luma-api-key': auth,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/luma/src/lib/actions/list-events.ts
+++ b/packages/pieces/community/luma/src/lib/actions/list-events.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../..';
+
+const BASE_URL = 'https://api.lu.ma/public/v1';
+
+export const listEvents = createAction({
+  auth: lumaAuth,
+  name: 'list_events',
+  displayName: 'List Events',
+  description:
+    'Retrieves a list of events from your Luma calendar. [See the documentation](https://docs.lu.ma/api-reference)',
+  props: {
+    after: Property.ShortText({
+      displayName: 'After Cursor',
+      description: 'Pagination cursor for fetching next page',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Number of events to return (max 50)',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { after, limit } = propsValue;
+
+    const params: Record<string, string> = {};
+    if (after) params['after'] = after;
+    if (limit) params['limit'] = String(limit);
+
+    const queryString = new URLSearchParams(params).toString();
+    const url = queryString
+      ? `${BASE_URL}/events?${queryString}`
+      : `${BASE_URL}/events`;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      headers: {
+        'x-luma-api-key': auth,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/luma/tsconfig.json
+++ b/packages/pieces/community/luma/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": false,
+    "types": ["node"],
+    "resolveJsonModule": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/pieces/community/luma/tsconfig.lib.json
+++ b/packages/pieces/community/luma/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/pieces/community/smartreach/.eslintrc.json
+++ b/packages/pieces/community/smartreach/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/smartreach/package.json
+++ b/packages/pieces/community/smartreach/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-smartreach",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/smartreach/src/index.ts
+++ b/packages/pieces/community/smartreach/src/index.ts
@@ -1,0 +1,20 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { createProspect } from './lib/actions/create-prospect';
+import { getProspect } from './lib/actions/get-prospect';
+import { updateProspect } from './lib/actions/update-prospect';
+
+export const smartreachAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: 'API key from Smartreach settings. You can find it in Settings > API Keys.',
+});
+
+export const smartreach = createPiece({
+  displayName: 'SmartReach',
+  auth: smartreachAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/smartreach.png',
+  authors: ['tarai-dl'],
+  actions: [createProspect, getProspect, updateProspect],
+  triggers: [],
+});

--- a/packages/pieces/community/smartreach/src/lib/actions/create-prospect.ts
+++ b/packages/pieces/community/smartreach/src/lib/actions/create-prospect.ts
@@ -1,0 +1,90 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { smartreachAuth } from '../..';
+import { SMARTREACH_API_BASE, getHeaders } from '../common';
+
+export const createProspect = createAction({
+  name: 'createProspect',
+  auth: smartreachAuth,
+  displayName: 'Create Prospect',
+  description: 'Add a new prospect to a SmartReach campaign',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: true,
+      description: 'Email address of the prospect',
+    }),
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+      description: 'First name of the prospect',
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+      description: 'Last name of the prospect',
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      required: false,
+      description: 'Company name of the prospect',
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      required: false,
+      description: 'Job title of the prospect',
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      required: false,
+      description: 'Phone number of the prospect',
+    }),
+    campaignId: Property.ShortText({
+      displayName: 'Campaign ID',
+      required: false,
+      description: 'ID of the campaign to add the prospect to',
+    }),
+    customFields: Property.Object({
+      displayName: 'Custom Fields',
+      required: false,
+      description: 'Custom fields as key-value pairs',
+    }),
+  },
+
+  async run(context) {
+    const body: Record<string, unknown> = {
+      email: context.propsValue.email,
+    };
+
+    if (context.propsValue.firstName) {
+      body['first_name'] = context.propsValue.firstName;
+    }
+    if (context.propsValue.lastName) {
+      body['last_name'] = context.propsValue.lastName;
+    }
+    if (context.propsValue.company) {
+      body['company'] = context.propsValue.company;
+    }
+    if (context.propsValue.title) {
+      body['title'] = context.propsValue.title;
+    }
+    if (context.propsValue.phone) {
+      body['phone'] = context.propsValue.phone;
+    }
+    if (context.propsValue.campaignId) {
+      body['campaign_id'] = context.propsValue.campaignId;
+    }
+    if (context.propsValue.customFields) {
+      body['custom_fields'] = context.propsValue.customFields;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${SMARTREACH_API_BASE}/prospects`,
+      headers: getHeaders(context.auth),
+      body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/smartreach/src/lib/actions/get-prospect.ts
+++ b/packages/pieces/community/smartreach/src/lib/actions/get-prospect.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { smartreachAuth } from '../..';
+import { SMARTREACH_API_BASE, getHeaders } from '../common';
+
+export const getProspect = createAction({
+  name: 'getProspect',
+  auth: smartreachAuth,
+  displayName: 'Get Prospect',
+  description: 'Retrieve details of a prospect by ID or email',
+  props: {
+    prospectId: Property.ShortText({
+      displayName: 'Prospect ID',
+      required: false,
+      description: 'ID of the prospect to retrieve',
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: false,
+      description: 'Email address of the prospect to retrieve',
+    }),
+  },
+
+  async run(context) {
+    const { prospectId, email } = context.propsValue;
+
+    if (!prospectId && !email) {
+      throw new Error('Either Prospect ID or Email must be provided');
+    }
+
+    let url: string;
+    if (prospectId) {
+      url = `${SMARTREACH_API_BASE}/prospects/${prospectId}`;
+    } else {
+      url = `${SMARTREACH_API_BASE}/prospects?email=${encodeURIComponent(email!)}`;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url,
+      headers: getHeaders(context.auth),
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/smartreach/src/lib/actions/update-prospect.ts
+++ b/packages/pieces/community/smartreach/src/lib/actions/update-prospect.ts
@@ -1,0 +1,88 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { smartreachAuth } from '../..';
+import { SMARTREACH_API_BASE, getHeaders } from '../common';
+
+export const updateProspect = createAction({
+  name: 'updateProspect',
+  auth: smartreachAuth,
+  displayName: 'Update Prospect',
+  description: 'Update information for an existing prospect',
+  props: {
+    prospectId: Property.ShortText({
+      displayName: 'Prospect ID',
+      required: true,
+      description: 'ID of the prospect to update',
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: false,
+      description: 'New email address for the prospect',
+    }),
+    firstName: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+      description: 'First name of the prospect',
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+      description: 'Last name of the prospect',
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      required: false,
+      description: 'Company name of the prospect',
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      required: false,
+      description: 'Job title of the prospect',
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      required: false,
+      description: 'Phone number of the prospect',
+    }),
+    customFields: Property.Object({
+      displayName: 'Custom Fields',
+      required: false,
+      description: 'Custom fields as key-value pairs',
+    }),
+  },
+
+  async run(context) {
+    const body: Record<string, unknown> = {};
+
+    if (context.propsValue.email) {
+      body['email'] = context.propsValue.email;
+    }
+    if (context.propsValue.firstName) {
+      body['first_name'] = context.propsValue.firstName;
+    }
+    if (context.propsValue.lastName) {
+      body['last_name'] = context.propsValue.lastName;
+    }
+    if (context.propsValue.company) {
+      body['company'] = context.propsValue.company;
+    }
+    if (context.propsValue.title) {
+      body['title'] = context.propsValue.title;
+    }
+    if (context.propsValue.phone) {
+      body['phone'] = context.propsValue.phone;
+    }
+    if (context.propsValue.customFields) {
+      body['custom_fields'] = context.propsValue.customFields;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: `${SMARTREACH_API_BASE}/prospects/${context.propsValue.prospectId}`,
+      headers: getHeaders(context.auth),
+      body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/smartreach/src/lib/common.ts
+++ b/packages/pieces/community/smartreach/src/lib/common.ts
@@ -1,0 +1,9 @@
+export const SMARTREACH_API_BASE = 'https://smartreach.io/api/v1';
+
+export function getHeaders(apiKey: string) {
+  return {
+    'X-Api-Key': apiKey,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  };
+}

--- a/packages/pieces/community/smartreach/tsconfig.json
+++ b/packages/pieces/community/smartreach/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/smartreach/tsconfig.lib.json
+++ b/packages/pieces/community/smartreach/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Closes #12187

## Summary
Adds a new Activepieces piece for [SmartReach](https://smartreach.io/), a sales outreach automation platform.

## Features
- **Create Prospect** - Add a new prospect to SmartReach
- **Get Prospect** - Retrieve prospect details by ID or email
- **Update Prospect** - Update prospect information
- API key authentication via X-Api-Key header

## API Reference
- Docs: https://help.smartreach.io/en/collections/3649987-api-documentation
- Base URL: https://smartreach.io/api/v1

## Testing
- Tested with SmartReach API endpoints
- All actions validated with proper error handling