### PR TITLE
feat(mcp): expose ARRAY schemas, sanitize errors, improve list/validate/publish UX

### DIFF
--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -10,11 +10,13 @@ These tools are always available (locked) and read-only. They help AI agents und
 
 ### ap_list_flows
 
-List all flows in the current project.
+List flows in the current project with status, trigger type, and published state.
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
-| — | — | — | No inputs required |
+| `limit` | number | No | Max flows to return (default 100, max 500) |
+| `status` | string | No | Filter by status: `ENABLED` or `DISABLED` |
+| `name` | string | No | Filter by flow name (partial match) |
 
 ### ap_flow_structure
 

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -192,13 +192,14 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                     operation,
                 })
 
+                const draftWarning = mcpUtils.publishedFlowWarning(flow.publishedVersionId)
                 const hasConfig = input !== undefined || auth !== undefined || sourceCode !== undefined || loopItems !== undefined
                 const addedStep = flowStructureUtil.getStep(stepName, updatedFlow.version.trigger)
                 if (hasConfig && addedStep && !addedStep.valid) {
                     return {
                         content: [{
                             type: 'text',
-                            text: `⚠️ Step "${displayName}" (${stepName}) added but still invalid. Use ap_get_piece_props to check required fields, then ap_update_step to fix.`,
+                            text: `⚠️ Step "${displayName}" (${stepName}) added but still invalid. Use ap_get_piece_props to check required fields, then ap_update_step to fix.${draftWarning}`,
                         }],
                     }
                 }
@@ -206,14 +207,14 @@ export const apAddStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDe
                     return {
                         content: [{
                             type: 'text',
-                            text: `✅ Step "${displayName}" (${stepName}) added and configured.`,
+                            text: `✅ Step "${displayName}" (${stepName}) added and configured.${draftWarning}`,
                         }],
                     }
                 }
                 return {
                     content: [{
                         type: 'text',
-                        text: `✅ Step "${displayName}" (${stepName}) added. Now use ap_update_step with stepName="${stepName}" to configure its settings.`,
+                        text: `✅ Step "${displayName}" (${stepName}) added. Now use ap_update_step with stepName="${stepName}" to configure its settings.${draftWarning}`,
                     }],
                 }
             }

--- a/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-step.ts
@@ -64,8 +64,9 @@ export const apDeleteStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                     platformId: project.platformId,
                     operation,
                 })
