### PR TITLE
feat(pieces): add Luma event management piece

### DIFF
--- a/packages/pieces/community/luma/.eslintrc.json
+++ b/packages/pieces/community/luma/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/luma/package.json
+++ b/packages/pieces/community/luma/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-luma",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/luma/src/index.ts
+++ b/packages/pieces/community/luma/src/index.ts
@@ -1,0 +1,33 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { lumaAuth } from './lib/auth';
+import { lumaCommon } from './lib/common';
+import { createEventAction } from './lib/actions/create-event';
+import { getEventAction } from './lib/actions/get-event';
+import { listEventsAction } from './lib/actions/list-events';
+import { addGuestsAction } from './lib/actions/add-guests';
+
+export const luma = createPiece({
+  displayName: 'Luma',
+  description: 'Modern event management platform for tech communities and conferences',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/luma.png',
+  categories: [PieceCategory.PRODUCTIVITY],
+  authors: ['tarai-dl'],
+  auth: lumaAuth,
+  actions: [
+    createEventAction,
+    getEventAction,
+    listEventsAction,
+    addGuestsAction,
+    createCustomApiCallAction({
+      baseUrl: () => lumaCommon.BASE_URL,
+      auth: lumaAuth,
+      authMapping: async (auth) => ({
+        'x-luma-api-key': auth as string,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/luma/src/lib/actions/add-guests.ts
+++ b/packages/pieces/community/luma/src/lib/actions/add-guests.ts
@@ -1,0 +1,38 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../auth';
+import { lumaCommon } from '../common';
+
+export const addGuestsAction = createAction({
+  auth: lumaAuth,
+  name: 'add-guests',
+  displayName: 'Add Guests',
+  description: 'Register guests for a Luma event',
+  props: {
+    event_id: Property.ShortText({
+      displayName: 'Event ID',
+      description: 'The event ID (starts with evt-)',
+      required: true,
+    }),
+    emails: Property.Array({
+      displayName: 'Guest Emails',
+      description: 'Email addresses of guests to add',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const guests = (propsValue.emails as string[]).map((email) => ({
+      email,
+    }));
+
+    return lumaCommon.makeRequest({
+      apiKey: auth,
+      method: HttpMethod.POST,
+      path: '/event/add-guests',
+      body: {
+        event_id: propsValue.event_id,
+        guests,
+      },
+    });
+  },
+});

--- a/packages/pieces/community/luma/src/lib/actions/create-event.ts
+++ b/packages/pieces/community/luma/src/lib/actions/create-event.ts
@@ -1,0 +1,76 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../auth';
+import { lumaCommon } from '../common';
+
+export const createEventAction = createAction({
+  auth: lumaAuth,
+  name: 'create-event',
+  displayName: 'Create Event',
+  description: 'Create a new event on Luma',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Event Name',
+      required: true,
+    }),
+    start_at: Property.DateTime({
+      displayName: 'Start Date & Time',
+      required: true,
+    }),
+    end_at: Property.DateTime({
+      displayName: 'End Date & Time',
+      required: false,
+    }),
+    timezone: Property.ShortText({
+      displayName: 'Timezone',
+      description: 'IANA timezone, e.g. America/New_York',
+      required: true,
+    }),
+    description_md: Property.LongText({
+      displayName: 'Description',
+      description: 'Event description in markdown',
+      required: false,
+    }),
+    meeting_url: Property.ShortText({
+      displayName: 'Meeting URL',
+      description: 'Online meeting link (Zoom, Google Meet, etc.)',
+      required: false,
+    }),
+    visibility: Property.StaticDropdown({
+      displayName: 'Visibility',
+      required: false,
+      options: {
+        options: [
+          { label: 'Public', value: 'public' },
+          { label: 'Private', value: 'private' },
+          { label: 'Unlisted', value: 'unlisted' },
+        ],
+      },
+    }),
+    max_capacity: Property.Number({
+      displayName: 'Max Capacity',
+      description: 'Maximum number of guests. Leave empty for unlimited.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const body: Record<string, unknown> = {
+      name: propsValue.name,
+      start_at: new Date(propsValue.start_at).toISOString(),
+      timezone: propsValue.timezone,
+    };
+
+    if (propsValue.end_at) body.end_at = new Date(propsValue.end_at).toISOString();
+    if (propsValue.description_md) body.description_md = propsValue.description_md;
+    if (propsValue.meeting_url) body.meeting_url = propsValue.meeting_url;
+    if (propsValue.visibility) body.visibility = propsValue.visibility;
+    if (propsValue.max_capacity) body.max_capacity = propsValue.max_capacity;
+
+    return lumaCommon.makeRequest({
+      apiKey: auth,
+      method: HttpMethod.POST,
+      path: '/event/create',
+      body,
+    });
+  },
+});

--- a/packages/pieces/community/luma/src/lib/actions/get-event.ts
+++ b/packages/pieces/community/luma/src/lib/actions/get-event.ts
@@ -1,0 +1,26 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../auth';
+import { lumaCommon } from '../common';
+
+export const getEventAction = createAction({
+  auth: lumaAuth,
+  name: 'get-event',
+  displayName: 'Get Event',
+  description: 'Retrieve details of a Luma event',
+  props: {
+    event_id: Property.ShortText({
+      displayName: 'Event ID',
+      description: 'The event ID (starts with evt-) or the event URL slug',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    return lumaCommon.makeRequest({
+      apiKey: auth,
+      method: HttpMethod.GET,
+      path: '/event/get',
+      queryParams: { event_id: propsValue.event_id },
+    });
+  },
+});

--- a/packages/pieces/community/luma/src/lib/actions/list-events.ts
+++ b/packages/pieces/community/luma/src/lib/actions/list-events.ts
@@ -1,0 +1,54 @@
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { lumaAuth } from '../auth';
+import { lumaCommon } from '../common';
+
+export const listEventsAction = createAction({
+  auth: lumaAuth,
+  name: 'list-events',
+  displayName: 'List Events',
+  description: 'List events from your Luma calendar',
+  props: {
+    after: Property.DateTime({
+      displayName: 'After',
+      description: 'Only return events starting after this date',
+      required: false,
+    }),
+    before: Property.DateTime({
+      displayName: 'Before',
+      description: 'Only return events starting before this date',
+      required: false,
+    }),
+    pagination_limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Number of events to return (max 50)',
+      required: false,
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      required: false,
+      options: {
+        options: [
+          { label: 'Approved', value: 'approved' },
+          { label: 'Pending', value: 'pending' },
+          { label: 'Rejected', value: 'rejected' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const queryParams: Record<string, string> = {};
+
+    if (propsValue.after) queryParams.after = new Date(propsValue.after).toISOString();
+    if (propsValue.before) queryParams.before = new Date(propsValue.before).toISOString();
+    if (propsValue.pagination_limit) queryParams.pagination_limit = String(propsValue.pagination_limit);
+    if (propsValue.status) queryParams.status = propsValue.status;
+
+    return lumaCommon.makeRequest({
+      apiKey: auth,
+      method: HttpMethod.GET,
+      path: '/calendar/list-events',
+      queryParams,
+    });
+  },
+});

--- a/packages/pieces/community/luma/src/lib/auth.ts
+++ b/packages/pieces/community/luma/src/lib/auth.ts
@@ -1,0 +1,31 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { tryCatch } from '@activepieces/shared';
+
+const BASE_URL = 'https://api.lu.ma/public/v1';
+
+async function validateApiKey(apiKey: string) {
+  return httpClient.sendRequest({
+    method: HttpMethod.GET,
+    url: `${BASE_URL}/user/get-self`,
+    headers: { 'x-luma-api-key': apiKey },
+  });
+}
+
+export const lumaAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: 'Luma API key from your calendar settings (Settings → API Keys)',
+  validate: async ({ auth }) => {
+    const { error } = await tryCatch(() => validateApiKey(auth));
+
+    if (error) {
+      return {
+        valid: false,
+        error: 'Invalid API key. Please check your Luma calendar API key.',
+      };
+    }
+
+    return { valid: true };
+  },
+});

--- a/packages/pieces/community/luma/src/lib/common.ts
+++ b/packages/pieces/community/luma/src/lib/common.ts
@@ -1,0 +1,31 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.lu.ma/public/v1';
+
+async function makeRequest({
+  apiKey,
+  method,
+  path,
+  body,
+  queryParams,
+}: {
+  apiKey: string;
+  method: HttpMethod;
+  path: string;
+  body?: Record<string, unknown>;
+  queryParams?: Record<string, string>;
+}) {
+  const response = await httpClient.sendRequest({
+    method,
+    url: `${BASE_URL}${path}`,
+    headers: {
+      'x-luma-api-key': apiKey,
+      'Content-Type': 'application/json',
+    },
+    body,
+    queryParams,
+  });
+  return response.body;
+}
+
+export const lumaCommon = { BASE_URL, makeRequest };

--- a/packages/pieces/community/luma/tsconfig.json
+++ b/packages/pieces/community/luma/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/luma/tsconfig.lib.json
+++ b/packages/pieces/community/luma/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

Adds a [Luma](https://lu.ma) piece for event management integration.

### Actions
- **Create Event** — Create a new event listing on Luma
- **Get Event** — Retrieve event details by ID
- **List Events** — Browse calendar events with date filtering
- **Add Guests** — Register guests for an event by email
- **Custom API Call** — Make any Luma API request

### Auth
Uses Luma's API key authentication (`x-luma-api-key` header).

### Issue
Closes #12171
