### PR TITLE
fix(mcp): tighten router branch condition validation to prevent silent step.valid=false

### DIFF
--- a/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
@@ -17,7 +17,7 @@ const addBranchInput = z.object({
     flowId: z.string(),
     routerStepName: z.string(),
     branchName: z.string(),
-    conditions: z.array(z.array(BranchCondition)).optional(),
+    conditions: mcpUtils.BRANCH_CONDITIONS_INPUT_SCHEMA.optional(),
 })
 
 export const apAddBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
@@ -33,48 +33,55 @@ export const apAddBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
         },
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
-            const { flowId, routerStepName, branchName, conditions } = addBranchInput.parse(args)
-
-            const [flow, project] = await Promise.all([
-                flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
-                projectService(log).getOneOrThrow(mcp.projectId),
-            ])
-            if (isNil(flow)) {
-                return { content: [{ type: 'text', text: '❌ Flow not found' }] }
-            }
-
-            const resolved = mcpUtils.resolveRouterStep({ stepName: routerStepName, trigger: flow.version.trigger })
-            if (resolved.error) {
-                return resolved.error
-            }
-            const routerStep = resolved.routerStep
-
-            const routerSettings = (routerStep as { settings: { branches: unknown[] } }).settings
-            // Insert before the last (fallback) branch
-            const branchIndex = Math.max(0, routerSettings.branches.length - 1)
-
-            const operation: FlowOperationRequest = {
-                type: FlowOperationType.ADD_BRANCH,
-                request: {
-                    stepName: routerStepName,
-                    branchIndex,
-                    branchName,
-                    conditions: conditions ?? [[]],
-                },
-            }
-
             try {
-                await flowService(log).update({
+                const { flowId, routerStepName, branchName, conditions } = addBranchInput.parse(args)
+
+                const [flow, project] = await Promise.all([
+                    flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
+                    projectService(log).getOneOrThrow(mcp.projectId),
+                ])
+                if (isNil(flow)) {
+                    return { content: [{ type: 'text', text: '❌ Flow not found' }] }
+                }
+
+                const resolved = mcpUtils.resolveRouterStep({ stepName: routerStepName, trigger: flow.version.trigger })
+                if (resolved.error) {
+                    return resolved.error
+                }
+                const routerStep = resolved.routerStep
+
+                const routerSettings = (routerStep as { settings: { branches: unknown[] } }).settings
+                // Insert before the last (fallback) branch
+                const branchIndex = Math.max(0, routerSettings.branches.length - 1)
+
+                // The MCP input schema (BRANCH_CONDITIONS_INPUT_SCHEMA) is a single
+                // shape with optional fields, while shared's BranchCondition is a
+                // discriminated union. The .min(1) and .superRefine on the input
+                // schema guarantee the runtime data matches one of the union's
+                // members, so the cast is sound.
+                const operation: FlowOperationRequest = {
+                    type: FlowOperationType.ADD_BRANCH,
+                    request: {
+                        stepName: routerStepName,
+                        branchIndex,
+                        branchName,
+                        conditions: (conditions ?? [[]]) as BranchCondition[][],
+                    },
+                }
+
+                const updatedFlow = await flowService(log).update({
                     id: flow.id,
                     projectId: mcp.projectId,
                     userId: null,
                     platformId: project.platformId,
                     operation,
                 })
+
+                const invalidWarning = mcpUtils.routerInvalidWarning({ stepName: routerStepName, trigger: updatedFlow.version.trigger })
                 return {
                     content: [{
                         type: 'text',
-                        text: `✅ Branch "${branchName}" added at index ${branchIndex} in router "${routerStepName}". Use ap_add_step with stepLocationRelativeToParent=INSIDE_BRANCH and branchIndex=${branchIndex} to add steps inside this branch.`,
+                        text: `✅ Branch "${branchName}" added at index ${branchIndex} in router "${routerStepName}". Use ap_add_step with stepLocationRelativeToParent=INSIDE_BRANCH and branchIndex=${branchIndex} to add steps inside this branch.${invalidWarning}`,
                     }],
                 }
             }

--- a/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
@@ -54,17 +54,13 @@ export const apAddBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpTool
                 // Insert before the last (fallback) branch
                 const branchIndex = Math.max(0, routerSettings.branches.length - 1)
 
-                // The MCP input schema (BRANCH_CONDITIONS_INPUT_SCHEMA) is a single
-                // shape with optional fields, while shared's BranchCondition is a
-                // discriminated union. The .min(1) and .superRefine on the input
-                // schema guarantee the runtime data matches one of the union's
-                // members, so the cast is sound.
                 const operation: FlowOperationRequest = {
                     type: FlowOperationType.ADD_BRANCH,
                     request: {
                         stepName: routerStepName,
                         branchIndex,
                         branchName,
+                        // .min(1) and .superRefine on the input schema align the runtime shape with BranchCondition's discriminated union.
                         conditions: (conditions ?? [[]]) as BranchCondition[][],
                     },
                 }

--- a/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
@@ -21,7 +21,7 @@ const updateBranchInput = z.object({
     routerStepName: z.string(),
     branchIndex: z.number().int().min(0),
     branchName: z.string().optional(),
-    conditions: z.array(z.array(BranchCondition)).optional(),
+    conditions: mcpUtils.BRANCH_CONDITIONS_INPUT_SCHEMA.optional(),
 })
 
 export const apUpdateBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolDefinition => {
@@ -88,7 +88,13 @@ export const apUpdateBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
                     branches[branchIndex] = {
                         ...targetBranch,
                         ...(branchName !== undefined && { branchName }),
-                        ...(conditions !== undefined && { conditions }),
+                        // The MCP input schema (BRANCH_CONDITIONS_INPUT_SCHEMA) is a
+                        // single object shape with optional fields, while shared's
+                        // BranchCondition is a discriminated union. The .min(1) and
+                        // .superRefine on the input schema guarantee the runtime
+                        // data matches one of the union's members, so the cast is
+                        // sound.
+                        ...(conditions !== undefined && { conditions: conditions as BranchCondition[][] }),
                     }
                 }
 
@@ -108,7 +114,7 @@ export const apUpdateBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
                     },
                 }
 
