### PR TITLE
fix: resolve eslint single-quote violation in app.ts

### DIFF
--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -246,7 +246,7 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
             }
             return reply
                 .type('text/html')
-                .header('Content-Security-Policy', "default-src 'none'; script-src 'unsafe-inline'")
+                .header('Content-Security-Policy', 'default-src \'none\'; script-src \'unsafe-inline\'')
                 .header('X-Content-Type-Options', 'nosniff')
                 .send(Mustache.render(REDIRECT_HTML_TEMPLATE, { code }))
         },


### PR DESCRIPTION
## Summary
- Fixes an ESLint `@typescript-eslint/quotes` violation in `app.ts`
- Converts double-quoted CSP header string to single-quoted with escaped inner quotes to comply with the project's `single` quote rule

## Test plan
- [x] Run `npm run lint-dev` and confirm no lint errors in `packages/server/api/src/app/app.ts`
- [ ] Verify the redirect endpoint behaviour is unchanged (CSP header value is identical at runtime)