### PR TITLE
fix(chat): improve streaming reliability and error recovery

### DIFF
--- a/packages/server/api/src/app/chat/chat-controller.ts
+++ b/packages/server/api/src/app/chat/chat-controller.ts
@@ -222,6 +222,11 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
 
                                     if (historyReplayFilter.shouldSuppress(update)) return
 
+                                    const missedText = historyReplayFilter.drainMissedText()
+                                    if (missedText) {
+                                        streamWriter.appendText(missedText)
+                                    }
+
                                     streamWriter.write(update)
                                 })
 
@@ -251,6 +256,7 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
                             }
                         }
 
+                        streamWriter.endAll()
                         writer.write({ type: 'finish', finishReason: 'stop' })
                     }
                     finally {

--- a/packages/server/api/src/app/chat/chat-controller.ts
+++ b/packages/server/api/src/app/chat/chat-controller.ts
@@ -245,6 +245,7 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
                         finally {
                             clearInterval(keepalive)
                             unsubscribe?.()
+                            streamWriter.endAll()
                             void userSandboxService.updateLastUsed({ userId }).catch(() => undefined)
                             if (pendingTitle && promptCompleted) {
                                 void service.updateConversation({
@@ -256,7 +257,6 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
                             }
                         }
 
-                        streamWriter.endAll()
                         writer.write({ type: 'finish', finishReason: 'stop' })
                     }
                     finally {

--- a/packages/server/api/src/app/chat/sandbox/stream-adapter.ts
+++ b/packages/server/api/src/app/chat/sandbox/stream-adapter.ts
@@ -8,7 +8,7 @@ export function createStreamWriter({ writer, textPartId, reasoningPartId, onSess
     textPartId: string
     reasoningPartId: string
     onSessionTitle?: (title: string) => void
-}): { write: (update: Record<string, unknown>) => void } {
+}): { write: (update: Record<string, unknown>) => void, appendText: (delta: string) => void, endAll: () => void } {
     const text = chunkedPart({ writer, id: textPartId, kind: 'text' })
     const reasoning = chunkedPart({ writer, id: reasoningPartId, kind: 'reasoning' })
 
@@ -76,14 +76,30 @@ export function createStreamWriter({ writer, textPartId, reasoningPartId, onSess
                     break
             }
         },
+        appendText(delta: string): void {
+            text.append(delta)
+        },
+        endAll(): void {
+            text.end()
+            reasoning.end()
+        },
     }
 }
 
-export function createHistoryReplayFilter(): { shouldSuppress: (update: Record<string, unknown>) => boolean } {
+export function createHistoryReplayFilter(): {
+    shouldSuppress: (update: Record<string, unknown>) => boolean
+    drainMissedText: () => string
+} {
     let state: 'detecting' | 'suppressing' | 'passthrough' = 'detecting'
     let buffer = ''
+    let missedText = ''
 
     return {
+        drainMissedText(): string {
+            const text = missedText
+            missedText = ''
+            return text
+        },
         shouldSuppress(update: Record<string, unknown>): boolean {
             if (state === 'passthrough') return false
             const isTextChunk = getString(update, 'sessionUpdate') === SandboxSessionUpdateType.AGENT_MESSAGE_CHUNK
@@ -95,6 +111,7 @@ export function createHistoryReplayFilter(): { shouldSuppress: (update: Record<s
             buffer += text
             if (chatEventUtils.isHistoryReplayContent(buffer)) {
                 buffer = ''
+                missedText = ''
                 state = 'suppressing'
                 return true
             }
@@ -103,6 +120,9 @@ export function createHistoryReplayFilter(): { shouldSuppress: (update: Record<s
                 buffer = ''
                 state = 'passthrough'
                 return false
+            }
+            if (state === 'suppressing') {
+                missedText += text
             }
             return state === 'suppressing'
         },

--- a/packages/server/api/src/app/chat/sandbox/stream-adapter.ts
+++ b/packages/server/api/src/app/chat/sandbox/stream-adapter.ts
@@ -119,6 +119,8 @@ export function createHistoryReplayFilter(): {
             if (buffer.length > limit) {
                 buffer = ''
                 state = 'passthrough'
+                // missedText holds previously suppressed chunks; the current chunk
+                // returns false and is written directly by the caller via streamWriter.write()
                 return false
             }
             if (state === 'suppressing') {

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -236,6 +236,15 @@ export function useAgentChat({
     },
     onError: () => {
       setPendingMessages([]);
+      const convId = conversationIdRef.current;
+      if (convId) {
+        void chatApi
+          .getMessages(convId)
+          .then((result) => {
+            setUiMessages(mapHistoryToUIMessages(result.data));
+          })
+          .catch(() => undefined);
+      }
     },
   });
 


### PR DESCRIPTION
## Summary
- Close text/reasoning parts (`text-end`) before `finish` event to comply with AI SDK stream protocol — without it, text parts stay in `state: 'streaming'` permanently
- Recover up to 200 chars of suppressed content in the history replay filter when transitioning from suppression to passthrough on session resume
- Reload conversation from persisted history on stream error instead of leaving truncated content with broken markdown

## Test plan
- [ ] Send a chat message and verify the full response streams and renders markdown correctly
- [ ] Resume a conversation (session resume path) and verify no content is lost at the start of the response
- [ ] Simulate a network error mid-stream (e.g. throttle/disconnect in DevTools) and verify the content reloads from history instead of showing truncated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)