### PR TITLE
fix(mcp): handle expired step data and unblock status-only run filters

### DIFF
--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -621,7 +621,7 @@ async function queueOrCreateInstantly(params: CreateParams, log: FastifyBaseLogg
     }
 }
 
-function isOutsideRetentionWindow(createdTime: string, retentionDays: number): boolean {
+export function isOutsideRetentionWindow(createdTime: string, retentionDays: number): boolean {
     if (!createdTime) return false
     return apDayjs(createdTime).add(retentionDays, 'day').isBefore(apDayjs())
 }

--- a/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
@@ -1,4 +1,4 @@
-import { FlowRunStatus, McpServer, McpToolDefinition, Permission } from '@activepieces/shared'
+import { FlowRunStatus, isNil, McpServer, McpToolDefinition, Permission, RunEnvironment } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowRunService } from '../../flows/flow-run/flow-run-service'
@@ -6,10 +6,12 @@ import { formatRunSummary } from './flow-run-utils'
 import { mcpUtils } from './mcp-utils'
 
 const runStatusValues = Object.values(FlowRunStatus) as [FlowRunStatus, ...FlowRunStatus[]]
+const runEnvironmentValues = Object.values(RunEnvironment) as [RunEnvironment, ...RunEnvironment[]]
 
 const listRunsInput = z.object({
     flowId: z.string().optional().describe('Filter by flow ID. Use ap_list_flows to find it.'),
     status: z.enum(runStatusValues).optional().describe('Filter by status: SUCCEEDED, FAILED, RUNNING, QUEUED, PAUSED, TIMEOUT, etc.'),
+    environment: z.enum(runEnvironmentValues).optional().describe('Filter by environment: PRODUCTION (live runs) or TESTING (manual test runs). Defaults to PRODUCTION when no flowId is given, since cross-environment scans on the runs table are slow.'),
     limit: z.number().min(1).max(50).optional().describe('Max runs to return (default 10, max 50)'),
 })
 
