### PR TITLE
feat(mcp): add duplicate flow, update branch conditions, and show step configs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",
@@ -1056,7 +1057,7 @@
     },
     "packages/pieces/community/bigcommerce": {
       "name": "@activepieces/piece-bigcommerce",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -2913,7 +2914,7 @@
     },
     "packages/pieces/community/gmail": {
       "name": "@activepieces/piece-gmail",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6190,7 +6191,7 @@
     },
     "packages/pieces/community/slack": {
       "name": "@activepieces/piece-slack",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -8124,7 +8125,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.60.0",
+      "version": "0.61.0",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",

--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -52,9 +52,9 @@ Tools are organized into categories. **Discovery tools** are always available. O
 | Category | Description |
 |----------|-------------|
 | Discovery | Read-only tools for exploring flows, pieces, connections, tables, runs, and validation |
-| Flow Management | Create, rename, publish, and enable/disable flows |
+| Flow Management | Create, duplicate, rename, publish, and enable/disable flows |
 | Flow Building | Add, update, and delete steps and triggers |
-| Router & Branching | Add and delete conditional branches |
+| Router & Branching | Add, update, and delete conditional branches |
 | Annotations | Manage canvas notes |
 | Tables | Full CRUD for tables, fields, and records |
 | Testing & Runs | Test flows, inspect results, retry failures |

--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -18,7 +18,7 @@ List all flows in the current project.
 
 ### ap_flow_structure
 
-Get the structure of a flow: step tree, configuration status, and valid insert locations.
+Get the full structure of a flow: step tree, configuration status, step input values, router branch conditions, and valid insert locations. Shows the actual configured inputs for each step (URL, body, headers, etc.) so the AI can read and edit existing configurations.
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -151,6 +151,19 @@ Create a new empty flow.
 |-------|------|----------|-------------|
 | `flowName` | string | Yes | Display name for the flow |
 
+### ap_duplicate_flow
+
+Duplicate an existing flow. Creates a new copy with all steps, configuration, and canvas notes. Connections and sample data are not copied.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `flowId` | string | Yes | The flow ID to duplicate |
+| `name` | string | No | Name for the copy (defaults to "Copy of {original name}") |
+
+<Tip>
+After duplicating, use `ap_flow_structure` on the new flow to check configuration status. Steps that reference connections will need to be re-configured with `ap_update_step`.
+</Tip>
+
 ### ap_rename_flow
 
 Rename an existing flow.
@@ -268,26 +281,50 @@ Delete a step from a flow.
 
 ## Router & Branching
 
-Manage conditional branches in router steps.
+Manage conditional branches in router steps. Use `ap_flow_structure` to see existing branch conditions and indices.
 
 ### ap_add_branch
 
-Add a conditional branch to a router step.
+Add a conditional branch to a router step. The branch is inserted before the fallback (Otherwise) branch.
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
 | `flowId` | string | Yes | The flow ID |
-| `stepName` | string | Yes | The router step name |
+| `routerStepName` | string | Yes | The router step name |
+| `branchName` | string | Yes | Display name for the branch |
+| `conditions` | array | No | Conditions array (see below) |
+
+**Conditions format:** Outer array = OR groups, inner array = AND conditions. Each condition has:
+- `firstValue` (string) — left-hand value, can use `{{step_1.field}}` template syntax
+- `operator` (string) — e.g. `TEXT_CONTAINS`, `NUMBER_IS_GREATER_THAN`, `EXISTS`, `BOOLEAN_IS_TRUE`
+- `secondValue` (string, optional) — right-hand value (not needed for single-value operators)
+- `caseSensitive` (boolean, optional) — for text operators
+
+### ap_update_branch
+
+Update the conditions and/or name of an existing router branch without affecting the steps inside it.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `flowId` | string | Yes | The flow ID |
+| `routerStepName` | string | Yes | The router step name |
+| `branchIndex` | number | Yes | Branch index (0-based) |
+| `branchName` | string | No | New display name |
+| `conditions` | array | No | New conditions (same format as `ap_add_branch`). Replaces existing conditions entirely. |
+
+<Warning>
+Cannot set conditions on the fallback branch — only `branchName` can be updated for fallback branches.
+</Warning>
 
 ### ap_delete_branch
 
-Delete a branch from a router step.
+Delete a branch from a router step. Cannot delete the fallback (last) branch.
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
 | `flowId` | string | Yes | The flow ID |
-| `stepName` | string | Yes | The router step name |
-| `branchIndex` | number | Yes | Which branch to delete |
+| `routerStepName` | string | Yes | The router step name |
+| `branchIndex` | number | Yes | Branch index to delete (0-based) |
 
 ---
 

--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -158,7 +158,7 @@ Duplicate an existing flow. Creates a new copy with all steps, configuration, an
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
 | `flowId` | string | Yes | The flow ID to duplicate |
-| `name` | string | No | Name for the copy (defaults to "Copy of {original name}") |
+| `name` | string | No | Name for the copy (defaults to "Copy of \{original name\}") |
 
 <Tip>
 After duplicating, use `ap_flow_structure` on the new flow to check configuration status. Steps that reference connections will need to be re-configured with `ap_update_step`.

--- a/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
@@ -1,9 +1,7 @@
 import {
     BranchCondition,
-    FlowActionType,
     FlowOperationRequest,
     FlowOperationType,
-    flowStructureUtil,
     isNil,
     McpServer,
     McpToolDefinition,
@@ -31,16 +29,7 @@ export const apAddBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
             flowId: z.string().describe('The id of the flow'),
             routerStepName: z.string().describe('The name of the ROUTER step to add a branch to. Use ap_flow_structure to get valid values.'),
             branchName: z.string().describe('Display name for the new branch (e.g. "Branch 1")'),
-            conditions: z.array(
-                z.array(
-                    z.object({
-                        firstValue: z.string().describe('Left-hand value (can be a template expression like {{step_1.output}})'),
-                        operator: z.string().optional().describe('Comparison operator (e.g. TEXT_CONTAINS, NUMBER_IS_GREATER_THAN, EXISTS)'),
-                        secondValue: z.string().optional().describe('Right-hand value (not needed for single-value operators like EXISTS, BOOLEAN_IS_TRUE)'),
-                        caseSensitive: z.boolean().optional().describe('For text operators: whether to match case sensitively'),
-                    }),
-                ),
-            ).optional().describe('Conditions array (outer array = OR groups, inner array = AND conditions). Required for condition-type branches; omit to use an empty condition group.'),
+            conditions: mcpUtils.BRANCH_CONDITIONS_INPUT_SCHEMA.optional().describe('Conditions array (outer array = OR groups, inner array = AND conditions). Required for condition-type branches; omit to use an empty condition group.'),
         },
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
@@ -54,19 +43,11 @@ export const apAddBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                 return { content: [{ type: 'text', text: '❌ Flow not found' }] }
             }
 
