### PR TITLE
fix(baserow): revert triggers to manual webhook setup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1029,7 +1029,7 @@
     },
     "packages/pieces/community/baserow": {
       "name": "@activepieces/piece-baserow",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/baserow/package.json
+++ b/packages/pieces/community/baserow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-baserow",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/baserow/src/lib/triggers/row-created.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/row-created.ts
@@ -1,9 +1,6 @@
-import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { Property, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { MarkdownVariant } from '@activepieces/shared';
 import { baserowAuth } from '../auth';
-import { baserowCommon } from '../common';
-import { createWebhookTriggerHooks } from '../common/webhook-trigger';
-
-const webhookHooks = createWebhookTriggerHooks('rows.created', 'baserow_row_created');
 
 export const rowCreatedTrigger = createTrigger({
   name: 'baserow_row_created',
@@ -12,18 +9,33 @@ export const rowCreatedTrigger = createTrigger({
   description: 'Triggers when a new row is created in a Baserow table.',
   type: TriggerStrategy.WEBHOOK,
   props: {
-    table_id: baserowCommon.tableId(),
+    instructions: Property.MarkDown({
+      value: `
+## Setup Instructions
+
+1. In Baserow, click the **···** menu beside your table and select **Webhooks**.
+2. Click **Create webhook +**.
+3. Set the HTTP method to **POST**.
+4. Paste the following URL into the endpoint field:
+\`\`\`text
+{{webhookUrl}}
+\`\`\`
+5. Under events, select **Rows created**.
+6. Click **Save**.
+`,
+      variant: MarkdownVariant.INFO,
+    }),
   },
   sampleData: {
     id: 1,
     order: '1.00000000000000000000',
     Name: 'Example row',
   },
-  async onEnable(context) {
-    await webhookHooks.onEnable(context);
+  async onEnable() {
+    // Manual setup required — user registers the webhook URL in Baserow UI.
   },
-  async onDisable(context) {
-    await webhookHooks.onDisable(context);
+  async onDisable() {
+    // Manual cleanup — user deletes the webhook in Baserow UI.
   },
   async run(context) {
     const body = context.payload.body as { items?: unknown[] };

--- a/packages/pieces/community/baserow/src/lib/triggers/row-deleted.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/row-deleted.ts
@@ -1,9 +1,6 @@
-import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { Property, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { MarkdownVariant } from '@activepieces/shared';
 import { baserowAuth } from '../auth';
-import { baserowCommon } from '../common';
-import { createWebhookTriggerHooks } from '../common/webhook-trigger';
-
-const webhookHooks = createWebhookTriggerHooks('rows.deleted', 'baserow_row_deleted');
 
 export const rowDeletedTrigger = createTrigger({
   name: 'baserow_row_deleted',
@@ -12,16 +9,31 @@ export const rowDeletedTrigger = createTrigger({
   description: 'Triggers when a row is deleted from a Baserow table.',
   type: TriggerStrategy.WEBHOOK,
   props: {
-    table_id: baserowCommon.tableId(),
+    instructions: Property.MarkDown({
+      value: `
+## Setup Instructions
+
+1. In Baserow, click the **···** menu beside your table and select **Webhooks**.
+2. Click **Create webhook +**.
+3. Set the HTTP method to **POST**.
+4. Paste the following URL into the endpoint field:
+\`\`\`text
+{{webhookUrl}}
+\`\`\`
+5. Under events, select **Rows deleted**.
+6. Click **Save**.
+`,
+      variant: MarkdownVariant.INFO,
+    }),
   },
   sampleData: {
     id: 1,
   },
-  async onEnable(context) {
-    await webhookHooks.onEnable(context);
+  async onEnable() {
+    // Manual setup required — user registers the webhook URL in Baserow UI.
   },
-  async onDisable(context) {
-    await webhookHooks.onDisable(context);
+  async onDisable() {
+    // Manual cleanup — user deletes the webhook in Baserow UI.
   },
   async run(context) {
     const body = context.payload.body as { row_ids?: number[] };

--- a/packages/pieces/community/baserow/src/lib/triggers/row-updated.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/row-updated.ts
@@ -1,9 +1,6 @@
-import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { Property, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { MarkdownVariant } from '@activepieces/shared';
 import { baserowAuth } from '../auth';
-import { baserowCommon } from '../common';
-import { createWebhookTriggerHooks } from '../common/webhook-trigger';
-
-const webhookHooks = createWebhookTriggerHooks('rows.updated', 'baserow_row_updated');
 
 export const rowUpdatedTrigger = createTrigger({
   name: 'baserow_row_updated',
@@ -12,7 +9,22 @@ export const rowUpdatedTrigger = createTrigger({
   description: 'Triggers when an existing row is updated in a Baserow table.',
   type: TriggerStrategy.WEBHOOK,
   props: {
-    table_id: baserowCommon.tableId(),
+    instructions: Property.MarkDown({
+      value: `
+## Setup Instructions
+
+1. In Baserow, click the **···** menu beside your table and select **Webhooks**.
+2. Click **Create webhook +**.
+3. Set the HTTP method to **POST**.
+4. Paste the following URL into the endpoint field:
+\`\`\`text
+{{webhookUrl}}
+\`\`\`
+5. Under events, select **Rows updated**.
+6. Click **Save**.
+`,
+      variant: MarkdownVariant.INFO,
+    }),
   },
   sampleData: {
     row: {
@@ -26,11 +38,11 @@ export const rowUpdatedTrigger = createTrigger({
       Name: 'Original row',
     },
   },
-  async onEnable(context) {
-    await webhookHooks.onEnable(context);
+  async onEnable() {
+    // Manual setup required — user registers the webhook URL in Baserow UI.
   },
-  async onDisable(context) {
-    await webhookHooks.onDisable(context);
+  async onDisable() {
+    // Manual cleanup — user deletes the webhook in Baserow UI.
   },
   async run(context) {
     const body = context.payload.body as {

--- a/packages/pieces/community/baserow/src/lib/triggers/rows-created.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/rows-created.ts
@@ -1,9 +1,6 @@
-import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { Property, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { MarkdownVariant } from '@activepieces/shared';
 import { baserowAuth } from '../auth';
-import { baserowCommon } from '../common';
-import { createWebhookTriggerHooks } from '../common/webhook-trigger';
-
-const webhookHooks = createWebhookTriggerHooks('rows.created', 'baserow_rows_created');
 
 export const rowsCreatedTrigger = createTrigger({
   name: 'baserow_rows_created',
@@ -13,7 +10,22 @@ export const rowsCreatedTrigger = createTrigger({
     'Triggers when new rows are created in a Baserow table. Returns all rows from the event as a single batch.',
   type: TriggerStrategy.WEBHOOK,
   props: {
-    table_id: baserowCommon.tableId(),
+    instructions: Property.MarkDown({
+      value: `
+## Setup Instructions
+
+1. In Baserow, click the **···** menu beside your table and select **Webhooks**.
+2. Click **Create webhook +**.
+3. Set the HTTP method to **POST**.
+4. Paste the following URL into the endpoint field:
+\`\`\`text
+{{webhookUrl}}
+\`\`\`
+5. Under events, select **Rows created**.
+6. Click **Save**.
+`,
+      variant: MarkdownVariant.INFO,
+    }),
   },
   sampleData: {
     rows: [
@@ -22,11 +34,11 @@ export const rowsCreatedTrigger = createTrigger({
     ],
     count: 2,
   },
-  async onEnable(context) {
-    await webhookHooks.onEnable(context);
+  async onEnable() {
+    // Manual setup required — user registers the webhook URL in Baserow UI.
   },
-  async onDisable(context) {
-    await webhookHooks.onDisable(context);
+  async onDisable() {
+    // Manual cleanup — user deletes the webhook in Baserow UI.
   },
   async run(context) {
     const body = context.payload.body as { items?: unknown[] };

--- a/packages/pieces/community/baserow/src/lib/triggers/rows-deleted.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/rows-deleted.ts
@@ -1,9 +1,6 @@
-import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { Property, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { MarkdownVariant } from '@activepieces/shared';
 import { baserowAuth } from '../auth';
-import { baserowCommon } from '../common';
-import { createWebhookTriggerHooks } from '../common/webhook-trigger';
-
-const webhookHooks = createWebhookTriggerHooks('rows.deleted', 'baserow_rows_deleted');
 
 export const rowsDeletedTrigger = createTrigger({
   name: 'baserow_rows_deleted',
@@ -13,17 +10,32 @@ export const rowsDeletedTrigger = createTrigger({
     'Triggers when rows are deleted from a Baserow table. Returns all deleted row IDs from the event as a single batch.',
   type: TriggerStrategy.WEBHOOK,
   props: {
-    table_id: baserowCommon.tableId(),
+    instructions: Property.MarkDown({
+      value: `
+## Setup Instructions
+
+1. In Baserow, click the **···** menu beside your table and select **Webhooks**.
+2. Click **Create webhook +**.
+3. Set the HTTP method to **POST**.
+4. Paste the following URL into the endpoint field:
+\`\`\`text
+{{webhookUrl}}
+\`\`\`
+5. Under events, select **Rows deleted**.
+6. Click **Save**.
+`,
+      variant: MarkdownVariant.INFO,
+    }),
   },
   sampleData: {
     rows: [{ id: 1 }, { id: 2 }],
     count: 2,
   },
-  async onEnable(context) {
-    await webhookHooks.onEnable(context);
+  async onEnable() {
+    // Manual setup required — user registers the webhook URL in Baserow UI.
   },
-  async onDisable(context) {
-    await webhookHooks.onDisable(context);
+  async onDisable() {
+    // Manual cleanup — user deletes the webhook in Baserow UI.
   },
   async run(context) {
     const body = context.payload.body as { row_ids?: number[] };

--- a/packages/pieces/community/baserow/src/lib/triggers/rows-updated.ts
+++ b/packages/pieces/community/baserow/src/lib/triggers/rows-updated.ts
@@ -1,9 +1,6 @@
-import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { Property, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { MarkdownVariant } from '@activepieces/shared';
 import { baserowAuth } from '../auth';
-import { baserowCommon } from '../common';
-import { createWebhookTriggerHooks } from '../common/webhook-trigger';
-
-const webhookHooks = createWebhookTriggerHooks('rows.updated', 'baserow_rows_updated');
 
 export const rowsUpdatedTrigger = createTrigger({
   name: 'baserow_rows_updated',
@@ -13,7 +10,22 @@ export const rowsUpdatedTrigger = createTrigger({
     'Triggers when existing rows are updated in a Baserow table. Returns all rows from the event as a single batch.',
   type: TriggerStrategy.WEBHOOK,
   props: {
-    table_id: baserowCommon.tableId(),
+    instructions: Property.MarkDown({
+      value: `
+## Setup Instructions
+
+1. In Baserow, click the **···** menu beside your table and select **Webhooks**.
+2. Click **Create webhook +**.
+3. Set the HTTP method to **POST**.
+4. Paste the following URL into the endpoint field:
+\`\`\`text
+{{webhookUrl}}
+\`\`\`
+5. Under events, select **Rows updated**.
+6. Click **Save**.
+`,
+      variant: MarkdownVariant.INFO,
+    }),
   },
   sampleData: {
     rows: [
@@ -24,11 +36,11 @@ export const rowsUpdatedTrigger = createTrigger({
     ],
     count: 1,
   },
-  async onEnable(context) {
-    await webhookHooks.onEnable(context);
+  async onEnable() {
+    // Manual setup required — user registers the webhook URL in Baserow UI.
   },
-  async onDisable(context) {
-    await webhookHooks.onDisable(context);
+  async onDisable() {
+    // Manual cleanup — user deletes the webhook in Baserow UI.
   },
   async run(context) {
     const body = context.payload.body as {


### PR DESCRIPTION
Auto-webhook creation required JWT auth which is no longer available in the piece. Reverts all 6 triggers (row/rows created/updated/deleted) to manual setup with copy-paste URL instructions, removing the table_id prop and no-op onEnable/onDisable. Payload parsing logic is unchanged.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
