### PR TITLE
fix(attio): normalize record values and add Get Record action

### DIFF
--- a/packages/pieces/community/attio/package.json
+++ b/packages/pieces/community/attio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-attio",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/attio/src/index.ts
+++ b/packages/pieces/community/attio/src/index.ts
@@ -5,6 +5,7 @@ import { PieceCategory } from '@activepieces/shared';
 import { createRecordAction } from './lib/actions/create-record';
 import { updateRecordAction } from './lib/actions/update-record';
 import { findRecordAction } from './lib/actions/find-record';
+import { getRecordAction } from './lib/actions/get-record';
 import { createEntryAction } from './lib/actions/create-entry';
 import { updateEntryAction } from './lib/actions/update-entry';
 import { findListEntryAction } from './lib/actions/find-list-entry';
@@ -38,6 +39,7 @@ export const attio = createPiece({
 		createRecordAction,
 		updateRecordAction,
 		findRecordAction,
+		getRecordAction,
 		createEntryAction,
 		updateEntryAction,
 		findListEntryAction,

--- a/packages/pieces/community/attio/src/lib/actions/find-list-entry.ts
+++ b/packages/pieces/community/attio/src/lib/actions/find-list-entry.ts
@@ -1,7 +1,8 @@
 import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { attioAuth } from '../auth';
-import { attioPaginatedApiCall } from '../common/client';
+import { attioPaginatedApiCall, buildMembersMap, normalizeRecord } from '../common/client';
+import { AttioRecordResponse } from '../common/types';
 import { formatInputFields, listFields, listIdDropdown } from '../common/props';
 
 export const findListEntryAction = createAction({
@@ -29,7 +30,7 @@ export const findListEntryAction = createAction({
 		const formattedFields = await formatInputFields(accessToken, 'lists', listId, inputFields, true);
 
 		// https://docs.attio.com/rest-api/endpoint-reference/entries/list-entries
-		const response = await attioPaginatedApiCall({
+		const records = await attioPaginatedApiCall<AttioRecordResponse>({
 			method: HttpMethod.POST,
 			accessToken,
 			resourceUri: `/lists/${listId}/entries/query`,
@@ -38,9 +39,10 @@ export const findListEntryAction = createAction({
 			},
 		});
 
+		const membersMap = await buildMembersMap(accessToken, records);
 		return {
-			found: response.length > 0,
-			result: response,
+			found: records.length > 0,
+			result: records.map((r) => normalizeRecord(r, membersMap)),
 		};
 	},
 });

--- a/packages/pieces/community/attio/src/lib/actions/find-record.ts
+++ b/packages/pieces/community/attio/src/lib/actions/find-record.ts
@@ -2,7 +2,8 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { attioAuth } from '../auth';
 import { formatInputFields, objectFields, objectTypeIdDropdown } from '../common/props';
-import { attioApiCall, attioPaginatedApiCall } from '../common/client';
+import { attioApiCall, attioPaginatedApiCall, buildMembersMap, normalizeRecord } from '../common/client';
+import { AttioRecordResponse } from '../common/types';
 
 export const findRecordAction = createAction({
 	name: 'find_record',
@@ -31,14 +32,16 @@ export const findRecordAction = createAction({
 		}
 
 		if (recordId) {
-			const response = await attioApiCall<{ data: Record<string, unknown> }>({
+			const response = await attioApiCall<{ data: AttioRecordResponse }>({
 				method: HttpMethod.GET,
 				accessToken,
 				resourceUri: `/objects/${objectTypeId}/records/${recordId}`,
 			});
+			const records = [response.data];
+			const membersMap = await buildMembersMap(accessToken, records);
 			return {
 				found: true,
-				result: [response.data],
+				result: records.map((r) => normalizeRecord(r, membersMap)),
 			};
 		}
 
@@ -52,7 +55,7 @@ export const findRecordAction = createAction({
 		);
 
 		// https://docs.attio.com/rest-api/endpoint-reference/records/list-records
-		const response = await attioPaginatedApiCall({
+		const records = await attioPaginatedApiCall<AttioRecordResponse>({
 			method: HttpMethod.POST,
 			accessToken,
 			resourceUri: `/objects/${objectTypeId}/records/query`,
@@ -61,9 +64,10 @@ export const findRecordAction = createAction({
 			},
 		});
 
+		const membersMap = await buildMembersMap(accessToken, records);
 		return {
-			found: response.length > 0,
-			result: response,
+			found: records.length > 0,
+			result: records.map((r) => normalizeRecord(r, membersMap)),
 		};
 	},
 });

--- a/packages/pieces/community/attio/src/lib/actions/get-record.ts
+++ b/packages/pieces/community/attio/src/lib/actions/get-record.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { attioAuth } from '../auth';
+import { objectTypeIdDropdown } from '../common/props';
+import { attioApiCall, buildMembersMap, normalizeRecord } from '../common/client';
+import { AttioRecordResponse } from '../common/types';
+
+export const getRecordAction = createAction({
+	name: 'get_record',
+	displayName: 'Get Record',
+	description: 'Retrieve a single record by ID and return its normalized attribute values.',
+	auth: attioAuth,
+	props: {
+		objectTypeId: objectTypeIdDropdown({
+			displayName: 'Object',
+			required: true,
+		}),
+		recordId: Property.ShortText({
+			displayName: 'Record ID',
+			required: true,
+		}),
+	},
+	async run(context) {
+		const accessToken = context.auth.secret_text;
+		const { objectTypeId, recordId } = context.propsValue;
+
+		if (!objectTypeId) {
+			throw new Error('Provided object type is invalid.');
+		}
+
+		const response = await attioApiCall<{ data: AttioRecordResponse }>({
+			method: HttpMethod.GET,
+			accessToken,
+			resourceUri: `/objects/${objectTypeId}/records/${recordId}`,
+		});
+
+		const records = [response.data];
+		const membersMap = await buildMembersMap(accessToken, records);
+		return normalizeRecord(response.data, membersMap);
+	},
+});

--- a/packages/pieces/community/attio/src/lib/common/client.ts
+++ b/packages/pieces/community/attio/src/lib/common/client.ts
@@ -7,6 +7,7 @@ import {
 	QueryParams,
 } from '@activepieces/pieces-common';
 import crypto from 'crypto';
+import { AttioAttributeValue, AttioRecordResponse, WorkspaceMemberResponse } from './types';
 
 export const BASE_URL = 'https://api.attio.com/v2';
 
@@ -90,6 +91,107 @@ export async function attioPaginatedApiCall<T extends HttpMessageBody>({
 	} while (hasMoreItems);
 
 	return resultData;
+}
+
+export async function buildMembersMap(
+	accessToken: string,
+	records: AttioRecordResponse[],
+): Promise<Record<string, WorkspaceMemberResponse>> {
+	const actorIds = new Set<string>();
+	for (const record of records) {
+		for (const valueArray of Object.values(record.values)) {
+			for (const item of valueArray) {
+				if (item.attribute_type === 'actor-reference' && item.referenced_actor_id) {
+					actorIds.add(item.referenced_actor_id);
+				}
+			}
+		}
+	}
+
+	if (actorIds.size === 0) return {};
+
+	const members = await Promise.all(
+		[...actorIds].map((id) =>
+			attioApiCall<{ data: WorkspaceMemberResponse }>({
+				accessToken,
+				method: HttpMethod.GET,
+				resourceUri: `/workspace_members/${id}`,
+			}).then((res) => res.data),
+		),
+	);
+
+	return Object.fromEntries(members.map((m) => [m.id.workspace_member_id, m]));
+}
+
+function extractAttributeValue(
+	item: AttioAttributeValue,
+	membersMap: Record<string, WorkspaceMemberResponse>,
+): unknown {
+	switch (item.attribute_type) {
+		case 'text':
+		case 'number':
+		case 'checkbox':
+		case 'rating':
+		case 'date':
+		case 'timestamp':
+			return item.value ?? null;
+		case 'currency':
+			return { value: item.currency_value, currency_code: item.currency_code };
+		case 'email-address':
+			return item.email_address;
+		case 'personal-name':
+			return item.full_name;
+		case 'phone-number':
+			return item.phone_number;
+		case 'domain':
+			return item.domain;
+		case 'location': {
+			const loc: Partial<typeof item> = {};
+			for (const field of [
+				'line_1', 'line_2', 'line_3', 'line_4',
+				'locality', 'region', 'postcode', 'country_code',
+				'latitude', 'longitude',
+			] as const) {
+				if (item[field] !== null && item[field] !== undefined) {
+					loc[field] = item[field];
+				}
+			}
+			return Object.keys(loc).length > 0 ? loc : null;
+		}
+		case 'select':
+			return item.option.title;
+		case 'status':
+			return item.status.title;
+		case 'record-reference':
+			return item.target_record_id;
+		case 'actor-reference':
+			return item.referenced_actor_id
+				? (membersMap[item.referenced_actor_id] ?? item.referenced_actor_id)
+				: null;
+		case 'interaction':
+			return item.interacted_at;
+	}
+}
+
+export function normalizeRecord(
+	record: AttioRecordResponse,
+	membersMap: Record<string, WorkspaceMemberResponse>,
+): Record<string, unknown> {
+	const flatValues: Record<string, unknown> = {};
+
+	for (const [key, valueArray] of Object.entries(record.values)) {
+		if (valueArray.length === 0) {
+			flatValues[key] = null;
+			continue;
+		}
+		const extracted = valueArray
+			.map((item) => extractAttributeValue(item, membersMap))
+			.filter((v) => v !== null && v !== undefined);
+		flatValues[key] =
+			extracted.length === 0 ? null : extracted.length === 1 ? extracted[0] : extracted;
+	}
+
+	return { ...record, values: flatValues };
 }
 
 export function verifyWebhookSignature(

--- a/packages/pieces/community/attio/src/lib/common/client.ts
+++ b/packages/pieces/community/attio/src/lib/common/client.ts
@@ -101,7 +101,7 @@ export async function buildMembersMap(
 	for (const record of records) {
 		for (const valueArray of Object.values(record.values)) {
 			for (const item of valueArray) {
-				if (item.attribute_type === 'actor-reference' && item.referenced_actor_id) {
+				if (item.attribute_type === 'actor-reference' && item.referenced_actor_type === 'workspace-member' && item.referenced_actor_id) {
 					actorIds.add(item.referenced_actor_id);
 				}
 			}
@@ -159,9 +159,9 @@ function extractAttributeValue(
 			return Object.keys(loc).length > 0 ? loc : null;
 		}
 		case 'select':
-			return item.option.title;
+			return item.option?.title ?? null;
 		case 'status':
-			return item.status.title;
+			return item.status?.title ?? null;
 		case 'record-reference':
 			return item.target_record_id;
 		case 'actor-reference':

--- a/packages/pieces/community/attio/src/lib/common/types.ts
+++ b/packages/pieces/community/attio/src/lib/common/types.ts
@@ -1,3 +1,101 @@
+interface AttioBaseValue {
+	active_from: string | null;
+	active_until: string | null;
+	created_by_actor: { type: 'workspace-member' | 'api-token' | 'system' | 'app'; id: string | null } | null;
+}
+
+export type AttioAttributeValue =
+	| (AttioBaseValue & { attribute_type: 'text'; value: string | null })
+	| (AttioBaseValue & { attribute_type: 'number'; value: number | null })
+	| (AttioBaseValue & { attribute_type: 'checkbox'; value: boolean | null })
+	| (AttioBaseValue & { attribute_type: 'rating'; value: number | null })
+	| (AttioBaseValue & { attribute_type: 'date'; value: string | null })
+	| (AttioBaseValue & { attribute_type: 'timestamp'; value: string | null })
+	| (AttioBaseValue & {
+			attribute_type: 'currency';
+			currency_value: number | null;
+			currency_code: string | null;
+	  })
+	| (AttioBaseValue & {
+			attribute_type: 'email-address';
+			email_address: string;
+			email_domain: string;
+			email_root_domain: string;
+			original_email_address: string;
+			email_local_specifier: string;
+	  })
+	| (AttioBaseValue & {
+			attribute_type: 'personal-name';
+			first_name: string | null;
+			last_name: string | null;
+			full_name: string | null;
+	  })
+	| (AttioBaseValue & {
+			attribute_type: 'phone-number';
+			original_phone_number: string;
+			phone_number: string;
+			country_code: string | null;
+	  })
+	| (AttioBaseValue & { attribute_type: 'domain'; domain: string; root_domain: string })
+	| (AttioBaseValue & {
+			attribute_type: 'location';
+			line_1: string | null;
+			line_2: string | null;
+			line_3: string | null;
+			line_4: string | null;
+			locality: string | null;
+			region: string | null;
+			postcode: string | null;
+			country_code: string | null;
+			latitude: string | null;
+			longitude: string | null;
+	  })
+	| (AttioBaseValue & {
+			attribute_type: 'select';
+			option: { id: Record<string, string>; title: string; is_archived: boolean };
+	  })
+	| (AttioBaseValue & {
+			attribute_type: 'status';
+			status: { id: Record<string, string>; title: string; is_archived: boolean; celebration_enabled: boolean; target_time_in_status: unknown };
+	  })
+	| (AttioBaseValue & {
+			attribute_type: 'record-reference';
+			target_object: string;
+			target_record_id: string;
+	  })
+	| (AttioBaseValue & {
+			attribute_type: 'actor-reference';
+			referenced_actor_type: 'workspace-member' | 'api-token' | 'system' | 'app';
+			referenced_actor_id: string | null;
+	  })
+	| (AttioBaseValue & {
+			attribute_type: 'interaction';
+			interaction_type: 'calendar-event' | 'call' | 'chat-thread' | 'email' | 'in-person-meeting' | 'meeting';
+			interacted_at: string;
+			owner_actor: { type: string; id: string | null };
+	  });
+
+export interface AttioRecordResponse {
+	id: {
+		workspace_id: string;
+		object_id: string;
+		record_id: string;
+	};
+	created_at: string;
+	values: Record<string, AttioAttributeValue[]>;
+}
+
+export interface WorkspaceMemberResponse {
+	id: {
+		workspace_id: string;
+		workspace_member_id: string;
+	};
+	first_name: string | null;
+	last_name: string | null;
+	email_address: string;
+	avatar_url: string | null;
+}
+
 export interface ObjectResponse {
 	id: {
 		workspace_id: string;


### PR DESCRIPTION
## What does this PR do?


- Flatten `values` in Find Record and Find List Entry responses so attribute values are directly readable (e.g. `values.stage = "Lead"` instead of a nested array)
- Resolve actor-reference fields to full workspace member objects via GET /workspace_members/{id}
- Add proper discriminated union types for all Attio attribute value types
- Add new Get Record action that fetches a single record by ID with normalized output
