### PR TITLE
fix(webhooks): serialize multipart file arrays as URLs

### DIFF
--- a/packages/server/api/src/app/webhooks/webhook-request-converter.ts
+++ b/packages/server/api/src/app/webhooks/webhook-request-converter.ts
@@ -1,4 +1,5 @@
 import {
+    ApMultipartFile,
     EventPayload,
     FAIL_PARENT_ON_FAILURE_HEADER,
     FlowRun,
@@ -64,16 +65,22 @@ async function convertBody(
 
         for (const [key, value] of requestBodyEntries) {
             if (isMultipartFile(value)) {
-                const file = await stepFileService(request.log).saveAndEnrich({
-                    data: value.data as Buffer,
-                    fileName: value.filename,
-                    stepName: 'trigger',
+                jsonResult[key] = await saveMultipartFileAsUrl({
+                    file: value,
+                    request,
                     flowId,
-                    contentLength: value.data.length,
-                    platformId,
                     projectId,
+                    platformId,
                 })
-                jsonResult[key] = file.url
+            }
+            else if (Array.isArray(value) && value.every(isMultipartFile)) {
+                jsonResult[key] = await Promise.all(value.map((file) => saveMultipartFileAsUrl({
+                    file,
+                    request,
+                    flowId,
+                    projectId,
+                    platformId,
+                })))
             }
             else {
                 jsonResult[key] = value
@@ -102,4 +109,26 @@ async function convertBody(
     }
 
     return request.body
+}
+
+async function saveMultipartFileAsUrl(params: SaveMultipartFileAsUrlParams): Promise<string> {
+    const { file, request, flowId, projectId, platformId } = params
+    const saved = await stepFileService(request.log).saveAndEnrich({
+        data: file.data,
+        fileName: file.filename,
+        stepName: 'trigger',
+        flowId,
+        contentLength: file.data.length,
+        platformId,
+        projectId,
+    })
+    return saved.url
+}
+
+type SaveMultipartFileAsUrlParams = {
+    file: ApMultipartFile
+    request: FastifyRequest
+    flowId: string
+    projectId: string
+    platformId: string
 }

--- a/packages/server/api/test/integration/ce/webhooks/webhook-multipart-file.test.ts
+++ b/packages/server/api/test/integration/ce/webhooks/webhook-multipart-file.test.ts
@@ -1,0 +1,108 @@
+import { FileType, Flow, FlowStatus, Project } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import FormData from 'form-data'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../helpers/db'
+import { createMockFlow, createMockFlowVersion, mockAndSaveBasicSetup } from '../../../helpers/mocks'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Webhook multipart file', () => {
+    it('should serialize a single multipart file as a URL and persist it', async () => {
+        const { mockFlow, mockProject } = await createEnabledFlow()
+
+        const form = new FormData()
+        form.append('userName', 'John')
+        form.append('upload', Buffer.from('hello pdf'), {
+            filename: 'doc.pdf',
+            contentType: 'application/pdf',
+        })
+
+        const response = await app.inject({
+            method: 'POST',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: form.getHeaders(),
+            payload: form.getBuffer(),
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(response.headers['x-webhook-id']).toBeDefined()
+        expect(response.json()).toEqual({})
+
+        const savedFile = await db.findOneBy<SavedFile>(
+            'file',
+            { projectId: mockProject.id, type: FileType.FLOW_STEP_FILE },
+        )
+        expect(savedFile).not.toBeNull()
+        expect(savedFile!.id).toBeTruthy()
+        expect(savedFile!.fileName).toBe('doc.pdf')
+        expect(savedFile!.type).toBe(FileType.FLOW_STEP_FILE)
+        expect(savedFile!.projectId).toBe(mockProject.id)
+    })
+
+    it('should serialize multiple multipart files sharing a field name as an array of URLs', async () => {
+        const { mockFlow, mockProject } = await createEnabledFlow()
+
+        const form = new FormData()
+        form.append('uploads', Buffer.from('first pdf'), {
+            filename: 'first.pdf',
+            contentType: 'application/pdf',
+        })
+        form.append('uploads', Buffer.from('second pdf'), {
+            filename: 'second.pdf',
+            contentType: 'application/pdf',
+        })
+
+        const response = await app.inject({
+            method: 'POST',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: form.getHeaders(),
+            payload: form.getBuffer(),
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(response.headers['x-webhook-id']).toBeDefined()
+        expect(response.json()).toEqual({})
+
+        const firstFile = await db.findOneBy<SavedFile>(
+            'file',
+            { projectId: mockProject.id, fileName: 'first.pdf' },
+        )
+        const secondFile = await db.findOneBy<SavedFile>(
+            'file',
+            { projectId: mockProject.id, fileName: 'second.pdf' },
+        )
+        expect(firstFile).not.toBeNull()
+        expect(firstFile!.id).toBeTruthy()
+        expect(firstFile!.type).toBe(FileType.FLOW_STEP_FILE)
+        expect(secondFile).not.toBeNull()
+        expect(secondFile!.id).toBeTruthy()
+        expect(secondFile!.type).toBe(FileType.FLOW_STEP_FILE)
+    })
+})
+
+async function createEnabledFlow(): Promise<{ mockFlow: Flow, mockProject: Project }> {
+    const { mockProject } = await mockAndSaveBasicSetup()
+    const mockFlow = createMockFlow({ projectId: mockProject.id, status: FlowStatus.ENABLED })
+    await db.save('flow', [mockFlow])
+    const mockFlowVersion = createMockFlowVersion({ flowId: mockFlow.id })
+    await db.save('flow_version', [mockFlowVersion])
+    await db.update('flow', mockFlow.id, { publishedVersionId: mockFlowVersion.id })
+    return { mockFlow, mockProject }
+}
+
+type SavedFile = {
+    id: string
+    fileName: string
+    type: FileType
+    projectId: string
+}


### PR DESCRIPTION
## Summary

- When a multipart webhook form had multiple files under the same field name, `@fastify/multipart` (with `attachFieldsToBody: 'keyValues'`) delivered them as an array of `ApMultipartFile`. The old converter only matched a single `isMultipartFile(value)`, so the array fell through and the flow received raw Buffers instead of signed step-file URLs.
- `convertBody` now also handles arrays of multipart files and saves each one via `stepFileService.saveAndEnrich`, emitting an array of URL strings — consistent with the single-file branch.
- Adds integration tests that post a real multipart request (via `app.inject`) for both single-file and multi-file cases and assert webhook response shape + persisted `file` rows.

## Test plan

- [x] `vitest run test/integration/ce/webhooks` — 20/20 green (includes 2 new cases)
- [x] `vitest run test/unit/app/webhooks` — 35/35 green
- [x] Pre-push `turbo run lint && test-ce && test-ee && test-cloud` (via `CLAUDE_PUSH=yes git push`) — all 14 tasks successful
- [ ] CI is green on the PR