### PR TITLE
fix(runs): reset startTime and clear finishTime on retry from failed step

### DIFF
--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -156,6 +156,8 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
                     projectId: oldFlowRun.projectId,
                 }, {
                     status: FlowRunStatus.QUEUED,
+                    startTime: apDayjs().toISOString(),
+                    finishTime: null,
                 })
                 const updatedFlowRun = await findFlowRunOrThrow(oldFlowRun.id)
                 const platformId = await projectService(log).getPlatformId(updatedFlowRun.projectId)

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -140,7 +140,7 @@ function statusIcon(status: FlowRunStatus): string {
     return '❌'
 }
 
-function formatDuration(startTime?: string, finishTime?: string): string {
+function formatDuration(startTime?: string | null, finishTime?: string | null): string {
     if (!startTime || !finishTime) return 'N/A'
     return `${((new Date(finishTime).getTime() - new Date(startTime).getTime()) / 1000).toFixed(1)}s`
 }

--- a/packages/server/api/src/app/workers/job/runs-metadata-queue-factory.ts
+++ b/packages/server/api/src/app/workers/job/runs-metadata-queue-factory.ts
@@ -108,8 +108,8 @@ export type RunsMetadataUpsertData = {
     flowVersionId?: string
     environment?: RunEnvironment
     triggeredBy?: string
-    startTime?: string
-    finishTime?: string
+    startTime?: string | null
+    finishTime?: string | null
     status?: FlowRunStatus
     tags?: string[]
     failedStep?: { name: string, displayName: string }

--- a/packages/server/api/test/integration/ce/flows/flow-run/retry-flow-run.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow-run/retry-flow-run.test.ts
@@ -22,6 +22,8 @@ beforeEach(async () => {
 
 async function createFailedFlowRun(params: {
     projectId: string
+    startTime?: string
+    finishTime?: string
 }) {
     const flow = createMockFlow({ projectId: params.projectId })
     await db.save('flow', flow)
@@ -38,6 +40,8 @@ async function createFailedFlowRun(params: {
         flowVersionId: flowVersion.id,
         status: FlowRunStatus.FAILED,
         environment: RunEnvironment.PRODUCTION,
+        startTime: params.startTime,
+        finishTime: params.finishTime,
     })
     await db.save('flow_run', flowRun)
 
@@ -59,6 +63,28 @@ describe('Retry flow run', () => {
 
         const updatedRun = await db.findOneByOrFail<{ id: string, status: string }>('flow_run', { id: flowRun.id })
         expect(updatedRun.status).toBe(FlowRunStatus.QUEUED)
+    })
+
+    it('should reset startTime and clear finishTime when retrying from failed step', async () => {
+        const originalStartTime = new Date('2020-01-01T00:00:00.000Z').toISOString()
+        const originalFinishTime = new Date('2020-01-01T00:05:00.000Z').toISOString()
+        const { flowRun } = await createFailedFlowRun({
+            projectId: ctx.project.id,
+            startTime: originalStartTime,
+            finishTime: originalFinishTime,
+        })
+
+        const response = await ctx.post(`/v1/flow-runs/${flowRun.id}/retry`, {
+            strategy: FlowRetryStrategy.FROM_FAILED_STEP,
+            projectId: ctx.project.id,
+        })
+
+        expect(response.statusCode).toBe(200)
+
+        const updatedRun = await db.findOneByOrFail<{ id: string, startTime: Date | null, finishTime: Date | null }>('flow_run', { id: flowRun.id })
+        expect(updatedRun.startTime).not.toBeNull()
+        expect(new Date(updatedRun.startTime!).getTime()).toBeGreaterThan(new Date(originalStartTime).getTime())
+        expect(updatedRun.finishTime).toBeNull()
     })
 
     it('should retry on latest version and create a new run', async () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/automation/flow-run/flow-run.ts
+++ b/packages/shared/src/lib/automation/flow-run/flow-run.ts
@@ -39,8 +39,8 @@ export const FlowRun = z.object({
     }).optional(),
     logsFileId: Nullable(z.string()),
     status: z.nativeEnum(FlowRunStatus),
-    startTime: z.string().optional(),
-    finishTime: z.string().optional(),
+    startTime: z.string().nullish(),
+    finishTime: z.string().nullish(),
     environment: z.nativeEnum(RunEnvironment),
     // The steps data may be missing if the flow has not started yet,
     // or if the run is older than AP_EXECUTION_DATA_RETENTION_DAYS and its execution data has been purged.

--- a/packages/shared/src/lib/ee/audit-events/index.ts
+++ b/packages/shared/src/lib/ee/audit-events/index.ts
@@ -107,8 +107,8 @@ export const FlowRunEvent = z.object({
     data: z.object({
         flowRun: z.object({
             id: z.string(),
-            startTime: z.string().optional(),
-            finishTime: z.string().optional(),
+            startTime: z.string().nullish(),
+            finishTime: z.string().nullish(),
             duration: z.number().optional(),
             triggeredBy: z.string().optional(),
             environment: z.string(),


### PR DESCRIPTION
## Summary

- When retrying a flow run with `FROM_FAILED_STEP`, only `status` was reset to `QUEUED` while `startTime` and `finishTime` still pointed at the original failed execution. The UI computes duration as `finishTime − startTime`, so retried runs appeared to take the full wall-clock distance since the original failure (often hours or days) instead of the actual retry duration.
- The engine only emits a fresh `startTime` on `ExecutionType.BEGIN` (never on `RESUME`), so the worker does not repopulate it for retries. Fix stamps a fresh `startTime` and clears `finishTime` in the retry service at the same point that transitions the run to `QUEUED`.
- Aligns the `FlowRun` shared schema with the DB reality: `startTime` / `finishTime` are `nullable: true` columns, so the Zod types are switched to `.nullish()` (with matching updates to the audit-events schema and `RunsMetadataUpsertData`). `@activepieces/shared` patch version bumped to `0.66.1`.

## Test plan

- [x] `npm run lint-dev` — 0 errors
- [x] Build passes for `api`, `web`, `@activepieces/shared`, `@activepieces/engine`
- [x] Added `retry-flow-run.test.ts` assertion: after `FROM_FAILED_STEP` retry, `startTime` is advanced past the original and `finishTime` is `null`
- [ ] Manual end-to-end: run a flow that fails, wait so the original `startTime` is meaningfully in the past, trigger "Retry from failed step", confirm duration column reflects the retry's own execution time