### PR TITLE
fix(drupal): remove redundant peerDependencies causing publish pipeline failure

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2254,17 +2254,12 @@
     },
     "packages/pieces/community/drupal": {
       "name": "@activepieces/piece-drupal",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
         "@activepieces/shared": "workspace:*",
         "tslib": "2.6.2",
-      },
-      "peerDependencies": {
-        "@activepieces/pieces-common": "*",
-        "@activepieces/pieces-framework": "*",
-        "@activepieces/shared": "*",
       },
     },
     "packages/pieces/community/dub": {

--- a/packages/pieces/community/drupal/package.json
+++ b/packages/pieces/community/drupal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-drupal",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -9,11 +9,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@activepieces/shared": "workspace:*",
     "tslib": "2.6.2"
-  },
-  "peerDependencies": {
-    "@activepieces/shared": "*",
-    "@activepieces/pieces-framework": "*",
-    "@activepieces/pieces-common": "*"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",


### PR DESCRIPTION
## Summary

- Removes `peerDependencies` from `packages/pieces/community/drupal/package.json`
- The `peerDependencies` block declared `@activepieces/shared`, `@activepieces/pieces-framework`, and `@activepieces/pieces-common` with wildcard `"*"` versions
- The release pipeline's `stripSemverRanges` utility does not support `"*"` and was throwing an error, blocking drupal from being published

## Root Cause

`stripSemverRanges` only handles exact versions and `^`/`~` ranges. The plain `"*"` wildcard passed through `resolveWorkspaceDependencies` unchanged (it only resolves `workspace:*` prefixes), causing the throw at `workspace-utils.ts:73`.

## Why This Is Safe

The three packages are already pinned in `dependencies` via `workspace:*`, so removing `peerDependencies` has no functional impact. Pieces are not consumed as npm libraries, so declaring peers adds no value.

## Test Plan

- [ ] Run the prepare-pieces-for-publish script locally with `CHANGED_PIECES` set to `packages/pieces/community/drupal` and confirm it completes without error