### PR TITLE
fix: update worker version to match app version in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     networks:
       - activepieces
   worker:
-    image: ghcr.io/activepieces/activepieces:0.79.0
+    image: ghcr.io/activepieces/activepieces:0.80.1
     restart: unless-stopped
     depends_on:
       - app


### PR DESCRIPTION
## What does this PR do?
Updates the `worker` image tag in `docker-compose.yml` from `0.79.0` to `0.80.1` to perfectly match the `app` image. This resolves a version mismatch that causes the worker to crash with a `Host is required is null or undefined` error when trying to connect to Redis.

Fixes #12869