### PR TITLE
feat(cli): add OpenAPI-to-piece generator

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -359,6 +359,7 @@
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "*",
         "@activepieces/shared": "*",
+        "@apidevtools/swagger-parser": "^10.1.0",
         "axios": "1.15.0",
         "chalk": "4.1.2",
         "commander": "11.1.0",
@@ -366,11 +367,13 @@
         "dotenv": "17.2.3",
         "form-data": "4.0.4",
         "inquirer": "8.2.7",
+        "js-yaml": "^4.1.0",
         "jsonwebtoken": "9.0.1",
         "nanoid": "3.3.8",
         "tslib": "2.6.2",
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "24.11.0",
       },
     },
@@ -2574,6 +2577,16 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/flat": {
+      "name": "@activepieces/piece-flat",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/flipando": {
       "name": "@activepieces/piece-flipando",
       "version": "0.0.5",
@@ -2875,6 +2888,16 @@
         "@activepieces/pieces-framework": "workspace:*",
         "@activepieces/shared": "workspace:*",
         "tslib": "^2.3.0",
+      },
+    },
+    "packages/pieces/community/giphy": {
+      "name": "@activepieces/piece-giphy",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
       },
     },
     "packages/pieces/community/gistly": {
@@ -8775,6 +8798,8 @@
 
     "@activepieces/piece-fireflies-ai": ["@activepieces/piece-fireflies-ai@workspace:packages/pieces/community/fireflies-ai"],
 
+    "@activepieces/piece-flat": ["@activepieces/piece-flat@workspace:packages/pieces/community/flat"],
+
     "@activepieces/piece-flipando": ["@activepieces/piece-flipando@workspace:packages/pieces/community/flipando"],
 
     "@activepieces/piece-fliqr-ai": ["@activepieces/piece-fliqr-ai@workspace:packages/pieces/community/fliqr-ai"],
@@ -8834,6 +8859,8 @@
     "@activepieces/piece-ghostcms": ["@activepieces/piece-ghostcms@workspace:packages/pieces/community/ghostcms"],
 
     "@activepieces/piece-giftbit": ["@activepieces/piece-giftbit@workspace:packages/pieces/community/giftbit"],
+
+    "@activepieces/piece-giphy": ["@activepieces/piece-giphy@workspace:packages/pieces/community/giphy"],
 
     "@activepieces/piece-gistly": ["@activepieces/piece-gistly@workspace:packages/pieces/community/gistly"],
 
@@ -9799,7 +9826,13 @@
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.39.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg=="],
 
+    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.7.2", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA=="],
+
+    "@apidevtools/openapi-schemas": ["@apidevtools/openapi-schemas@2.1.0", "", {}, "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="],
+
     "@apidevtools/swagger-methods": ["@apidevtools/swagger-methods@3.0.2", "", {}, "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="],
+
+    "@apidevtools/swagger-parser": ["@apidevtools/swagger-parser@10.1.1", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "11.7.2", "@apidevtools/openapi-schemas": "^2.1.0", "@apidevtools/swagger-methods": "^3.0.2", "@jsdevtools/ono": "^7.1.3", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "call-me-maybe": "^1.0.2" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA=="],
 
     "@apify/consts": ["@apify/consts@2.52.1", "", {}, "sha512-Nhal8FiIgAw5ylVL4U2DAeJJyKow0bFObAX/og5BJjB9xJ2csQcyVAx4ChnO7XOaeRU8HbRn9u0QUGzPt5NNqA=="],
 
@@ -15977,7 +16010,7 @@
 
     "@dnd-kit/accessibility/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@dust-tt/client/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@github:dust-tt/typescript-sdk#bca26e4", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "dust-tt-typescript-sdk-bca26e4", "sha512-oxLE3SEGCVIhVNbn7xB9YgL7I6zrKujcH9s6e/1KcAj1VOht4lnM/oetqhwh9XhBh02cDHwkqHTzzIEBnBViiw=="],
+    "@dust-tt/client/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@github:dust-tt/typescript-sdk#bca26e4", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "dust-tt-typescript-sdk-bca26e4"],
 
     "@dust-tt/client/eventsource-parser": ["eventsource-parser@1.1.2", "", {}, "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA=="],
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "push-i18n": "crowdin upload sources",
     "i18n:extract": "i18next --config packages/web/i18next-parser.config.js",
     "bump-translated-pieces": "npx ts-node --project tools/tsconfig.tools.json tools/scripts/pieces/bump-translated-pieces.ts",
-    "bump-all-pieces-patch-version": "npx ts-node --project tools/tsconfig.tools.json tools/scripts/pieces/bump-all-pieces-patch-version.ts"
+    "bump-all-pieces-patch-version": "npx ts-node --project tools/tsconfig.tools.json tools/scripts/pieces/bump-all-pieces-patch-version.ts",
+    "create-piece-from-openapi": "npx ts-node -r tsconfig-paths/register --project packages/cli/tsconfig.json packages/cli/src/index.ts pieces from-openapi"
   },
   "private": true,
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,11 +20,14 @@
     "dotenv": "17.2.3",
     "form-data": "4.0.4",
     "inquirer": "8.2.7",
+    "@apidevtools/swagger-parser": "^10.1.0",
+    "js-yaml": "^4.1.0",
     "jsonwebtoken": "9.0.1",
     "nanoid": "3.3.8",
     "tslib": "2.6.2"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "24.11.0"
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { publishPieceCommand } from './lib/commands/publish-piece';
 import { buildPieceCommand } from './lib/commands/build-piece';
 import { generateWorkerTokenCommand } from './lib/commands/generate-worker-token';
 import { generateTranslationFileForAllPiecesCommand, generateTranslationFileForPieceCommand } from './lib/commands/generate-translation-file-for-piece';
+import { generateFromOpenApiCommand } from './lib/commands/generate-piece-from-openapi';
 
 const pieceCommand = new Command('pieces')
   .description('Manage pieces');
@@ -17,6 +18,7 @@ pieceCommand.addCommand(publishPieceCommand);
 pieceCommand.addCommand(buildPieceCommand);
 pieceCommand.addCommand(generateTranslationFileForPieceCommand);
 pieceCommand.addCommand(generateTranslationFileForAllPiecesCommand);
+pieceCommand.addCommand(generateFromOpenApiCommand);
 const actionCommand = new Command('actions')
   .description('Manage actions');
 

