### PR TITLE
fix(web): show correct paste options on big add buttons

### DIFF
--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -30,6 +30,7 @@
   "Paste Inside Loop": "Paste Inside Loop",
   "Paste After": "Paste After",
   "Paste Inside...": "Paste Inside...",
+  "Paste Inside {branchName}": "Paste Inside {branchName}",
   "New Branch": "New Branch",
   "Delete": "Delete",
   "Otherwise": "Otherwise",

--- a/packages/web/src/app/builder/flow-canvas/context-menu/canvas-context-menu-content.tsx
+++ b/packages/web/src/app/builder/flow-canvas/context-menu/canvas-context-menu-content.tsx
@@ -3,6 +3,8 @@ import {
   FlowActionType,
   FlowOperationType,
   flowStructureUtil,
+  FlowTrigger,
+  isNil,
   StepLocationRelativeToParent,
 } from '@activepieces/shared';
 import { t } from 'i18next';
@@ -36,6 +38,7 @@ import {
   pasteNodes,
   toggleSkipSelectedNodes,
 } from '../utils/bulk-actions';
+import { ApButtonData } from '../utils/types';
 
 import { CanvasContextMenuProps, ContextMenuType } from './canvas-context-menu';
 
@@ -54,8 +57,41 @@ const ShortcutWrapper = ({
   );
 };
 
