### PR TITLE
fix(web): default landing page to Automations instead of Chat

### DIFF
--- a/packages/web/src/lib/route-utils.ts
+++ b/packages/web/src/lib/route-utils.ts
@@ -20,11 +20,11 @@ export const routesThatRequireProjectId = {
 export const determineDefaultRoute = (
   checkAccess: (permission: Permission) => boolean,
 ) => {
-  if (checkAccess(Permission.READ_CHAT)) {
-    return authenticationSession.appendProjectRoutePrefix('/chat');
-  }
   if (checkAccess(Permission.READ_FLOW) || checkAccess(Permission.READ_TABLE)) {
     return authenticationSession.appendProjectRoutePrefix('/automations');
+  }
+  if (checkAccess(Permission.READ_CHAT)) {
+    return authenticationSession.appendProjectRoutePrefix('/chat');
   }
   if (checkAccess(Permission.READ_RUN)) {
     return authenticationSession.appendProjectRoutePrefix('/runs');


### PR DESCRIPTION
## Summary
- Changed the default route priority so navigating into a project (e.g. from platform admin) lands on `/automations` instead of `/chat`

## Test plan
- [ ] Navigate into a project from platform admin and verify it lands on Automations
- [ ] Verify users with only `READ_CHAT` permission (no flow/table access) still land on Chat
- [ ] Verify users with only `READ_RUN` permission still land on Runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)