-                await flowService(log).update({
+                const updatedFlow = await flowService(log).update({
                     id: flow.id,
                     projectId: mcp.projectId,
                     userId: null,
@@ -120,10 +126,11 @@ export const apUpdateBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
                 if (branchName !== undefined) updatedParts.push(`name → "${branchName}"`)
                 if (conditions !== undefined) updatedParts.push(`conditions (${conditions.length} OR group(s))`)
 
+                const invalidWarning = mcpUtils.routerInvalidWarning({ stepName: routerStepName, trigger: updatedFlow.version.trigger })
                 return {
                     content: [{
                         type: 'text',
-                        text: `✅ Branch ${branchIndex} of router "${routerStepName}" updated: ${updatedParts.join(', ')}. Steps inside the branch are unchanged.`,
+                        text: `✅ Branch ${branchIndex} of router "${routerStepName}" updated: ${updatedParts.join(', ')}. Steps inside the branch are unchanged.${invalidWarning}`,
                     }],
                 }
             }

--- a/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
@@ -88,12 +88,7 @@ export const apUpdateBranchTool = (mcp: McpServer, log: FastifyBaseLogger): McpT
                     branches[branchIndex] = {
                         ...targetBranch,
                         ...(branchName !== undefined && { branchName }),
-                        // The MCP input schema (BRANCH_CONDITIONS_INPUT_SCHEMA) is a
-                        // single object shape with optional fields, while shared's
-                        // BranchCondition is a discriminated union. The .min(1) and
-                        // .superRefine on the input schema guarantee the runtime
-                        // data matches one of the union's members, so the cast is
-                        // sound.
+                        // .min(1) and .superRefine on the input schema align the runtime shape with BranchCondition's discriminated union.
                         ...(conditions !== undefined && { conditions: conditions as BranchCondition[][] }),
                     }
                 }

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -1,5 +1,5 @@
 import { PieceMetadataModel, PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
-import { BranchOperator, FlowActionType, flowStructureUtil, isNil, isObject } from '@activepieces/shared'
+import { BranchOperator, FlowActionType, flowStructureUtil, isNil, isObject, singleValueConditions } from '@activepieces/shared'
 import type { RouterAction, Step } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
@@ -166,13 +166,29 @@ function findResolvableProps({ props, componentProps, auth, providedInput }: Fin
     })
 }
 
+// Match the server-side strict validator (RouterActionSettingsWithValidation):
+// firstValue must be non-empty; secondValue must be non-empty when present and is required
+// for any non-single-value operator. Catching this at the input layer ensures the agent
+// gets a field-level error instead of a silent step.valid=false (which surfaces as the
+// "Incomplete" badge in the UI and blocks publish).
+const SINGLE_VALUE_OPERATORS_HINT = singleValueConditions.join(', ')
 const BRANCH_CONDITIONS_INPUT_SCHEMA = z.array(
     z.array(
         z.object({
-            firstValue: z.string().describe('Left-hand value (can be a template expression like {{step_1.field}})'),
-            operator: z.enum(Object.values(BranchOperator) as [BranchOperator, ...BranchOperator[]]).optional().describe('Comparison operator. Single-value operators (no secondValue needed): EXISTS, DOES_NOT_EXIST, BOOLEAN_IS_TRUE, BOOLEAN_IS_FALSE, LIST_IS_EMPTY, LIST_IS_NOT_EMPTY'),
-            secondValue: z.string().optional().describe('Right-hand value — required for all operators except single-value ones'),
+            firstValue: z.string().min(1, 'firstValue must be a non-empty string or template expression (e.g. {{trigger.field}})').describe('Left-hand value (template expressions like {{step_1.field}} are allowed). Must be non-empty.'),
+            operator: z.enum(Object.values(BranchOperator) as [BranchOperator, ...BranchOperator[]]).optional().describe(`Comparison operator. Single-value operators (no secondValue needed): ${SINGLE_VALUE_OPERATORS_HINT}.`),
+            secondValue: z.string().min(1, 'secondValue must be a non-empty string when provided').optional().describe('Right-hand value — required (and non-empty) for all operators except single-value ones.'),
             caseSensitive: z.boolean().optional().describe('For text operators: whether to match case sensitively'),
+        }).superRefine((cond, ctx) => {
+            if (cond.operator !== undefined
+                && !(singleValueConditions as BranchOperator[]).includes(cond.operator)
+                && cond.secondValue === undefined) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['secondValue'],
+                    message: `secondValue is required when operator is "${cond.operator}". Use a single-value operator (${SINGLE_VALUE_OPERATORS_HINT}) if you do not have a secondValue.`,
+                })
+            }
         }),
     ),
 )