@@ -22,12 +24,18 @@ export const apListRunsTool = (mcp: McpServer, log: FastifyBaseLogger): McpToolD
         annotations: { readOnlyHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
-                const { flowId, status, limit } = listRunsInput.parse(args)
+                const { flowId, status, environment, limit } = listRunsInput.parse(args)
+
+                // Composite indexes on flow_run all begin with (projectId, environment, ...).
+                // Without an environment filter and without a flowId-narrowed scan, the planner
+                // falls back to slow paths that time out for large projects, so default to PRODUCTION.
+                const effectiveEnvironment = environment ?? (isNil(flowId) ? RunEnvironment.PRODUCTION : undefined)
 
                 const result = await flowRunService(log).list({
                     projectId: mcp.projectId,
                     flowId: flowId ? [flowId] : undefined,
                     status: status ? [status] : undefined,
+                    environment: effectiveEnvironment,
                     cursor: null,
                     limit: limit ?? 10,
                 })

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -1,8 +1,10 @@
 import { FlowOperationType, FlowRun, FlowRunStatus, flowStructureUtil, isFlowRunStateTerminal, isNil, RunEnvironment, SampleDataFileType, StepOutputStatus } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { flowService } from '../../flows/flow/flow.service'
-import { flowRunService } from '../../flows/flow-run/flow-run-service'
+import { flowRunService, isOutsideRetentionWindow } from '../../flows/flow-run/flow-run-service'
 import { sampleDataService } from '../../flows/step-run/sample-data.service'
+import { system } from '../../helper/system/system'
+import { AppSystemProp } from '../../helper/system/system-props'
 import { projectService } from '../../project/project-service'
 import { mcpUtils } from './mcp-utils'
 
@@ -115,12 +117,17 @@ export function formatRunResult(run: FlowRun): string {
     }
 
     const steps = run.steps
-    if (!isNil(steps) && typeof steps === 'object') {
-        lines.push('')
+    const hasSteps = !isNil(steps) && typeof steps === 'object' && Object.keys(steps).length > 0
+
+    lines.push('')
+    if (hasSteps) {
         lines.push('Steps:')
-        for (const [name, step] of Object.entries(steps)) {
+        for (const [name, step] of Object.entries(steps as Record<string, unknown>)) {
             lines.push(formatStepOutput(name, step))
         }
+    }
+    else {
+        lines.push(`Steps: ${stepDataUnavailableReason(run)}`)
     }
 
     return lines.join('\n')
@@ -131,7 +138,8 @@ export function formatRunSummary(run: FlowRun): string {
     const failed = run.failedStep ? ` | Failed: ${run.failedStep.displayName ?? run.failedStep.name}` : ''
     const dur = formatDuration(run.startTime, run.finishTime)
     const durStr = dur !== 'N/A' ? ` | ${dur}` : ''
-    return `${statusIcon(run.status)} ${run.id} — ${run.status}${env}${durStr}${failed} | ${run.created}`
+    const expired = isStepDataExpired(run) ? ' | step data expired' : ''
+    return `${statusIcon(run.status)} ${run.id} — ${run.status}${env}${durStr}${failed}${expired} | ${run.created}`
 }
 
 function statusIcon(status: FlowRunStatus): string {
@@ -169,5 +177,24 @@ function formatStepOutput(name: string, step: unknown): string {
     }
 
     return parts.join('\n')
+}
+
+function stepDataUnavailableReason(run: FlowRun): string {
+    if (!isFlowRunStateTerminal({ status: run.status, ignoreInternalError: false })) {
+        return 'not yet available — run is still in progress.'
+    }
+    if (isStepDataExpired(run)) {
+        const retentionDays = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
+        return `not available — execution data is purged after ${retentionDays} days. Re-run the flow with ap_test_flow or ap_retry_run to capture fresh step data.`
+    }
+    return 'not available for this run.'
+}
+
+function isStepDataExpired(run: FlowRun): boolean {
+    if (!isFlowRunStateTerminal({ status: run.status, ignoreInternalError: false })) {
+        return false
+    }
+    const retentionDays = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
+    return isOutsideRetentionWindow(run.created, retentionDays)
 }
 

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -117,12 +117,14 @@ export function formatRunResult(run: FlowRun): string {
     }
 
     const steps = run.steps
-    const hasSteps = !isNil(steps) && typeof steps === 'object' && Object.keys(steps).length > 0
+    const stepEntries = !isNil(steps) && typeof steps === 'object'
+        ? Object.entries(steps as Record<string, unknown>)
+        : []
 
     lines.push('')
-    if (hasSteps) {
+    if (stepEntries.length > 0) {
         lines.push('Steps:')
-        for (const [name, step] of Object.entries(steps as Record<string, unknown>)) {
+        for (const [name, step] of stepEntries) {
             lines.push(formatStepOutput(name, step))
         }
     }
@@ -183,8 +185,8 @@ function stepDataUnavailableReason(run: FlowRun): string {
     if (!isFlowRunStateTerminal({ status: run.status, ignoreInternalError: false })) {
         return 'not yet available — run is still in progress.'
     }
-    if (isStepDataExpired(run)) {
-        const retentionDays = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
+    const retentionDays = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
+    if (isOutsideRetentionWindow(run.created, retentionDays)) {
         return `not available — execution data is purged after ${retentionDays} days. Re-run the flow with ap_test_flow or ap_retry_run to capture fresh step data.`
     }
     return 'not available for this run.'

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -15,6 +15,8 @@ import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/
 import { createTestContext } from '../../../helpers/test-context'
 import { db } from '../../../helpers/db'
 import { createMockPieceMetadata } from '../../../helpers/mocks'
+import { system } from '../../../../src/app/helper/system/system'
+import { AppSystemProp } from '../../../../src/app/helper/system/system-props'
 import { apListFlowsTool } from '../../../../src/app/mcp/tools/ap-list-flows'
 import { apBuildFlowTool } from '../../../../src/app/mcp/tools/ap-build-flow'
 import { apCreateFlowTool } from '../../../../src/app/mcp/tools/ap-create-flow'
@@ -2290,9 +2292,10 @@ describe('MCP Tools integration', () => {
         await db.update('flow_run', expiredRunId, { created: '2024-01-01T00:00:00.000Z' })
 
         const result = await apGetRunTool(mcp, mockLog).execute({ flowRunId: expiredRunId })
+        const retentionDays = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
 
         expect(text(result)).toContain('purged')
-        expect(text(result)).toContain('30 days')
+        expect(text(result)).toContain(`${retentionDays} days`)
     })
 
     it('83. ap_get_run — reports "still in progress" when a non-terminal run has no step data', async () => {

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -3,10 +3,12 @@ import { FastifyBaseLogger, FastifyInstance } from 'fastify'
 import {
     apId,
     FlowActionType,
+    FlowRunStatus,
     McpServer,
     McpServerStatus,
     PackageType,
     PieceType,
+    RunEnvironment,
     StepLocationRelativeToParent,
 } from '@activepieces/shared'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
@@ -31,6 +33,8 @@ import { apValidateFlowTool } from '../../../../src/app/mcp/tools/ap-validate-fl
 import { apUpdateTriggerTool } from '../../../../src/app/mcp/tools/ap-update-trigger'
 import { apDuplicateFlowTool } from '../../../../src/app/mcp/tools/ap-duplicate-flow'
 import { apUpdateBranchTool } from '../../../../src/app/mcp/tools/ap-update-branch'
+import { apListRunsTool } from '../../../../src/app/mcp/tools/ap-list-runs'
+import { apGetRunTool } from '../../../../src/app/mcp/tools/ap-get-run'
 import { mcpUtils } from '../../../../src/app/mcp/tools/mcp-utils'
 
 let app: FastifyInstance
@@ -2187,5 +2191,131 @@ describe('MCP Tools integration', () => {
 
         expect(text(result)).toContain('❌')
         expect(text(result)).toContain('operator')
+    })
+
+    it('80. ap_list_runs — defaults environment to PRODUCTION when no flowId is given', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const flowId = await createFlowAndGetId(mcp, 'Run Listing Defaults')
+        const flowVersion = await db.findOneByOrFail<{ id: string }>('flow_version', { flowId })
+
+        const prodRunId = apId()
+        const testRunId = apId()
+        await db.save('flow_run', [
+            {
+                id: prodRunId,
+                projectId: ctx.project.id,
+                flowId,
+                flowVersionId: flowVersion.id,
+                environment: RunEnvironment.PRODUCTION,
+                status: FlowRunStatus.SUCCEEDED,
+                stepsCount: 0,
+                failParentOnFailure: true,
+            },
+            {
+                id: testRunId,
+                projectId: ctx.project.id,
+                flowId,
+                flowVersionId: flowVersion.id,
+                environment: RunEnvironment.TESTING,
+                status: FlowRunStatus.SUCCEEDED,
+                stepsCount: 0,
+                failParentOnFailure: true,
+            },
+        ])
+
+        const result = await apListRunsTool(mcp, mockLog).execute({})
+
+        expect(text(result)).toContain(prodRunId)
+        expect(text(result)).not.toContain(testRunId)
+    })
+
+    it('81. ap_list_runs — caller-supplied environment overrides the PRODUCTION default', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const flowId = await createFlowAndGetId(mcp, 'Run Listing Override')
+        const flowVersion = await db.findOneByOrFail<{ id: string }>('flow_version', { flowId })
+
+        const prodRunId = apId()
+        const testRunId = apId()
+        await db.save('flow_run', [
+            {
+                id: prodRunId,
+                projectId: ctx.project.id,
+                flowId,
+                flowVersionId: flowVersion.id,
+                environment: RunEnvironment.PRODUCTION,
+                status: FlowRunStatus.SUCCEEDED,
+                stepsCount: 0,
+                failParentOnFailure: true,
+            },
+            {
+                id: testRunId,
+                projectId: ctx.project.id,
+                flowId,
+                flowVersionId: flowVersion.id,
+                environment: RunEnvironment.TESTING,
+                status: FlowRunStatus.SUCCEEDED,
+                stepsCount: 0,
+                failParentOnFailure: true,
+            },
+        ])
+
+        const result = await apListRunsTool(mcp, mockLog).execute({ environment: RunEnvironment.TESTING })
+
+        expect(text(result)).toContain(testRunId)
+        expect(text(result)).not.toContain(prodRunId)
+    })
+
+    it('82. ap_get_run — surfaces a clear "purged" message when run is past retention', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const flowId = await createFlowAndGetId(mcp, 'Expired Run')
+        const flowVersion = await db.findOneByOrFail<{ id: string }>('flow_version', { flowId })
+
+        const expiredRunId = apId()
+        await db.save('flow_run', {
+            id: expiredRunId,
+            projectId: ctx.project.id,
+            flowId,
+            flowVersionId: flowVersion.id,
+            environment: RunEnvironment.PRODUCTION,
+            status: FlowRunStatus.SUCCEEDED,
+            stepsCount: 0,
+            failParentOnFailure: true,
+        })
+        await db.update('flow_run', expiredRunId, { created: '2024-01-01T00:00:00.000Z' })
+
+        const result = await apGetRunTool(mcp, mockLog).execute({ flowRunId: expiredRunId })
+
+        expect(text(result)).toContain('purged')
+        expect(text(result)).toContain('30 days')
+    })
+
+    it('83. ap_get_run — reports "still in progress" when a non-terminal run has no step data', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+
+        const flowId = await createFlowAndGetId(mcp, 'Running Run')
+        const flowVersion = await db.findOneByOrFail<{ id: string }>('flow_version', { flowId })
+
+        const runningRunId = apId()
+        await db.save('flow_run', {
+            id: runningRunId,
+            projectId: ctx.project.id,
+            flowId,
+            flowVersionId: flowVersion.id,
+            environment: RunEnvironment.PRODUCTION,
+            status: FlowRunStatus.RUNNING,
+            stepsCount: 0,
+            failParentOnFailure: true,
+        })
+
+        const result = await apGetRunTool(mcp, mockLog).execute({ flowRunId: runningRunId })
+
+        expect(text(result)).toContain('still in progress')
     })
 })


### PR DESCRIPTION
## What does this PR do?

Two papercuts in the MCP run-inspection tools shipped in #12297.

### `ap_get_run` silently returned an empty `Steps:` block for runs past retention

`formatRunResult` and `formatRunSummary` now distinguish three cases instead of emitting a dangling header:

- **non-terminal run** → `Steps: not yet available — run is still in progress.`
- **terminal run past `AP_EXECUTION_DATA_RETENTION_DAYS`** → `Steps: not available — execution data is purged after N days. Re-run the flow with ap_test_flow or ap_retry_run to capture fresh step data.`
- **terminal run with no steps, within retention** → `Steps: not available for this run.`

`formatRunSummary` also tags expired runs in list output (`| step data expired`) so callers can skip the round-trip.

### `ap_list_runs` timed out on status-only filters

Every composite index on `flow_run` starts with `(projectId, environment, …)`, so without an environment filter the planner falls back to slow paths and the request hangs on large projects. Reproduced live: `ap_list_runs({ status: 'FAILED' })` and `ap_list_runs({})` both timed out, while `ap_list_runs({ flowId })` returned instantly.

Added an optional `environment` parameter and default it to `PRODUCTION` when no `flowId` is given. Callers can override with `TESTING` if they want test runs. The flowId-scoped path is unchanged.

### Relevant User Scenarios

Anyone using the MCP run-inspection tools to debug a flow that ran more than 30 days ago, or to scan failed runs across a project. Both queries previously failed silently or timed out — now they return useful data or a clear explanation.

### Tests

4 new integration tests (#80–83) in `mcp-tools.test.ts`. `ap_list_runs` and `ap_get_run` had no prior coverage.

- **#80** defaults to PRODUCTION when no flowId
- **#81** explicit `environment: TESTING` overrides the default
- **#82** surfaces the "purged" message with retention-days count for old runs
- **#83** surfaces the "still in progress" message for non-terminal runs