### PR TITLE
chore(security): add gitleaks scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,73 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  # schedule:
+  #   - cron: '17 3 * * 1'   # weekly Monday 03:17 UTC, for full-history job
+  # workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+env:
+  GITLEAKS_VERSION: 8.30.1
+
+jobs:
+  pr-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sSL -o gl.tgz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar xzf gl.tgz gitleaks
+          sudo mv gitleaks /usr/local/bin/
+
+      - name: Scan PR diff
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          gitleaks detect \
+            --config=.gitleaks.toml \
+            --log-opts="--no-merges $BASE_SHA..HEAD" \
+            --report-format sarif --report-path gitleaks.sarif \
+            --redact --no-banner
+
+      - uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+
+  # full-history:
+  #   if: github.event_name != 'pull_request'
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #
+  #     - name: Install gitleaks
+  #       run: |
+  #         curl -sSL -o gl.tgz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+  #         tar xzf gl.tgz gitleaks
+  #         sudo mv gitleaks /usr/local/bin/
+  #
+  #     - name: Scan full history
+  #       continue-on-error: true
+  #       run: |
+  #         gitleaks detect \
+  #           --config=.gitleaks.toml \
+  #           --report-format sarif --report-path gitleaks.sarif \
+  #           --redact --no-banner
+  #
+  #     - uses: github/codeql-action/upload-sarif@v3
+  #       if: always()
+  #       with:
+  #         sarif_file: gitleaks.sarif
+  #         category: gitleaks

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,67 @@
+[extend]
+useDefault = true
+
+# Suppress findings inside sampleData blocks in piece triggers.
+[[allowlists]]
+description = "piece-sample-data"
+condition   = "AND"
+regexTarget = "match"
+regexes     = ['''sampleData\s*:\s*\{[\s\S]*?\}''']
+paths       = ['''packages/pieces/community/.*/src/lib/triggers?/.*\.ts''']
+
+# Env placeholders + test fixtures.
+[[allowlists]]
+description = "env-placeholders-and-fixtures"
+paths = [
+  '''\.env\.example$''',
+  '''\.env\.e2e$''',
+  '''\.env\.dev$''',
+  '''packages/server/worker/test/fixtures/.*''',
+  '''packages/server/worker/test/e2e/fixtures/.*''',
+  '''packages/tests-e2e/fixtures/.*''',
+]
+
+# Snowflake — private-key placeholder strings.
+[[allowlists]]
+description = "snowflake-private-key-placeholders"
+targetRules = ["private-key"]
+paths       = ['''packages/pieces/community/snowflake/src/lib/.*\.ts''']
+
+# Piece trigger sample data + i18n locale strings.
+[[allowlists]]
+description = "piece-trigger-sample-data-and-i18n"
+targetRules = [
+  "generic-api-key",
+  "jwt",
+  "aws-access-token",
+  "stripe-access-token",
+  "openai-api-key",
+  "sendgrid-api-token",
+  "rapidapi-access-token",
+  "linkedin-client-id",
+  "curl-auth-header",
+  "private-key",
+  "gcp-api-key",
+]
+paths = [
+  '''packages/pieces/community/.+/src/lib/triggers?/.*\.ts''',
+  '''packages/pieces/.+/src/i18n/.+\.json''',
+]
+
+# Paths gone from HEAD.
+[[allowlists]]
+description = "gone-from-head-historical-paths"
+paths = [
+  '''^packages/backend/.*''',
+  '''^packages/frontend/.*''',
+  '''^packages/ui/.*''',
+  '''^packages/chatbots/.*''',
+  '''^packages/engine/.*''',
+  '''^packages/ee/product-embed/.*''',
+  '''^packages/pieces/linkedin/.*''',
+  '''^packages/pieces/custom/.+/.*''',
+  '''^packages/server/api/src/app/request-writer/.*''',
+  '''^src/backend/.*''',
+  '''^src/frontend/.*''',
+  '''^src/worker/.*''',
+]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,3 +9,16 @@ if [ -n "$ENV_FILES" ]; then
   echo "Please unstage them with: git reset HEAD <file>"
   exit 1
 fi
+
+# Scan staged diff for secrets (this hook is happy-path defense in depth).
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks protect --staged --config=.gitleaks.toml --redact --no-banner || {
+    echo
+    echo "gitleaks blocked the commit — a potential secret was detected above."
+    echo "If this is a false positive, run: git commit --no-verify"
+    exit 1
+  }
+else
+  echo "warning: gitleaks not installed — skipping local secret scan."
+  echo "  install: https://github.com/gitleaks/gitleaks#installing"
+fi


### PR DESCRIPTION
## Summary
- `.gitleaks.toml` — shared allowlist config (env placeholders, fixtures, piece samples, paths gone from HEAD)
- `.husky/pre-commit` — scans staged diff for secrets; warns and skips if gitleaks isn't installed
- `.github/workflows/gitleaks.yml` — PR-diff scan, warn-only
- Periodic full-history scan is included in the workflow but commented out for now

## Test plan
- [ ] Workflow runs on this PR
- [ ] `gitleaks detect --config=.gitleaks.toml --no-git --source=/dev/null` parses cleanly locally
- [ ] Pre-commit hook blocks a fake key in a sandbox file