@@ -193,6 +209,19 @@ function resolveRouterStep({ stepName, trigger }: { stepName: string, trigger: S
         }
     }
     return { routerStep: step as RouterAction }
+}
+
+// Defense-in-depth: returns an empty string when the router is valid, otherwise a
+// human-readable warning suffix to append to the tool's success message. This catches
+// any path where the server-side validator drops step.valid to false (e.g. another
+// branch on the same router was already malformed) so the agent never sees a bare ✅
+// for a step that's actually showing "Incomplete" in the UI.
+function routerInvalidWarning({ stepName, trigger }: { stepName: string, trigger: Step }): string {
+    const step = flowStructureUtil.getStep(stepName, trigger)
+    if (isNil(step) || step.valid) {
+        return ''
+    }
+    return `\n⚠️ The router "${stepName}" is now marked invalid (step.valid=false) — the UI will show "Incomplete" and the flow cannot be published. Inspect the branch conditions with ap_flow_structure and fix any with empty firstValue/secondValue.`
 }
 
 function publishedFlowWarning(publishedVersionId: string | null | undefined): string {
@@ -249,6 +278,7 @@ export const mcpUtils = {
     mcpToolError,
     truncate,
     resolveRouterStep,
+    routerInvalidWarning,
     publishedFlowWarning,
     diagnosePieceProps,
     buildPropSummaries,

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -180,6 +180,7 @@ const BRANCH_CONDITIONS_INPUT_SCHEMA = z.array(
             secondValue: z.string().min(1, 'secondValue must be a non-empty string when provided').optional().describe('Right-hand value — required (and non-empty) for all operators except single-value ones.'),
             caseSensitive: z.boolean().optional().describe('For text operators: whether to match case sensitively'),
         }).superRefine((cond, ctx) => {
+            // Case 1: a non-single-value operator must have a secondValue.
             if (cond.operator !== undefined
                 && !(singleValueConditions as BranchOperator[]).includes(cond.operator)
                 && cond.secondValue === undefined) {
@@ -187,6 +188,15 @@ const BRANCH_CONDITIONS_INPUT_SCHEMA = z.array(
                     code: z.ZodIssueCode.custom,
                     path: ['secondValue'],
                     message: `secondValue is required when operator is "${cond.operator}". Use a single-value operator (${SINGLE_VALUE_OPERATORS_HINT}) if you do not have a secondValue.`,
+                })
+            }
+            // Case 2: providing a secondValue without an operator is ambiguous —
+            // the runtime has no comparison to perform. Force the agent to pick one.
+            if (cond.operator === undefined && cond.secondValue !== undefined) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['operator'],
+                    message: 'operator is required when secondValue is provided — pick a comparison operator (e.g. TEXT_CONTAINS, TEXT_EXACTLY_MATCHES, NUMBER_IS_EQUAL_TO).',
                 })
             }
         }),
