### PR TITLE
fix(egress): allow DNS /53 to configured nameservers in kernel lockdown

### DIFF
--- a/packages/server/worker/src/lib/egress/iptables-lockdown.ts
+++ b/packages/server/worker/src/lib/egress/iptables-lockdown.ts
@@ -1,3 +1,4 @@
+import net from 'node:net'
 import { tryCatch } from '@activepieces/shared'
 import { Logger } from 'pino'
 import { spawnWithKill } from '../utils/exec'
@@ -16,7 +17,7 @@ export const iptablesLockdown = {
         await preflightCleanup({ log, params })
 
         for (const family of FAMILIES) {
-            for (const args of buildApplyCommandsForFamily({ params, rejectWith: family.rejectWith })) {
+            for (const args of buildApplyCommandsForFamily({ params, rejectWith: family.rejectWith, family: family.ipFamily })) {
                 const { error } = await tryCatch(() => runRule({ binary: family.binary, args }))
                 if (error) {
                     log.error({ err: error, binary: family.binary, args }, 'iptables rule failed; rolling back')
@@ -33,7 +34,7 @@ export const iptablesLockdown = {
     },
 
     buildApplyCommands(params: ApplyParams): string[][] {
-        return buildApplyCommandsForFamily({ params, rejectWith: IPV4.rejectWith })
+        return buildApplyCommandsForFamily({ params, rejectWith: IPV4.rejectWith, family: 4 })
     },
 
     buildRemoveCommands({ firstBoxUid, numBoxes }: ApplyParams): string[][] {
@@ -50,6 +51,8 @@ const rule = {
     createChain: (name: string): string[] => ['-N', name],
     allowLoopbackTcp: ({ chain, dport }: { chain: string, dport: string }): string[] =>
         ['-A', chain, '-o', 'lo', '-p', 'tcp', '--dport', dport, '-j', 'ACCEPT'],
+    allowDns: ({ chain, protocol, nameserver }: { chain: string, protocol: 'tcp' | 'udp', nameserver: string }): string[] =>
+        ['-A', chain, '-d', nameserver, '-p', protocol, '--dport', '53', '-j', 'ACCEPT'],
     rejectAll: ({ chain, rejectWith }: { chain: string, rejectWith: string }): string[] =>
         ['-A', chain, '-j', 'REJECT', '--reject-with', rejectWith],
     jumpFromOutputForUid: ({ uidRange, target }: { uidRange: string, target: string }): string[] =>
@@ -60,13 +63,18 @@ const rule = {
     deleteChain: (name: string): string[] => ['-X', name],
 }
 
-function buildApplyCommandsForFamily({ params, rejectWith }: { params: ApplyParams, rejectWith: string }): string[][] {
-    const { proxyPort, wsRpcPortRange, firstBoxUid, numBoxes } = params
+function buildApplyCommandsForFamily({ params, rejectWith, family }: { params: ApplyParams, rejectWith: string, family: 4 | 6 }): string[][] {
+    const { proxyPort, wsRpcPortRange, firstBoxUid, numBoxes, nameservers } = params
     const uidRange = `${firstBoxUid}-${firstBoxUid + numBoxes - 1}`
+    const familyNameservers = nameservers.filter((ns) => net.isIP(ns) === family)
     return [
         rule.createChain(CHAIN),
         rule.allowLoopbackTcp({ chain: CHAIN, dport: String(proxyPort) }),
         ...(wsRpcPortRange ? [rule.allowLoopbackTcp({ chain: CHAIN, dport: `${wsRpcPortRange.first}:${wsRpcPortRange.last}` })] : []),
+        ...familyNameservers.flatMap((ns) => [
+            rule.allowDns({ chain: CHAIN, protocol: 'udp', nameserver: ns }),
+            rule.allowDns({ chain: CHAIN, protocol: 'tcp', nameserver: ns }),
+        ]),
         rule.rejectAll({ chain: CHAIN, rejectWith }),
         rule.jumpFromOutputForUid({ uidRange, target: CHAIN }),
     ]
@@ -110,8 +118,8 @@ export class IptablesLockdownError extends Error {
     }
 }
 
-const IPV4 = { binary: 'iptables', rejectWith: 'icmp-host-prohibited' } as const
-const IPV6 = { binary: 'ip6tables', rejectWith: 'icmp6-adm-prohibited' } as const
+const IPV4 = { binary: 'iptables', rejectWith: 'icmp-host-prohibited', ipFamily: 4 } as const
+const IPV6 = { binary: 'ip6tables', rejectWith: 'icmp6-adm-prohibited', ipFamily: 6 } as const
 const FAMILIES = [IPV4, IPV6] as const
 
 const IPTABLES_TIMEOUT_MS = 5_000
@@ -121,6 +129,7 @@ type ApplyParams = {
     wsRpcPortRange?: { first: number, last: number }
     firstBoxUid: number
     numBoxes: number
+    nameservers: string[]
     log: Logger
 }
 

--- a/packages/server/worker/src/lib/egress/lifecycle.ts
+++ b/packages/server/worker/src/lib/egress/lifecycle.ts
@@ -1,3 +1,4 @@
+import dnsSync from 'node:dns'
 import dns from 'node:dns/promises'
 import net from 'node:net'
 import { ActivepiecesError, ErrorCode, ExecutionMode, NetworkMode, tryCatch, WorkerSettingsResponse } from '@activepieces/shared'
@@ -54,17 +55,28 @@ async function maybeApplyIptablesLockdown({ log, proxy, settings }: ApplyLockdow
             },
         })
     }
+    const nameservers = listDnsNameservers()
+    if (nameservers.length === 0) {
+        const message = 'No DNS nameservers configured on the worker host — refusing to apply kernel lockdown that would starve the sandbox of name resolution. ' +
+            'Ensure /etc/resolv.conf has at least one valid nameserver, or inspect dns.getServers() output.'
+        throw new ActivepiecesError(
+            { code: ErrorCode.ENGINE_OPERATION_FAILURE, params: { message } },
+            message,
+        )
+    }
     const lockdown = await iptablesLockdown.apply({
         log,
         proxyPort: proxy.port,
         wsRpcPortRange: sandboxCapacity.wsRpcPortRange,
         firstBoxUid: sandboxCapacity.firstBoxUid,
         numBoxes: sandboxCapacity.numBoxes,
+        nameservers,
     })
     log.info({
         proxyPort: proxy.port,
         firstBoxUid: sandboxCapacity.firstBoxUid,
         numBoxes: sandboxCapacity.numBoxes,
+        nameservers,
     }, 'Kernel-level SSRF lockdown applied')
     return lockdown
 }
@@ -85,6 +97,19 @@ async function resolveHostToIps({ rawUrl }: ResolveHostParams): Promise<string[]
     if (net.isIP(hostname) > 0) return [hostname]
     const addresses = await dns.lookup(hostname, { all: true })
     return addresses.map((a) => a.address)
+}
+
+function listDnsNameservers(): string[] {
+    return dnsSync.getServers().map(extractNameserverIp).filter((ip): ip is string => ip !== null)
+}
+
+function extractNameserverIp(server: string): string | null {
+    if (net.isIP(server) > 0) return server
+    const bracketed = server.match(/^\[([^\]]+)\](?::\d+)?$/)
+    if (bracketed && net.isIP(bracketed[1]) > 0) return bracketed[1]
+    const v4WithPort = server.match(/^(\d+\.\d+\.\d+\.\d+):\d+$/)
+    if (v4WithPort && net.isIP(v4WithPort[1]) === 4) return v4WithPort[1]
+    return null
 }
 
 type StartParams = {

--- a/packages/server/worker/test/e2e/iptables-lockdown.e2e.test.ts
+++ b/packages/server/worker/test/e2e/iptables-lockdown.e2e.test.ts
@@ -12,6 +12,8 @@ const execFileAsync = promisify(execFile)
 const SANDBOX_UID = sandboxCapacity.firstBoxUid
 const SANDBOX_GID = sandboxCapacity.firstBoxUid
 const CHAIN = 'AP_EGRESS_LOCKDOWN'
+const ALLOWED_NAMESERVER = '127.0.0.1'
+const BLOCKED_NAMESERVER = '8.8.8.8'
 
 const skip = requireLinuxPrivileged()
 
@@ -40,6 +42,7 @@ describe.skipIf(skip)('iptables-lockdown — real kernel rules', () => {
             wsRpcPortRange: { first: rpcEcho.port, last: rpcEcho.port },
             firstBoxUid: SANDBOX_UID,
             numBoxes: 1,
+            nameservers: [ALLOWED_NAMESERVER],
         })
     })
 
@@ -86,6 +89,20 @@ describe.skipIf(skip)('iptables-lockdown — real kernel rules', () => {
         expect(result.status).toBe('OK')
     })
 
+    it('installs DNS nameserver allow rules for UDP and TCP /53', async () => {
+        const { stdout } = await execFileAsync('iptables', ['-S', CHAIN])
+        expect(stdout).toMatch(new RegExp(`-A ${CHAIN} -d ${ALLOWED_NAMESERVER}(/32)? -p udp -m udp --dport 53 -j ACCEPT`))
+        expect(stdout).toMatch(new RegExp(`-A ${CHAIN} -d ${ALLOWED_NAMESERVER}(/32)? -p tcp -m tcp --dport 53 -j ACCEPT`))
+    })
+
+    it('rejects the sandbox UID from sending UDP /53 to a non-allowlisted nameserver', async () => {
+        const result = await probeUdp({ host: BLOCKED_NAMESERVER, port: 53, uid: SANDBOX_UID, gid: SANDBOX_GID })
+        expect(result.status).toBe('ERR')
+        if (result.status === 'ERR') {
+            expect(result.code).toMatch(/EHOSTUNREACH|ENETUNREACH|EPERM|EACCES/)
+        }
+    })
+
     it('removes the chain cleanly so a subsequent lookup returns nothing', async () => {
         await lockdown!.remove()
         lockdown = null
@@ -104,6 +121,42 @@ s.setTimeout(2000);
 s.on('connect', () => { process.stdout.write('OK'); s.destroy(); process.exit(0); });
 s.on('timeout', () => { process.stdout.write('TIMEOUT'); process.exit(2); });
 s.on('error', (e) => { process.stdout.write('ERR:' + (e.code || e.message)); process.exit(1); });`
+    return new Promise((resolve) => {
+        const child = spawn(process.execPath, ['-e', script], {
+            uid,
+            gid,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        })
+        const chunks: Buffer[] = []
+        child.stdout.on('data', (d: Buffer) => chunks.push(d))
+        child.on('close', () => {
+            const out = Buffer.concat(chunks).toString()
+            if (out === 'OK') {
+                resolve({ status: 'OK' })
+                return
+            }
+            if (out.startsWith('ERR:')) {
+                resolve({ status: 'ERR', code: out.slice(4) })
+                return
+            }
+            resolve({ status: 'ERR', code: out || 'EMPTY' })
+        })
+    })
+}
+
+async function probeUdp({ host, port, uid, gid }: {
+    host: string
+    port: number
+    uid: number | undefined
+    gid: number | undefined
+}): Promise<ProbeResult> {
+    const script = `const dgram = require('node:dgram');
+const s = dgram.createSocket('udp4');
+let settled = false;
+const done = (out) => { if (settled) return; settled = true; process.stdout.write(out); s.close(); process.exit(0); };
+s.on('error', (e) => done('ERR:' + (e.code || e.message)));
+s.send(Buffer.from([0]), ${port}, '${host}', (err) => { if (err) done('ERR:' + (err.code || err.message)); });
+setTimeout(() => done('OK'), 500);`
     return new Promise((resolve) => {
         const child = spawn(process.execPath, ['-e', script], {
             uid,

--- a/packages/server/worker/test/e2e/sandbox-egress.e2e.test.ts
+++ b/packages/server/worker/test/e2e/sandbox-egress.e2e.test.ts
@@ -48,6 +48,7 @@ describe.skipIf(skip)('sandbox egress — full stack (proxy + iptables + isolate
             proxyPort: proxy.port,
             firstBoxUid: SANDBOX_UID,
             numBoxes: 1,
+            nameservers: [],
         })
     })
 

--- a/packages/server/worker/test/e2e/sandbox-engine-ssrf.e2e.test.ts
+++ b/packages/server/worker/test/e2e/sandbox-engine-ssrf.e2e.test.ts
@@ -48,6 +48,7 @@ describe.skipIf(skip)('sandbox engine ssrf-guard — real hooks under real proxy
             wsRpcPortRange: { first: wsRpcListener.port, last: wsRpcListener.port },
             firstBoxUid: SANDBOX_UID,
             numBoxes: 1,
+            nameservers: [],
         })
 
         const plan: ProbePlanItem[] = [

--- a/packages/server/worker/test/lib/egress/iptables-lockdown.test.ts
+++ b/packages/server/worker/test/lib/egress/iptables-lockdown.test.ts
@@ -9,6 +9,7 @@ describe('iptables-lockdown command builder', () => {
         wsRpcPortRange: { first: 52000, last: 52999 },
         firstBoxUid: 60000,
         numBoxes: 10,
+        nameservers: [] as string[],
         log,
     }
 
@@ -55,5 +56,49 @@ describe('iptables-lockdown command builder', () => {
         const cmds = iptablesLockdown.buildApplyCommands({ ...baseParams, firstBoxUid: 60000, numBoxes: 1 })
         const jump = cmds[cmds.length - 1]
         expect(jump).toEqual(['-A', 'OUTPUT', '-m', 'owner', '--uid-owner', '60000-60000', '-j', 'AP_EGRESS_LOCKDOWN'])
+    })
+
+    describe('DNS nameserver allow rules', () => {
+        it('emits a UDP and a TCP /53 ACCEPT for a single IPv4 nameserver', () => {
+            const cmds = iptablesLockdown.buildApplyCommands({ ...baseParams, nameservers: ['10.0.0.2'] })
+            const udp = cmds.find((c) => c.includes('10.0.0.2') && c.includes('udp'))
+            const tcp = cmds.find((c) => c.includes('10.0.0.2') && c.includes('tcp') && c.includes('--dport') && c[c.indexOf('--dport') + 1] === '53')
+            expect(udp).toEqual(['-A', 'AP_EGRESS_LOCKDOWN', '-d', '10.0.0.2', '-p', 'udp', '--dport', '53', '-j', 'ACCEPT'])
+            expect(tcp).toEqual(['-A', 'AP_EGRESS_LOCKDOWN', '-d', '10.0.0.2', '-p', 'tcp', '--dport', '53', '-j', 'ACCEPT'])
+        })
+
+        it('emits UDP+TCP /53 rules for each nameserver in input order', () => {
+            const cmds = iptablesLockdown.buildApplyCommands({ ...baseParams, nameservers: ['10.0.0.2', '169.254.169.253'] })
+            const dnsRules = cmds.filter((c) => c[0] === '-A' && c[1] === 'AP_EGRESS_LOCKDOWN' && c.includes('--dport') && c[c.indexOf('--dport') + 1] === '53')
+            expect(dnsRules).toEqual([
+                ['-A', 'AP_EGRESS_LOCKDOWN', '-d', '10.0.0.2', '-p', 'udp', '--dport', '53', '-j', 'ACCEPT'],
+                ['-A', 'AP_EGRESS_LOCKDOWN', '-d', '10.0.0.2', '-p', 'tcp', '--dport', '53', '-j', 'ACCEPT'],
+                ['-A', 'AP_EGRESS_LOCKDOWN', '-d', '169.254.169.253', '-p', 'udp', '--dport', '53', '-j', 'ACCEPT'],
+                ['-A', 'AP_EGRESS_LOCKDOWN', '-d', '169.254.169.253', '-p', 'tcp', '--dport', '53', '-j', 'ACCEPT'],
+            ])
+        })
+
+        it('omits all DNS rules when nameservers is empty', () => {
+            const cmds = iptablesLockdown.buildApplyCommands({ ...baseParams, nameservers: [] })
+            const dnsRules = cmds.filter((c) => c.includes('--dport') && c[c.indexOf('--dport') + 1] === '53')
+            expect(dnsRules).toHaveLength(0)
+        })
+
+        it('places DNS rules after loopback ACCEPTs and strictly before the REJECT', () => {
+            const cmds = iptablesLockdown.buildApplyCommands({ ...baseParams, nameservers: ['10.0.0.2'] })
+            const lastLoopbackIdx = cmds.findLastIndex((c) => c.includes('-o') && c.includes('lo'))
+            const firstDnsIdx = cmds.findIndex((c) => c.includes('--dport') && c[c.indexOf('--dport') + 1] === '53')
+            const rejectIdx = cmds.findIndex((c) => c.includes('REJECT'))
+            expect(firstDnsIdx).toBeGreaterThan(lastLoopbackIdx)
+            expect(firstDnsIdx).toBeLessThan(rejectIdx)
+        })
+
+        it('IPv4 builder skips IPv6 nameservers', () => {
+            const cmds = iptablesLockdown.buildApplyCommands({ ...baseParams, nameservers: ['10.0.0.2', 'fd00::1'] })
+            const ipv6Rules = cmds.filter((c) => c.includes('fd00::1'))
+            expect(ipv6Rules).toHaveLength(0)
+            const ipv4Rules = cmds.filter((c) => c.includes('10.0.0.2'))
+            expect(ipv4Rules).toHaveLength(2)
+        })
     })
 })

--- a/packages/server/worker/test/lib/egress/lifecycle.test.ts
+++ b/packages/server/worker/test/lib/egress/lifecycle.test.ts
@@ -1,6 +1,7 @@
+import dnsSync from 'node:dns'
 import { ExecutionMode, NetworkMode, WorkerSettingsResponse } from '@activepieces/shared'
 import pino from 'pino'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const log = pino({ level: 'silent' })
 
@@ -46,9 +47,14 @@ function stubSettings({ network, execution }: { network: NetworkMode, execution:
 }
 
 describe('startEgressStack', () => {
+    beforeEach(() => {
+        vi.spyOn(dnsSync, 'getServers').mockReturnValue(['10.0.0.2'])
+    })
+
     afterEach(() => {
         vi.mocked(startEgressProxy).mockClear()
         vi.mocked(iptablesLockdown.apply).mockClear()
+        vi.restoreAllMocks()
     })
 
     it('UNRESTRICTED + isolate: skips proxy and kernel lockdown (no crash)', async () => {
@@ -76,6 +82,33 @@ describe('startEgressStack', () => {
         expect(startEgressProxy).toHaveBeenCalledTimes(1)
         expect(iptablesLockdown.apply).toHaveBeenCalledTimes(1)
         await stack.shutdown()
+    })
+
+    it('STRICT + isolate: passes host DNS nameservers to the lockdown', async () => {
+        vi.mocked(dnsSync.getServers).mockReturnValue(['10.0.0.2', '169.254.169.253'])
+        stubSettings({ network: NetworkMode.STRICT, execution: ExecutionMode.SANDBOX_PROCESS })
+        const stack = await startEgressStack({ log, apiUrl: 'http://127.0.0.1:3000' })
+        expect(iptablesLockdown.apply).toHaveBeenCalledWith(
+            expect.objectContaining({ nameservers: ['10.0.0.2', '169.254.169.253'] }),
+        )
+        await stack.shutdown()
+    })
+
+    it('STRICT + isolate: strips port suffixes from dns.getServers() entries', async () => {
+        vi.mocked(dnsSync.getServers).mockReturnValue(['8.8.8.8:53', '[2001:4860:4860::8888]:53'])
+        stubSettings({ network: NetworkMode.STRICT, execution: ExecutionMode.SANDBOX_PROCESS })
+        const stack = await startEgressStack({ log, apiUrl: 'http://127.0.0.1:3000' })
+        expect(iptablesLockdown.apply).toHaveBeenCalledWith(
+            expect.objectContaining({ nameservers: ['8.8.8.8', '2001:4860:4860::8888'] }),
+        )
+        await stack.shutdown()
+    })
+
+    it('STRICT + isolate: throws fail-fast when no nameservers are configured', async () => {
+        vi.mocked(dnsSync.getServers).mockReturnValue([])
+        stubSettings({ network: NetworkMode.STRICT, execution: ExecutionMode.SANDBOX_PROCESS })
+        await expect(startEgressStack({ log, apiUrl: 'http://127.0.0.1:3000' })).rejects.toThrow(/No DNS nameservers configured/)
+        expect(iptablesLockdown.apply).not.toHaveBeenCalled()
     })
 
     it('STRICT + unsandboxed: starts proxy but does NOT apply kernel lockdown', async () => {


### PR DESCRIPTION
## Summary

- The egress iptables lockdown introduced in #12700 rejected every outbound packet from sandbox UIDs except loopback TCP to the proxy and WS RPC ports, so any client that called `dns.lookup` before connecting (libsql, pg, mysql2, native fetch) got `getaddrinfo EAI_AGAIN` — the root cause of the 2026-04-23 Cloud outage ([forum thread](https://community.activepieces.com/t/outbound-dns-failing-on-activepieces-cloud-for-over-60-mins/11880)).
- Lifecycle now reads the host's configured nameservers via `dns.getServers()`, strips port suffixes, and passes them to `iptablesLockdown.apply`, which inserts UDP + TCP `/53` ACCEPT rules scoped to each nameserver IP (per address family) before the final REJECT. Fails fast if no nameservers are configured rather than applying a silently-broken lockdown.
- Defense-in-depth unchanged: the engine's `dns-lookup-guard` still rejects DNS responses that resolve to private/loopback/link-local/metadata IPs, and the egress proxy still enforces the allow list on HTTP/HTTPS flows.

## Test plan

- [x] `npm run test` in `packages/server/worker` — 196 tests pass, including 5 new iptables-lockdown unit cases covering single/multi nameserver rule emission, empty-list behavior, ordering (after loopback ACCEPTs, before REJECT), and IPv4/IPv6 family filtering.
- [x] 3 new `startEgressStack` lifecycle cases covering nameserver pass-through, port-suffix stripping for `8.8.8.8:53` / `[::1]:53`, and the new fail-fast when `dns.getServers()` returns `[]`.
- [x] 2 new e2e cases (Linux + `NET_ADMIN`) verifying the DNS allow rules appear in `iptables -S AP_EGRESS_LOCKDOWN` and that UDP `/53` to a non-allowlisted nameserver (`8.8.8.8`) is REJECTed for the sandbox UID.
- [x] `npm run lint-dev` clean.
- [ ] Staging verification: deploy with `AP_NETWORK_MODE=STRICT`, run a code step with `fetch('https://api.github.com')` and with a DB driver that resolves its own hostname — both should succeed, and `fetch('http://10.0.0.1/')` should still return an SSRF error (not `EAI_AGAIN`).