### PR TITLE
docs: document waitpoints and durable execution

### DIFF
--- a/.agents/features/flow-runs.md
+++ b/.agents/features/flow-runs.md
@@ -26,7 +26,8 @@ Flow Runs records every execution of a flow, tracking its full lifecycle from qu
 - **FlowRun**: A single execution instance of a specific flow version, from trigger to terminal state.
 - **FlowRunStatus**: One of 12 states — 3 non-terminal (QUEUED, RUNNING, PAUSED) and 9 terminal (SUCCEEDED, FAILED, TIMEOUT, CANCELED, QUOTA_EXCEEDED, MEMORY_LIMIT_EXCEEDED, INTERNAL_ERROR, LOG_SIZE_EXCEEDED, plus PAUSED terminal via delay).
 - **LogsFile**: Zstd-compressed File entity (type FLOW_RUN_LOG) storing the full `FlowExecutorContext` after execution.
-- **PauseMetadata**: JSONB column distinguishing DELAY pauses (scheduled resume) from WEBHOOK pauses (external callback).
+- **Waitpoint**: Row in the `waitpoint` table representing one paused step on a run. Fields: `type` (DELAY|WEBHOOK), `version` (V0|V1 — V1 is the current API), `status` (PENDING|COMPLETED), `stepName`, `resumeDateTime`, `responseToSend`, `resumePayload`, `workerHandlerId`, `httpRequestId`. Unique on `(flow_run_id, step_name)`.
+- **PauseMetadata** *(legacy/V0)*: JSONB column on `flow_run` distinguishing DELAY vs WEBHOOK pauses. Deprecated 2026-04-13 (0.82.0); still read for in-flight V0 runs, scheduled for removal. V1 runs store this information on the `waitpoint` row instead.
 - **Retry Strategy**: FROM_FAILED_STEP (resume from exact failure point, keeping prior outputs) or ON_LATEST_VERSION (fresh run on current published version).
 - **Subflow**: A child run linked via `parentRunId`, created when a flow calls another flow as a step.
 - **failedStep**: JSONB snapshot of `{ name, type, errorMessage }` for the step that caused failure, enabling filtered retries.
@@ -48,8 +49,11 @@ Flow Runs records every execution of a flow, tracking its full lifecycle from qu
 - `POST /retry` — Bulk retry with filters
 - `POST /cancel` — Bulk cancel paused/queued runs
 - `POST /archive` — Bulk soft delete (set archivedAt)
-- `ALL /:id/requests/:requestId` — Resume paused webhook run with payload
-- `ALL /:id/requests/:requestId/sync` — Resume and return response synchronously
+- `POST /v1/waitpoints` — Engine-only: create a waitpoint (PENDING) for a paused step
+- `ALL /:id/waitpoints/:waitpointId` — Resume a paused run via waitpoint (V1, async)
+- `ALL /:id/waitpoints/:waitpointId/sync` — Resume and return the flow's response synchronously (V1)
+- `ALL /:id/requests/:requestId` — V0 legacy resume route (pauseMetadata-based)
+- `ALL /:id/requests/:requestId/sync` — V0 legacy sync resume
 
 ## Retry Strategies
 
@@ -66,10 +70,14 @@ Flow Runs records every execution of a flow, tracking its full lifecycle from qu
 
 ## Pause & Resume
 
-- **DelayPauseMetadata**: `{ type: DELAY, resumeDateTime }` → BullMQ delayed job resumes at scheduled time
-- **WebhookPauseMetadata**: `{ type: WEBHOOK, requestId }` → waits for HTTP callback at `/flow-runs/{id}/requests/{requestId}`
-- On resume: fetch state from logs → rebuild context → re-run from paused step with `ExecutionType.RESUME`
-- On server restart: `refill-paused-jobs` migration re-queues all paused runs
+- **Waitpoints (V1, current):** pieces call `ctx.run.createWaitpoint({ type, ... })` + `ctx.run.waitForWaitpoint(id)`. Engine POSTs `/v1/waitpoints`; server inserts a PENDING row keyed on `(flow_run_id, step_name)`.
+  - `DELAY` waitpoint: server upserts a `SystemJobName.RESUME_DELAY_WAITPOINT` BullMQ job scheduled at `resumeDateTime`. When it fires, `resumeService.resumeFromWaitpoint` enqueues the resume.
+  - `WEBHOOK` waitpoint: resume signal arrives as an HTTP call on `/:id/waitpoints/:waitpointId[/sync]`. Optional `responseToSend` is replied immediately to the original webhook trigger.
+- **Pre-completion (resume-before-pause race):** `waitpoint-service.complete()` takes a pessimistic write lock on the PENDING row. If no row yet, it inserts a COMPLETED row with the `resumePayload`. When the flow then transitions to PAUSED, `flow-runs-queue.ts` sees the COMPLETED waitpoint and enqueues the resume immediately. Prevents dropped early callbacks.
+- **On resume:** fetch state from logs file → rebuild `FlowExecutorContext` → re-run the paused step with `ExecutionType.RESUME` and `ctx.resumePayload = waitpoint.resumePayload`.
+- **Limits:** `AP_PAUSED_FLOW_TIMEOUT_DAYS` caps DELAY `resumeDateTime`; engine throws `PausedFlowTimeoutError` beyond that.
+- **Legacy (V0) path:** `pauseMetadata` on `flow_run` + `ctx.run.pause({ pauseMetadata })` + `ctx.generateResumeUrl()` + `/requests/:requestId[/sync]` routes. Still functional for in-flight runs; scheduled for removal.
+- **On server restart:** `refill-paused-jobs` migration re-queues legacy paused runs. Waitpoint DELAYs are BullMQ delayed jobs and survive restarts natively.
 
 ## Side Effects
 

