### PR TITLE
fix: stop pinning transitive deps after building the piece 

### DIFF
--- a/packages/cli/src/lib/utils/prepare-piece-utils.ts
+++ b/packages/cli/src/lib/utils/prepare-piece-utils.ts
@@ -1,140 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, copyFileSync, readdirSync, mkdirSync, symlinkSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { cwd } from 'node:process'
-import { parse as parseJsonc, printParseErrorCode } from 'jsonc-parser'
-import type { ParseError } from 'jsonc-parser'
 import { buildWorkspaceVersionMap, resolveWorkspaceDependencies, stripSemverRanges } from './workspace-utils'
-
-/**
- * Parses bun.lock and builds a map of every resolved (non-workspace) package.
- * Workspace entries (e.g. "name@workspace:path") are skipped.
- */
-function parseBunLock(): ParsedBunLock {
-    const lockPath = join(cwd(), 'bun.lock')
-    const raw = readFileSync(lockPath, 'utf-8')
-    const errors: ParseError[] = []
-    const lock = parseJsonc(raw, errors, { allowTrailingComma: true })
-    if (errors.length > 0) {
-        const details = errors.map((e) => `${printParseErrorCode(e.error)} at offset ${e.offset}`).join(', ')
-        throw new Error(`[parseBunLock] failed to parse ${lockPath}: ${details}`)
-    }
-    const packages: Record<string, BunLockPackageTuple> = lock.packages
-
-    const resolvedPackages = new Map<string, ResolvedPackage>()
-
-    for (const [packagePath, [nameAtVersion, _registry, metadata]] of Object.entries(packages)) {
-        if (!nameAtVersion || nameAtVersion.includes('workspace:')) {
-            continue
-        }
-
-        const atIndex = nameAtVersion.lastIndexOf('@')
-        if (atIndex <= 0) {
-            continue
-        }
-
-        const pkgName = nameAtVersion.slice(0, atIndex)
-        const version = nameAtVersion.slice(atIndex + 1)
-
-        resolvedPackages.set(packagePath, {
-            pkgName,
-            version,
-            dependencies: metadata?.dependencies ?? {},
-        })
-    }
-
-    return { resolvedPackages }
-}
-
-/**
- * Looks up a dependency in the resolved packages map.
- * Bun nests duplicates under their parent's path (e.g. "axios/follow-redirects"),
- * so we first check `parentPackagePath/depName`, then fall back to the top-level `depName`.
- */
-function lookupResolvedPackage({ depName, parentPackagePath, resolvedPackages }: { depName: string, parentPackagePath: string, resolvedPackages: Map<string, ResolvedPackage> }): { packagePath: string, pkg: ResolvedPackage } | null {
-    if (parentPackagePath) {
-        const nestedKey = `${parentPackagePath}/${depName}`
-        const pkg = resolvedPackages.get(nestedKey)
-        if (pkg) {
-            return { packagePath: nestedKey, pkg }
-        }
-    }
-
-    const pkg = resolvedPackages.get(depName)
-    if (pkg) {
-        return { packagePath: depName, pkg }
-    }
-
-    return null
-}
-
-/**
- * BFS-walks the dependency tree starting from `directDeps`, collecting every
- * transitive dependency with its exact pinned version from the lockfile.
- */
-function flattenTransitiveDeps(
-    directDeps: Record<string, string>,
-    parsedLock: ParsedBunLock,
-): Record<string, string> {
-    const { resolvedPackages } = parsedLock
-    const result: Record<string, string> = {}
-    const visited = new Set<string>()
-    const queue: { name: string, parentPackagePath: string }[] = []
-
-    for (const depName of Object.keys(directDeps)) {
-        if (depName.startsWith('@activepieces/')) {
-            continue
-        }
-        queue.push({ name: depName, parentPackagePath: '' })
-    }
-
-    while (queue.length > 0) {
-        const { name, parentPackagePath } = queue.shift()!
-
-        const resolved = lookupResolvedPackage({ depName: name, parentPackagePath, resolvedPackages })
-        if (!resolved) {
-            throw new Error(`[flattenTransitiveDeps] dependency "${name}" not found in bun.lock — lockfile may be stale, run "bun install"`)
-        }
-
-        const { packagePath, pkg } = resolved
-        if (visited.has(packagePath)) {
-            continue
-        }
-        visited.add(packagePath)
-
-        if (pkg.pkgName in result) {
-            if (result[pkg.pkgName] !== pkg.version) {
-                console.warn(`[flattenTransitiveDeps] version conflict for "${pkg.pkgName}": pinning ${result[pkg.pkgName]}, skipping ${pkg.version}`)
-            }
-        } else {
-            result[pkg.pkgName] = pkg.version
-        }
-
-        for (const subDepName of Object.keys(pkg.dependencies)) {
-            if (subDepName.startsWith('@activepieces/')) {
-                continue
-            }
-            queue.push({ name: subDepName, parentPackagePath: packagePath })
-        }
-    }
-
-    return result
-}
-
-function pinDependenciesFromLockfile(
-    deps: Record<string, string>,
-    parsedLock: ParsedBunLock,
-): Record<string, string> {
-    const transitiveDeps = flattenTransitiveDeps(deps, parsedLock)
-    const merged: Record<string, string> = { ...transitiveDeps }
-    for (const [name, version] of Object.entries(deps)) {
-        if (name.startsWith('@activepieces/')) {
-            merged[name] = version
-        } else {
-            merged[name] = transitiveDeps[name] ?? version
-        }
-    }
-    return merged
-}
 
 function copyPackageJson({ piecePath, distPath }: PieceDistPaths): void {
     const srcPackageJson = join(piecePath, 'package.json')
@@ -168,7 +35,7 @@ function symlinkNodeModules({ piecePath, distPath }: PieceDistPaths): void {
     symlinkSync(resolve(srcNodeModules), distNodeModules, 'dir')
 }
 
-function preparePieceDistForPublish(piecePath: string, parsedLock?: ParsedBunLock): void {
+function preparePieceDistForPublish(piecePath: string): void {
     const distPath = join(piecePath, 'dist')
 
     if (!existsSync(distPath)) {
@@ -180,7 +47,6 @@ function preparePieceDistForPublish(piecePath: string, parsedLock?: ParsedBunLoc
     copyI18nAssets(paths)
     symlinkNodeModules(paths)
 
-    const resolvedLockData = parsedLock ?? parseBunLock()
     const workspaceVersionMap = buildWorkspaceVersionMap(cwd())
 
     const distPackageJsonPath = join(distPath, 'package.json')
@@ -190,41 +56,11 @@ function preparePieceDistForPublish(piecePath: string, parsedLock?: ParsedBunLoc
     json.devDependencies = stripSemverRanges(resolveWorkspaceDependencies(json.devDependencies, workspaceVersionMap))
     json.peerDependencies = stripSemverRanges(resolveWorkspaceDependencies(json.peerDependencies, workspaceVersionMap))
 
-    // Only pin transitive deps for `dependencies` — devDependencies aren't installed by consumers,
-    // and peerDependencies should not be pinned (they're provided by the consumer's project).
-    if (json.dependencies) {
-        json.dependencies = pinDependenciesFromLockfile(json.dependencies, resolvedLockData)
-    }
-
     writeFileSync(distPackageJsonPath, JSON.stringify(json, null, 2) + '\n')
     console.info(`[preparePiece] prepared ${piecePath} (${Object.keys(json.dependencies ?? {}).length} deps)`)
 }
 
-export { parseBunLock, flattenTransitiveDeps, pinDependenciesFromLockfile, preparePieceDistForPublish }
-
-/**
- * Shape of each entry in bun.lock's `packages` record:
- *   [0] = resolved identifier, e.g. "axios@1.13.5"
- *   [1] = registry (empty string = default npm)
- *   [2] = metadata object containing `dependencies`
- *   [3] = integrity hash
- */
-type BunLockPackageTuple = [
-    nameAtVersion: string,
-    registry: string,
-    metadata?: { dependencies?: Record<string, string> },
-    integrity?: string,
-]
-
-type ResolvedPackage = {
-    pkgName: string
-    version: string
-    dependencies: Record<string, string>
-}
-
-type ParsedBunLock = {
-    resolvedPackages: Map<string, ResolvedPackage>
-}
+export { preparePieceDistForPublish }
 
 type PieceDistPaths = {
     piecePath: string

--- a/tools/scripts/pieces/prepare-pieces-for-publish.ts
+++ b/tools/scripts/pieces/prepare-pieces-for-publish.ts
@@ -1,5 +1,5 @@
 import { findAllPiecesDirectoryInSource } from '../utils/piece-script-utils'
-import { parseBunLock, preparePieceDistForPublish } from '../../../packages/cli/src/lib/utils/prepare-piece-utils'
+import { preparePieceDistForPublish } from '../../../packages/cli/src/lib/utils/prepare-piece-utils'
 
 function getChangedPiecePaths(): string[] | null {
     const changedPieces = process.env['CHANGED_PIECES']
@@ -15,10 +15,8 @@ async function main(): Promise<void> {
 
     console.info(`[preparePieces] processing ${piecePaths.length} pieces${changedPaths ? ' (scoped to changed)' : ' (all)'}`)
 
-    const parsedBunLock = parseBunLock()
-
     for (const piecePath of piecePaths) {
-        preparePieceDistForPublish(piecePath, parsedBunLock)
+        preparePieceDistForPublish(piecePath)
     }
 
     console.info(`[preparePieces] done, prepared ${piecePaths.length} pieces`)


### PR DESCRIPTION
## Summary

- Removes the transitive dependency flattening/pinning logic from `preparePieceDistForPublish` that was causing version conflicts in published pieces
- The previous approach BFS-walked `bun.lock` to inline all transitive deps with pinned versions into the piece's `package.json`, but this forced a single version per package — when two sub-trees needed different versions of the same package (e.g. `@ai-sdk/provider@3.0.8` vs `3.0.4`), one would silently get the wrong version at runtime
- Published pieces now only list their direct dependencies with exact versions; the consumer's package manager handles transitive resolution correctly, including installing multiple versions when needed

## Test plan

- [ ] Build a piece locally (`npx ts-node packages/cli/src/index.ts build ai`) and verify `dist/package.json` only contains direct deps (no transitive deps inlined)
- [ ] Verify `workspace:*` deps are still resolved to concrete versions
- [ ] Verify `^`/`~` ranges are still stripped
- [ ] Publish a piece and confirm it installs correctly with all transitive deps resolved by the package manager