-            const routerStep = flowStructureUtil.getStep(routerStepName, flow.version.trigger)
-            if (isNil(routerStep) || routerStep.type !== FlowActionType.ROUTER) {
-                const routers = flowStructureUtil.getAllSteps(flow.version.trigger)
-                    .filter(s => s.type === FlowActionType.ROUTER)
-                    .map(s => s.name)
-                    .join(', ')
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `❌ Step "${routerStepName}" is not a ROUTER step. Available routers: ${routers || 'none'}`,
-                    }],
-                }
+            const resolved = mcpUtils.resolveRouterStep({ stepName: routerStepName, trigger: flow.version.trigger })
+            if (resolved.error) {
+                return resolved.error
             }
+            const routerStep = resolved.routerStep
 
             const routerSettings = (routerStep as { settings: { branches: unknown[] } }).settings
             // Insert before the last (fallback) branch

--- a/packages/server/api/src/app/mcp/tools/ap-delete-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-branch.ts
@@ -1,8 +1,6 @@
 import {
-    FlowActionType,
     FlowOperationRequest,
     FlowOperationType,
-    flowStructureUtil,
     isNil,
     McpServer,
     McpToolDefinition,
@@ -42,15 +40,11 @@ export const apDeleteBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
                 return { content: [{ type: 'text', text: '❌ Flow not found' }] }
             }
 
-            const routerStep = flowStructureUtil.getStep(routerStepName, flow.version.trigger)
-            if (isNil(routerStep) || routerStep.type !== FlowActionType.ROUTER) {
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `❌ Step "${routerStepName}" is not a ROUTER step. Use ap_flow_structure to find router steps.`,
-                    }],
-                }
+            const resolved = mcpUtils.resolveRouterStep({ stepName: routerStepName, trigger: flow.version.trigger })
+            if (resolved.error) {
+                return resolved.error
             }
+            const routerStep = resolved.routerStep
 
             const branches = (routerStep as { settings: { branches: unknown[] } }).settings.branches
             if (branchIndex < 0 || branchIndex >= branches.length) {

--- a/packages/server/api/src/app/mcp/tools/ap-duplicate-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-duplicate-flow.ts
@@ -27,9 +27,9 @@ export const apDuplicateFlowTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
         },
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
-            const { flowId, name } = duplicateFlowInput.parse(args)
-
             try {
+                const { flowId, name } = duplicateFlowInput.parse(args)
+
                 const [sourceFlow, project] = await Promise.all([
                     flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
                     projectService(log).getOneOrThrow(mcp.projectId),
@@ -48,27 +48,36 @@ export const apDuplicateFlowTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                     },
                 })
 
