### PR TITLE
fix(chat): improve streaming stability with diagnostics and recovery

### DIFF
--- a/packages/server/api/src/app/chat/chat-controller.ts
+++ b/packages/server/api/src/app/chat/chat-controller.ts
@@ -24,7 +24,7 @@ import { userSandboxService } from './user-sandbox-service'
 const CHAT_PRINCIPALS = [PrincipalType.USER] as const
 const EVENT_QUIESCENCE_MS = 1_500
 const MAX_QUIESCENCE_WAIT_MS = 10_000
-const KEEPALIVE_INTERVAL_MS = 15_000
+const KEEPALIVE_INTERVAL_MS = 10_000
 
 function isExpectedStreamError(error: unknown): boolean {
     if (!(error instanceof Error)) return false
@@ -248,6 +248,7 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
                                 })
 
                                 reply.raw.on('close', () => {
+                                    log.info({ conversationId, promptCompleted, resolved, timeSinceLastEvent: Date.now() - lastEventAt }, 'Chat stream connection closed by client')
                                     safeResolve()
                                 })
 

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -239,25 +239,31 @@ export function useAgentChat({
     },
     onError: () => {
       setPendingMessages([]);
+      if (cancelledRef.current) return;
       const convId = conversationIdRef.current;
       if (!convId) return;
       const recoverMessages = async (): Promise<void> => {
         const previousCount = messageCountRef.current;
         for (let attempt = 0; attempt < RECOVERY_MAX_ATTEMPTS; attempt++) {
           await new Promise((r) => setTimeout(r, RECOVERY_DELAY_MS));
+          if (cancelledRef.current || conversationIdRef.current !== convId)
+            return;
           const { data: result, error } = await tryCatch(() =>
             chatApi.getMessages(convId),
           );
           if (error) continue;
           if (result.data.length > previousCount) {
+            if (conversationIdRef.current !== convId) return;
             setUiMessages(mapHistoryToUIMessages(result.data));
             return;
           }
         }
+        if (conversationIdRef.current !== convId) return;
         const { data: finalResult } = await tryCatch(() =>
           chatApi.getMessages(convId),
         );
         if (finalResult) {
+          if (conversationIdRef.current !== convId) return;
           setUiMessages(mapHistoryToUIMessages(finalResult.data));
         }
       };

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -15,6 +15,8 @@ import { chatApi } from './chat-api';
 import { ChatUIMessage } from './chat-types';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const RECOVERY_DELAY_MS = 3_000;
+const RECOVERY_MAX_ATTEMPTS = 5;
 
 const ALLOWED_MIME_SET: ReadonlySet<string> = new Set(CHAT_ALLOWED_MIME_TYPES);
 
@@ -176,6 +178,7 @@ export function useAgentChat({
   const lastSentFileNamesRef = useRef<string[]>([]);
   const conversationIdRef = useRef<string | null>(null);
   const cancelledRef = useRef(false);
+  const messageCountRef = useRef(0);
   const onTitleUpdateRef = useRef(onTitleUpdate);
   onTitleUpdateRef.current = onTitleUpdate;
   const onConversationCreatedRef = useRef(onConversationCreated);
@@ -237,16 +240,32 @@ export function useAgentChat({
     onError: () => {
       setPendingMessages([]);
       const convId = conversationIdRef.current;
-      if (convId) {
-        void chatApi
-          .getMessages(convId)
-          .then((result) => {
+      if (!convId) return;
+      const recoverMessages = async (): Promise<void> => {
+        const previousCount = messageCountRef.current;
+        for (let attempt = 0; attempt < RECOVERY_MAX_ATTEMPTS; attempt++) {
+          await new Promise((r) => setTimeout(r, RECOVERY_DELAY_MS));
+          const { data: result, error } = await tryCatch(() =>
+            chatApi.getMessages(convId),
+          );
+          if (error) continue;
+          if (result.data.length > previousCount) {
             setUiMessages(mapHistoryToUIMessages(result.data));
-          })
-          .catch(() => undefined);
-      }
+            return;
+          }
+        }
+        const { data: finalResult } = await tryCatch(() =>
+          chatApi.getMessages(convId),
+        );
+        if (finalResult) {
+          setUiMessages(mapHistoryToUIMessages(finalResult.data));
+        }
+      };
+      void recoverMessages();
     },
   });
+
+  messageCountRef.current = uiMessages.length;
 
   const sdkIsStreaming = status === 'streaming' || status === 'submitted';
   const lastLiveMessage = uiMessages[uiMessages.length - 1];


### PR DESCRIPTION
## Summary
- Reduce keepalive interval from 15s to 10s for better reverse proxy compatibility during long tool executions
- Add diagnostic logging on connection close (conversationId, promptCompleted state, time since last event) to identify root cause of mid-stream cutoffs
- Client-side stream recovery: when `onError` fires (stream breaks mid-response), poll `getMessages` up to 5 times with 3s delay instead of fetching immediately — the E2B agent keeps running after disconnect and events are persisted to Postgres, so delayed refetch gets the full response

## Test plan
- [ ] Send a chat message that triggers a long response with tool calls — verify full response arrives
- [ ] Check server logs for the new `Chat stream connection closed by client` log entry with timing info
- [ ] Simulate a network interruption during streaming — verify the client recovers and shows the complete response after reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)