### PR TITLE
fix(license): apply chatEnabled from license key to platform plan

### DIFF
--- a/packages/server/api/src/app/ee/license-keys/license-keys-service.ts
+++ b/packages/server/api/src/app/ee/license-keys/license-keys-service.ts
@@ -161,6 +161,7 @@ export const licenseKeysService = (log: FastifyBaseLogger) => ({
                 secretManagersEnabled: key.secretManagersEnabled,
                 agentsEnabled: key.agentsEnabled,
                 aiProvidersEnabled: key.aiProvidersEnabled ?? true,
+                chatEnabled: key.chatEnabled ?? false,
             },
         })
     },
@@ -187,4 +188,5 @@ const turnedOffFeatures: Omit<LicenseKeyEntity, 'id' | 'createdAt' | 'expiresAt'
     secretManagersEnabled: false,
     agentsEnabled: false,
     aiProvidersEnabled: false,
+    chatEnabled: false,
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.68.1",
+  "version": "0.68.2",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/core/license-keys/index.ts
+++ b/packages/shared/src/lib/core/license-keys/index.ts
@@ -34,6 +34,7 @@ export const LicenseKeyEntity = z.object({
     secretManagersEnabled: z.boolean(),
     agentsEnabled: z.boolean(),
     aiProvidersEnabled: z.boolean(),
+    chatEnabled: z.boolean().optional(),
 })
 
 


### PR DESCRIPTION
## Summary
- Added `chatEnabled` to `LicenseKeyEntity` schema (optional, for backward compatibility with existing keys)
- Mapped `chatEnabled` from license key to platform plan in `applyLimits`
- Added `chatEnabled: false` to `turnedOffFeatures` for free plan downgrade

## Test plan
- [ ] Apply a license key with `chatEnabled: true` and verify the platform plan reflects it
- [ ] Apply a license key without `chatEnabled` and verify it defaults to `false`
- [ ] Downgrade to free plan and verify `chatEnabled` is set to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)