-                const updatedFlow = await flowService(log).update({
-                    id: newFlow.id,
-                    projectId: mcp.projectId,
-                    userId: null,
-                    platformId: project.platformId,
-                    operation: {
-                        type: FlowOperationType.IMPORT_FLOW,
-                        request: {
-                            displayName,
-                            trigger: sourceFlow.version.trigger,
-                            schemaVersion: sourceFlow.version.schemaVersion ?? null,
-                            notes: sourceFlow.version.notes ?? null,
+                try {
+                    const updatedFlow = await flowService(log).update({
+                        id: newFlow.id,
+                        projectId: mcp.projectId,
+                        userId: null,
+                        platformId: project.platformId,
+                        operation: {
+                            type: FlowOperationType.IMPORT_FLOW,
+                            request: {
+                                displayName,
+                                trigger: sourceFlow.version.trigger,
+                                schemaVersion: sourceFlow.version.schemaVersion ?? null,
+                                notes: sourceFlow.version.notes ?? null,
+                            },
                         },
-                    },
-                })
+                    })
 
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `✅ Flow duplicated successfully.\n  Original: "${sourceFlow.version.displayName}" (id: ${sourceFlow.id})\n  Copy: "${updatedFlow.version.displayName}" (id: ${updatedFlow.id})\n\nNote: Connections are not copied — use ap_flow_structure on the new flow to check configuration status and re-configure steps as needed.`,
-                    }],
+                    return {
+                        content: [{
+                            type: 'text',
+                            text: `✅ Flow duplicated successfully.\n  Original: "${sourceFlow.version.displayName}" (id: ${sourceFlow.id})\n  Copy: "${updatedFlow.version.displayName}" (id: ${updatedFlow.id})\n\nNote: Connections are not copied — use ap_flow_structure on the new flow to check configuration status and re-configure steps as needed.`,
+                        }],
+                    }
+                }
+                catch (importErr) {
+                    try {
+                        await flowService(log).delete({ id: newFlow.id, projectId: mcp.projectId })
+                    }
+                    catch { /* best-effort cleanup */ }
+                    return mcpUtils.mcpToolError('Flow duplication failed', importErr)
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-duplicate-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-duplicate-flow.ts
@@ -1,0 +1,79 @@
+import {
+    FlowOperationType,
+    isNil,
+    McpServer,
+    McpToolDefinition,
+    Permission,
+} from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { flowService } from '../../flows/flow/flow.service'
+import { projectService } from '../../project/project-service'
+import { mcpUtils } from './mcp-utils'
+
+const duplicateFlowInput = z.object({
+    flowId: z.string(),
+    name: z.string().optional(),
+})
+
+export const apDuplicateFlowTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_duplicate_flow',
+        permission: Permission.WRITE_FLOW,
+        description: 'Duplicate an existing flow. Creates a new copy with all steps and configuration. Connections and sample data are not copied.',
+        inputSchema: {
+            flowId: z.string().describe('The id of the flow to duplicate. Use ap_list_flows to find it.'),
+            name: z.string().optional().describe('Name for the duplicated flow. Defaults to "Copy of {original name}".'),
+        },
+        annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
+        execute: async (args) => {
+            const { flowId, name } = duplicateFlowInput.parse(args)
+
+            try {
+                const [sourceFlow, project] = await Promise.all([
+                    flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
+                    projectService(log).getOneOrThrow(mcp.projectId),
+                ])
+                if (isNil(sourceFlow)) {
+                    return { content: [{ type: 'text', text: '❌ Flow not found' }] }
+                }
+
+                const displayName = name ?? `Copy of ${sourceFlow.version.displayName}`
+
+                const newFlow = await flowService(log).create({
+                    projectId: mcp.projectId,
+                    request: {
+                        displayName,
+                        projectId: mcp.projectId,
+                    },
+                })
+
+                const updatedFlow = await flowService(log).update({
+                    id: newFlow.id,
+                    projectId: mcp.projectId,
+                    userId: null,
+                    platformId: project.platformId,
+                    operation: {
+                        type: FlowOperationType.IMPORT_FLOW,
+                        request: {
+                            displayName,
+                            trigger: sourceFlow.version.trigger,
+                            schemaVersion: sourceFlow.version.schemaVersion ?? null,
+                            notes: sourceFlow.version.notes ?? null,
+                        },
+                    },
+                })
+
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `✅ Flow duplicated successfully.\n  Original: "${sourceFlow.version.displayName}" (id: ${sourceFlow.id})\n  Copy: "${updatedFlow.version.displayName}" (id: ${updatedFlow.id})\n\nNote: Connections are not copied — use ap_flow_structure on the new flow to check configuration status and re-configure steps as needed.`,
+                    }],
+                }
+            }
+            catch (err) {
+                return mcpUtils.mcpToolError('Flow duplication failed', err)
+            }
+        },
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
@@ -1,4 +1,5 @@
 import {
+    BranchCondition,
     BranchExecutionType,
     FlowActionType,
     flowCanvasUtils,
@@ -58,6 +59,52 @@ function hasSampleData(step: Step): boolean {
     }
     const sampleData = step.settings.sampleData
     return typeof sampleData === 'object' && sampleData !== null && 'sampleDataFileId' in sampleData && sampleData.sampleDataFileId != null
+}
+
+function formatStepSettings(step: Step): string[] {
+    const lines: string[] = []
+    const settings = step.settings as Record<string, unknown>
+
+    if (step.type === FlowTriggerType.PIECE || step.type === FlowActionType.PIECE) {
+        const input = settings.input as Record<string, unknown> | undefined
+        if (input && Object.keys(input).length > 0) {
+            lines.push(`  input: ${mcpUtils.truncate(JSON.stringify(input), 500)}`)
+        }
+    }
+    else if (step.type === FlowActionType.CODE) {
+        const sourceCode = settings.sourceCode as { code?: string, packageJson?: string } | undefined
+        if (sourceCode?.code) {
+            lines.push(`  sourceCode: ${mcpUtils.truncate(sourceCode.code, 300)}`)
+        }
+        if (sourceCode?.packageJson && sourceCode.packageJson !== '{}') {
+            lines.push(`  packageJson: ${mcpUtils.truncate(sourceCode.packageJson, 200)}`)
+        }
+        const input = settings.input as Record<string, unknown> | undefined
+        if (input && Object.keys(input).length > 0) {
+            lines.push(`  input: ${mcpUtils.truncate(JSON.stringify(input), 300)}`)
+        }
+    }
+    else if (step.type === FlowActionType.LOOP_ON_ITEMS) {
+        const items = settings.items as string | undefined
+        if (items) {
+            lines.push(`  loopItems: ${items}`)
+        }
+    }
+    return lines
+}
+
+function formatBranchConditions(conditions: BranchCondition[][]): string {
+    const groups = conditions.map((andGroup) => {
+        const parts = andGroup.map((c) => {
+            const op = c.operator ?? '?'
+            const caseSensitive = 'caseSensitive' in c && c.caseSensitive ? ' [case-sensitive]' : ''
+            return 'secondValue' in c
+                ? `${c.firstValue} ${op} ${c.secondValue}${caseSensitive}`
+                : `${c.firstValue} ${op}${caseSensitive}`
+        })
+        return parts.join(' AND ')
+    })
+    return groups.join(' OR ')
 }
 
 function buildFlowStructure(trigger: Step): { structure: StepInfo[], stepByName: Map<string, Step> } {
@@ -146,6 +193,9 @@ function formatFlowStructure(
                 triggerDetail = ` (piece: ${fullStep.settings.pieceName}, trigger: ${fullStep.settings.triggerName ?? 'not set'})`
             }
             lines.push(`- [TRIGGER] ${step.name} | ${step.type} | "${step.displayName}"${triggerDetail} | parent: — | ${step.configStatus}${sampleLabel}${skipLabel}${canvasLabel}`)
+            if (fullStep) {
+                lines.push(...formatStepSettings(fullStep))
+            }
             continue
         }
 
