### PR TITLE
feat(pieces): add Moosend email marketing piece

### DIFF
--- a/packages/pieces/community/moosend/README.md
+++ b/packages/pieces/community/moosend/README.md
@@ -1,0 +1,7 @@
+# Moosend
+
+Moosend is an email marketing and automation platform.
+
+## Authentication
+
+You need a Moosend API key. Find it in your Moosend account under Settings → API Key.

--- a/packages/pieces/community/moosend/package.json
+++ b/packages/pieces/community/moosend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-moosend",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/moosend/src/index.ts
+++ b/packages/pieces/community/moosend/src/index.ts
@@ -1,0 +1,35 @@
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { addSubscriber } from './lib/actions/add-subscriber';
+import { unsubscribeMember } from './lib/actions/unsubscribe-member';
+import { getMailingLists } from './lib/actions/get-mailing-lists';
+import { newSubscriber } from './lib/triggers/new-subscriber';
+
+export const moosendAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Moosend API key. Find it in Settings → API Key.',
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      const response = await fetch(
+        `https://api.moosend.com/v3/lists.json?apikey=${encodeURIComponent(auth)}`
+      );
+      if (response.ok) return { valid: true };
+      return { valid: false, error: 'Invalid Moosend API key.' };
+    } catch {
+      return { valid: false, error: 'Connection error.' };
+    }
+  },
+});
+
+export const moosend = createPiece({
+  displayName: 'Moosend',
+  description: 'Email marketing and automation platform for growing businesses.',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/moosend.png',
+  categories: [PieceCategory.MARKETING],
+  authors: ['tosh2308'],
+  auth: moosendAuth,
+  actions: [addSubscriber, unsubscribeMember, getMailingLists],
+  triggers: [newSubscriber],
+});