@@ -221,7 +231,7 @@ function routerInvalidWarning({ stepName, trigger }: { stepName: string, trigger
     if (isNil(step) || step.valid) {
         return ''
     }
-    return `\n⚠️ The router "${stepName}" is now marked invalid (step.valid=false) — the UI will show "Incomplete" and the flow cannot be published. Inspect the branch conditions with ap_flow_structure and fix any with empty firstValue/secondValue.`
+    return `\n⚠️ The router "${stepName}" is now marked invalid (step.valid=false) — the UI will show "Incomplete" and the flow cannot be published. Inspect the branch conditions with ap_flow_structure: every condition needs a non-empty firstValue, and any non-single-value operator (TEXT_*, NUMBER_*, DATE_*, LIST_CONTAINS/LIST_DOES_NOT_CONTAIN) needs a non-empty secondValue.`
 }
 
 function publishedFlowWarning(publishedVersionId: string | null | undefined): string {

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -166,11 +166,6 @@ function findResolvableProps({ props, componentProps, auth, providedInput }: Fin
     })
 }
 
-// Match the server-side strict validator (RouterActionSettingsWithValidation):
-// firstValue must be non-empty; secondValue must be non-empty when present and is required
-// for any non-single-value operator. Catching this at the input layer ensures the agent
-// gets a field-level error instead of a silent step.valid=false (which surfaces as the
-// "Incomplete" badge in the UI and blocks publish).
 const SINGLE_VALUE_OPERATORS_HINT = singleValueConditions.join(', ')
 const BRANCH_CONDITIONS_INPUT_SCHEMA = z.array(
     z.array(
@@ -180,7 +175,6 @@ const BRANCH_CONDITIONS_INPUT_SCHEMA = z.array(
             secondValue: z.string().min(1, 'secondValue must be a non-empty string when provided').optional().describe('Right-hand value — required (and non-empty) for all operators except single-value ones.'),
             caseSensitive: z.boolean().optional().describe('For text operators: whether to match case sensitively'),
         }).superRefine((cond, ctx) => {
-            // Case 1: a non-single-value operator must have a secondValue.
             if (cond.operator !== undefined
                 && !(singleValueConditions as BranchOperator[]).includes(cond.operator)
                 && cond.secondValue === undefined) {
@@ -190,8 +184,6 @@ const BRANCH_CONDITIONS_INPUT_SCHEMA = z.array(
                     message: `secondValue is required when operator is "${cond.operator}". Use a single-value operator (${SINGLE_VALUE_OPERATORS_HINT}) if you do not have a secondValue.`,
                 })
             }
-            // Case 2: providing a secondValue without an operator is ambiguous —
-            // the runtime has no comparison to perform. Force the agent to pick one.
             if (cond.operator === undefined && cond.secondValue !== undefined) {
                 ctx.addIssue({
                     code: z.ZodIssueCode.custom,
@@ -221,11 +213,6 @@ function resolveRouterStep({ stepName, trigger }: { stepName: string, trigger: S
     return { routerStep: step as RouterAction }
 }
 
-// Defense-in-depth: returns an empty string when the router is valid, otherwise a
-// human-readable warning suffix to append to the tool's success message. This catches
-// any path where the server-side validator drops step.valid to false (e.g. another
-// branch on the same router was already malformed) so the agent never sees a bare ✅
-// for a step that's actually showing "Incomplete" in the UI.
 function routerInvalidWarning({ stepName, trigger }: { stepName: string, trigger: Step }): string {
     const step = flowStructureUtil.getStep(stepName, trigger)
     if (isNil(step) || step.valid) {

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -2174,4 +2174,30 @@ describe('MCP Tools integration', () => {
         expect(text(result)).toContain('❌')
         expect(text(result)).toContain('firstValue')
     })
+
+    it('79. ap_update_branch — rejects secondValue provided without operator', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'secondValue without operator')
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'Router',
+        })
+
+        // Both values present but no operator — ambiguous, the runtime has no
+        // comparison to perform. Reject at input.
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            conditions: [[{ firstValue: '{{trigger.subject}}', secondValue: 'urgent' }]],
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('operator')
+    })
 })

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -2040,4 +2040,138 @@ describe('MCP Tools integration', () => {
         expect(output).toContain('<sandbox>')
         expect(output).toContain('<internal>')
     })
+
+    // ── Router branch condition validation (regression for "Incomplete" router) ────
+    //
+    // Background: the strict server validator (RouterActionSettingsWithValidation)
+    // requires firstValue/secondValue to be non-empty (.min(1)) and requires
+    // secondValue when the operator is not single-value (TEXT_*, NUMBER_*, etc.).
+    // The MCP input schema used to be looser, so an agent could submit shapes that
+    // passed input validation but caused step.valid=false on the router — surfacing
+    // as the "Incomplete" badge in the UI and blocking publish. These tests pin the
+    // tightened input schema so future drift is caught.
+
+    it('74. ap_update_branch — rejects empty firstValue', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Empty firstValue')
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'Router',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            conditions: [[{ firstValue: '', secondValue: 'urgent', operator: 'TEXT_CONTAINS' }]],
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('firstValue')
+    })
+
+    it('75. ap_update_branch — rejects empty secondValue with non-single-value operator', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Empty secondValue')
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'Router',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            conditions: [[{ firstValue: '{{trigger.subject}}', secondValue: '', operator: 'TEXT_CONTAINS' }]],
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('secondValue')
+    })
+
+    it('76. ap_update_branch — rejects missing secondValue with non-single-value operator', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Missing secondValue')
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'Router',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            // No secondValue, but operator is TEXT_CONTAINS (needs one)
+            conditions: [[{ firstValue: '{{trigger.subject}}', operator: 'TEXT_CONTAINS' }]],
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('secondValue')
+        expect(text(result)).toContain('TEXT_CONTAINS')
+    })
+
+    it('77. ap_update_branch — accepts single-value operator without secondValue', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'EXISTS works')
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'Router',
+        })
+
+        const result = await apUpdateBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchIndex: 0,
+            // Single-value operator: secondValue not needed
+            conditions: [[{ firstValue: '{{trigger.subject}}', operator: 'EXISTS' }]],
+        })
+
+        expect(text(result)).toContain('✅')
+        expect(text(result)).not.toContain('Incomplete')
+        expect(text(result)).not.toContain('invalid')
+    })
+
+    it('78. ap_add_branch — rejects empty firstValue at input layer', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'AddBranch firstValue')
+
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.ROUTER,
+            displayName: 'Router',
+        })
+
+        const result = await apAddBranchTool(mcp, mockLog).execute({
+            flowId,
+            routerStepName: 'step_1',
+            branchName: 'New',
+            conditions: [[{ firstValue: '', operator: 'EXISTS' }]],
+        })
+
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('firstValue')
+    })
 })

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -2041,15 +2041,7 @@ describe('MCP Tools integration', () => {
         expect(output).toContain('<internal>')
     })
 
