### PR TITLE
fix(builder): resizing sample data section in the builder wasn't working on first try

### DIFF
--- a/packages/web/src/app/builder/step-settings/index.tsx
+++ b/packages/web/src/app/builder/step-settings/index.tsx
@@ -158,6 +158,7 @@ const StepSettingsContainer = () => {
   }, []);
 
   const { height, setHeight } = useResizableVerticalPanelsContext();
+  const initialHeightRef = useRef(height);
 
   return (
     <Form {...form}>
@@ -278,7 +279,7 @@ const StepSettingsContainer = () => {
               <>
                 <ResizableHandle withHandle={true} />
                 <ResizablePanel
-                  defaultSize={`${height}%`}
+                  defaultSize={`${initialHeightRef.current}%`}
                   onResize={(panelSize) => setHeight(panelSize.asPercentage)}
                   className="min-h-[130px]"
                 >

--- a/packages/web/src/components/ui/resizable-panel.tsx
+++ b/packages/web/src/components/ui/resizable-panel.tsx
@@ -36,7 +36,7 @@ function ResizableHandle({
     <ResizablePrimitive.Separator
       data-slot="resizable-handle"
       className={cn(
-        'bg-border z-40 relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90',
+        'bg-border z-40 relative flex w-px items-center justify-center outline-none after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90',
         className,
       )}
       {...props}


### PR DESCRIPTION
Fixes a bug in the flow builder's step settings sidebar where the Generate Sample Data panel ignores the first drag of its
  resize handle and only responds on the second attempt. After this change, dragging the handle expands or collapses the
  panel on the very first try, every time.
  
  Here is the bug: 
https://github.com/user-attachments/assets/bcabca07-8781-4673-9909-ae40c2dfe650

