### PR TITLE
fix(worker): accept /api/v1/health on worker health server

### DIFF
--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -360,7 +360,7 @@ function sleep(ms: number): Promise<void> {
 
 function startHealthServer(): ReturnType<typeof createServer> {
     const port = Number(process.env[WorkerSystemProp.PORT] ?? system.get(WorkerSystemProp.PORT))
-    const healthPaths = new Set(['/worker/health', '/v1/health'])
+    const healthPaths = new Set(['/worker/health', '/v1/health', '/api/v1/health'])
     const server = createServer((req, res) => {
         if (req.method === 'GET' && req.url && healthPaths.has(req.url)) {
             res.writeHead(200, { 'Content-Type': 'application/json' })

--- a/packages/server/worker/test/lib/worker.test.ts
+++ b/packages/server/worker/test/lib/worker.test.ts
@@ -517,6 +517,13 @@ describe('worker integration', () => {
             expect(await res.json()).toEqual({ status: 'ok' })
         }, 5_000)
 
+        it('responds 200 with status ok on /api/v1/health', async () => {
+            await startWithHealthServer()
+            const res = await fetch(`http://127.0.0.1:${healthPort}/api/v1/health`)
+            expect(res.status).toBe(200)
+            expect(await res.json()).toEqual({ status: 'ok' })
+        }, 5_000)
+
         it('responds 404 on unknown paths', async () => {
             await startWithHealthServer()
             const res = await fetch(`http://127.0.0.1:${healthPort}/unknown`)


### PR DESCRIPTION
## Summary

The 0.80.0 breaking-changes notice instructs operators to update health probes from `/v1/health` to `/api/v1/health`. That works for the API container (Fastify with the `/api` prefix), but the **worker** runs a separate standalone `http.createServer` with no prefix, so `/api/v1/health` returns 404 on worker pods.

This was reported by a user upgrading from 0.79 → 0.82: their k8s probes broke on the worker side after following the docs.

This PR adds `/api/v1/health` to the worker health server's allowlist so the documented endpoint works on both containers, and adds a test for it.

- `packages/server/worker/src/lib/worker.ts` — extend `healthPaths` set with `/api/v1/health`
- `packages/server/worker/test/lib/worker.test.ts` — new test mirroring the existing `/v1/health` and `/worker/health` cases

Existing paths (`/v1/health`, `/worker/health`) continue to work — additive change only.

## Test plan

- [x] `cd packages/server/worker && npx vitest run test/lib/worker.test.ts` — 19/19 pass including new case
- [x] `npm run lint-dev` — 0 errors
- [ ] Manual: start worker and confirm `/api/v1/health`, `/v1/health`, `/worker/health` all return 200, unknown paths return 404