@@ -164,11 +214,21 @@ function formatFlowStructure(
 
         lines.push(`- ${step.name} | ${step.type} | "${step.displayName}"${stepDetail} | parent: ${step.parentName} | ${rel} | ${step.configStatus}${sampleLabel}${skipLabel}${canvasLabel}`)
 
+        if (fullStep) {
+            lines.push(...formatStepSettings(fullStep))
+        }
+
         if (step.type === FlowActionType.ROUTER && fullStep) {
-            const branches = (fullStep.settings as { branches?: { branchName?: string, branchType?: string }[] })?.branches ?? []
+            const branches = (fullStep.settings as { branches?: { branchName?: string, branchType?: string, conditions?: BranchCondition[][] }[] })?.branches ?? []
             branches.forEach((b, i) => {
                 const btype = b.branchType === BranchExecutionType.FALLBACK ? 'fallback' : 'condition'
-                lines.push(`  branch[${i}]: "${b.branchName ?? ''}" (${btype})`)
+                if (btype === 'condition' && b.conditions && b.conditions.length > 0) {
+                    const condStr = formatBranchConditions(b.conditions)
+                    lines.push(`  branch[${i}]: "${b.branchName ?? ''}" (${btype}) | conditions: ${condStr}`)
+                }
+                else {
+                    lines.push(`  branch[${i}]: "${b.branchName ?? ''}" (${btype})`)
+                }
             })
         }
     }

--- a/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
@@ -1,0 +1,135 @@
+import {
+    BranchCondition,
+    BranchExecutionType,
+    FlowActionType,
+    FlowOperationRequest,
+    FlowOperationType,
+    isNil,
+    McpServer,
+    McpToolDefinition,
+    Permission,
+    RouterActionSettings,
+} from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { flowService } from '../../flows/flow/flow.service'
+import { projectService } from '../../project/project-service'
+import { mcpUtils } from './mcp-utils'
+
+const updateBranchInput = z.object({
+    flowId: z.string(),
+    routerStepName: z.string(),
+    branchIndex: z.number().int().min(0),
+    branchName: z.string().optional(),
+    conditions: z.array(z.array(BranchCondition)).optional(),
+})
+
+export const apUpdateBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_update_branch',
+        permission: Permission.WRITE_FLOW,
+        description: 'Update the conditions and/or name of an existing router branch. Does not affect the steps inside the branch.',
+        inputSchema: {
+            flowId: z.string().describe('The id of the flow'),
+            routerStepName: z.string().describe('The name of the ROUTER step. Use ap_flow_structure to get valid values.'),
+            branchIndex: z.number().describe('The index of the branch to update (0-based). Cannot update the fallback branch conditions.'),
+            branchName: z.string().optional().describe('New display name for the branch'),
+            conditions: mcpUtils.BRANCH_CONDITIONS_INPUT_SCHEMA.optional().describe('New conditions array (outer array = OR groups, inner array = AND conditions). Replaces the existing conditions entirely.'),
+        },
+        annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        execute: async (args) => {
+            const { flowId, routerStepName, branchIndex, branchName, conditions } = updateBranchInput.parse(args)
+            if (isNil(branchName) && isNil(conditions)) {
+                return { content: [{ type: 'text', text: '❌ Nothing to update. Provide at least branchName or conditions.' }] }
+            }
+
+            const [flow, project] = await Promise.all([
+                flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
+                projectService(log).getOneOrThrow(mcp.projectId),
+            ])
+            if (isNil(flow)) {
+                return { content: [{ type: 'text', text: '❌ Flow not found' }] }
+            }
+
+            const resolved = mcpUtils.resolveRouterStep({ stepName: routerStepName, trigger: flow.version.trigger })
+            if (resolved.error) {
+                return resolved.error
+            }
+            const routerStep = resolved.routerStep
+
+            const branches = [...routerStep.settings.branches]
+
+            if (branchIndex < 0 || branchIndex >= branches.length) {
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `❌ branchIndex ${branchIndex} is out of range. Valid indices are 0–${branches.length - 1}.`,
+                    }],
+                }
+            }
+
+            const targetBranch = branches[branchIndex]
+            if (targetBranch.branchType === BranchExecutionType.FALLBACK) {
+                if (conditions !== undefined) {
+                    return {
+                        content: [{
+                            type: 'text',
+                            text: `❌ Cannot set conditions on the fallback branch (index ${branchIndex}). Only branchName can be updated for fallback branches.`,
+                        }],
+                    }
+                }
+                branches[branchIndex] = {
+                    ...targetBranch,
+                    ...(branchName !== undefined && { branchName }),
+                }
+            }
+            else {
+                branches[branchIndex] = {
+                    ...targetBranch,
+                    ...(branchName !== undefined && { branchName }),
+                    ...(conditions !== undefined && { conditions }),
+                }
+            }
+
+            const updatedSettings: RouterActionSettings = {
+                ...routerStep.settings,
+                branches,
+            }
+
+            const operation: FlowOperationRequest = {
+                type: FlowOperationType.UPDATE_ACTION,
+                request: {
+                    type: FlowActionType.ROUTER,
+                    name: routerStep.name,
+                    displayName: routerStep.displayName,
+                    valid: routerStep.valid,
+                    settings: updatedSettings,
+                },
+            }
+
+            try {
+                await flowService(log).update({
+                    id: flow.id,
+                    projectId: mcp.projectId,
+                    userId: null,
+                    platformId: project.platformId,
+                    operation,
+                })
+
+                const updatedParts: string[] = []
+                if (branchName !== undefined) updatedParts.push(`name → "${branchName}"`)
+                if (conditions !== undefined) updatedParts.push(`conditions (${conditions.length} OR group(s))`)
+
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `✅ Branch ${branchIndex} of router "${routerStepName}" updated: ${updatedParts.join(', ')}. Steps inside the branch are unchanged.`,
+                    }],
+                }
+            }
+            catch (err) {
+                return mcpUtils.mcpToolError('Update branch failed', err)
+            }
+        },
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
@@ -38,76 +38,76 @@ export const apUpdateBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
         },
         annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
