### PR TITLE
fix(chat): wait for in-flight events before closing stream

### DIFF
--- a/packages/server/api/src/app/chat/chat-controller.ts
+++ b/packages/server/api/src/app/chat/chat-controller.ts
@@ -248,6 +248,7 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
                                 chatSandboxAgent.sendPrompt({ session, text: content, systemPrompt, files })
                                     .then(() => {
                                         promptCompleted = true
+                                        lastEventAt = Date.now()
                                         const waitStart = Date.now()
                                         const checkQuiescence = (): void => {
                                             if (resolved) return

--- a/packages/server/api/src/app/chat/chat-controller.ts
+++ b/packages/server/api/src/app/chat/chat-controller.ts
@@ -214,9 +214,15 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
 
                         try {
                             await new Promise<void>((resolve, reject) => {
+                                let quiescenceTimer: ReturnType<typeof setTimeout> | undefined
+
                                 const safeResolve = (): void => {
                                     if (resolved) return
                                     resolved = true
+                                    if (quiescenceTimer !== undefined) {
+                                        clearTimeout(quiescenceTimer)
+                                        quiescenceTimer = undefined
+                                    }
                                     resolve()
                                 }
 
@@ -258,9 +264,9 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
                                                 safeResolve()
                                                 return
                                             }
-                                            setTimeout(checkQuiescence, Math.min(EVENT_QUIESCENCE_MS - sinceLastEvent, 200))
+                                            quiescenceTimer = setTimeout(checkQuiescence, Math.min(EVENT_QUIESCENCE_MS - sinceLastEvent, 200))
                                         }
-                                        setTimeout(checkQuiescence, 200)
+                                        quiescenceTimer = setTimeout(checkQuiescence, 200)
                                     })
                                     .catch(reject)
                             })

--- a/packages/server/api/src/app/chat/chat-controller.ts
+++ b/packages/server/api/src/app/chat/chat-controller.ts
@@ -22,6 +22,9 @@ import { ChatUIMessage, createHistoryReplayFilter, createStreamWriter } from './
 import { userSandboxService } from './user-sandbox-service'
 
 const CHAT_PRINCIPALS = [PrincipalType.USER] as const
+const EVENT_QUIESCENCE_MS = 1_500
+const MAX_QUIESCENCE_WAIT_MS = 10_000
+const KEEPALIVE_INTERVAL_MS = 15_000
 
 function isExpectedStreamError(error: unknown): boolean {
     if (!(error instanceof Error)) return false
@@ -190,7 +193,6 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
                         })
                         const session = resumed.session
 
-                        const KEEPALIVE_INTERVAL_MS = 25_000
                         const keepalive = setInterval(() => {
                             writer.write({ type: 'data-usage', data: { inputTokens: 0, outputTokens: 0 }, transient: true })
                         }, KEEPALIVE_INTERVAL_MS)
@@ -207,9 +209,17 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
                         })
                         let unsubscribe: (() => void) | undefined
                         let promptCompleted = false
+                        let lastEventAt = Date.now()
+                        let resolved = false
 
                         try {
                             await new Promise<void>((resolve, reject) => {
+                                const safeResolve = (): void => {
+                                    if (resolved) return
+                                    resolved = true
+                                    resolve()
+                                }
+
                                 unsubscribe = session.onEvent((event) => {
                                     if (event.sender !== 'agent') return
 
@@ -228,16 +238,28 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
                                     }
 
                                     streamWriter.write(update)
+                                    lastEventAt = Date.now()
                                 })
 
                                 reply.raw.on('close', () => {
-                                    resolve()
+                                    safeResolve()
                                 })
 
                                 chatSandboxAgent.sendPrompt({ session, text: content, systemPrompt, files })
                                     .then(() => {
                                         promptCompleted = true
-                                        resolve()
+                                        const waitStart = Date.now()
+                                        const checkQuiescence = (): void => {
+                                            if (resolved) return
+                                            const now = Date.now()
+                                            const sinceLastEvent = now - lastEventAt
+                                            if (sinceLastEvent >= EVENT_QUIESCENCE_MS || now - waitStart >= MAX_QUIESCENCE_WAIT_MS) {
+                                                safeResolve()
+                                                return
+                                            }
+                                            setTimeout(checkQuiescence, Math.min(EVENT_QUIESCENCE_MS - sinceLastEvent, 200))
+                                        }
+                                        setTimeout(checkQuiescence, 200)
                                     })
                                     .catch(reject)
                             })


### PR DESCRIPTION
## Summary
- Fix race condition where `sendPrompt()` resolves when E2B acknowledges the prompt, but streaming events arrive asynchronously — the `finally` block was calling `unsubscribe()` and `endAll()` before all events were delivered, dropping the tail of responses
- Add quiescence wait: after sendPrompt resolves, poll until no events arrive for 1.5s (capped at 10s) before cleaning up
- Reduce keepalive interval from 25s to 15s for better reverse proxy compatibility
- Move `KEEPALIVE_INTERVAL_MS` to module-level constant for consistency

## Test plan
- [ ] Send a chat message that triggers a long response — verify full response arrives without truncation
- [ ] Send a message that triggers tool calls — verify tool results stream completely
- [ ] Close browser tab during streaming — verify server cleans up correctly
- [ ] Switch tabs during streaming — verify stream continues uninterrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)