### PR TITLE
fix(worker): retain failed jobs per queue default for non-event-destination jobs

### DIFF
--- a/packages/server/api/src/app/workers/job-queue/job-queue.ts
+++ b/packages/server/api/src/app/workers/job-queue/job-queue.ts
@@ -46,7 +46,7 @@ export const jobQueue = (log: FastifyBaseLogger) => ({
                     priority: JOB_PRIORITY[getDefaultJobPriority(data)],
                     delay: params.delay,
                     jobId: params.id,
-                    removeOnFail: data.jobType === WorkerJobType.EVENT_DESTINATION,
+                    ...(data.jobType === WorkerJobType.EVENT_DESTINATION ? { removeOnFail: true } : {}),
                     ...isUserInteractionJob(data.jobType) ? {
                         attempts: 1,
                         removeOnComplete: { age: 300 },


### PR DESCRIPTION


The previous boolean ternary set `removeOnFail: false` for every non-EVENT_DESTINATION job, overriding the queue's default `{ age, count }` retention policy and causing failed subflow / webhook / polling jobs to accumulate in Redis forever. Only override to `true` for EVENT_DESTINATION; otherwise let the queue-level default apply.
