### PR TITLE
feat(tavily): migrate to Bearer token auth and add custom API call action

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1029,7 +1029,7 @@
     },
     "packages/pieces/community/baserow": {
       "name": "@activepieces/piece-baserow",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -6580,7 +6580,7 @@
     },
     "packages/pieces/community/tavily": {
       "name": "@activepieces/piece-tavily",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/tavily/package.json
+++ b/packages/pieces/community/tavily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-tavily",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/tavily/src/index.ts
+++ b/packages/pieces/community/tavily/src/index.ts
@@ -1,17 +1,9 @@
-import { httpClient, HttpMethod } from '@activepieces/pieces-common';
-import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import { searchAction } from './lib/actions/search';
 import { extractAction } from './lib/actions/extract';
 import { tavilyAuth } from './lib/auth';
-
-const markdownDescription = `
-Follow these steps to obtain your Tavily API Key:
-
-1. Visit [tavily](https://tavily.com/) and create an account.
-2. Log in and navigate to your dashboard.
-3. Locate and copy your API key from the dashboard.
-`;
 
 export const tavily = createPiece({
 	displayName: 'Tavily',
@@ -21,6 +13,12 @@ export const tavily = createPiece({
 	categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
 	authors: ['OsamaHaikal'],
 	auth: tavilyAuth,
-	actions: [searchAction, extractAction],
+	actions: [searchAction, extractAction,
+		createCustomApiCallAction({
+			baseUrl: () => 'https://api.tavily.com',
+			auth: tavilyAuth,
+			authMapping: async (auth) => ({ Authorization: `Bearer ${auth.secret_text}` }),
+		})
+	],
 	triggers: [],
 });

--- a/packages/pieces/community/tavily/src/lib/actions/extract.ts
+++ b/packages/pieces/community/tavily/src/lib/actions/extract.ts
@@ -1,5 +1,5 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { tavilyAuth } from '../auth';
 
 export const extractAction = createAction({
@@ -24,11 +24,14 @@ export const extractAction = createAction({
     const response = await httpClient.sendRequest({
       method: HttpMethod.POST,
       url: 'https://api.tavily.com/extract',
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.secret_text
+      },
       headers: {
         'Content-Type': 'application/json',
       },
       body: {
-        api_key: auth,
         urls: propsValue.urls,
         include_images: propsValue.include_images,
       },

--- a/packages/pieces/community/tavily/src/lib/actions/search.ts
+++ b/packages/pieces/community/tavily/src/lib/actions/search.ts
@@ -1,5 +1,5 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { tavilyAuth } from '../auth';
 
 export const searchAction = createAction({
@@ -105,11 +105,14 @@ export const searchAction = createAction({
     const response = await httpClient.sendRequest({
       method: HttpMethod.POST,
       url: 'https://api.tavily.com/search',
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.secret_text
+      },
       headers: {
         'Content-Type': 'application/json',
       },
       body: {
-        api_key: auth,
         query: propsValue.query,
         search_depth: propsValue.search_depth,
         topic: propsValue.topic,

--- a/packages/pieces/community/tavily/src/lib/auth.ts
+++ b/packages/pieces/community/tavily/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { PieceAuth } from '@activepieces/pieces-framework';
-import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
 
 const markdownDescription = `
 Follow these steps to obtain your Tavily API Key:
@@ -16,16 +16,15 @@ export const tavilyAuth = PieceAuth.SecretText({
 	validate: async ({ auth }) => {
 		try {
 			await httpClient.sendRequest({
-				method: HttpMethod.POST,
-				url: 'https://api.tavily.com/search',
+				method: HttpMethod.GET,
+				url: 'https://api.tavily.com/usage',
 				headers: {
 					'Content-Type': 'application/json',
 				},
-				body: {
-					api_key: auth,
-					query: 'test',
-					search_depth: 'basic',
-				},
+				authentication: {
+					type: AuthenticationType.BEARER_TOKEN,
+					token: auth
+				}
 			});
 			return {
 				valid: true,

--- a/packages/pieces/community/tavily/src/lib/auth.ts
+++ b/packages/pieces/community/tavily/src/lib/auth.ts
@@ -18,9 +18,6 @@ export const tavilyAuth = PieceAuth.SecretText({
 			await httpClient.sendRequest({
 				method: HttpMethod.GET,
 				url: 'https://api.tavily.com/usage',
-				headers: {
-					'Content-Type': 'application/json',
-				},
 				authentication: {
 					type: AuthenticationType.BEARER_TOKEN,
 					token: auth


### PR DESCRIPTION
Switch from API key in request body to Bearer token authentication for search, extract, and auth validation. Update auth validation to use the /usage endpoint (GET) instead of a search request. Add createCustomApiCallAction to enable arbitrary API calls.

