### PR TITLE
feat(sendbird): add Sendbird messaging piece (#12186)

### DIFF
--- a/packages/pieces/community/sendbird/.eslintrc.json
+++ b/packages/pieces/community/sendbird/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/sendbird/package.json
+++ b/packages/pieces/community/sendbird/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-sendbird",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "devDependencies": {}
+}

--- a/packages/pieces/community/sendbird/src/index.ts
+++ b/packages/pieces/community/sendbird/src/index.ts
@@ -1,0 +1,31 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { sendMessage } from './lib/actions/send-message';
+import { listMessages } from './lib/actions/list-messages';
+import { sendbirdAuth, SendbirdAuthValue } from './lib/auth';
+
+export const sendbird = createPiece({
+  displayName: 'Sendbird',
+  description: 'Messaging and chat API platform for building real-time messaging features',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/sendbird.png',
+  authors: ['tarai-dl'],
+  categories: [PieceCategory.COMMUNICATION],
+  auth: sendbirdAuth,
+  actions: [
+    sendMessage,
+    listMessages,
+    createCustomApiCallAction({
+      baseUrl: (auth) => {
+        const { appId } = auth as SendbirdAuthValue;
+        return `https://api-${appId}.sendbird.com/v3`;
+      },
+      auth: sendbirdAuth,
+      authMapping: async (auth) => ({
+        'Api-Token': (auth as SendbirdAuthValue).apiToken,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/sendbird/src/lib/actions/list-messages.ts
+++ b/packages/pieces/community/sendbird/src/lib/actions/list-messages.ts
@@ -1,0 +1,68 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { sendbirdAuth, SendbirdAuthValue } from '../auth';
+
+export const listMessages = createAction({
+  name: 'list_messages',
+  auth: sendbirdAuth,
+  displayName: 'List Messages',
+  description: 'List messages in a Sendbird channel',
+  props: {
+    channelType: Property.StaticDropdown({
+      displayName: 'Channel Type',
+      description: 'Type of the channel',
+      required: true,
+      options: {
+        options: [
+          { label: 'Open Channel', value: 'open_channels' },
+          { label: 'Group Channel', value: 'group_channels' },
+        ],
+      },
+    }),
+    channelUrl: Property.ShortText({
+      displayName: 'Channel URL',
+      description: 'The URL of the channel to list messages from',
+      required: true,
+    }),
+    messageTs: Property.ShortText({
+      displayName: 'Message Timestamp',
+      description: 'Timestamp to retrieve messages sent before (Unix timestamp in milliseconds). Leave empty for latest messages.',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of messages to retrieve (default: 20, max: 200)',
+      required: false,
+      defaultValue: 20,
+    }),
+  },
+  async run({ propsValue, auth }) {
+    const { appId, apiToken } = auth as SendbirdAuthValue;
+    const { channelType, channelUrl, messageTs, limit } = propsValue;
+
+    const queryParams: Record<string, string> = {
+      limit: String(Math.min(limit || 20, 200)),
+    };
+
+    if (messageTs) {
+      queryParams.message_ts = messageTs;
+    }
+
+    const queryString = new URLSearchParams(queryParams).toString();
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api-${appId}.sendbird.com/v3/${channelType}/${channelUrl}/messages?${queryString}`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: apiToken,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/sendbird/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/sendbird/src/lib/actions/send-message.ts
@@ -1,0 +1,75 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { sendbirdAuth, SendbirdAuthValue } from '../auth';
+
+export const sendMessage = createAction({
+  name: 'send_message',
+  auth: sendbirdAuth,
+  displayName: 'Send Message',
+  description: 'Send a message to a channel in Sendbird',
+  props: {
+    channelType: Property.StaticDropdown({
+      displayName: 'Channel Type',
+      description: 'Type of the channel',
+      required: true,
+      options: {
+        options: [
+          { label: 'Open Channel', value: 'open_channels' },
+          { label: 'Group Channel', value: 'group_channels' },
+        ],
+      },
+    }),
+    channelUrl: Property.ShortText({
+      displayName: 'Channel URL',
+      description: 'The URL of the channel to send the message to',
+      required: true,
+    }),
+    messageType: Property.StaticDropdown({
+      displayName: 'Message Type',
+      description: 'Type of the message',
+      required: true,
+      options: {
+        options: [
+          { label: 'MESG (User Message)', value: 'MESG' },
+          { label: 'FILE (File Message)', value: 'FILE' },
+          { label: 'ADMM (Admin Message)', value: 'ADMM' },
+        ],
+      },
+      defaultValue: 'MESG',
+    }),
+    message: Property.LongText({
+      displayName: 'Message',
+      description: 'The content of the message',
+      required: true,
+    }),
+    senderId: Property.ShortText({
+      displayName: 'Sender User ID',
+      description: 'The user ID of the sender',
+      required: true,
+    }),
+  },
+  async run({ propsValue, auth }) {
+    const { appId, apiToken } = auth as SendbirdAuthValue;
+    const { channelType, channelUrl, messageType, message, senderId } = propsValue;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `https://api-${appId}.sendbird.com/v3/${channelType}/${channelUrl}/messages`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: apiToken,
+      },
+      body: {
+        message_type: messageType,
+        message: message,
+        user_id: senderId,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/sendbird/src/lib/auth.ts
+++ b/packages/pieces/community/sendbird/src/lib/auth.ts
@@ -1,0 +1,23 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const sendbirdAuth = PieceAuth.CustomAuth({
+  description: 'Authenticate with your Sendbird application.',
+  required: true,
+  props: {
+    appId: PieceAuth.SecretText({
+      displayName: 'Application ID',
+      description: 'Your Sendbird Application ID (found in Sendbird Dashboard)',
+      required: true,
+    }),
+    apiToken: PieceAuth.SecretText({
+      displayName: 'API Token',
+      description: 'Your Sendbird API Token (found in Sendbird Dashboard > Settings > General)',
+      required: true,
+    }),
+  },
+});
+
+export type SendbirdAuthValue = {
+  appId: string;
+  apiToken: string;
+};

--- a/packages/pieces/community/sendbird/tsconfig.json
+++ b/packages/pieces/community/sendbird/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/sendbird/tsconfig.lib.json
+++ b/packages/pieces/community/sendbird/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a new Activepieces piece for [Sendbird](https://sendbird.com/), a messaging and chat API platform.

Closes #12186

## Changes

### New Piece: `@activepieces/piece-sendbird`

**Authentication:** API Token (`X-API-Token` header) + Application ID

**Actions:**
1. **Send Message** (`send_message`) — Send a message to an open or group channel
   - Channel type selector (Open/Group)
   - Channel URL input
   - Message type (MESG/FILE/ADMM)
   - Message content
   - Sender User ID

2. **List Messages** (`list_messages`) — List messages in a channel with pagination
   - Channel type selector (Open/Group)
   - Channel URL input
   - Optional message timestamp filter
   - Configurable limit (default 20, max 200)

3. **Custom API Call** — For advanced use cases

## API Reference
- [Sendbird Platform API v3](https://sendbird.com/docs/chat/platform-api/v3/overview)
- [Pipedream Sendbird components](https://github.com/PipedreamHQ/pipedream/tree/master/components/sendbird)

## Testing
Requires a Sendbird application with API token. Sign up at https://dashboard.sendbird.com/