### PR TITLE
fix(pieces/baserow): remove JWT auth and unify to database token only

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1029,7 +1029,7 @@
     },
     "packages/pieces/community/baserow": {
       "name": "@activepieces/piece-baserow",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/baserow/package.json
+++ b/packages/pieces/community/baserow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-baserow",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/baserow/src/index.ts
+++ b/packages/pieces/community/baserow/src/index.ts
@@ -20,8 +20,7 @@ import { rowDeletedTrigger } from './lib/triggers/row-deleted';
 import { rowsCreatedTrigger } from './lib/triggers/rows-created';
 import { rowsUpdatedTrigger } from './lib/triggers/rows-updated';
 import { rowsDeletedTrigger } from './lib/triggers/rows-deleted';
-import { baserowAuth, isDatabaseTokenAuth } from './lib/auth';
-import { BaserowClient } from './lib/common/client';
+import { baserowAuth } from './lib/auth';
 
 export const baserow = createPiece({
   displayName: 'Baserow',
@@ -30,7 +29,7 @@ export const baserow = createPiece({
   minimumSupportedRelease: '0.30.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/baserow.png',
   categories: [PieceCategory.PRODUCTIVITY],
-  authors: ["kishanprmr","MoShizzle","abuaboud",'bst1n','sanket-a11y'],
+  authors: ["kishanprmr", "MoShizzle", "abuaboud", 'bst1n', 'sanket-a11y'],
   actions: [
     createRowAction,
     deleteRowAction,
@@ -52,15 +51,7 @@ export const baserow = createPiece({
       },
       auth: baserowAuth,
       authMapping: async (auth) => {
-        if (isDatabaseTokenAuth(auth)) {
-          return { Authorization: `Token ${auth.props.token}` };
-        }
-        const jwt = await BaserowClient.getJwtToken(
-          auth.props.apiUrl,
-          auth.props.email,
-          auth.props.password
-        );
-        return { Authorization: `JWT ${jwt}` };
+        return { Authorization: `Token ${auth.props.token}` };
       },
     }),
   ],

--- a/packages/pieces/community/baserow/src/lib/auth.ts
+++ b/packages/pieces/community/baserow/src/lib/auth.ts
@@ -3,10 +3,9 @@ import {
   PieceAuth,
   Property,
 } from '@activepieces/pieces-framework';
-import { AppConnectionType } from '@activepieces/shared';
 import { HttpMethod, httpClient } from '@activepieces/pieces-common';
 
-const databaseTokenAuth = PieceAuth.CustomAuth({
+export const baserowAuth = PieceAuth.CustomAuth({
   displayName: 'Database Token',
   description: `
   1. Log in to your Baserow Account.
@@ -39,56 +38,6 @@ const databaseTokenAuth = PieceAuth.CustomAuth({
     }
   },
 });
-
-const jwtAuth = PieceAuth.CustomAuth({
-  displayName: 'Email & Password (JWT)',
-  description: `Authenticate with your Baserow email and password. This mode enables automatic webhook registration for triggers — no manual setup needed.\n\n**Note:** Two-factor authentication (2FA) is not supported. If your Baserow account has 2FA enabled, use the Database Token authentication instead.`,
-  required: true,
-  props: {
-    apiUrl: Property.ShortText({
-      displayName: 'API URL',
-      required: true,
-      defaultValue: 'https://api.baserow.io',
-    }),
-    email: Property.ShortText({
-      displayName: 'Email',
-      required: true,
-    }),
-    password: PieceAuth.SecretText({
-      displayName: 'Password',
-      required: true,
-    }),
-  },
-  validate: async ({ auth }) => {
-    try {
-      await httpClient.sendRequest({
-        method: HttpMethod.POST,
-        url: `${auth.apiUrl}/api/user/token-auth/`,
-        body: { email: auth.email, password: auth.password },
-      });
-      return { valid: true };
-    } catch {
-      return {
-        valid: false,
-        error: 'Invalid email, password, or API URL.',
-      };
-    }
-  },
-});
-
-function isDatabaseToken(
-  auth: BaserowAuthValue
-): auth is BaserowAuthValue & {
-  type: typeof AppConnectionType.CUSTOM_AUTH;
-  props: { apiUrl: string; token: string };
-} {
-  return (
-    auth.type === AppConnectionType.CUSTOM_AUTH && 'token' in auth.props
-  );
-}
-
-export const baserowAuth = [databaseTokenAuth, jwtAuth];
-export const isDatabaseTokenAuth = isDatabaseToken;
 
 export type BaserowAuthValue = AppConnectionValueForAuthProperty<
   typeof baserowAuth

--- a/packages/pieces/community/baserow/src/lib/common/client.ts
+++ b/packages/pieces/community/baserow/src/lib/common/client.ts
@@ -34,20 +34,7 @@ export class BaserowClient {
   constructor(
     private baseUrl: string,
     private authHeader: string
-  ) {}
-
-  static async getJwtToken(
-    baseUrl: string,
-    email: string,
-    password: string
-  ): Promise<string> {
-    const res = await httpClient.sendRequest<{ token: string }>({
-      method: HttpMethod.POST,
-      url: `${baseUrl}/api/user/token-auth/`,
-      body: { email, password },
-    });
-    return res.body.token;
-  }
+  ) { }
 
   async makeRequest<T extends HttpMessageBody>(
     method: HttpMethod,

--- a/packages/pieces/community/baserow/src/lib/common/index.ts
+++ b/packages/pieces/community/baserow/src/lib/common/index.ts
@@ -6,7 +6,6 @@ import {
 import {
   baserowAuth,
   BaserowAuthValue,
-  isDatabaseTokenAuth,
 } from '../auth';
 import { BaserowClient } from './client';
 import { BaserowFieldType } from './constants';
@@ -14,15 +13,7 @@ import { BaserowFieldType } from './constants';
 export async function makeClient(
   auth: BaserowAuthValue
 ): Promise<BaserowClient> {
-  if (isDatabaseTokenAuth(auth)) {
-    return new BaserowClient(auth.props.apiUrl, `Token ${auth.props.token}`);
-  }
-  const jwt = await BaserowClient.getJwtToken(
-    auth.props.apiUrl,
-    auth.props.email,
-    auth.props.password
-  );
-  return new BaserowClient(auth.props.apiUrl, `JWT ${jwt}`);
+  return new BaserowClient(auth.props.apiUrl, `Token ${auth.props.token}`);
 }
 
 export function formatFieldValues(
@@ -189,9 +180,7 @@ export const baserowCommon = {
                     required: false,
                     description: `Enter date in ${field.date_format} format ${
                       field.date_include_time
-                        ? 'and time in ' +
-                          field.date_time_format +
-                          ' hour format'
+                        ? 'and time in ' + field.date_time_format + ' hour format'
                         : ''
                     }.`,
                   });

--- a/packages/pieces/community/baserow/src/lib/common/webhook-trigger.ts
+++ b/packages/pieces/community/baserow/src/lib/common/webhook-trigger.ts
@@ -1,4 +1,4 @@
-import { BaserowAuthValue, isDatabaseTokenAuth } from '../auth';
+import { BaserowAuthValue } from '../auth';
 import { makeClient } from './index';
 
 export function createWebhookTriggerHooks(
@@ -14,11 +14,6 @@ export function createWebhookTriggerHooks(
         put: <T>(key: string, value: T) => Promise<T>;
       };
     }): Promise<void> {
-      if (isDatabaseTokenAuth(context.auth)) {
-        throw new Error(
-          'Baserow triggers require Email & Password (JWT) authentication. Please reconnect using the "Email & Password (JWT)" option.'
-        );
-      }
       if (!context.propsValue.table_id) return;
       const client = await makeClient(context.auth);
       const webhook = await client.createWebhook(
@@ -36,7 +31,6 @@ export function createWebhookTriggerHooks(
         delete: (key: string) => Promise<void>;
       };
     }): Promise<void> {
-      if (isDatabaseTokenAuth(context.auth)) return;
       const data = await context.store.get<{ webhookId: number }>(storeKey);
       if (!data?.webhookId) return;
       const client = await makeClient(context.auth);


### PR DESCRIPTION
## Summary

- Removes the Email & Password (JWT) authentication option from the Baserow piece
- Renames `databaseTokenAuth` to `baserowAuth` as the single exported auth
- Cleans up `isDatabaseTokenAuth` type guard, `BaserowClient.getJwtToken` static method, and all JWT branching logic in `makeClient`, webhook triggers, and the custom API call `authMapping`

## Test plan

- [x] Connect a Baserow account using Database Token auth — verify connection validates successfully
- [x] Run a Create Row / Get Row action — verify it works end-to-end
- [x] Enable a Row Created trigger — verify webhook registers in Baserow and fires correctly