### PR TITLE
docs: document piece packaging, syncing, and version pinning

### DIFF
--- a/docs/admin-guide/guides/manage-pieces.mdx
+++ b/docs/admin-guide/guides/manage-pieces.mdx
@@ -23,6 +23,10 @@ There are **two levels** of piece management:
 | **Platform Level** | Platform Admin | Install and remove across the entire platform |
 | **Project Level** | Project Admin | Show/hide specific pieces for specfic project |
 
+<Note>
+Pieces are standard npm packages — official pieces are **auto-synced from the registry hourly**, so you don't need to upgrade the server to get new versions. Each step in a flow is pinned to a specific piece version, and drafts can be upgraded from the builder. See [Piece Syncing & Versioning](/install/architecture/piece-syncing) for the full pipeline.
+</Note>
+
 ---
 
 ## Platform-Level Management

--- a/docs/build-pieces/piece-reference/piece-versioning.mdx
+++ b/docs/build-pieces/piece-reference/piece-versioning.mdx
@@ -1,43 +1,40 @@
 ---
-title: 'Piece Versioning'
-icon: 'code-compare'
-description: 'Learn how to version your pieces'
+title: "Piece versioning"
+icon: "code-compare"
+description: "How to choose a version number when publishing a piece"
 ---
 
-Pieces are npm packages and follows **semantic versioning**.
+Pieces are npm packages and follow **semantic versioning**.
 
-## Semantic Versioning
+<Note>
+This page is for *piece authors* deciding what version number to publish. For how flows adopt new piece versions, see [Piece syncing & versioning](/install/architecture/piece-syncing).
+</Note>
 
-The version number consists of three numbers: `MAJOR.MINOR.PATCH`, where:
+## Semantic versioning
 
-- **MAJOR** It should be incremented when there are breaking changes to the piece.
-- **MINOR** It should be incremented for new features or functionality that is compatible with the previous version, unless the major version is less than 1.0, in which case it can be a breaking change.
-- **PATCH** It should be incremented for bug fixes and small changes that do not introduce new features or break backward compatibility.
+The version number is `MAJOR.MINOR.PATCH`:
 
-## Engine
-The engine will use the most up-to-date compatible version for a given piece version during the **DRAFT** flow versions. Once the flow is published, all pieces will be locked to a specific version.
+- **MAJOR** — bump when you make a breaking change.
+- **MINOR** — bump when you add functionality without breaking existing flows.
+- **PATCH** — bump for bug fixes that don't change behavior.
 
-**Case 1: Piece Version is Less Than 1.0**:
-The engine will select the latest **patch** version that shares the same **minor** version number.
+## Classifying changes
 
-**Case 2: Piece Version Reaches Version 1.0**:
-The engine will select the latest **minor** version that shares the same **major** version number.
+Use this checklist when deciding which segment to bump.
 
-## Examples
-<Tip>
-when you make a change, remember to increment the version accordingly.
-</Tip>
+### Breaking changes (MAJOR)
 
-### Breaking changes
-- Remove an existing action.
-- Add a required `action` prop.
-- Remove an existing action prop, whether required or optional.
+- Remove an existing action or trigger.
+- Add a required prop to an existing action or trigger.
+- Remove an existing prop, whether required or optional.
 - Remove an attribute from an action output.
-- Change the existing behavior of an action/trigger.
+- Change the existing behavior of an action or trigger.
 
-### Non-breaking changes
-- Add a new action.
-- Add an optional `action` prop.
+### Non-breaking changes (MINOR or PATCH)
+
+- Add a new action or trigger.
+- Add an optional prop.
 - Add an attribute to an action output.
+- Fix a bug without changing the public surface (PATCH).
 
-i.e., any removal is breaking, any required addition is breaking, everything else is not breaking.
+The rule of thumb: **any removal is breaking, any required addition is breaking, everything else is not.**

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -203,6 +203,7 @@
                      "install/architecture/durable-execution",
                      "install/architecture/waitpoints",
                      "install/architecture/network-security",
+                     "install/architecture/piece-syncing",
                      "install/architecture/benchmark"
                   ]
                }