--- a/packages/cli/src/lib/commands/generate-piece-from-openapi.ts
+++ b/packages/cli/src/lib/commands/generate-piece-from-openapi.ts
@@ -1,0 +1,93 @@
+import chalk from 'chalk';
+import { Command } from 'commander';
+import inquirer from 'inquirer';
+import { join } from 'node:path';
+import { cwd } from 'node:process';
+import { orchestrator } from '../generate/orchestrator';
+import { checkIfFileExists } from '../utils/files';
+
+export const generateFromOpenApiCommand = new Command('from-openapi')
+  .description('Generate a piece from an OpenAPI specification')
+  .option('-s, --spec <path>', 'Path to OpenAPI spec (JSON or YAML)')
+  .option('-n, --name <name>', 'Piece slug name (e.g. mixmax)')
+  .option('-t, --type <type>', 'Piece type: community or custom', 'community')
+  .option('--tags <tags>', 'Comma-separated OpenAPI tags to include (e.g. "Contacts,Deals")')
+  .option('--dry-run', 'Print files without writing', false)
+  .action(async (options: { spec?: string; name?: string; type?: string; tags?: string; dryRun?: boolean }) => {
+    const answers = await gatherInputs({ options });
+    await runGeneration({ answers });
+  });
+
+async function gatherInputs({
+  options,
+}: {
+  options: { spec?: string; name?: string; type?: string; tags?: string; dryRun?: boolean };
+}): Promise<GenerationAnswers> {
+  const questions: inquirer.Question[] = [];
+
+  if (!options.spec) {
+    questions.push({
+      type: 'input',
+      name: 'spec',
+      message: 'Path to OpenAPI spec file (JSON or YAML):',
+    });
+  }
+
+  if (!options.name) {
+    questions.push({
+      type: 'input',
+      name: 'name',
+      message: 'Piece slug name (e.g. mixmax, my-api):',
+    });
+  }
+
+  const prompted = questions.length > 0 ? await inquirer.prompt(questions) : {};
+
+  const specPath = options.spec ?? (prompted as Record<string, string>)['spec'];
+  const pieceName = (options.name ?? (prompted as Record<string, string>)['name']).toLowerCase();
+  const pieceType = options.type ?? 'community';
+
+  const displayName = pieceName
+    .split('-')
+    .map(s => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(' ');
+
+  const packageName = `@activepieces/piece-${pieceName}`;
+  const outputDir = join(cwd(), 'packages', 'pieces', pieceType, pieceName);
+  const tags = options.tags ? options.tags.split(',').map(t => t.trim()).filter(Boolean) : undefined;
+
+  return { specPath, pieceName, packageName, displayName, outputDir, pieceType, tags, dryRun: options.dryRun ?? false };
+}
+
+async function runGeneration({ answers }: { answers: GenerationAnswers }): Promise<void> {
+  const { specPath, pieceName, packageName, displayName, outputDir, pieceType, tags, dryRun } = answers;
+
+  if (!dryRun) {
+    const exists = await checkIfFileExists(join(outputDir, 'package.json'));
+    if (exists) {
+      console.log(chalk.red(`🚨 Piece already exists at ${outputDir}. Use --dry-run to preview.`));
+      process.exit(1);
+    }
+  }
+
+  console.log(chalk.blue(`\nGenerating piece '${pieceName}' (${packageName})...`));
+
+  try {
+    await orchestrator.run({ specPath, pieceName, packageName, displayName, outputDir, pieceType, tags, dryRun });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.log(chalk.red(`\n🚨 Generation failed: ${msg}`));
+    process.exit(1);
+  }
+}
+
+type GenerationAnswers = {
+  specPath: string;
+  pieceName: string;
+  packageName: string;
+  displayName: string;
+  outputDir: string;
+  pieceType: string;
+  tags?: string[];
+  dryRun: boolean;
+};

--- a/packages/cli/src/lib/generate/auth-extractor.ts
+++ b/packages/cli/src/lib/generate/auth-extractor.ts
@@ -1,0 +1,41 @@
+import { ExtractedAuth, OpenAPISpec } from './types';
+
+export const authExtractor = { extract };
+
+function extract({ spec }: { spec: OpenAPISpec }): ExtractedAuth {
+  const schemes = spec.components?.securitySchemes;
+  if (!schemes || Object.keys(schemes).length === 0) return { kind: 'none' };
+
+  const [, scheme] = Object.entries(schemes)[0];
+
+  if (scheme.type === 'apiKey') {
+    const location = scheme.in ?? 'header';
+    return {
+      kind: 'apiKey',
+      location: location as 'header' | 'query' | 'cookie',
+      headerName: scheme.name ?? 'X-API-Key',
+    };
+  }
+
+  if (scheme.type === 'http') {
+    if (scheme.scheme === 'basic') return { kind: 'basic' };
+    return { kind: 'bearer' };
+  }
+
+  if (scheme.type === 'oauth2') {
+    const flow =
+      scheme.flows?.authorizationCode ??
+      scheme.flows?.clientCredentials ??
+      scheme.flows?.implicit;
+
+    if (!flow) return { kind: 'bearer' };
+
+    const authUrl = 'authorizationUrl' in flow ? flow.authorizationUrl : '';
+    const tokenUrl = 'tokenUrl' in flow ? flow.tokenUrl : '';
+    const scopes = Object.keys(flow.scopes ?? {});
+
+    return { kind: 'oauth2', authUrl, tokenUrl, scopes };
+  }
+
+  return { kind: 'none' };
+}

--- a/packages/cli/src/lib/generate/generators/action.ts
+++ b/packages/cli/src/lib/generate/generators/action.ts
@@ -1,0 +1,338 @@
+import { NormalizedOperation, NormalizedParam, GeneratorContext, MappedProperty, DynamicDropdownConfig } from '../types';
+
+export function generateAction({
+  op,
+  ctx,
+}: {
+  op: NormalizedOperation;
+  ctx: GeneratorContext;
+}): string {
+  const camel = toCamelCase(ctx.pieceName);
+  const authVarName = `${camel}Auth`;
+  const clientVarName = `${camel}ApiClient`;
+  const hasAuth = ctx.spec.auth.kind !== 'none';
+
+  const exportName = `${operationIdToCamel(op.operationId)}Action`;
+
+  const allProps = [...op.pathParams, ...op.queryParams];
+  const bodyProps = op.hasComplexBody ? [] : op.bodyParams;
+  // Body params win over query params with the same name (POST/PUT body is the primary input).
+  const bodyParamNames = new Set(bodyProps.map(p => p.name));
+  const deduplicatedAllProps = allProps.filter(p => !bodyParamNames.has(p.name));
+  const dynamicDropdowns = ctx.dynamicDropdowns ?? {};
+
+  const propsBlock = buildPropsBlock({
+    params: [...deduplicatedAllProps, ...bodyProps],
+    hasComplexBody: op.hasComplexBody,
+    dynamicDropdowns,
+    authVarName,
+    hasAuth,
+  });
+  const runBlock = buildRunBlock({ op, clientVarName, hasComplexBody: op.hasComplexBody, hasAuth });
+
+  const authImports = hasAuth ? `import { ${authVarName} } from '../auth';\n` : '';
+
+  return `import { createAction, Property } from '@activepieces/pieces-framework';
+${authImports}import { ${clientVarName} } from '../common';
+
+export const ${exportName} = createAction({${hasAuth ? `\n  auth: ${authVarName},` : ''}
+  name: '${op.actionName}',
+  displayName: '${escapeString(op.displayName)}',
+  description: '${escapeString(op.description)}',
+  props: {
+${propsBlock}  },
+  async run({ ${hasAuth ? 'auth, ' : ''}propsValue }) {
+${runBlock}  },
+});
+`;
+}
+
+function buildPropsBlock({
+  params,
+  hasComplexBody,
+  dynamicDropdowns,
+  authVarName,
+  hasAuth,
+}: {
+  params: NormalizedParam[];
+  hasComplexBody: boolean;
+  dynamicDropdowns: Record<string, DynamicDropdownConfig>;
+  authVarName: string;
+  hasAuth: boolean;
+}): string {
+  const lines = params.map(p => {
+    const dropdownConfig = dynamicDropdowns[p.name] ?? dynamicDropdowns[p.safeName];
+    if (dropdownConfig) {
+      return `    ${p.safeName}: ${buildDropdownCall({ param: p, config: dropdownConfig, authVarName, hasAuth })},`;
+    }
+    return `    ${p.safeName}: ${buildPropertyCall(p.mappedProperty)},`;
+  });
+
+  if (hasComplexBody) {
+    lines.push(`    body: Property.Json({
+      displayName: 'Request Body',
+      description: 'JSON body for this request.',
+      required: false,
+    }),`);
+  }
+
+  return lines.join('\n') + (lines.length > 0 ? '\n' : '');
+}
+
+function buildDropdownCall({
+  param,
+  config,
+  authVarName,
+  hasAuth,
+}: {
+  param: NormalizedParam;
+  config: DynamicDropdownConfig;
+  authVarName: string;
+  hasAuth: boolean;
+}): string {
+  const refreshers = config.refreshers && config.refreshers.length > 0
+    ? config.refreshers.map(r => `'${r}'`).join(', ')
+    : '';
+
+  const itemsExpr = config.itemsPath
+    ? buildItemsPathExpr(config.itemsPath)
+    : `Array.isArray(body) ? body as Record<string, unknown>[] : ((body['data'] ?? body['items'] ?? []) as Record<string, unknown>[])`;
+
+  const authProp = hasAuth ? `\n      auth: ${authVarName},` : '';
+  const authArg = hasAuth ? 'auth, ' : '';
+
+  return `Property.Dropdown({
+      displayName: '${escapeString(param.mappedProperty.displayName)}',
+      description: '${escapeString(param.mappedProperty.description)}',
+      required: ${param.required},${authProp}
+      refreshers: [${refreshers}],
+      options: async ({ auth }) => {
+        const response = await ${authVarName.replace('Auth', 'ApiClient')}.get({ ${authArg}endpoint: '${config.endpoint}' });
+        const body = response.body as Record<string, unknown>;
+        const items = ${itemsExpr};
+        return {
+          options: items.map(item => ({
+            label: String(item['${config.labelField}']),
+            value: item['${config.valueField}'],
+          })),
+        };
+      },
+    })`;
+}
+
+function buildItemsPathExpr(itemsPath: string): string {
+  const parts = itemsPath.split('.');
+  const chain = parts.reduce((acc, part) => `(${acc} as Record<string, unknown>)['${part}']`, 'body');
+  return `(${chain} ?? []) as Record<string, unknown>[]`;
+}
+
+function buildPropertyCall(prop: MappedProperty): string {
+  const defaultLine = prop.defaultValue !== undefined
+    ? `\n      defaultValue: ${JSON.stringify(prop.defaultValue)},`
+    : '';
+  const descLine = prop.description ? `\n      description: '${escapeString(prop.description)}',` : '';
+
+  switch (prop.propertyKind) {
+    case 'SHORT_TEXT':
+      return `Property.ShortText({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+    })`;
+
+    case 'LONG_TEXT':
+      return `Property.LongText({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+    })`;
+
+    case 'NUMBER':
+      return `Property.Number({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+    })`;
+
+    case 'CHECKBOX':
+      return `Property.Checkbox({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+    })`;
+
+    case 'DATE_TIME':
+      return `Property.DateTime({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+    })`;
+
+    case 'FILE':
+      return `Property.File({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},
+    })`;
+
+    case 'ARRAY':
+      return `Property.Array({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+    })`;
+
+    case 'OBJECT':
+      return `Property.Object({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+    })`;
+
+    case 'JSON':
+      return `Property.Json({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+    })`;
+
+    case 'STATIC_DROPDOWN': {
+      const opts = (prop.enumOptions ?? []).map(o => `{ label: '${escapeString(String(o.label))}', value: ${JSON.stringify(o.value)} }`).join(', ');
+      return `Property.StaticDropdown({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+      options: {
+        options: [${opts}],
+      },
+    })`;
+    }
+
+    case 'STATIC_MULTI_SELECT': {
+      const opts = (prop.enumOptions ?? []).map(o => `{ label: '${escapeString(String(o.label))}', value: ${JSON.stringify(o.value)} }`).join(', ');
+      return `Property.StaticMultiSelectDropdown({
+      displayName: '${escapeString(prop.displayName)}',${descLine}
+      required: ${prop.required},${defaultLine}
+      options: {
+        options: [${opts}],
+      },
+    })`;
+    }
+  }
+}
+
+function buildRunBlock({
+  op,
+  clientVarName,
+  hasComplexBody,
+  hasAuth,
+}: {
+  op: NormalizedOperation;
+  clientVarName: string;
+  hasComplexBody: boolean;
+  hasAuth: boolean;
+}): string {
+  const resolvedPath = op.pathParams.length > 0
+    ? buildInterpolatedPath(op.path, op.pathParams)
+    : `'${op.path}'`;
+
+  const authArg = hasAuth ? 'auth, ' : '';
+
+  const method = op.method.toLowerCase() as 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+  if (method === 'get') {
+    if (op.pagination) {
+      return buildPaginatedRun({ op, clientVarName, resolvedPath, authArg });
+    }
+
+    const queryEntries = op.queryParams.map(p => `        ${p.name}: propsValue.${p.safeName},`).join('\n');
+    const queryArg = op.queryParams.length > 0
+      ? `,\n      queryParams: {\n${queryEntries}\n      }`
+      : '';
+
+    return `    const response = await ${clientVarName}.get({
+      ${authArg}endpoint: ${resolvedPath}${queryArg},
+    });
+    return response.body;
+`;
+  }
+
+  if (method === 'delete') {
+    return `    const response = await ${clientVarName}.delete({
+      ${authArg}endpoint: ${resolvedPath},
+    });
+    return response.body;
+`;
+  }
+
+  const bodyContent = hasComplexBody
+    ? '...(propsValue.body as Record<string, unknown>)'
+    : op.bodyParams.map(p => `        ${p.name}: propsValue.${p.safeName},`).join('\n');
+
+  const bodyBlock = hasComplexBody
+    ? `body: { ${bodyContent} }`
+    : `body: {\n${bodyContent}\n      }`;
+
+  return `    const response = await ${clientVarName}.${method}({
+      ${authArg}endpoint: ${resolvedPath},
+      ${bodyBlock},
+    });
+    return response.body;
+`;
+}
+
+function buildInterpolatedPath(path: string, pathParams: NormalizedParam[]): string {
+  let result = path;
+  for (const p of pathParams) {
+    result = result.replace(`{${p.name}}`, `\${propsValue.${p.safeName}}`);
+  }
+  return '`' + result + '`';
+}
+
+function buildPaginatedRun({
+  op,
+  clientVarName,
+  resolvedPath,
+  authArg,
+}: {
+  op: NormalizedOperation;
+  clientVarName: string;
+  resolvedPath: string;
+  authArg: string;
+}): string {
+  const pagination = op.pagination!;
+  const strategy = pagination.strategy;
+  const cursorVar = strategy === 'page' ? 'page' : 'cursor';
+  const cursorInit = strategy === 'page' ? '1' : 'undefined';
+  const nextCursorExpr = strategy === 'page'
+    ? "typeof response.body === 'object' && response.body !== null ? (response.body as Record<string, unknown>)['has_more'] === true ? currentPage + 1 : undefined : undefined"
+    : "typeof response.body === 'object' && response.body !== null ? (response.body as Record<string, unknown>)['next_cursor'] as string | undefined : undefined";
+
+  return `    const allItems: unknown[] = [];
+    let ${cursorVar}: ${strategy === 'page' ? 'number' : 'string | undefined'} = ${cursorInit};
+    do {
+      const response = await ${clientVarName}.get({
+        ${authArg}endpoint: ${resolvedPath},
+        queryParams: {
+          ${pagination.limitParam}: propsValue.${op.queryParams.find(p => p.name === pagination.limitParam)?.safeName ?? 'limit'} ?? 100,
+          ${pagination.cursorParam}: ${cursorVar},
+        },
+      });
+      const body = response.body as Record<string, unknown>;
+      const items = Array.isArray(body['data']) ? body['data'] : (Array.isArray(body['items']) ? body['items'] : [body]);
+      allItems.push(...(items as unknown[]));
+      ${strategy === 'page' ? `const currentPage = ${cursorVar};
+      ` : ''}${cursorVar} = ${nextCursorExpr};
+    } while (${cursorVar});
+    return allItems;
+`;
+}
+
+function escapeString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, ' ');
+}
+
+function operationIdToCamel(id: string): string {
+  const camel = id.replace(/[-_](.)/g, (_, c: string) => c.toUpperCase()).replace(/^(.)/, c => c.toLowerCase());
+  return /^[0-9]/.test(camel) ? `p${camel}` : camel;
+}
+
+function toPascalCase(kebab: string): string {
+  const result = kebab.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('');
+  return /^[0-9]/.test(result) ? `P${result}` : result;
+}
+
+function toCamelCase(kebab: string): string {
+  const p = toPascalCase(kebab);
+  return p.charAt(0).toLowerCase() + p.slice(1);
+}

