### PR TITLE
fix(shared): remap step references in router branch conditions on duplicate/paste

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8160,7 +8160,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.67.1",
+      "version": "0.67.2",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",
@@ -15271,6 +15271,8 @@
 
     "@activepieces/piece-ai/@activepieces/pieces-framework": ["@activepieces/pieces-framework@0.26.2", "", { "dependencies": { "@activepieces/shared": "0.53.2", "ai": "^6.0.0", "semver": "7.6.0", "tslib": "2.6.2", "zod": "4.3.6" } }, "sha512-1u835arkO4TKGKfKuz9jeT7Ua1exCeSFCR0+stzB5fqQgtqWgACRFKBNpfPdKcTZK4zTuVeungMe0Hvayq6FqA=="],
 
+    "@activepieces/piece-ai/@activepieces/shared": ["@activepieces/shared@0.67.1", "", { "dependencies": { "dayjs": "1.11.9", "deepmerge-ts": "7.1.0", "ipaddr.js": "2.3.0", "nanoid": "3.3.8", "semver": "7.6.0", "socket.io-client": "4.8.1", "tslib": "2.6.2", "zod": "4.3.6" } }, "sha512-2CBOmqkL3niZoZj4VsbfBO6aVFbwZyBx4/1oGkxJ2SF7slebpqCgwxgvVSexaNNgS4vMMSfxMxfzvEbi1iptDQ=="],
+
     "@activepieces/piece-ai/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.67", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-FFX4P5Fd6lcQJc2OLngZQkbbJHa0IDDZi087Edb8qRZx6h90krtM61ArbMUL8us/7ZUwojCXnyJ/wQ2Eflx2jQ=="],
 
     "@activepieces/piece-ai/@ai-sdk/azure": ["@ai-sdk/azure@3.0.52", "", { "dependencies": { "@ai-sdk/openai": "3.0.51", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-SsRR97cT6QpGeFzt5kEnFz8aRCu09TGksjMtS2b48f7dQJ4dDvsMi5J29CkrjvTQWyFVajZpH+iHvYUHCcEdig=="],
@@ -15286,6 +15288,8 @@
     "@activepieces/piece-aiprise/@activepieces/pieces-common": ["@activepieces/pieces-common@0.12.1", "", { "dependencies": { "@activepieces/pieces-framework": "0.26.2", "@activepieces/shared": "0.53.2", "axios": "1.13.5", "axios-retry": "4.4.1", "form-data": "4.0.4", "mime-types": "2.1.35", "request-filtering-agent": "2.0.1", "tslib": "2.6.2", "zod": "4.3.6" } }, "sha512-2ptt9o8igQxHMuNWBkrX8eInkFDbeQLFg4wO1FlnC1b67jxdGtFjXZQ9zeMPB9PgPWxNUow6koAn0ttL3LPZgg=="],
 
     "@activepieces/piece-aiprise/@activepieces/pieces-framework": ["@activepieces/pieces-framework@0.26.2", "", { "dependencies": { "@activepieces/shared": "0.53.2", "ai": "^6.0.0", "semver": "7.6.0", "tslib": "2.6.2", "zod": "4.3.6" } }, "sha512-1u835arkO4TKGKfKuz9jeT7Ua1exCeSFCR0+stzB5fqQgtqWgACRFKBNpfPdKcTZK4zTuVeungMe0Hvayq6FqA=="],
+
+    "@activepieces/piece-aiprise/@activepieces/shared": ["@activepieces/shared@0.67.1", "", { "dependencies": { "dayjs": "1.11.9", "deepmerge-ts": "7.1.0", "ipaddr.js": "2.3.0", "nanoid": "3.3.8", "semver": "7.6.0", "socket.io-client": "4.8.1", "tslib": "2.6.2", "zod": "4.3.6" } }, "sha512-2CBOmqkL3niZoZj4VsbfBO6aVFbwZyBx4/1oGkxJ2SF7slebpqCgwxgvVSexaNNgS4vMMSfxMxfzvEbi1iptDQ=="],
 
     "@activepieces/piece-aiprise/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -15322,6 +15326,8 @@
     "@activepieces/piece-pagerduty/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@activepieces/piece-pdf/@activepieces/pieces-framework": ["@activepieces/pieces-framework@0.26.2", "", { "dependencies": { "@activepieces/shared": "0.53.2", "ai": "^6.0.0", "semver": "7.6.0", "tslib": "2.6.2", "zod": "4.3.6" } }, "sha512-1u835arkO4TKGKfKuz9jeT7Ua1exCeSFCR0+stzB5fqQgtqWgACRFKBNpfPdKcTZK4zTuVeungMe0Hvayq6FqA=="],
+
+    "@activepieces/piece-pdf/@activepieces/shared": ["@activepieces/shared@0.67.1", "", { "dependencies": { "dayjs": "1.11.9", "deepmerge-ts": "7.1.0", "ipaddr.js": "2.3.0", "nanoid": "3.3.8", "semver": "7.6.0", "socket.io-client": "4.8.1", "tslib": "2.6.2", "zod": "4.3.6" } }, "sha512-2CBOmqkL3niZoZj4VsbfBO6aVFbwZyBx4/1oGkxJ2SF7slebpqCgwxgvVSexaNNgS4vMMSfxMxfzvEbi1iptDQ=="],
 
     "@activepieces/piece-postiz/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -17936,6 +17942,8 @@
     "@activepieces/piece-aiprise/@activepieces/pieces-framework/ai": ["ai@6.0.149", "", { "dependencies": { "@ai-sdk/gateway": "3.0.91", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3asRb/m3ZGH7H4+VTuTgj8eQYJZ9IJUmV0ljLslY92mQp6Zj+NVn4SmFj0TBr2Y/wFBWC3xgn++47tSGOXxdbw=="],
 
     "@activepieces/piece-aiprise/@activepieces/pieces-framework/tslib": ["tslib@2.6.2", "", {}, "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="],
+
+    "@activepieces/piece-aiprise/@activepieces/shared/tslib": ["tslib@2.6.2", "", {}, "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="],
 
     "@activepieces/piece-amazon-secrets-manager/@aws-sdk/client-secrets-manager/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.989.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-eKmAOeQM4Qusq0jtcbZPiNWky8XaojByKC/n+THbJ8vJf7t4ys8LlcZ4PrBSHZISe9cC484mQsPVOQh6iySjqw=="],
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.67.1",
+  "version": "0.67.2",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/automation/flows/operations/add-action-util.ts
+++ b/packages/shared/src/lib/automation/flows/operations/add-action-util.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { applyFunctionToValuesSync, isString } from '../../../core/common'
-import { FlowAction } from '../actions/action'
+import { BranchCondition, BranchExecutionType, FlowAction, FlowActionType } from '../actions/action'
 import { FlowVersion } from '../flow-version'
 import { flowStructureUtil } from '../util/flow-structure-util'
 
@@ -41,6 +41,32 @@ function replaceOldStepNameWithNewOne({
     })
 }
 
+function replaceInBranchConditions(
+    conditions: BranchCondition[][],
+    oldNameToNewName: Record<string, string>,
+): BranchCondition[][] {
+    return conditions.map(group =>
+        group.map((condition) => {
+            const newCondition = { ...condition }
+            Object.keys(oldNameToNewName).forEach((oldName) => {
+                const newStepName = oldNameToNewName[oldName]
+                newCondition.firstValue = replaceOldStepNameWithNewOne({
+                    input: newCondition.firstValue,
+                    oldStepName: oldName,
+                    newStepName,
+                })
+                if ('secondValue' in newCondition) {
+                    newCondition.secondValue = replaceOldStepNameWithNewOne({
+                        input: newCondition.secondValue,
+                        oldStepName: oldName,
+                        newStepName,
+                    })
+                }
+            })
+            return newCondition
+        }),
+    )
+}
 
 function clone(step: FlowAction, oldNameToNewName: Record<string, string>): FlowAction {
     step.displayName = `${step.displayName} Copy`
@@ -63,6 +89,17 @@ function clone(step: FlowAction, oldNameToNewName: Record<string, string>): Flow
             )
         })
     }
+    if (step.type === FlowActionType.ROUTER && step.settings.branches) {
+        step.settings.branches = step.settings.branches.map((branch) => {
+            if (branch.branchType !== BranchExecutionType.CONDITION || !branch.conditions) {
+                return branch
+            }
+            return {
+                ...branch,
+                conditions: replaceInBranchConditions(branch.conditions, oldNameToNewName),
+            }
+        })
+    }
     if (step.settings.sampleData) {
         step.settings = {
             ...step.settings,
@@ -76,4 +113,5 @@ function clone(step: FlowAction, oldNameToNewName: Record<string, string>): Flow
 export const addActionUtils = {
     mapToNewNames,
     clone,
+    replaceInBranchConditions,
 }

--- a/packages/shared/src/lib/automation/flows/operations/add-action-util.ts
+++ b/packages/shared/src/lib/automation/flows/operations/add-action-util.ts
@@ -50,11 +50,13 @@ function replaceInBranchConditions(
             const newCondition = { ...condition }
             Object.keys(oldNameToNewName).forEach((oldName) => {
                 const newStepName = oldNameToNewName[oldName]
-                newCondition.firstValue = replaceOldStepNameWithNewOne({
-                    input: newCondition.firstValue,
-                    oldStepName: oldName,
-                    newStepName,
-                })
+                newCondition.firstValue = newCondition.firstValue
+                    ? replaceOldStepNameWithNewOne({
+                        input: newCondition.firstValue,
+                        oldStepName: oldName,
+                        newStepName,
+                    })
+                    : newCondition.firstValue
                 if ('secondValue' in newCondition) {
                     newCondition.secondValue = replaceOldStepNameWithNewOne({
                         input: newCondition.secondValue,

--- a/packages/shared/src/lib/automation/flows/operations/duplicate-step.ts
+++ b/packages/shared/src/lib/automation/flows/operations/duplicate-step.ts
@@ -39,36 +39,52 @@ function _duplicateBranch(
 ): FlowOperationRequest[] {
     const router = flowStructureUtil.getActionOrThrow(routerName, flowVersion.trigger)
     const clonedRouter: RouterAction = JSON.parse(JSON.stringify(router))
-    const operations: FlowOperationRequest[] = [{
-        type: FlowOperationType.ADD_BRANCH,
-        request: {
-            branchName: `${clonedRouter.settings.branches[childIndex].branchName} Copy`,
-            branchIndex: childIndex + 1,
-            stepName: routerName,
-            conditions: clonedRouter.settings.branches[childIndex].branchType === BranchExecutionType.CONDITION ? clonedRouter.settings.branches[childIndex].conditions : undefined,
-        },
-    }]
-
     const childRouter = clonedRouter.children[childIndex]
+    const originalConditions = clonedRouter.settings.branches[childIndex].branchType === BranchExecutionType.CONDITION ? clonedRouter.settings.branches[childIndex].conditions : undefined
+    let conditions = originalConditions
     if (!isNil(childRouter)) {
         const oldNameToNewName = addActionUtils.mapToNewNames(flowVersion, [childRouter])
+        if (conditions) {
+            conditions = addActionUtils.replaceInBranchConditions(conditions, oldNameToNewName)
+        }
         const clonedSubflow = flowStructureUtil.transferStep(childRouter, (step: FlowAction) => {
             return addActionUtils.clone(step, oldNameToNewName)
         })
         const importOperations = _getImportOperations(clonedSubflow)
-        operations.push({
-            type: FlowOperationType.ADD_ACTION,
-            request: {
-                stepLocationRelativeToParent: StepLocationRelativeToParent.INSIDE_BRANCH,
-                action: clonedSubflow as FlowAction,
-                parentStep: routerName,
-                branchIndex: childIndex + 1,
+        return [
+            {
+                type: FlowOperationType.ADD_BRANCH,
+                request: {
+                    branchName: `${clonedRouter.settings.branches[childIndex].branchName} Copy`,
+                    branchIndex: childIndex + 1,
+                    stepName: routerName,
+                    conditions,
+                },
             },
-        })
-        operations.push(...importOperations)
+            {
+                type: FlowOperationType.ADD_ACTION,
+                request: {
+                    stepLocationRelativeToParent: StepLocationRelativeToParent.INSIDE_BRANCH,
+                    action: clonedSubflow as FlowAction,
+                    parentStep: routerName,
+                    branchIndex: childIndex + 1,
+                },
+            },
+            ...importOperations,
+        ]
     }
 
-    return operations
+    return [
+        {
+            type: FlowOperationType.ADD_BRANCH,
+            request: {
+                branchName: `${clonedRouter.settings.branches[childIndex].branchName} Copy`,
+                branchIndex: childIndex + 1,
+                stepName: routerName,
+                conditions,
+            },
+        },
+    ]
 }
 
 export { _duplicateStep, _duplicateBranch }

--- a/packages/shared/test/flow/duplicate-and-paste.test.ts
+++ b/packages/shared/test/flow/duplicate-and-paste.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect } from 'vitest'
+import {
+    BranchExecutionType,
+    BranchOperator,
+    FlowAction,
+    FlowActionType,
+    FlowOperationType,
+    FlowTriggerType,
+    FlowVersion,
+    FlowVersionState,
+    RouterExecutionType,
+    StepLocationRelativeToParent,
+    flowOperations,
+} from '../../src'
+import { _getOperationsForPaste } from '../../src/lib/automation/flows/operations/paste-operations'
+import { _duplicateBranch } from '../../src/lib/automation/flows/operations/duplicate-step'
+
+function makeFlowVersion(): FlowVersion {
+    return {
+        id: 'fv-1',
+        created: '2024-01-01T00:00:00Z',
+        updated: '2024-01-01T00:00:00Z',
+        flowId: 'flow-1',
+        displayName: 'Test Flow',
+        trigger: {
+            name: 'trigger',
+            type: FlowTriggerType.EMPTY,
+            valid: true,
+            settings: {},
+        },
+        updatedBy: null,
+        valid: true,
+        schemaVersion: null,
+        agentIds: [],
+        state: FlowVersionState.DRAFT,
+        connectionIds: [],
+        backupFiles: null,
+        notes: [],
+    }
+}
+
+describe('duplicate and paste step name remapping', () => {
+    describe('_duplicateBranch', () => {
+        it('should remap step references inside branch conditions', () => {
+            const routerAction: FlowAction = {
+                name: 'router_1',
+                displayName: 'Router',
+                type: FlowActionType.ROUTER,
+                valid: true,
+                settings: {
+                    branches: [
+                        {
+                            branchName: 'Branch 1',
+                            branchType: BranchExecutionType.CONDITION,
+                            conditions: [
+                                [
+                                    {
+                                        firstValue: '{{step_1.body}}',
+                                        secondValue: '{{step_1.status}}',
+                                        operator: BranchOperator.TEXT_CONTAINS,
+                                        caseSensitive: false,
+                                    },
+                                ],
+                            ],
+                        },
+                    ],
+                    executionType: RouterExecutionType.EXECUTE_FIRST_MATCH,
+                },
+                children: [
+                    {
+                        name: 'step_1',
+                        displayName: 'Code',
+                        type: FlowActionType.CODE,
+                        valid: true,
+                        settings: {
+                            input: {},
+                            sourceCode: {
+                                code: 'test',
+                                packageJson: '{}',
+                            },
+                        },
+                    },
+                ],
+            }
+
+            const flowVersion: FlowVersion = {
+                ...makeFlowVersion(),
+                trigger: {
+                    ...makeFlowVersion().trigger,
+                    nextAction: routerAction,
+                },
+            }
+
+            const operations = _duplicateBranch('router_1', 0, flowVersion)
+            const addBranchOp = operations.find(op => op.type === FlowOperationType.ADD_BRANCH)
+            expect(addBranchOp).toBeDefined()
+            const conditions = addBranchOp!.request.conditions
+            expect(conditions).toBeDefined()
+            expect(conditions[0][0].firstValue).toBe('{{step_2.body}}')
+            expect(conditions[0][0].secondValue).toBe('{{step_2.status}}')
+
+            const addActionOp = operations.find(op => op.type === FlowOperationType.ADD_ACTION)
+            expect(addActionOp).toBeDefined()
+            expect(addActionOp!.request.action.name).toBe('step_2')
+        })
+
+        it('should not remap references to steps outside the duplicated branch', () => {
+            const routerAction: FlowAction = {
+                name: 'router_1',
+                displayName: 'Router',
+                type: FlowActionType.ROUTER,
+                valid: true,
+                settings: {
+                    branches: [
+                        {
+                            branchName: 'Branch 1',
+                            branchType: BranchExecutionType.CONDITION,
+                            conditions: [
+                                [
+                                    {
+                                        firstValue: '{{trigger.body}}',
+                                        operator: BranchOperator.EXISTS,
+                                    },
+                                ],
+                            ],
+                        },
+                    ],
+                    executionType: RouterExecutionType.EXECUTE_FIRST_MATCH,
+                },
+                children: [
+                    {
+                        name: 'step_1',
+                        displayName: 'Code',
+                        type: FlowActionType.CODE,
+                        valid: true,
+                        settings: {
+                            input: {},
+                            sourceCode: {
+                                code: 'test',
+                                packageJson: '{}',
+                            },
+                        },
+                    },
+                ],
+            }
+
+            const flowVersion: FlowVersion = {
+                ...makeFlowVersion(),
+                trigger: {
+                    ...makeFlowVersion().trigger,
+                    nextAction: routerAction,
+                },
+            }
+
+            const operations = _duplicateBranch('router_1', 0, flowVersion)
+            const addBranchOp = operations.find(op => op.type === FlowOperationType.ADD_BRANCH)
+            expect(addBranchOp!.request.conditions[0][0].firstValue).toBe('{{trigger.body}}')
+        })
+    })
+
+    describe('_getOperationsForPaste', () => {
+        it('should remap step references inside pasted router branch conditions', () => {
+            const routerAction: FlowAction = {
+                name: 'step_3',
+                displayName: 'Router',
+                type: FlowActionType.ROUTER,
+                valid: true,
+                settings: {
+                    branches: [
+                        {
+                            branchName: 'Branch 1',
+                            branchType: BranchExecutionType.CONDITION,
+                            conditions: [
+                                [
+                                    {
+                                        firstValue: '{{step_4.body}}',
+                                        secondValue: 'static',
+                                        operator: BranchOperator.TEXT_CONTAINS,
+                                        caseSensitive: false,
+                                    },
+                                ],
+                            ],
+                        },
+                    ],
+                    executionType: RouterExecutionType.EXECUTE_FIRST_MATCH,
+                },
+                children: [
+                    {
+                        name: 'step_4',
+                        displayName: 'Code',
+                        type: FlowActionType.CODE,
+                        valid: true,
+                        settings: {
+                            input: {
+                                value: '{{step_3.output}}',
+                            },
+                            sourceCode: {
+                                code: 'test',
+                                packageJson: '{}',
+                            },
+                        },
+                    },
+                ],
+            }
+
+            const flowVersion: FlowVersion = {
+                ...makeFlowVersion(),
+                trigger: {
+                    ...makeFlowVersion().trigger,
+                    nextAction: {
+                        name: 'existing_step',
+                        displayName: 'Existing',
+                        type: FlowActionType.CODE,
+                        valid: true,
+                        settings: {
+                            input: {},
+                            sourceCode: {
+                                code: 'test',
+                                packageJson: '{}',
+                            },
+                        },
+                    },
+                },
+            }
+
+            const operations = _getOperationsForPaste(
+                [routerAction],
+                flowVersion,
+                {
+                    parentStepName: 'existing_step',
+                    stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+                },
+            )
+
+            const addActionOp = operations.find(op => op.type === FlowOperationType.ADD_ACTION)
+            expect(addActionOp).toBeDefined()
+            const pastedRouter = addActionOp!.request.action
+            expect(pastedRouter.type).toBe(FlowActionType.ROUTER)
+            expect(pastedRouter.name).toBe('step_1')
+            const conditions = pastedRouter.settings.branches[0].conditions
+            expect(conditions[0][0].firstValue).toBe('{{step_2.body}}')
+            expect(pastedRouter.children[0].name).toBe('step_2')
+            expect(pastedRouter.children[0].settings.input.value).toBe('{{step_1.output}}')
+        })
+    })
+
+    describe('regression: both input and conditions remapped together', () => {
+        it('should remap conditions and inputs when duplicating a branch', () => {
+            const routerAction: FlowAction = {
+                name: 'router_1',
+                displayName: 'Router',
+                type: FlowActionType.ROUTER,
+                valid: true,
+                settings: {
+                    branches: [
+                        {
+                            branchName: 'Branch 1',
+                            branchType: BranchExecutionType.CONDITION,
+                            conditions: [
+                                [
+                                    {
+                                        firstValue: '{{step_1.body}}',
+                                        secondValue: '{{step_1.status}}',
+                                        operator: BranchOperator.TEXT_CONTAINS,
+                                        caseSensitive: false,
+                                    },
+                                ],
+                            ],
+                        },
+                    ],
+                    executionType: RouterExecutionType.EXECUTE_FIRST_MATCH,
+                },
+                children: [
+                    {
+                        name: 'step_1',
+                        displayName: 'Code',
+                        type: FlowActionType.CODE,
+                        valid: true,
+                        settings: {
+                            input: {
+                                ref: '{{step_1.nested}}',
+                            },
+                            sourceCode: {
+                                code: 'test',
+                                packageJson: '{}',
+                            },
+                        },
+                    },
+                ],
+            }
+
+            const flowVersion: FlowVersion = {
+                ...makeFlowVersion(),
+                trigger: {
+                    ...makeFlowVersion().trigger,
+                    nextAction: routerAction,
+                },
+            }
+
+            const result = flowOperations.apply(flowVersion, {
+                type: FlowOperationType.DUPLICATE_BRANCH,
+                request: {
+                    stepName: 'router_1',
+                    branchIndex: 0,
+                },
+            })
+
+            const router = result.trigger.nextAction
+            expect(router.type).toBe(FlowActionType.ROUTER)
+            expect(router.settings.branches).toHaveLength(2)
+
+            const duplicatedBranch = router.settings.branches[1]
+            expect(duplicatedBranch.conditions[0][0].firstValue).toBe('{{step_2.body}}')
+            expect(duplicatedBranch.conditions[0][0].secondValue).toBe('{{step_2.status}}')
+
+            const duplicatedChild = router.children[1]
+            expect(duplicatedChild!.name).toBe('step_2')
+            expect(duplicatedChild!.settings.input.ref).toBe('{{step_2.nested}}')
+        })
+
+        it('should remap conditions and inputs when duplicating a router step', () => {
+            const routerAction: FlowAction = {
+                name: 'router_1',
+                displayName: 'Router',
+                type: FlowActionType.ROUTER,
+                valid: true,
+                settings: {
+                    branches: [
+                        {
+                            branchName: 'Branch 1',
+                            branchType: BranchExecutionType.CONDITION,
+                            conditions: [
+                                [
+                                    {
+                                        firstValue: '{{step_1.body}}',
+                                        operator: BranchOperator.TEXT_CONTAINS,
+                                        caseSensitive: false,
+                                    },
+                                ],
+                            ],
+                        },
+                    ],
+                    executionType: RouterExecutionType.EXECUTE_FIRST_MATCH,
+                },
+                children: [
+                    {
+                        name: 'step_1',
+                        displayName: 'Code',
+                        type: FlowActionType.CODE,
+                        valid: true,
+                        settings: {
+                            input: {
+                                ref: '{{step_1.nested}}',
+                            },
+                            sourceCode: {
+                                code: 'test',
+                                packageJson: '{}',
+                            },
+                        },
+                    },
+                ],
+            }
+
+            const flowVersion: FlowVersion = {
+                ...makeFlowVersion(),
+                trigger: {
+                    ...makeFlowVersion().trigger,
+                    nextAction: routerAction,
+                },
+            }
+
+            const result = flowOperations.apply(flowVersion, {
+                type: FlowOperationType.DUPLICATE_ACTION,
+                request: {
+                    stepName: 'router_1',
+                },
+            })
+
+            const originalRouter = result.trigger.nextAction
+            const duplicatedRouter = originalRouter.nextAction
+            expect(duplicatedRouter.type).toBe(FlowActionType.ROUTER)
+            expect(duplicatedRouter.name).toBe('step_2')
+            expect(duplicatedRouter.settings.branches[0].conditions[0][0].firstValue).toBe('{{step_3.body}}')
+            expect(duplicatedRouter.children[0].name).toBe('step_3')
+            expect(duplicatedRouter.children[0].settings.input.ref).toBe('{{step_3.nested}}')
+        })
+    })
+})


### PR DESCRIPTION
When duplicating or pasting a router step or branch, the branch conditions were not updated to reference the newly cloned steps, causing them to still point to the original step names.

Fixes #9600