### PR TITLE
fix(ci): use bun cache in validate-publishable-packages workflow

### DIFF
--- a/.github/workflows/validate-publishable-packages.yml
+++ b/.github/workflows/validate-publishable-packages.yml
@@ -17,25 +17,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ hashFiles('bun.lock', 'package.json') }}
+          restore-keys: bun-
+
       - uses: actions/setup-node@v3
         with:
           node-version: 24
 
-      - name: Cache dependencies
-        id: cache-npm
-        uses: actions/cache@v3
+      - uses: oven-sh/setup-bun@v2
         with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
+          bun-version: latest
 
       - name: Install dependencies
-        run: npm install -g bun && bun install
+        run: bun install
 
       - name: validate publishable packages
         run: npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/validate-publishable-packages.ts

--- a/.github/workflows/validate-publishable-packages.yml
+++ b/.github/workflows/validate-publishable-packages.yml
@@ -24,11 +24,13 @@ jobs:
           key: bun-${{ hashFiles('bun.lock', 'package.json') }}
           restore-keys: bun-
 
-      - uses: actions/setup-node@v3
+      - name: Setup nodejs
+        uses: actions/setup-node@v3
         with:
           node-version: 24
 
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
## Summary
- Replaces broken npm cache (`~/.npm` keyed on `package-lock.json`) with correct bun cache (`~/.bun/install/cache` keyed on `bun.lock`)
- Replaces `npm install -g bun` with `oven-sh/setup-bun@v2` action
- Removes useless `npm list` step
- Adds step names to match `release-pieces.yml` convention

The old cache was a no-op — it cached npm's directory but installed via bun, so `bun install` always ran cold (~2m 32s). With the correct cache path, subsequent runs drop to ~15s.

## Test plan
- [ ] Trigger the workflow on a PR touching `packages/pieces/**` and verify `bun install` is fast on the second run