--- a/packages/cli/src/lib/generate/generators/auth.ts
+++ b/packages/cli/src/lib/generate/generators/auth.ts
@@ -1,0 +1,64 @@
+import { ExtractedAuth, GeneratorContext } from '../types';
+
+export function generateAuth({ ctx }: { ctx: GeneratorContext }): string {
+  const { auth } = ctx.spec;
+  const pascal = toPascalCase(ctx.pieceName);
+  const camel = toCamelCase(ctx.pieceName);
+  const authVarName = `${camel}Auth`;
+  const authTypeName = `${pascal}Auth`;
+
+  return `import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const ${authVarName} = ${buildAuthCall({ auth, pascal })};
+
+export type ${authTypeName} = typeof ${authVarName};
+`;
+}
+
+function buildAuthCall({ auth, pascal }: { auth: ExtractedAuth; pascal: string }): string {
+  switch (auth.kind) {
+    case 'apiKey':
+      return `PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your ${pascal} API key.',
+  required: true,
+})`;
+
+    case 'bearer':
+      return `PieceAuth.SecretText({
+  displayName: 'Bearer Token',
+  description: 'Your ${pascal} bearer token.',
+  required: true,
+})`;
+
+    case 'basic':
+      return `PieceAuth.BasicAuth({
+  displayName: 'Credentials',
+  required: true,
+  username: { displayName: 'Username' },
+  password: { displayName: 'Password' },
+})`;
+
+    case 'oauth2':
+      return `PieceAuth.OAuth2({
+  displayName: 'OAuth2 Connection',
+  required: true,
+  authUrl: '${auth.authUrl}',
+  tokenUrl: '${auth.tokenUrl}',
+  scope: [${auth.scopes.map(s => `'${s}'`).join(', ')}],
+})`;
+
+    case 'none':
+      return 'PieceAuth.None()';
+  }
+}
+
+function toPascalCase(kebab: string): string {
+  const result = kebab.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('');
+  return /^[0-9]/.test(result) ? `P${result}` : result;
+}
+
+function toCamelCase(kebab: string): string {
+  const pascal = toPascalCase(kebab);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}

--- a/packages/cli/src/lib/generate/generators/common.ts
+++ b/packages/cli/src/lib/generate/generators/common.ts
@@ -1,0 +1,161 @@
+import { ExtractedAuth, GeneratorContext } from '../types';
+
+export function generateCommon({ ctx }: { ctx: GeneratorContext }): string {
+  const { auth, baseUrl } = ctx.spec;
+  const camel = toCamelCase(ctx.pieceName);
+  const clientVarName = `${camel}ApiClient`;
+
+  const { importLine, authParamType } = buildAuthImport(auth);
+  const headersFn = buildHeadersFn({ auth, authParamType });
+  const hasAuth = auth.kind !== 'none';
+
+  return `import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+${importLine}
+export const ${clientVarName} = { get: getRequest, post: postRequest, put: putRequest, patch: patchRequest, delete: deleteRequest };
+
+async function getRequest({ auth, endpoint, queryParams }: GetParams) {
+  const url = new URL(\`\${BASE_URL}\${endpoint}\`);
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+  return httpClient.sendRequest({
+    method: HttpMethod.GET,
+    url: url.toString(),
+    headers: ${hasAuth ? 'buildHeaders(auth)' : '{}'},
+  });
+}
+
+async function postRequest({ auth, endpoint, body }: WriteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: \`\${BASE_URL}\${endpoint}\`,
+    headers: ${hasAuth ? 'buildHeaders(auth)' : "{ 'Content-Type': 'application/json' }"},
+    body,
+  });
+}
+
+async function putRequest({ auth, endpoint, body }: WriteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.PUT,
+    url: \`\${BASE_URL}\${endpoint}\`,
+    headers: ${hasAuth ? 'buildHeaders(auth)' : "{ 'Content-Type': 'application/json' }"},
+    body,
+  });
+}
+
+async function patchRequest({ auth, endpoint, body }: WriteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.PATCH,
+    url: \`\${BASE_URL}\${endpoint}\`,
+    headers: ${hasAuth ? 'buildHeaders(auth)' : "{ 'Content-Type': 'application/json' }"},
+    body,
+  });
+}
+
+async function deleteRequest({ auth, endpoint }: DeleteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.DELETE,
+    url: \`\${BASE_URL}\${endpoint}\`,
+    headers: ${hasAuth ? 'buildHeaders(auth)' : '{}'},
+  });
+}
+
+${headersFn}
+const BASE_URL = '${baseUrl}';
+
+${hasAuth ? buildParamTypes({ authParamType }) : buildNoAuthParamTypes()}`;
+}
+
+function buildAuthImport(auth: ExtractedAuth): { importLine: string; authParamType: string } {
+  switch (auth.kind) {
+    case 'oauth2':
+      return {
+        importLine: "import { OAuth2ConnectionValueWithApp } from '@activepieces/shared';",
+        authParamType: 'OAuth2ConnectionValueWithApp',
+      };
+    case 'bearer':
+    case 'apiKey':
+      return {
+        importLine: "import { SecretTextConnectionValue } from '@activepieces/shared';",
+        authParamType: 'SecretTextConnectionValue',
+      };
+    case 'basic':
+      return {
+        importLine: "import { BasicAuthConnectionValue } from '@activepieces/shared';",
+        authParamType: 'BasicAuthConnectionValue',
+      };
+    case 'none':
+      return { importLine: '', authParamType: 'never' };
+  }
+}
+
+function buildHeadersFn({ auth, authParamType }: { auth: ExtractedAuth; authParamType: string }): string {
+  switch (auth.kind) {
+    case 'apiKey':
+      if (auth.location === 'header') {
+        return `function buildHeaders(auth: ${authParamType}) {
+  return {
+    '${auth.headerName}': auth.secret_text,
+    'Content-Type': 'application/json',
+  };
+}`;
+      }
+      return `function buildHeaders(_auth: ${authParamType}) {
+  return { 'Content-Type': 'application/json' };
+}`;
+
+    case 'bearer':
+      return `function buildHeaders(auth: ${authParamType}) {
+  return {
+    'Authorization': \`Bearer \${auth.secret_text}\`,
+    'Content-Type': 'application/json',
+  };
+}`;
+
+    case 'basic':
+      return `function buildHeaders(auth: ${authParamType}) {
+  const encoded = Buffer.from(\`\${auth.username}:\${auth.password}\`).toString('base64');
+  return {
+    'Authorization': \`Basic \${encoded}\`,
+    'Content-Type': 'application/json',
+  };
+}`;
+
+    case 'oauth2':
+      return `function buildHeaders(auth: ${authParamType}) {
+  return {
+    'Authorization': \`Bearer \${auth.access_token}\`,
+    'Content-Type': 'application/json',
+  };
+}`;
+
+    case 'none':
+      return '';
+  }
+}
+
+function buildParamTypes({ authParamType }: { authParamType: string }): string {
+  return `type GetParams = { auth: ${authParamType}; endpoint: string; queryParams?: Record<string, unknown> };
+type WriteParams = { auth: ${authParamType}; endpoint: string; body: Record<string, unknown> };
+type DeleteParams = { auth: ${authParamType}; endpoint: string };`;
+}
+
+function buildNoAuthParamTypes(): string {
+  return `type GetParams = { auth?: never; endpoint: string; queryParams?: Record<string, unknown> };
+type WriteParams = { auth?: never; endpoint: string; body: Record<string, unknown> };
+type DeleteParams = { auth?: never; endpoint: string };`;
+}
+
+function toPascalCase(kebab: string): string {
+  const result = kebab.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('');
+  return /^[0-9]/.test(result) ? `P${result}` : result;
+}
+
+function toCamelCase(kebab: string): string {
+  const p = toPascalCase(kebab);
+  return p.charAt(0).toLowerCase() + p.slice(1);
+}

--- a/packages/cli/src/lib/generate/generators/piece-index.ts
+++ b/packages/cli/src/lib/generate/generators/piece-index.ts
@@ -1,0 +1,57 @@
+import { GeneratorContext } from '../types';
+
+export function generatePieceIndex({ ctx }: { ctx: GeneratorContext }): string {
+  const camel = toCamelCase(ctx.pieceName);
+  const hasAuth = ctx.spec.auth.kind !== 'none';
+  const authVarName = `${camel}Auth`;
+
+  const actionImports = ctx.spec.operations
+    .map(op => {
+      const exportName = `${operationIdToCamel(op.operationId)}Action`;
+      return `import { ${exportName} } from './lib/actions/${op.fileName}';`;
+    })
+    .join('\n');
+
+  const actionList = ctx.spec.operations
+    .map(op => {
+      const exportName = `${operationIdToCamel(op.operationId)}Action`;
+      return `    ${exportName},`;
+    })
+    .join('\n');
+
+  return `import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+${hasAuth ? `import { ${authVarName} } from './lib/auth';\n` : ''}${actionImports}
+
+export const ${camel} = createPiece({
+  displayName: '${ctx.displayName}',
+  description: '${escapeString(ctx.spec.description)}',
+  auth: ${hasAuth ? authVarName : 'PieceAuth.None()'},
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/${ctx.pieceName}.png',
+  authors: [],
+  actions: [
+${actionList}
+  ],
+  triggers: [],
+});
+`;
+}
+
+function escapeString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, ' ');
+}
+
+function operationIdToCamel(id: string): string {
+  const camel = id.replace(/[-_](.)/g, (_, c: string) => c.toUpperCase()).replace(/^(.)/, c => c.toLowerCase());
+  return /^[0-9]/.test(camel) ? `p${camel}` : camel;
+}
+
+function toPascalCase(kebab: string): string {
+  const result = kebab.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('');
+  return /^[0-9]/.test(result) ? `P${result}` : result;
+}
+
+function toCamelCase(kebab: string): string {
+  const p = toPascalCase(kebab);
+  return p.charAt(0).toLowerCase() + p.slice(1);
+}