-            const { flowId, routerStepName, branchIndex, branchName, conditions } = updateBranchInput.parse(args)
-            if (isNil(branchName) && isNil(conditions)) {
-                return { content: [{ type: 'text', text: '❌ Nothing to update. Provide at least branchName or conditions.' }] }
-            }
-
-            const [flow, project] = await Promise.all([
-                flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
-                projectService(log).getOneOrThrow(mcp.projectId),
-            ])
-            if (isNil(flow)) {
-                return { content: [{ type: 'text', text: '❌ Flow not found' }] }
-            }
-
-            const resolved = mcpUtils.resolveRouterStep({ stepName: routerStepName, trigger: flow.version.trigger })
-            if (resolved.error) {
-                return resolved.error
-            }
-            const routerStep = resolved.routerStep
-
-            const branches = [...routerStep.settings.branches]
-
-            if (branchIndex < 0 || branchIndex >= branches.length) {
-                return {
-                    content: [{
-                        type: 'text',
-                        text: `❌ branchIndex ${branchIndex} is out of range. Valid indices are 0–${branches.length - 1}.`,
-                    }],
+            try {
+                const { flowId, routerStepName, branchIndex, branchName, conditions } = updateBranchInput.parse(args)
+                if (isNil(branchName) && isNil(conditions)) {
+                    return { content: [{ type: 'text', text: '❌ Nothing to update. Provide at least branchName or conditions.' }] }
                 }
-            }
 
-            const targetBranch = branches[branchIndex]
-            if (targetBranch.branchType === BranchExecutionType.FALLBACK) {
-                if (conditions !== undefined) {
+                const [flow, project] = await Promise.all([
+                    flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
+                    projectService(log).getOneOrThrow(mcp.projectId),
+                ])
+                if (isNil(flow)) {
+                    return { content: [{ type: 'text', text: '❌ Flow not found' }] }
+                }
+
+                const resolved = mcpUtils.resolveRouterStep({ stepName: routerStepName, trigger: flow.version.trigger })
+                if (resolved.error) {
+                    return resolved.error
+                }
+                const routerStep = resolved.routerStep
+
+                const branches = [...routerStep.settings.branches]
+
+                if (branchIndex < 0 || branchIndex >= branches.length) {
                     return {
                         content: [{
                             type: 'text',
-                            text: `❌ Cannot set conditions on the fallback branch (index ${branchIndex}). Only branchName can be updated for fallback branches.`,
+                            text: `❌ branchIndex ${branchIndex} is out of range. Valid indices are 0–${branches.length - 1}.`,
                         }],
                     }
                 }
-                branches[branchIndex] = {
-                    ...targetBranch,
-                    ...(branchName !== undefined && { branchName }),
+
+                const targetBranch = branches[branchIndex]
+                if (targetBranch.branchType === BranchExecutionType.FALLBACK) {
+                    if (conditions !== undefined) {
+                        return {
+                            content: [{
+                                type: 'text',
+                                text: `❌ Cannot set conditions on the fallback branch (index ${branchIndex}). Only branchName can be updated for fallback branches.`,
+                            }],
+                        }
+                    }
+                    branches[branchIndex] = {
+                        ...targetBranch,
+                        ...(branchName !== undefined && { branchName }),
+                    }
                 }
-            }
-            else {
-                branches[branchIndex] = {
-                    ...targetBranch,
-                    ...(branchName !== undefined && { branchName }),
-                    ...(conditions !== undefined && { conditions }),
+                else {
+                    branches[branchIndex] = {
+                        ...targetBranch,
+                        ...(branchName !== undefined && { branchName }),
+                        ...(conditions !== undefined && { conditions }),
+                    }
                 }
-            }
 
-            const updatedSettings: RouterActionSettings = {
-                ...routerStep.settings,
-                branches,
-            }
+                const updatedSettings: RouterActionSettings = {
+                    ...routerStep.settings,
+                    branches,
+                }
 
-            const operation: FlowOperationRequest = {
-                type: FlowOperationType.UPDATE_ACTION,
-                request: {
-                    type: FlowActionType.ROUTER,
-                    name: routerStep.name,
-                    displayName: routerStep.displayName,
-                    valid: routerStep.valid,
-                    settings: updatedSettings,
-                },
-            }
+                const operation: FlowOperationRequest = {
+                    type: FlowOperationType.UPDATE_ACTION,
+                    request: {
+                        type: FlowActionType.ROUTER,
+                        name: routerStep.name,
+                        displayName: routerStep.displayName,
+                        valid: routerStep.valid,
+                        settings: updatedSettings,
+                    },
+                }
 
-            try {
                 await flowService(log).update({
                     id: flow.id,
                     projectId: mcp.projectId,

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -4,6 +4,7 @@ import { flowService } from '../../flows/flow/flow.service'
 import { flowRunService } from '../../flows/flow-run/flow-run-service'
 import { sampleDataService } from '../../flows/step-run/sample-data.service'
 import { projectService } from '../../project/project-service'
+import { mcpUtils } from './mcp-utils'
 
 const POLL_INTERVAL_MS = 2000
 const MAX_WAIT_MS = 120_000
@@ -160,16 +161,13 @@ function formatStepOutput(name: string, step: unknown): string {
 
     if (status === StepOutputStatus.FAILED && errorMessage !== undefined) {
         const errStr = typeof errorMessage === 'string' ? errorMessage : JSON.stringify(errorMessage)
-        parts.push(`    Error: ${truncate(errStr, 300)}`)
+        parts.push(`    Error: ${mcpUtils.truncate(errStr, 300)}`)
     }
     else if (output !== undefined) {
         const outStr = typeof output === 'string' ? output : JSON.stringify(output)
-        parts.push(`    Output: ${truncate(outStr, 500)}`)
+        parts.push(`    Output: ${mcpUtils.truncate(outStr, 500)}`)
     }
 
     return parts.join('\n')
 }
 
-function truncate(str: string, max: number): string {
-    return str.length <= max ? str : str.slice(0, max) + '... (truncated)'
-}

--- a/packages/server/api/src/app/mcp/tools/index.ts
+++ b/packages/server/api/src/app/mcp/tools/index.ts
@@ -10,6 +10,7 @@ import { apDeleteBranchTool } from './ap-delete-branch'
 import { apDeleteRecordsTool } from './ap-delete-records'
 import { apDeleteStepTool } from './ap-delete-step'
 import { apDeleteTableTool } from './ap-delete-table'
+import { apDuplicateFlowTool } from './ap-duplicate-flow'
 import { apFindRecordsTool } from './ap-find-records'
 import { apFlowStructureTool } from './ap-flow-structure'
 import { apGetPiecePropsTool } from './ap-get-piece-props'
@@ -29,6 +30,7 @@ import { apRetryRunTool } from './ap-retry-run'
 import { apSetupGuideTool } from './ap-setup-guide'
 import { apTestFlowTool } from './ap-test-flow'
 import { apTestStepTool } from './ap-test-step'
+import { apUpdateBranchTool } from './ap-update-branch'
 import { apUpdateRecordTool } from './ap-update-record'
 import { apUpdateStepTool } from './ap-update-step'
 import { apUpdateTriggerTool } from './ap-update-trigger'
@@ -57,12 +59,14 @@ export const LOCKED_TOOL_NAMES: string[] = [
 export const ALL_CONTROLLABLE_TOOL_NAMES: string[] = [
     'ap_build_flow',
     'ap_create_flow',
+    'ap_duplicate_flow',
     'ap_rename_flow',
     'ap_update_trigger',
     'ap_add_step',
     'ap_update_step',
     'ap_delete_step',
     'ap_add_branch',
+    'ap_update_branch',
     'ap_delete_branch',
     'ap_lock_and_publish',
     'ap_change_flow_status',
@@ -81,6 +85,7 @@ export const ALL_CONTROLLABLE_TOOL_NAMES: string[] = [
 export const activepiecesTools = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition[] => [
     apBuildFlowTool(mcp, log),
     apCreateFlowTool(mcp, log),
+    apDuplicateFlowTool(mcp, log),
     apRenameFlowTool(mcp, log),
     apListFlowsTool(mcp, log),
     apFlowStructureTool(mcp, log),
@@ -94,6 +99,7 @@ export const activepiecesTools = (mcp: McpServer, log: FastifyBaseLogger): McpTo
     apUpdateStepTool(mcp, log),
     apDeleteStepTool(mcp, log),
     apAddBranchTool(mcp, log),
+    apUpdateBranchTool(mcp, log),
     apDeleteBranchTool(mcp, log),
     apLockAndPublishTool(mcp, log),
     apChangeFlowStatusTool(mcp, log),

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -1,6 +1,8 @@
 import { PieceMetadataModel, PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
-import { isNil } from '@activepieces/shared'
+import { BranchOperator, FlowActionType, flowStructureUtil, isNil } from '@activepieces/shared'
+import type { RouterAction, Step } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 
 const NON_INPUT_PROP_TYPES = new Set<PropertyType>([
@@ -149,6 +151,35 @@ function findResolvableProps({ props, componentProps, auth, providedInput }: Fin
     })
 }
 
+const BRANCH_CONDITIONS_INPUT_SCHEMA = z.array(
+    z.array(
+        z.object({
+            firstValue: z.string().describe('Left-hand value (can be a template expression like {{step_1.field}})'),
+            operator: z.enum(Object.values(BranchOperator) as [BranchOperator, ...BranchOperator[]]).optional().describe('Comparison operator. Single-value operators (no secondValue needed): EXISTS, DOES_NOT_EXIST, BOOLEAN_IS_TRUE, BOOLEAN_IS_FALSE, LIST_IS_EMPTY, LIST_IS_NOT_EMPTY'),
+            secondValue: z.string().optional().describe('Right-hand value — required for all operators except single-value ones'),
+            caseSensitive: z.boolean().optional().describe('For text operators: whether to match case sensitively'),
+        }),
+    ),
+)
+
+function truncate(str: string, max: number): string {
+    return str.length <= max ? str : str.slice(0, max) + '... (truncated)'
+}
+
+function resolveRouterStep({ stepName, trigger }: { stepName: string, trigger: Step }): ResolveRouterStepResult {
+    const step = flowStructureUtil.getStep(stepName, trigger)
+    if (isNil(step) || step.type !== FlowActionType.ROUTER) {
+        const routers = flowStructureUtil.getAllSteps(trigger)
+            .filter(s => s.type === FlowActionType.ROUTER)
+            .map(s => s.name)
+            .join(', ')
+        return {
+            error: { content: [{ type: 'text', text: `❌ Step "${stepName}" is not a ROUTER step. Available routers: ${routers || 'none'}` }] },
+        }
+    }
+    return { routerStep: step as RouterAction }
+}
+
 function validateAuth(auth: string | undefined): { content: [{ type: 'text', text: string }] } | null {
     if (auth !== undefined && /['{}\[\]]/.test(auth)) {
         return { content: [{ type: 'text', text: '❌ auth must be a plain externalId with no special characters. Use the exact value from ap_list_connections.' }] }
@@ -192,7 +223,7 @@ async function fillDefaultsForMissingOptionalProps({ settings, platformId, log }
     }
 }
 
-export const mcpUtils = { mcpToolError, diagnosePieceProps, buildPropSummaries, normalizePieceName, lookupPieceComponent, findResolvableProps, validateAuth, fillDefaultsForMissingOptionalProps, STEP_REFERENCE_HINT }
+export const mcpUtils = { mcpToolError, truncate, resolveRouterStep, diagnosePieceProps, buildPropSummaries, normalizePieceName, lookupPieceComponent, findResolvableProps, validateAuth, fillDefaultsForMissingOptionalProps, STEP_REFERENCE_HINT, BRANCH_CONDITIONS_INPUT_SCHEMA }
 
 export type { PropSummary }
 
@@ -241,3 +272,9 @@ type LookupPieceComponentParams = {
 type LookupPieceComponentResult =
     | { piece: PieceMetadataModel, component: { props: PiecePropertyMap, requireAuth: boolean, name: string, displayName: string, description: string }, pieceName: string, error?: never }
     | { error: { content: [{ type: 'text', text: string }] }, piece?: never, component?: never, pieceName?: never }
+
+type McpToolResult = { content: [{ type: 'text', text: string }] }
+
+type ResolveRouterStepResult =
+    | { routerStep: RouterAction, error?: never }
+    | { error: McpToolResult, routerStep?: never }

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -29,6 +29,8 @@ import { apGetPiecePropsTool } from '../../../../src/app/mcp/tools/ap-get-piece-
 import { apValidateStepConfigTool } from '../../../../src/app/mcp/tools/ap-validate-step-config'
 import { apValidateFlowTool } from '../../../../src/app/mcp/tools/ap-validate-flow'
 import { apUpdateTriggerTool } from '../../../../src/app/mcp/tools/ap-update-trigger'
+import { apDuplicateFlowTool } from '../../../../src/app/mcp/tools/ap-duplicate-flow'
+import { apUpdateBranchTool } from '../../../../src/app/mcp/tools/ap-update-branch'
 
 let app: FastifyInstance
 let mockLog: FastifyBaseLogger
@@ -1261,5 +1263,597 @@ describe('MCP Tools integration', () => {
         const validation = await apValidateFlowTool(mcp, mockLog).execute({ flowId: flowId! })
         expect(text(validation)).toContain('✅')
         expect(text(validation)).toContain('ready to publish')
+    })
+
+    // ── ap_flow_structure — step input visibility ────────────────────
+
+    it('50. ap_flow_structure — shows CODE step sourceCode and input in output', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Structure Input Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'My Code',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            sourceCode: 'export const code = async (inputs) => { return { msg: inputs.name }; };',
+            input: { name: '{{trigger.from}}' },
+        })
+
+        const result = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        const output = text(result)
+
+        expect(output).toContain('sourceCode:')
+        expect(output).toContain('inputs.name')
+        expect(output).toContain('input:')
+        expect(output).toContain('{{trigger.from}}')
+    })
+
+    it('51. ap_flow_structure — shows LOOP step loopItems expression', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Loop Items Visibility Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.LOOP_ON_ITEMS,
+            displayName: 'My Loop',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            loopItems: '{{trigger.items}}',
+        })
+
+        const result = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        const output = text(result)
+
+        expect(output).toContain('loopItems: {{trigger.items}}')
+    })
+
+    it('52. ap_flow_structure — shows router branch conditions', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Router Condition Visibility Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        await apAddBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchName: 'VIP',
+            conditions: [[{
+                firstValue: '{{trigger.type}}',
+                operator: 'TEXT_EXACTLY_MATCHES',
+                secondValue: 'vip',
+            }]],
+        })
+
+        const result = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        const output = text(result)
+
+        expect(output).toContain('VIP')
+        expect(output).toContain('conditions:')
+        expect(output).toContain('{{trigger.type}}')
+        expect(output).toContain('TEXT_EXACTLY_MATCHES')
+        expect(output).toContain('vip')
+    })
+
+    // ── ap_duplicate_flow ────────────────────────────────────────────
+
+    it('53. ap_duplicate_flow — duplicates a flow with all steps preserved', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Original Flow')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'Transform',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            sourceCode: 'export const code = async () => { return { x: 42 }; };',
+            input: {},
+        })
+
+        const dupResult = await apDuplicateFlowTool(mcp, mockLog).execute({ flowId })
+        const dupOutput = text(dupResult)
+
+        expect(dupOutput).toContain('✅')
+        expect(dupOutput).toContain('Copy of Original Flow')
+
+        const copyFlowId = dupOutput.match(/Copy: ".*?" \(id: (\S+?)\)/)?.[1]
+        expect(copyFlowId).toBeDefined()
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId: copyFlowId! })
+        const structOutput = text(structure)
+        expect(structOutput).toContain('Copy of Original Flow')
+        expect(structOutput).toContain('step_1')
+        expect(structOutput).toContain('Transform')
+        expect(structOutput).toContain('configured')
+    })
+
+    it('54. ap_duplicate_flow — uses custom name when provided', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Source Flow')
+
+        const dupResult = await apDuplicateFlowTool(mcp, mockLog).execute({
+            flowId,
+            name: 'My Custom Copy',
+        })
+
+        expect(text(dupResult)).toContain('✅')
+        expect(text(dupResult)).toContain('My Custom Copy')
+    })
+
+    it('55. ap_duplicate_flow — returns error for non-existent flow', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apDuplicateFlowTool(mcp, mockLog).execute({ flowId: 'nonexistent123' })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('not found')
+    })
+
+    it('56. ap_duplicate_flow — original flow is not modified', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Immutable Original')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        const structBefore = text(await apFlowStructureTool(mcp, mockLog).execute({ flowId }))
+
+        await apDuplicateFlowTool(mcp, mockLog).execute({ flowId })
+
+        const structAfter = text(await apFlowStructureTool(mcp, mockLog).execute({ flowId }))
+
+        expect(structAfter).toContain('Immutable Original')
+        expect(structBefore).toEqual(structAfter)
+    })
+
+    it('57. ap_duplicate_flow — preserves router with branches and steps inside', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Router Dup Source')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'step_1',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.INSIDE_BRANCH,
+            branchIndex: 0,
+            stepType: FlowActionType.CODE,
+            displayName: 'Branch Code',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_2',
+            sourceCode: 'export const code = async () => { return { branch: true }; };',
+            input: {},
+        })
+
+        const dupResult = await apDuplicateFlowTool(mcp, mockLog).execute({ flowId })
+        const copyFlowId = text(dupResult).match(/Copy: ".*?" \(id: (\S+?)\)/)?.[1]
+        expect(copyFlowId).toBeDefined()
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId: copyFlowId! })
+        const output = text(structure)
+        expect(output).toContain('My Router')
+        expect(output).toContain('ROUTER')
+        expect(output).toContain('Branch Code')
+        expect(output).toContain('branch 0')
+    })
+
+    // ── ap_update_branch ─────────────────────────────────────────────
+
+    it('58. ap_update_branch — sets conditions on a branch', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Update Branch Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            branchName: 'VIP Branch',
+            conditions: [[{
+                firstValue: '{{trigger.type}}',
+                operator: 'TEXT_EXACTLY_MATCHES',
+                secondValue: 'vip',
+            }]],
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('VIP Branch')
+        expect(text(result)).toContain('1 OR group')
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        const output = text(structure)
+        expect(output).toContain('VIP Branch')
+        expect(output).toContain('{{trigger.type}}')
+        expect(output).toContain('TEXT_EXACTLY_MATCHES')
+    })
+
+    it('59. ap_update_branch — renames a branch without changing conditions', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Rename Branch Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            branchName: 'Renamed Branch',
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('Renamed Branch')
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        expect(text(structure)).toContain('Renamed Branch')
+    })
+
+    it('60. ap_update_branch — rejects setting conditions on fallback branch', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Fallback Guard Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        // Branch 1 is the fallback (Otherwise)
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 1,
+            conditions: [[{ firstValue: 'test', operator: 'EXISTS' }]],
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('fallback')
+    })
+
+    it('61. ap_update_branch — allows renaming the fallback branch', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Fallback Rename Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 1,
+            branchName: 'Default Case',
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('Default Case')
+    })
+
+    it('62. ap_update_branch — rejects non-router step', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Non-Router Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'My Code',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            branchName: 'Test',
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('not a ROUTER')
+    })
+
+    it('63. ap_update_branch — rejects out-of-range branch index', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'OOB Index Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 99,
+            branchName: 'Test',
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('out of range')
+    })
+
+    it('64. ap_update_branch — rejects empty update (no name or conditions)', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Empty Update Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('Nothing to update')
+    })
+
+    it('65. ap_update_branch — preserves steps inside the branch after condition update', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Preserve Steps Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'My Router',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'step_1',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.INSIDE_BRANCH,
+            branchIndex: 0,
+            stepType: FlowActionType.CODE,
+            displayName: 'Inner Code',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_2',
+            sourceCode: 'export const code = async () => { return { inside: true }; };',
+            input: {},
+        })
+
+        // Update the branch conditions — step_2 should survive
+        await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            branchName: 'Updated Branch',
+            conditions: [[{
+                firstValue: '{{trigger.status}}',
+                operator: 'TEXT_EXACTLY_MATCHES',
+                secondValue: 'active',
+            }]],
+        })
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        const output = text(structure)
+
+        expect(output).toContain('Updated Branch')
+        expect(output).toContain('Inner Code')
+        expect(output).toContain('step_2')
+        expect(output).toContain('branch 0')
+        expect(output).toContain('{{trigger.status}}')
+    })
+
+    it('66. ap_update_branch — handles complex multi-group conditions', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Complex Conditions Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'Complex Router',
+        })
+
+        // Set conditions with 2 OR groups, first group has 2 AND conditions
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            conditions: [
+                [
+                    { firstValue: '{{trigger.status}}', operator: 'TEXT_EXACTLY_MATCHES', secondValue: 'active' },
+                    { firstValue: '{{trigger.role}}', operator: 'TEXT_CONTAINS', secondValue: 'admin' },
+                ],
+                [
+                    { firstValue: '{{trigger.override}}', operator: 'EXISTS' },
+                ],
+            ],
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).toContain('2 OR group')
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        const output = text(structure)
+        expect(output).toContain('TEXT_EXACTLY_MATCHES')
+        expect(output).toContain('TEXT_CONTAINS')
+        expect(output).toContain('AND')
+        expect(output).toContain('OR')
+        expect(output).toContain('EXISTS')
     })
 })

