### PR TITLE
fix(web): respect hideFolders in import flow dialog

### DIFF
--- a/packages/web/src/features/flows/components/import-flow-dialog.tsx
+++ b/packages/web/src/features/flows/components/import-flow-dialog.tsx
@@ -15,6 +15,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { LoadingSpinner } from '@/components/custom/spinner';
+import { useEmbedding } from '@/components/providers/embed-provider';
 import { useTelemetry } from '@/components/providers/telemetry-provider';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -75,6 +76,7 @@ const ImportFlowDialog = (
   props: ImportFlowDialogProps & { children: React.ReactNode },
 ) => {
   const { capture } = useTelemetry();
+  const { embedState } = useEmbedding();
   const [templates, setTemplates] = useState<Template[]>([]);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -258,7 +260,7 @@ const ImportFlowDialog = (
               onChange={handleFileChange}
             />
           </div>
-          {!props.insideBuilder && (
+          {!props.insideBuilder && !embedState.hideFolders && (
             <div className="w-full flex flex-col gap-2 justify-between items-start">
               <span className="w-16 text-sm font-medium text-gray-700">
                 {t('Folder')}


### PR DESCRIPTION
## Summary

The **Folder** select inside the import-flow dialog ignored `embedState.hideFolders`, so embedders that hid folders everywhere else still saw a folder picker in the import modal.

Gate the Folder section on `!embedState.hideFolders`, matching the pattern already used in `flow-actions-menu`, `automations-filters`, `automations-table-row`, and `automations-selection-bar`.

## Changes

- `packages/web/src/features/flows/components/import-flow-dialog.tsx` — read `embedState` via `useEmbedding()` and guard the Folder select on `!embedState.hideFolders`. No prop surface change; `selectedFolderId` still defaults to the caller's `props.folderId`, so the import lands in the expected folder when the picker is hidden.

## Test plan

- [ ] With an embedding config that sets `hideFolders: true`, open the import-flow dialog from the dashboard and confirm the Folder select is not rendered.
- [ ] With `hideFolders: false` (default), confirm the Folder select still renders and lets the user pick a folder.
- [ ] Inside the builder (`insideBuilder: true`), confirm nothing changes — the folder picker was already hidden in that branch.