### PR TITLE
feat(pdf): add image to pdf action

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -375,7 +375,7 @@
     },
     "packages/ee/embed-sdk": {
       "name": "ee-embed-sdk",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "tslib": "2.6.2",
       },
@@ -7736,7 +7736,7 @@
     },
     "packages/pieces/core/pdf": {
       "name": "@activepieces/piece-pdf",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7748,6 +7748,7 @@
         "unpdf": "1.4.0",
       },
       "devDependencies": {
+        "@types/mime-types": "2.1.1",
         "vitest": "3.0.8",
       },
     },

--- a/packages/pieces/core/pdf/package.json
+++ b/packages/pieces/core/pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pdf",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/pdf/package.json
+++ b/packages/pieces/core/pdf/package.json
@@ -11,7 +11,8 @@
     "nanoid": "3.3.8",
     "pdf-lib": "1.17.1",
     "unpdf": "1.4.0",
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "@types/mime-types": "2.1.1"
   },
   "devDependencies": {
     "vitest": "3.0.8"

--- a/packages/pieces/core/pdf/package.json
+++ b/packages/pieces/core/pdf/package.json
@@ -11,11 +11,11 @@
     "nanoid": "3.3.8",
     "pdf-lib": "1.17.1",
     "unpdf": "1.4.0",
-    "tslib": "2.6.2",
-    "@types/mime-types": "2.1.1"
+    "tslib": "2.6.2"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "@types/mime-types": "2.1.1"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/core/pdf/src/index.ts
+++ b/packages/pieces/core/pdf/src/index.ts
@@ -8,6 +8,7 @@ import { pdfPageCount } from './lib/actions/pdf-page-count';
 import { extractPdfPages } from './lib/actions/extract-pdf-pages';
 import { mergePdfs } from './lib/actions/merge-pdfs';
 import { addTextToPdf } from './lib/actions/add-text-to-pdf';
+import { addImageToPdf } from './lib/actions/add-image-to-pdf';
 
 export const PDF = createPiece({
   displayName: 'PDF',
@@ -31,7 +32,8 @@ export const PDF = createPiece({
     pdfPageCount,
     extractPdfPages,
     mergePdfs,
-    addTextToPdf
+    addTextToPdf,
+    addImageToPdf
   ],
   triggers: [],
 });

--- a/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument, degrees } from 'pdf-lib';
-import { getTargetPages, mapVisualToIntrinsic, savePdfToContext } from '../common';
+import { getTargetPages, mapVisualToIntrinsic } from '../common';
 import mime from 'mime-types';
 
 export const addImageToPdf = createAction({
@@ -139,7 +139,13 @@ export const addImageToPdf = createAction({
         }
       }
 
-      return await savePdfToContext(pdfDoc, file.filename, 'image_stamped', context);
+      const pdfBytes = await pdfDoc.save();
+      const base64Pdf = Buffer.from(pdfBytes).toString('base64');
+
+      return context.files.write({
+        data: Buffer.from(base64Pdf, 'base64'),
+        fileName: `image_stamped_${file.filename}`,
+      });
 
     } catch (error) {
       throw new Error(`Failed to add image to PDF: ${(error as Error).message}`);

--- a/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument, degrees } from 'pdf-lib';
 import { getTargetPages, mapVisualToIntrinsic, savePdfToContext } from '../common';
+import mime from 'mime-types';
 
 export const addImageToPdf = createAction({
   name: 'addImageToPdf',
@@ -83,17 +84,20 @@ export const addImageToPdf = createAction({
         }
 
         const imageData = item.imageFile.data;
-        const filename = item.imageFile.filename || '';
-        const extension = filename.split('.').pop()?.toLowerCase();
+        const filename = item.imageFile.filename || `item ${i + 1}`;
+        
+        const mimeType = item.imageFile.extension
+          ? mime.lookup(item.imageFile.extension) || 'application/octet-stream'
+          : 'application/octet-stream';
 
         let embeddedImage;
-        if (extension === 'png') {
+        if (mimeType === 'image/png') {
           embeddedImage = await pdfDoc.embedPng(imageData);
-        } else if (extension === 'jpg' || extension === 'jpeg') {
+        } else if (mimeType === 'image/jpeg') {
           embeddedImage = await pdfDoc.embedJpg(imageData);
         } else {
           throw new Error(
-            `Unsupported image format for item ${i + 1}. The file "${filename}" must have a .png, .jpg, or .jpeg extension.`
+            `Unsupported image format for "${filename}". Expected a PNG or JPEG, but could not verify the file type.`
           );
         }
 

--- a/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
@@ -1,0 +1,191 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { PDFDocument, degrees } from 'pdf-lib';
+
+export const addImageToPdf = createAction({
+  name: 'addImageToPdf',
+  displayName: 'Add Image to PDF',
+  description: 'Stamps one or more images (PNG or JPG) at exact pixel distances from the top-left corner.',
+  props: {
+    file: Property.File({
+      displayName: 'PDF File or URL',
+      required: true,
+    }),
+    imageItems: Property.Array({
+      displayName: 'Image Items to Insert',
+      description: 'Add each image you want to stamp.',
+      required: true,
+      properties: {
+        imageFile: Property.File({
+          displayName: 'Image File (PNG/JPG)',
+          description: 'The signature or image file to insert.',
+          required: true,
+        }),
+        applyToAllPages: Property.Checkbox({
+          displayName: 'Apply to all pages?',
+          description: 'If checked, this image is stamped on every page.',
+          required: false,
+          defaultValue: false,
+        }),
+        pageNumber: Property.Number({
+          displayName: 'Page Number',
+          description: 'Which page to stamp? (Leave blank or ignore if applying to all pages)',
+          required: false,
+          defaultValue: 1,
+        }),
+        distanceFromLeft: Property.Number({
+          displayName: 'Distance from Left Edge (in pixels)',
+          description: '0 is the far left edge of the page. Standard A4 width is about 595 pts.',
+          required: true,
+        }),
+        distanceFromTop: Property.Number({
+          displayName: 'Distance from Top Edge (in pixels)',
+          description: '0 is the very top edge of the page. Standard A4 height is about 842 pts.',
+          required: true,
+        }),
+        scale: Property.Number({
+          displayName: 'Image Scale',
+          description: 'Scale multiplier for the image (e.g., 0.5 for half size, 1.0 for original size).',
+          required: true,
+          defaultValue: 1.0,
+        }),
+      },
+    }),
+  },
+  errorHandlingOptions: {
+    continueOnFailure: {
+      defaultValue: false,
+    },
+    retryOnFailure: {
+      hide: true,
+    },
+  },
+  async run(context) {
+    try {
+      const file = context.propsValue.file;
+      const imageItems = context.propsValue.imageItems as Array<{
+        imageFile: any;
+        applyToAllPages?: boolean;
+        pageNumber?: number;
+        distanceFromLeft: number;
+        distanceFromTop: number;
+        scale: number;
+      }>;
+
+      const pdfDoc = await PDFDocument.load(file.data as any); 
+      const pages = pdfDoc.getPages();
+      const totalPages = pages.length;
+
+      for (let i = 0; i < imageItems.length; i++) {
+        const item = imageItems[i];
+        
+        if (item.scale <= 0) {
+          throw new Error(`Scale must be a positive number. You provided ${item.scale} for image item ${i + 1}.`);
+        }
+
+        // Detect and embed image (pdf-lib requires different methods for PNG vs JPG)
+        let embeddedImage;
+        const imageData = item.imageFile.data;
+        try {
+          embeddedImage = await pdfDoc.embedPng(imageData);
+        } catch (pngError) {
+          try {
+            embeddedImage = await pdfDoc.embedJpg(imageData);
+          } catch (jpgError) {
+            throw new Error(`Failed to embed image item ${i + 1}. Ensure the file is a valid PNG or JPG format.`);
+          }
+        }
+
+        const imgDims = embeddedImage.scale(item.scale);
+        const scaledWidth = imgDims.width;
+        const scaledHeight = imgDims.height;
+
+        const targetPages = [];
+        
+        if (item.applyToAllPages) {
+          targetPages.push(...pages);
+        } else {
+          if (item.pageNumber === undefined) {
+            throw new Error(`Page Number is required when "Apply to all pages?" is not checked for image item ${i + 1}.`);
+          }
+          const pageIndex = Number(item.pageNumber) - 1;
+          
+          if (pageIndex < 0 || pageIndex >= totalPages) {
+            throw new Error(`You requested Page ${item.pageNumber} for image item ${i + 1}, but this document only has ${totalPages} page(s).`);
+          }
+          targetPages.push(pages[pageIndex]);
+        }
+
+        for (const targetPage of targetPages) {
+          const { width, height } = targetPage.getSize();
+          const rotationAngle = ((targetPage.getRotation()?.angle ?? 0) % 360 + 360) % 360;
+
+          const isLandscape = rotationAngle === 90 || rotationAngle === 270;
+          const vWidth = isLandscape ? height : width;
+          const vHeight = isLandscape ? width : height;
+
+          const vX = item.distanceFromLeft;
+          const vY = vHeight - item.distanceFromTop;
+          
+          // Check Left Edge
+          if (vX < 0 || vX > vWidth) {
+            throw new Error(`The Left distance (${item.distanceFromLeft}pts) for image item ${i + 1} is outside the page width.`);
+          }
+
+          // Check Right Edge
+          if (vX + scaledWidth > vWidth) {
+              throw new Error(`Image item ${i + 1} is too wide and runs off the right edge. Reduce the Left distance or Scale.`);
+          }
+
+          // Check Top Edge
+          if (vY < 0 || vY > vHeight) {
+            throw new Error(`The Top distance (${item.distanceFromTop}pts) for image item ${i + 1} is outside the page height.`);
+          }
+
+          // Check Bottom Edge
+          if (vY - scaledHeight < 0) {
+            throw new Error(`Image item ${i + 1} is too tall and runs off the bottom edge. Reduce the Top distance or Scale.`);
+          }
+
+          // Map Visual coordinates back to Intrinsic coordinates for pdf-lib
+          // Note: pdf-lib draws images from the bottom-left corner, not the top-left.
+          // Therefore, the visual Y anchor is `vY - scaledHeight`.
+          let iX = vX;
+          let iY = vY - scaledHeight;
+          let imageRotation = 0;
+
+          if (rotationAngle === 90) {
+            iX = vHeight - (vY - scaledHeight); 
+            iY = vX;
+            imageRotation = 90;
+          } else if (rotationAngle === 180) {
+            iX = vWidth - vX;
+            iY = vHeight - (vY - scaledHeight);
+            imageRotation = 180;
+          } else if (rotationAngle === 270) {
+            iX = vY - scaledHeight;
+            iY = vWidth - vX;
+            imageRotation = -90;
+          }
+
+          targetPage.drawImage(embeddedImage, {
+            x: iX,
+            y: iY,
+            width: scaledWidth,
+            height: scaledHeight,
+            rotate: degrees(imageRotation),
+          });
+        }
+      }
+
+      const pdfBytes = await pdfDoc.save();
+      const base64Pdf = Buffer.from(pdfBytes).toString('base64');
+
+      return context.files.write({
+        data: Buffer.from(base64Pdf, 'base64'),
+        fileName: `image_stamped_${file.filename}`,
+      });
+    } catch (error) {
+      throw new Error(`Failed to add image to PDF: ${(error as Error).message}`);
+    }
+  },
+});

--- a/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument, degrees } from 'pdf-lib';
-import { getTargetPages, mapVisualToIntrinsic, savePdfToContext } from '../common';
+import { getTargetPages, mapVisualToIntrinsic, savePdfToContext, detectImageType } from '../common';
 
 export const addImageToPdf = createAction({
   name: 'addImageToPdf',
@@ -82,16 +82,18 @@ export const addImageToPdf = createAction({
           throw new Error(`Scale must be a positive number. You provided ${item.scale} for image item ${i + 1}.`);
         }
 
-        let embeddedImage;
         const imageData = item.imageFile.data;
-        try {
+        const filename = item.imageFile.filename || `item ${i + 1}`;
+        
+        const imageType = detectImageType(imageData, `"${filename}"`);
+
+        let embeddedImage;
+        if (imageType === 'png') {
           embeddedImage = await pdfDoc.embedPng(imageData);
-        } catch (pngError) {
-          try {
-            embeddedImage = await pdfDoc.embedJpg(imageData);
-          } catch (jpgError) {
-            throw new Error(`Failed to embed image item ${i + 1}. Ensure the file is a valid PNG or JPG format.`);
-          }
+        } else if (imageType === 'jpg') {
+          embeddedImage = await pdfDoc.embedJpg(imageData);
+        } else {
+          throw new Error(`Unsupported image type "${imageType}" for image item ${i + 1}. Only PNG and JPG are supported.`);
         }
 
         const imgDims = embeddedImage.scale(item.scale);

--- a/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
@@ -88,7 +88,7 @@ export const addImageToPdf = createAction({
         
         const mimeType = item.imageFile.extension
           ? mime.lookup(item.imageFile.extension) || 'application/octet-stream'
-          : 'application/octet-stream';
+          : mime.lookup(item.imageFile.filename || '') || 'application/octet-stream';
 
         let embeddedImage;
         if (mimeType === 'image/png') {
@@ -140,10 +140,9 @@ export const addImageToPdf = createAction({
       }
 
       const pdfBytes = await pdfDoc.save();
-      const base64Pdf = Buffer.from(pdfBytes).toString('base64');
 
       return context.files.write({
-        data: Buffer.from(base64Pdf, 'base64'),
+        data: Buffer.from(pdfBytes),
         fileName: `image_stamped_${file.filename}`,
       });
 

--- a/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
@@ -1,5 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument, degrees } from 'pdf-lib';
+import { getTargetPages, mapVisualToIntrinsic, savePdfToContext } from '../common';
 
 export const addImageToPdf = createAction({
   name: 'addImageToPdf',
@@ -73,7 +74,6 @@ export const addImageToPdf = createAction({
 
       const pdfDoc = await PDFDocument.load(file.data as any); 
       const pages = pdfDoc.getPages();
-      const totalPages = pages.length;
 
       for (let i = 0; i < imageItems.length; i++) {
         const item = imageItems[i];
@@ -82,7 +82,6 @@ export const addImageToPdf = createAction({
           throw new Error(`Scale must be a positive number. You provided ${item.scale} for image item ${i + 1}.`);
         }
 
-        // Detect and embed image (pdf-lib requires different methods for PNG vs JPG)
         let embeddedImage;
         const imageData = item.imageFile.data;
         try {
@@ -99,21 +98,7 @@ export const addImageToPdf = createAction({
         const scaledWidth = imgDims.width;
         const scaledHeight = imgDims.height;
 
-        const targetPages = [];
-        
-        if (item.applyToAllPages) {
-          targetPages.push(...pages);
-        } else {
-          if (item.pageNumber === undefined) {
-            throw new Error(`Page Number is required when "Apply to all pages?" is not checked for image item ${i + 1}.`);
-          }
-          const pageIndex = Number(item.pageNumber) - 1;
-          
-          if (pageIndex < 0 || pageIndex >= totalPages) {
-            throw new Error(`You requested Page ${item.pageNumber} for image item ${i + 1}, but this document only has ${totalPages} page(s).`);
-          }
-          targetPages.push(pages[pageIndex]);
-        }
+        const targetPages = getTargetPages(pages, item.applyToAllPages, item.pageNumber, `image item ${i + 1}`);
 
         for (const targetPage of targetPages) {
           const { width, height } = targetPage.getSize();
@@ -126,64 +111,29 @@ export const addImageToPdf = createAction({
           const vX = item.distanceFromLeft;
           const vY = vHeight - item.distanceFromTop;
           
-          // Check Left Edge
-          if (vX < 0 || vX > vWidth) {
-            throw new Error(`The Left distance (${item.distanceFromLeft}pts) for image item ${i + 1} is outside the page width.`);
-          }
+          // Boundary Checks
+          if (vX < 0 || vX > vWidth) throw new Error(`The Left distance (${item.distanceFromLeft}pts) for image item ${i + 1} is outside the page width.`);
+          if (vX + scaledWidth > vWidth) throw new Error(`Image item ${i + 1} is too wide and runs off the right edge.`);
+          if (vY < 0 || vY > vHeight) throw new Error(`The Top distance (${item.distanceFromTop}pts) for image item ${i + 1} is outside the page height.`);
+          if (vY - scaledHeight < 0) throw new Error(`Image item ${i + 1} is too tall and runs off the bottom edge.`);
 
-          // Check Right Edge
-          if (vX + scaledWidth > vWidth) {
-              throw new Error(`Image item ${i + 1} is too wide and runs off the right edge. Reduce the Left distance or Scale.`);
-          }
-
-          // Check Top Edge
-          if (vY < 0 || vY > vHeight) {
-            throw new Error(`The Top distance (${item.distanceFromTop}pts) for image item ${i + 1} is outside the page height.`);
-          }
-
-          // Check Bottom Edge
-          if (vY - scaledHeight < 0) {
-            throw new Error(`Image item ${i + 1} is too tall and runs off the bottom edge. Reduce the Top distance or Scale.`);
-          }
-
-          // Map Visual coordinates back to Intrinsic coordinates for pdf-lib
-          // Note: pdf-lib draws images from the bottom-left corner, not the top-left.
-          // Therefore, the visual Y anchor is `vY - scaledHeight`.
-          let iX = vX;
-          let iY = vY - scaledHeight;
-          let imageRotation = 0;
-
-          if (rotationAngle === 90) {
-            iX = vHeight - (vY - scaledHeight); 
-            iY = vX;
-            imageRotation = 90;
-          } else if (rotationAngle === 180) {
-            iX = vWidth - vX;
-            iY = vHeight - (vY - scaledHeight);
-            imageRotation = 180;
-          } else if (rotationAngle === 270) {
-            iX = vY - scaledHeight;
-            iY = vWidth - vX;
-            imageRotation = -90;
-          }
+          // Use helper to calculate rotated mapping
+          // (pdf-lib draws images from bottom-left corner, so anchor is vY - scaledHeight)
+          const anchorY = vY - scaledHeight;
+          const { iX, iY, mappedRotation } = mapVisualToIntrinsic(vX, anchorY, vWidth, vHeight, rotationAngle);
 
           targetPage.drawImage(embeddedImage, {
             x: iX,
             y: iY,
             width: scaledWidth,
             height: scaledHeight,
-            rotate: degrees(imageRotation),
+            rotate: degrees(mappedRotation),
           });
         }
       }
 
-      const pdfBytes = await pdfDoc.save();
-      const base64Pdf = Buffer.from(pdfBytes).toString('base64');
+      return await savePdfToContext(pdfDoc, file.filename, 'image_stamped', context);
 
-      return context.files.write({
-        data: Buffer.from(base64Pdf, 'base64'),
-        fileName: `image_stamped_${file.filename}`,
-      });
     } catch (error) {
       throw new Error(`Failed to add image to PDF: ${(error as Error).message}`);
     }

--- a/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument, degrees } from 'pdf-lib';
-import { getTargetPages, mapVisualToIntrinsic, savePdfToContext, detectImageType } from '../common';
+import { getTargetPages, mapVisualToIntrinsic, savePdfToContext } from '../common';
 
 export const addImageToPdf = createAction({
   name: 'addImageToPdf',
@@ -83,17 +83,18 @@ export const addImageToPdf = createAction({
         }
 
         const imageData = item.imageFile.data;
-        const filename = item.imageFile.filename || `item ${i + 1}`;
-        
-        const imageType = detectImageType(imageData, `"${filename}"`);
+        const filename = item.imageFile.filename || '';
+        const extension = filename.split('.').pop()?.toLowerCase();
 
         let embeddedImage;
-        if (imageType === 'png') {
+        if (extension === 'png') {
           embeddedImage = await pdfDoc.embedPng(imageData);
-        } else if (imageType === 'jpg') {
+        } else if (extension === 'jpg' || extension === 'jpeg') {
           embeddedImage = await pdfDoc.embedJpg(imageData);
         } else {
-          throw new Error(`Unsupported image type "${imageType}" for image item ${i + 1}. Only PNG and JPG are supported.`);
+          throw new Error(
+            `Unsupported image format for item ${i + 1}. The file "${filename}" must have a .png, .jpg, or .jpeg extension.`
+          );
         }
 
         const imgDims = embeddedImage.scale(item.scale);

--- a/packages/pieces/core/pdf/src/lib/actions/add-text-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-text-to-pdf.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument, rgb, StandardFonts, PDFFont, degrees } from 'pdf-lib';
-import { getTargetPages, mapVisualToIntrinsic, savePdfToContext } from '../common';
+import { getTargetPages, mapVisualToIntrinsic } from '../common';
 
 const fontOptions = Object.entries(StandardFonts).map(([key, value]) => {
   const formattedLabel = key.replace(/([A-Z])/g, ' $1').trim();
@@ -160,7 +160,13 @@ export const addTextToPdf = createAction({
         }
       }
 
-      return await savePdfToContext(pdfDoc, file.filename, 'text_stamped', context);
+      const pdfBytes = await pdfDoc.save();
+      const base64Pdf = Buffer.from(pdfBytes).toString('base64');
+
+      return context.files.write({
+        data: Buffer.from(base64Pdf, 'base64'),
+        fileName: `text_stamped_${file.filename}`,
+      });
 
     } catch (error) {
       throw new Error(`Failed to add text to PDF: ${(error as Error).message}`);

--- a/packages/pieces/core/pdf/src/lib/actions/add-text-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-text-to-pdf.ts
@@ -161,10 +161,9 @@ export const addTextToPdf = createAction({
       }
 
       const pdfBytes = await pdfDoc.save();
-      const base64Pdf = Buffer.from(pdfBytes).toString('base64');
 
       return context.files.write({
-        data: Buffer.from(base64Pdf, 'base64'),
+        data: Buffer.from(pdfBytes),
         fileName: `text_stamped_${file.filename}`,
       });
 

--- a/packages/pieces/core/pdf/src/lib/actions/add-text-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-text-to-pdf.ts
@@ -1,5 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument, rgb, StandardFonts, PDFFont, degrees } from 'pdf-lib';
+import { getTargetPages, mapVisualToIntrinsic, savePdfToContext } from '../common';
 
 const fontOptions = Object.entries(StandardFonts).map(([key, value]) => {
   const formattedLabel = key.replace(/([A-Z])/g, ' $1').trim();
@@ -34,16 +35,16 @@ export const addTextToPdf = createAction({
           displayName: 'Page Number',
           description: 'Which page to stamp? (Leave blank or ignore if applying to all pages)',
           required: false,
-					defaultValue: 1,
+          defaultValue: 1,
         }),
         distanceFromLeft: Property.Number({
           displayName: 'Distance from Left Edge (in pixels)',
-					description: '0 is the far left edge of the page. Standard A4 width is about 595 pts.',
+          description: '0 is the far left edge of the page. Standard A4 width is about 595 pts.',
           required: true,
         }),
         distanceFromTop: Property.Number({
           displayName: 'Distance from Top Edge (in pixels)',
-					description: '0 is the very top edge of the page. Standard A4 height is about 842 pts.',
+          description: '0 is the very top edge of the page. Standard A4 height is about 842 pts.',
           required: true,
         }),
         font: Property.StaticDropdown({
@@ -93,8 +94,6 @@ export const addTextToPdf = createAction({
 
       const pdfDoc = await PDFDocument.load(file.data as any); 
       const pages = pdfDoc.getPages();
-      const totalPages = pages.length;
-
       const embeddedFonts: Record<string, PDFFont> = {};
 
       for (const item of textItems) {
@@ -104,48 +103,24 @@ export const addTextToPdf = createAction({
         const lineSpacing = item.lineSpacing ?? 1.15;
 
         if (lineSpacing <= 0) {
-          throw new Error(
-            `Line Spacing must be a positive number greater than 0. You provided ${lineSpacing} for text "${cleanTextSample}..."`
-          );
+          throw new Error(`Line Spacing must be a positive number greater than 0. You provided ${lineSpacing} for text "${cleanTextSample}..."`);
+        }
+        if (item.fontSize <= 0) {
+          throw new Error(`Font Size must be a positive number greater than 0. You provided ${item.fontSize} for text "${cleanTextSample}..."`);
         }
 
-				if (item.fontSize <= 0) {
-					throw new Error(
-						`Font Size must be a positive number greater than 0. You provided ${item.fontSize} for text "${cleanTextSample}..."`
-					);
-				}
-
         const actualLineHeight = item.fontSize * lineSpacing;
-
         const fontEnum = item.font;
+        
         if (!embeddedFonts[fontEnum]) {
           embeddedFonts[fontEnum] = await pdfDoc.embedFont(fontEnum);
         }
         const font = embeddedFonts[fontEnum];
 
-        const maxTextWidth = Math.max(
-          ...lines.map(line => font.widthOfTextAtSize(line, item.fontSize))
-        );
-
-        const targetPages = [];
+        const maxTextWidth = Math.max(...lines.map(line => font.widthOfTextAtSize(line, item.fontSize)));
         
-        if (item.applyToAllPages) {
-          targetPages.push(...pages);
-        } else {
-					if (item.pageNumber === undefined) {
-						throw new Error(
-							`Page Number is required when "Apply to all pages?" is not checked for text "${cleanTextSample}...".`
-						);
-					}
-          const pageIndex = Number(item.pageNumber) - 1;
-          
-          if (pageIndex < 0 || pageIndex >= totalPages) {
-            throw new Error(
-              `You requested Page ${item.pageNumber} for text "${cleanTextSample}...", but this document only has ${totalPages} page(s).`
-            );
-          }
-          targetPages.push(pages[pageIndex]);
-        }
+        // Use helper to resolve target pages
+        const targetPages = getTargetPages(pages, item.applyToAllPages, item.pageNumber, `text "${cleanTextSample}..."`);
 
         for (const targetPage of targetPages) {
           const { width, height } = targetPage.getSize();
@@ -158,78 +133,20 @@ export const addTextToPdf = createAction({
           const vX = item.distanceFromLeft;
           const vY = vHeight - item.distanceFromTop;
           
-          // Check Left Edge
-          if (vX < 0 || vX > vWidth) {
-            throw new Error(
-              `The Left distance (${item.distanceFromLeft}pts) for "${cleanTextSample}..." is outside the page width. Current PDF's max width is ${Math.round(vWidth)}pts.`
-            );
-          }
+          // Boundary Checks
+          if (vX < 0 || vX > vWidth) throw new Error(`The Left distance (${item.distanceFromLeft}pts) for "${cleanTextSample}..." is outside the page width.`);
+          if (vX + maxTextWidth > vWidth) throw new Error(`The text "${cleanTextSample}..." is too long and runs off the right edge.`);
+          if (vY < 0 || vY > vHeight) throw new Error(`The Top distance (${item.distanceFromTop}pts) for "${cleanTextSample}..." is outside the page height.`);
 
-          // Check Right Edge (Long text running off the right edge)
-          if (vX + maxTextWidth > vWidth) {
-              throw new Error(
-                `The text "${cleanTextSample}..." is too long and runs off the right edge. Reduce the Left distance or font size.`
-              );
-          }
-
-          // Check Top Edge
-          if (vY < 0 || vY > vHeight) {
-            throw new Error(
-              `The Top distance (${item.distanceFromTop}pts) for "${cleanTextSample}..." is outside the page height. Current PDF's max height is ${Math.round(vHeight)}pts.`
-            );
-          }
-
-          // Check multi-line overflow along the axis that lines stack on after page rotation:
-          // 0°   → lines stack downward  → check vY - (n-1)*lineHeight >= 0
-          // 90°  → lines stack leftward  → check vX - (n-1)*lineHeight >= 0
-          // 180° → lines stack upward    → check vY + (n-1)*lineHeight <= vHeight
-          // 270° → lines stack rightward → check vX + (n-1)*lineHeight <= vWidth
           const lineOverflow = (lines.length - 1) * actualLineHeight;
-          if (rotationAngle === 90) {
-            if (vX - lineOverflow < 0) {
-              throw new Error(
-                `The text "${cleanTextSample}..." contains too many lines and runs off the left edge of the page. Reduce the Left distance, Font Size, or Line Spacing.`
-              );
-            }
-          } else if (rotationAngle === 180) {
-            if (vY + lineOverflow > vHeight) {
-              throw new Error(
-                `The text "${cleanTextSample}..." contains too many lines and runs off the top of the page. Reduce the Top distance, Font Size, or Line Spacing.`
-              );
-            }
-          } else if (rotationAngle === 270) {
-            if (vX + lineOverflow > vWidth) {
-              throw new Error(
-                `The text "${cleanTextSample}..." contains too many lines and runs off the right edge of the page. Reduce the Left distance, Font Size, or Line Spacing.`
-              );
-            }
-          } else {
-            // 0° — lines stack downward
-            if (vY - lineOverflow < 0) {
-              throw new Error(
-                `The text "${cleanTextSample}..." contains too many lines and runs off the bottom of the page. Reduce the Top distance, Font Size, or Line Spacing.`
-              );
-            }
-          }
+          if (rotationAngle === 90 && vX - lineOverflow < 0) throw new Error(`The text "${cleanTextSample}..." runs off the left edge.`);
+          else if (rotationAngle === 180 && vY + lineOverflow > vHeight) throw new Error(`The text "${cleanTextSample}..." runs off the top.`);
+          else if (rotationAngle === 270 && vX + lineOverflow > vWidth) throw new Error(`The text "${cleanTextSample}..." runs off the right edge.`);
+          else if (rotationAngle === 0 && vY - lineOverflow < 0) throw new Error(`The text "${cleanTextSample}..." runs off the bottom.`);
 
-          // Map Visual coordinates back to Intrinsic coordinates for pdf-lib
-          let iX = vX;
-          let iY = vY;
-          let textRotation = 0;
-
-          if (rotationAngle === 90) {
-            iX = vHeight - vY; 
-            iY = vX;
-            textRotation = 90;
-          } else if (rotationAngle === 180) {
-            iX = vWidth - vX;
-            iY = vHeight - vY;
-            textRotation = 180;
-          } else if (rotationAngle === 270) {
-            iX = vY;
-            iY = vWidth - vX;
-            textRotation = -90;
-          }
+          // Use helper to calculate rotated mapping 
+          // (pdf-lib draws text from the baseline, so vY is our anchor)
+          const { iX, iY, mappedRotation } = mapVisualToIntrinsic(vX, vY, vWidth, vHeight, rotationAngle);
 
           targetPage.drawText(cleanText, {
             x: iX,
@@ -238,18 +155,13 @@ export const addTextToPdf = createAction({
             font: font,
             color: rgb(0, 0, 0),
             lineHeight: actualLineHeight,
-            rotate: degrees(textRotation),
+            rotate: degrees(mappedRotation),
           });
         }
       }
 
-      const pdfBytes = await pdfDoc.save();
-      const base64Pdf = Buffer.from(pdfBytes).toString('base64');
+      return await savePdfToContext(pdfDoc, file.filename, 'text_stamped', context);
 
-      return context.files.write({
-        data: Buffer.from(base64Pdf, 'base64'),
-        fileName: `stamped_${file.filename}`,
-      });
     } catch (error) {
       throw new Error(`Failed to add text to PDF: ${(error as Error).message}`);
     }

--- a/packages/pieces/core/pdf/src/lib/common.ts
+++ b/packages/pieces/core/pdf/src/lib/common.ts
@@ -76,22 +76,3 @@ export async function savePdfToContext(
     fileName: `${prefix}_${originalFilename}`,
   });
 }
-
-/**
- * Detects if a buffer is a PNG or JPG based on its magic numbers.
- */
-export function detectImageType(buffer: Buffer, itemIdentifier: string): 'png' | 'jpg' {
-  if (buffer.length >= 8) {
-    // PNG signature: 89 50 4E 47
-    if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) {
-      return 'png';
-    }
-
-    // JPG/JPEG signature: FF D8 FF
-    if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
-      return 'jpg';
-    }
-  }
-
-  throw new Error(`Unable to detect image type for ${itemIdentifier}. Ensure the buffer is a valid PNG or JPG.`);
-}

--- a/packages/pieces/core/pdf/src/lib/common.ts
+++ b/packages/pieces/core/pdf/src/lib/common.ts
@@ -1,4 +1,4 @@
-import { PDFPage, PDFDocument } from 'pdf-lib';
+import { PDFPage } from 'pdf-lib';
 
 /**
  * Resolves which pages to apply the stamp to based on user input.
@@ -57,22 +57,4 @@ export function mapVisualToIntrinsic(
   }
 
   return { iX, iY, mappedRotation };
-}
-
-/**
- * Saves the PDF and writes it to the Activepieces file system.
- */
-export async function savePdfToContext(
-  pdfDoc: PDFDocument,
-  originalFilename: string,
-  prefix: string,
-  context: any 
-) {
-  const pdfBytes = await pdfDoc.save();
-  const base64Pdf = Buffer.from(pdfBytes).toString('base64');
-
-  return context.files.write({
-    data: Buffer.from(base64Pdf, 'base64'),
-    fileName: `${prefix}_${originalFilename}`,
-  });
 }

--- a/packages/pieces/core/pdf/src/lib/common.ts
+++ b/packages/pieces/core/pdf/src/lib/common.ts
@@ -1,0 +1,78 @@
+import { PDFPage, PDFDocument } from 'pdf-lib';
+
+/**
+ * Resolves which pages to apply the stamp to based on user input.
+ */
+export function getTargetPages(
+  pages: PDFPage[],
+  applyToAllPages: boolean = false,
+  pageNumber?: number,
+  itemName: string = 'Item'
+): PDFPage[] {
+  const totalPages = pages.length;
+
+  if (applyToAllPages) {
+    return [...pages];
+  }
+
+  if (pageNumber === undefined) {
+    throw new Error(`Page Number is required when "Apply to all pages?" is not checked for ${itemName}.`);
+  }
+
+  const pageIndex = Number(pageNumber) - 1;
+  
+  if (pageIndex < 0 || pageIndex >= totalPages) {
+    throw new Error(`You requested Page ${pageNumber} for ${itemName}, but this document only has ${totalPages} page(s).`);
+  }
+
+  return [pages[pageIndex]];
+}
+
+/**
+ * Maps visual coordinates (Top/Left) to pdf-lib intrinsic coordinates based on page rotation.
+ */
+export function mapVisualToIntrinsic(
+  vX: number,
+  anchorY: number, 
+  vWidth: number,
+  vHeight: number,
+  rotationAngle: number
+) {
+  let iX = vX;
+  let iY = anchorY;
+  let mappedRotation = 0;
+
+  if (rotationAngle === 90) {
+    iX = vHeight - anchorY; 
+    iY = vX;
+    mappedRotation = 90;
+  } else if (rotationAngle === 180) {
+    iX = vWidth - vX;
+    iY = vHeight - anchorY;
+    mappedRotation = 180;
+  } else if (rotationAngle === 270) {
+    iX = anchorY;
+    iY = vWidth - vX;
+    mappedRotation = -90;
+  }
+
+  return { iX, iY, mappedRotation };
+}
+
+/**
+ * Saves the PDF and writes it to the Activepieces file system.
+ */
+export async function savePdfToContext(
+  pdfDoc: PDFDocument,
+  originalFilename: string,
+  prefix: string,
+  context: any 
+) {
+  const pdfBytes = await pdfDoc.save();
+  const base64Pdf = Buffer.from(pdfBytes).toString('base64');
+
+  return context.files.write({
+    data: Buffer.from(base64Pdf, 'base64'),
+    fileName: `${prefix}_${originalFilename}`,
+  });
+}

--- a/packages/pieces/core/pdf/src/lib/common.ts
+++ b/packages/pieces/core/pdf/src/lib/common.ts
@@ -76,3 +76,22 @@ export async function savePdfToContext(
     fileName: `${prefix}_${originalFilename}`,
   });
 }
+
+/**
+ * Detects if a buffer is a PNG or JPG based on its magic numbers.
+ */
+export function detectImageType(buffer: Buffer, itemIdentifier: string): 'png' | 'jpg' {
+  if (buffer.length >= 8) {
+    // PNG signature: 89 50 4E 47
+    if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) {
+      return 'png';
+    }
+
+    // JPG/JPEG signature: FF D8 FF
+    if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+      return 'jpg';
+    }
+  }
+
+  throw new Error(`Unable to detect image type for ${itemIdentifier}. Ensure the buffer is a valid PNG or JPG.`);
+}


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new `Add Image to PDF` action, allowing users to precisely overlay images (PNG/JPG) onto existing PDF documents. Additionally, it refactors the underlying PDF manipulation logic, such as coordinate mapping and page rotation handling into a shared common utility file to improve maintainability and share logic with the `Add Text to PDF` action.

### Explain How the Feature Works

The user provides a source PDF and configures one or more image items to be stamped onto the document. For each image, the user specifies:
* The image file (PNG or JPG).
* Target pages (apply to a specific page number or all pages).
* Precise placement using pixel distances from the **Top** and **Left** edges of the page.
* An image scale multiplier (e.g., 0.5 for half size).

Under the hood, the action automatically handles complex document formatting. It accounts for page rotation (0°, 90°, 180°, 270°) and seamlessly translates the user's visual top-down coordinates into `pdf-lib`'s native bottom-up coordinate system, ensuring the image lands exactly where intended.

### Relevant User Scenarios

* **Automated Document Signing:** A user receives a document approval request via Slack. The automation downloads the borrower's PDF, uses this action to stamp a pre-approved signature image at specific coordinates, and returns the signed file or reacts with a success emoji.
* **Watermarking:** Stamping a transparent company logo onto every page of an incoming invoice or report. 