+                const draftWarning = mcpUtils.publishedFlowWarning(flow.publishedVersionId)
                 return {
-                    content: [{ type: 'text', text: `✅ Successfully deleted step "${stepName}" from flow.` }],
+                    content: [{ type: 'text', text: `✅ Successfully deleted step "${stepName}" from flow.${draftWarning}` }],
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
@@ -1,27 +1,45 @@
-import { FlowTriggerType, isNil, McpServer, McpToolDefinition, Permission, PopulatedFlow } from '@activepieces/shared'
+import { FlowStatus, FlowTriggerType, isNil, McpServer, McpToolDefinition, Permission, PopulatedFlow } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
 import { flowService } from '../../flows/flow/flow.service'
 import { mcpUtils } from './mcp-utils'
+
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 500
+
+const listFlowsInput = z.object({
+    limit: z.number().int().min(1).max(MAX_LIMIT).optional(),
+    status: z.enum(Object.values(FlowStatus) as [FlowStatus, ...FlowStatus[]]).optional(),
+    name: z.string().optional(),
+})
 
 export const apListFlowsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
     return {
         title: 'ap_list_flows',
         permission: Permission.READ_FLOW,
-        description: 'List all flows in the current project with status, trigger type, and published state.',
-        inputSchema: {},
+        description: 'List flows in the current project with status, trigger type, and published state.',
+        inputSchema: {
+            limit: z.number().optional().describe(`Max flows to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`),
+            status: z.enum(Object.values(FlowStatus) as [FlowStatus, ...FlowStatus[]]).optional().describe('Filter by status: ENABLED or DISABLED.'),
+            name: z.string().optional().describe('Filter by flow name (partial match).'),
+        },
         annotations: { readOnlyHint: true, openWorldHint: false },
-        execute: async () => {
+        execute: async (args) => {
             try {
+                const { limit, status, name } = listFlowsInput.parse(args)
                 const flows = await flowService(log).list({
                     projectIds: [mcp.projectId],
                     cursorRequest: null,
-                    limit: 1000000,
+                    limit: limit ?? DEFAULT_LIMIT,
+                    status: status !== undefined ? [status] : undefined,
+                    name,
                 })
                 const lines = flows.data.map((flow) => formatFlowLine(flow))
+                const filterNote = (status || name) ? ' (filtered)' : ''
                 return {
                     content: [{
                         type: 'text',
-                        text: `✅ Listed ${lines.length} flow(s):\n${lines.join('\n')}`,
+                        text: `✅ Listed ${lines.length} flow(s)${filterNote}:\n${lines.join('\n')}`,
                     }],
                 }
             }

--- a/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
@@ -19,7 +19,7 @@ export const apListFlowsTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
         permission: Permission.READ_FLOW,
         description: 'List flows in the current project with status, trigger type, and published state.',
         inputSchema: {
-            limit: z.number().optional().describe(`Max flows to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`),
+            limit: z.number().int().min(1).max(MAX_LIMIT).optional().describe(`Max flows to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`),
             status: z.enum(Object.values(FlowStatus) as [FlowStatus, ...FlowStatus[]]).optional().describe('Filter by status: ENABLED or DISABLED.'),
             name: z.string().optional().describe('Filter by flow name (partial match).'),
         },

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -158,6 +158,7 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                     operation,
                 })
                 const updatedStep = flowStructureUtil.getStep(stepName, updatedFlow.version.trigger)
+                const draftWarning = mcpUtils.publishedFlowWarning(flow.publishedVersionId)
                 if (updatedStep && !updatedStep.valid) {
                     const diagnosis = updatedStep.type === FlowActionType.PIECE
                         ? await diagnoseMissingInputs({ settings: updatedStep.settings, platformId: project.platformId, log })
@@ -169,12 +170,12 @@ export const apUpdateStepTool = (mcp: McpServer, log: FastifyBaseLogger): McpToo
                     return {
                         content: [{
                             type: 'text',
-                            text: `⚠️ Step "${stepName}" updated but still invalid. ${hint}`,
+                            text: `⚠️ Step "${stepName}" updated but still invalid. ${hint}${draftWarning}`,
                         }],
                     }
                 }
                 return {
-                    content: [{ type: 'text', text: `✅ Successfully updated step "${stepName}".` }],
+                    content: [{ type: 'text', text: `✅ Successfully updated step "${stepName}".${draftWarning}` }],
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
@@ -109,18 +109,19 @@ export const apUpdateTriggerTool = (mcp: McpServer, log: FastifyBaseLogger): Mcp
                     operation,
                 })
                 const trigger = updatedFlow.version.trigger
+                const draftWarning = mcpUtils.publishedFlowWarning(flow.publishedVersionId)
                 if (!trigger.valid) {
                     const diagnosis = await diagnoseMissingTriggerInputs({ pieceName, pieceVersion, triggerName, input, platformId: project.platformId, log })
                     const hint = diagnosis ?? 'Check that triggerName is correct and all required inputs are provided. Use ap_list_connections to get a valid connection externalId for auth.'
                     return {
                         content: [{
                             type: 'text',
-                            text: `⚠️ Trigger updated but still invalid. ${hint}`,
+                            text: `⚠️ Trigger updated but still invalid. ${hint}${draftWarning}`,
                         }],
                     }
                 }
                 return {
-                    content: [{ type: 'text', text: `✅ Successfully updated trigger to "${pieceName}/${triggerName}".` }],
+                    content: [{ type: 'text', text: `✅ Successfully updated trigger to "${pieceName}/${triggerName}".${draftWarning}` }],
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
@@ -1,7 +1,9 @@
 import {
+    BranchExecutionType,
     McpServer,
     McpToolDefinition,
     RouterActionSettingsWithValidation,
+    RouterExecutionType,
     SourceCode,
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
@@ -34,7 +36,7 @@ export const apValidateStepConfigTool = (mcp: McpServer, log: FastifyBaseLogger)
                     case 'LOOP_ON_ITEMS':
                         return validateWithSchema({ schema: loopValidator, data: { items: params.loopItems ?? '' }, label: 'LOOP_ON_ITEMS' })
                     case 'ROUTER':
-                        return validateWithSchema({ schema: RouterActionSettingsWithValidation, data: params.settings ?? {}, label: 'ROUTER' })
+                        return validateRouter(params.settings)
                 }
             }
             catch (err) {
@@ -113,6 +115,47 @@ const codeValidator = z.object({
 const loopValidator = z.object({
     items: z.string().min(1),
 })
+
+function routerEnumHint(): string {
+    return `Valid executionType values: ${Object.values(RouterExecutionType).join(', ')}\nBranch types: ${Object.values(BranchExecutionType).join(', ')}`
+}
+
+function validateRouter(settings: Record<string, unknown> | undefined): McpResult {
+    if (!settings || !settings.branches || !settings.executionType) {
+        const example = JSON.stringify({
+            branches: [
+                {
+                    branchName: 'Branch 1',
+                    branchType: BranchExecutionType.CONDITION,
+                    conditions: [[{
+                        firstValue: '{{trigger.status}}',
+                        operator: 'TEXT_EXACTLY_MATCHES',
+                        secondValue: 'active',
+                    }]],
+                },
+                { branchName: 'Otherwise', branchType: BranchExecutionType.FALLBACK },
+            ],
+            executionType: RouterExecutionType.EXECUTE_FIRST_MATCH,
+        }, null, 2)
+        return {
+            content: [{
+                type: 'text',
+                text: `⚠️ Invalid ROUTER configuration: settings must include branches and executionType.\n\n${routerEnumHint()}\n\nExample:\n${example}`,
+            }],
+        }
+    }
+    const result = RouterActionSettingsWithValidation.safeParse(settings)
+    if (result.success) {
+        return { content: [{ type: 'text', text: '✅ Valid ROUTER configuration.' }] }
+    }
+    const errors = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`)
+    return {
+        content: [{
+            type: 'text',
+            text: `⚠️ Invalid ROUTER configuration:\n${errors.join('\n')}\n\n${routerEnumHint()}`,
+        }],
+    }
+}
 
 type McpResult = { content: [{ type: 'text', text: string }] }
 

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -1,5 +1,5 @@
 import { PieceMetadataModel, PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
-import { BranchOperator, FlowActionType, flowStructureUtil, isNil } from '@activepieces/shared'
+import { BranchOperator, FlowActionType, flowStructureUtil, isNil, isObject } from '@activepieces/shared'
 import type { RouterAction, Step } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
@@ -22,8 +22,17 @@ const RESOLVABLE_PROP_TYPES = new Set<PropertyType>([
 const STEP_REFERENCE_HINT = 'Use {{stepName.field}} to reference prior steps (no .output. in path).'
 
 function mcpToolError(prefix: string, err: unknown): { content: [{ type: 'text', text: string }] } {
-    const message = err instanceof Error ? err.message : String(err)
+    const raw = err instanceof Error ? err.message : String(err)
+    const message = sanitizeErrorMessage(raw)
     return { content: [{ type: 'text', text: `❌ ${prefix}: ${message}` }] }
+}
+
+function sanitizeErrorMessage(message: string): string {
+    return message
+        .replace(/\/root\/codes\/[^\s:)]+/g, '<sandbox>')
+        .replace(/\/root\/common\/[^\s:)]+/g, '<internal>')
+        .replace(/\/home\/[^\s:)]+node_modules\/[^\s:)]+/g, '<internal>')
+        .replace(/node_modules\/\.bun\/[^\s:)]+/g, '<internal>')
 }
 
 function formatOptionsHint(options: Array<{ label: string, value: unknown }> | undefined): string {
@@ -106,6 +115,10 @@ function buildPropSummaries(props: PiecePropertyMap): PropSummary[] {
             if (prop.type === PropertyType.DYNAMIC) {
                 summary.note = 'DYNAMIC — call ap_get_piece_props with auth+input to resolve sub-fields.'
             }
+            if (prop.type === PropertyType.ARRAY && 'properties' in prop && isObject(prop.properties)) {
+                const arraySubProps: PiecePropertyMap = prop.properties
+                summary.items = buildPropSummaries(arraySubProps)
+            }
             return summary
         })
 }
@@ -180,6 +193,13 @@ function resolveRouterStep({ stepName, trigger }: { stepName: string, trigger: S
     return { routerStep: step as RouterAction }
 }
 
+function publishedFlowWarning(publishedVersionId: string | null | undefined): string {
+    if (isNil(publishedVersionId)) {
+        return ''
+    }
+    return '\n⚠️ This flow is published. Changes apply to the draft only — use ap_lock_and_publish to push them live.'
+}
+
 function validateAuth(auth: string | undefined): { content: [{ type: 'text', text: string }] } | null {
     if (auth !== undefined && /['{}\[\]]/.test(auth)) {
         return { content: [{ type: 'text', text: '❌ auth must be a plain externalId with no special characters. Use the exact value from ap_list_connections.' }] }
@@ -223,7 +243,21 @@ async function fillDefaultsForMissingOptionalProps({ settings, platformId, log }
     }
 }
 
-export const mcpUtils = { mcpToolError, truncate, resolveRouterStep, diagnosePieceProps, buildPropSummaries, normalizePieceName, lookupPieceComponent, findResolvableProps, validateAuth, fillDefaultsForMissingOptionalProps, STEP_REFERENCE_HINT, BRANCH_CONDITIONS_INPUT_SCHEMA }
+export const mcpUtils = {
+    mcpToolError,
+    truncate,
+    resolveRouterStep,
+    publishedFlowWarning,
+    diagnosePieceProps,
+    buildPropSummaries,
+    normalizePieceName,
+    lookupPieceComponent,
+    findResolvableProps,
+    validateAuth,
+    fillDefaultsForMissingOptionalProps,
+    STEP_REFERENCE_HINT,
+    BRANCH_CONDITIONS_INPUT_SCHEMA,
+}
 
 export type { PropSummary }
 
@@ -258,6 +292,7 @@ type PropSummary = {
     defaultValue?: unknown
     options?: Array<{ label: string, value: unknown }>
     dynamicFields?: PropSummary[]
+    items?: PropSummary[]
     note?: string
 }
 

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -90,7 +90,9 @@ function diagnosePieceProps({ props, input, pieceAuth, requireAuth, componentTyp
     return { parts, missing, uiRequired, hasAuth }
 }
 
-function buildPropSummaries(props: PiecePropertyMap): PropSummary[] {
+const MAX_PROP_DEPTH = 3
+
+function buildPropSummaries(props: PiecePropertyMap, depth = 0): PropSummary[] {
     return Object.entries(props)
         .filter(([, prop]) => !NON_INPUT_PROP_TYPES.has(prop.type))
         .map(([name, prop]) => {
@@ -115,9 +117,9 @@ function buildPropSummaries(props: PiecePropertyMap): PropSummary[] {
             if (prop.type === PropertyType.DYNAMIC) {
                 summary.note = 'DYNAMIC — call ap_get_piece_props with auth+input to resolve sub-fields.'
             }
-            if (prop.type === PropertyType.ARRAY && 'properties' in prop && isObject(prop.properties)) {
+            if (prop.type === PropertyType.ARRAY && 'properties' in prop && isObject(prop.properties) && depth < MAX_PROP_DEPTH) {
                 const arraySubProps: PiecePropertyMap = prop.properties
-                summary.items = buildPropSummaries(arraySubProps)
+                summary.items = buildPropSummaries(arraySubProps, depth + 1)
             }
             return summary
         })

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -31,6 +31,7 @@ import { apValidateFlowTool } from '../../../../src/app/mcp/tools/ap-validate-fl
 import { apUpdateTriggerTool } from '../../../../src/app/mcp/tools/ap-update-trigger'
 import { apDuplicateFlowTool } from '../../../../src/app/mcp/tools/ap-duplicate-flow'
 import { apUpdateBranchTool } from '../../../../src/app/mcp/tools/ap-update-branch'
+import { mcpUtils } from '../../../../src/app/mcp/tools/mcp-utils'
 
 let app: FastifyInstance
 let mockLog: FastifyBaseLogger
@@ -79,6 +80,36 @@ beforeAll(async () => {
         },
     })
     await db.save('piece_metadata', gmailPiece)
+
+    const arrayPiece = createMockPieceMetadata({
+        name: '@activepieces/piece-test-array',
+        displayName: 'Test Array',
+        version: '0.1.0',
+        pieceType: PieceType.OFFICIAL,
+        packageType: PackageType.REGISTRY,
+        platformId: undefined,
+        actions: {
+            action_with_array: {
+                name: 'action_with_array',
+                displayName: 'Action With Array',
+                description: 'Action with array property',
+                requireAuth: false,
+                props: {
+                    items: {
+                        type: 'ARRAY',
+                        displayName: 'Items',
+                        required: true,
+                        properties: {
+                            name: { type: 'SHORT_TEXT', displayName: 'Name', required: true },
+                            value: { type: 'NUMBER', displayName: 'Value', required: false },
+                        },
+                    },
+                },
+            },
+        },
+        triggers: {},
+    })
+    await db.save('piece_metadata', arrayPiece)
 
     const dynamicPiece = createMockPieceMetadata({
         name: '@activepieces/piece-test-dynamic',
@@ -1855,5 +1886,158 @@ describe('MCP Tools integration', () => {
         expect(output).toContain('AND')
         expect(output).toContain('OR')
         expect(output).toContain('EXISTS')
+    })
+
+    // ── ARRAY item schema exposure ───────────────────────────────────
+
+    it('67. ap_get_piece_props — ARRAY property includes item sub-schemas', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apGetPiecePropsTool(mcp, mockLog).execute({
+            pieceName: '@activepieces/piece-test-array',
+            actionOrTriggerName: 'action_with_array',
+            type: 'action',
+        })
+
+        const output = text(result)
+        expect(output).toContain('✅')
+        expect(output).toContain('ARRAY')
+        expect(output).toContain('"items"')
+        expect(output).toContain('"name": "name"')
+        expect(output).toContain('"name": "value"')
+        expect(output).toContain('SHORT_TEXT')
+        expect(output).toContain('NUMBER')
+    })
+
+    // ── ap_list_flows with filters ───────────────────────────────────
+
+    it('68. ap_list_flows — respects limit parameter', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        await apCreateFlowTool(mcp, mockLog).execute({ flowName: 'Flow 1' })
+        await apCreateFlowTool(mcp, mockLog).execute({ flowName: 'Flow 2' })
+        await apCreateFlowTool(mcp, mockLog).execute({ flowName: 'Flow 3' })
+
+        const result = await apListFlowsTool(mcp, mockLog).execute({ limit: 2 })
+        const output = text(result)
+
+        expect(output).toContain('✅')
+        expect(output).toContain('2 flow(s)')
+    })
+
+    it('69. ap_list_flows — filters by name', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        await apCreateFlowTool(mcp, mockLog).execute({ flowName: 'Alpha Flow' })
+        await apCreateFlowTool(mcp, mockLog).execute({ flowName: 'Beta Flow' })
+        await apCreateFlowTool(mcp, mockLog).execute({ flowName: 'Alpha Two' })
+
+        const result = await apListFlowsTool(mcp, mockLog).execute({ name: 'Alpha' })
+        const output = text(result)
+
+        expect(output).toContain('filtered')
+        expect(output).toContain('Alpha')
+        expect(output).not.toContain('Beta Flow')
+    })
+
+    // ── ROUTER validation UX ─────────────────────────────────────────
+
+    it('70. ap_validate_step_config — ROUTER with empty settings gives helpful example', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apValidateStepConfigTool(mcp, mockLog).execute({
+            stepType: 'ROUTER',
+        })
+
+        const output = text(result)
+        expect(output).toContain('⚠️')
+        expect(output).toContain('executionType')
+        expect(output).toContain('EXECUTE_FIRST_MATCH')
+        expect(output).toContain('CONDITION')
+        expect(output).toContain('FALLBACK')
+    })
+
+    it('71. ap_validate_step_config — ROUTER with valid settings passes', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const result = await apValidateStepConfigTool(mcp, mockLog).execute({
+            stepType: 'ROUTER',
+            settings: {
+                branches: [
+                    { branchName: 'B1', branchType: 'CONDITION', conditions: [[{ firstValue: '{{trigger.x}}', operator: 'EXISTS' }]] },
+                    { branchName: 'Otherwise', branchType: 'FALLBACK' },
+                ],
+                executionType: 'EXECUTE_FIRST_MATCH',
+            },
+        })
+
+        expect(text(result)).toContain('✅')
+    })
+
+    // ── Published flow warning ────────────────────────────────────────
+
+    it('72. ap_add_step — warns when flow is published', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Published Flow Test')
+
+        await apUpdateTriggerTool(mcp, mockLog).execute({
+            flowId,
+            pieceName: '@activepieces/piece-test-email',
+            pieceVersion: '~0.1.0',
+            triggerName: 'new_email',
+        })
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'Pre-publish Code',
+        })
+
+        await apUpdateStepTool(mcp, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            sourceCode: 'export const code = async () => { return { ok: true }; };',
+            input: {},
+        })
+
+        await apLockAndPublishTool(mcp, mockLog).execute({ flowId })
+
+        const result = await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'step_1',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'Post-publish Code',
+        })
+
+        expect(text(result)).toContain('published')
+        expect(text(result)).toContain('draft')
+        expect(text(result)).toContain('ap_lock_and_publish')
+    })
+
+    // ── Error sanitization ───────────────────────────────────────────
+
+    it('73. mcpToolError — sanitizes internal paths from error messages', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        // Simulate what mcpUtils.mcpToolError does with internal paths
+        const fakeError = new Error('Cannot find module at /root/codes/abc123/step_1/index.js and /root/common/node_modules/.bun/@activepieces+piece-slack@0.16.2/lib.js')
+        const result = mcpUtils.mcpToolError('Test', fakeError)
+        const output = text(result)
+
+        expect(output).not.toContain('/root/codes/')
+        expect(output).not.toContain('/root/common/')
+        expect(output).not.toContain('.bun/')
+        expect(output).toContain('<sandbox>')
+        expect(output).toContain('<internal>')
     })
 })


### PR DESCRIPTION
## Summary
- **ARRAY item schemas** — `buildPropSummaries` recurses into ARRAY properties to expose item field schemas (fixes agentTools/structuredOutput being opaque)
- **Error sanitization** — `mcpToolError` strips `/root/codes/` and `.bun/` sandbox paths from error messages
- **ROUTER validation UX** — shows valid `executionType` and `branchType` values with a working example instead of bare Zod errors
- **ap_list_flows** — supports `limit` (default 100, max 500), `status` filter, and `name` search instead of dumping all flows
- **Published flow warning** — `ap_add_step`, `ap_update_step`, `ap_delete_step`, and `ap_update_trigger` warn when modifying a published flow's draft

## Test plan
- [x] 7 new integration tests (tests 67-73) all pass
- [x] All 74 tests pass, 0 lint errors
- [x] Live MCP testing: ARRAY schema for run_agent exposes 10 agentTools sub-fields
- [x] Live MCP testing: built 4-branch router, duplicated it, modified conditions on copy