### PR TITLE
feat: add ip2geo piece

### DIFF
--- a/packages/pieces/community/ip2geo/.eslintrc.json
+++ b/packages/pieces/community/ip2geo/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/ip2geo/package.json
+++ b/packages/pieces/community/ip2geo/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-ip2geo",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/ip2geo/src/i18n/translation.json
+++ b/packages/pieces/community/ip2geo/src/i18n/translation.json
@@ -1,0 +1,9 @@
+{
+  "Convert IP addresses into geolocation data including city, country, timezone, ASN, and currency.": "Convert IP addresses into geolocation data including city, country, timezone, ASN, and currency.",
+  "\nTo get your API Key:\n\n1. Sign up at https://ip2geo.dev\n2. Create a project and generate an API key\n3. Copy your secret key (starts with i2g_sk)\n4. Paste it here\n": "\nTo get your API Key:\n\n1. Sign up at https://ip2geo.dev\n2. Create a project and generate an API key\n3. Copy your secret key (starts with i2g_sk)\n4. Paste it here\n",
+  "IP Lookup": "IP Lookup",
+  "Convert an IP address into geolocation data including city, country, timezone, ASN, and currency": "Convert an IP address into geolocation data including city, country, timezone, ASN, and currency",
+  "IP Address": "IP Address",
+  "The IP address to look up (IPv4 or IPv6)": "The IP address to look up (IPv4 or IPv6)",
+  "API Key": "API Key"
+}

--- a/packages/pieces/community/ip2geo/src/index.ts
+++ b/packages/pieces/community/ip2geo/src/index.ts
@@ -1,0 +1,17 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { ip2geoAuth } from './lib/common/auth';
+import { ipLookup } from './lib/actions/ip-lookup';
+
+export const ip2geo = createPiece({
+  displayName: 'ip2geo',
+  description:
+    'Convert IP addresses into geolocation data including city, country, timezone, ASN, and currency.',
+  auth: ip2geoAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/ip2geo.png',
+  categories: [PieceCategory.DEVELOPER_TOOLS],
+  authors: ['bfzli'],
+  actions: [ipLookup],
+  triggers: [],
+});

