### PR TITLE
chore(pieces): patch-bump pieces stuck on the inflated 0.82.0 floor

### DIFF
--- a/packages/pieces/community/ai/package.json
+++ b/packages/pieces/community/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ai",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/amazon-textract/package.json
+++ b/packages/pieces/community/amazon-textract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-textract",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/attio/package.json
+++ b/packages/pieces/community/attio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-attio",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/azure-ad/package.json
+++ b/packages/pieces/community/azure-ad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-azure-ad",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bigcommerce/package.json
+++ b/packages/pieces/community/bigcommerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bigcommerce",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bigcommerce/src/index.ts
+++ b/packages/pieces/community/bigcommerce/src/index.ts
@@ -34,7 +34,7 @@ export const bigcommerce = createPiece({
   description:
     'BigCommerce is a leading e-commerce platform that enables businesses to create and manage online stores.',
   auth: bigcommerceAuth,
-  minimumSupportedRelease: '0.82.0',
+  minimumSupportedRelease: '0.36.1',
   logoUrl: 'https://cdn.activepieces.com/pieces/bigcommerce.png',
   authors: ['gs03-dev', 'sanket-a11y', 'Angelebeats'],
   actions: [

--- a/packages/pieces/community/campaign-monitor/package.json
+++ b/packages/pieces/community/campaign-monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-campaign-monitor",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/claude/package.json
+++ b/packages/pieces/community/claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-claude",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/crisp/package.json
+++ b/packages/pieces/community/crisp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-crisp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/docusign/package.json
+++ b/packages/pieces/community/docusign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-docusign",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/firecrawl/package.json
+++ b/packages/pieces/community/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-firecrawl",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/help-scout/package.json
+++ b/packages/pieces/community/help-scout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-help-scout",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/imap/package.json
+++ b/packages/pieces/community/imap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-imap",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/jira-cloud/package.json
+++ b/packages/pieces/community/jira-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jira-cloud",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/kizeo-forms/package.json
+++ b/packages/pieces/community/kizeo-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-kizeo-forms",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/kustomer/package.json
+++ b/packages/pieces/community/kustomer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-kustomer",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/microsoft-onedrive/package.json
+++ b/packages/pieces/community/microsoft-onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-onedrive",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/oracle-database/package.json
+++ b/packages/pieces/community/oracle-database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-oracle-database",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/pastebin/package.json
+++ b/packages/pieces/community/pastebin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pastebin",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/rss/package.json
+++ b/packages/pieces/community/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-rss",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/salesforce/package.json
+++ b/packages/pieces/community/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-salesforce",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/snowflake/package.json
+++ b/packages/pieces/community/snowflake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-snowflake",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/stripe/package.json
+++ b/packages/pieces/community/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-stripe",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/tally/package.json
+++ b/packages/pieces/community/tally/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-tally",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/telnyx/package.json
+++ b/packages/pieces/community/telnyx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-telnyx",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/vtex/package.json
+++ b/packages/pieces/community/vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-vtex",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/youtube/package.json
+++ b/packages/pieces/community/youtube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-youtube",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/zoho-mail/package.json
+++ b/packages/pieces/community/zoho-mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-zoho-mail",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/graphql/package.json
+++ b/packages/pieces/core/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-graphql",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/http/package.json
+++ b/packages/pieces/core/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-http",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/pdf/package.json
+++ b/packages/pieces/core/pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pdf",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/smtp/package.json
+++ b/packages/pieces/core/smtp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-smtp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Republishes the 8 pieces whose current cloud-registry entries still carry minimumSupportedRelease: '0.82.0' from the pre-fix Piece constructor floor. Cross-checked every floor-window piece against the cloud registry; the other 24 are already at '0.73.0' (pre-Apr-12 floor) and don't need a bump.

Pieces bumped: ai, azure-ad, bigcommerce, docusign, google-drive, jira-cloud, microsoft-onedrive, pdf.

bigcommerce's declared minimumSupportedRelease is also lowered from '0.82.0' back to its original '0.36.1' — the 0.82.0 value was added by copy-paste in #12586 but the piece doesn't use createWaitpoint / waitForWaitpoint / pause / generateResumeUrl.
