### PR TITLE
feat(piece): add Chess.com community piece

### DIFF
--- a/packages/pieces/community/chess-com/package.json
+++ b/packages/pieces/community/chess-com/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-chess-com",
+  "version": "0.1.5",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/chess-com/src/index.ts
+++ b/packages/pieces/community/chess-com/src/index.ts
@@ -1,0 +1,16 @@
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { getPlayerProfile } from './lib/actions/get-player-profile';
+import { getPlayerStats } from './lib/actions/get-player-stats';
+import { getDailyPuzzle } from './lib/actions/get-daily-puzzle';
+
+export const chesscom = createPiece({
+  displayName: 'Chess.com',
+  description: 'Access Chess.com player data',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/chess-com.png',
+  categories: [],
+  authors: ['FionnHughes'],
+  actions: [getPlayerProfile, getPlayerStats, getDailyPuzzle],
+  triggers: [],
+});

--- a/packages/pieces/community/chess-com/src/lib/actions/get-daily-puzzle.ts
+++ b/packages/pieces/community/chess-com/src/lib/actions/get-daily-puzzle.ts
@@ -1,0 +1,16 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getDailyPuzzle = createAction({
+  name: 'get_daily_puzzle',
+  displayName: 'Get Daily Puzzle',
+  description: "Retrieve today's Chess.com daily puzzle.",
+  props: {},
+  async run() {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.chess.com/pub/puzzle',
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/chess-com/src/lib/actions/get-player-profile.ts
+++ b/packages/pieces/community/chess-com/src/lib/actions/get-player-profile.ts
@@ -1,0 +1,22 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getPlayerProfile = createAction({
+  name: 'get_player_profile',
+  displayName: 'Get Player Profile',
+  description: 'Retrieve a Chess.com player profile by username.',
+  props: {
+    username: Property.ShortText({
+      displayName: 'Username',
+      description: 'The Chess.com username to look up.',
+      required: true,
+    }),
+  },
+  async run({ propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.chess.com/pub/player/${propsValue.username}`,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/chess-com/src/lib/actions/get-player-stats.ts
+++ b/packages/pieces/community/chess-com/src/lib/actions/get-player-stats.ts
@@ -1,0 +1,22 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getPlayerStats = createAction({
+  name: 'get_player_stats',
+  displayName: 'Get Player Stats',
+  description: 'Retrieve ratings and statistics for a Chess.com player.',
+  props: {
+    username: Property.ShortText({
+      displayName: 'Username',
+      description: 'The Chess.com username to look up.',
+      required: true,
+    }),
+  },
+  async run({ propsValue }) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.chess.com/pub/player/${propsValue.username}/stats`,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/chess-com/tsconfig.json
+++ b/packages/pieces/community/chess-com/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/chess-com/tsconfig.lib.json
+++ b/packages/pieces/community/chess-com/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -237,6 +237,9 @@
       "@activepieces/piece-chatwoot": [
         "packages/pieces/community/chatwoot/src/index.ts"
       ],
+      "@activepieces/piece-chess-com": [
+        "packages/pieces/community/chess-com/src/index.ts"
+      ],
       "@activepieces/piece-checkout": [
         "packages/pieces/community/checkout/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Adds a Chess.com community piece. The Chess.com public API is fully public — no connection or API key needed.

**Actions:**

- **Get Player Profile** — `GET /pub/player/{username}` — returns avatar, country, join date, followers
- **Get Player Stats** — `GET /pub/player/{username}/stats` — returns ratings and W/D/L for rapid, blitz, bullet, chess960
- **Get Daily Puzzle** — `GET /pub/puzzle` — returns today's puzzle (FEN, PGN, URL)

**Example use cases:**

- Post the daily puzzle to a Discord or Slack channel each morning
- Poll a player's stats on a schedule and alert when they hit a rating milestone
- Feed profile and stats into a spreadsheet for a club leaderboard