--- a/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
+++ b/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
@@ -83,6 +83,11 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
         description: 'Create a new flow',
       },
       {
+        name: 'ap_duplicate_flow',
+        description:
+          'Duplicate an existing flow with all steps and configuration',
+      },
+      {
         name: 'ap_rename_flow',
         description: 'Rename an existing flow',
       },
@@ -127,6 +132,11 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       {
         name: 'ap_add_branch',
         description: 'Add a conditional branch to a router step',
+      },
+      {
+        name: 'ap_update_branch',
+        description:
+          'Update the conditions or name of an existing router branch',
       },
       {
         name: 'ap_delete_branch',


### PR DESCRIPTION
## Summary
- **ap_flow_structure** now shows step input configs (URL, body, headers), source code, loop items, and full router branch conditions
- New **ap_duplicate_flow** tool creates a copy with all steps, configuration, and notes preserved
- New **ap_update_branch** tool modifies branch conditions and/or name without losing steps inside the branch
- Branch operator uses `z.enum(BranchOperator)` so the AI sees all 22 valid values
- Extracted shared utilities to mcpUtils: `truncate`, `resolveRouterStep`, `BRANCH_CONDITIONS_INPUT_SCHEMA`

## Test plan
- [x] 17 new integration tests (tests 50-66) all pass
- [x] `npm run lint-dev` passes with 0 errors
- [x] Live MCP testing: duplicate flow, read step configs, update branch conditions
- [x] Verify new tools appear in Settings → MCP Server UI panel