### PR TITLE
fix: remove dangerouslySetInnerHTML XSS risk in code block

### DIFF
--- a/packages/web/src/components/prompt-kit/code-block.tsx
+++ b/packages/web/src/components/prompt-kit/code-block.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { codeToHtml } from 'shiki';
+import {
+  bundledLanguages,
+  codeToTokens,
+  type BundledLanguage,
+  type ThemedToken,
+} from 'shiki';
 
 import { cn } from '@/lib/utils';
-
-export type CodeBlockProps = {
-  children?: React.ReactNode;
-  className?: string;
-} & React.HTMLProps<HTMLDivElement>;
 
 function CodeBlock({ children, className, ...props }: CodeBlockProps) {
   return (
@@ -23,13 +23,6 @@ function CodeBlock({ children, className, ...props }: CodeBlockProps) {
   );
 }
 
-export type CodeBlockCodeProps = {
-  code: string;
-  language?: string;
-  theme?: string;
-  className?: string;
-} & React.HTMLProps<HTMLDivElement>;
-
 function CodeBlockCode({
   code,
   language = 'tsx',
@@ -37,15 +30,17 @@ function CodeBlockCode({
   className,
   ...props
 }: CodeBlockCodeProps) {
-  const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null);
+  const [tokenResult, setTokenResult] = useState<TokenResult | null>(null);
 
   useEffect(() => {
-    async function highlight() {
-      if (!code) {
-        setHighlightedHtml('<pre><code></code></pre>');
-        return;
-      }
+    if (!code) {
+      setTokenResult(null);
+      return;
+    }
 
+    let cancelled = false;
+
+    async function highlight() {
       const themeOptions = theme
         ? { theme }
         : {
@@ -53,21 +48,43 @@ function CodeBlockCode({
             defaultColor: false as const,
           };
 
+      const lang = isBundledLanguage(language) ? language : 'plaintext';
+
+      let result;
       try {
-        const html = await codeToHtml(code, {
-          lang: language,
-          ...themeOptions,
-        });
-        setHighlightedHtml(html);
+        result = await codeToTokens(code, { lang, ...themeOptions });
       } catch {
-        const html = await codeToHtml(code, {
-          lang: 'plaintext',
-          ...themeOptions,
-        });
-        setHighlightedHtml(html);
+        if (lang === 'plaintext') return;
+        try {
+          result = await codeToTokens(code, {
+            lang: 'plaintext',
+            ...themeOptions,
+          });
+        } catch {
+          return;
+        }
       }
+
+      if (cancelled) return;
+
+      setTokenResult({
+        lines: result.tokens.map((line) =>
+          line.map((token) => ({
+            content: token.content,
+            style: getTokenStyle(token),
+          })),
+        ),
+        preStyle:
+          typeof result.rootStyle === 'string'
+            ? parseCssProperties(result.rootStyle)
+            : {},
+      });
     }
+
     highlight();
+    return () => {
+      cancelled = true;
+    };
   }, [code, language, theme]);
 
   const classNames = cn(
@@ -75,23 +92,37 @@ function CodeBlockCode({
     className,
   );
 
-  // SSR fallback: render plain code if not hydrated yet
-  return highlightedHtml ? (
-    <div
-      className={classNames}
-      dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-      {...props}
-    />
-  ) : (
+  if (!tokenResult) {
+    return (
+      <div className={classNames} {...props}>
+        <pre>
+          <code>{code}</code>
+        </pre>
+      </div>
+    );
+  }
+
+  const lastLineIndex = tokenResult.lines.length - 1;
+
+  return (
     <div className={classNames} {...props}>
-      <pre>
-        <code>{code}</code>
+      <pre className="shiki" style={tokenResult.preStyle}>
+        <code>
+          {tokenResult.lines.map((line, lineIndex) => (
+            <span key={lineIndex} className="line">
+              {line.map((token, tokenIndex) => (
+                <span key={tokenIndex} style={token.style}>
+                  {token.content}
+                </span>
+              ))}
+              {lineIndex < lastLineIndex ? '\n' : ''}
+            </span>
+          ))}
+        </code>
       </pre>
     </div>
   );
 }
-
-export type CodeBlockGroupProps = React.HTMLAttributes<HTMLDivElement>;
 
 function CodeBlockGroup({
   children,
@@ -107,5 +138,61 @@ function CodeBlockGroup({
     </div>
   );
 }
+
+const EMPTY_STYLE: React.CSSProperties = {};
+
+function getTokenStyle(token: ThemedToken): React.CSSProperties {
+  if (token.htmlStyle) {
+    const style: React.CSSProperties = {};
+    Object.assign(style, token.htmlStyle);
+    return style;
+  }
+  if (token.color) {
+    return { color: token.color };
+  }
+  return EMPTY_STYLE;
+}
+
+function parseCssProperties(cssString: string): React.CSSProperties {
+  const style: React.CSSProperties = {};
+  for (const part of cssString.split(';')) {
+    const colonIndex = part.indexOf(':');
+    if (colonIndex === -1) continue;
+    const key = part.slice(0, colonIndex).trim();
+    const value = part.slice(colonIndex + 1).trim();
+    if (key && value) {
+      Object.assign(style, { [key]: value });
+    }
+  }
+  return style;
+}
+
+function isBundledLanguage(lang: string): lang is BundledLanguage {
+  return lang in bundledLanguages;
+}
+
+type PrecomputedToken = {
+  content: string;
+  style: React.CSSProperties;
+};
+
+type TokenResult = {
+  lines: PrecomputedToken[][];
+  preStyle: React.CSSProperties;
+};
+
+export type CodeBlockProps = {
+  children?: React.ReactNode;
+  className?: string;
+} & React.HTMLProps<HTMLDivElement>;
+
+export type CodeBlockCodeProps = {
+  code: string;
+  language?: string;
+  theme?: string;
+  className?: string;
+} & React.HTMLProps<HTMLDivElement>;
+
+export type CodeBlockGroupProps = React.HTMLAttributes<HTMLDivElement>;
 
 export { CodeBlockGroup, CodeBlockCode, CodeBlock };

--- a/packages/web/src/components/prompt-kit/code-block.tsx
+++ b/packages/web/src/components/prompt-kit/code-block.tsx
@@ -140,17 +140,30 @@ function CodeBlockGroup({
 }
 
 const EMPTY_STYLE: React.CSSProperties = {};
+const FONT_STYLE_ITALIC = 1;
+const FONT_STYLE_BOLD = 2;
+const FONT_STYLE_UNDERLINE = 4;
 
 function getTokenStyle(token: ThemedToken): React.CSSProperties {
   if (token.htmlStyle) {
     const style: React.CSSProperties = {};
-    Object.assign(style, token.htmlStyle);
+    for (const [key, value] of Object.entries(token.htmlStyle)) {
+      Object.assign(style, { [toCssPropertyKey(key)]: value });
+    }
     return style;
   }
+  const style: React.CSSProperties = {};
   if (token.color) {
-    return { color: token.color };
+    style.color = token.color;
   }
-  return EMPTY_STYLE;
+  if (token.fontStyle) {
+    if (token.fontStyle & FONT_STYLE_ITALIC) style.fontStyle = 'italic';
+    if (token.fontStyle & FONT_STYLE_BOLD) style.fontWeight = 'bold';
+    if (token.fontStyle & FONT_STYLE_UNDERLINE)
+      style.textDecoration = 'underline';
+  }
+  if (!token.color && !token.fontStyle) return EMPTY_STYLE;
+  return style;
 }
 
 function parseCssProperties(cssString: string): React.CSSProperties {
@@ -161,10 +174,15 @@ function parseCssProperties(cssString: string): React.CSSProperties {
     const key = part.slice(0, colonIndex).trim();
     const value = part.slice(colonIndex + 1).trim();
     if (key && value) {
-      Object.assign(style, { [key]: value });
+      Object.assign(style, { [toCssPropertyKey(key)]: value });
     }
   }
   return style;
+}
+
+function toCssPropertyKey(key: string): string {
+  if (key.startsWith('--')) return key;
+  return key.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
 }
 
 function isBundledLanguage(lang: string): lang is BundledLanguage {


### PR DESCRIPTION
## Summary
- Replace `codeToHtml` + `dangerouslySetInnerHTML` with `codeToTokens` API, rendering syntax-highlighted code as React elements to eliminate XSS surface
- Fix race condition in async `useEffect` by adding cancellation flag
- Precompute token styles once during highlighting instead of per-render, reducing allocations for large code blocks

## Test plan
- [ ] Open Chat with AI, send a prompt that produces a code block response (e.g. "Write a JavaScript function that reverses a string")
- [ ] Verify syntax highlighting renders correctly with colored tokens
- [ ] Toggle light/dark theme and confirm code block colors update
- [ ] Verify the copy button in the code block header still works
- [ ] Test with an unrecognized language in markdown (e.g. ```foobar) — should fall back to plaintext

🤖 Generated with [Claude Code](https://claude.com/claude-code)