### PR TITLE
fix(server): always revalidate index.html to avoid stale assets behind Cloudflare

### DIFF
--- a/packages/server/api/src/app/server.ts
+++ b/packages/server/api/src/app/server.ts
@@ -66,7 +66,7 @@ export const setupServer = async (): Promise<FastifyInstance> => {
             setHeaders: (res, filepath) => {
                 const normalized = filepath.replace(/\\/g, '/')
                 if (normalized.endsWith('.html')) {
-                    void res.setHeader('Cache-Control', 'public, max-age=120')
+                    void res.setHeader('Cache-Control', 'no-cache')
                 }
                 else if (normalized.includes('/assets/')) {
                     void res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')

--- a/packages/server/api/src/app/server.ts
+++ b/packages/server/api/src/app/server.ts
@@ -64,11 +64,15 @@ export const setupServer = async (): Promise<FastifyInstance> => {
         await app.register(fastifyStatic, {
             root: frontendPath,
             setHeaders: (res, filepath) => {
-                if (filepath.endsWith('.html')) {
-                    void res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
+                const normalized = filepath.replace(/\\/g, '/')
+                if (normalized.endsWith('.html')) {
+                    void res.setHeader('Cache-Control', 'public, max-age=120')
+                }
+                else if (normalized.includes('/assets/')) {
+                    void res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
                 }
                 else {
-                    void res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+                    void res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
                 }
             },
         })

--- a/packages/server/api/src/app/server.ts
+++ b/packages/server/api/src/app/server.ts
@@ -65,7 +65,7 @@ export const setupServer = async (): Promise<FastifyInstance> => {
             root: frontendPath,
             setHeaders: (res, filepath) => {
                 if (filepath.endsWith('.html')) {
-                    void res.setHeader('Cache-Control', 'public, max-age=120')
+                    void res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
                 }
                 else {
                     void res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')


### PR DESCRIPTION
## Summary

After deploys, users behind Cloudflare were occasionally seeing **unstyled pages** with the browser logging:

> Refused to apply style from '…/assets/index-XXXX.css' because its MIME type ('application/json') is not a supported stylesheet MIME type.

**Root cause.** `index.html` was served with `Cache-Control: public, max-age=120`, so for up to two minutes after a deploy Cloudflare's edge could keep returning a stale `index.html` whose hashed asset URLs (e.g. `/assets/index-OLDHASH.js`) no longer existed at the origin. The browser then requested those vanished hashes, our `setNotFoundHandler` returned a JSON 404 body, and the browser refused to load JSON as JS/CSS — boom, unstyled page.

**Fix.** Switch the HTML cache header to `no-cache`. Browsers and CDNs may store the file but must revalidate against the origin every time, so stale HTML can never reference dead asset hashes. `fastify-static`'s ETag handling keeps the common case to a cheap 304. Hashed `/assets/*` files keep their 1-year `immutable` cache; all other static files revalidate via `public, max-age=0, must-revalidate`.

## Test plan

- [ ] Deploy two builds back-to-back; confirm the second build's users get the fresh `index.html` immediately (no 2-minute window of broken styles).
- [ ] `curl -I https://<host>/index.html` → `Cache-Control: no-cache`.
- [ ] `curl -I https://<host>/assets/<hashed>.js` → `Cache-Control: public, max-age=31536000, immutable` (unchanged).
- [ ] Repeated page loads issue conditional `If-None-Match` requests and receive `304 Not Modified` (verify in devtools network tab).