### PR TITLE
feat: upgrade chat model lists to latest versions

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.68.4",
+  "version": "0.68.5",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/shared/src/lib/management/ai-providers/index.ts
@@ -255,11 +255,11 @@ export type AIErrorResponse = z.infer<typeof AIErrorResponse>
  * prefixes or missing input fall back to the raw inputs so callers never end up with a
  * wrong-but-confident answer.
  */
-const OPENAI_CHAT_MODELS = ['gpt-5.2', 'gpt-5.1', 'gpt-5-mini'] as const
-const ANTHROPIC_CHAT_MODELS = ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5', 'claude-haiku-4-5-20251001'] as const
-const ANTHROPIC_OPENROUTER_CHAT_MODELS = ['claude-opus-4.6', 'claude-sonnet-4.6', 'claude-haiku-4.5', 'claude-haiku-4-5-20251001'] as const
-const GOOGLE_CHAT_MODELS = ['gemini-2.5-flash-lite-preview-09-2025', 'gemini-2.5-flash-preview-09-2025', 'gemini-3-flash-preview', 'gemini-3.1-pro-preview'] as const
-const X_AI_OPENROUTER_CHAT_MODELS = ['grok-4.1-fast'] as const
+const OPENAI_CHAT_MODELS = ['gpt-5.5', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-4.1', 'gpt-4.1-mini'] as const
+const ANTHROPIC_CHAT_MODELS = ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'] as const
+const ANTHROPIC_OPENROUTER_CHAT_MODELS = ['claude-opus-4.7', 'claude-sonnet-4.6', 'claude-haiku-4.5'] as const
+const GOOGLE_CHAT_MODELS = ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-3.1-pro-preview', 'gemini-3-flash-preview'] as const
+const X_AI_OPENROUTER_CHAT_MODELS = ['grok-4.20', 'grok-4-1-fast-reasoning'] as const
 
 export const ALLOWED_CHAT_MODELS_BY_PROVIDER: Partial<Record<AIProviderName, readonly string[]>> = {
     [AIProviderName.OPENAI]: OPENAI_CHAT_MODELS,

--- a/packages/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/shared/src/lib/management/ai-providers/index.ts
@@ -259,7 +259,7 @@ const OPENAI_CHAT_MODELS = ['gpt-5.5', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-4.1'
 const ANTHROPIC_CHAT_MODELS = ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'] as const
 const ANTHROPIC_OPENROUTER_CHAT_MODELS = ['claude-opus-4.7', 'claude-sonnet-4.6', 'claude-haiku-4.5'] as const
 const GOOGLE_CHAT_MODELS = ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-3.1-pro-preview', 'gemini-3-flash-preview'] as const
-const X_AI_OPENROUTER_CHAT_MODELS = ['grok-4.20', 'grok-4-1-fast-reasoning'] as const
+const X_AI_OPENROUTER_CHAT_MODELS = ['grok-4.20', 'grok-4.1-fast'] as const
 
 export const ALLOWED_CHAT_MODELS_BY_PROVIDER: Partial<Record<AIProviderName, readonly string[]>> = {
     [AIProviderName.OPENAI]: OPENAI_CHAT_MODELS,


### PR DESCRIPTION
## Summary

- Upgrade all AI chat model lists to latest available versions
- **OpenAI**: gpt-5.5, gpt-5.4-mini, gpt-5.4-nano, gpt-4.1, gpt-4.1-mini
- **Anthropic**: claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5
- **Google**: gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-flash-preview
- **xAI**: grok-4.20, grok-4.1-fast
- Remove deprecated date-pinned model versions

## Test plan

- [ ] Open chat, check model selector shows all new models
- [ ] Test with gpt-5.5 (OpenAI provider)
- [ ] Test with claude-opus-4-7 (Anthropic provider)
- [ ] Test with gemini-2.5-pro (Google provider)
- [ ] Verify OpenRouter/Activepieces provider shows all models with provider prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)