--- a/packages/cli/src/lib/generate/generators/scaffolding.ts
+++ b/packages/cli/src/lib/generate/generators/scaffolding.ts
@@ -1,0 +1,71 @@
+import { GeneratorContext } from '../types';
+
+export function generateScaffolding({ ctx }: { ctx: GeneratorContext }): Record<string, string> {
+  const depth = ctx.pieceType === 'community' ? '../../../../' : '../../../';
+
+  const packageJson = {
+    name: ctx.packageName,
+    version: '0.0.1',
+    type: 'commonjs',
+    main: './dist/src/index.js',
+    types: './dist/src/index.d.ts',
+    dependencies: {
+      '@activepieces/pieces-common': 'workspace:*',
+      '@activepieces/pieces-framework': 'workspace:*',
+      '@activepieces/shared': 'workspace:*',
+      tslib: '2.6.2',
+    },
+    scripts: {
+      build: 'tsc -p tsconfig.lib.json && cp package.json dist/',
+      lint: "eslint 'src/**/*.ts'",
+    },
+  };
+
+  const tsconfig = {
+    extends: `${depth}tsconfig.base.json`,
+    compilerOptions: {
+      module: 'commonjs',
+      forceConsistentCasingInFileNames: true,
+      strict: true,
+      noImplicitOverride: true,
+      noPropertyAccessFromIndexSignature: true,
+      noImplicitReturns: true,
+      noFallthroughCasesInSwitch: true,
+    },
+    files: [],
+    include: [],
+    references: [{ path: './tsconfig.lib.json' }],
+  };
+
+  const tsconfigLib = {
+    extends: './tsconfig.json',
+    compilerOptions: {
+      rootDir: '.',
+      baseUrl: '.',
+      paths: {},
+      outDir: './dist',
+      declaration: true,
+      declarationMap: true,
+      types: ['node'],
+    },
+    include: ['src/**/*.ts'],
+    exclude: ['jest.config.ts', 'src/**/*.spec.ts', 'src/**/*.test.ts'],
+  };
+
+  const eslintConfig = {
+    extends: [`${depth}.eslintrc.json`],
+    ignorePatterns: ['!**/*'],
+    overrides: [
+      { files: ['*.ts', '*.tsx', '*.js', '*.jsx'], rules: {} },
+      { files: ['*.ts', '*.tsx'], rules: {} },
+      { files: ['*.js', '*.jsx'], rules: {} },
+    ],
+  };
+
+  return {
+    'package.json': JSON.stringify(packageJson, null, 2),
+    'tsconfig.json': JSON.stringify(tsconfig, null, 2),
+    'tsconfig.lib.json': JSON.stringify(tsconfigLib, null, 2),
+    '.eslintrc.json': JSON.stringify(eslintConfig, null, 2),
+  };
+}

--- a/packages/cli/src/lib/generate/loader.ts
+++ b/packages/cli/src/lib/generate/loader.ts
@@ -1,0 +1,36 @@
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+import SwaggerParser from '@apidevtools/swagger-parser';
+import yaml from 'js-yaml';
+import { OpenAPISpec } from './types';
+
+export const specLoader = { load };
+
+async function load({ filePath }: { filePath: string }): Promise<OpenAPISpec> {
+  const raw = await readFile(filePath, 'utf-8');
+  const ext = extname(filePath).toLowerCase();
+  const parsed = ext === '.json'
+    ? JSON.parse(raw) as Record<string, unknown>
+    : yaml.load(raw) as Record<string, unknown>;
+
+  // Strip vendor extension keys at every level before dereferencing so that
+  // swagger-parser does not follow $refs inside x-* fields (e.g. x-spotify-policy).
+  const cleaned = stripExtensions(parsed);
+
+  const api = await SwaggerParser.dereference(cleaned as Parameters<typeof SwaggerParser.dereference>[0], {
+    dereference: { circular: 'ignore' },
+  });
+  return api as unknown as OpenAPISpec;
+}
+
+function stripExtensions(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(stripExtensions);
+  if (node !== null && typeof node === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (!key.startsWith('x-')) out[key] = stripExtensions(value);
+    }
+    return out;
+  }
+  return node;
+}

