### PR TITLE
fix(chat): resolve system prompt path from project root

### DIFF
--- a/packages/server/api/src/app/chat/chat-service.ts
+++ b/packages/server/api/src/app/chat/chat-service.ts
@@ -252,7 +252,7 @@ function sanitizeProjectName(name: string): string {
 }
 
 const SYSTEM_PROMPT_TEMPLATE = readFileSync(
-    path.resolve(__dirname, '../../assets/prompts/chat-system-prompt.md'),
+    path.resolve('packages/server/api/src/assets/prompts/chat-system-prompt.md'),
     'utf8',
 )
 


### PR DESCRIPTION
## Summary
- The `chat-system-prompt.md` file was referenced via `__dirname` which resolves to the `dist/` directory after compilation. Since `tsc` doesn't copy non-TS assets, the file was missing at runtime causing a crash.
- Changed to project-root-relative path, consistent with how email templates are already resolved.

## Test plan
- [ ] Deploy and verify the chat service starts without `ENOENT` error for `chat-system-prompt.md`
- [ ] Verify AI chat conversations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)