### PR TITLE
fix(chat): stop killing active streams on tab visibility change

### DIFF
--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -6,7 +6,7 @@ import {
 } from '@activepieces/shared';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { API_URL } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
@@ -247,33 +247,6 @@ export function useAgentChat({
       }
     },
   });
-
-  const statusRef = useRef(status);
-  statusRef.current = status;
-
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== 'visible') return;
-      const convId = conversationIdRef.current;
-      if (!convId) return;
-      if (
-        statusRef.current !== 'streaming' &&
-        statusRef.current !== 'submitted'
-      )
-        return;
-      void stop();
-      setPendingMessages([]);
-      void chatApi
-        .getMessages(convId)
-        .then((result) => {
-          setUiMessages(mapHistoryToUIMessages(result.data));
-        })
-        .catch(() => undefined);
-    };
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () =>
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [stop, setUiMessages]);
 
   const sdkIsStreaming = status === 'streaming' || status === 'submitted';
   const lastLiveMessage = uiMessages[uiMessages.length - 1];


### PR DESCRIPTION
## Summary
- Remove the `visibilitychange` handler that was aborting active streaming fetches every time the page regained visibility (tab switch, URL bar click, DevTools open, etc.)
- This caused two bugs: streams cutting off randomly in production, and last sent message disappearing after switching tabs
- The existing `onError` callback already handles recovery when the browser actually kills the connection in the background, making this handler redundant

## Test plan
- [ ] Start a chat conversation and send a message that triggers a long streaming response
- [ ] While streaming, switch to another tab and switch back — stream should continue uninterrupted
- [ ] While streaming, click the URL bar and click back — stream should continue
- [ ] Leave a tab in the background for an extended period, come back — should show completed response or recover via onError
- [ ] Verify the stop button still works to manually cancel streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)