### PR TITLE
fix(engine): bind plain http.Agent for worker RPC in STRICT mode

### DIFF
--- a/packages/server/engine/src/lib/worker-socket.ts
+++ b/packages/server/engine/src/lib/worker-socket.ts
@@ -1,3 +1,4 @@
+import http from 'node:http'
 import { inspect } from 'node:util'
 import {
     createNotifyClient,
@@ -6,10 +7,11 @@ import {
     EngineContract,
     EngineResponse,
     ERROR_MESSAGES_TO_REDACT,
+    NetworkMode,
     WorkerContract,
     WorkerNotifyContract,
 } from '@activepieces/shared'
-import { io, type Socket } from 'socket.io-client'
+import { io, type ManagerOptions, type Socket, type SocketOptions } from 'socket.io-client'
 import { runProgressService } from './handler/run-progress'
 import { execute } from './operations'
 
@@ -20,12 +22,7 @@ let notifyClient: WorkerNotifyContract | undefined
 export const workerSocket = {
     init: (sandboxId: string): void => {
         const wsUrl = `ws://127.0.0.1:${process.env.AP_SANDBOX_WS_PORT ?? '12345'}`
-        socket = io(wsUrl, {
-            path: '/worker/ws',
-            auth: { sandboxId },
-            autoConnect: false,
-            reconnection: true,
-        })
+        socket = io(wsUrl, buildSocketOptions(sandboxId))
 
         workerClient = createRpcClient<WorkerContract>(socket, 60_000)
         notifyClient = createNotifyClient<WorkerNotifyContract>(socket)
@@ -84,4 +81,19 @@ export const workerSocket = {
     sendError: (error: unknown): void => {
         notifyClient?.stderr({ message: inspect(error) })
     },
+}
+
+function buildSocketOptions(sandboxId: string): Partial<ManagerOptions & SocketOptions> {
+    const base: Partial<ManagerOptions & SocketOptions> = {
+        path: '/worker/ws',
+        auth: { sandboxId },
+        autoConnect: false,
+        reconnection: true,
+    }
+    // In STRICT mode ssrf-guard rebinds http.globalAgent to HttpProxyAgent; a
+    // plain http.Agent here keeps the loopback worker RPC handshake off the proxy.
+    if (process.env['AP_NETWORK_MODE'] === NetworkMode.STRICT) {
+        Object.assign(base, { agent: new http.Agent() })
+    }
+    return base
 }

--- a/packages/server/engine/src/lib/worker-socket.ts
+++ b/packages/server/engine/src/lib/worker-socket.ts
@@ -81,6 +81,13 @@ export const workerSocket = {
     sendError: (error: unknown): void => {
         notifyClient?.stderr({ message: inspect(error) })
     },
+
+    disconnect: (): void => {
+        socket?.disconnect()
+        socket = undefined
+        workerClient = undefined
+        notifyClient = undefined
+    },
 }
 
 function buildSocketOptions(sandboxId: string): Partial<ManagerOptions & SocketOptions> {

--- a/packages/server/engine/test/network/worker-socket.test.ts
+++ b/packages/server/engine/test/network/worker-socket.test.ts
@@ -22,6 +22,7 @@ describe('workerSocket — STRICT-mode handshake', () => {
     })
 
     afterEach(async () => {
+        workerSocket.disconnect()
         http.globalAgent = originalHttpAgent
         if (originalNetworkMode === undefined) delete process.env['AP_NETWORK_MODE']
         else process.env['AP_NETWORK_MODE'] = originalNetworkMode

--- a/packages/server/engine/test/network/worker-socket.test.ts
+++ b/packages/server/engine/test/network/worker-socket.test.ts
@@ -1,0 +1,74 @@
+import http from 'node:http'
+import { NetworkMode } from '@activepieces/shared'
+import { HttpProxyAgent } from 'http-proxy-agent'
+import { Server as SocketIOServer } from 'socket.io'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { workerSocket } from '../../src/lib/worker-socket'
+
+describe('workerSocket — STRICT-mode handshake', () => {
+    const originalNetworkMode = process.env['AP_NETWORK_MODE']
+    const originalWsPort = process.env['AP_SANDBOX_WS_PORT']
+    const originalHttpAgent = http.globalAgent
+
+    let httpServer: http.Server
+    let io: SocketIOServer
+    let wsPort: number
+
+    beforeEach(async () => {
+        httpServer = http.createServer()
+        io = new SocketIOServer(httpServer, { path: '/worker/ws' })
+        await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', () => resolve()))
+        wsPort = (httpServer.address() as { port: number }).port
+    })
+
+    afterEach(async () => {
+        http.globalAgent = originalHttpAgent
+        if (originalNetworkMode === undefined) delete process.env['AP_NETWORK_MODE']
+        else process.env['AP_NETWORK_MODE'] = originalNetworkMode
+        if (originalWsPort === undefined) delete process.env['AP_SANDBOX_WS_PORT']
+        else process.env['AP_SANDBOX_WS_PORT'] = originalWsPort
+        await io.close()
+        await new Promise<void>((resolve) => httpServer.close(() => resolve()))
+    })
+
+    it('connects to the worker RPC server when ssrf-guard rebinds http.globalAgent to HttpProxyAgent', async () => {
+        // Simulate STRICT-mode bootstrap: ssrf-guard swaps the global agent to
+        // route piece HTTP via the egress proxy. Before the fix, socket.io-client's
+        // polling transport would fall back through Node's `agent:false` path,
+        // which calls `new defaultAgent.constructor(opts)` — i.e. `new HttpProxyAgent({})`
+        // without a URL — and crash the handshake. The worker then logs
+        // "Sandbox <id> did not connect within 30 seconds".
+        process.env['AP_NETWORK_MODE'] = NetworkMode.STRICT
+        process.env['AP_SANDBOX_WS_PORT'] = String(wsPort)
+        http.globalAgent = new HttpProxyAgent('http://127.0.0.1:1') // unreachable proxy by design
+
+        const connection = new Promise<string>((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error('sandbox did not connect')), 5_000)
+            io.on('connection', (socket) => {
+                clearTimeout(timer)
+                resolve(socket.handshake.auth.sandboxId as string)
+            })
+        })
+
+        workerSocket.init('test-sandbox')
+
+        await expect(connection).resolves.toBe('test-sandbox')
+    })
+
+    it('does not pin an agent outside STRICT mode', async () => {
+        delete process.env['AP_NETWORK_MODE']
+        process.env['AP_SANDBOX_WS_PORT'] = String(wsPort)
+
+        const connection = new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error('sandbox did not connect')), 5_000)
+            io.on('connection', () => {
+                clearTimeout(timer)
+                resolve()
+            })
+        })
+
+        workerSocket.init('test-sandbox-unrestricted')
+
+        await expect(connection).resolves.toBeUndefined()
+    })
+})

