### PR TITLE
fix: update PR pieces labels to use correct GitHub label names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,9 @@ npm run lint-dev      # Lint with auto-fix (ALWAYS before done)
   - **`feature`** — new functionality
   - **`bug`** — bug fix
   - **`skip-changelog`** — changes that should not appear in the changelog (docs, CI tweaks, internal refactors, etc.)
-- If the PR includes any contributions to pieces (integrations under `packages/pieces`), also add the **`pieces`** label (in addition to the primary label above).
+- If the PR includes any contributions to pieces (integrations under `packages/pieces`), also add the appropriate pieces label (in addition to the primary label above):
+  - **`area/third-party-pieces`** — for third-party integrations (most pieces under `packages/pieces/community/`)
+  - **`area/core-pieces`** — for core pieces (under `packages/pieces/core/`)
 
 ## Database Migrations
 


### PR DESCRIPTION
## Summary
- Replaces the non-existent `pieces` label in AGENTS.md with the two actual GitHub labels: `area/third-party-pieces` and `area/core-pieces`
- Adds guidance on which label to use: community integrations vs core pieces

## Test plan
- [ ] Verify `area/third-party-pieces` and `area/core-pieces` labels exist on the repo