### PR TITLE
fix(chat): invalidate connections query after creating connection in chat

### DIFF
--- a/packages/web/src/app/routes/chat-with-ai/components/message-content.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/message-content.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { Check, Zap } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -174,6 +175,7 @@ export function ConnectionRequiredCard({
   connectedPieces?: Set<string>;
   onPieceConnected?: (piece: string) => void;
 }) {
+  const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const connected = connectedPieces?.has(connection.piece) ?? false;
   const shortName = connection.piece.replace(/[^a-z0-9-]/gi, '');
@@ -246,6 +248,9 @@ export function ConnectionRequiredCard({
             setDialogOpen(open);
             if (createdConnection) {
               onPieceConnected?.(connection.piece);
+              void queryClient.invalidateQueries({
+                queryKey: ['app-connections'],
+              });
               onSend?.(
                 `Done — ${connection.displayName} is connected. [auth externalId: ${createdConnection.externalId}]`,
               );


### PR DESCRIPTION
## Summary
- The ConnectedAppsList in the chat was not refreshing after creating a connection via the in-chat dialog
- Root cause: nothing invalidated the `app-connections` React Query cache after the `CreateOrEditConnectionDialog` successfully created a connection
- Added `queryClient.invalidateQueries({ queryKey: ['app-connections'] })` in `ConnectionRequiredCard` after successful connection creation

## Test plan
- [ ] Open chat, trigger a message that requires a connection (e.g., ask to send a Slack message)
- [ ] Click "Connect" on the connection card, complete the OAuth flow
- [ ] After connecting, verify the ConnectedAppsList below the input updates to show the new connection icon
- [ ] Verify the connection card switches to the "connected" state with checkmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)