### PR TITLE
feat(docker): run container as non-root user

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Build Docker image
         run: docker build -t activepieces-benchmark:local .
 
+      - name: Verify image runs as non-root user (uid=1001)
+        run: |
+          actual=$(docker run --rm --entrypoint id activepieces-benchmark:local)
+          echo "$actual"
+          echo "$actual" | grep -q 'uid=1001(app)'
+
       - name: Start stack
         run: |
           APP_REPLICAS=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,36 +95,46 @@ RUN rm -rf packages/pieces/core packages/pieces/custom && \
 ### STAGE 2: Run ###
 FROM base AS run
 
+# Create the unprivileged runtime user early so --chown can resolve "app:app"
+RUN groupadd --system --gid 1001 app && \
+    useradd --system --uid 1001 --gid app \
+            --home-dir /home/app --create-home app
+
 WORKDIR /usr/src/app
 
 # Copy static configuration files first (better layer caching)
 COPY --from=build /usr/src/app/packages/server/api/src/assets/default.cf /usr/local/etc/isolate
-COPY docker-entrypoint.sh .
+COPY --chown=app:app docker-entrypoint.sh .
 
-# Create all necessary directories in one layer
+# WORKDIR creates /usr/src/app as root; retag so bun install can write here as app
 RUN mkdir -p \
     /usr/src/app/dist/packages/engine && \
-    chmod +x docker-entrypoint.sh
+    chmod +x docker-entrypoint.sh && \
+    chown app:app /usr/src/app
 
 # Copy root config files needed for dependency resolution
-COPY --from=build /usr/src/app/package.json ./
-COPY --from=build /usr/src/app/.npmrc ./
-COPY --from=build /usr/src/app/bun.lock ./
-COPY --from=build /usr/src/app/bunfig.toml ./
-COPY --from=build /usr/src/app/LICENSE .
+COPY --chown=app:app --from=build /usr/src/app/package.json ./
+COPY --chown=app:app --from=build /usr/src/app/.npmrc ./
+COPY --chown=app:app --from=build /usr/src/app/bun.lock ./
+COPY --chown=app:app --from=build /usr/src/app/bunfig.toml ./
+COPY --chown=app:app --from=build /usr/src/app/LICENSE .
 
 # Copy workspace package.json files (needed for bun workspace resolution)
-COPY --from=build /usr/src/app/packages ./packages
+COPY --chown=app:app --from=build /usr/src/app/packages ./packages
 
 # Copy built engine
-COPY --from=build /usr/src/app/dist/packages/engine/ ./dist/packages/engine/
+COPY --chown=app:app --from=build /usr/src/app/dist/packages/engine/ ./dist/packages/engine/
 
-# Regenerate lockfile and install production dependencies (pieces were trimmed from workspace)
-RUN --mount=type=cache,target=/root/.bun/install/cache \
+USER app
+
+# Regenerate lockfile and install production dependencies as the app user
+RUN --mount=type=cache,target=/home/app/.bun/install/cache,uid=1001,gid=1001 \
     bun install --production
 
 # Copy frontend files
-COPY --from=build /usr/src/app/dist/packages/web ./dist/packages/web/
+COPY --chown=app:app --from=build /usr/src/app/dist/packages/web ./dist/packages/web/
+
+ENV PM2_HOME=/home/app/.pm2
 
 LABEL service=activepieces
 

--- a/docs/install/architecture/sandboxing.mdx
+++ b/docs/install/architecture/sandboxing.mdx
@@ -44,6 +44,10 @@ The engine runs as a plain `child_process.fork` with a memory cap. In `SANDBOX_C
 
 The engine runs inside [ioi/isolate](https://github.com/ioi/isolate), which creates fresh PID, mount, user, and UTS namespaces per run and mounts the engine and code artifacts read-only. Arbitrary `npm` packages are safe inside Code steps because filesystem and process state are scoped to the box. The cost: cold boot per run (not reusable), and the worker container must hold `CAP_SYS_ADMIN` — `--privileged` in Docker, `securityContext.privileged: true` in Kubernetes.
 
+<Warning>
+The default Activepieces image runs as the unprivileged `app` user. The `isolate` binary refuses non-root callers, so for `SANDBOX_PROCESS` and `SANDBOX_CODE_AND_PROCESS` the worker container must additionally be run as root. In Docker Compose, set `user: "root"` on the worker service alongside `privileged: true`. In Kubernetes, set `securityContext.runAsUser: 0` alongside `securityContext.privileged: true`. The `app` and other services should keep the default unprivileged user.
+</Warning>
+
 ## Network Isolation
 
 Execution mode decides *how* user code runs; `AP_NETWORK_MODE` decides *what it can reach*. See [Network Security](./network-security) for the SSRF guard, egress proxy, and iptables lockdown that layer on top of every sandbox mode.

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -268,10 +268,26 @@ async function fetchAndStoreSettings(sock: Socket): Promise<void> {
                 }
             }
             workerSettings.set(response)
+            assertRootIfProcessSandbox(response.EXECUTION_MODE as ExecutionMode | undefined)
             logger.info({ environment: response.ENVIRONMENT, executionMode: response.EXECUTION_MODE }, 'Worker settings loaded')
             resolve()
         })
     })
+}
+
+// The isolate binary checks getuid() == 0 in user-space; setcap won't bypass it.
+function assertRootIfProcessSandbox(executionMode: ExecutionMode | undefined): void {
+    const needsRoot = executionMode === ExecutionMode.SANDBOX_PROCESS
+        || executionMode === ExecutionMode.SANDBOX_CODE_AND_PROCESS
+    if (!needsRoot || process.getuid?.() === 0) return
+    logger.fatal(
+        { executionMode, uid: process.getuid?.() },
+        `AP_EXECUTION_MODE=${executionMode} requires the worker to run as root inside the container ` +
+        'because the isolate binary refuses non-root callers. ' +
+        'Set user: "root" (Docker) or securityContext.runAsUser: 0 (Kubernetes) on the worker service ' +
+        'alongside the existing privileged requirement.',
+    )
+    process.exit(1)
 }
 
 function getWorkerProps(): Record<string, string> {


### PR DESCRIPTION
## Summary

Image now runs as the unprivileged `app` user (uid=1001) by default instead of root. Closes the "RCE → root inside container → Docker breakout" path on `UNSANDBOXED` self-hosted deployments.

## Migration

- **Docker bind mounts:** `sudo chown -R 1001:1001 ./cache` before upgrading
- **Helm/K8s:** set `podSecurityContext.fsGroup: 1001` so PVCs stay writable
- **SANDBOX_PROCESS / SANDBOX_CODE_AND_PROCESS only:** add `user: "root"` (Docker) or `runAsUser: 0` (K8s) on the worker, alongside the existing `--privileged` requirement  (the `isolate` binary refuses non-root callers)

`UNSANDBOXED` and `SANDBOX_CODE_ONLY` users need no config changes beyond the cache `chown`.

## Test plan
- [x] `docker run --rm <img> id` returns uid=1001
- [x] Code step runs in UNSANDBOXED (non-root)
- [x] Code step runs in SANDBOX_CODE_ONLY (V8 isolation verified)
- [x] Code step runs in SANDBOX_PROCESS with `user: "root"` + `privileged: true`