--- a/packages/pieces/community/ip2geo/src/lib/actions/ip-lookup.ts
+++ b/packages/pieces/community/ip2geo/src/lib/actions/ip-lookup.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { ip2geoAuth } from '../common/auth';
+import { ip2geoApiCall } from '../common/client';
+
+export const ipLookup = createAction({
+  auth: ip2geoAuth,
+  name: 'ip_lookup',
+  displayName: 'IP Lookup',
+  description:
+    'Convert an IP address into geolocation data including city, country, timezone, ASN, and currency',
+  props: {
+    ip: Property.ShortText({
+      displayName: 'IP Address',
+      description: 'The IP address to look up (IPv4 or IPv6)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { ip } = context.propsValue;
+
+    return await ip2geoApiCall({
+      method: HttpMethod.GET,
+      path: '/convert',
+      queryParams: {
+        ip,
+      },
+      auth: context.auth,
+    });
+  },
+});

--- a/packages/pieces/community/ip2geo/src/lib/common/auth.ts
+++ b/packages/pieces/community/ip2geo/src/lib/common/auth.ts
@@ -1,0 +1,52 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+const BASE_URL = 'https://api.ip2geo.dev';
+
+export const ip2geoAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: `
+To get your API Key:
+
+1. Sign up at https://ip2geo.dev
+2. Create a project and generate an API key
+3. Copy your secret key (starts with i2g_sk)
+4. Paste it here
+`,
+  required: true,
+  validate: async ({ auth }) => {
+    if (!auth) {
+      return {
+        valid: false,
+        error: 'API key is required',
+      };
+    }
+
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${BASE_URL}/convert?ip=8.8.8.8`,
+        headers: {
+          'X-Api-Key': auth,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.status === 200) {
+        return {
+          valid: true,
+        };
+      }
+
+      return {
+        valid: false,
+        error: 'Invalid API key',
+      };
+    } catch (error: unknown) {
+      return {
+        valid: false,
+        error: 'Invalid API key. Please check your API key and try again.',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/ip2geo/src/lib/common/client.ts
+++ b/packages/pieces/community/ip2geo/src/lib/common/client.ts
@@ -1,0 +1,72 @@
+import {
+  HttpMethod,
+  httpClient,
+  HttpMessageBody,
+  QueryParams,
+} from '@activepieces/pieces-common';
+import {
+  AppConnectionValueForAuthProperty,
+} from '@activepieces/pieces-framework';
+import { ip2geoAuth } from './auth';
+
+const BASE_URL = 'https://api.ip2geo.dev';
+
+export type Ip2geoApiCallParams = {
+  method: HttpMethod;
+  path: string;
+  queryParams?: Record<string, string | undefined>;
+  auth: AppConnectionValueForAuthProperty<typeof ip2geoAuth>;
+};
+
+export async function ip2geoApiCall<T extends HttpMessageBody>({
+  method,
+  path,
+  queryParams,
+  auth,
+}: Ip2geoApiCallParams): Promise<T> {
+  const url = `${BASE_URL}${path}`;
+
+  const headers: Record<string, string> = {
+    'X-Api-Key': auth.secret_text,
+    'Content-Type': 'application/json',
+  };
+
+  const qs: QueryParams = {};
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      if (value !== null && value !== undefined) {
+        qs[key] = String(value);
+      }
+    }
+  }
+
+  try {
+    const response = await httpClient.sendRequest<T>({
+      method,
+      url,
+      headers,
+      queryParams: qs,
+    });
+
+    return response.body;
+  } catch (error: unknown) {
+    const err = error as { response?: { status?: number } ; message?: string };
+    const statusCode = err.response?.status;
+
+    if (statusCode === 401 || statusCode === 403) {
+      throw new Error(
+        'Authentication failed. Please check your API key.',
+      );
+    }
+
+    if (statusCode === 429) {
+      throw new Error(
+        'Rate limit exceeded. Please wait and try again.',
+      );
+    }
+
+    throw new Error(
+      `ip2geo API error: ${err.message || String(error)}`,
+    );
+  }
+}

--- a/packages/pieces/community/ip2geo/tsconfig.json
+++ b/packages/pieces/community/ip2geo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/ip2geo/tsconfig.lib.json
+++ b/packages/pieces/community/ip2geo/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1505,6 +1505,9 @@
       "@activepieces/piece-greip": [
         "packages/pieces/community/greip/src/index.ts"
       ],
+      "@activepieces/piece-ip2geo": [
+        "packages/pieces/community/ip2geo/src/index.ts"
+      ],
       "@activepieces/piece-chaindesk": [
         "packages/pieces/community/chaindesk/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Adds a new community piece for [ip2geo](https://ip2geo.dev) — an IP geolocation API that converts IP addresses into location data.

### Action: IP Lookup
- Input: IP address (IPv4 or IPv6)
- Output: Full geolocation data (city, country, timezone, ASN, currency, coordinates, continent, flag, etc.)

### Authentication
- Secret key via `X-Api-Key` header
- Validation endpoint included (tests key against live API)

## Files

```
packages/pieces/community/ip2geo/
├── src/
│   ├── index.ts
│   ├── i18n/translation.json
│   └── lib/
│       ├── common/
│       │   ├── auth.ts
│       │   └── client.ts
│       └── actions/
│           └── ip-lookup.ts
├── package.json
├── tsconfig.json
├── tsconfig.lib.json
└── .eslintrc.json
```

Also updated `tsconfig.base.json` with path mapping.

## Test plan

- [x] All TypeScript files valid
- [x] Follows greip piece pattern (same structure)
- [x] i18n translation file included
- [x] tsconfig.base.json path mapping added