### PR TITLE
fix: ignore canvas shortcuts when focus is inside an input field

### DIFF
--- a/packages/web/src/app/builder/shortcuts.ts
+++ b/packages/web/src/app/builder/shortcuts.ts
@@ -36,6 +36,15 @@ export const useHandleKeyPressOnCanvas = () => {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isTyping =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable;
+      if (isTyping) {
+        return;
+      }
+
       const insideSelectionRect =
         e.target instanceof HTMLElement &&
         e.target.classList.contains(


### PR DESCRIPTION
Fixes #12535

## Problem

Canvas keyboard shortcuts (e.g. **Ctrl+E** to skip a step, **Ctrl+C** to copy, **Shift+Delete** to delete) fire even when the user is actively typing inside a step's input field, textarea, or any `contenteditable` element.

This means pressing Ctrl+E while editing a text input unexpectedly skips the selected step, and can also trigger `ENTITY_NOT_FOUND` errors.

## Solution

Added an early return guard at the top of the `handleKeyDown` callback in `shortcuts.ts` that skips all shortcut processing when the keyboard event originates from an editable element (`INPUT`, `TEXTAREA`, or `contenteditable`).

```ts
const target = e.target as HTMLElement;
const isTyping =
  target.tagName === 'INPUT' ||
  target.tagName === 'TEXTAREA' ||
  target.isContentEditable;
if (isTyping) {
  return;
}
```

## Testing

1. Open a flow in the builder and select a step.
2. Click into one of the step's input fields and type something.
3. Press **Ctrl+E** — the step should **not** be skipped.
4. Click outside the input to return focus to the canvas, then press **Ctrl+E** — the step should be skipped as expected.