### PR TITLE
fix(pieces-framework): restore forced 0.82.0 minimumSupportedRelease floor

### DIFF
--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/framework/src/lib/context/versioning.ts
+++ b/packages/pieces/framework/src/lib/context/versioning.ts
@@ -6,11 +6,9 @@ export enum ContextVersion {
     V1 = '1',
     V2 = '2',
 }
-// When introducing a new context version:
-// 1. add it to the switch in backwardCompatabilityContextUtils below
-// 2. pieces that use APIs exclusive to the new version must manually declare
-//    a matching `minimumSupportedRelease` — the SDK no longer enforces a floor
+//bump these two constants after creating a new context version
 export const LATEST_CONTEXT_VERSION = ContextVersion.V2;
+export const MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION = '0.82.0';
 
 export const backwardCompatabilityContextUtils = {
     makeActionContextBackwardCompatible({ context, contextVersion }: MakeActionContextBackwardCompatibleParams): ActionContext<PieceAuthProperty, InputPropertyMap> {

--- a/packages/pieces/framework/src/lib/context/versioning.ts
+++ b/packages/pieces/framework/src/lib/context/versioning.ts
@@ -6,7 +6,14 @@ export enum ContextVersion {
     V1 = '1',
     V2 = '2',
 }
-//bump these two constants after creating a new context version
+// When introducing a new context version, bump BOTH constants together.
+// The floor is load-bearing: older engines bundle an older framework whose
+// switch below only knows the older ContextVersion cases. A piece compiled
+// against a newer framework reports the new version via getContextInfo(),
+// the switch falls through, returns undefined, and the engine then invokes
+// run(undefined) — surfacing as "Cannot read properties of undefined".
+// Enforcing the floor in piece.ts keeps such pieces out of the registry on
+// incompatible servers instead of crashing at execution time.
 export const LATEST_CONTEXT_VERSION = ContextVersion.V2;
 export const MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION = '0.82.0';
 

--- a/packages/pieces/framework/src/lib/piece.ts
+++ b/packages/pieces/framework/src/lib/piece.ts
@@ -8,7 +8,8 @@ import {
 import { PieceBase, PieceMetadata} from './piece-metadata';
 import { PieceAuthProperty } from './property/authentication';
 import { ServerContext } from './context';
-import { ContextVersion, LATEST_CONTEXT_VERSION } from './context/versioning';
+import { ContextVersion, LATEST_CONTEXT_VERSION, MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION } from './context/versioning';
+import * as semver from 'semver';
 
 
 
@@ -28,10 +29,13 @@ export class Piece<PieceAuth extends PieceAuthProperty | PieceAuthProperty[] | u
     triggers: Trigger[],
     public readonly categories: PieceCategory[],
     public readonly auth?: PieceAuth,
-    public readonly minimumSupportedRelease?: string,
+    public readonly minimumSupportedRelease: string = MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION,
     public readonly maximumSupportedRelease?: string,
     public readonly description = '',
   ) {
+    if(!semver.valid(minimumSupportedRelease) || semver.lt(minimumSupportedRelease, MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION)) {
+      this.minimumSupportedRelease = MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION;
+    }
     actions.forEach((action) => (this._actions[action.name] = action));
     triggers.forEach((trigger) => (this._triggers[trigger.name] = trigger));
   }


### PR DESCRIPTION
## Summary

Reverts #12764. Re-enforces the `MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION = '0.82.0'` floor in `Piece`'s constructor so any piece compiled against framework >= `0.28.0` (i.e. reporting `contextVersion: V2`) is gated behind an Activepieces 0.82.0+ server.

## Why the floor is load-bearing

Engines on 0.81.x bundle an older `@activepieces/pieces-framework` whose `backwardCompatabilityContextUtils.makeActionContextBackwardCompatible` switch only has cases for `undefined` and `V1`:

```ts
// 0.81.4's versioning.ts
switch (contextVersion) {
    case undefined:         return migrateActionContextV1ToV0(context);
    case ContextVersion.V1: return context;
}
```

A piece compiled against the current framework reports `V2` via `getContextInfo()`. That value matches no case, the switch falls through, and the function returns `undefined`. The engine then calls `pieceAction.run(undefined)`, so inside the piece `context.auth` throws:

```
TypeError: Cannot read properties of undefined (reading 'auth')
  at .../piece-google-drive@0.7.4/.../get-file-by-id.js:24:77
```

With the floor back in place the registry filter (`isSupportedRelease` in `piece-cache-utils.ts`) excludes these pieces from 0.81.x servers up front — restoring the "piece not available" behaviour rather than a runtime crash.

## Changes

- `packages/pieces/framework/src/lib/context/versioning.ts` — restore `MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION` export and add a comment explaining why the floor is load-bearing.
- `packages/pieces/framework/src/lib/piece.ts` — restore the default value + semver guard that coerces any missing/lower floor up to `0.82.0`.
- `packages/pieces/framework/package.json` — bump to `0.28.1`.

## Test plan

- [ ] Confirm `createPiece({ minimumSupportedRelease: '0.5.6', ... })` now yields a `Piece` with `minimumSupportedRelease === '0.82.0'`.
- [ ] Confirm `createPiece({ minimumSupportedRelease: '0.83.0', ... })` keeps `'0.83.0'`.
- [ ] Confirm a 0.81.x server's `/pieces/registry?release=0.81.4` no longer returns pieces compiled against this framework.
- [ ] `npm run lint-dev` clean for the framework package.