### PR TITLE
fix(saml): support Microsoft Entra schema-qualified claims and harden SAML response parsing

### DIFF
--- a/packages/server/api/src/app/ee/authentication/saml-authn/saml-attributes.ts
+++ b/packages/server/api/src/app/ee/authentication/saml-authn/saml-attributes.ts
@@ -2,128 +2,94 @@ import { ActivepiecesError, ErrorCode, isNil, SAMLAttributeMapping } from '@acti
 
 export const resolveSamlAttributes = ({ rawAttributes, mapping }: ResolveArgs): SamlAttributes => {
     const safeAttributes = rawAttributes ?? {}
-    const candidates = buildCandidates(mapping)
-
-    const email = pickAttribute({ rawAttributes: safeAttributes, candidates: candidates.email })
-    const firstName = pickAttribute({ rawAttributes: safeAttributes, candidates: candidates.firstName })
-    const lastName = pickAttribute({ rawAttributes: safeAttributes, candidates: candidates.lastName })
-
+    const email = pickFirstValue({ source: safeAttributes, keys: candidatesFor({ field: 'email', mapping }) })
+    const firstName = pickFirstValue({ source: safeAttributes, keys: candidatesFor({ field: 'firstName', mapping }) })
+    const lastName = pickFirstValue({ source: safeAttributes, keys: candidatesFor({ field: 'lastName', mapping }) })
     if (isNil(email) || isNil(firstName) || isNil(lastName)) {
-        const missing = collectMissing({ email, firstName, lastName })
-        const receivedKeys = Object.keys(safeAttributes).join(', ')
-        throw new ActivepiecesError({
-            code: ErrorCode.INVALID_SAML_RESPONSE,
-            params: {
-                message: `Invalid SAML response. Missing required field(s): ${missing.join(', ')}. Received attribute keys: [${receivedKeys}]. Configure attributeMapping in SSO settings if your IdP uses non-standard claim names.`,
-            },
+        throw missingFieldsError({
+            resolved: { email, firstName, lastName },
+            receivedKeys: Object.keys(safeAttributes),
         })
     }
-
     return { email, firstName, lastName }
 }
 
-function buildCandidates(mapping: SAMLAttributeMapping | undefined): FieldCandidates {
-    return {
-        email: prepend({ override: mapping?.email, defaults: DEFAULT_EMAIL_KEYS }),
-        firstName: prepend({ override: mapping?.firstName, defaults: DEFAULT_FIRST_NAME_KEYS }),
-        lastName: prepend({ override: mapping?.lastName, defaults: DEFAULT_LAST_NAME_KEYS }),
-    }
+function candidatesFor({ field, mapping }: CandidatesArgs): string[] {
+    const override = mapping?.[field]?.trim()
+    return isNil(override) || override.length === 0
+        ? DEFAULT_KEYS[field]
+        : [override, ...DEFAULT_KEYS[field]]
 }
 
-function prepend({ override, defaults }: PrependArgs): string[] {
-    if (isNil(override) || override.trim().length === 0) {
-        return defaults
-    }
-    return [override, ...defaults]
+function pickFirstValue({ source, keys }: PickArgs): string | undefined {
+    return keys.map((key) => unwrap(source[key])).find(isNonEmptyString)
 }
 
-function pickAttribute({ rawAttributes, candidates }: PickArgs): string | undefined {
-    for (const key of candidates) {
-        const value = readNonEmpty({ rawAttributes, key })
-        if (!isNil(value)) {
-            return value
-        }
-    }
-    return undefined
+function unwrap(value: unknown): unknown {
+    return Array.isArray(value) ? value.find(isNonEmptyString) : value
 }
 
-function readNonEmpty({ rawAttributes, key }: ReadArgs): string | undefined {
-    const value = rawAttributes[key]
-    const flat = Array.isArray(value)
-        ? value.find((entry) => typeof entry === 'string' && entry.length > 0)
-        : value
-    if (typeof flat === 'string' && flat.length > 0) {
-        return flat
-    }
-    return undefined
+function isNonEmptyString(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0
 }
 
-function collectMissing({ email, firstName, lastName }: ResolvedTriple): string[] {
+function missingFieldsError({ resolved, receivedKeys }: MissingFieldsErrorArgs): ActivepiecesError {
     const missing: string[] = []
-    if (isNil(email)) {
+    if (isNil(resolved.email)) {
         missing.push('email')
     }
-    if (isNil(firstName)) {
+    if (isNil(resolved.firstName)) {
         missing.push('firstName')
     }
-    if (isNil(lastName)) {
+    if (isNil(resolved.lastName)) {
         missing.push('lastName')
     }
-    return missing
+    return new ActivepiecesError({
+        code: ErrorCode.INVALID_SAML_RESPONSE,
+        params: {
+            message: `Invalid SAML response. Missing required field(s): ${missing.join(', ')}. Received attribute keys: [${receivedKeys.join(', ')}]. Configure attributeMapping in SSO settings if your IdP uses non-standard claim names.`,
+        },
+    })
 }
 
-const DEFAULT_EMAIL_KEYS = [
-    'email',
-    'emailaddress',
-    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
-]
-
-const DEFAULT_FIRST_NAME_KEYS = [
-    'firstName',
-    'firstname',
-    'givenname',
-    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
-]
-
-const DEFAULT_LAST_NAME_KEYS = [
-    'lastName',
-    'lastname',
-    'surname',
-    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
-]
-
-type RawAttributes = Record<string, unknown>
+const DEFAULT_KEYS: Record<keyof SamlAttributes, string[]> = {
+    email: [
+        'email',
+        'emailaddress',
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+    ],
+    firstName: [
+        'firstName',
+        'firstname',
+        'givenname',
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
+    ],
+    lastName: [
+        'lastName',
+        'lastname',
+        'surname',
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
+    ],
+}
 
 type ResolveArgs = {
-    rawAttributes: RawAttributes | null | undefined
+    rawAttributes: Record<string, unknown> | null | undefined
     mapping?: SAMLAttributeMapping
 }
 
+type CandidatesArgs = {
+    field: keyof SamlAttributes
+    mapping: SAMLAttributeMapping | undefined
+}
+
 type PickArgs = {
-    rawAttributes: RawAttributes
-    candidates: string[]
+    source: Record<string, unknown>
+    keys: string[]
 }
 
-type ReadArgs = {
-    rawAttributes: RawAttributes
-    key: string
-}
-
-type PrependArgs = {
-    override: string | undefined
-    defaults: string[]
-}
-
-type FieldCandidates = {
-    email: string[]
-    firstName: string[]
-    lastName: string[]
-}
-
-type ResolvedTriple = {
-    email: string | undefined
-    firstName: string | undefined
-    lastName: string | undefined
+type MissingFieldsErrorArgs = {
+    resolved: Partial<SamlAttributes>
+    receivedKeys: string[]
 }
 
 export type SamlAttributes = {

--- a/packages/server/api/src/app/ee/authentication/saml-authn/saml-attributes.ts
+++ b/packages/server/api/src/app/ee/authentication/saml-authn/saml-attributes.ts
@@ -1,0 +1,128 @@
+import { ActivepiecesError, ErrorCode, isNil, SAMLAttributeMapping } from '@activepieces/shared'
+
+export const resolveSamlAttributes = ({ rawAttributes, mapping }: ResolveArgs): SamlAttributes => {
+    const safeAttributes = rawAttributes ?? {}
+    const candidates = buildCandidates(mapping)
+
+    const email = pickAttribute({ rawAttributes: safeAttributes, candidates: candidates.email })
+    const firstName = pickAttribute({ rawAttributes: safeAttributes, candidates: candidates.firstName })
+    const lastName = pickAttribute({ rawAttributes: safeAttributes, candidates: candidates.lastName })
+
+    if (isNil(email) || isNil(firstName) || isNil(lastName)) {
+        const missing = collectMissing({ email, firstName, lastName })
+        const receivedKeys = Object.keys(safeAttributes).join(', ')
+        throw new ActivepiecesError({
+            code: ErrorCode.INVALID_SAML_RESPONSE,
+            params: {
+                message: `Invalid SAML response. Missing required field(s): ${missing.join(', ')}. Received attribute keys: [${receivedKeys}]. Configure attributeMapping in SSO settings if your IdP uses non-standard claim names.`,
+            },
+        })
+    }
+
+    return { email, firstName, lastName }
+}
+
+function buildCandidates(mapping: SAMLAttributeMapping | undefined): FieldCandidates {
+    return {
+        email: prepend(mapping?.email, DEFAULT_EMAIL_KEYS),
+        firstName: prepend(mapping?.firstName, DEFAULT_FIRST_NAME_KEYS),
+        lastName: prepend(mapping?.lastName, DEFAULT_LAST_NAME_KEYS),
+    }
+}
+
+function prepend(override: string | undefined, defaults: string[]): string[] {
+    if (isNil(override) || override.trim().length === 0) {
+        return defaults
+    }
+    return [override, ...defaults]
+}
+
+function pickAttribute({ rawAttributes, candidates }: PickArgs): string | undefined {
+    for (const key of candidates) {
+        const value = readNonEmpty({ rawAttributes, key })
+        if (!isNil(value)) {
+            return value
+        }
+    }
+    return undefined
+}
+
+function readNonEmpty({ rawAttributes, key }: ReadArgs): string | undefined {
+    const value = rawAttributes[key]
+    const flat = Array.isArray(value)
+        ? value.find((entry) => typeof entry === 'string' && entry.length > 0)
+        : value
+    if (typeof flat === 'string' && flat.length > 0) {
+        return flat
+    }
+    return undefined
+}
+
+function collectMissing({ email, firstName, lastName }: ResolvedTriple): string[] {
+    const missing: string[] = []
+    if (isNil(email)) {
+        missing.push('email')
+    }
+    if (isNil(firstName)) {
+        missing.push('firstName')
+    }
+    if (isNil(lastName)) {
+        missing.push('lastName')
+    }
+    return missing
+}
+
+const DEFAULT_EMAIL_KEYS = [
+    'email',
+    'emailaddress',
+    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+]
+
+const DEFAULT_FIRST_NAME_KEYS = [
+    'firstName',
+    'firstname',
+    'givenname',
+    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
+]
+
+const DEFAULT_LAST_NAME_KEYS = [
+    'lastName',
+    'lastname',
+    'surname',
+    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
+]
+
+type RawAttributes = Record<string, unknown>
+
+type ResolveArgs = {
+    rawAttributes: RawAttributes | null | undefined
+    mapping?: SAMLAttributeMapping
+}
+
+type PickArgs = {
+    rawAttributes: RawAttributes
+    candidates: string[]
+}
+
+type ReadArgs = {
+    rawAttributes: RawAttributes
+    key: string
+}
+
+type FieldCandidates = {
+    email: string[]
+    firstName: string[]
+    lastName: string[]
+}
+
+type ResolvedTriple = {
+    email: string | undefined
+    firstName: string | undefined
+    lastName: string | undefined
+}
+
+export type SamlAttributes = {
+    email: string
+    firstName: string
+    lastName: string
+}

--- a/packages/server/api/src/app/ee/authentication/saml-authn/saml-attributes.ts
+++ b/packages/server/api/src/app/ee/authentication/saml-authn/saml-attributes.ts
@@ -24,13 +24,13 @@ export const resolveSamlAttributes = ({ rawAttributes, mapping }: ResolveArgs): 
 
 function buildCandidates(mapping: SAMLAttributeMapping | undefined): FieldCandidates {
     return {
-        email: prepend(mapping?.email, DEFAULT_EMAIL_KEYS),
-        firstName: prepend(mapping?.firstName, DEFAULT_FIRST_NAME_KEYS),
-        lastName: prepend(mapping?.lastName, DEFAULT_LAST_NAME_KEYS),
+        email: prepend({ override: mapping?.email, defaults: DEFAULT_EMAIL_KEYS }),
+        firstName: prepend({ override: mapping?.firstName, defaults: DEFAULT_FIRST_NAME_KEYS }),
+        lastName: prepend({ override: mapping?.lastName, defaults: DEFAULT_LAST_NAME_KEYS }),
     }
 }
 
-function prepend(override: string | undefined, defaults: string[]): string[] {
+function prepend({ override, defaults }: PrependArgs): string[] {
     if (isNil(override) || override.trim().length === 0) {
         return defaults
     }
@@ -107,6 +107,11 @@ type PickArgs = {
 type ReadArgs = {
     rawAttributes: RawAttributes
     key: string
+}
+
+type PrependArgs = {
+    override: string | undefined
+    defaults: string[]
 }
 
 type FieldCandidates = {

--- a/packages/server/api/src/app/ee/authentication/saml-authn/saml-client.ts
+++ b/packages/server/api/src/app/ee/authentication/saml-authn/saml-client.ts
@@ -1,50 +1,9 @@
-
 import { safeHttp } from '@activepieces/server-utils'
 import { ActivepiecesError, ErrorCode, SAMLAttributeMapping, SAMLAuthnProviderConfig, tryCatch } from '@activepieces/shared'
 import * as validator from '@authenio/samlify-node-xmllint'
 import * as saml from 'samlify'
 import { domainHelper } from '../../custom-domains/domain-helper'
 import { resolveSamlAttributes, SamlAttributes } from './saml-attributes'
-
-class SamlClient {
-    private static readonly LOGIN_REQUEST_BINDING = 'redirect'
-    private static readonly LOGIN_RESPONSE_BINDING = 'post'
-
-    constructor(
-        private readonly idp: saml.IdentityProviderInstance,
-        private readonly sp: saml.ServiceProviderInstance,
-        private readonly attributeMapping: SAMLAttributeMapping | undefined,
-    ) {}
-
-    getLoginUrl(): string {
-        const loginRequest = this.sp.createLoginRequest(
-            this.idp,
-            SamlClient.LOGIN_REQUEST_BINDING,
-        )
-
-        return loginRequest.context
-    }
-
-    async parseAndValidateLoginResponse(idpLoginResponse: IdpLoginResponse): Promise<SamlAttributes> {
-        const { data: loginResult, error: parseError } = await tryCatch(() => this.sp.parseLoginResponse(
-            this.idp,
-            SamlClient.LOGIN_RESPONSE_BINDING,
-            idpLoginResponse,
-        ))
-        if (parseError !== null) {
-            throw new ActivepiecesError({
-                code: ErrorCode.INVALID_SAML_RESPONSE,
-                params: {
-                    message: `Failed to parse SAML response: ${parseError.message}`,
-                },
-            })
-        }
-        const rawAttributes = loginResult.extract?.attributes
-        return resolveSamlAttributes({ rawAttributes, mapping: this.attributeMapping })
-    }
-}
-
-const instanceCache = new Map<string, SamlClient>()
 
 export const createSamlClient = async (platformId: string, samlProvider: SAMLAuthnProviderConfig): Promise<SamlClient> => {
     const cached = instanceCache.get(platformId)
@@ -54,8 +13,8 @@ export const createSamlClient = async (platformId: string, samlProvider: SAMLAut
     saml.setSchemaValidator(validator)
     const metadataXml = await resolveIdpMetadata(samlProvider.idpMetadata)
     const idp = createIdp(metadataXml)
-    const sp = await createSp(platformId, samlProvider.idpCertificate)
-    const client = new SamlClient(idp, sp, samlProvider.attributeMapping)
+    const sp = await createSp({ platformId, privateKey: samlProvider.idpCertificate })
+    const client = samlClient({ idp, sp, attributeMapping: samlProvider.attributeMapping })
     instanceCache.set(platformId, client)
     return client
 }
@@ -63,6 +22,29 @@ export const createSamlClient = async (platformId: string, samlProvider: SAMLAut
 export const invalidateSamlClientCache = (platformId: string): void => {
     instanceCache.delete(platformId)
 }
+
+const samlClient = ({ idp, sp, attributeMapping }: SamlClientArgs) => ({
+    getLoginUrl(): string {
+        return sp.createLoginRequest(idp, LOGIN_REQUEST_BINDING).context
+    },
+    async parseAndValidateLoginResponse(idpLoginResponse: IdpLoginResponse): Promise<SamlAttributes> {
+        const { data: loginResult, error: parseError } = await tryCatch(
+            () => sp.parseLoginResponse(idp, LOGIN_RESPONSE_BINDING, idpLoginResponse),
+        )
+        if (parseError !== null) {
+            throw new ActivepiecesError({
+                code: ErrorCode.INVALID_SAML_RESPONSE,
+                params: {
+                    message: `Failed to parse SAML response: ${parseError.message}`,
+                },
+            })
+        }
+        return resolveSamlAttributes({
+            rawAttributes: loginResult.extract?.attributes,
+            mapping: attributeMapping,
+        })
+    },
+})
 
 const createIdp = (metadata: string): saml.IdentityProviderInstance => {
     return saml.IdentityProvider({
@@ -78,32 +60,34 @@ const resolveIdpMetadata = async (idpMetadata: string): Promise<string> => {
     if (!/^https?:\/\//i.test(trimmed)) {
         return idpMetadata
     }
-    try {
-        const response = await safeHttp.axios.get<string>(trimmed, {
-            responseType: 'text',
-            timeout: 10_000,
-            maxContentLength: 5 * 1024 * 1024,
-            maxBodyLength: 5 * 1024 * 1024,
-            transformResponse: (data) => data,
-        })
-        const contentType = String(response.headers['content-type'] ?? '').toLowerCase()
-        if (contentType !== '' && !contentType.includes('xml') && !contentType.includes('text/plain')) {
-            throw new Error(`Unexpected content-type "${contentType}" — expected XML.`)
-        }
-        return typeof response.data === 'string' ? response.data : String(response.data)
-    }
-    catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
+    const { data: response, error } = await tryCatch(() => safeHttp.axios.get<string>(trimmed, {
+        responseType: 'text',
+        timeout: 10_000,
+        maxContentLength: 5 * 1024 * 1024,
+        maxBodyLength: 5 * 1024 * 1024,
+        transformResponse: (data) => data,
+    }))
+    if (error !== null) {
         throw new ActivepiecesError({
             code: ErrorCode.INVALID_SAML_RESPONSE,
             params: {
-                message: `Failed to fetch IdP metadata from URL: ${message}`,
+                message: `Failed to fetch IdP metadata from URL: ${error.message}`,
             },
         })
     }
+    const contentType = String(response.headers['content-type'] ?? '').toLowerCase()
+    if (contentType !== '' && !contentType.includes('xml') && !contentType.includes('text/plain')) {
+        throw new ActivepiecesError({
+            code: ErrorCode.INVALID_SAML_RESPONSE,
+            params: {
+                message: `Failed to fetch IdP metadata from URL: Unexpected content-type "${contentType}" — expected XML.`,
+            },
+        })
+    }
+    return typeof response.data === 'string' ? response.data : String(response.data)
 }
 
-const createSp = async (platformId: string, privateKey: string): Promise<saml.ServiceProviderInstance> => {
+const createSp = async ({ platformId, privateKey }: CreateSpArgs): Promise<saml.ServiceProviderInstance> => {
     const acsUrl = await domainHelper.getPublicUrl({ path: '/api/v1/authn/saml/acs', platformId })
     return saml.ServiceProvider({
         entityID: 'Activepieces',
@@ -119,6 +103,24 @@ const createSp = async (platformId: string, privateKey: string): Promise<saml.Se
         }],
         signatureConfig: {},
     })
+}
+
+const LOGIN_REQUEST_BINDING = 'redirect'
+const LOGIN_RESPONSE_BINDING = 'post'
+
+const instanceCache = new Map<string, SamlClient>()
+
+type SamlClient = ReturnType<typeof samlClient>
+
+type SamlClientArgs = {
+    idp: saml.IdentityProviderInstance
+    sp: saml.ServiceProviderInstance
+    attributeMapping: SAMLAttributeMapping | undefined
+}
+
+type CreateSpArgs = {
+    platformId: string
+    privateKey: string
 }
 
 export type IdpLoginResponse = {

--- a/packages/server/api/src/app/ee/authentication/saml-authn/saml-client.ts
+++ b/packages/server/api/src/app/ee/authentication/saml-authn/saml-client.ts
@@ -35,7 +35,7 @@ const samlClient = ({ idp, sp, attributeMapping }: SamlClientArgs) => ({
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_SAML_RESPONSE,
                 params: {
-                    message: `Failed to parse SAML response: ${parseError.message}`,
+                    message: `Failed to parse SAML response: ${toErrorMessage(parseError)}`,
                 },
             })
         }
@@ -71,7 +71,7 @@ const resolveIdpMetadata = async (idpMetadata: string): Promise<string> => {
         throw new ActivepiecesError({
             code: ErrorCode.INVALID_SAML_RESPONSE,
             params: {
-                message: `Failed to fetch IdP metadata from URL: ${error.message}`,
+                message: `Failed to fetch IdP metadata from URL: ${toErrorMessage(error)}`,
             },
         })
     }
@@ -103,6 +103,10 @@ const createSp = async ({ platformId, privateKey }: CreateSpArgs): Promise<saml.
         }],
         signatureConfig: {},
     })
+}
+
+const toErrorMessage = (error: unknown): string => {
+    return error instanceof Error ? error.message : String(error)
 }
 
 const LOGIN_REQUEST_BINDING = 'redirect'

--- a/packages/server/api/src/app/ee/authentication/saml-authn/saml-client.ts
+++ b/packages/server/api/src/app/ee/authentication/saml-authn/saml-client.ts
@@ -1,17 +1,10 @@
 
 import { safeHttp } from '@activepieces/server-utils'
-import { ActivepiecesError, ErrorCode, SAMLAuthnProviderConfig } from '@activepieces/shared'
+import { ActivepiecesError, ErrorCode, SAMLAttributeMapping, SAMLAuthnProviderConfig, tryCatch } from '@activepieces/shared'
 import * as validator from '@authenio/samlify-node-xmllint'
 import * as saml from 'samlify'
-import { z } from 'zod'
 import { domainHelper } from '../../custom-domains/domain-helper'
-
-
-const samlResponseValidator = z.object({
-    email: z.string(),
-    firstName: z.string(),
-    lastName: z.string(),
-})
+import { resolveSamlAttributes, SamlAttributes } from './saml-attributes'
 
 class SamlClient {
     private static readonly LOGIN_REQUEST_BINDING = 'redirect'
@@ -20,6 +13,7 @@ class SamlClient {
     constructor(
         private readonly idp: saml.IdentityProviderInstance,
         private readonly sp: saml.ServiceProviderInstance,
+        private readonly attributeMapping: SAMLAttributeMapping | undefined,
     ) {}
 
     getLoginUrl(): string {
@@ -32,23 +26,21 @@ class SamlClient {
     }
 
     async parseAndValidateLoginResponse(idpLoginResponse: IdpLoginResponse): Promise<SamlAttributes> {
-        const loginResult = await this.sp.parseLoginResponse(
+        const { data: loginResult, error: parseError } = await tryCatch(() => this.sp.parseLoginResponse(
             this.idp,
             SamlClient.LOGIN_RESPONSE_BINDING,
             idpLoginResponse,
-        )
-
-        const atts = loginResult.extract.attributes
-        if (!samlResponseValidator.safeParse(atts).success) {
+        ))
+        if (parseError !== null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_SAML_RESPONSE,
                 params: {
-                    message: 'Invalid SAML response, It should contain these firstName, lastName, email fields.',
+                    message: `Failed to parse SAML response: ${parseError.message}`,
                 },
-            
             })
         }
-        return atts
+        const rawAttributes = loginResult.extract?.attributes
+        return resolveSamlAttributes({ rawAttributes, mapping: this.attributeMapping })
     }
 }
 
@@ -63,7 +55,7 @@ export const createSamlClient = async (platformId: string, samlProvider: SAMLAut
     const metadataXml = await resolveIdpMetadata(samlProvider.idpMetadata)
     const idp = createIdp(metadataXml)
     const sp = await createSp(platformId, samlProvider.idpCertificate)
-    const client = new SamlClient(idp, sp)
+    const client = new SamlClient(idp, sp, samlProvider.attributeMapping)
     instanceCache.set(platformId, client)
     return client
 }
@@ -134,8 +126,4 @@ export type IdpLoginResponse = {
     query: Record<string, unknown>
 }
 
-export type SamlAttributes = {
-    email: string
-    firstName: string
-    lastName: string
-}
+export type { SamlAttributes } from './saml-attributes'

--- a/packages/server/api/test/unit/app/ee/authentication/saml-authn/saml-attributes.test.ts
+++ b/packages/server/api/test/unit/app/ee/authentication/saml-authn/saml-attributes.test.ts
@@ -1,0 +1,186 @@
+import { ActivepiecesError, ErrorCode } from '@activepieces/shared'
+import { resolveSamlAttributes } from '../../../../../../src/app/ee/authentication/saml-authn/saml-attributes'
+
+describe('resolveSamlAttributes', () => {
+    describe('default mappings', () => {
+        it('resolves simple email/firstName/lastName keys', () => {
+            const result = resolveSamlAttributes({
+                rawAttributes: {
+                    email: 'mario@flix.com',
+                    firstName: 'Mario',
+                    lastName: 'Siebeck',
+                },
+            })
+
+            expect(result).toEqual({
+                email: 'mario@flix.com',
+                firstName: 'Mario',
+                lastName: 'Siebeck',
+            })
+        })
+
+        it('resolves Microsoft Entra schema-qualified URIs out of the box', () => {
+            const result = resolveSamlAttributes({
+                rawAttributes: {
+                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'mario.siebeck@flix.com',
+                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname': 'Mario',
+                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname': 'Siebeck',
+                },
+            })
+
+            expect(result).toEqual({
+                email: 'mario.siebeck@flix.com',
+                firstName: 'Mario',
+                lastName: 'Siebeck',
+            })
+        })
+
+        it('ignores unrelated and null-valued claims while resolving the required fields', () => {
+            const result = resolveSamlAttributes({
+                rawAttributes: {
+                    'http://schemas.microsoft.com/identity/claims/tenantid': 'd8d0ad3e',
+                    'http://schemas.microsoft.com/identity/claims/objectidentifier': '788ab09e',
+                    'http://schemas.microsoft.com/ws/2008/06/identity/claims/role': null,
+                    'http://schemas.microsoft.com/claims/authnmethodsreferences': [null],
+                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'mario.siebeck@flix.com',
+                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname': 'Mario',
+                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname': 'Siebeck',
+                },
+            })
+
+            expect(result.email).toBe('mario.siebeck@flix.com')
+            expect(result.firstName).toBe('Mario')
+            expect(result.lastName).toBe('Siebeck')
+        })
+
+        it('flattens single-element string arrays returned by samlify', () => {
+            const result = resolveSamlAttributes({
+                rawAttributes: {
+                    email: ['mario@flix.com'],
+                    firstName: ['Mario'],
+                    lastName: ['Siebeck'],
+                },
+            })
+
+            expect(result.email).toBe('mario@flix.com')
+            expect(result.firstName).toBe('Mario')
+            expect(result.lastName).toBe('Siebeck')
+        })
+
+        it('is case-insensitive for the simple lowercase variants exposed by Entra', () => {
+            const result = resolveSamlAttributes({
+                rawAttributes: {
+                    emailaddress: 'mario@flix.com',
+                    givenname: 'Mario',
+                    surname: 'Siebeck',
+                },
+            })
+
+            expect(result.email).toBe('mario@flix.com')
+            expect(result.firstName).toBe('Mario')
+            expect(result.lastName).toBe('Siebeck')
+        })
+    })
+
+    describe('custom mapping', () => {
+        it('honours admin-supplied mapping ahead of the defaults', () => {
+            const result = resolveSamlAttributes({
+                rawAttributes: {
+                    'urn:oid:0.9.2342.19200300.100.1.3': 'mario@flix.com',
+                    'urn:oid:2.5.4.42': 'Mario',
+                    'urn:oid:2.5.4.4': 'Siebeck',
+                    email: 'fallback@flix.com',
+                },
+                mapping: {
+                    email: 'urn:oid:0.9.2342.19200300.100.1.3',
+                    firstName: 'urn:oid:2.5.4.42',
+                    lastName: 'urn:oid:2.5.4.4',
+                },
+            })
+
+            expect(result.email).toBe('mario@flix.com')
+            expect(result.firstName).toBe('Mario')
+            expect(result.lastName).toBe('Siebeck')
+        })
+
+        it('falls back to default keys when the override key is missing', () => {
+            const result = resolveSamlAttributes({
+                rawAttributes: {
+                    email: 'mario@flix.com',
+                    firstName: 'Mario',
+                    lastName: 'Siebeck',
+                },
+                mapping: {
+                    email: 'custom-email',
+                    firstName: 'custom-first',
+                    lastName: 'custom-last',
+                },
+            })
+
+            expect(result.email).toBe('mario@flix.com')
+            expect(result.firstName).toBe('Mario')
+            expect(result.lastName).toBe('Siebeck')
+        })
+
+        it('treats blank override strings as unset', () => {
+            const result = resolveSamlAttributes({
+                rawAttributes: {
+                    email: 'mario@flix.com',
+                    firstName: 'Mario',
+                    lastName: 'Siebeck',
+                },
+                mapping: {
+                    email: '   ',
+                    firstName: '',
+                    lastName: '\t',
+                },
+            })
+
+            expect(result.email).toBe('mario@flix.com')
+            expect(result.firstName).toBe('Mario')
+            expect(result.lastName).toBe('Siebeck')
+        })
+    })
+
+    describe('error reporting', () => {
+        it('throws INVALID_SAML_RESPONSE listing missing fields and received keys', () => {
+            expect(() => resolveSamlAttributes({
+                rawAttributes: {
+                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'mario@flix.com',
+                },
+            })).toThrow(ActivepiecesError)
+
+            try {
+                resolveSamlAttributes({
+                    rawAttributes: {
+                        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'mario@flix.com',
+                    },
+                })
+            }
+            catch (error) {
+                const e = error as ActivepiecesError
+                expect(e.error.code).toBe(ErrorCode.INVALID_SAML_RESPONSE)
+                const message = String((e.error.params as { message: string }).message)
+                expect(message).toContain('firstName')
+                expect(message).toContain('lastName')
+                expect(message).toContain('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress')
+                expect(message).toContain('attributeMapping')
+            }
+        })
+
+        it('throws when rawAttributes is null or undefined', () => {
+            expect(() => resolveSamlAttributes({ rawAttributes: null })).toThrow(ActivepiecesError)
+            expect(() => resolveSamlAttributes({ rawAttributes: undefined })).toThrow(ActivepiecesError)
+        })
+
+        it('treats empty-string and null-valued claims as missing', () => {
+            expect(() => resolveSamlAttributes({
+                rawAttributes: {
+                    email: '',
+                    firstName: null,
+                    lastName: undefined,
+                },
+            })).toThrow(ActivepiecesError)
+        })
+    })
+})

--- a/packages/server/api/test/unit/app/ee/authentication/saml-authn/saml-attributes.test.ts
+++ b/packages/server/api/test/unit/app/ee/authentication/saml-authn/saml-attributes.test.ts
@@ -144,28 +144,21 @@ describe('resolveSamlAttributes', () => {
 
     describe('error reporting', () => {
         it('throws INVALID_SAML_RESPONSE listing missing fields and received keys', () => {
-            expect(() => resolveSamlAttributes({
+            const run = () => resolveSamlAttributes({
                 rawAttributes: {
                     'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'mario@flix.com',
                 },
-            })).toThrow(ActivepiecesError)
+            })
 
-            try {
-                resolveSamlAttributes({
-                    rawAttributes: {
-                        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'mario@flix.com',
-                    },
-                })
-            }
-            catch (error) {
-                const e = error as ActivepiecesError
-                expect(e.error.code).toBe(ErrorCode.INVALID_SAML_RESPONSE)
-                const message = String((e.error.params as { message: string }).message)
-                expect(message).toContain('firstName')
-                expect(message).toContain('lastName')
-                expect(message).toContain('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress')
-                expect(message).toContain('attributeMapping')
-            }
+            expect(run).toThrow(ActivepiecesError)
+
+            const error = captureActivepiecesError(run)
+            expect(error.error.code).toBe(ErrorCode.INVALID_SAML_RESPONSE)
+            const message = readMessage(error)
+            expect(message).toContain('firstName')
+            expect(message).toContain('lastName')
+            expect(message).toContain('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress')
+            expect(message).toContain('attributeMapping')
         })
 
         it('throws when rawAttributes is null or undefined', () => {
@@ -184,3 +177,24 @@ describe('resolveSamlAttributes', () => {
         })
     })
 })
+
+function captureActivepiecesError(run: () => unknown): ActivepiecesError {
+    try {
+        run()
+    }
+    catch (error) {
+        if (error instanceof ActivepiecesError) {
+            return error
+        }
+        throw error
+    }
+    throw new Error('Expected ActivepiecesError to be thrown')
+}
+
+function readMessage(error: ActivepiecesError): string {
+    const params = error.error.params
+    if (params && typeof params === 'object' && 'message' in params && typeof params.message === 'string') {
+        return params.message
+    }
+    return ''
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.68.6",
+  "version": "0.69.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/core/federated-authn/index.ts
+++ b/packages/shared/src/lib/core/federated-authn/index.ts
@@ -29,9 +29,17 @@ export const GithubAuthnProviderConfig = z.object({
 })
 export type GithubAuthnProviderConfig = z.infer<typeof GithubAuthnProviderConfig>
 
+export const SAMLAttributeMapping = z.object({
+    email: z.string(),
+    firstName: z.string(),
+    lastName: z.string(),
+})
+export type SAMLAttributeMapping = z.infer<typeof SAMLAttributeMapping>
+
 export const SAMLAuthnProviderConfig = z.object({
     idpMetadata: z.string(),
     idpCertificate: z.string(),
+    attributeMapping: SAMLAttributeMapping.optional(),
 })
 export type SAMLAuthnProviderConfig = z.infer<typeof SAMLAuthnProviderConfig>
 


### PR DESCRIPTION
## Summary

Customer (Microsoft Entra / Azure AD) hit two errors configuring SAML SSO:

1. `INVALID_SAML_RESPONSE — "should contain firstName, lastName, email fields"` — even when the customer had those fields, because Entra sends `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` etc., and our validator only looked up the literal keys `email` / `firstName` / `lastName`.
2. `500 Internal Server Error — Cannot read properties of null (reading 'map')` — once the customer added extra Entra claims (tenantid, objectidentifier, role, authnmethodsreferences). The error originates inside `samlify`'s attribute aggregation when extracted values are `null` and bubbled up as a generic 500 with no diagnostic.

This PR fixes both:

- **Out-of-the-box Entra / AD-FS support** — resolve `email` / `firstName` / `lastName` from a candidate list that includes simple names, lowercase variants, and the standard `http://schemas.xmlsoap.org/...` URIs.
- **Optional `attributeMapping`** added to `SAMLAuthnProviderConfig` for IdPs that use custom names (e.g. `urn:oid:0.9.2342.19200300.100.1.3`). Admin overrides win, defaults are the fallback.
- **`tryCatch` around `parseLoginResponse`** so samlify internals failing on null-valued claims surface as `INVALID_SAML_RESPONSE` (4xx) instead of 500.
- **Better error message** — names the missing field(s), lists the attribute keys actually received, and points admins at `attributeMapping`.
- **Unit tests** (11) covering Entra defaults, custom mapping, blank-override fallback, single-element arrays, null/empty values, and error paths.
- `@activepieces/shared` minor bump (new exported `SAMLAttributeMapping` type and `attributeMapping` field).

## Test plan

- [x] `npm run lint-dev` — 0 errors
- [x] `npx vitest run test/unit/app/ee/authentication/saml-authn/saml-attributes.test.ts` — 11/11 pass
- [x] Pre-push test suite — 340 cloud integration tests pass
- [ ] Manual: replay the customer's full Entra claim set (with `tenantid`, `objectidentifier`, `role`, etc.) and confirm login succeeds without trimming claims.
- [ ] Manual: configure `attributeMapping` on an IdP that uses `urn:oid:*` attributes and confirm login succeeds.
- [ ] Manual: send a SAML response missing `email` and confirm the error message lists the received keys.