+function getBigAddButtonPasteLabel(
+  bigAddButtonData: ApButtonData | null | undefined,
+  trigger: FlowTrigger,
+) {
+  if (!bigAddButtonData) {
+    return '';
+  }
+  if (
+    bigAddButtonData.stepLocationRelativeToParent ===
+    StepLocationRelativeToParent.INSIDE_LOOP
+  ) {
+    return t('Paste Inside Loop');
+  }
+  if (
+    bigAddButtonData.stepLocationRelativeToParent ===
+    StepLocationRelativeToParent.INSIDE_BRANCH
+  ) {
+    const parentRouter = flowStructureUtil.getStep(
+      bigAddButtonData.parentStepName,
+      trigger,
+    );
+    const branchName =
+      parentRouter?.type === FlowActionType.ROUTER
+        ? parentRouter.settings.branches[bigAddButtonData.branchIndex]
+            ?.branchName ?? ''
+        : '';
+    return t('Paste Inside {branchName}', { branchName });
+  }
+  // Big add buttons are never created with AFTER (only INSIDE_LOOP and INSIDE_BRANCH)
+  return t('Paste After');
+}
+
 export const CanvasContextMenuContent = ({
   contextMenuType,
+  bigAddButtonData,
 }: CanvasContextMenuProps) => {
   const [
     selectedNodes,
@@ -89,7 +125,13 @@ export const CanvasContextMenuContent = ({
     flowVersion.trigger,
   );
   const showPasteAfterLastStep =
-    !readonly && contextMenuType === ContextMenuType.CANVAS;
+    !readonly &&
+    contextMenuType === ContextMenuType.CANVAS &&
+    isNil(bigAddButtonData);
+  const showPasteAsBigAddButtonAction =
+    !readonly &&
+    contextMenuType === ContextMenuType.CANVAS &&
+    !isNil(bigAddButtonData);
   const showPasteAsFirstLoopAction =
     selectedNodes.length === 1 &&
     firstSelectedStep?.type === FlowActionType.LOOP_ON_ITEMS &&
@@ -143,6 +185,7 @@ export const CanvasContextMenuContent = ({
     showPasteAsBranchChild ||
     showPasteAfterCurrentStep ||
     showPasteAfterLastStep ||
+    showPasteAsBigAddButtonAction ||
     showDelete;
   if (!showContextMenuContent) {
     return null;
@@ -224,6 +267,20 @@ export const CanvasContextMenuContent = ({
           >
             <ClipboardPlus className="w-4 h-4"></ClipboardPlus>{' '}
             {t('Paste After Last Step')}
+          </ContextMenuItem>
+        )}
+
+        {showPasteAsBigAddButtonAction && (
+          <ContextMenuItem
+            onClick={() => {
+              if (bigAddButtonData) {
+                pasteNodes(flowVersion, bigAddButtonData, applyOperation);
+              }
+            }}
+            className="flex items-center gap-2"
+          >
+            <ClipboardPaste className="w-4 h-4"></ClipboardPaste>{' '}
+            {getBigAddButtonPasteLabel(bigAddButtonData, flowVersion.trigger)}
           </ContextMenuItem>
         )}
 

--- a/packages/web/src/app/builder/flow-canvas/context-menu/canvas-context-menu.tsx
+++ b/packages/web/src/app/builder/flow-canvas/context-menu/canvas-context-menu.tsx
@@ -1,6 +1,8 @@
 import { ShortcutProps } from '@/components/custom/shortcut';
 import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu';
 
+import { ApButtonData } from '../utils/types';
+
 import { CanvasContextMenuContent } from './canvas-context-menu-content';
 
 export type CanvasShortcutsProps = Record<
@@ -15,16 +17,19 @@ export enum ContextMenuType {
 export type CanvasContextMenuProps = {
   children?: React.ReactNode;
   contextMenuType: ContextMenuType;
+  bigAddButtonData?: ApButtonData | null;
 };
 export const CanvasContextMenu = ({
   contextMenuType,
   children,
+  bigAddButtonData,
 }: CanvasContextMenuProps) => {
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
       <CanvasContextMenuContent
         contextMenuType={contextMenuType}
+        bigAddButtonData={bigAddButtonData}
       ></CanvasContextMenuContent>
     </ContextMenu>
   );

--- a/packages/web/src/app/builder/flow-canvas/index.tsx
+++ b/packages/web/src/app/builder/flow-canvas/index.tsx
@@ -6,6 +6,7 @@ import {
   isNil,
   Note,
   Step,
+  StepLocationRelativeToParent,
 } from '@activepieces/shared';
 import {
   ReactFlow,
@@ -34,6 +35,7 @@ import { FlowDragLayer } from './flow-drag-layer';
 import { flowCanvasHooks } from './hooks';
 import { flowCanvasConsts } from './utils/consts';
 import { flowCanvasUtils } from './utils/flow-canvas-utils';
+import { ApButtonData } from './utils/types';
 import { AboveFlowWidgets } from './widgets';
 import Minimap from './widgets/minimap';
 import { useShowChevronNextToSelection } from './widgets/selection-chevron-button';
@@ -90,6 +92,8 @@ export const FlowCanvas = React.memo(
     const [contextMenuType, setContextMenuType] = useState<ContextMenuType>(
       ContextMenuType.CANVAS,
     );
+    const [bigAddButtonData, setBigAddButtonData] =
+      useState<ApButtonData | null>(null);
 
     const onContextMenu = useCallback(
       (ev: React.MouseEvent<HTMLDivElement>) => {
@@ -108,6 +112,36 @@ export const FlowCanvas = React.memo(
             selectStepByName(stepName);
             reactFlowStore.getState().addSelectedNodes([stepName]);
           }
+
+          const bigAddButtonElement = ev.target.closest(
+            `[data-${flowCanvasConsts.BIG_ADD_BUTTON_CONTEXT_MENU_ATTRIBUTE}]`,
+          );
+          const bigAddButtonDataAttr = bigAddButtonElement?.getAttribute(
+            `data-${flowCanvasConsts.BIG_ADD_BUTTON_CONTEXT_MENU_ATTRIBUTE}`,
+          );
+          let parsedBigAddButtonData: ApButtonData | null = null;
+          if (bigAddButtonElement && bigAddButtonDataAttr) {
+            try {
+              const parsed = JSON.parse(bigAddButtonDataAttr);
+              if (
+                parsed &&
+                typeof parsed === 'object' &&
+                typeof parsed.parentStepName === 'string' &&
+                typeof parsed.edgeId === 'string' &&
+                (parsed.stepLocationRelativeToParent ===
+                  StepLocationRelativeToParent.INSIDE_LOOP ||
+                  (parsed.stepLocationRelativeToParent ===
+                    StepLocationRelativeToParent.INSIDE_BRANCH &&
+                    typeof parsed.branchIndex === 'number'))
+              ) {
+                parsedBigAddButtonData = parsed as ApButtonData;
+              }
+            } catch {
+              parsedBigAddButtonData = null;
+            }
+          }
+          setBigAddButtonData(parsedBigAddButtonData);
+
           const targetIsSelectionChevron = ev.target.closest(
             `[data-${flowCanvasConsts.SELECTION_RECT_CHEVRON_ATTRIBUTE}]`,
           );
@@ -200,7 +234,10 @@ export const FlowCanvas = React.memo(
         }}
       >
         <FlowDragLayer>
-          <CanvasContextMenu contextMenuType={contextMenuType}>
+          <CanvasContextMenu
+            contextMenuType={contextMenuType}
+            bigAddButtonData={bigAddButtonData}
+          >
             <ReactFlow
               className="bg-builder-background"
               onContextMenu={onContextMenu}

--- a/packages/web/src/app/builder/flow-canvas/nodes/big-add-button-node.tsx
+++ b/packages/web/src/app/builder/flow-canvas/nodes/big-add-button-node.tsx
@@ -65,6 +65,10 @@ const ApBigAddButtonCanvasNode = React.memo(
                       width: `${flowCanvasConsts.AP_NODE_SIZE.BIG_ADD_BUTTON.width}px`,
                     }}
                     id={id}
+                    {...{
+                      [`data-${flowCanvasConsts.BIG_ADD_BUTTON_CONTEXT_MENU_ATTRIBUTE}`]:
+                        JSON.stringify(data),
+                    }}
                     className={cn('rounded-lg bg-background relative', {
                       'bg-primary/80':
                         isShowingDropIndicator || isPieceSelectorOpened,

--- a/packages/web/src/app/builder/flow-canvas/utils/consts.ts
+++ b/packages/web/src/app/builder/flow-canvas/utils/consts.ts
@@ -121,6 +121,7 @@ export const flowCanvasConsts = {
   NOTE_CREATION_OVERLAY_WIDTH,
   NOTE_CREATION_OVERLAY_HEIGHT,
   STEP_CONTEXT_MENU_ATTRIBUTE: 'step-context-menu',
+  BIG_ADD_BUTTON_CONTEXT_MENU_ATTRIBUTE: 'big-add-button',
   SELECTION_RECT_CHEVRON_ATTRIBUTE: 'selection-rect-chevron',
   NODE_SELECTION_RECT_CLASS_NAME: 'react-flow__nodesselection-rect',
   SIDEBAR_ANIMATION_DURATION: 200,


### PR DESCRIPTION
Big add buttons in empty loops or branches showed Paste After Last Step because their PasteLocation was not exposed to the context menu. Now the canvas detects the location from a data attribute and shows the correct option (Paste Inside Loop or Paste Inside {branchName}).

### Before

<img width="635" height="490" alt="image" src="https://github.com/user-attachments/assets/cfce8938-4a37-4334-adfa-b77295d8b61c" />

### After

<img width="635" height="490" alt="image" src="https://github.com/user-attachments/assets/206b4c6f-c32a-43a2-beed-2f973ca48a32" />

---

Fixes #12441

