### PR TITLE
fix(runs): Select All + Retry now scopes to the default 7-day window

### DIFF
--- a/packages/server/api/test/integration/ce/flows/flow-run/bulk-retry-flow-run.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow-run/bulk-retry-flow-run.test.ts
@@ -1,0 +1,199 @@
+import { FlowRetryStrategy, FlowRunStatus, FlowVersionState, RunEnvironment } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { databaseConnection } from '../../../../../src/app/database/database-connection'
+import { db } from '../../../../helpers/db'
+import { createMockFlow, createMockFlowRun, createMockFlowVersion, mockAndSaveBasicSetup } from '../../../../helpers/mocks'
+import { createTestContext, TestContext } from '../../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../../helpers/test-setup'
+
+let app: FastifyInstance
+let ctx: TestContext
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+beforeEach(async () => {
+    ctx = await createTestContext(app)
+})
+
+describe('Bulk retry flow runs (POST /v1/flow-runs/retry)', () => {
+    it('scopes retry to the createdAfter window when Select All is used', async () => {
+        const projectId = ctx.project.id
+        const tenDaysAgo = new Date(Date.now() - 10 * DAY_MS).toISOString()
+        const threeDaysAgo = new Date(Date.now() - 3 * DAY_MS).toISOString()
+        const now = new Date().toISOString()
+
+        const { run: oldRun } = await createFailedRun({ projectId, createdAt: tenDaysAgo })
+        const { run: midRun } = await createFailedRun({ projectId, createdAt: threeDaysAgo })
+        const { run: newRun } = await createFailedRun({ projectId, createdAt: now })
+
+        const cutoff = new Date(Date.now() - 5 * DAY_MS).toISOString()
+        const response = await ctx.post('/v1/flow-runs/retry', {
+            projectId,
+            strategy: FlowRetryStrategy.ON_LATEST_VERSION,
+            createdAfter: cutoff,
+        })
+
+        expect(response.statusCode).toBe(200)
+
+        const totalRuns = await countRunsForProject(projectId)
+        expect(totalRuns).toBe(5)
+
+        const oldStatus = await readStatus(oldRun.id)
+        expect(oldStatus).toBe(FlowRunStatus.FAILED)
+
+        const midStatus = await readStatus(midRun.id)
+        expect(midStatus).toBe(FlowRunStatus.FAILED)
+        const newStatus = await readStatus(newRun.id)
+        expect(newStatus).toBe(FlowRunStatus.FAILED)
+    })
+
+    it('retries every matching run when createdAfter is omitted', async () => {
+        const projectId = ctx.project.id
+        await createFailedRun({ projectId, createdAt: new Date(Date.now() - 10 * DAY_MS).toISOString() })
+        await createFailedRun({ projectId, createdAt: new Date(Date.now() - 3 * DAY_MS).toISOString() })
+        await createFailedRun({ projectId, createdAt: new Date().toISOString() })
+
+        const response = await ctx.post('/v1/flow-runs/retry', {
+            projectId,
+            strategy: FlowRetryStrategy.ON_LATEST_VERSION,
+        })
+
+        expect(response.statusCode).toBe(200)
+        const totalRuns = await countRunsForProject(projectId)
+        expect(totalRuns).toBe(6)
+    })
+
+    it('scopes retry to the status filter', async () => {
+        const projectId = ctx.project.id
+        const { run: failed } = await createFailedRun({ projectId })
+        const { run: succeeded } = await createFailedRun({
+            projectId,
+            status: FlowRunStatus.SUCCEEDED,
+        })
+
+        const response = await ctx.post('/v1/flow-runs/retry', {
+            projectId,
+            strategy: FlowRetryStrategy.ON_LATEST_VERSION,
+            status: [FlowRunStatus.FAILED],
+        })
+
+        expect(response.statusCode).toBe(200)
+        const totalRuns = await countRunsForProject(projectId)
+        expect(totalRuns).toBe(3)
+        expect(await readStatus(failed.id)).toBe(FlowRunStatus.FAILED)
+        expect(await readStatus(succeeded.id)).toBe(FlowRunStatus.SUCCEEDED)
+    })
+
+    it('scopes retry to the flowId filter', async () => {
+        const projectId = ctx.project.id
+        const { run: runA, flow: flowA } = await createFailedRun({ projectId })
+        const { run: runB } = await createFailedRun({ projectId })
+
+        const response = await ctx.post('/v1/flow-runs/retry', {
+            projectId,
+            strategy: FlowRetryStrategy.ON_LATEST_VERSION,
+            flowId: [flowA.id],
+        })
+
+        expect(response.statusCode).toBe(200)
+        const runsForFlowA = await countRunsForFlow(flowA.id)
+        expect(runsForFlowA).toBe(2)
+        expect(await readStatus(runA.id)).toBe(FlowRunStatus.FAILED)
+        expect(await readStatus(runB.id)).toBe(FlowRunStatus.FAILED)
+    })
+
+    it('skips runs listed in excludeFlowRunIds', async () => {
+        const projectId = ctx.project.id
+        const { run: run1 } = await createFailedRun({ projectId })
+        const { run: run2 } = await createFailedRun({ projectId })
+        const { run: run3 } = await createFailedRun({ projectId })
+
+        const response = await ctx.post('/v1/flow-runs/retry', {
+            projectId,
+            strategy: FlowRetryStrategy.ON_LATEST_VERSION,
+            excludeFlowRunIds: [run2.id],
+        })
+
+        expect(response.statusCode).toBe(200)
+        const totalRuns = await countRunsForProject(projectId)
+        expect(totalRuns).toBe(5)
+        expect(await readStatus(run1.id)).toBe(FlowRunStatus.FAILED)
+        expect(await readStatus(run2.id)).toBe(FlowRunStatus.FAILED)
+        expect(await readStatus(run3.id)).toBe(FlowRunStatus.FAILED)
+    })
+
+    it('never touches runs in other projects', async () => {
+        const projectId = ctx.project.id
+        await createFailedRun({ projectId })
+
+        const { mockProject: otherProject } = await mockAndSaveBasicSetup()
+        const { run: otherRun } = await createFailedRun({ projectId: otherProject.id })
+
+        const response = await ctx.post('/v1/flow-runs/retry', {
+            projectId,
+            strategy: FlowRetryStrategy.ON_LATEST_VERSION,
+        })
+
+        expect(response.statusCode).toBe(200)
+        expect(await countRunsForProject(otherProject.id)).toBe(1)
+        expect(await readStatus(otherRun.id)).toBe(FlowRunStatus.FAILED)
+    })
+})
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+async function createFailedRun({
+    projectId,
+    createdAt,
+    status = FlowRunStatus.FAILED,
+}: {
+    projectId: string
+    createdAt?: string
+    status?: FlowRunStatus
+}): Promise<{ flow: { id: string }, flowVersion: { id: string }, run: { id: string } }> {
+    const flow = createMockFlow({ projectId })
+    await db.save('flow', flow)
+
+    const flowVersion = createMockFlowVersion({
+        flowId: flow.id,
+        state: FlowVersionState.LOCKED,
+    })
+    await db.save('flow_version', flowVersion)
+
+    const run = createMockFlowRun({
+        projectId,
+        flowId: flow.id,
+        flowVersionId: flowVersion.id,
+        status,
+        environment: RunEnvironment.PRODUCTION,
+    })
+    await db.save('flow_run', run)
+
+    if (createdAt) {
+        await databaseConnection().query(
+            'UPDATE flow_run SET created = $1 WHERE id = $2',
+            [createdAt, run.id],
+        )
+    }
+
+    return { flow, flowVersion, run }
+}
+
+async function countRunsForProject(projectId: string): Promise<number> {
+    return databaseConnection().getRepository('flow_run').count({ where: { projectId } })
+}
+
+async function countRunsForFlow(flowId: string): Promise<number> {
+    return databaseConnection().getRepository('flow_run').count({ where: { flowId } })
+}
+
+async function readStatus(runId: string): Promise<FlowRunStatus> {
+    const row = await db.findOneByOrFail<{ status: FlowRunStatus }>('flow_run', { id: runId })
+    return row.status
+}