--- a/docs/build-pieces/piece-reference/flow-control.mdx
+++ b/docs/build-pieces/piece-reference/flow-control.mdx
@@ -40,6 +40,8 @@ import { ExecutionType } from '@activepieces/shared';
 async run(ctx) {
   if (ctx.executionType === ExecutionType.BEGIN) {
     // First invocation: create the waitpoint and pause.
+    // A real WEBHOOK waitpoint must surface waitpoint.buildResumeUrl(...) to
+    // the outside world — see the "Wait for a webhook callback" section below.
     const waitpoint = await ctx.run.createWaitpoint({ type: 'WEBHOOK' });
     ctx.run.waitForWaitpoint(waitpoint.id);
     return {};
@@ -152,7 +154,7 @@ async run(ctx) {
 On the `RESUME` branch, `ctx.resumePayload` is whatever the resume call carried in:
 
 ```typescript
-ctx.resumePayload.body        // request body, or the DELAY job payload
+ctx.resumePayload.body        // request body from the webhook caller (empty for DELAY)
 ctx.resumePayload.headers     // HTTP headers from the webhook caller
 ctx.resumePayload.queryParams // parsed ?foo=bar query string
 ```

--- a/docs/build-pieces/piece-reference/flow-control.mdx
+++ b/docs/build-pieces/piece-reference/flow-control.mdx
@@ -1,16 +1,16 @@
 ---
 title: 'Flow Control'
 icon: 'Joystick'
-description: 'Learn How to Control Flow from Inside the Piece'
+description: 'Learn how to control flow execution from inside a piece'
 ---
 
-Flow Controls provide the ability to control the flow of execution from inside a piece. By using the `ctx` parameter in the `run` method of actions, you can perform various operations to control the flow.
+Flow Controls let an action change the shape of the run — stop it early, send an intermediate HTTP response, or **pause the flow and resume later** when an external signal arrives. All of these are exposed on the `ctx` parameter of the action's `run` method.
 
 ## Stop Flow
 
-You can stop the flow and provide a response to the webhook trigger. This can be useful when you want to terminate the execution of the piece and send a specific response back.
+Stop the flow and (optionally) return a response to the webhook trigger that started it.
 
-**Example with Response:**
+**With a response:**
 
 ```typescript
 context.run.stop({
@@ -22,44 +22,143 @@ context.run.stop({
 });
 ```
 
-**Example without Response:**
+**Without a response:**
 
 ```typescript
 context.run.stop();
 ```
 
-## Pause Flow and Wait for Webhook
+## Pause with a waitpoint
 
-You can pause flow and return HTTP response, also provide a callback to URL that you can call with certain payload and continue the flow.
+A **waitpoint** is a durable checkpoint: the run is marked `PAUSED`, its execution state is persisted, and the action will be invoked a second time once the waitpoint is resumed. Waitpoints survive worker restarts — see [Durable Execution](/install/architecture/durable-execution) for the full model.
 
-**Example:**
-
-```typescript
-ctx.run.pause({
-  pauseMetadata: {
-    type: PauseType.WEBHOOK,
-    response: {
-      callbackUrl: context.generateResumeUrl({
-        queryParams: {},
-      }),
-    },
-  },
-});
-```
-
-## Pause Flow and Delay
-
-You can pause or delay the flow until a specific timestamp. Currently, the only supported type of pause is a delay based on a future timestamp.
-
-**Example:**
+The same action runs twice — once to create the waitpoint, once to read the resume payload — so every pausing action branches on `ctx.executionType`:
 
 ```typescript
-ctx.run.pause({
-    pauseMetadata: {
-        type: PauseType.DELAY,
-        resumeDateTime: futureTime.toUTCString()
-    }
-});
+import { ExecutionType } from '@activepieces/shared';
+
+async run(ctx) {
+  if (ctx.executionType === ExecutionType.BEGIN) {
+    // First invocation: create the waitpoint and pause.
+    const waitpoint = await ctx.run.createWaitpoint({ type: 'WEBHOOK' });
+    ctx.run.waitForWaitpoint(waitpoint.id);
+    return {};
+  }
+
+  // Second invocation: the waitpoint was resumed.
+  return {
+    body: ctx.resumePayload.body,
+    headers: ctx.resumePayload.headers,
+    queryParams: ctx.resumePayload.queryParams,
+  };
+}
 ```
 
-These flow hooks give you control over the execution of the piece by allowing you to stop the flow or pause it until a certain condition is met. You can use these hooks to customize the behavior and flow of your actions.
+Two hooks do the work:
+
+- `ctx.run.createWaitpoint({ type, ... })` — registers the waitpoint on the server and returns `{ id, resumeUrl, buildResumeUrl }`.
+- `ctx.run.waitForWaitpoint(waitpointId)` — tells the engine the step's verdict is `paused`; the run transitions to `PAUSED` after the action returns.
+
+There are two waitpoint types.
+
+### Wait for a webhook callback
+
+Create a `WEBHOOK` waitpoint and expose its resume URL — the flow will resume whenever that URL is called.
+
+```typescript
+async run(ctx) {
+  if (ctx.executionType === ExecutionType.BEGIN) {
+    const waitpoint = await ctx.run.createWaitpoint({ type: 'WEBHOOK' });
+
+    const callbackUrl = waitpoint.buildResumeUrl({
+      queryParams: { runId: ctx.run.id },
+    });
+
+    // Send `callbackUrl` somewhere the outside world can reach it
+    // (email, Slack message, third-party API, etc).
+
+    ctx.run.waitForWaitpoint(waitpoint.id);
+    return {};
+  }
+
+  return {
+    approved: ctx.resumePayload.queryParams['action'] === 'approve',
+  };
+}
+```
+
+`buildResumeUrl` takes an optional `sync: true` to return the caller a synchronous response produced by the remainder of the flow, and a `queryParams` object that is carried through to `ctx.resumePayload.queryParams` on resume.
+
+### Respond immediately and wait for the next webhook
+
+Pause the flow **and** immediately reply to the webhook trigger — useful for "we got your submission, we'll call you back" patterns. Pass `responseToSend` and your HTTP response is sent right away; the flow then sits paused until the returned URL is called.
+
+```typescript
+async run(ctx) {
+  if (ctx.executionType === ExecutionType.BEGIN) {
+    const waitpoint = await ctx.run.createWaitpoint({
+      type: 'WEBHOOK',
+      responseToSend: {
+        status: 200,
+        headers: {},
+        body: { accepted: true },
+      },
+    });
+
+    const nextWebhookUrl = waitpoint.buildResumeUrl({
+      queryParams: { created: new Date().toISOString() },
+      sync: true,
+    });
+
+    // nextWebhookUrl is what the counterpart should call to resume this run.
+
+    ctx.run.waitForWaitpoint(waitpoint.id);
+    return { nextWebhookUrl };
+  }
+
+  return {
+    body: ctx.resumePayload.body,
+    headers: ctx.resumePayload.headers,
+    queryParams: ctx.resumePayload.queryParams,
+  };
+}
+```
+
+### Delay until a timestamp
+
+Create a `DELAY` waitpoint with the UTC timestamp you want to resume at. The server schedules a one-time job that fires at `resumeDateTime` and resumes the run automatically.
+
+```typescript
+async run(ctx) {
+  if (ctx.executionType === ExecutionType.RESUME) {
+    return { success: true };
+  }
+
+  const futureTime = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+  const waitpoint = await ctx.run.createWaitpoint({
+    type: 'DELAY',
+    resumeDateTime: futureTime.toUTCString(),
+  });
+  ctx.run.waitForWaitpoint(waitpoint.id);
+  return {};
+}
+```
+
+`resumeDateTime` is capped by the server's `AP_PAUSED_FLOW_TIMEOUT_DAYS` setting; the engine throws `PausedFlowTimeoutError` if you ask for a longer delay.
+
+## Reading the resume payload
+
+On the `RESUME` branch, `ctx.resumePayload` is whatever the resume call carried in:
+
+```typescript
+ctx.resumePayload.body        // request body, or the DELAY job payload
+ctx.resumePayload.headers     // HTTP headers from the webhook caller
+ctx.resumePayload.queryParams // parsed ?foo=bar query string
+```
+
+For `DELAY` waitpoints there is no incoming HTTP request, so the payload is empty — use the `RESUME` branch simply to produce the step's final output.
+
+<Warning>
+  **Deprecated:** older pieces use `ctx.run.pause({ pauseMetadata: { type: PauseType.WEBHOOK | PauseType.DELAY, ... } })` together with `ctx.generateResumeUrl(...)`. That V0 API is kept for backwards compatibility with in-flight paused runs and will be removed. New actions must use `ctx.run.createWaitpoint` + `ctx.run.waitForWaitpoint`.
+</Warning>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -200,6 +200,8 @@
                      "install/architecture/overview",
                      "install/architecture/workers",
                      "install/architecture/engine",
+                     "install/architecture/durable-execution",
+                     "install/architecture/waitpoints",
                      "install/architecture/network-security",
                      "install/architecture/benchmark"
                   ]

--- a/docs/install/architecture/durable-execution.mdx
+++ b/docs/install/architecture/durable-execution.mdx
@@ -1,0 +1,47 @@
+---
+title: "Durable Execution"
+icon: "shield-check"
+---
+
+Flow runs in Activepieces are durable: progress survives worker crashes, deployments, and long pauses because state is persisted on every step boundary rather than held in a worker process.
+
+## Guarantees
+
+- A completed step is never re-executed implicitly. Retries are explicit (per-step or per-run).
+- A paused step is never dropped. Pause state is a row in Postgres, not memory.
+- Any worker can resume any run. There is no sticky worker and no leader election.
+
+## How state is persisted
+
+Every run is represented by a `FlowExecutorContext` — the graph's current position, every completed step's output, the run verdict, and the loop/branch path. The context is serialized and zstd-compressed into a log file on object storage.
+
+- Checkpointed on every step boundary and on a 15-second backup.
+- Worst-case data loss on crash is the in-flight step, which is retried from the last checkpoint.
+- The same checkpoint powers "retry from failed step": the engine rebuilds the pre-failure context and re-runs from the exact failure point, keeping prior outputs.
+
+## How execution is scheduled
+
+Runs move between states via BullMQ jobs on Redis, not in-process calls:
+
+1. A trigger enqueues a run. Any worker claims it.
+2. When a step pauses or finishes, the worker writes the updated context and returns.
+3. When a resume signal arrives (timer or callback), it enqueues a resume job against the persisted context.
+
+Workers hold no durable state of their own, so restarts are safe and scaling is linear.
+
+## How pause works
+
+A paused step is represented by a **waitpoint** — a Postgres row recording which run is paused, at which step, waiting for what, plus the resume payload once it arrives. Waitpoints make two things possible:
+
+- A timer-based pause that outlives a deployment is a BullMQ delayed job plus a Postgres row. Nothing in memory.
+- A webhook callback that arrives before the `PAUSED` transition is committed is recorded against the waitpoint and replayed into the run as soon as it reaches `PAUSED`.
+
+From the piece author's side, a paused step is invoked exactly twice — once to create the waitpoint, once to read the resume payload — regardless of how many workers handle the run in between.
+
+The waitpoint schema, lifecycle, and race-handling protocol are on the [Waitpoints](/install/architecture/waitpoints) page.
+
+## Consistency notes
+
+- Flow state transitions are committed to Postgres before any side effect is acknowledged to a caller.
+- Resume signals are idempotent: a waitpoint is completed at most once, and duplicate callbacks are absorbed by a uniqueness constraint on `(flow_run_id, step_name)`.
+- On a race between "run finished pausing" and "callback arrived," the callback is pre-recorded and replayed once the run reaches `PAUSED`.

--- a/docs/install/architecture/durable-execution.mdx
+++ b/docs/install/architecture/durable-execution.mdx
@@ -3,66 +3,68 @@ title: "Durable Execution"
 icon: "shield-check"
 ---
 
-Flow runs in Activepieces are durable: progress survives worker crashes, deployments, and long pauses because state is persisted on every step boundary rather than held in a worker process.
+A worker is halfway through a five-step flow when its container is recycled. Another worker picks the run up seconds later, walks the graph from the trigger, and for every step whose output is already in the run's log it skips execution and reuses the cached output. It stops at the first step that is not yet in the log and runs that one. The flow finishes as if nothing happened. That is durable execution in Activepieces — one mechanism that covers crashes, deploys, multi-day pauses, and retries.
+
+## The run log
+
+Every flow run has a **run log**: a single compressed checkpoint file that holds everything needed to resume the run on a fresh worker.
+
+What is in it:
+
+- One entry per completed step, keyed by step name: its input (with secrets censored), its output, its status, its duration, and — for failed steps — the error message.
+- Loop iterations and router branches are recorded with the same shape, nested under their parent step.
+- Run-level tags.
+
+When it is written:
+
+- **Once at the start of the run**, before the first step executes, so a crash in step one still has something to resume from.
+- **Every 15 seconds during execution**, by a background loop that snapshots whatever steps have completed since the last write.
+- **Once on the final state** — success, failure, or pause.
+
+Each write overwrites the previous copy of the log. Only the latest checkpoint is retained, and the file is compressed before upload so a long-running flow with large step outputs does not bloat storage.
+
+## Replay and skip
+
+Resume is not a special path. Every time a worker starts executing a run — the first time or the hundredth — it walks the flow graph from the trigger, and at every step asks: *is the output of this step already in the log?*
+
+- If yes, and the step completed (`SUCCEEDED` or `PAUSED`), the engine returns the cached output immediately and moves to the next step.
+- If no, the engine executes the step for real, records its output, and continues.
+
+The first time a run is scheduled, the log is empty, so every step runs for real. After a resume, the log is full up to the interruption, so the engine fast-forwards through all of that and only executes whatever came next.
 
 ```mermaid
-stateDiagram-v2
-    [*] --> QUEUED: trigger fires
-    QUEUED --> RUNNING: worker claims job
-    RUNNING --> PAUSED: waitpoint created
-    PAUSED --> RUNNING: resume signal
-    RUNNING --> SUCCEEDED
-    RUNNING --> FAILED
-    SUCCEEDED --> [*]
-    FAILED --> [*]
+sequenceDiagram
+    participant Worker
+    participant Log as Run log
+    participant Flow as Flow graph
+
+    Worker->>Log: load checkpoint
+    Worker->>Flow: walk from trigger
+    Flow-->>Worker: step A
+    Worker->>Log: output for A?
+    Log-->>Worker: yes (cached)
+    Note over Worker: skip A, reuse output
+    Flow-->>Worker: step B
+    Worker->>Log: output for B?
+    Log-->>Worker: yes (cached)
+    Note over Worker: skip B, reuse output
+    Flow-->>Worker: step C
+    Worker->>Log: output for C?
+    Log-->>Worker: no
+    Note over Worker: execute C, append to log
 ```
 
-## Guarantees
+Worst-case data loss on an abrupt crash is the single step that was executing when the worker died — it is simply re-run from the last checkpoint. Everything before it is already in the log and is skipped.
 
-- A completed step is never re-executed implicitly. Retries are explicit (per-step or per-run).
-- A paused step is never dropped. Pause state is a durable row in Postgres, not memory.
-- Any worker can resume any run. There is no sticky worker and no leader election.
+## What triggers a resume
 
-## How state is persisted
+Every kind of interruption resolves through the same replay path; only the trigger differs.
 
-A running flow carries an execution context — the graph's current position, every completed step's output, the run verdict, and the loop/branch path. That context is serialized and compressed into a log file on object storage.
+- **Worker crash or deployment.** The queue reassigns the run to another worker, which loads the run log and replays.
+- **Paused step.** The piece creates a [waitpoint](/install/architecture/waitpoints) (a timer or a webhook callback). When the waitpoint fires, a resume job is enqueued and a worker replays the run.
+- **Retry from failed step.** The same run log is reused — the failed step stays in the log, the run is re-queued, and a worker replays up to that step and re-runs forward from there.
+- **Normal progression within one worker.** The replay model still applies; the worker just never had to leave the process to do it.
 
-- Checkpointed on every step boundary, with a periodic background backup.
-- Worst-case data loss on crash is the in-flight step, which is retried from the last checkpoint.
-- The same checkpoint powers "retry from failed step": the pre-failure context is rebuilt and the run resumes from the exact failure point, keeping prior outputs.
+## Piece-author contract
 
-## How execution is scheduled
-
-Runs move between states via a durable job queue on Redis, not in-process calls:
-
-1. A trigger enqueues a run. Any worker claims it.
-2. When a step pauses or finishes, the worker writes the updated context and returns.
-3. When a resume signal arrives (timer or callback), it enqueues a resume job against the persisted context.
-
-Workers hold no durable state of their own, so restarts are safe and scaling is linear.
-
-```mermaid
-flowchart LR
-    Trigger([Trigger]) --> Queue[(Job queue)]
-    Queue -->|claim| Worker[Worker]
-    Worker <-->|context| Logs[(Log file)]
-    Worker -->|state| PG[(Postgres)]
-    Resume([Resume signal]) --> Queue
-```
-
-## How pause works
-
-A paused step is represented by a **waitpoint** — a row that records which run is paused, at which step, waiting for what, plus the resume payload once it arrives. Waitpoints make two things possible:
-
-- A timer-based pause that outlives a deployment is a delayed job plus a Postgres row. Nothing in memory.
-- A callback that arrives before the `PAUSED` transition is committed is recorded against the waitpoint and replayed into the run as soon as it reaches `PAUSED`.
-
-From the piece author's side, a paused step is invoked exactly twice — once to create the waitpoint, once to read the resume payload — regardless of how many workers handle the run in between.
-
-The waitpoint schema, lifecycle, and race-handling protocol are on the [Waitpoints](/install/architecture/waitpoints) page.
-
-## Consistency notes
-
-- Flow state transitions are committed to Postgres before any side effect is acknowledged to a caller.
-- Resume signals are idempotent: a waitpoint is completed at most once, and duplicate callbacks are absorbed by a uniqueness constraint on the paused step.
-- On a race between "run finished pausing" and "callback arrived," the callback is pre-recorded and replayed once the run reaches `PAUSED`.
+Actions are executed once per run. The only exception is an action that explicitly pauses itself: its code is entered twice — once to create the waitpoint, once to read the resume payload — regardless of how many workers the run bounces between. Everything else shows up in the log as a single entry with a single output.

--- a/docs/install/architecture/durable-execution.mdx
+++ b/docs/install/architecture/durable-execution.mdx
@@ -5,23 +5,35 @@ icon: "shield-check"
 
 Flow runs in Activepieces are durable: progress survives worker crashes, deployments, and long pauses because state is persisted on every step boundary rather than held in a worker process.
 
+```mermaid
+stateDiagram-v2
+    [*] --> QUEUED: trigger fires
+    QUEUED --> RUNNING: worker claims job
+    RUNNING --> PAUSED: waitpoint created
+    PAUSED --> RUNNING: resume signal
+    RUNNING --> SUCCEEDED
+    RUNNING --> FAILED
+    SUCCEEDED --> [*]
+    FAILED --> [*]
+```
+
 ## Guarantees
 
 - A completed step is never re-executed implicitly. Retries are explicit (per-step or per-run).
-- A paused step is never dropped. Pause state is a row in Postgres, not memory.
+- A paused step is never dropped. Pause state is a durable row in Postgres, not memory.
 - Any worker can resume any run. There is no sticky worker and no leader election.
 
 ## How state is persisted
 
-Every run is represented by a `FlowExecutorContext` — the graph's current position, every completed step's output, the run verdict, and the loop/branch path. The context is serialized and zstd-compressed into a log file on object storage.
+A running flow carries an execution context — the graph's current position, every completed step's output, the run verdict, and the loop/branch path. That context is serialized and compressed into a log file on object storage.
 
-- Checkpointed on every step boundary and on a 15-second backup.
+- Checkpointed on every step boundary, with a periodic background backup.
 - Worst-case data loss on crash is the in-flight step, which is retried from the last checkpoint.
-- The same checkpoint powers "retry from failed step": the engine rebuilds the pre-failure context and re-runs from the exact failure point, keeping prior outputs.
+- The same checkpoint powers "retry from failed step": the pre-failure context is rebuilt and the run resumes from the exact failure point, keeping prior outputs.
 
 ## How execution is scheduled
 
-Runs move between states via BullMQ jobs on Redis, not in-process calls:
+Runs move between states via a durable job queue on Redis, not in-process calls:
 
 1. A trigger enqueues a run. Any worker claims it.
 2. When a step pauses or finishes, the worker writes the updated context and returns.
@@ -29,12 +41,21 @@ Runs move between states via BullMQ jobs on Redis, not in-process calls:
 
 Workers hold no durable state of their own, so restarts are safe and scaling is linear.
 
+```mermaid
+flowchart LR
+    Trigger([Trigger]) --> Queue[(Job queue)]
+    Queue -->|claim| Worker[Worker]
+    Worker <-->|context| Logs[(Log file)]
+    Worker -->|state| PG[(Postgres)]
+    Resume([Resume signal]) --> Queue
+```
+
 ## How pause works
 
-A paused step is represented by a **waitpoint** — a Postgres row recording which run is paused, at which step, waiting for what, plus the resume payload once it arrives. Waitpoints make two things possible:
+A paused step is represented by a **waitpoint** — a row that records which run is paused, at which step, waiting for what, plus the resume payload once it arrives. Waitpoints make two things possible:
 
-- A timer-based pause that outlives a deployment is a BullMQ delayed job plus a Postgres row. Nothing in memory.
-- A webhook callback that arrives before the `PAUSED` transition is committed is recorded against the waitpoint and replayed into the run as soon as it reaches `PAUSED`.
+- A timer-based pause that outlives a deployment is a delayed job plus a Postgres row. Nothing in memory.
+- A callback that arrives before the `PAUSED` transition is committed is recorded against the waitpoint and replayed into the run as soon as it reaches `PAUSED`.
 
 From the piece author's side, a paused step is invoked exactly twice — once to create the waitpoint, once to read the resume payload — regardless of how many workers handle the run in between.
 
@@ -43,5 +64,5 @@ The waitpoint schema, lifecycle, and race-handling protocol are on the [Waitpoin
 ## Consistency notes
 
 - Flow state transitions are committed to Postgres before any side effect is acknowledged to a caller.
-- Resume signals are idempotent: a waitpoint is completed at most once, and duplicate callbacks are absorbed by a uniqueness constraint on `(flow_run_id, step_name)`.
+- Resume signals are idempotent: a waitpoint is completed at most once, and duplicate callbacks are absorbed by a uniqueness constraint on the paused step.
 - On a race between "run finished pausing" and "callback arrived," the callback is pre-recorded and replayed once the run reaches `PAUSED`.

--- a/docs/install/architecture/durable-execution.mdx
+++ b/docs/install/architecture/durable-execution.mdx
@@ -3,34 +3,34 @@ title: "Durable Execution"
 icon: "shield-check"
 ---
 
-A worker is halfway through a five-step flow when its container is recycled. Another worker picks the run up seconds later, walks the graph from the trigger, and for every step whose output is already in the run's log it skips execution and reuses the cached output. It stops at the first step that is not yet in the log and runs that one. The flow finishes as if nothing happened. That is durable execution in Activepieces — one mechanism that covers crashes, deploys, multi-day pauses, and retries.
+A worker is halfway through a flow when its container is recycled. Another worker picks the run up, walks the graph from the trigger, and for every step whose output is already in the run's log it skips execution and reuses the cached output. It stops at the first step that is not yet in the log and runs that one. One mechanism covers crashes, deploys, multi-day pauses, and retries.
 
 ## The run log
 
-Every flow run has a **run log**: a single compressed checkpoint file that holds everything needed to resume the run on a fresh worker.
+Every flow run has a **run log**: a single compressed checkpoint file holding everything needed to resume the run on a fresh worker.
 
 What is in it:
 
-- One entry per completed step, keyed by step name: its input (with secrets censored), its output, its status, its duration, and — for failed steps — the error message.
+- One entry per completed step, keyed by step name: input (secrets censored), output, status, duration, and error message for failed steps.
 - Loop iterations and router branches are recorded with the same shape, nested under their parent step.
 - Run-level tags.
 
 When it is written:
 
-- **Once at the start of the run**, before the first step executes, so a crash in step one still has something to resume from.
-- **Every 15 seconds during execution**, by a background loop that snapshots whatever steps have completed since the last write.
-- **Once on the final state** — success, failure, or pause.
+- Once at the start of the run, before the first step executes.
+- Every 15 seconds during execution, from a background loop that snapshots whatever has completed since the last write.
+- Once on the final state (success, failure, or pause).
 
-Each write overwrites the previous copy of the log. Only the latest checkpoint is retained, and the file is compressed before upload so a long-running flow with large step outputs does not bloat storage.
+Each write overwrites the previous copy. Only the latest checkpoint is retained, and the file is compressed before upload.
 
 ## Replay and skip
 
-Resume is not a special path. Every time a worker starts executing a run — the first time or the hundredth — it walks the flow graph from the trigger, and at every step asks: *is the output of this step already in the log?*
+Resume is not a special path. Every time a worker starts executing a run, it walks the flow graph from the trigger and at every step asks: *is the output of this step already in the log?*
 
-- If yes, and the step completed (`SUCCEEDED` or `PAUSED`), the engine returns the cached output immediately and moves to the next step.
-- If no, the engine executes the step for real, records its output, and continues.
+- If yes, and the step completed (`SUCCEEDED` or `PAUSED`), the engine returns the cached output and moves on.
+- If no, the engine executes the step, records its output, and continues.
 
-The first time a run is scheduled, the log is empty, so every step runs for real. After a resume, the log is full up to the interruption, so the engine fast-forwards through all of that and only executes whatever came next.
+The first time a run is scheduled the log is empty, so every step runs. After a resume the log is full up to the interruption, so the engine fast-forwards through all of it and only executes whatever came next.
 
 ```mermaid
 sequenceDiagram
@@ -54,17 +54,13 @@ sequenceDiagram
     Note over Worker: execute C, append to log
 ```
 
-Worst-case data loss on an abrupt crash is the single step that was executing when the worker died — it is simply re-run from the last checkpoint. Everything before it is already in the log and is skipped.
+Worst-case data loss on an abrupt crash is the single step that was executing when the worker died. It is re-run from the last checkpoint; everything before it is skipped.
 
 ## What triggers a resume
 
 Every kind of interruption resolves through the same replay path; only the trigger differs.
 
-- **Worker crash or deployment.** The queue reassigns the run to another worker, which loads the run log and replays.
-- **Paused step.** The piece creates a [waitpoint](/install/architecture/waitpoints) (a timer or a webhook callback). When the waitpoint fires, a resume job is enqueued and a worker replays the run.
-- **Retry from failed step.** The same run log is reused — the failed step stays in the log, the run is re-queued, and a worker replays up to that step and re-runs forward from there.
-- **Normal progression within one worker.** The replay model still applies; the worker just never had to leave the process to do it.
-
-## Piece-author contract
-
-Actions are executed once per run. The only exception is an action that explicitly pauses itself: its code is entered twice — once to create the waitpoint, once to read the resume payload — regardless of how many workers the run bounces between. Everything else shows up in the log as a single entry with a single output.
+- **Worker crash or deployment.** The queue reassigns the run to another worker, which loads the log and replays.
+- **Paused step.** The piece creates a [waitpoint](/install/architecture/waitpoints). When the waitpoint fires, a resume job is enqueued and a worker replays the run.
+- **Retry from failed step.** The same log is reused; the run is re-queued and a worker replays from the failure point.
+- **Normal progression within one worker.** Same replay model, without leaving the process.

--- a/docs/install/architecture/waitpoints.mdx
+++ b/docs/install/architecture/waitpoints.mdx
@@ -1,0 +1,59 @@
+---
+title: "Waitpoints"
+icon: "hourglass-half"
+---
+
+A **waitpoint** is the durable row that represents a paused step on a flow run. It is the single source of truth for a pause — the flow run row only carries status (`PAUSED`, `RUNNING`, …); the *why* lives on the waitpoint.
+
+## Schema
+
+| Field | Meaning |
+| --- | --- |
+| `flowRunId`, `stepName` | Which run/step is paused. Unique together — a step has at most one waitpoint. |
+| `type` | `DELAY` or `WEBHOOK`. |
+| `status` | `PENDING` until the resume signal arrives, then `COMPLETED`. |
+| `resumeDateTime` | For `DELAY`: when to fire the resume. |
+| `responseToSend` | For `WEBHOOK`: optional HTTP response returned immediately to the original webhook trigger. |
+| `resumePayload` | `{ body, headers, queryParams }` from the resume call, surfaced to the piece as `ctx.resumePayload`. |
+| `workerHandlerId`, `httpRequestId` | Routing hints for synchronous resumes. |
+| `version` | `V1` (current). `V0` is the legacy `pauseMetadata`-based path, kept for in-flight runs. |
+
+## Types
+
+- **`DELAY`** — resumes at `resumeDateTime`. On insert, the server upserts a one-time BullMQ job (`RESUME_DELAY_WAITPOINT`) scheduled at that timestamp. The delay is capped by `AP_PAUSED_FLOW_TIMEOUT_DAYS`; the engine throws `PausedFlowTimeoutError` beyond that.
+- **`WEBHOOK`** — resumes on any HTTP call to the waitpoint's resume URL. If `responseToSend` is set, it is replied immediately to the original trigger so a single webhook can respond-then-pause.
+
+## Lifecycle
+
+1. **Create.** The piece calls `ctx.run.createWaitpoint({ type, ... })` + `ctx.run.waitForWaitpoint(id)`. The engine sets the step verdict to `paused` and `POST`s `/v1/waitpoints`. The server inserts a `PENDING` row (idempotent via `ON CONFLICT DO NOTHING` on `flow_run_id + step_name`).
+2. **Checkpoint.** The engine serializes `FlowExecutorContext` into the run's log file and transitions the flow run to `PAUSED`.
+3. **Resume signal.** Either an HTTP call on `/v1/flow-runs/:id/waitpoints/:waitpointId[/sync]` or the scheduled BullMQ job firing. Both land in `WaitpointService.handleResumeSignal` with the callback's `{ body, headers, queryParams }`.
+4. **Re-run.** A worker rebuilds the context from the log file and re-invokes the same action with `ctx.executionType === ExecutionType.RESUME` and `ctx.resumePayload` populated.
+
+## Resume-before-pause race
+
+A callback can arrive before the flow run has finished writing `PAUSED` to disk. The protocol absorbs the race:
+
+- `WaitpointService.complete()` takes a pessimistic write lock on the `PENDING` row. If it exists, it flips to `COMPLETED` and stores `resumePayload`. If it does not, a **pre-completed** row is inserted.
+- When the flow run transitions to `PAUSED`, the `runsMetadataQueue` handler checks for a matching `COMPLETED` waitpoint and enqueues the resume job immediately.
+
+Duplicate callbacks are absorbed by the uniqueness constraint; the engine never processes a resume twice.
+
+## Endpoints
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/v1/waitpoints` | Engine-only. Creates a `PENDING` waitpoint, returns its resume URL. |
+| `ALL` | `/v1/flow-runs/:id/waitpoints/:waitpointId` | Resume, async. |
+| `ALL` | `/v1/flow-runs/:id/waitpoints/:waitpointId/sync` | Resume, sync — the HTTP response is whatever the flow produces after resuming. |
+| `ALL` | `/v1/flow-runs/:id/requests/:requestId[/sync]` | **V0 legacy**, kept for in-flight `pauseMetadata`-based runs. |
+
+## Restart behavior
+
+- `WEBHOOK` waitpoints sit in Postgres; nothing to restart.
+- `DELAY` waitpoints are BullMQ delayed jobs and survive worker restarts natively.
+- Legacy paused runs are re-queued by the `refill-paused-jobs` migration.
+
+## Piece API
+
+Piece authors create waitpoints with `ctx.run.createWaitpoint` / `ctx.run.waitForWaitpoint`. Patterns for `WEBHOOK`, `DELAY`, and `responseToSend` are in Flow Control.

--- a/docs/install/architecture/waitpoints.mdx
+++ b/docs/install/architecture/waitpoints.mdx
@@ -3,7 +3,7 @@ title: "Waitpoints"
 icon: "hourglass-half"
 ---
 
-A **waitpoint** is the durable row that represents a paused step on a flow run. It is the single source of truth for a pause — the flow run row only carries status (`PAUSED`, `RUNNING`, …); the *why* lives on the waitpoint.
+A **waitpoint** is the durable row that represents a paused step on a flow run. The flow run row only carries status (`PAUSED`, `RUNNING`, …); the *why* lives on the waitpoint.
 
 ```mermaid
 stateDiagram-v2
@@ -17,7 +17,7 @@ stateDiagram-v2
 
 | Field | Meaning |
 | --- | --- |
-| `flowRunId`, `stepName` | Which run/step is paused. Unique together — a step has at most one waitpoint. |
+| `flowRunId`, `stepName` | Which run/step is paused. Unique together: a step has at most one waitpoint. |
 | `type` | `DELAY` or `WEBHOOK`. |
 | `status` | `PENDING` until the resume signal arrives, then `COMPLETED`. |
 | `resumeDateTime` | For `DELAY`: when to fire the resume. |
@@ -26,14 +26,14 @@ stateDiagram-v2
 
 ## Types
 
-- **`DELAY`** — resumes at `resumeDateTime`. The server schedules a one-time job for that timestamp. The delay is bounded by a configurable server-side maximum.
-- **`WEBHOOK`** — resumes on any HTTP call to the waitpoint's resume URL. If `responseToSend` is set, it is replied immediately to the original trigger so a single webhook can respond-then-pause.
+- **`DELAY`**: resumes at `resumeDateTime`. The server schedules a one-time job for that timestamp. The delay is bounded by a configurable server-side maximum.
+- **`WEBHOOK`**: resumes on any HTTP call to the waitpoint's resume URL. If `responseToSend` is set, it is replied immediately to the original trigger so a single webhook can respond-then-pause.
 
 ## Lifecycle
 
-1. **Create.** The piece calls `ctx.run.createWaitpoint({ type, ... })` + `ctx.run.waitForWaitpoint(id)`. The engine sets the step verdict to `paused` and asks the server to insert a `PENDING` row. The insert is idempotent on the `(flow run, step)` pair.
+1. **Create.** The piece calls `ctx.run.createWaitpoint({ type, ... })` + `ctx.run.waitForWaitpoint(id)`. The engine marks the step as `paused` and asks the server to insert a `PENDING` row. The insert is idempotent on the `(flow run, step)` pair.
 2. **Checkpoint.** The engine serializes the execution context and transitions the flow run to `PAUSED`.
-3. **Resume signal.** Either an HTTP call on the resume URL or the scheduled job firing. Both carry a payload of `{ body, headers, queryParams }`.
+3. **Resume signal.** Either an HTTP call on the resume URL or the scheduled job firing. Both carry `{ body, headers, queryParams }`.
 4. **Re-run.** A worker rebuilds the context and re-invokes the same action with `ctx.executionType === ExecutionType.RESUME` and `ctx.resumePayload` populated.
 
 ```mermaid
@@ -70,7 +70,7 @@ Duplicate callbacks are absorbed by the uniqueness constraint; the engine never 
 | --- | --- | --- |
 | `POST` | `/v1/waitpoints` | Engine-only. Creates a `PENDING` waitpoint, returns its resume URL. |
 | `ALL` | `/v1/flow-runs/:id/waitpoints/:waitpointId` | Resume, async. |
-| `ALL` | `/v1/flow-runs/:id/waitpoints/:waitpointId/sync` | Resume, sync — the HTTP response is whatever the flow produces after resuming. |
+| `ALL` | `/v1/flow-runs/:id/waitpoints/:waitpointId/sync` | Resume, sync. The HTTP response is whatever the flow produces after resuming. |
 
 ## Piece API
 

--- a/docs/install/architecture/waitpoints.mdx
+++ b/docs/install/architecture/waitpoints.mdx
@@ -48,12 +48,6 @@ Duplicate callbacks are absorbed by the uniqueness constraint; the engine never 
 | `ALL` | `/v1/flow-runs/:id/waitpoints/:waitpointId/sync` | Resume, sync — the HTTP response is whatever the flow produces after resuming. |
 | `ALL` | `/v1/flow-runs/:id/requests/:requestId[/sync]` | **V0 legacy**, kept for in-flight `pauseMetadata`-based runs. |
 
-## Restart behavior
-
-- `WEBHOOK` waitpoints sit in Postgres; nothing to restart.
-- `DELAY` waitpoints are BullMQ delayed jobs and survive worker restarts natively.
-- Legacy paused runs are re-queued by the `refill-paused-jobs` migration.
-
 ## Piece API
 
 Piece authors create waitpoints with `ctx.run.createWaitpoint` / `ctx.run.waitForWaitpoint`. Patterns for `WEBHOOK`, `DELAY`, and `responseToSend` are in Flow Control.

--- a/docs/install/architecture/waitpoints.mdx
+++ b/docs/install/architecture/waitpoints.mdx
@@ -5,6 +5,15 @@ icon: "hourglass-half"
 
 A **waitpoint** is the durable row that represents a paused step on a flow run. It is the single source of truth for a pause — the flow run row only carries status (`PAUSED`, `RUNNING`, …); the *why* lives on the waitpoint.
 
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING: createWaitpoint
+    PENDING --> COMPLETED: resume signal
+    COMPLETED --> [*]: flow resumes
+    [*] --> COMPLETED: pre-completed
+(resume arrived first)
+```
+
 ## Schema
 
 | Field | Meaning |
@@ -15,27 +24,44 @@ A **waitpoint** is the durable row that represents a paused step on a flow run. 
 | `resumeDateTime` | For `DELAY`: when to fire the resume. |
 | `responseToSend` | For `WEBHOOK`: optional HTTP response returned immediately to the original webhook trigger. |
 | `resumePayload` | `{ body, headers, queryParams }` from the resume call, surfaced to the piece as `ctx.resumePayload`. |
-| `workerHandlerId`, `httpRequestId` | Routing hints for synchronous resumes. |
-| `version` | `V1` (current). `V0` is the legacy `pauseMetadata`-based path, kept for in-flight runs. |
 
 ## Types
 
-- **`DELAY`** — resumes at `resumeDateTime`. On insert, the server upserts a one-time BullMQ job (`RESUME_DELAY_WAITPOINT`) scheduled at that timestamp. The delay is capped by `AP_PAUSED_FLOW_TIMEOUT_DAYS`; the engine throws `PausedFlowTimeoutError` beyond that.
+- **`DELAY`** — resumes at `resumeDateTime`. The server schedules a one-time job for that timestamp. The delay is bounded by a configurable server-side maximum.
 - **`WEBHOOK`** — resumes on any HTTP call to the waitpoint's resume URL. If `responseToSend` is set, it is replied immediately to the original trigger so a single webhook can respond-then-pause.
 
 ## Lifecycle
 
-1. **Create.** The piece calls `ctx.run.createWaitpoint({ type, ... })` + `ctx.run.waitForWaitpoint(id)`. The engine sets the step verdict to `paused` and `POST`s `/v1/waitpoints`. The server inserts a `PENDING` row (idempotent via `ON CONFLICT DO NOTHING` on `flow_run_id + step_name`).
-2. **Checkpoint.** The engine serializes `FlowExecutorContext` into the run's log file and transitions the flow run to `PAUSED`.
-3. **Resume signal.** Either an HTTP call on `/v1/flow-runs/:id/waitpoints/:waitpointId[/sync]` or the scheduled BullMQ job firing. Both land in `WaitpointService.handleResumeSignal` with the callback's `{ body, headers, queryParams }`.
-4. **Re-run.** A worker rebuilds the context from the log file and re-invokes the same action with `ctx.executionType === ExecutionType.RESUME` and `ctx.resumePayload` populated.
+1. **Create.** The piece calls `ctx.run.createWaitpoint({ type, ... })` + `ctx.run.waitForWaitpoint(id)`. The engine sets the step verdict to `paused` and asks the server to insert a `PENDING` row. The insert is idempotent on the `(flow run, step)` pair.
+2. **Checkpoint.** The engine serializes the execution context and transitions the flow run to `PAUSED`.
+3. **Resume signal.** Either an HTTP call on the resume URL or the scheduled job firing. Both carry a payload of `{ body, headers, queryParams }`.
+4. **Re-run.** A worker rebuilds the context and re-invokes the same action with `ctx.executionType === ExecutionType.RESUME` and `ctx.resumePayload` populated.
+
+```mermaid
+sequenceDiagram
+    participant Piece
+    participant Engine
+    participant Server
+    participant Queue as Job queue
+    participant Caller as Resume caller
+
+    Piece->>Engine: createWaitpoint + waitForWaitpoint
+    Engine->>Server: register waitpoint
+    Server-->>Engine: { id, resumeUrl }
+    Engine->>Engine: checkpoint context, status = PAUSED
+    Note over Piece,Server: ...time passes...
+    Caller->>Server: HTTP call on resumeUrl
+    Server->>Queue: enqueue resume job
+    Queue->>Engine: resume
+    Engine->>Piece: re-invoke with resumePayload
+```
 
 ## Resume-before-pause race
 
 A callback can arrive before the flow run has finished writing `PAUSED` to disk. The protocol absorbs the race:
 
-- `WaitpointService.complete()` takes a pessimistic write lock on the `PENDING` row. If it exists, it flips to `COMPLETED` and stores `resumePayload`. If it does not, a **pre-completed** row is inserted.
-- When the flow run transitions to `PAUSED`, the `runsMetadataQueue` handler checks for a matching `COMPLETED` waitpoint and enqueues the resume job immediately.
+- Completing a waitpoint takes a write lock on the `PENDING` row. If it exists, it flips to `COMPLETED` and stores the `resumePayload`. If it does not, a **pre-completed** row is inserted instead.
+- When the flow run transitions to `PAUSED`, the server checks for a matching `COMPLETED` waitpoint and enqueues the resume job immediately.
 
 Duplicate callbacks are absorbed by the uniqueness constraint; the engine never processes a resume twice.
 
@@ -46,7 +72,6 @@ Duplicate callbacks are absorbed by the uniqueness constraint; the engine never 
 | `POST` | `/v1/waitpoints` | Engine-only. Creates a `PENDING` waitpoint, returns its resume URL. |
 | `ALL` | `/v1/flow-runs/:id/waitpoints/:waitpointId` | Resume, async. |
 | `ALL` | `/v1/flow-runs/:id/waitpoints/:waitpointId/sync` | Resume, sync — the HTTP response is whatever the flow produces after resuming. |
-| `ALL` | `/v1/flow-runs/:id/requests/:requestId[/sync]` | **V0 legacy**, kept for in-flight `pauseMetadata`-based runs. |
 
 ## Piece API
 

--- a/docs/install/architecture/waitpoints.mdx
+++ b/docs/install/architecture/waitpoints.mdx
@@ -10,8 +10,7 @@ stateDiagram-v2
     [*] --> PENDING: createWaitpoint
     PENDING --> COMPLETED: resume signal
     COMPLETED --> [*]: flow resumes
-    [*] --> COMPLETED: pre-completed
-(resume arrived first)
+    [*] --> COMPLETED: pre-completed (resume arrived first)
 ```
 
 ## Schema


### PR DESCRIPTION
## Summary

- Adds two technical architecture pages: **Durable Execution** (guarantees, state persistence, scheduling, consistency) and **Waitpoints** (schema, types, lifecycle, resume-before-pause race, endpoints).
- Rewrites `build-pieces/piece-reference/flow-control.mdx` around the current `ctx.run.createWaitpoint` / `ctx.run.waitForWaitpoint` / `waitpoint.buildResumeUrl` API, covering `WEBHOOK`, `DELAY`, and `responseToSend` patterns, with a deprecation warning on the V0 `ctx.run.pause` + `generateResumeUrl` path.
- Wires the two new architecture pages into `docs/docs.json`.
- Updates `.agents/features/flow-runs.md` to document the `Waitpoint` entity, V1 `/waitpoints/:waitpointId[/sync]` endpoints, pre-completion race handling, and marks the V0 `pauseMetadata` + `/requests/:requestId` path as legacy.

## Test plan

- [ ] `cd docs && mintlify dev` — Architecture → Durable Execution and Architecture → Waitpoints render and appear in the sidebar.
- [ ] Build Pieces → Piece Reference → Flow Control renders with the new waitpoint examples.
- [ ] Cross-check the example snippets against `packages/pieces/core/{delay,approval,webhook}` so they remain copy-pasteable.