### PR TITLE
fix(pieces): use /registry for version listing so release-incompatible versions aren't offered

### DIFF
--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -20,6 +20,7 @@ Fastify 5 + TypeORM (PostgreSQL) + BullMQ (Redis) + `fastify-type-provider-zod`.
 
 ## Patterns
 
+- **Reuse existing endpoints before adding new ones** — Before adding a new endpoint, scan the controller you're working in (and any sibling controllers that handle the same resource) for an existing route that already returns the data you need. Prefer re-using or extending an existing endpoint over introducing a new one. New endpoints duplicate validation, caching, security configuration, docs, and test surface — and parallel endpoints tend to drift (different filters, different cache policies, different response shapes) and cause bugs. Only add a new endpoint when no existing route satisfies the use case.
 - **Controllers**: Use `FastifyPluginAsyncTypebox` pattern for route definitions with TypeBox schema validation
 - **HTTP methods**: Use `POST` for all create and update operations
 - **Database migrations**: Generated and managed via TypeORM

--- a/packages/server/api/src/app/pieces/metadata/piece-metadata-controller.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-metadata-controller.ts
@@ -9,9 +9,6 @@ import {
     GetPieceRequestWithScopeParams,
     isNil,
     ListPiecesRequestQuery,
-    ListPieceVersionsRequestParams,
-    ListPieceVersionsResponse,
-    ListPieceVersionsWithScopeRequestParams,
     LocalesEnum,
     PieceCategory,
     PieceOptionRequest,
@@ -81,35 +78,6 @@ const basePiecesController: FastifyPluginAsyncZod = async (app) => {
     })
 
     app.get(
-        '/:scope/:name/versions',
-        ListPieceVersionsWithScopeRequest,
-        async (req): Promise<ListPieceVersionsResponse> => {
-            const { name, scope } = req.params
-            const decodeScope = decodeURIComponent(scope)
-            const decodedName = decodeURIComponent(name)
-            return pieceMetadataService(req.log).listVersions({
-                name: `${decodeScope}/${decodedName}`,
-                platformId: req.principal.platform.id,
-                projectId: req.projectId,
-            })
-        },
-    )
-
-    app.get(
-        '/:name/versions',
-        ListPieceVersionsRequest,
-        async (req): Promise<ListPieceVersionsResponse> => {
-            const { name } = req.params
-            const decodedName = decodeURIComponent(name)
-            return pieceMetadataService(req.log).listVersions({
-                name: decodedName,
-                platformId: req.principal.platform.id,
-                projectId: req.projectId,
-            })
-        },
-    )
-
-    app.get(
         '/:scope/:name',
         GetPieceParamsWithScopeRequest,
         async (req) => {
@@ -148,6 +116,7 @@ const basePiecesController: FastifyPluginAsyncZod = async (app) => {
     app.get('/registry', RegistryPiecesRequest, async (req) => {
         const pieces = await pieceMetadataService(req.log).registry({
             release: req.query.release,
+            platformId: getPlatformId(req.principal),
         })
         return pieces
     })
@@ -244,28 +213,6 @@ const OptionsPieceRequest = {
         security: securityAccess.project([PrincipalType.USER], undefined, {
             type: ProjectResourceType.BODY,
         }),
-    },
-}
-
-const ListPieceVersionsRequest = {
-    config: {
-        security: securityAccess.project([PrincipalType.USER], undefined, {
-            type: ProjectResourceType.QUERY,
-        }),
-    },
-    schema: {
-        params: ListPieceVersionsRequestParams,
-    },
-}
-
-const ListPieceVersionsWithScopeRequest = {
-    config: {
-        security: securityAccess.project([PrincipalType.USER], undefined, {
-            type: ProjectResourceType.QUERY,
-        }),
-    },
-    schema: {
-        params: ListPieceVersionsWithScopeRequestParams,
     },
 }
 

--- a/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
@@ -6,7 +6,6 @@ import {
     ErrorCode,
     EXACT_VERSION_REGEX,
     isNil,
-    ListPieceVersionsResponse,
     LocalesEnum,
     PackageType,
     PieceCategory,
@@ -54,30 +53,11 @@ export const pieceMetadataService = (log: FastifyBaseLogger) => {
             return toPieceMetadataModelSummary(filteredPieces, translatedPieces, params.suggestionType)
         },
         async registry(params: RegistryParams): Promise<PiecePackageInformation[]> {
-            const registry = await pieceCache(log).getRegistry({ release: params.release })
+            const registry = await pieceCache(log).getRegistry({ release: params.release, platformId: params.platformId })
             return registry.map((piece) => ({
                 name: piece.name,
                 version: piece.version,
             }))
-        },
-        async listVersions({ name, platformId, projectId }: ListVersionsParams): Promise<ListPieceVersionsResponse> {
-            const piece = await this.get({ name, platformId, projectId })
-            if (isNil(piece)) {
-                return {
-                    data: [],
-                    next: null,
-                    previous: null,
-                }
-            }
-            const registry = await pieceCache(log).getRegistry({ release: undefined, platformId })
-            const versions = registry
-                .filter((entry) => entry.name === name)
-                .map((entry) => entry.version)
-            return {
-                data: versions.sort((a, b) => semVer.rcompare(a, b)).map((version) => ({ version })),
-                next: null,
-                previous: null,
-            }
         },
         async get({ projectId, platformId, version, name }: GetOrThrowParams): Promise<PieceMetadataModel | undefined> {
             const bestMatch = await findExactVersion(log, { name, version, platformId })
@@ -441,11 +421,6 @@ type GetExactPieceVersionParams = {
 
 type RegistryParams = {
     release: string
-}
-
-type ListVersionsParams = {
-    name: string
-    platformId: string 
-    projectId: string
+    platformId?: string
 }
 

--- a/packages/shared/src/lib/automation/pieces/dto/piece-requests.ts
+++ b/packages/shared/src/lib/automation/pieces/dto/piece-requests.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 import { ApMultipartFile } from '../../../core/common'
 import { OptionalArrayFromQuery, OptionalBooleanFromQuery } from '../../../core/common/base-model'
-import { SeekPage } from '../../../core/common/seek-page'
 import { ApEdition } from '../../../core/flag/flag'
 import { PackageType, PieceCategory } from '../piece'
 
@@ -112,16 +111,3 @@ export const AddPieceRequestBody = z.union([
 
 export type AddPieceRequestBody = z.infer<typeof AddPieceRequestBody>
 
-export const ListPieceVersionsRequestParams = z.object({
-    name: z.string(),
-})
-export const ListPieceVersionsWithScopeRequestParams = z.object({
-    name: z.string(),
-    scope: z.string(),
-})
-export type ListPieceVersionsWithScopeRequestParams = z.infer<typeof ListPieceVersionsWithScopeRequestParams>
-
-export type ListPieceVersionsRequestParams = z.infer<typeof ListPieceVersionsRequestParams>
-
-export const ListPieceVersionsResponse = z.object({ version: z.string() })
-export type ListPieceVersionsResponse = SeekPage<z.infer<typeof ListPieceVersionsResponse>>

--- a/packages/web/src/features/pieces/api/pieces-api.ts
+++ b/packages/web/src/features/pieces/api/pieces-api.ts
@@ -1,16 +1,17 @@
 import {
   PieceMetadataModel,
   PieceMetadataModelSummary,
+  PiecePackageInformation,
   PropertyType,
   ExecutePropsResult,
   InputPropertyMap,
 } from '@activepieces/pieces-framework';
 import {
   AddPieceRequestBody,
+  ApEdition,
   GetPieceRequestParams,
   GetPieceRequestQuery,
   ListPiecesRequestQuery,
-  ListPieceVersionsResponse,
   PackageType,
   PieceOptionRequest,
 } from '@activepieces/shared';
@@ -18,7 +19,6 @@ import { t } from 'i18next';
 
 import { internalErrorToast } from '@/components/ui/sonner';
 import { api } from '@/lib/api';
-import { authenticationSession } from '@/lib/authentication-session';
 
 export const piecesApi = {
   list(request: ListPiecesRequestQuery): Promise<PieceMetadataModelSummary[]> {
@@ -90,14 +90,14 @@ export const piecesApi = {
       'Content-Type': 'multipart/form-data',
     });
   },
-  listVersions(name: string): Promise<ListPieceVersionsResponse> {
-    const projectId = authenticationSession.getProjectId()!;
-    return api.get<ListPieceVersionsResponse>(
-      `/v1/pieces/${encodeURIComponent(name)}/versions`,
-      {
-        projectId,
-      },
-    );
+  registry(
+    release: string,
+    edition: ApEdition,
+  ): Promise<PiecePackageInformation[]> {
+    return api.get<PiecePackageInformation[]>('/v1/pieces/registry', {
+      release,
+      edition,
+    });
   },
   delete(id: string) {
     return api.delete(`/v1/pieces/${id}`);

--- a/packages/web/src/features/pieces/hooks/pieces-hooks.ts
+++ b/packages/web/src/features/pieces/hooks/pieces-hooks.ts
@@ -6,6 +6,7 @@ import {
 } from '@activepieces/pieces-framework';
 import {
   AddPieceRequestBody,
+  ApEdition,
   FlowActionType,
   flowPieceUtil,
   LocalesEnum,
@@ -19,6 +20,7 @@ import {
 import { useMutation, useQueries, useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { useTranslation } from 'react-i18next';
+import semver from 'semver';
 
 import { useTelemetry } from '@/components/providers/telemetry-provider';
 import { appConnectionsApi } from '@/features/connections/api/app-connections';
@@ -322,14 +324,23 @@ export const piecesHooks = {
     });
   },
   usePieceVersions: (pieceName: string) => {
+    const { data: release } = flagsHooks.useFlag<string>(
+      ApFlagId.CURRENT_VERSION,
+    );
+    const { data: edition } = flagsHooks.useFlag<ApEdition>(ApFlagId.EDITION);
     const query = useQuery({
-      queryKey: ['piece-versions', pieceName],
-      queryFn: () => piecesApi.listVersions(pieceName),
+      queryKey: ['pieces-registry', release, edition],
+      queryFn: () => piecesApi.registry(release!, edition!),
       staleTime: Infinity,
-      enabled: !!pieceName,
+      enabled: !!pieceName && !!release && !!edition,
+      select: (registry) =>
+        registry
+          .filter((entry) => entry.name === pieceName)
+          .map((entry) => ({ version: entry.version }))
+          .sort((a, b) => semver.rcompare(a.version, b.version)),
     });
     return {
-      pieceVersions: query.data?.data,
+      pieceVersions: query.data,
       isLoading: query.isLoading,
     };
   },


### PR DESCRIPTION

## Fix

- Re-point the frontend to the existing `GET /v1/pieces/registry` endpoint, which already applies the release filter via `getRegistry({ release: currentRelease })`.
- Propagate `platformId` from the principal into the registry service so platform-scoped CUSTOM pieces remain visible in the dropdown (strictly additive — OFFICIAL pieces are unaffected).
- Rewrite `usePieceVersions` to read `ApFlagId.CURRENT_VERSION` + `ApFlagId.EDITION`, share a single registry cache across callers (`['pieces-registry', release, edition]`), and derive the per-piece version list with React Query's `select`.
- Delete the redundant `/:name/versions` and `/:scope/:name/versions` routes, the `listVersions` service method, and the dead `ListPieceVersions*` shared types.
- Added a note to `packages/server/AGENTS.md` to scan sibling routes for reuse before adding new endpoints (this bug was a classic case of parallel endpoints drifting).

## Test plan

- [x] Open the upgrade dialog on an `@activepieces/piece-ai` step → only release-compatible versions appear; upgrading no longer errors with `piece_metadata_not_found`.
- [x] Confirm the Advanced version-picker view still lists patch/minor/major correctly.
- [x] Add a new step of any piece via the piece selector → still lands on the latest compatible version.
- [x] Custom platform pieces still appear in the upgrade dropdown (regression check for the `platformId` propagation).
- [x] `npm run lint-dev` passes.
