### PR TITLE
fix(pieces): guard against crash when installing .tgz piece

### DIFF
--- a/packages/server/api/src/app/pieces/piece-install-service.ts
+++ b/packages/server/api/src/app/pieces/piece-install-service.ts
@@ -55,7 +55,7 @@ export const pieceInstallService = (log: FastifyBaseLogger) => ({
         catch (error) {
             log.error({ err: error }, '[pieceInstallService#add] Failed to add piece')
 
-            if ((error as ActivepiecesError).error.code === ErrorCode.VALIDATION) {
+            if (error instanceof ActivepiecesError && error.error.code === ErrorCode.VALIDATION) {
                 throw error
             }
             throw new ActivepiecesError({


### PR DESCRIPTION
## Summary

- Fixed a 500 error when installing a `.tgz` piece via the platform UI
- The catch block in `pieceInstallService` was using an unsafe type cast `(error as ActivepiecesError).error.code`, which crashes with "Cannot read properties of undefined (reading 'code')" when the engine throws a plain `Error` (e.g. during failed piece metadata extraction)
- Replaced the cast with an `instanceof ActivepiecesError` guard so non-`ActivepiecesError` throws correctly fall through to the `ENGINE_OPERATION_FAILURE` path

## Test plan

- [ ] Upload a valid `.tgz` piece and verify it installs successfully
- [ ] Upload an invalid/corrupt `.tgz` piece and verify the error response is `ENGINE_OPERATION_FAILURE` (not a 500 crash)
- [ ] Upload a `.tgz` that triggers a `VALIDATION` error and verify it is re-thrown as-is