--- a/packages/pieces/community/moosend/src/lib/actions/add-subscriber.ts
+++ b/packages/pieces/community/moosend/src/lib/actions/add-subscriber.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { moosendAuth } from '../../index';
+import { moosendRequest } from '../common/client';
+
+export const addSubscriber = createAction({
+  name: 'add_subscriber',
+  displayName: 'Add Subscriber',
+  description: 'Add a new subscriber to a mailing list.',
+  auth: moosendAuth,
+  props: {
+    mailingListId: Property.ShortText({
+      displayName: 'Mailing List ID',
+      description: 'The ID of the mailing list.',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email Address',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Full Name',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { mailingListId, email, name } = propsValue;
+    return moosendRequest(auth, HttpMethod.POST, `/subscribers/${mailingListId}/subscribe.json`, {
+      Email: email,
+      Name: name ?? '',
+    });
+  },
+});

--- a/packages/pieces/community/moosend/src/lib/actions/get-mailing-lists.ts
+++ b/packages/pieces/community/moosend/src/lib/actions/get-mailing-lists.ts
@@ -1,0 +1,17 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { moosendAuth } from '../../index';
+import { moosendRequest, MoosendMailingList } from '../common/client';
+
+export const getMailingLists = createAction({
+  name: 'get_mailing_lists',
+  displayName: 'Get Mailing Lists',
+  description: 'Retrieve all mailing lists in your Moosend account.',
+  auth: moosendAuth,
+  props: {},
+  async run({ auth }) {
+    return moosendRequest<{ Context: { MailingLists: MoosendMailingList[] } }>(
+      auth, HttpMethod.GET, '/lists.json'
+    );
+  },
+});

--- a/packages/pieces/community/moosend/src/lib/actions/unsubscribe-member.ts
+++ b/packages/pieces/community/moosend/src/lib/actions/unsubscribe-member.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { moosendAuth } from '../../index';
+import { moosendRequest } from '../common/client';
+
+export const unsubscribeMember = createAction({
+  name: 'unsubscribe_member',
+  displayName: 'Unsubscribe Member',
+  description: 'Unsubscribe a member from a mailing list.',
+  auth: moosendAuth,
+  props: {
+    mailingListId: Property.ShortText({
+      displayName: 'Mailing List ID',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email Address',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { mailingListId, email } = propsValue;
+    return moosendRequest(auth, HttpMethod.POST, `/subscribers/${mailingListId}/${encodeURIComponent(email)}/unsubscribe.json`);
+  },
+});

--- a/packages/pieces/community/moosend/src/lib/common/client.ts
+++ b/packages/pieces/community/moosend/src/lib/common/client.ts
@@ -1,0 +1,38 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const MOOSEND_BASE_URL = 'https://api.moosend.com/v3';
+
+export async function moosendRequest<T>(
+  apiKey: string,
+  method: HttpMethod,
+  path: string,
+  body?: Record<string, unknown>
+): Promise<T> {
+  const url = `${MOOSEND_BASE_URL}${path}?apikey=${encodeURIComponent(apiKey)}`;
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url,
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+  return response.body;
+}
+
+export interface MoosendMailingList {
+  ID: string;
+  Name: string;
+  ActiveMemberCount: number;
+  UnsubscribedMemberCount: number;
+  BouncedMemberCount: number;
+  RemovedMemberCount: number;
+  CreatedOn: string;
+}
+
+export interface MoosendSubscriber {
+  Email: string;
+  Name: string;
+  SubscribeType: number;
+  SubscribeDate: string;
+  Tags: string;
+  CustomFields: unknown[];
+}

--- a/packages/pieces/community/moosend/src/lib/triggers/new-subscriber.ts
+++ b/packages/pieces/community/moosend/src/lib/triggers/new-subscriber.ts
@@ -1,0 +1,75 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { moosendAuth } from '../../index';
+import { moosendRequest, MoosendSubscriber } from '../common/client';
+
+interface PollingState {
+  lastSeenEmails: string[];
+  lastCheckedAt: string;
+}
+
+export const newSubscriber = createTrigger({
+  name: 'new_subscriber',
+  displayName: 'New Subscriber',
+  description: 'Triggers when a new subscriber joins a mailing list.',
+  auth: moosendAuth,
+  props: {
+    mailingListId: Property.ShortText({
+      displayName: 'Mailing List ID',
+      description: 'The ID of the mailing list to monitor.',
+      required: true,
+    }),
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    Email: 'subscriber@example.com',
+    Name: 'New Subscriber',
+    SubscribeType: 1,
+    SubscribeDate: '2026-04-19T00:00:00',
+    Tags: '',
+    CustomFields: [],
+  },
+  async onEnable(context) {
+    await context.store.put<PollingState>('moosend_state', {
+      lastSeenEmails: [],
+      lastCheckedAt: new Date().toISOString(),
+    });
+  },
+  async onDisable(context) {
+    await context.store.delete('moosend_state');
+  },
+  async run(context) {
+    const { mailingListId } = context.propsValue;
+    const state = await context.store.get<PollingState>('moosend_state') ?? {
+      lastSeenEmails: [],
+      lastCheckedAt: new Date(0).toISOString(),
+    };
+
+    const result = await moosendRequest<{
+      Context: { SubscriberCollection: { Subscribers: MoosendSubscriber[] } };
+    }>(context.auth, HttpMethod.GET, `/subscribers/${mailingListId}/members.json`);
+
+    const members = result?.Context?.SubscriberCollection?.Subscribers ?? [];
+    const newMembers = members.filter((m) => !state.lastSeenEmails.includes(m.Email));
+
+    if (newMembers.length > 0) {
+      await context.store.put<PollingState>('moosend_state', {
+        lastSeenEmails: members.map((m) => m.Email),
+        lastCheckedAt: new Date().toISOString(),
+      });
+    }
+
+    return newMembers;
+  },
+  async test(context) {
+    const { mailingListId } = context.propsValue;
+    const result = await moosendRequest<{
+      Context: { SubscriberCollection: { Subscribers: MoosendSubscriber[] } };
+    }>(context.auth, HttpMethod.GET, `/subscribers/${mailingListId}/members.json`);
+    return result?.Context?.SubscriberCollection?.Subscribers?.slice(0, 3) ?? [];
+  },
+});

--- a/packages/pieces/community/moosend/tsconfig.json
+++ b/packages/pieces/community/moosend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/moosend/tsconfig.lib.json
+++ b/packages/pieces/community/moosend/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

This PR adds a new community piece for **Moosend**, an email marketing and automation platform.

Closes #12192 (Piece: Moosend)

### What's included

- **Authentication**: API key auth with live validation against the Moosend `/lists.json` endpoint
- **Actions**:
  - `Add Subscriber` — Add a subscriber to a mailing list
  - `Unsubscribe Member` — Unsubscribe a member from a mailing list
  - `Get Mailing Lists` — Retrieve all mailing lists in the account
- **Triggers**:
  - `New Subscriber` — Polling trigger that fires when a new subscriber joins a mailing list

### How to test

1. Obtain a Moosend API key from **Settings → API Key** in your Moosend account
2. Connect the Moosend piece and verify the API key validates successfully
3. Create a flow using the **Add Subscriber** action to add a test subscriber to a list
4. Verify **Get Mailing Lists** returns your account's lists
5. Set up **New Subscriber** trigger and confirm it polls and returns new subscribers

### Checklist

- [x] Piece follows the community piece structure conventions
- [x] Auth uses `PieceAuth.SecretText` with validation
- [x] Actions use `createAction` with typed props
- [x] Trigger uses `TriggerStrategy.POLLING` with proper state management
- [x] All imports use workspace dependencies