### PR TITLE
feat(descript): add Descript integration with actions and triggers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2091,6 +2091,16 @@
         "tslib": "^2.3.0",
       },
     },
+    "packages/pieces/community/descript": {
+      "name": "@activepieces/piece-descript",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/detecting-ai": {
       "name": "@activepieces/piece-detecting-ai",
       "version": "0.0.5",
@@ -8644,6 +8654,8 @@
     "@activepieces/piece-delay": ["@activepieces/piece-delay@workspace:packages/pieces/core/delay"],
 
     "@activepieces/piece-denser-ai": ["@activepieces/piece-denser-ai@workspace:packages/pieces/community/denser-ai"],
+
+    "@activepieces/piece-descript": ["@activepieces/piece-descript@workspace:packages/pieces/community/descript"],
 
     "@activepieces/piece-detecting-ai": ["@activepieces/piece-detecting-ai@workspace:packages/pieces/community/detecting-ai"],
 

--- a/packages/pieces/community/descript/.eslintrc.json
+++ b/packages/pieces/community/descript/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+    "extends": ["../../../../.eslintrc.base.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        { "files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {} },
+        { "files": ["*.ts", "*.tsx"], "rules": {} },
+        { "files": ["*.js", "*.jsx"], "rules": {} }
+    ]
+}

--- a/packages/pieces/community/descript/package.json
+++ b/packages/pieces/community/descript/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@activepieces/piece-descript",
+    "version": "0.0.1",
+    "main": "./dist/src/index.js",
+    "types": "./dist/src/index.d.ts",
+    "scripts": {
+        "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+        "lint": "eslint 'src/**/*.ts'"
+    },
+    "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2"
+    }
+}