--- a/packages/cli/src/lib/generate/op-extractor.ts
+++ b/packages/cli/src/lib/generate/op-extractor.ts
@@ -1,0 +1,239 @@
+import { NormalizedOperation, NormalizedParam, OpenAPISpec, OpenAPIOperation, OpenAPISchema, PaginationHint } from './types';
+import { schemaMapper } from './schema-mapper';
+
+export const opExtractor = { extract };
+
+const ALLOWED_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete']);
+const RESERVED_WORDS = new Set(['from', 'default', 'class', 'import', 'export', 'return', 'new', 'delete', 'type', 'in', 'of', 'for', 'if', 'else', 'function', 'const', 'let', 'var', 'this']);
+
+function extract({ spec, tags }: { spec: OpenAPISpec; tags?: string[] }): NormalizedOperation[] {
+  const operations: NormalizedOperation[] = [];
+  const usedNames = new Set<string>();
+  const tagFilter = tags && tags.length > 0 ? new Set(tags.map(t => t.toLowerCase())) : null;
+
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const [method, opRaw] of Object.entries(pathItem)) {
+      if (!ALLOWED_METHODS.has(method)) continue;
+      const op = opRaw as OpenAPIOperation;
+
+      if (tagFilter) {
+        const opTags = (op.tags ?? []).map(t => t.toLowerCase());
+        if (!opTags.some(t => tagFilter.has(t))) continue;
+      }
+
+      const operation = normalizeOperation({ op, path, method: method as NormalizedOperation['method'], usedNames });
+      if (operation) operations.push(operation);
+    }
+  }
+
+  return operations;
+}
+
+function normalizeOperation({
+  op,
+  path,
+  method,
+  usedNames,
+}: {
+  op: OpenAPIOperation;
+  path: string;
+  method: NormalizedOperation['method'];
+  usedNames: Set<string>;
+}): NormalizedOperation | null {
+  const rawId = op.operationId ?? deriveOperationId({ method, path });
+  const operationId = dedupeId({ id: rawId, used: usedNames });
+  usedNames.add(operationId);
+
+  const actionName = toSnakeCase(operationId);
+  const fileName = toKebabCase(operationId);
+
+  const pathParams = extractParams({ params: op.parameters ?? [], location: 'path' });
+  const queryParams = extractParams({ params: op.parameters ?? [], location: 'query' });
+
+  const { bodyParams, hasComplexBody, mediaType } = extractBody({ op });
+
+  const pagination = detectPagination({ queryParams });
+
+  return {
+    operationId,
+    actionName,
+    fileName,
+    method: method.toUpperCase() as NormalizedOperation['method'],
+    path,
+    displayName: op.summary ?? humanizeId(operationId),
+    description: op.description ?? op.summary ?? '',
+    pathParams,
+    queryParams,
+    bodyParams,
+    hasComplexBody,
+    mediaType,
+    deprecated: op.deprecated ?? false,
+    pagination,
+  };
+}
+
+function extractParams({
+  params,
+  location,
+}: {
+  params: Array<{ name: string; in: string; description?: string; required?: boolean; schema?: OpenAPISchema; deprecated?: boolean }>;
+  location: 'path' | 'query' | 'header';
+}): NormalizedParam[] {
+  return params
+    .filter(p => p.in === location && !p.deprecated)
+    .map(p => {
+      const safeName = makeSafeName(p.name);
+      return {
+        name: p.name,
+        safeName,
+        displayName: humanize(p.name),
+        description: p.description ?? '',
+        required: location === 'path' ? true : (p.required ?? false),
+        mappedProperty: schemaMapper.mapParam({
+          name: p.name,
+          schema: p.schema,
+          required: location === 'path' ? true : (p.required ?? false),
+          description: p.description ?? '',
+        }),
+      };
+    });
+}
+
+function extractBody({ op }: { op: OpenAPIOperation }): {
+  bodyParams: NormalizedParam[];
+  hasComplexBody: boolean;
+  mediaType: 'json' | 'form-data' | null;
+} {
+  if (!op.requestBody?.content) return { bodyParams: [], hasComplexBody: false, mediaType: null };
+
+  const content = op.requestBody.content;
+
+  if (content['application/json']?.schema) {
+    const schema = content['application/json'].schema as OpenAPISchema;
+    const { params, complex } = flattenSchemaToParams({ schema });
+    return { bodyParams: params, hasComplexBody: complex, mediaType: 'json' };
+  }
+
+  if (content['multipart/form-data']?.schema || content['application/x-www-form-urlencoded']?.schema) {
+    const schema = (content['multipart/form-data']?.schema ?? content['application/x-www-form-urlencoded']?.schema) as OpenAPISchema;
+    const { params, complex } = flattenSchemaToParams({ schema });
+    return { bodyParams: params, hasComplexBody: complex, mediaType: 'form-data' };
+  }
+
+  return { bodyParams: [], hasComplexBody: true, mediaType: 'json' };
+}
+
+function flattenSchemaToParams({ schema }: { schema: OpenAPISchema }): { params: NormalizedParam[]; complex: boolean } {
+  if (schema.type !== 'object' || !schema.properties) {
+    return { params: [], complex: true };
+  }
+
+  const requiredFields = new Set(schema.required ?? []);
+  const props = schema.properties;
+
+  if (Object.keys(props).length > 15) {
+    return { params: [], complex: true };
+  }
+
+  const params: NormalizedParam[] = Object.entries(props).map(([name, fieldSchema]) => {
+    const isRequired = requiredFields.has(name);
+    const safeName = makeSafeName(name);
+    return {
+      name,
+      safeName,
+      displayName: humanize(name),
+      description: fieldSchema.description ?? '',
+      required: isRequired,
+      mappedProperty: schemaMapper.mapSchema({
+        schema: fieldSchema,
+        required: isRequired,
+        displayName: humanize(name),
+        description: fieldSchema.description ?? '',
+      }),
+    };
+  });
+
+  return { params, complex: false };
+}
+
+function detectPagination({ queryParams }: { queryParams: NormalizedParam[] }): PaginationHint | null {
+  const names = queryParams.map(p => p.name.toLowerCase());
+  const hasLimit = names.some(n => ['limit', 'per_page', 'page_size', 'count'].includes(n));
+  const cursorParam = queryParams.find(p => ['cursor', 'next_cursor', 'after', 'page_token'].includes(p.name.toLowerCase()));
+  const offsetParam = queryParams.find(p => ['offset', 'skip', 'page'].includes(p.name.toLowerCase()));
+
+  if (!hasLimit) return null;
+
+  const limitParam = queryParams.find(p => ['limit', 'per_page', 'page_size', 'count'].includes(p.name.toLowerCase()))?.name ?? 'limit';
+
+  if (cursorParam) {
+    return { strategy: 'cursor', limitParam, cursorParam: cursorParam.name };
+  }
+  if (offsetParam) {
+    const strategy = offsetParam.name.toLowerCase() === 'page' ? 'page' : 'offset';
+    return { strategy, limitParam, cursorParam: offsetParam.name };
+  }
+
+  return null;
+}
+
+function deriveOperationId({ method, path }: { method: string; path: string }): string {
+  const segments = path
+    .split('/')
+    .filter(Boolean)
+    .map(s => s.replace(/[{}]/g, '').replace(/[^a-zA-Z0-9]/g, '_'))
+    .filter(Boolean);
+  return `${method}_${segments.join('_')}`;
+}
+
+function dedupeId({ id, used }: { id: string; used: Set<string> }): string {
+  if (!used.has(id)) return id;
+  let i = 2;
+  while (used.has(`${id}_${i}`)) i++;
+  return `${id}_${i}`;
+}
+
+function toSnakeCase(str: string): string {
+  return str
+    .replace(/([A-Z])/g, '_$1')
+    .replace(/[-\s]+/g, '_')
+    .toLowerCase()
+    .replace(/^_/, '');
+}
+
+function toKebabCase(str: string): string {
+  return toSnakeCase(str).replace(/_/g, '-');
+}
+
+function humanize(name: string): string {
+  return name
+    .replace(/[-_]/g, ' ')
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+
+function humanizeId(id: string): string {
+  return id
+    .replace(/[-_]/g, ' ')
+    .replace(/([A-Z])/g, ' $1')
+    .trim()
+    .split(' ')
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function makeSafeName(name: string): string {
+  let safe = name
+    .replace(/[-.\s]+(.)/g, (_, c: string) => c.toUpperCase())
+    .replace(/[^a-zA-Z0-9_]/g, '_');
+
+  if (/^[0-9]/.test(safe)) safe = '_' + safe;
+
+  if (RESERVED_WORDS.has(safe)) safe = safe + 'Value';
+
+  return safe;
+}

--- a/packages/cli/src/lib/generate/orchestrator.ts
+++ b/packages/cli/src/lib/generate/orchestrator.ts
@@ -1,0 +1,124 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import chalk from 'chalk';
+import { specLoader } from './loader';
+import { authExtractor } from './auth-extractor';
+import { opExtractor } from './op-extractor';
+import { DynamicDropdownConfig, GeneratorContext, ParsedSpec } from './types';
+import { generateAuth } from './generators/auth';
+import { generateCommon } from './generators/common';
+import { generateAction } from './generators/action';
+import { generatePieceIndex } from './generators/piece-index';
+import { generateScaffolding } from './generators/scaffolding';
+
+export const orchestrator = { run };
+
+async function run({
+  specPath,
+  pieceName,
+  packageName,
+  displayName,
+  outputDir,
+  pieceType,
+  tags,
+  dynamicDropdowns,
+  dryRun,
+}: {
+  specPath: string;
+  pieceName: string;
+  packageName: string;
+  displayName: string;
+  outputDir: string;
+  pieceType: string;
+  tags?: string[];
+  dynamicDropdowns?: Record<string, DynamicDropdownConfig>;
+  dryRun: boolean;
+}): Promise<void> {
+  console.log(chalk.blue(`Loading spec from ${specPath}...`));
+  const spec = await loadSpec({ specPath, displayName, tags });
+
+  const ctx: GeneratorContext = { spec, pieceName, packageName, displayName, outputDir, pieceType, dynamicDropdowns };
+
+  const files = collectFiles({ ctx });
+
+  if (dryRun) {
+    console.log(chalk.yellow('\n[dry-run] Files that would be generated:'));
+    for (const [path] of files) console.log(chalk.gray(`  ${path}`));
+    return;
+  }
+
+  await writeFiles({ files, outputDir });
+
+  console.log(chalk.green(`\n✨ Piece '${pieceName}' generated at ${outputDir}`));
+  console.log(chalk.yellow(`\nNext steps:`));
+  console.log(chalk.white(`  1. Review generated files`));
+  console.log(chalk.white(`  2. Add piece to tsconfig.base.json paths`));
+  console.log(chalk.white(`  3. Run: cd ${outputDir} && npm run build`));
+}
+
+async function loadSpec({
+  specPath,
+  displayName,
+  tags,
+}: {
+  specPath: string;
+  displayName: string;
+  tags?: string[];
+}): Promise<ParsedSpec> {
+  const raw = await specLoader.load({ filePath: specPath });
+  const auth = authExtractor.extract({ spec: raw });
+  const operations = opExtractor.extract({ spec: raw, tags });
+
+  const baseUrl = raw.servers?.[0]?.url ?? 'https://api.example.com';
+
+  console.log(chalk.blue(`  Auth: ${auth.kind}`));
+  console.log(chalk.blue(`  Operations: ${operations.length}`));
+
+  return {
+    title: raw.info.title,
+    description: raw.info.description ?? displayName,
+    version: raw.info.version,
+    baseUrl,
+    auth,
+    operations,
+  };
+}
+
+function collectFiles({ ctx }: { ctx: GeneratorContext }): Map<string, string> {
+  const files = new Map<string, string>();
+
+  const scaffolding = generateScaffolding({ ctx });
+  for (const [name, content] of Object.entries(scaffolding)) {
+    files.set(name, content);
+  }
+
+  if (ctx.spec.auth.kind !== 'none') {
+    files.set('src/lib/auth.ts', generateAuth({ ctx }));
+  }
+
+  files.set('src/lib/common.ts', generateCommon({ ctx }));
+
+  for (const op of ctx.spec.operations) {
+    files.set(`src/lib/actions/${op.fileName}.ts`, generateAction({ op, ctx }));
+  }
+
+  files.set('src/index.ts', generatePieceIndex({ ctx }));
+
+  return files;
+}
+
+async function writeFiles({
+  files,
+  outputDir,
+}: {
+  files: Map<string, string>;
+  outputDir: string;
+}): Promise<void> {
+  for (const [relativePath, content] of files) {
+    const fullPath = join(outputDir, relativePath);
+    const dir = fullPath.substring(0, fullPath.lastIndexOf('/'));
+    await mkdir(dir, { recursive: true });
+    await writeFile(fullPath, content, { encoding: 'utf-8' });
+    console.log(chalk.gray(`  wrote ${relativePath}`));
+  }
+}

--- a/packages/cli/src/lib/generate/schema-mapper.ts
+++ b/packages/cli/src/lib/generate/schema-mapper.ts
@@ -1,0 +1,120 @@
+import { MappedProperty, OpenAPISchema, EnumOption } from './types';
+
+export const schemaMapper = { mapParam, mapSchema };
+
+function mapParam({
+  name,
+  schema,
+  required,
+  description,
+}: {
+  name: string;
+  schema: OpenAPISchema | undefined;
+  required: boolean;
+  description: string;
+}): MappedProperty {
+  return mapSchema({ schema: schema ?? {}, required, displayName: humanize(name), description });
+}
+
+function mapSchema({
+  schema,
+  required,
+  displayName,
+  description,
+}: {
+  schema: OpenAPISchema;
+  required: boolean;
+  displayName: string;
+  description: string;
+}): MappedProperty {
+  const baseDescription = schema.description ?? description;
+  const defaultValue = schema.default;
+
+  if (schema.enum && schema.enum.length > 0) {
+    const enumOptions: EnumOption[] = schema.enum.map(v => ({
+      label: String(v),
+      value: v as string | number,
+    }));
+    return {
+      propertyKind: 'STATIC_DROPDOWN',
+      displayName,
+      description: baseDescription,
+      required,
+      defaultValue,
+      enumOptions,
+    };
+  }
+
+  if (schema.allOf || schema.anyOf || schema.oneOf) {
+    return { propertyKind: 'JSON', displayName, description: baseDescription, required, defaultValue };
+  }
+
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+
+  switch (type) {
+    case 'integer':
+    case 'number':
+      return { propertyKind: 'NUMBER', displayName, description: baseDescription, required, defaultValue };
+
+    case 'boolean':
+      return { propertyKind: 'CHECKBOX', displayName, description: baseDescription, required, defaultValue };
+
+    case 'array': {
+      const items = schema.items;
+      if (items?.enum && items.enum.length > 0) {
+        const enumOptions: EnumOption[] = items.enum.map(v => ({
+          label: String(v),
+          value: v as string | number,
+        }));
+        return {
+          propertyKind: 'STATIC_MULTI_SELECT',
+          displayName,
+          description: baseDescription,
+          required,
+          defaultValue,
+          enumOptions,
+        };
+      }
+      return { propertyKind: 'ARRAY', displayName, description: baseDescription, required, defaultValue };
+    }
+
+    case 'object':
+      if (schema.properties && isShallowObject(schema.properties)) {
+        return { propertyKind: 'OBJECT', displayName, description: baseDescription, required, defaultValue };
+      }
+      return { propertyKind: 'JSON', displayName, description: baseDescription, required, defaultValue };
+
+    case 'string':
+    default: {
+      const format = schema.format;
+      if (format === 'date' || format === 'date-time') {
+        return { propertyKind: 'DATE_TIME', displayName, description: baseDescription, required, defaultValue };
+      }
+      if (format === 'binary' || format === 'byte') {
+        return { propertyKind: 'FILE', displayName, description: baseDescription, required };
+      }
+      if (format === 'textarea' || (typeof schema.maxLength === 'number' && schema.maxLength > 500)) {
+        return { propertyKind: 'LONG_TEXT', displayName, description: baseDescription, required, defaultValue };
+      }
+      return { propertyKind: 'SHORT_TEXT', displayName, description: baseDescription, required, defaultValue };
+    }
+  }
+}
+
+function isShallowObject(properties: Record<string, OpenAPISchema>): boolean {
+  return Object.values(properties).every(
+    p => p.type !== 'object' && !p.properties && !p.allOf && !p.anyOf && !p.oneOf
+  );
+}
+
+function humanize(name: string): string {
+  return name
+    .replace(/[-_]/g, ' ')
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+

--- a/packages/cli/src/lib/generate/types.ts
+++ b/packages/cli/src/lib/generate/types.ts
@@ -1,0 +1,154 @@
+export type ExtractedAuth =
+  | { kind: 'apiKey'; location: 'header' | 'query' | 'cookie'; headerName: string }
+  | { kind: 'bearer' }
+  | { kind: 'basic' }
+  | { kind: 'oauth2'; authUrl: string; tokenUrl: string; scopes: string[] }
+  | { kind: 'none' };
+
+export type MappedPropertyKind =
+  | 'SHORT_TEXT' | 'LONG_TEXT' | 'NUMBER' | 'CHECKBOX'
+  | 'STATIC_DROPDOWN' | 'STATIC_MULTI_SELECT' | 'OBJECT'
+  | 'JSON' | 'ARRAY' | 'FILE' | 'DATE_TIME';
+
+export type EnumOption = { label: string; value: string | number };
+
+export type MappedProperty = {
+  propertyKind: MappedPropertyKind;
+  displayName: string;
+  description: string;
+  required: boolean;
+  defaultValue?: unknown;
+  enumOptions?: EnumOption[];
+};
+
+export type NormalizedParam = {
+  name: string;
+  safeName: string;
+  displayName: string;
+  description: string;
+  required: boolean;
+  mappedProperty: MappedProperty;
+};
+
+export type NormalizedOperation = {
+  operationId: string;
+  actionName: string;
+  fileName: string;
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  path: string;
+  displayName: string;
+  description: string;
+  pathParams: NormalizedParam[];
+  queryParams: NormalizedParam[];
+  bodyParams: NormalizedParam[];
+  hasComplexBody: boolean;
+  mediaType: 'json' | 'form-data' | null;
+  deprecated: boolean;
+  pagination: PaginationHint | null;
+};
+
+export type PaginationHint = {
+  strategy: 'offset' | 'cursor' | 'page';
+  limitParam: string;
+  cursorParam: string;
+};
+
+export type ParsedSpec = {
+  title: string;
+  description: string;
+  version: string;
+  baseUrl: string;
+  auth: ExtractedAuth;
+  operations: NormalizedOperation[];
+};
+
+export type DynamicDropdownConfig = {
+  endpoint: string;       // e.g. '/boards' — GET this to populate options
+  labelField: string;     // e.g. 'name' — response item field used as label
+  valueField: string;     // e.g. 'id' — response item field used as value
+  refreshers?: string[];  // prop names that trigger a refresh, e.g. ['workspaceId']
+  itemsPath?: string;     // dot-path into response body, e.g. 'data' or 'result.items'
+};
+
+export type GeneratorContext = {
+  spec: ParsedSpec;
+  pieceName: string;
+  packageName: string;
+  displayName: string;
+  outputDir: string;
+  pieceType: string;
+  // keyed by the OpenAPI field name (e.g. 'boardId')
+  dynamicDropdowns?: Record<string, DynamicDropdownConfig>;
+};
+
+export type OpenAPISchema = {
+  type?: string;
+  format?: string;
+  enum?: unknown[];
+  properties?: Record<string, OpenAPISchema>;
+  items?: OpenAPISchema;
+  required?: string[];
+  description?: string;
+  default?: unknown;
+  allOf?: OpenAPISchema[];
+  anyOf?: OpenAPISchema[];
+  oneOf?: OpenAPISchema[];
+  maxLength?: number;
+  nullable?: boolean;
+};
+
+export type OpenAPIParameter = {
+  name: string;
+  in: 'path' | 'query' | 'header' | 'cookie';
+  description?: string;
+  required?: boolean;
+  schema?: OpenAPISchema;
+  deprecated?: boolean;
+};
+
+export type OpenAPISecurityScheme = {
+  type: 'apiKey' | 'http' | 'oauth2' | 'openIdConnect';
+  in?: 'header' | 'query' | 'cookie';
+  name?: string;
+  scheme?: string;
+  flows?: {
+    authorizationCode?: {
+      authorizationUrl: string;
+      tokenUrl: string;
+      scopes: Record<string, string>;
+    };
+    clientCredentials?: {
+      tokenUrl: string;
+      scopes: Record<string, string>;
+    };
+    implicit?: {
+      authorizationUrl: string;
+      scopes: Record<string, string>;
+    };
+  };
+};
+
+export type OpenAPIOperation = {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  parameters?: OpenAPIParameter[];
+  requestBody?: {
+    required?: boolean;
+    content?: Record<string, { schema?: OpenAPISchema }>;
+  };
+  security?: Record<string, string[]>[];
+  tags?: string[];
+  deprecated?: boolean;
+};
+
+export type OpenAPISpec = {
+  info: { title: string; description?: string; version: string };
+  servers?: Array<{ url: string }>;
+  security?: Record<string, string[]>[];
+  components?: {
+    securitySchemes?: Record<string, OpenAPISecurityScheme>;
+    schemas?: Record<string, OpenAPISchema>;
+  };
+  paths?: Record<string, Record<string, OpenAPIOperation>>;
+};

--- a/packages/pieces/community/flat/.eslintrc.json
+++ b/packages/pieces/community/flat/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/flat/package.json
+++ b/packages/pieces/community/flat/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-flat",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/flat/src/index.ts
+++ b/packages/pieces/community/flat/src/index.ts
@@ -1,0 +1,32 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { flatAuth } from './lib/auth';
+import { listCollectionsAction } from './lib/actions/list-collections';
+import { createCollectionAction } from './lib/actions/create-collection';
+import { deleteCollectionAction } from './lib/actions/delete-collection';
+import { getCollectionAction } from './lib/actions/get-collection';
+import { editCollectionAction } from './lib/actions/edit-collection';
+import { listCollectionScoresAction } from './lib/actions/list-collection-scores';
+import { deleteScoreFromCollectionAction } from './lib/actions/delete-score-from-collection';
+import { addScoreToCollectionAction } from './lib/actions/add-score-to-collection';
+import { untrashCollectionAction } from './lib/actions/untrash-collection';
+
+export const flat = createPiece({
+  displayName: 'Flat',
+  description: 'The Flat API allows you to easily extend the abilities of the [Flat Platform](https://flat.io), with a wide range of use cases including the following:  * Creating and importing new music scores using MusicXML, MIDI, Guitar Pro (GP3, GP4, GP5, GPX, GP), PowerTab, TuxGuitar and MuseScore files * Browsing, updating, copying, exporting the user\'s scores (for example in MP3, WAV or MIDI) * Managing educational resources with Flat for Education: creating & updating the organization accounts, the classes, rosters and assignments.  The Flat API is built on HTTP. Our API is RESTful It has predictable resource URLs. It returns HTTP response codes to indicate errors. It also accepts and returns JSON in the HTTP body. The [schema](/swagger.yaml) of this API follows the [OpenAPI Initiative (OAI) specification](https://www.openapis.org/), you can use and work with [compatible Swagger tools](http://swagger.io/open-source-integrations/). This API features Cross-Origin Resource Sharing (CORS) implemented in compliance with [W3C spec](https://www.w3.org/TR/cors/).  You can use your favorite HTTP/REST library for your programming language to use Flat\'s API. This specification and reference is [available on Github](https://github.com/FlatIO/api-reference).  Getting Started and learn more:  * [API Overview and introduction](https://flat.io/developers/docs/api/) * [Authentication (Personal Access Tokens or OAuth2)](https://flat.io/developers/docs/api/authentication.html) * [SDKs](https://flat.io/developers/docs/api/sdks.html) * [Rate Limits](https://flat.io/developers/docs/api/rate-limits.html) * [Changelog](https://flat.io/developers/docs/api/changelog.html) ',
+  auth: flatAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/flat.png',
+  authors: [],
+  actions: [
+    listCollectionsAction,
+    createCollectionAction,
+    deleteCollectionAction,
+    getCollectionAction,
+    editCollectionAction,
+    listCollectionScoresAction,
+    deleteScoreFromCollectionAction,
+    addScoreToCollectionAction,
+    untrashCollectionAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/flat/src/lib/actions/add-score-to-collection.ts
+++ b/packages/pieces/community/flat/src/lib/actions/add-score-to-collection.ts
@@ -1,0 +1,21 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { flatAuth } from '../auth';
+import { flatApiClient } from '../common';
+
+export const addScoreToCollectionAction = createAction({
+  auth: flatAuth,
+  name: 'add_score_to_collection',
+  displayName: 'Add a score to the collection',
+  description: 'This operation will add a score to a collection. The default behavior will make the score available across multiple collections. You must have the capability `canAddScores` on the provided `collection` to perform the action. ',
+  props: {
+  },
+  async run({ auth, propsValue }) {
+    const response = await flatApiClient.put({
+      auth, endpoint: '/collections/{collection}/scores/{score}',
+      body: {
+
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flat/src/lib/actions/create-collection.ts
+++ b/packages/pieces/community/flat/src/lib/actions/create-collection.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { flatAuth } from '../auth';
+import { flatApiClient } from '../common';
+
+export const createCollectionAction = createAction({
+  auth: flatAuth,
+  name: 'create_collection',
+  displayName: 'Create a new collection',
+  description: 'This method will create a new collection and add it to your `root` collection. ',
+  props: {
+    privacy: Property.StaticDropdown({
+      displayName: 'Privacy',
+      description: 'The collection main privacy mode. - `private`: The collection is private and can be only accessed, modified and administred by specified collaborators users. ',
+      required: true,
+      options: {
+        options: [{ label: 'private', value: "private" }],
+      },
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The title of the collection',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await flatApiClient.post({
+      auth, endpoint: '/collections',
+      body: {
+        privacy: propsValue.privacy,
+        title: propsValue.title,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flat/src/lib/actions/delete-collection.ts
+++ b/packages/pieces/community/flat/src/lib/actions/delete-collection.ts
@@ -1,0 +1,18 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { flatAuth } from '../auth';
+import { flatApiClient } from '../common';
+
+export const deleteCollectionAction = createAction({
+  auth: flatAuth,
+  name: 'delete_collection',
+  displayName: 'Delete the collection',
+  description: 'This method will schedule the deletion of the collection. Until deleted, the collection will be available in the `trash`. ',
+  props: {
+  },
+  async run({ auth, propsValue }) {
+    const response = await flatApiClient.delete({
+      auth, endpoint: '/collections/{collection}',
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flat/src/lib/actions/delete-score-from-collection.ts
+++ b/packages/pieces/community/flat/src/lib/actions/delete-score-from-collection.ts
@@ -1,0 +1,18 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { flatAuth } from '../auth';
+import { flatApiClient } from '../common';
+
+export const deleteScoreFromCollectionAction = createAction({
+  auth: flatAuth,
+  name: 'delete_score_from_collection',
+  displayName: 'Delete a score from the collection',
+  description: 'This method will delete a score from the collection. Unlike [`DELETE /scores/{score}`](#operation/deleteScore), this score will not remove the score from your account, but only from the collection. This can be used to *move* a score from one collection to another, or simply remove a score from one collection when this one is contained in multiple collections. ',
+  props: {
+  },
+  async run({ auth, propsValue }) {
+    const response = await flatApiClient.delete({
+      auth, endpoint: '/collections/{collection}/scores/{score}',
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flat/src/lib/actions/edit-collection.ts
+++ b/packages/pieces/community/flat/src/lib/actions/edit-collection.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { flatAuth } from '../auth';
+import { flatApiClient } from '../common';
+
+export const editCollectionAction = createAction({
+  auth: flatAuth,
+  name: 'edit_collection',
+  displayName: 'Update a collection\'s metadata',
+  description: 'Update a collection\'s metadata',
+  props: {
+    privacy: Property.StaticDropdown({
+      displayName: 'Privacy',
+      description: 'The collection main privacy mode. - `private`: The collection is private and can be only accessed, modified and administred by specified collaborators users. ',
+      required: false,
+      options: {
+        options: [{ label: 'private', value: "private" }],
+      },
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The title of the collection',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await flatApiClient.put({
+      auth, endpoint: '/collections/{collection}',
+      body: {
+        privacy: propsValue.privacy,
+        title: propsValue.title,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flat/src/lib/actions/get-collection.ts
+++ b/packages/pieces/community/flat/src/lib/actions/get-collection.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { flatAuth } from '../auth';
+import { flatApiClient } from '../common';
+
+export const getCollectionAction = createAction({
+  auth: flatAuth,
+  name: 'get_collection',
+  displayName: 'Get collection details',
+  description: 'Get collection details',
+  props: {
+    sharingKey: Property.ShortText({
+      displayName: 'Sharing Key',
+      description: 'This sharing key must be specified to access to a score or collection with a `privacy` mode set to `privateLink` and the current user is not a collaborator of the document. ',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await flatApiClient.get({
+      auth, endpoint: '/collections/{collection}',
+      queryParams: {
+        sharingKey: propsValue.sharingKey,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flat/src/lib/actions/list-collection-scores.ts
+++ b/packages/pieces/community/flat/src/lib/actions/list-collection-scores.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { flatAuth } from '../auth';
+import { flatApiClient } from '../common';
+
+export const listCollectionScoresAction = createAction({
+  auth: flatAuth,
+  name: 'list_collection_scores',
+  displayName: 'List the scores contained in a collection',
+  description: 'Use this method to list the scores contained in a collection. If no sort option is provided, the scores are sorted by `modificationDate` `desc`. ',
+  props: {
+    sort: Property.StaticDropdown({
+      displayName: 'Sort',
+      description: 'Sort',
+      required: false,
+      options: {
+        options: [{ label: 'creationDate', value: "creationDate" }, { label: 'modificationDate', value: "modificationDate" }, { label: 'title', value: "title" }],
+      },
+    }),
+    direction: Property.StaticDropdown({
+      displayName: 'Direction',
+      description: 'Sort direction',
+      required: false,
+      options: {
+        options: [{ label: 'asc', value: "asc" }, { label: 'desc', value: "desc" }],
+      },
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'This is the maximum number of objects that may be returned',
+      required: false,
+      defaultValue: 25,
+    }),
+    next: Property.ShortText({
+      displayName: 'Next',
+      description: 'An opaque string cursor to fetch the next page of data. The paginated API URLs are returned in the `Link` header when requesting the API. These URLs will contain a `next` and `previous` cursor based on the available data. ',
+      required: false,
+    }),
+    previous: Property.ShortText({
+      displayName: 'Previous',
+      description: 'An opaque string cursor to fetch the previous page of data. The paginated API URLs are returned in the `Link` header when requesting the API. These URLs will contain a `next` and `previous` cursor based on the available data. ',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await flatApiClient.get({
+      auth, endpoint: '/collections/{collection}/scores',
+      queryParams: {
+        sort: propsValue.sort,
+        direction: propsValue.direction,
+        limit: propsValue.limit,
+        next: propsValue.next,
+        previous: propsValue.previous,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flat/src/lib/actions/list-collections.ts
+++ b/packages/pieces/community/flat/src/lib/actions/list-collections.ts
@@ -1,0 +1,64 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { flatAuth } from '../auth';
+import { flatApiClient } from '../common';
+
+export const listCollectionsAction = createAction({
+  auth: flatAuth,
+  name: 'list_collections',
+  displayName: 'List the collections',
+  description: 'Use this method to list the user\'s collections contained in `parent` (by default in the `root` collection). If no sort option is provided, the collections are sorted by `creationDate` `desc`.  Note that this method will not include the `parent` collection in the listing. For example, if you need the details of the `root` collection, you can use `GET /v2/collections/root`. ',
+  props: {
+    parent: Property.ShortText({
+      displayName: 'Parent',
+      description: 'List the collection contained in this `parent` collection.  This option doesn\'t provide a complete multi-level collection support. When sharing a collection with someone, this one will have as `parent` `sharedWithMe`. ',
+      required: false,
+      defaultValue: "root",
+    }),
+    sort: Property.StaticDropdown({
+      displayName: 'Sort',
+      description: 'Sort',
+      required: false,
+      options: {
+        options: [{ label: 'creationDate', value: "creationDate" }, { label: 'title', value: "title" }],
+      },
+    }),
+    direction: Property.StaticDropdown({
+      displayName: 'Direction',
+      description: 'Sort direction',
+      required: false,
+      options: {
+        options: [{ label: 'asc', value: "asc" }, { label: 'desc', value: "desc" }],
+      },
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'This is the maximum number of objects that may be returned',
+      required: false,
+      defaultValue: 25,
+    }),
+    next: Property.ShortText({
+      displayName: 'Next',
+      description: 'An opaque string cursor to fetch the next page of data. The paginated API URLs are returned in the `Link` header when requesting the API. These URLs will contain a `next` and `previous` cursor based on the available data. ',
+      required: false,
+    }),
+    previous: Property.ShortText({
+      displayName: 'Previous',
+      description: 'An opaque string cursor to fetch the previous page of data. The paginated API URLs are returned in the `Link` header when requesting the API. These URLs will contain a `next` and `previous` cursor based on the available data. ',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await flatApiClient.get({
+      auth, endpoint: '/collections',
+      queryParams: {
+        parent: propsValue.parent,
+        sort: propsValue.sort,
+        direction: propsValue.direction,
+        limit: propsValue.limit,
+        next: propsValue.next,
+        previous: propsValue.previous,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flat/src/lib/actions/untrash-collection.ts
+++ b/packages/pieces/community/flat/src/lib/actions/untrash-collection.ts
@@ -1,0 +1,21 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { flatAuth } from '../auth';
+import { flatApiClient } from '../common';
+
+export const untrashCollectionAction = createAction({
+  auth: flatAuth,
+  name: 'untrash_collection',
+  displayName: 'Untrash a collection',
+  description: 'This method will restore the collection by removing it from the `trash` and add it back to the `root` collection. ',
+  props: {
+  },
+  async run({ auth, propsValue }) {
+    const response = await flatApiClient.post({
+      auth, endpoint: '/collections/{collection}/untrash',
+      body: {
+
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/flat/src/lib/auth.ts
+++ b/packages/pieces/community/flat/src/lib/auth.ts
@@ -1,0 +1,11 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const flatAuth = PieceAuth.OAuth2({
+  displayName: 'OAuth2 Connection',
+  required: true,
+  authUrl: 'https://flat.io/auth/oauth',
+  tokenUrl: 'https://api.flat.io/oauth/access_token',
+  scope: ['account.education_profile', 'account.email', 'account.public_profile', 'collections', 'collections.add_scores', 'collections.readonly', 'edu.admin', 'edu.admin.lti', 'edu.admin.lti.readonly', 'edu.admin.users', 'edu.admin.users.readonly', 'edu.assignments', 'edu.assignments.readonly', 'edu.classes', 'edu.classes.readonly', 'scores', 'scores.readonly', 'scores.social'],
+});
+
+export type FlatAuth = typeof flatAuth;

--- a/packages/pieces/community/flat/src/lib/common.ts
+++ b/packages/pieces/community/flat/src/lib/common.ts
@@ -1,0 +1,66 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { OAuth2ConnectionValueWithApp } from '@activepieces/shared';
+export const flatApiClient = { get: getRequest, post: postRequest, put: putRequest, patch: patchRequest, delete: deleteRequest };
+
+async function getRequest({ auth, endpoint, queryParams }: GetParams) {
+  const url = new URL(`${BASE_URL}${endpoint}`);
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+  return httpClient.sendRequest({
+    method: HttpMethod.GET,
+    url: url.toString(),
+    headers: buildHeaders(auth),
+  });
+}
+
+async function postRequest({ auth, endpoint, body }: WriteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: `${BASE_URL}${endpoint}`,
+    headers: buildHeaders(auth),
+    body,
+  });
+}
+
+async function putRequest({ auth, endpoint, body }: WriteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.PUT,
+    url: `${BASE_URL}${endpoint}`,
+    headers: buildHeaders(auth),
+    body,
+  });
+}
+
+async function patchRequest({ auth, endpoint, body }: WriteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.PATCH,
+    url: `${BASE_URL}${endpoint}`,
+    headers: buildHeaders(auth),
+    body,
+  });
+}
+
+async function deleteRequest({ auth, endpoint }: DeleteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.DELETE,
+    url: `${BASE_URL}${endpoint}`,
+    headers: buildHeaders(auth),
+  });
+}
+
+function buildHeaders(auth: OAuth2ConnectionValueWithApp) {
+  return {
+    'Authorization': `Bearer ${auth.access_token}`,
+    'Content-Type': 'application/json',
+  };
+}
+const BASE_URL = 'https://api.flat.io/v2';
+
+type GetParams = { auth: OAuth2ConnectionValueWithApp; endpoint: string; queryParams?: Record<string, unknown> };
+type WriteParams = { auth: OAuth2ConnectionValueWithApp; endpoint: string; body: Record<string, unknown> };
+type DeleteParams = { auth: OAuth2ConnectionValueWithApp; endpoint: string };

--- a/packages/pieces/community/flat/tsconfig.json
+++ b/packages/pieces/community/flat/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/flat/tsconfig.lib.json
+++ b/packages/pieces/community/flat/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/packages/pieces/community/giphy/.eslintrc.json
+++ b/packages/pieces/community/giphy/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/giphy/package.json
+++ b/packages/pieces/community/giphy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-giphy",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/giphy/src/index.ts
+++ b/packages/pieces/community/giphy/src/index.ts
@@ -1,0 +1,34 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { giphyAuth } from './lib/auth';
+import { getGifsByIdAction } from './lib/actions/get-gifs-by-id';
+import { randomGifAction } from './lib/actions/random-gif';
+import { searchGifsAction } from './lib/actions/search-gifs';
+import { translateGifAction } from './lib/actions/translate-gif';
+import { trendingGifsAction } from './lib/actions/trending-gifs';
+import { getGifByIdAction } from './lib/actions/get-gif-by-id';
+import { randomStickerAction } from './lib/actions/random-sticker';
+import { searchStickersAction } from './lib/actions/search-stickers';
+import { translateStickerAction } from './lib/actions/translate-sticker';
+import { trendingStickersAction } from './lib/actions/trending-stickers';
+
+export const giphy = createPiece({
+  displayName: 'Giphy',
+  description: 'Giphy API',
+  auth: giphyAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/giphy.png',
+  authors: [],
+  actions: [
+    getGifsByIdAction,
+    randomGifAction,
+    searchGifsAction,
+    translateGifAction,
+    trendingGifsAction,
+    getGifByIdAction,
+    randomStickerAction,
+    searchStickersAction,
+    translateStickerAction,
+    trendingStickersAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/giphy/src/lib/actions/get-gif-by-id.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/get-gif-by-id.ts
@@ -1,0 +1,23 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const getGifByIdAction = createAction({
+  auth: giphyAuth,
+  name: 'get_gif_by_id',
+  displayName: 'Get GIF by Id',
+  description: 'Returns a GIF given that GIF\'s unique ID ',
+  props: {
+    gifId: Property.Number({
+      displayName: 'Gif Id',
+      description: 'Filters results by specified GIF ID.',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await giphyApiClient.get({
+      auth, endpoint: `/gifs/${propsValue.gifId}`,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/actions/get-gifs-by-id.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/get-gifs-by-id.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const getGifsByIdAction = createAction({
+  auth: giphyAuth,
+  name: 'get_gifs_by_id',
+  displayName: 'Get GIFs by ID',
+  description: 'A multiget version of the get GIF by ID endpoint. ',
+  props: {
+    ids: Property.ShortText({
+      displayName: 'Ids',
+      description: 'Filters results by specified GIF IDs, separated by commas.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await giphyApiClient.get({
+      auth, endpoint: '/gifs',
+      queryParams: {
+        ids: propsValue.ids,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/actions/random-gif.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/random-gif.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const randomGifAction = createAction({
+  auth: giphyAuth,
+  name: 'random_gif',
+  displayName: 'Random GIF',
+  description: 'Returns a random GIF, limited by tag. Excluding the tag parameter will return a random GIF from the GIPHY catalog. ',
+  props: {
+    tag: Property.ShortText({
+      displayName: 'Tag',
+      description: 'Filters results by specified tag.',
+      required: false,
+    }),
+    rating: Property.ShortText({
+      displayName: 'Rating',
+      description: 'Filters results by specified rating.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await giphyApiClient.get({
+      auth, endpoint: '/gifs/random',
+      queryParams: {
+        tag: propsValue.tag,
+        rating: propsValue.rating,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/actions/random-sticker.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/random-sticker.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const randomStickerAction = createAction({
+  auth: giphyAuth,
+  name: 'random_sticker',
+  displayName: 'Random Sticker',
+  description: 'Returns a random GIF, limited by tag. Excluding the tag parameter will return a random GIF from the GIPHY catalog. ',
+  props: {
+    tag: Property.ShortText({
+      displayName: 'Tag',
+      description: 'Filters results by specified tag.',
+      required: false,
+    }),
+    rating: Property.ShortText({
+      displayName: 'Rating',
+      description: 'Filters results by specified rating.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await giphyApiClient.get({
+      auth, endpoint: '/stickers/random',
+      queryParams: {
+        tag: propsValue.tag,
+        rating: propsValue.rating,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/actions/search-gifs.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/search-gifs.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const searchGifsAction = createAction({
+  auth: giphyAuth,
+  name: 'search_gifs',
+  displayName: 'Search GIFs',
+  description: 'Search all GIPHY GIFs for a word or phrase. Punctuation will be stripped and ignored.  Use a plus or url encode for phrases. Example paul+rudd, ryan+gosling or american+psycho. ',
+  props: {
+    q: Property.ShortText({
+      displayName: 'Q',
+      description: 'Search query term or prhase.',
+      required: true,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'The maximum number of records to return.',
+      required: false,
+      defaultValue: 25,
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      description: 'An optional results offset.',
+      required: false,
+      defaultValue: 0,
+    }),
+    rating: Property.ShortText({
+      displayName: 'Rating',
+      description: 'Filters results by specified rating.',
+      required: false,
+    }),
+    lang: Property.ShortText({
+      displayName: 'Lang',
+      description: 'Specify default language for regional content; use a 2-letter ISO 639-1 language code.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const allItems: unknown[] = [];
+    let cursor: string | undefined = undefined;
+    do {
+      const response = await giphyApiClient.get({
+        auth, endpoint: '/gifs/search',
+        queryParams: {
+          limit: propsValue.limit ?? 100,
+          offset: cursor,
+        },
+      });
+      const body = response.body as Record<string, unknown>;
+      const items = Array.isArray(body['data']) ? body['data'] : (Array.isArray(body['items']) ? body['items'] : [body]);
+      allItems.push(...(items as unknown[]));
+      cursor = typeof response.body === 'object' && response.body !== null ? (response.body as Record<string, unknown>)['next_cursor'] as string | undefined : undefined;
+    } while (cursor);
+    return allItems;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/actions/search-stickers.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/search-stickers.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const searchStickersAction = createAction({
+  auth: giphyAuth,
+  name: 'search_stickers',
+  displayName: 'Search Stickers',
+  description: 'Replicates the functionality and requirements of the classic GIPHY search, but returns animated stickers rather than GIFs. ',
+  props: {
+    q: Property.ShortText({
+      displayName: 'Q',
+      description: 'Search query term or prhase.',
+      required: true,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'The maximum number of records to return.',
+      required: false,
+      defaultValue: 25,
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      description: 'An optional results offset.',
+      required: false,
+      defaultValue: 0,
+    }),
+    rating: Property.ShortText({
+      displayName: 'Rating',
+      description: 'Filters results by specified rating.',
+      required: false,
+    }),
+    lang: Property.ShortText({
+      displayName: 'Lang',
+      description: 'Specify default language for regional content; use a 2-letter ISO 639-1 language code.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const allItems: unknown[] = [];
+    let cursor: string | undefined = undefined;
+    do {
+      const response = await giphyApiClient.get({
+        auth, endpoint: '/stickers/search',
+        queryParams: {
+          limit: propsValue.limit ?? 100,
+          offset: cursor,
+        },
+      });
+      const body = response.body as Record<string, unknown>;
+      const items = Array.isArray(body['data']) ? body['data'] : (Array.isArray(body['items']) ? body['items'] : [body]);
+      allItems.push(...(items as unknown[]));
+      cursor = typeof response.body === 'object' && response.body !== null ? (response.body as Record<string, unknown>)['next_cursor'] as string | undefined : undefined;
+    } while (cursor);
+    return allItems;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/actions/translate-gif.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/translate-gif.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const translateGifAction = createAction({
+  auth: giphyAuth,
+  name: 'translate_gif',
+  displayName: 'Translate phrase to GIF',
+  description: 'The translate API draws on search, but uses the GIPHY `special sauce` to handle translating from one vocabulary to another. In this case, words and phrases to GIF ',
+  props: {
+    s: Property.ShortText({
+      displayName: 'S',
+      description: 'Search term.',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await giphyApiClient.get({
+      auth, endpoint: '/gifs/translate',
+      queryParams: {
+        s: propsValue.s,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/actions/translate-sticker.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/translate-sticker.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const translateStickerAction = createAction({
+  auth: giphyAuth,
+  name: 'translate_sticker',
+  displayName: 'Translate phrase to Sticker',
+  description: 'The translate API draws on search, but uses the GIPHY `special sauce` to handle translating from one vocabulary to another. In this case, words and phrases to GIFs. ',
+  props: {
+    s: Property.ShortText({
+      displayName: 'S',
+      description: 'Search term.',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const response = await giphyApiClient.get({
+      auth, endpoint: '/stickers/translate',
+      queryParams: {
+        s: propsValue.s,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/actions/trending-gifs.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/trending-gifs.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const trendingGifsAction = createAction({
+  auth: giphyAuth,
+  name: 'trending_gifs',
+  displayName: 'Trending GIFs',
+  description: 'Fetch GIFs currently trending online. Hand curated by the GIPHY editorial team.  The data returned mirrors the GIFs showcased on the GIPHY homepage. Returns 25 results by default. ',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'The maximum number of records to return.',
+      required: false,
+      defaultValue: 25,
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      description: 'An optional results offset.',
+      required: false,
+      defaultValue: 0,
+    }),
+    rating: Property.ShortText({
+      displayName: 'Rating',
+      description: 'Filters results by specified rating.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const allItems: unknown[] = [];
+    let cursor: string | undefined = undefined;
+    do {
+      const response = await giphyApiClient.get({
+        auth, endpoint: '/gifs/trending',
+        queryParams: {
+          limit: propsValue.limit ?? 100,
+          offset: cursor,
+        },
+      });
+      const body = response.body as Record<string, unknown>;
+      const items = Array.isArray(body['data']) ? body['data'] : (Array.isArray(body['items']) ? body['items'] : [body]);
+      allItems.push(...(items as unknown[]));
+      cursor = typeof response.body === 'object' && response.body !== null ? (response.body as Record<string, unknown>)['next_cursor'] as string | undefined : undefined;
+    } while (cursor);
+    return allItems;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/actions/trending-stickers.ts
+++ b/packages/pieces/community/giphy/src/lib/actions/trending-stickers.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { giphyAuth } from '../auth';
+import { giphyApiClient } from '../common';
+
+export const trendingStickersAction = createAction({
+  auth: giphyAuth,
+  name: 'trending_stickers',
+  displayName: 'Trending Stickers',
+  description: 'Fetch Stickers currently trending online. Hand curated by the GIPHY editorial team. Returns 25 results by default. ',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'The maximum number of records to return.',
+      required: false,
+      defaultValue: 25,
+    }),
+    offset: Property.Number({
+      displayName: 'Offset',
+      description: 'An optional results offset.',
+      required: false,
+      defaultValue: 0,
+    }),
+    rating: Property.ShortText({
+      displayName: 'Rating',
+      description: 'Filters results by specified rating.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const allItems: unknown[] = [];
+    let cursor: string | undefined = undefined;
+    do {
+      const response = await giphyApiClient.get({
+        auth, endpoint: '/stickers/trending',
+        queryParams: {
+          limit: propsValue.limit ?? 100,
+          offset: cursor,
+        },
+      });
+      const body = response.body as Record<string, unknown>;
+      const items = Array.isArray(body['data']) ? body['data'] : (Array.isArray(body['items']) ? body['items'] : [body]);
+      allItems.push(...(items as unknown[]));
+      cursor = typeof response.body === 'object' && response.body !== null ? (response.body as Record<string, unknown>)['next_cursor'] as string | undefined : undefined;
+    } while (cursor);
+    return allItems;
+  },
+});

--- a/packages/pieces/community/giphy/src/lib/auth.ts
+++ b/packages/pieces/community/giphy/src/lib/auth.ts
@@ -1,0 +1,9 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const giphyAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'Your Giphy API key.',
+  required: true,
+});
+
+export type GiphyAuth = typeof giphyAuth;

--- a/packages/pieces/community/giphy/src/lib/common.ts
+++ b/packages/pieces/community/giphy/src/lib/common.ts
@@ -1,0 +1,63 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { SecretTextConnectionValue } from '@activepieces/shared';
+export const giphyApiClient = { get: getRequest, post: postRequest, put: putRequest, patch: patchRequest, delete: deleteRequest };
+
+async function getRequest({ auth, endpoint, queryParams }: GetParams) {
+  const url = new URL(`${BASE_URL}${endpoint}`);
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+  return httpClient.sendRequest({
+    method: HttpMethod.GET,
+    url: url.toString(),
+    headers: buildHeaders(auth),
+  });
+}
+
+async function postRequest({ auth, endpoint, body }: WriteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: `${BASE_URL}${endpoint}`,
+    headers: buildHeaders(auth),
+    body,
+  });
+}
+
+async function putRequest({ auth, endpoint, body }: WriteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.PUT,
+    url: `${BASE_URL}${endpoint}`,
+    headers: buildHeaders(auth),
+    body,
+  });
+}
+
+async function patchRequest({ auth, endpoint, body }: WriteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.PATCH,
+    url: `${BASE_URL}${endpoint}`,
+    headers: buildHeaders(auth),
+    body,
+  });
+}
+
+async function deleteRequest({ auth, endpoint }: DeleteParams) {
+  return httpClient.sendRequest({
+    method: HttpMethod.DELETE,
+    url: `${BASE_URL}${endpoint}`,
+    headers: buildHeaders(auth),
+  });
+}
+
+function buildHeaders(_auth: SecretTextConnectionValue) {
+  return { 'Content-Type': 'application/json' };
+}
+const BASE_URL = 'https://api.giphy.com/v1';
+
+type GetParams = { auth: SecretTextConnectionValue; endpoint: string; queryParams?: Record<string, unknown> };
+type WriteParams = { auth: SecretTextConnectionValue; endpoint: string; body: Record<string, unknown> };
+type DeleteParams = { auth: SecretTextConnectionValue; endpoint: string };

--- a/packages/pieces/community/giphy/tsconfig.json
+++ b/packages/pieces/community/giphy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/giphy/tsconfig.lib.json
+++ b/packages/pieces/community/giphy/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -421,6 +421,9 @@
       "@activepieces/piece-figma": [
         "packages/pieces/community/figma/src/index.ts"
       ],
+      "@activepieces/piece-flat": [
+        "packages/pieces/community/flat/src/index.ts"
+      ],
       "@activepieces/piece-file-helper": [
         "packages/pieces/core/file-helper/src/index.ts"
       ],
@@ -490,6 +493,9 @@
       ],
       "@activepieces/piece-ghostcms": [
         "packages/pieces/community/ghostcms/src/index.ts"
+      ],
+      "@activepieces/piece-giphy": [
+        "packages/pieces/community/giphy/src/index.ts"
       ],
       "@activepieces/piece-github": [
         "packages/pieces/community/github/src/index.ts"


### PR DESCRIPTION
 This have been on the works for awhile now, I got the idea after I saw this n8n repo: https://github.com/oneflow-ai/create-n8n-nodes/blob/main/README.md, and thought its a great thing to have, AI still makes alot of mistakes even when given docs, and we have to do alot of back and forth with it, I think with this, round trips with AI pieces implementation would reduce. 
   
   
   Adds  CLI command that scaffolds a fully typed
   Activepieces piece from any OpenAPI 3.x spec.

   - Parses specs via @apidevtools/swagger-parser with x-* vendor extension stripping to avoid broken external  (e.g. Spotify policies.yaml)
   - Extracts auth (bearer → SecretText, OAuth2, basic, apiKey) and maps to the correct PieceAuth variant with proper runtime connection value types (OAuth2ConnectionValueWithApp, SecretTextConnectionValue, etc.)
   - Normalises operations: path/query/body params, duplicate deduplication (body wins over query), pagination detection (cursor/offset/page), complex body fallback to Property.Json
   - Generates auth.ts, common.ts, per-action files, piece index, and all scaffolding (package.json, tsconfig, eslintrc)
   - Supports --tags for filtering by OpenAPI tag, --dry-run for preview, and config-driven dynamic dropdowns via DynamicDropdownConfig
   - Includes two sample pieces built from real public specs:
       - giphy (API key / query param, 10 actions)
       - flat (OAuth2 authorizationCode, 9 actions)