--- a/packages/web/src/components/custom/date-time-picker-range.tsx
+++ b/packages/web/src/components/custom/date-time-picker-range.tsx
@@ -112,7 +112,7 @@ const detectPreset = (
   return null;
 };
 
-const getDefaultRange = (presetKey: PresetKey) => {
+export const getDefaultRange = (presetKey: PresetKey) => {
   const preset = PRESETS[presetKey]();
   preset.from!.setHours(0, 0, 0, 0);
   preset.to!.setHours(23, 59, 59, 999);

--- a/packages/web/src/features/flow-runs/components/runs-table/index.tsx
+++ b/packages/web/src/features/flow-runs/components/runs-table/index.tsx
@@ -18,7 +18,7 @@ import {
   X,
   Archive,
 } from 'lucide-react';
-import { useMemo, useCallback, useState } from 'react';
+import { useEffect, useMemo, useCallback, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -29,6 +29,7 @@ import {
   DataTable,
   DataTableFilters,
 } from '@/components/custom/data-table';
+import { getDefaultRange } from '@/components/custom/date-time-picker-range';
 import { MessageTooltip } from '@/components/custom/message-tooltip';
 import { PermissionNeededTooltip } from '@/components/custom/permission-needed-tooltip';
 import { Button } from '@/components/ui/button';
@@ -70,8 +71,30 @@ export const RunsTable = () => {
     Required<FlowRunWithRetryError>[]
   >([]);
   const [failedRetryDialogOpen, setFailedRetryDialogOpen] = useState(false);
+
+  const [hasSeededDefaultRange, setHasSeededDefaultRange] = useState(() =>
+    searchParams.has('createdAfter'),
+  );
+  useEffect(() => {
+    if (hasSeededDefaultRange) return;
+    const range = getDefaultRange(DEFAULT_DATE_PRESET);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (!next.has('createdAfter')) {
+          next.set('createdAfter', range.from.toISOString());
+          next.set('createdBefore', range.to.toISOString());
+        }
+        return next;
+      },
+      { replace: true },
+    );
+    setHasSeededDefaultRange(true);
+  }, [hasSeededDefaultRange, setSearchParams]);
+
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['flow-run-table', searchParams.toString(), projectId],
+    enabled: hasSeededDefaultRange,
     staleTime: 0,
     gcTime: 0,
     meta: { showErrorDialog: true, loadSubsetOptions: {} },
@@ -165,7 +188,7 @@ export const RunsTable = () => {
         title: t('Created'),
         accessorKey: 'created',
         icon: CheckIcon,
-        defaultPresetName: '7days',
+        defaultPresetName: DEFAULT_DATE_PRESET,
       },
       {
         type: 'checkbox',
@@ -550,3 +573,5 @@ export const RunsTable = () => {
     </div>
   );
 };
+
+const DEFAULT_DATE_PRESET = '7days' as const;


### PR DESCRIPTION
## Summary

- **Bug**: on `/runs`, clicking **Select All** then **Retry** retried every run in the project, ignoring the visible "Last 7 days" filter. Users reported that the retry bulk endpoint received no `createdAfter`.
- **Root cause**: the default 7-day preset only reached the URL through the date picker's `useEffect` in `DateTimePickerWithRange`. That effect runs after the first commit, so on fresh page load the URL was empty. If the user (or an automated flow) clicked Retry before the effect fired, `searchParams.get('createdAfter')` returned `null` and the bulk endpoint received no date filter.
- **Fix**: seed the URL with the default 7-day range directly from `RunsTable` on first mount, and gate the list `useQuery` (`enabled: hasSeededDefaultRange`) so the first fetch only runs after the seed lands. Once seeded, both the list query and both retry mutations read the same populated `searchParams`. Export `getDefaultRange` from `DateTimePickerWithRange` so the picker and the table share a single source of truth for the preset.
- **Regression test**: `packages/server/api/test/integration/ce/flows/flow-run/bulk-retry-flow-run.test.ts` pins the bulk `/v1/flow-runs/retry` contract — `createdAfter` window, no-timestamp case, `status` / `flowId` / `excludeFlowRunIds` narrowing, and cross-project isolation. Verified to fail (`expected 6 to be 5`) if the backend drops the `createdAfter` predicate.

## Test plan

- [x] `npx vitest run packages/server/api/test/integration/ce/flows/flow-run/bulk-retry-flow-run.test.ts` — 6/6 green.
- [x] Verified the window-filter test fails on the unpatched backend (`if (false && params.createdAfter)` → `6 to be 5`).
- [x] `cd packages/web && npm test` — 75/75 green.
- [x] Pre-push hook: 14/14 CE/EE/Cloud API suites pass.
- [x] Manual: open `/runs` with no query string, immediately click Select All → Retry; confirm the network request body contains `createdAfter` and only last-7-days runs are retried.