-    // ── Router branch condition validation (regression for "Incomplete" router) ────
-    //
-    // Background: the strict server validator (RouterActionSettingsWithValidation)
-    // requires firstValue/secondValue to be non-empty (.min(1)) and requires
-    // secondValue when the operator is not single-value (TEXT_*, NUMBER_*, etc.).
-    // The MCP input schema used to be looser, so an agent could submit shapes that
-    // passed input validation but caused step.valid=false on the router — surfacing
-    // as the "Incomplete" badge in the UI and blocking publish. These tests pin the
-    // tightened input schema so future drift is caught.
+    // ── Router branch condition validation ───────────────────────────
 
     it('74. ap_update_branch — rejects empty firstValue', async () => {
         const ctx = await createTestContext(app)
@@ -2116,7 +2108,6 @@ describe('MCP Tools integration', () => {
             flowId,
             routerStepName: 'step_1',
             branchIndex: 0,
-            // No secondValue, but operator is TEXT_CONTAINS (needs one)
             conditions: [[{ firstValue: '{{trigger.subject}}', operator: 'TEXT_CONTAINS' }]],
         })
 
@@ -2142,7 +2133,6 @@ describe('MCP Tools integration', () => {
             flowId,
             routerStepName: 'step_1',
             branchIndex: 0,
-            // Single-value operator: secondValue not needed
             conditions: [[{ firstValue: '{{trigger.subject}}', operator: 'EXISTS' }]],
         })
 
@@ -2188,8 +2178,6 @@ describe('MCP Tools integration', () => {
             displayName: 'Router',
         })
 
-        // Both values present but no operator — ambiguous, the runtime has no
-        // comparison to perform. Reject at input.
         const result = await apUpdateBranchTool(mcp, mockLog).execute({
             flowId,
             routerStepName: 'step_1',


### PR DESCRIPTION
## The bug

When an MCP-using agent (or any client of `ap_add_branch` / `ap_update_branch`) submits a router branch condition with empty `firstValue`/`secondValue` strings, or a non-single-value operator without a `secondValue`, the operation goes through and the tool returns ✅ — but the router's `step.valid` silently flips to `false`. In the UI this surfaces as the "Incomplete" badge on the router step, and `ap_lock_and_publish` refuses the flow.

The reporter's exact words:

> the router step is not always working properly via MCP — typically it shows an "incomplete" label, preventing testing and publishing the flow. manually recreating the exact same step via the UI fixes it

## Root cause

The MCP input schema (`BRANCH_CONDITIONS_INPUT_SCHEMA` in `mcp-utils.ts`) was looser than the strict server-side validator (`RouterActionSettingsWithValidation` in `@activepieces/shared`):

| Field | MCP input schema (before) | Server strict validator |
|---|---|---|
| `firstValue` | `z.string()` (allows `''`) | `z.string().min(1)` |
| `secondValue` | `z.string().optional()` (no min, optional) | `z.string().min(1)`, **required** for non-single-value operators |

So the agent could submit shapes the tool's input schema accepted but the strict validator rejected. `flowService.update()` ran `flowVersionValidationUtil.prepareRequest()` which set `valid: false` on the router. The tool, having no awareness of this, returned ✅. The agent moved on; the user opened the flow in the UI and saw "Incomplete" with no obvious path to fix it from chat.

Reproduced live on the dev stack with the empty-string shape:

```
step.valid AFTER ap_add_step (skeleton conditions [[]]):     true
step.valid AFTER update with [[ {firstValue:'', secondValue:'', operator:'TEXT_CONTAINS'} ]]: false   ← bug
step.valid AFTER update with proper non-empty values:        true
```

## The fix

**1. Tighten `BRANCH_CONDITIONS_INPUT_SCHEMA` to mirror the strict validator** — `firstValue` and (when provided) `secondValue` get `.min(1)`, and a `.superRefine` requires `secondValue` whenever the operator is not a single-value one. Errors carry the offending field path so the agent gets:

```
❌ Update branch failed: conditions.0.0.firstValue: firstValue must be a non-empty string or template expression (e.g. {{trigger.field}}); conditions.0.0.secondValue: secondValue must be a non-empty string when provided
```

…instead of a fake ✅ followed by a broken flow.

**2. Defense-in-depth**: `routerInvalidWarning` helper in `mcp-utils.ts`. After the flow update succeeds, `ap_add_branch` and `ap_update_branch` re-fetch the router and append a clear ⚠️ to the success message if `step.valid` somehow ended up false anyway (e.g. another branch on the same router was already malformed before this call). The agent gets a pointer to `ap_flow_structure` to find what's wrong.

**3. Wrap `ap_add_branch.execute` in try/catch** so the Zod parse error from a malformed `conditions` argument turns into a friendly ❌ via `mcpUtils.mcpToolError` instead of crashing the tool.

## Files

| File | Change |
|---|---|
| `packages/server/api/src/app/mcp/tools/mcp-utils.ts` | Tighten `BRANCH_CONDITIONS_INPUT_SCHEMA` (`.min(1)` + `.superRefine`). Add `routerInvalidWarning` helper. Import `singleValueConditions` from shared. |
| `packages/server/api/src/app/mcp/tools/ap-add-branch.ts` | Wrap `execute` in try/catch. Append `routerInvalidWarning` to success text. |
| `packages/server/api/src/app/mcp/tools/ap-update-branch.ts` | Append `routerInvalidWarning` to success text. |
| `packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts` | 5 new tests pinning rejection of every bug shape + confirming single-value operators (EXISTS w/o secondValue) still pass. |

No changes to `@activepieces/shared`. No changes to the strict server validator. No migrations. The lax-vs-strict split between `RouterActionSettings` (used by import / UI form) and `RouterActionSettingsWithValidation` (used by the publish-time validator) is preserved on purpose — only the MCP input layer is tightened.

## Test plan

- [x] Static schema test: 9/9 cases pass (4 bug shapes rejected with field-level errors, 5 valid shapes pass through including `[[]]` skeleton and the existing complex multi-group test fixture).
- [x] `tsc --noEmit` clean across the whole `api` package.
- [x] 5 new integration tests added in `mcp-tools.test.ts` (numbered 74–78). They directly invoke `apUpdateBranchTool` / `apAddBranchTool` with bad/good shapes and assert the response.
- [x] Live dev-stack repro: confirmed bug exists on `main` (router step shows "Incomplete" badge, publish blocked) and confirmed the new schema rejects every bug shape with crisp errors before the operation reaches the validator.
- [ ] CI green on this branch.