--- a/packages/pieces/community/descript/src/index.ts
+++ b/packages/pieces/community/descript/src/index.ts
@@ -1,0 +1,70 @@
+import { createCustomApiCallAction, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { AppConnectionValueForAuthProperty, PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { descriptAgentEditAction } from './lib/actions/agent-edit';
+import { descriptGetJobStatusAction } from './lib/actions/get-job-status';
+import { descriptGetProjectAction } from './lib/actions/get-project';
+import { descriptImportMediaAction } from './lib/actions/import-media';
+import { descriptListProjectsAction } from './lib/actions/list-projects';
+import { descriptPublishProjectAction } from './lib/actions/publish-project';
+import { descriptJobCompletedTrigger } from './lib/triggers/job-completed';
+
+export const descriptAuth = PieceAuth.SecretText({
+    displayName: 'API Token',
+    description: [
+        'To create an API token:',
+        '1. Open **Settings** in Descript.',
+        '2. Select **API tokens** from the sidebar.',
+        '3. Click **Create token**, give it a name, select a Drive, and click **Create token**.',
+        '4. Copy the token and paste it here — you can only view it once.',
+    ].join('\n'),
+    required: true,
+    validate: async ({ auth }) => {
+        try {
+            const token = getAuthToken(auth);
+            await httpClient.sendRequest({
+                method: HttpMethod.GET,
+                url: 'https://descriptapi.com/v1/projects?limit=1',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            });
+            return { valid: true };
+        } catch {
+            return { valid: false, error: 'Invalid API token. Please check and try again.' };
+        }
+    },
+});
+
+export const descript = createPiece({
+    displayName: 'Descript',
+    description:
+        'AI-powered video and podcast editor. Import media, run AI edits with Underlord, and publish.',
+    minimumSupportedRelease: '0.82.1',
+    logoUrl: 'https://cdn.activepieces.com/pieces/descript.png',
+    categories: [PieceCategory.CONTENT_AND_FILES],
+    auth: descriptAuth,
+    authors: ['hugh-codes'],
+    actions: [
+        descriptImportMediaAction,
+        descriptAgentEditAction,
+        descriptPublishProjectAction,
+        descriptGetJobStatusAction,
+        descriptListProjectsAction,
+        descriptGetProjectAction,
+        createCustomApiCallAction({
+            baseUrl: () => 'https://descriptapi.com/v1',
+            auth: descriptAuth,
+            authMapping: async (auth) => ({
+                Authorization: `Bearer ${getAuthToken(auth)}`,
+            }),
+        }),
+    ],
+    triggers: [descriptJobCompletedTrigger],
+});
+
+function getAuthToken(
+    auth: string | AppConnectionValueForAuthProperty<typeof descriptAuth>,
+): string {
+    return (typeof auth === 'string' ? auth : auth.secret_text).trim();
+}

--- a/packages/pieces/community/descript/src/lib/actions/agent-edit.ts
+++ b/packages/pieces/community/descript/src/lib/actions/agent-edit.ts
@@ -1,0 +1,89 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { descriptAuth } from '../../';
+import { descriptCommon } from '../common';
+
+export const descriptAgentEditAction = createAction({
+    auth: descriptAuth,
+    name: 'agent_edit',
+    displayName: 'Agent Edit (Underlord)',
+    description:
+        'Use Descript\'s AI agent "Underlord" to edit an existing project or create a new one with a natural language prompt.',
+    props: {
+        mode: Property.StaticDropdown({
+            displayName: 'Mode',
+            description: 'Choose whether to edit an existing project or create a brand new one.',
+            required: true,
+            defaultValue: 'existing',
+            options: {
+                options: [
+                    { label: 'Edit existing project', value: 'existing' },
+                    { label: 'Create new project from prompt', value: 'new' },
+                ],
+            },
+        }),
+        project_id: Property.Dropdown({
+            auth: descriptAuth,
+            displayName: 'Project',
+            description: 'Select the project for the agent to edit.',
+            refreshers: ['mode'],
+            required: false,
+            options: async ({ auth, mode }) => {
+                if (mode !== 'existing') return { disabled: true, options: [], placeholder: 'Not needed for new projects' };
+                if (!auth) return { disabled: true, options: [], placeholder: 'Please connect your account first' };
+                const projects = await descriptCommon.fetchAllProjects(
+                    descriptCommon.getAuthToken(auth),
+                );
+                return {
+                    disabled: false,
+                    options: projects.map((p) => ({ label: p.name, value: p.id })),
+                };
+            },
+        }),
+        project_name: Property.ShortText({
+            displayName: 'New Project Name',
+            description: 'Name for the new project (only used when creating a new project).',
+            required: false,
+        }),
+        composition_id: descriptCommon.compositionIdProp(false),
+        prompt: Property.LongText({
+            displayName: 'Prompt',
+            description:
+                'Natural language instruction for Underlord. Examples: "Add studio sound to every clip", "Remove all filler words", "Create a 30-second highlight reel with the best moments". Be specific — frame edits as a single one-shot instruction.',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { mode, project_id, project_name, composition_id, prompt } = context.propsValue;
+
+        const body: Record<string, unknown> = { prompt };
+
+        if (mode === 'existing') {
+            if (!project_id) throw new Error('Please select a project to edit.');
+            body['project_id'] = project_id;
+            if (composition_id) body['composition_id'] = composition_id;
+        } else {
+            if (!project_name) throw new Error('Please enter a project name for the new project.');
+            body['project_name'] = project_name;
+        }
+
+        const response = await descriptCommon.descriptApiCall<{
+            job_id: string;
+            drive_id: string;
+            project_id: string;
+            project_url: string;
+        }>({
+            apiKey: descriptCommon.getAuthToken(context.auth),
+            method: HttpMethod.POST,
+            path: '/jobs/agent',
+            body,
+        });
+
+        return {
+            job_id: response.body.job_id,
+            drive_id: response.body.drive_id,
+            project_id: response.body.project_id,
+            project_url: response.body.project_url,
+        };
+    },
+});

--- a/packages/pieces/community/descript/src/lib/actions/get-job-status.ts
+++ b/packages/pieces/community/descript/src/lib/actions/get-job-status.ts
@@ -1,0 +1,76 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { descriptAuth } from '../../';
+import { descriptCommon } from '../common';
+
+type JobResult = {
+    status?: string;
+    agent_response?: string;
+    project_changed?: boolean;
+    media_seconds_used?: number;
+    ai_credits_used?: number;
+    share_url?: string;
+    download_url?: string;
+    download_url_expires_at?: string;
+    error_message?: string;
+};
+
+type JobStatusResponse = {
+    job_id: string;
+    job_type: string;
+    job_state: string;
+    created_at: string;
+    stopped_at?: string;
+    drive_id: string;
+    project_id?: string;
+    project_url?: string;
+    result?: JobResult;
+    progress?: { label?: string; last_update_at?: string };
+};
+
+export const descriptGetJobStatusAction = createAction({
+    auth: descriptAuth,
+    name: 'get_job_status',
+    displayName: 'Get Job Status',
+    description:
+        'Retrieves the current status of a Descript background job (import, agent edit, or publish). Use the job_id returned by any job-creation action.',
+    props: {
+        job_id: Property.ShortText({
+            displayName: 'Job ID',
+            description:
+                'The job ID returned when you created the job (e.g. from "Import Media", "Agent Edit", or "Publish Project" actions).',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const response = await descriptCommon.descriptApiCall<JobStatusResponse>({
+            apiKey: descriptCommon.getAuthToken(context.auth),
+            method: HttpMethod.GET,
+            path: `/jobs/${context.propsValue.job_id}`,
+        });
+
+        const job = response.body;
+        const result = job.result ?? {};
+
+        return {
+            job_id: job.job_id,
+            job_type: job.job_type,
+            job_state: job.job_state,
+            created_at: job.created_at,
+            stopped_at: job.stopped_at ?? null,
+            drive_id: job.drive_id,
+            project_id: job.project_id ?? null,
+            project_url: job.project_url ?? null,
+            result_status: result.status ?? null,
+            result_agent_response: result.agent_response ?? null,
+            result_project_changed: result.project_changed ?? null,
+            result_media_seconds_used: result.media_seconds_used ?? null,
+            result_ai_credits_used: result.ai_credits_used ?? null,
+            result_share_url: result.share_url ?? null,
+            result_download_url: result.download_url ?? null,
+            result_download_url_expires_at: result.download_url_expires_at ?? null,
+            result_error_message: result.error_message ?? null,
+            progress_label: job.progress?.label ?? null,
+        };
+    },
+});

--- a/packages/pieces/community/descript/src/lib/actions/get-project.ts
+++ b/packages/pieces/community/descript/src/lib/actions/get-project.ts
@@ -1,0 +1,71 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { descriptAuth } from '../../';
+import { descriptCommon } from '../common';
+
+type Composition = {
+    id: string;
+    name: string;
+    duration?: number;
+    media_type?: string;
+};
+
+type MediaFile = {
+    type: string;
+    duration?: number;
+};
+
+type ProjectDetailResponse = {
+    id: string;
+    name: string;
+    drive_id: string;
+    created_at: string;
+    updated_at: string;
+    media_files: Record<string, MediaFile>;
+    compositions: Composition[];
+};
+
+export const descriptGetProjectAction = createAction({
+    auth: descriptAuth,
+    name: 'get_project',
+    displayName: 'Get Project',
+    description:
+        'Retrieves details for a Descript project including its compositions and media files.',
+    props: {
+        project_id: descriptCommon.projectIdProp,
+    },
+    async run(context) {
+        const response = await descriptCommon.descriptApiCall<ProjectDetailResponse>({
+            apiKey: descriptCommon.getAuthToken(context.auth),
+            method: HttpMethod.GET,
+            path: `/projects/${context.propsValue.project_id}`,
+        });
+
+        const project = response.body;
+
+        return {
+            project_id: project.id,
+            project_name: project.name,
+            drive_id: project.drive_id,
+            created_at: project.created_at,
+            updated_at: project.updated_at,
+            composition_count: project.compositions.length,
+            media_file_count: Object.keys(project.media_files).length,
+            compositions: JSON.stringify(
+                project.compositions.map((c) => ({
+                    id: c.id,
+                    name: c.name,
+                    duration_seconds: c.duration ?? null,
+                    media_type: c.media_type ?? null,
+                })),
+            ),
+            media_files: JSON.stringify(
+                Object.entries(project.media_files).map(([path, file]) => ({
+                    path,
+                    type: file.type,
+                    duration_seconds: file.duration ?? null,
+                })),
+            ),
+        };
+    },
+});

--- a/packages/pieces/community/descript/src/lib/actions/import-media.ts
+++ b/packages/pieces/community/descript/src/lib/actions/import-media.ts
@@ -1,0 +1,103 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { descriptAuth } from '../../';
+import { descriptCommon } from '../common';
+
+export const descriptImportMediaAction = createAction({
+    auth: descriptAuth,
+    name: 'import_media',
+    displayName: 'Import Media',
+    description:
+        'Creates a new Descript project, imports a media file from a URL, and optionally creates a composition (timeline) from it.',
+    props: {
+        project_name: Property.ShortText({
+            displayName: 'Project Name',
+            description: 'Name for the new project that will be created in Descript.',
+            required: true,
+        }),
+        media_name: Property.ShortText({
+            displayName: 'Media File Name',
+            description:
+                'Display name for the media file in the project (e.g. "intro.mp4" or "Recordings/interview.mp4"). You can use a folder path with "/" to organize files.',
+            required: true,
+            defaultValue: 'media.mp4',
+        }),
+        media_url: Property.ShortText({
+            displayName: 'Media URL',
+            description:
+                'Public URL of the media file to import. The URL must be accessible by Descript servers and support HTTP Range requests. Sign URLs for 12–48 hours if they expire.',
+            required: true,
+        }),
+        language: Property.ShortText({
+            displayName: 'Transcription Language',
+            description:
+                'ISO 639-1 language code for transcription (e.g. "en" for English, "es" for Spanish, "fr" for French). Leave blank to auto-detect from the audio.',
+            required: false,
+        }),
+        composition_name: Property.ShortText({
+            displayName: 'Composition Name',
+            description:
+                'Optional name for the composition (timeline) to create from the imported media. If left blank, no composition is created.',
+            required: false,
+        }),
+        folder_name: Property.ShortText({
+            displayName: 'Project Folder',
+            description:
+                'Optional folder path to place the new project in (e.g. "Clients/Acme"). Supports nested paths using "/" as separator. Missing folders are created automatically.',
+            required: false,
+        }),
+        team_access: Property.StaticDropdown({
+            displayName: 'Team Access',
+            description: 'Access level for other members of your Drive.',
+            required: false,
+            defaultValue: 'none',
+            options: {
+                options: [
+                    { label: 'None (private to owner)', value: 'none' },
+                    { label: 'View', value: 'view' },
+                    { label: 'Comment', value: 'comment' },
+                    { label: 'Edit', value: 'edit' },
+                ],
+            },
+        }),
+    },
+    async run(context) {
+        const { project_name, media_name, media_url, language, composition_name, folder_name, team_access } =
+            context.propsValue;
+
+        const mediaItem: Record<string, string> = { url: media_url };
+        if (language) mediaItem['language'] = language;
+
+        const body: Record<string, unknown> = {
+            project_name,
+            add_media: { [media_name]: mediaItem },
+        };
+
+        if (composition_name) {
+            body['add_compositions'] = [
+                { name: composition_name, clips: [{ media: media_name }] },
+            ];
+        }
+        if (folder_name) body['folder_name'] = folder_name;
+        if (team_access) body['team_access'] = team_access;
+
+        const response = await descriptCommon.descriptApiCall<{
+            job_id: string;
+            drive_id: string;
+            project_id: string;
+            project_url: string;
+        }>({
+            apiKey: descriptCommon.getAuthToken(context.auth),
+            method: HttpMethod.POST,
+            path: '/jobs/import/project_media',
+            body,
+        });
+
+        return {
+            job_id: response.body.job_id,
+            drive_id: response.body.drive_id,
+            project_id: response.body.project_id,
+            project_url: response.body.project_url,
+        };
+    },
+});

--- a/packages/pieces/community/descript/src/lib/actions/list-projects.ts
+++ b/packages/pieces/community/descript/src/lib/actions/list-projects.ts
@@ -1,0 +1,60 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { descriptAuth } from '../../';
+import { descriptCommon } from '../common';
+
+type Project = {
+    id: string;
+    name: string;
+    created_at: string;
+    updated_at: string;
+};
+
+export const descriptListProjectsAction = createAction({
+    auth: descriptAuth,
+    name: 'list_projects',
+    displayName: 'List Projects',
+    description: 'Returns all projects in your Descript Drive, sorted by name.',
+    props: {},
+    async run(context) {
+        const projects = await descriptCommon.fetchAllProjects(
+            descriptCommon.getAuthToken(context.auth),
+        );
+        const projectsWithDates: Project[] = [];
+
+        // Fetch extra fields by listing with full detail
+        const response = await descriptCommon.descriptApiCall<{
+            data: Project[];
+            pagination: { next_cursor?: string };
+        }>({
+            apiKey: descriptCommon.getAuthToken(context.auth),
+            method: HttpMethod.GET,
+            path: '/projects',
+            queryParams: { limit: '100', sort: 'name', direction: 'asc' },
+        });
+
+        projectsWithDates.push(...response.body.data);
+
+        let cursor = response.body.pagination.next_cursor;
+        while (cursor) {
+            const next = await descriptCommon.descriptApiCall<{
+                data: Project[];
+                pagination: { next_cursor?: string };
+            }>({
+                apiKey: descriptCommon.getAuthToken(context.auth),
+                method: HttpMethod.GET,
+                path: '/projects',
+                queryParams: { limit: '100', sort: 'name', direction: 'asc', cursor },
+            });
+            projectsWithDates.push(...next.body.data);
+            cursor = next.body.pagination.next_cursor;
+        }
+
+        return projectsWithDates.map((p) => ({
+            project_id: p.id,
+            project_name: p.name,
+            created_at: p.created_at,
+            updated_at: p.updated_at,
+        }));
+    },
+});

--- a/packages/pieces/community/descript/src/lib/actions/publish-project.ts
+++ b/packages/pieces/community/descript/src/lib/actions/publish-project.ts
@@ -1,0 +1,85 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { descriptAuth } from '../../';
+import { descriptCommon } from '../common';
+
+export const descriptPublishProjectAction = createAction({
+    auth: descriptAuth,
+    name: 'publish_project',
+    displayName: 'Publish Project',
+    description:
+        'Publishes a composition from a project to create a shareable link and a downloadable export file.',
+    props: {
+        project_id: descriptCommon.projectIdProp,
+        composition_id: descriptCommon.compositionIdProp(false),
+        media_type: Property.StaticDropdown({
+            displayName: 'Output Type',
+            description: 'Choose whether to export the project as a video or audio file.',
+            required: false,
+            defaultValue: 'Video',
+            options: {
+                options: [
+                    { label: 'Video', value: 'Video' },
+                    { label: 'Audio only', value: 'Audio' },
+                ],
+            },
+        }),
+        resolution: Property.StaticDropdown({
+            displayName: 'Video Resolution',
+            description: 'Resolution for the exported video. Only applies when Output Type is Video.',
+            required: false,
+            defaultValue: '1080p',
+            options: {
+                options: [
+                    { label: '480p', value: '480p' },
+                    { label: '720p', value: '720p' },
+                    { label: '1080p (Full HD)', value: '1080p' },
+                    { label: '1440p (2K)', value: '1440p' },
+                    { label: '4K', value: '4K' },
+                ],
+            },
+        }),
+        access_level: Property.StaticDropdown({
+            displayName: 'Share Access Level',
+            description:
+                'Who can view the published share page. Leave blank to use your Drive\'s default setting.',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Public (anyone)', value: 'public' },
+                    { label: 'Unlisted (link only)', value: 'unlisted' },
+                    { label: 'Drive members only', value: 'drive' },
+                    { label: 'Private (owner only)', value: 'private' },
+                ],
+            },
+        }),
+    },
+    async run(context) {
+        const { project_id, composition_id, media_type, resolution, access_level } = context.propsValue;
+
+        const body: Record<string, unknown> = { project_id };
+        if (composition_id) body['composition_id'] = composition_id;
+        if (media_type) body['media_type'] = media_type;
+        if (media_type === 'Video' && resolution) body['resolution'] = resolution;
+        if (access_level) body['access_level'] = access_level;
+
+        const response = await descriptCommon.descriptApiCall<{
+            job_id: string;
+            drive_id: string;
+            project_id: string;
+            project_url: string;
+        }>({
+            apiKey: descriptCommon.getAuthToken(context.auth),
+            method: HttpMethod.POST,
+            path: '/jobs/publish',
+            body,
+        });
+
+        return {
+            job_id: response.body.job_id,
+            drive_id: response.body.drive_id,
+            project_id: response.body.project_id,
+            project_url: response.body.project_url,
+        };
+    },
+});

--- a/packages/pieces/community/descript/src/lib/common/index.ts
+++ b/packages/pieces/community/descript/src/lib/common/index.ts
@@ -1,0 +1,243 @@
+import {
+    httpClient,
+    HttpMethod,
+    HttpError,
+    HttpMessageBody,
+    HttpResponse,
+} from '@activepieces/pieces-common';
+import { AppConnectionValueForAuthProperty, Property } from '@activepieces/pieces-framework';
+import { descriptAuth } from '../..';
+
+const BASE_URL = 'https://descriptapi.com/v1';
+
+async function descriptApiCall<T extends HttpMessageBody>({
+    apiKey,
+    method,
+    path,
+    body,
+    queryParams,
+}: {
+    apiKey: string;
+    method: HttpMethod;
+    path: string;
+    body?: unknown;
+    queryParams?: Record<string, string>;
+}): Promise<HttpResponse<T>> {
+    const request = {
+        method,
+        url: `${BASE_URL}${path}`,
+        headers: {
+            Authorization: `Bearer ${normalizeToken(apiKey)}`,
+        },
+        body,
+        queryParams,
+    };
+
+    logRequest({
+        method,
+        url: request.url,
+        apiKey,
+        body,
+        queryParams,
+    });
+
+    try {
+        const response = await httpClient.sendRequest<T>(request);
+        logResponse({
+            method,
+            url: request.url,
+            status: response.status,
+            body: response.body,
+        });
+        return response;
+    } catch (error) {
+        logError({
+            method,
+            url: request.url,
+            error,
+        });
+        throw error;
+    }
+}
+
+async function fetchAllProjects(apiKey: string): Promise<{ id: string; name: string }[]> {
+    const projects: { id: string; name: string }[] = [];
+    let cursor: string | undefined = undefined;
+
+    do {
+        const params: Record<string, string> = { limit: '100', sort: 'name', direction: 'asc' };
+        if (cursor) params['cursor'] = cursor;
+
+        const response = await descriptApiCall<{
+            data: { id: string; name: string }[];
+            pagination: { next_cursor?: string };
+        }>({
+            apiKey,
+            method: HttpMethod.GET,
+            path: '/projects',
+            queryParams: params,
+        });
+
+        projects.push(...response.body.data);
+        cursor = response.body.pagination.next_cursor;
+    } while (cursor);
+
+    return projects;
+}
+
+function getAuthToken(
+    auth: string | AppConnectionValueForAuthProperty<typeof descriptAuth>,
+): string {
+    return typeof auth === 'string' ? normalizeToken(auth) : normalizeToken(auth.secret_text);
+}
+
+function normalizeToken(token: string): string {
+    return token.trim();
+}
+
+function shouldDebugHttp(): boolean {
+    return process.env['AP_DESCRIPT_HTTP_DEBUG'] === 'true';
+}
+
+function logRequest({
+    method,
+    url,
+    apiKey,
+    body,
+    queryParams,
+}: {
+    method: HttpMethod;
+    url: string;
+    apiKey: string;
+    body?: unknown;
+    queryParams?: Record<string, string>;
+}): void {
+    if (!shouldDebugHttp()) {
+        return;
+    }
+
+    console.log('[descript][request]', {
+        method,
+        url,
+        authorization: `Bearer ${maskToken(apiKey)}`,
+        queryParams: queryParams ?? null,
+        body: body ?? null,
+    });
+}
+
+function logResponse({
+    method,
+    url,
+    status,
+    body,
+}: {
+    method: HttpMethod;
+    url: string;
+    status: number;
+    body: unknown;
+}): void {
+    if (!shouldDebugHttp()) {
+        return;
+    }
+
+    console.log('[descript][response]', {
+        method,
+        url,
+        status,
+        body,
+    });
+}
+
+function logError({
+    method,
+    url,
+    error,
+}: {
+    method: HttpMethod;
+    url: string;
+    error: unknown;
+}): void {
+    if (!shouldDebugHttp()) {
+        return;
+    }
+
+    if (error instanceof HttpError) {
+        console.error('[descript][error]', {
+            method,
+            url,
+            status: error.response.status,
+            responseBody: error.response.body,
+            requestBody: error.request.body,
+        });
+        return;
+    }
+
+    console.error('[descript][error]', {
+        method,
+        url,
+        error,
+    });
+}
+
+function maskToken(token: string): string {
+    const normalized = normalizeToken(token);
+    if (normalized.length <= 8) {
+        return '***';
+    }
+    return `${normalized.slice(0, 4)}...${normalized.slice(-4)}`;
+}
+
+const projectIdProp = Property.Dropdown({
+    auth: descriptAuth,
+    displayName: 'Project',
+    description: 'Select the Descript project to use.',
+    refreshers: [],
+    required: true,
+    options: async ({ auth }) => {
+        if (!auth) {
+            return { disabled: true, options: [], placeholder: 'Please connect your account first' };
+        }
+        const projects = await fetchAllProjects(getAuthToken(auth));
+        return {
+            disabled: false,
+            options: projects.map((p) => ({ label: p.name, value: p.id })),
+        };
+    },
+});
+
+const compositionIdProp = (required: boolean) =>
+    Property.Dropdown({
+        auth: descriptAuth,
+        displayName: 'Composition',
+        description:
+            'Select the composition (timeline) within the project. If omitted, the agent chooses automatically.',
+        refreshers: ['project_id'],
+        required,
+        options: async ({ auth, project_id }) => {
+            if (!auth || !project_id) {
+                return { disabled: true, options: [], placeholder: 'Please select a project first' };
+            }
+            const response = await descriptApiCall<{
+                id: string;
+                name: string;
+                compositions: { id: string; name: string }[];
+            }>({
+                apiKey: getAuthToken(auth),
+                method: HttpMethod.GET,
+                path: `/projects/${project_id as string}`,
+            });
+            return {
+                disabled: false,
+                options: response.body.compositions.map((c) => ({ label: c.name, value: c.id })),
+            };
+        },
+    });
+
+export const descriptCommon = {
+    BASE_URL,
+    descriptApiCall,
+    fetchAllProjects,
+    getAuthToken,
+    projectIdProp,
+    compositionIdProp,
+};

--- a/packages/pieces/community/descript/src/lib/triggers/job-completed.ts
+++ b/packages/pieces/community/descript/src/lib/triggers/job-completed.ts
@@ -1,0 +1,190 @@
+import {
+    createTrigger,
+    TriggerStrategy,
+    Property,
+    AppConnectionValueForAuthProperty,
+} from '@activepieces/pieces-framework';
+import {
+    DedupeStrategy,
+    Polling,
+    pollingHelper,
+    HttpMethod,
+} from '@activepieces/pieces-common';
+import { descriptAuth } from '../../';
+import { descriptCommon } from '../common';
+
+type JobResult = {
+    status?: string;
+    agent_response?: string;
+    project_changed?: boolean;
+    media_seconds_used?: number;
+    ai_credits_used?: number;
+    share_url?: string;
+    download_url?: string;
+    download_url_expires_at?: string;
+    error_message?: string;
+};
+
+type JobItem = {
+    job_id: string;
+    job_type: string;
+    job_state: string;
+    created_at: string;
+    stopped_at?: string;
+    drive_id: string;
+    project_id?: string;
+    project_url?: string;
+    result?: JobResult;
+};
+
+type TriggerProps = {
+    job_type_filter: string | undefined;
+};
+
+const TERMINAL_JOB_STATES = new Set([
+    'stopped',
+    'completed',
+    'complete',
+    'succeeded',
+    'failed',
+    'failure',
+    'errored',
+    'error',
+    'cancelled',
+    'canceled',
+]);
+
+const TERMINAL_RESULT_STATUSES = new Set([
+    'success',
+    'succeeded',
+    'failed',
+    'failure',
+    'error',
+    'cancelled',
+    'canceled',
+]);
+
+function normalizeState(value: string | undefined): string {
+    return value?.trim().toLowerCase() ?? '';
+}
+
+function isCompletedJob(job: JobItem): boolean {
+    const state = normalizeState(job.job_state);
+    if (TERMINAL_JOB_STATES.has(state)) {
+        return true;
+    }
+
+    const resultStatus = normalizeState(job.result?.status);
+    return TERMINAL_RESULT_STATUSES.has(resultStatus);
+}
+
+const SAMPLE_DATA = {
+    job_id: 'project-agent-edit-e2f89ce6',
+    job_type: 'agent',
+    job_state: 'stopped',
+    created_at: '2026-02-09T05:42:27.554Z',
+    stopped_at: '2026-02-09T05:43:15.296Z',
+    drive_id: '1df135a5-dc4a-4dc3-8f7d-681cfbe961e4',
+    project_id: 'e2f89ce6',
+    project_url: 'https://web.descript.com/e2f89ce6',
+    result_status: 'success',
+    result_agent_response:
+        "Done! I've applied Studio Sound and added captions to your video.",
+    result_project_changed: true,
+    result_media_seconds_used: 0,
+    result_ai_credits_used: 32,
+    result_share_url: null,
+    result_download_url: null,
+    result_download_url_expires_at: null,
+    result_error_message: null,
+};
+
+const polling: Polling<
+    AppConnectionValueForAuthProperty<typeof descriptAuth>,
+    TriggerProps
+> = {
+    strategy: DedupeStrategy.TIMEBASED,
+    items: async ({ auth, propsValue }) => {
+        const { job_type_filter } = propsValue;
+        const params: Record<string, string> = { limit: '100' };
+        if (job_type_filter && job_type_filter !== 'all') {
+            params['type'] = job_type_filter;
+        }
+
+        const response = await descriptCommon.descriptApiCall<{
+            data: JobItem[];
+            pagination: { next_cursor?: string };
+        }>({
+            apiKey: descriptCommon.getAuthToken(auth),
+            method: HttpMethod.GET,
+            path: '/jobs',
+            queryParams: params,
+        });
+
+        // Descript may use different terminal state labels across job types.
+        const stoppedJobs = response.body.data.filter(isCompletedJob);
+
+        return stoppedJobs.map((job) => {
+            const result = job.result ?? {};
+            return {
+                epochMilliSeconds: new Date(job.stopped_at ?? job.created_at).getTime(),
+                data: {
+                    job_id: job.job_id,
+                    job_type: job.job_type,
+                    job_state: job.job_state,
+                    created_at: job.created_at,
+                    stopped_at: job.stopped_at ?? null,
+                    drive_id: job.drive_id,
+                    project_id: job.project_id ?? null,
+                    project_url: job.project_url ?? null,
+                    result_status: result.status ?? null,
+                    result_agent_response: result.agent_response ?? null,
+                    result_project_changed: result.project_changed ?? null,
+                    result_media_seconds_used: result.media_seconds_used ?? null,
+                    result_ai_credits_used: result.ai_credits_used ?? null,
+                    result_share_url: result.share_url ?? null,
+                    result_download_url: result.download_url ?? null,
+                    result_download_url_expires_at: result.download_url_expires_at ?? null,
+                    result_error_message: result.error_message ?? null,
+                },
+            };
+        });
+    },
+};
+
+export const descriptJobCompletedTrigger = createTrigger({
+    auth: descriptAuth,
+    name: 'job_completed',
+    displayName: 'Job Completed',
+    description: 'Triggers when a Descript background job (import, agent edit, or publish) finishes.',
+    props: {
+        job_type_filter: Property.StaticDropdown({
+            displayName: 'Job Type Filter',
+            description: 'Only trigger for jobs of this type. Select "All job types" to trigger for any completed job.',
+            required: false,
+            defaultValue: 'all',
+            options: {
+                options: [
+                    { label: 'All job types', value: 'all' },
+                    { label: 'Import media', value: 'import/project_media' },
+                    { label: 'Agent edit (Underlord)', value: 'agent' },
+                    { label: 'Publish', value: 'publish' },
+                ],
+            },
+        }),
+    },
+    sampleData: SAMPLE_DATA,
+    type: TriggerStrategy.POLLING,
+    async test() {
+        return [SAMPLE_DATA];
+    },
+    async onEnable(context) {
+        await pollingHelper.onEnable(polling, context);
+    },
+    async onDisable(context) {
+        await pollingHelper.onDisable(polling, context);
+    },
+    async run(context) {
+        return await pollingHelper.poll(polling, context);
+    },
+});

--- a/packages/pieces/community/descript/tsconfig.json
+++ b/packages/pieces/community/descript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../../../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "files": [],
+    "include": [],
+    "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/packages/pieces/community/descript/tsconfig.lib.json
+++ b/packages/pieces/community/descript/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "baseUrl": ".",
+        "paths": {},
+        "outDir": "./dist",
+        "declaration": true,
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -359,6 +359,9 @@
         "packages/pieces/community/deepseek/src/index.ts"
       ],
       "@activepieces/piece-delay": ["packages/pieces/core/delay/src/index.ts"],
+      "@activepieces/piece-descript": [
+        "packages/pieces/community/descript/src/index.ts"
+      ],
       "@activepieces/piece-devin": [
         "packages/pieces/community/devin/src/index.ts"
       ],


### PR DESCRIPTION
- Implemented Descript API integration with various actions including:
  - Import Media
  - Agent Edit
  - Get Job Status
  - Get Project
  - List Projects
  - Publish Project
- Added a trigger for job completion.
- Created common utility functions for API calls and project fetching.
- Configured TypeScript settings and ESLint for the new package.

Have tested all scenarios 

## What does this PR do?

This PR implements the Descripts API https://docs.descriptapi.com


### Explain How the Feature Works
Follow the getting start guide in the docs https://docs.descriptapi.com/#tag/Getting-started to get your API token, then start exploring the API

### Relevant User Scenarios

- YouTube new video trigger -> socialkit download video -> Descript import media 
- Descript complete job trigger -> Descript AI Edit to apply template


Fixes # (issue)