--- a/docs/install/architecture/piece-syncing.mdx
+++ b/docs/install/architecture/piece-syncing.mdx
@@ -47,6 +47,14 @@ Custom and private pieces are managed manually — see [Manage pieces](/admin-gu
 
 Custom and private pieces are never touched by the sync job.
 
+## Server compatibility
+
+Every piece declares a `minimumSupportedRelease` (and optional `maximumSupportedRelease`) in its definition — the range of Activepieces server releases it works on. The catalog filters pieces against the running server's release, so an out-of-range piece is never listed in the builder and never served from the registry.
+
+<Warning>
+**Self-hosted: upgrade to `0.82.0` or newer.** Every new piece now declares `minimumSupportedRelease ≥ 0.82.0`, the floor that came in with the latest piece-context version. Servers below `0.82.0` will not pick up any newly published pieces or bug fixes. Cloud is always on the latest release.
+</Warning>
+
 ## Version pinning
 
 Adding a step records the exact piece version at that moment (e.g. `0.5.3`). The pin stays until a human changes it. To upgrade, open the step in the builder, click the version next to its name, and pick a new one. The dialog warns when the change crosses a minor or major boundary.

--- a/docs/install/architecture/piece-syncing.mdx
+++ b/docs/install/architecture/piece-syncing.mdx
@@ -42,8 +42,7 @@ Custom and private pieces are managed manually — see [Manage pieces](/admin-gu
 
 | `AP_PIECES_SYNC_MODE` | Behavior |
 |---|---|
-| `OFFICIAL_AUTO` | Hourly reconcile against the cloud registry. Default on Cloud. |
-| `NONE` | Disabled. Catalog only changes via admin actions. Use for air-gapped or change-controlled environments. |
+| `OFFICIAL_AUTO` | Hourly reconcile against the cloud registry. Default for all deployments. |
 
 Custom and private pieces are never touched by the sync job.
 

--- a/docs/install/architecture/piece-syncing.mdx
+++ b/docs/install/architecture/piece-syncing.mdx
@@ -1,0 +1,57 @@
+---
+title: "Piece syncing & versioning"
+description: "How pieces are packaged, distributed, and pinned to flow versions"
+icon: "puzzle-piece"
+---
+
+Pieces are standard [npm packages](https://www.npmjs.com/search?q=%40activepieces%2Fpiece-). Two facts follow from that:
+
+- **No server upgrade is needed for new pieces** — a sync job pulls fresh versions on its own.
+- **Each step is pinned to an exact version** — flows never auto-upgrade. Bumps are explicit, through the builder.
+
+```mermaid
+flowchart LR
+    REG["npm registry<br/>(@activepieces/piece-*)"]
+    CAT["Local piece catalog"]
+    STEP["Flow step<br/>pieceVersion: 0.5.3"]
+    UI["Builder version dialog"]
+
+    REG -- "hourly sync<br/>(OFFICIAL_AUTO)" --> CAT
+    CAT -- "exact version on add" --> STEP
+    UI -- "explicit upgrade" --> STEP
+
+    classDef src fill:#eef,stroke:#88a
+    classDef catalog fill:#efe,stroke:#7a7
+    classDef flow fill:#fee,stroke:#a77
+    class REG src
+    class CAT catalog
+    class STEP,UI flow
+```
+
+## Packaging
+
+| Type | Source | Installed by |
+|---|---|---|
+| Official | Activepieces cloud registry | Auto-sync |
+| Custom (npm) | npm registry, scoped to one platform | Platform admin |
+| Private (archive) | `.tgz` upload | Platform admin |
+
+Custom and private pieces are managed manually — see [Manage pieces](/admin-guide/guides/manage-pieces).
+
+## Auto-sync
+
+| `AP_PIECES_SYNC_MODE` | Behavior |
+|---|---|
+| `OFFICIAL_AUTO` | Hourly reconcile against the cloud registry. Default on Cloud. |
+| `NONE` | Disabled. Catalog only changes via admin actions. Use for air-gapped or change-controlled environments. |
+
+Custom and private pieces are never touched by the sync job.
+
+## Version pinning
+
+Adding a step records the exact piece version at that moment (e.g. `0.5.3`). The pin stays until a human changes it. To upgrade, open the step in the builder, click the version next to its name, and pick a new one. The dialog warns when the change crosses a minor or major boundary.
+
+## Related
+
+- [Manage pieces](/admin-guide/guides/manage-pieces) — install, hide, upload custom pieces.
+- [Piece versioning](/build-pieces/piece-reference/piece-versioning) — semver rules for piece authors.


### PR DESCRIPTION
## Summary

- New architecture page `install/architecture/piece-syncing` covering: pieces are standard npm packages, hourly auto-sync from the cloud registry (no server upgrade needed), and per-step exact-version pinning (no auto-upgrade — bumps go through the builder).
- Cross-link Note added to `admin-guide/guides/manage-pieces` and `build-pieces/piece-reference/piece-versioning` so all three places point to the same canonical explanation.
- Refreshed `piece-versioning.mdx` to reflect today's behavior — dropped the obsolete `~`/`^` auto-resolution rules and the `<1.0` MINOR caveat, kept only the author-facing semver guidance.
- Registered the new page in `docs.json` under the Architecture group.

## Test plan

- [ ] `cd docs && mintlify dev` — open `/install/architecture/piece-syncing`, confirm the mermaid diagram renders and all internal links resolve (`manage-pieces`, `piece-versioning`).
- [ ] Click the cross-link Note from `manage-pieces` and from `piece-versioning`; confirm round-trip navigation.
- [ ] `mint broken-links` and `mint validate` clean.