--- a/packages/server/worker/test/e2e/fixtures/engine-ssrf-probe.js
+++ b/packages/server/worker/test/e2e/fixtures/engine-ssrf-probe.js
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-// Probe that loads the bundled engine ssrf-guard (installs DNS/Socket/undici hooks
-// at require-time) and then runs each AP_PROBE_PLAN case against the hooked stack.
-// Uses node core only for egress; HTTP calls are plain http.request (the proxy env
-// is set via process.env.AP_EGRESS_PROXY_URL).
+// Probe that installs the bundled engine ssrf-guard (DNS/Socket + http/https
+// globalAgent + undici dispatcher) and then runs each AP_PROBE_PLAN case
+// against the hooked stack. Uses node core only for egress; HTTP calls are
+// plain http.request (the proxy URL is read from process.env.AP_EGRESS_PROXY_URL).
 
 const dns = require('node:dns')
 const http = require('node:http')
@@ -10,7 +10,8 @@ const net = require('node:net')
 const { URL } = require('node:url')
 
 const ssrfGuardModule = require('./ssrf-guard-bundle.js')
-const GUARD_ENABLED = ssrfGuardModule.ssrfGuard && ssrfGuardModule.ssrfGuard.isEnabled()
+ssrfGuardModule.ssrfGuard.install()
+const GUARD_ENABLED = ssrfGuardModule.ssrfGuard.isEnabled()
 
 async function main() {
     let plan
@@ -93,14 +94,17 @@ function dnsLookupExpectBlocked(action) {
 }
 
 function httpViaProxy(action) {
+    // Target the real destination and let http.globalAgent (installed by
+    // ssrf-guard as an HttpProxyAgent) route through the loopback proxy —
+    // mirrors how pieces issue requests rather than hand-addressing the proxy.
     return new Promise((resolve) => {
-        const proxyUrl = new URL(process.env.AP_EGRESS_PROXY_URL || '')
+        const target = new URL(action.url)
         const req = http.request({
-            host: proxyUrl.hostname,
-            port: parseInt(proxyUrl.port, 10),
+            host: target.hostname,
+            port: parseInt(target.port, 10) || 80,
             method: 'GET',
-            path: action.url,
-            headers: { host: new URL(action.url).host },
+            path: target.pathname + target.search,
+            headers: { host: target.host },
         }, (res) => {
             const chunks = []
             res.on('data', (c) => chunks.push(c))


### PR DESCRIPTION
## Summary

- **Fixes** the canary-observed `Sandbox <id> did not connect within 30 seconds` regression on `NETWORK_MODE=STRICT` + `SANDBOX_PROCESS`. The STRICT-mode ssrf-guard (PR #12724) rebinds `http.globalAgent` to `HttpProxyAgent` so pieces tunnel egress through the loopback proxy. That broke the engine's own worker RPC bootstrap: `socket.io-client`'s polling transport hits Node's `agent:false` fallback — `new defaultAgent.constructor(opts)` — which instantiates a new `HttpProxyAgent` with no URL and throws.
- **Fix**: in `worker-socket.ts`, in STRICT mode only, bind a plain `http.Agent` on the socket.io-client options so the loopback worker RPC handshake bypasses the proxy. No change outside STRICT.
- **Regression test**: `packages/server/engine/test/network/worker-socket.test.ts` — simulates STRICT mode with `http.globalAgent = new HttpProxyAgent(...)` and asserts the socket connects. Verified to fail on the pre-fix code.
- **E2E cleanup**: The sandbox-engine-ssrf e2e probe was never actually installing the guard (`ssrfGuard.isEnabled()` without `install()`), silently skipping 8 tests. Install the guard in the probe and switch its `httpViaProxy` case to hit the target URL directly so `http.globalAgent` routes it — matches how real pieces behave.

## Test plan

- [x] `npx vitest run packages/server/engine/test/network/` — 51/51 passing (incl. new STRICT regression test).
- [x] Confirmed the new test fails against the pre-fix `worker-socket.ts` with `sandbox did not connect`, passes with the fix.
- [x] `npm run test:sandbox-e2e` — 21/21 passing (previously 13/21 with 8 silently-skipped ssrf probe cases).
- [x] `npm run test-unit` — all 13 turbo tasks successful.
- [x] Pre-push hook: 14/14 CE+EE+Cloud API suites (323 tests) pass.