### PR TITLE
fix(pieces/baserow): unify trigger auth with piece-level auth to prev…

### DIFF
--- a/packages/pieces/community/baserow/package.json
+++ b/packages/pieces/community/baserow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-baserow",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/baserow/src/lib/auth.ts
+++ b/packages/pieces/community/baserow/src/lib/auth.ts
@@ -88,13 +88,8 @@ function isDatabaseToken(
 }
 
 export const baserowAuth = [databaseTokenAuth, jwtAuth];
-export const baserowJwtAuth = jwtAuth;
 export const isDatabaseTokenAuth = isDatabaseToken;
 
 export type BaserowAuthValue = AppConnectionValueForAuthProperty<
   typeof baserowAuth
->;
-
-export type BaserowJwtAuthValue = AppConnectionValueForAuthProperty<
-  typeof baserowJwtAuth
 >;

--- a/packages/pieces/community/baserow/src/lib/common/index.ts
+++ b/packages/pieces/community/baserow/src/lib/common/index.ts
@@ -6,7 +6,6 @@ import {
 import {
   baserowAuth,
   BaserowAuthValue,
-  BaserowJwtAuthValue,
   isDatabaseTokenAuth,
 } from '../auth';
 import { BaserowClient } from './client';
@@ -18,17 +17,6 @@ export async function makeClient(
   if (isDatabaseTokenAuth(auth)) {
     return new BaserowClient(auth.props.apiUrl, `Token ${auth.props.token}`);
   }
-  const jwt = await BaserowClient.getJwtToken(
-    auth.props.apiUrl,
-    auth.props.email,
-    auth.props.password
-  );
-  return new BaserowClient(auth.props.apiUrl, `JWT ${jwt}`);
-}
-
-export async function makeJwtClient(
-  auth: BaserowJwtAuthValue
-): Promise<BaserowClient> {
   const jwt = await BaserowClient.getJwtToken(
     auth.props.apiUrl,
     auth.props.email,

--- a/packages/pieces/community/baserow/src/lib/common/webhook-trigger.ts
+++ b/packages/pieces/community/baserow/src/lib/common/webhook-trigger.ts
@@ -1,5 +1,5 @@
-import { BaserowJwtAuthValue } from '../auth';
-import { makeJwtClient } from './index';
+import { BaserowAuthValue, isDatabaseTokenAuth } from '../auth';
+import { makeClient } from './index';
 
 export function createWebhookTriggerHooks(
   eventType: string,
@@ -7,15 +7,20 @@ export function createWebhookTriggerHooks(
 ) {
   return {
     async onEnable(context: {
-      auth: BaserowJwtAuthValue;
+      auth: BaserowAuthValue;
       propsValue: { table_id: number | undefined };
       webhookUrl: string;
       store: {
         put: <T>(key: string, value: T) => Promise<T>;
       };
     }): Promise<void> {
+      if (isDatabaseTokenAuth(context.auth)) {
+        throw new Error(
+          'Baserow triggers require Email & Password (JWT) authentication. Please reconnect using the "Email & Password (JWT)" option.'
+        );
+      }
       if (!context.propsValue.table_id) return;
-      const client = await makeJwtClient(context.auth);
+      const client = await makeClient(context.auth);
       const webhook = await client.createWebhook(
         context.propsValue.table_id,
         context.webhookUrl,
@@ -25,15 +30,16 @@ export function createWebhookTriggerHooks(
       await context.store.put(storeKey, { webhookId: webhook.id });
     },
     async onDisable(context: {
-      auth: BaserowJwtAuthValue;
+      auth: BaserowAuthValue;
       store: {
         get: <T>(key: string) => Promise<T | null>;
         delete: (key: string) => Promise<void>;
       };
     }): Promise<void> {
+      if (isDatabaseTokenAuth(context.auth)) return;
       const data = await context.store.get<{ webhookId: number }>(storeKey);
       if (!data?.webhookId) return;
-      const client = await makeJwtClient(context.auth);
+      const client = await makeClient(context.auth);
       try {
         await client.deleteWebhook(data.webhookId);
       } catch {

--- a/packages/pieces/community/baserow/src/lib/triggers/row-created.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/row-created.ts
@@ -1,5 +1,5 @@
 import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
-import { baserowJwtAuth } from '../auth';
+import { baserowAuth } from '../auth';
 import { baserowCommon } from '../common';
 import { createWebhookTriggerHooks } from '../common/webhook-trigger';
 
@@ -7,7 +7,7 @@ const webhookHooks = createWebhookTriggerHooks('rows.created', 'baserow_row_crea
 
 export const rowCreatedTrigger = createTrigger({
   name: 'baserow_row_created',
-  auth: baserowJwtAuth,
+  auth: baserowAuth,
   displayName: 'Row Created',
   description: 'Triggers when a new row is created in a Baserow table.',
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/baserow/src/lib/triggers/row-deleted.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/row-deleted.ts
@@ -1,5 +1,5 @@
 import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
-import { baserowJwtAuth } from '../auth';
+import { baserowAuth } from '../auth';
 import { baserowCommon } from '../common';
 import { createWebhookTriggerHooks } from '../common/webhook-trigger';
 
@@ -7,7 +7,7 @@ const webhookHooks = createWebhookTriggerHooks('rows.deleted', 'baserow_row_dele
 
 export const rowDeletedTrigger = createTrigger({
   name: 'baserow_row_deleted',
-  auth: baserowJwtAuth,
+  auth: baserowAuth,
   displayName: 'Row Deleted',
   description: 'Triggers when a row is deleted from a Baserow table.',
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/baserow/src/lib/triggers/row-updated.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/row-updated.ts
@@ -1,5 +1,5 @@
 import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
-import { baserowJwtAuth } from '../auth';
+import { baserowAuth } from '../auth';
 import { baserowCommon } from '../common';
 import { createWebhookTriggerHooks } from '../common/webhook-trigger';
 
@@ -7,7 +7,7 @@ const webhookHooks = createWebhookTriggerHooks('rows.updated', 'baserow_row_upda
 
 export const rowUpdatedTrigger = createTrigger({
   name: 'baserow_row_updated',
-  auth: baserowJwtAuth,
+  auth: baserowAuth,
   displayName: 'Row Updated',
   description: 'Triggers when an existing row is updated in a Baserow table.',
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/baserow/src/lib/triggers/rows-created.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/rows-created.ts
@@ -1,5 +1,5 @@
 import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
-import { baserowJwtAuth } from '../auth';
+import { baserowAuth } from '../auth';
 import { baserowCommon } from '../common';
 import { createWebhookTriggerHooks } from '../common/webhook-trigger';
 
@@ -7,7 +7,7 @@ const webhookHooks = createWebhookTriggerHooks('rows.created', 'baserow_rows_cre
 
 export const rowsCreatedTrigger = createTrigger({
   name: 'baserow_rows_created',
-  auth: baserowJwtAuth,
+  auth: baserowAuth,
   displayName: 'Rows Created (Batch)',
   description:
     'Triggers when new rows are created in a Baserow table. Returns all rows from the event as a single batch.',

--- a/packages/pieces/community/baserow/src/lib/triggers/rows-deleted.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/rows-deleted.ts
@@ -1,5 +1,5 @@
 import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
-import { baserowJwtAuth } from '../auth';
+import { baserowAuth } from '../auth';
 import { baserowCommon } from '../common';
 import { createWebhookTriggerHooks } from '../common/webhook-trigger';
 
@@ -7,7 +7,7 @@ const webhookHooks = createWebhookTriggerHooks('rows.deleted', 'baserow_rows_del
 
 export const rowsDeletedTrigger = createTrigger({
   name: 'baserow_rows_deleted',
-  auth: baserowJwtAuth,
+  auth: baserowAuth,
   displayName: 'Rows Deleted (Batch)',
   description:
     'Triggers when rows are deleted from a Baserow table. Returns all deleted row IDs from the event as a single batch.',

--- a/packages/pieces/community/baserow/src/lib/triggers/rows-updated.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/rows-updated.ts
@@ -1,5 +1,5 @@
 import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
-import { baserowJwtAuth } from '../auth';
+import { baserowAuth } from '../auth';
 import { baserowCommon } from '../common';
 import { createWebhookTriggerHooks } from '../common/webhook-trigger';
 
@@ -7,7 +7,7 @@ const webhookHooks = createWebhookTriggerHooks('rows.updated', 'baserow_rows_upd
 
 export const rowsUpdatedTrigger = createTrigger({
   name: 'baserow_rows_updated',
-  auth: baserowJwtAuth,
+  auth: baserowAuth,
   displayName: 'Rows Updated (Batch)',
   description:
     'Triggers when existing rows are updated in a Baserow table. Returns all rows from the event as a single batch.',


### PR DESCRIPTION
…ent duplicate connections

Triggers were using a separate `baserowJwtAuth` definition instead of the shared `baserowAuth` array, forcing users to create two separate connections — one for actions and one for triggers.

All six triggers now use `baserowAuth` so a single JWT connection covers the whole piece. `onEnable` guards against Database Token auth with a clear error, since Baserow's webhook API requires JWT.

Removes unused `baserowJwtAuth`, `BaserowJwtAuthValue`, and `makeJwtClient`.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
