### PR TITLE
feat(chat): add conversation compaction to prevent context window overflow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -911,7 +911,7 @@
     },
     "packages/pieces/community/avian": {
       "name": "@activepieces/piece-avian",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -1042,7 +1042,7 @@
     },
     "packages/pieces/community/baserow": {
       "name": "@activepieces/piece-baserow",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -8230,7 +8230,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.68.5",
+      "version": "0.68.6",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",
@@ -9846,11 +9846,11 @@
 
     "@apidevtools/swagger-methods": ["@apidevtools/swagger-methods@3.0.2", "", {}, "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="],
 
-    "@apify/consts": ["@apify/consts@2.52.2", "", {}, "sha512-82mKh1V/0OIcH3qzn2aaC9MixeKggH2Cbvfm1uQOzei3VtHXCaZrbIYGmGrIQ4UXsKugiFDHlYw9GqSICSbsaA=="],
+    "@apify/consts": ["@apify/consts@2.53.0", "", {}, "sha512-gYAPOL24Wry6d8dFJ/0qdzx1BgkEmrUTqhHZ70zmMY99/to47D8utpteUQDOMXMsMCrRP8c/z/dNTGDls1wWKA=="],
 
-    "@apify/log": ["@apify/log@2.5.37", "", { "dependencies": { "@apify/consts": "^2.52.2", "ansi-colors": "^4.1.1" } }, "sha512-ZeVrq85GKK8Bm5HSU6+Lr/K9voJkPthQkMnf4FReBa+MSEV+k2RG0z0uZMeGNKKRMpmRxhuo8KDAyAIs4u9f9A=="],
+    "@apify/log": ["@apify/log@2.5.38", "", { "dependencies": { "@apify/consts": "^2.53.0", "ansi-colors": "^4.1.1" } }, "sha512-Lzmrra3Vvb9Fi4JzWFWPOeSGxItAk50ZHpB070TsSPxuYf9mgJqQ1VlLWn3HNalcdbIf0OoPAFOW31BEs5Khsw=="],
 
-    "@apify/utilities": ["@apify/utilities@2.29.2", "", { "dependencies": { "@apify/consts": "^2.52.2", "@apify/log": "^2.5.37" } }, "sha512-g8xET78HrKFrIMIFO8Lrzz+no5q7TmkG4XK6aXpUwhNPpohdKf5s6p7VKzYpNRPlaRG/T9fV/DCKiDIFu+RS8g=="],
+    "@apify/utilities": ["@apify/utilities@2.29.3", "", { "dependencies": { "@apify/consts": "^2.53.0", "@apify/log": "^2.5.38" } }, "sha512-bbMFHOXlAoJwEfp8+vUauJEfX2pxNPFaAH+E5u1RTjawz6Xq2IcuFNRv33DAC2vPVjDh3oNMTnpfaa0qU8vFuw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
@@ -9860,7 +9860,7 @@
 
     "@atlaskit/adf-schema-generator": ["@atlaskit/adf-schema-generator@2.2.0", "", { "dependencies": { "@atlaskit/editor-prosemirror": "^7.3.0", "@babel/runtime": "^7.0.0", "lodash": "^4.17.21" } }, "sha512-6YtAVbMOBv2MncdT61/KgYQOcqaYlDXLAch+DgfoFDkLj+gr/3W/fxquXw9mSwqFuk7Ikn0BhyCLD1y2G0wBtw=="],
 
-    "@atlaskit/adf-utils": ["@atlaskit/adf-utils@19.27.46", "", { "dependencies": { "@atlaskit/adf-schema": "^52.6.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@atlaskit/tmp-editor-statsig": "^72.0.0", "@babel/runtime": "^7.0.0" } }, "sha512-/wVc7IDCCZTJtY7H5vQV/EaDCVLc5s9Rap7Wp+SwjlVZgqgoiz6uadHN4rJEtqPf10bSVGVWD+59OFGbQztNiw=="],
+    "@atlaskit/adf-utils": ["@atlaskit/adf-utils@19.28.0", "", { "dependencies": { "@atlaskit/adf-schema": "^52.7.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0" } }, "sha512-YwrP4VaHXQGXMAzu3O2guFAiB8E4SCD1FksEQmBZowtWn370vS6jXkLhGMSr79WtU762Nu9osWzHsWns4Kk17g=="],
 
     "@atlaskit/atlassian-context": ["@atlaskit/atlassian-context@0.2.0", "", { "dependencies": { "@babel/runtime": "^7.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-msLRSp0qck6eflkShplgyIoOogNKxKRc6QIWGQlSvKGxHQNEbLEkRGcDzdh8PuBxSs1gda7OqYrdtQYQiPbpTQ=="],
 
@@ -9880,7 +9880,7 @@
 
     "@atlaskit/react-ufo": ["@atlaskit/react-ufo@5.17.0", "", { "dependencies": { "@atlaskit/atlassian-context": "^0.8.0", "@atlaskit/browser-apis": "^0.0.1", "@atlaskit/feature-gate-js-client": "^5.5.0", "@atlaskit/interaction-context": "^3.1.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@opentelemetry/api": "^1.9.0", "bind-event-listener": "^3.0.0", "bowser-ultralight": "^1.0.6", "scheduler": "0.23.2", "uuid": "^3.1.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-81lZocFvJrOd0xpk2Iup6aXS/0Cz6Qlf79Y4UrvqumGROoU/qFvtFjP/nTkCBCBYBa6ATgAa/n+qkw8CRQg3iA=="],
 
-    "@atlaskit/tmp-editor-statsig": ["@atlaskit/tmp-editor-statsig@72.1.1", "", { "dependencies": { "@atlaskit/feature-gate-js-client": "^5.5.0", "@atlaskit/react-ufo": "^5.17.0", "@babel/runtime": "^7.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-1EpKJdpc2lFC4O7Oj/kWYZ2rQMIZ9BClGoZhtm0MKUXIqA0C/bRWTX6Ggq2aPXJww0nCPsceK89VUsJkrFtbqQ=="],
+    "@atlaskit/tmp-editor-statsig": ["@atlaskit/tmp-editor-statsig@73.0.0", "", { "dependencies": { "@atlaskit/feature-gate-js-client": "^5.5.0", "@atlaskit/react-ufo": "^5.17.0", "@babel/runtime": "^7.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-6bVLebWPS+OaHFocquVGkQSs+m0905CxvQcIWLDWtU+93ftPqek+nqTfwF09uAenCgFlgBnBIXRA4GNLPuYl6A=="],
 
     "@atproto/api": ["@atproto/api@0.16.0", "", { "dependencies": { "@atproto/common-web": "^0.4.2", "@atproto/lexicon": "^0.4.12", "@atproto/syntax": "^0.4.0", "@atproto/xrpc": "^0.7.1", "await-lock": "^2.2.2", "multiformats": "^9.9.0", "tlds": "^1.234.0", "zod": "^3.23.8" } }, "sha512-PQHeae6mz/L1YirUslfci7bknfg3RrSZjXpYwzLICxIOvqGKIkOi0+qukC2Py238RhXRo8YZ9dCuole9HQBXDw=="],
 
@@ -11742,7 +11742,7 @@
 
     "@types/semver": ["@types/semver@7.5.6", "", {}, "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="],
 
-    "@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
 
     "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
 
@@ -12658,7 +12658,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.345", "", {}, "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg=="],
 
     "elliptic": ["elliptic@6.5.4", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ=="],
 
@@ -13188,7 +13188,7 @@
 
     "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
 
-    "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
+    "hono": ["hono@4.12.16", "", {}, "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 
@@ -14410,7 +14410,7 @@
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
-    "quick-lru": ["quick-lru@4.0.1", "", {}, "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="],
+    "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
     "quick-temp": ["quick-temp@0.1.9", "", { "dependencies": { "mktemp": "^2.0.1", "rimraf": "^5.0.10", "underscore.string": "~3.3.6" } }, "sha512-yI0h7tIhKVObn03kD+Ln9JFi4OljD28lfaOsTdfpTR0xzrhGOod+q66CjGafUqYX2juUfT9oHIGrTBBo22mkRA=="],
 
@@ -15578,7 +15578,7 @@
 
     "@atlaskit/adf-schema-generator/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@atlaskit/adf-utils/@atlaskit/adf-schema": ["@atlaskit/adf-schema@52.6.5", "", { "dependencies": { "@atlaskit/adf-schema-generator": "^2.2.0", "@atlaskit/editor-prosemirror": "^7.3.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@atlaskit/tmp-editor-statsig": "^72.0.0", "@babel/runtime": "^7.0.0", "css-color-names": "0.0.4", "linkify-it": "^3.0.3", "memoize-one": "^6.0.0" } }, "sha512-9s2bX/TI6IIttfiHFgYFz18oUEmai6kGPbz4uQMI25EuMGTbq/JlqN/2nqM7ctwcVPGdjrwmc2MSu3jAF9Hw9A=="],
+    "@atlaskit/adf-utils/@atlaskit/adf-schema": ["@atlaskit/adf-schema@52.7.0", "", { "dependencies": { "@atlaskit/adf-schema-generator": "^2.2.0", "@atlaskit/editor-prosemirror": "^7.3.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@atlaskit/tmp-editor-statsig": "^73.0.0", "@babel/runtime": "^7.0.0", "css-color-names": "0.0.4", "linkify-it": "^3.0.3", "memoize-one": "^6.0.0" } }, "sha512-R15BZFw3KE1//FqMtqK8eTSEVt/5RWXUIJipLM3Y+iDd51XLTnJuexggQeFXbH55vUWGGgSILBx9ZI+82EiV2A=="],
 
     "@atlaskit/atlassian-context/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
@@ -16032,7 +16032,7 @@
 
     "@dnd-kit/accessibility/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@dust-tt/client/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@github:dust-tt/typescript-sdk#bca26e4", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "dust-tt-typescript-sdk-bca26e4"],
+    "@dust-tt/client/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@github:dust-tt/typescript-sdk#bca26e4", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "dust-tt-typescript-sdk-bca26e4", "sha512-oxLE3SEGCVIhVNbn7xB9YgL7I6zrKujcH9s6e/1KcAj1VOht4lnM/oetqhwh9XhBh02cDHwkqHTzzIEBnBViiw=="],
 
     "@dust-tt/client/eventsource-parser": ["eventsource-parser@1.1.2", "", {}, "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA=="],
 
@@ -16752,6 +16752,8 @@
 
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.0", "", { "dependencies": { "@radix-ui/react-slot": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw=="],
 
+    "@readme/better-ajv-errors/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "@rollup/pluginutils/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "@rollup/wasm-node/@types/estree": ["@types/estree@1.0.5", "", {}, "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="],
@@ -16918,8 +16920,6 @@
 
     "@tinyhttp/accepts/mime": ["mime@4.0.4", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ=="],
 
-    "@tinyhttp/accepts/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
-
     "@tinyhttp/res/mime": ["mime@4.0.4", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ=="],
 
     "@tinyhttp/send/mime": ["mime@4.0.4", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ=="],
@@ -16941,6 +16941,8 @@
     "@types/node-fetch/form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "@types/request/form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
+
+    "@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
@@ -17045,6 +17047,8 @@
     "camel-case/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "camelcase-keys/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "camelcase-keys/quick-lru": ["quick-lru@4.0.1", "", {}, "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="],
 
     "checkly/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.1", "@typescript-eslint/tsconfig-utils": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g=="],
 
@@ -17334,8 +17338,6 @@
 
     "http-call/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
 
-    "http2-wrapper/quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
-
     "hume/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "hume/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -17447,8 +17449,6 @@
     "make-fetch-happen/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
     "make-fetch-happen/socks-proxy-agent": ["socks-proxy-agent@6.2.1", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ=="],
 

--- a/packages/server/api/src/app/chat/chat-compaction.ts
+++ b/packages/server/api/src/app/chat/chat-compaction.ts
@@ -140,7 +140,24 @@ function buildCompactedPayload({ messages, summary, summarizedUpToIndex, provide
     }
 
     const trimmedRecent = recentMessages.slice(startIdx)
-    const finalPayload = [summaryMessage, ...trimmedRecent]
+    const summaryText = `[Previous conversation summary]\n${summary}\n[End of summary — conversation continues below]`
+
+    // Anthropic rejects consecutive same-role messages. If the first recent
+    // message is also 'user', merge the summary into it instead of prepending
+    // a separate user message.
+    let finalPayload: ModelMessage[]
+    if (trimmedRecent[0]?.role === 'user') {
+        const mergedFirst: ModelMessage = {
+            ...trimmedRecent[0],
+            content: typeof trimmedRecent[0].content === 'string'
+                ? `${summaryText}\n\n${trimmedRecent[0].content}`
+                : summaryText,
+        }
+        finalPayload = [mergedFirst, ...trimmedRecent.slice(1)]
+    }
+    else {
+        finalPayload = [summaryMessage, ...trimmedRecent]
+    }
     const finalEstimate = Math.ceil(runningCharLen / CHARS_PER_TOKEN_ESTIMATE)
 
     if (finalEstimate > maxContext) {

--- a/packages/server/api/src/app/chat/chat-compaction.ts
+++ b/packages/server/api/src/app/chat/chat-compaction.ts
@@ -1,0 +1,184 @@
+import { ActivepiecesError, AIProviderName, aiProviderUtils, ErrorCode } from '@activepieces/shared'
+import { generateText, LanguageModel, ModelMessage } from 'ai'
+import { FastifyBaseLogger } from 'fastify'
+
+const COMPACTION_THRESHOLD = 0.7
+const RECENT_WINDOW_RATIO = 0.3
+const CHARS_PER_TOKEN_ESTIMATE = 4
+const MIN_MESSAGES_BEFORE_COMPACTION = 6
+const ESTIMATED_TOKENS_PER_MESSAGE = 200
+
+const COMPACTION_SYSTEM_PROMPT = `You are a conversation summarizer. Summarize the conversation below for context continuity. You MUST preserve:
+- All user-stated facts, preferences, and decisions
+- Names of entities, flows, pieces, and connections referenced
+- Results of any tool calls (what was called and what it returned)
+- The current task or question being worked on
+- Any errors or issues encountered
+
+Output a concise context block using bullet points. Do NOT include pleasantries, greetings, or filler. Do NOT use narrative form.`
+
+function estimateTokenCount({ messages, systemPromptLength }: {
+    messages: ModelMessage[]
+    systemPromptLength: number
+}): number {
+    const totalChars = JSON.stringify(messages).length + systemPromptLength
+    return Math.ceil(totalChars / CHARS_PER_TOKEN_ESTIMATE)
+}
+
+function shouldCompact({ estimatedTokens, provider, messageCount }: {
+    estimatedTokens: number
+    provider: AIProviderName
+    messageCount: number
+}): boolean {
+    if (messageCount < MIN_MESSAGES_BEFORE_COMPACTION) {
+        return false
+    }
+    const maxContext = aiProviderUtils.getMaxContextTokens({ provider })
+    return estimatedTokens > maxContext * COMPACTION_THRESHOLD
+}
+
+/**
+ * Snaps a cutoff index forward to a safe message boundary.
+ * Anthropic requires that every tool_result has a preceding tool_use in the
+ * same context. If the cutoff lands on a 'tool' message (or inside an
+ * assistant→tool pair), we back up so the recent window starts at the
+ * assistant message that initiated the tool call.
+ */
+function snapToSafeMessageBoundary({ messages, rawCutoff }: {
+    messages: ModelMessage[]
+    rawCutoff: number
+}): number {
+    let idx = Math.max(0, Math.min(rawCutoff, messages.length - 1))
+
+    while (idx > 0 && messages[idx].role === 'tool') {
+        idx--
+    }
+
+    return idx
+}
+
+async function compactMessages({ messages, existingSummary, summarizedUpToIndex, provider, model, log }: {
+    messages: ModelMessage[]
+    existingSummary: string | null
+    summarizedUpToIndex: number | null
+    provider: AIProviderName
+    model: LanguageModel
+    log: FastifyBaseLogger
+}): Promise<{ summary: string, summarizedUpToIndex: number }> {
+    const maxContext = aiProviderUtils.getMaxContextTokens({ provider })
+    const targetRecentTokens = maxContext * RECENT_WINDOW_RATIO
+    const recentWindowSize = Math.min(
+        Math.max(2, Math.floor(targetRecentTokens / ESTIMATED_TOKENS_PER_MESSAGE)),
+        messages.length - 1,
+    )
+    const rawCutoff = messages.length - recentWindowSize
+    const newCutoffIndex = snapToSafeMessageBoundary({ messages, rawCutoff })
+
+    const startIndex = summarizedUpToIndex ?? 0
+    const messagesToSummarize = messages.slice(startIndex, newCutoffIndex)
+
+    let contentToSummarize = ''
+    if (existingSummary) {
+        contentToSummarize += `Previous conversation summary:\n${existingSummary}\n\nNew messages since last summary:\n`
+    }
+
+    for (const msg of messagesToSummarize) {
+        const content = extractTextContent(msg)
+        if (content) {
+            contentToSummarize += `[${msg.role}]: ${content}\n`
+        }
+    }
+
+    log.info({
+        totalMessages: messages.length,
+        messagesToSummarize: messagesToSummarize.length,
+        newCutoffIndex,
+        recentWindowSize,
+        hadExistingSummary: !!existingSummary,
+    }, 'Compacting chat messages')
+
+    const { text: summary } = await generateText({
+        model,
+        system: COMPACTION_SYSTEM_PROMPT,
+        prompt: contentToSummarize,
+    })
+
+    return { summary, summarizedUpToIndex: newCutoffIndex }
+}
+
+function buildCompactedPayload({ messages, summary, summarizedUpToIndex, provider }: {
+    messages: ModelMessage[]
+    summary: string | null
+    summarizedUpToIndex: number | null
+    provider: AIProviderName
+}): ModelMessage[] {
+    if (!summary || summarizedUpToIndex === null) {
+        return messages
+    }
+
+    const recentMessages = messages.slice(summarizedUpToIndex)
+    const summaryMessage: ModelMessage = {
+        role: 'user',
+        content: `[Previous conversation summary]\n${summary}\n[End of summary — conversation continues below]`,
+    }
+
+    const maxContext = aiProviderUtils.getMaxContextTokens({ provider })
+    const threshold = maxContext * COMPACTION_THRESHOLD
+    const summaryCharLen = JSON.stringify(summaryMessage).length
+    const recentLengths = recentMessages.map((m) => JSON.stringify(m).length)
+
+    let runningCharLen = summaryCharLen + recentLengths.reduce((a, b) => a + b, 0)
+    let startIdx = 0
+
+    while (
+        startIdx < recentMessages.length - 1
+        && (Math.ceil(runningCharLen / CHARS_PER_TOKEN_ESTIMATE) > threshold || recentMessages[startIdx].role === 'tool')
+    ) {
+        runningCharLen -= recentLengths[startIdx]
+        startIdx++
+    }
+
+    const trimmedRecent = recentMessages.slice(startIdx)
+    const finalPayload = [summaryMessage, ...trimmedRecent]
+    const finalEstimate = Math.ceil(runningCharLen / CHARS_PER_TOKEN_ESTIMATE)
+
+    if (finalEstimate > maxContext) {
+        throw new ActivepiecesError({
+            code: ErrorCode.CHAT_CONTEXT_LIMIT_EXCEEDED,
+            params: {},
+        })
+    }
+
+    return finalPayload
+}
+
+function extractTextContent(message: ModelMessage): string {
+    if (typeof message.content === 'string') return message.content
+    if (!Array.isArray(message.content)) return ''
+    let text = ''
+    for (const part of message.content) {
+        if (typeof part === 'string') {
+            text += part
+        }
+        else if (typeof part === 'object' && part !== null && 'type' in part) {
+            if (part.type === 'text' && 'text' in part) {
+                text += String(part.text)
+            }
+            else if (part.type === 'tool-call' && 'toolName' in part) {
+                text += `[Tool call: ${String(part.toolName)}]`
+            }
+            else if (part.type === 'tool-result' && 'output' in part) {
+                const output = typeof part.output === 'string' ? part.output : JSON.stringify(part.output)
+                text += `[Tool result: ${output.slice(0, 500)}]`
+            }
+        }
+    }
+    return text
+}
+
+export const chatCompaction = {
+    estimateTokenCount,
+    shouldCompact,
+    compactMessages,
+    buildCompactedPayload,
+}

--- a/packages/server/api/src/app/chat/chat-compaction.ts
+++ b/packages/server/api/src/app/chat/chat-compaction.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import { ActivepiecesError, AIProviderName, aiProviderUtils, ErrorCode } from '@activepieces/shared'
 import { generateText, LanguageModel, ModelMessage } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
@@ -8,14 +10,10 @@ const CHARS_PER_TOKEN_ESTIMATE = 4
 const MIN_MESSAGES_BEFORE_COMPACTION = 6
 const ESTIMATED_TOKENS_PER_MESSAGE = 200
 
-const COMPACTION_SYSTEM_PROMPT = `You are a conversation summarizer. Summarize the conversation below for context continuity. You MUST preserve:
-- All user-stated facts, preferences, and decisions
-- Names of entities, flows, pieces, and connections referenced
-- Results of any tool calls (what was called and what it returned)
-- The current task or question being worked on
-- Any errors or issues encountered
-
-Output a concise context block using bullet points. Do NOT include pleasantries, greetings, or filler. Do NOT use narrative form.`
+const COMPACTION_SYSTEM_PROMPT = readFileSync(
+    path.resolve('packages/server/api/src/assets/prompts/chat-compaction-prompt.md'),
+    'utf8',
+)
 
 function estimateTokenCount({ messages, systemPromptLength }: {
     messages: ModelMessage[]

--- a/packages/server/api/src/app/chat/chat-compaction.ts
+++ b/packages/server/api/src/app/chat/chat-compaction.ts
@@ -73,6 +73,9 @@ async function compactMessages({ messages, existingSummary, summarizedUpToIndex,
     const newCutoffIndex = snapToSafeMessageBoundary({ messages, rawCutoff })
 
     const startIndex = summarizedUpToIndex ?? 0
+    if (newCutoffIndex <= startIndex) {
+        return { summary: existingSummary ?? '', summarizedUpToIndex: startIndex }
+    }
     const messagesToSummarize = messages.slice(startIndex, newCutoffIndex)
 
     let contentToSummarize = ''

--- a/packages/server/api/src/app/chat/chat-compaction.ts
+++ b/packages/server/api/src/app/chat/chat-compaction.ts
@@ -143,7 +143,7 @@ function buildCompactedPayload({ messages, summary, summarizedUpToIndex, provide
                 ...trimmedRecent[0],
                 content: typeof trimmedRecent[0].content === 'string'
                     ? `${summaryText}\n\n${trimmedRecent[0].content}`
-                    : summaryText,
+                    : [{ type: 'text' as const, text: summaryText }, ...trimmedRecent[0].content],
             },
             ...trimmedRecent.slice(1),
         ]

--- a/packages/server/api/src/app/chat/chat-compaction.ts
+++ b/packages/server/api/src/app/chat/chat-compaction.ts
@@ -36,11 +36,8 @@ function shouldCompact({ estimatedTokens, provider, messageCount }: {
 }
 
 /**
- * Snaps a cutoff index forward to a safe message boundary.
  * Anthropic requires that every tool_result has a preceding tool_use in the
- * same context. If the cutoff lands on a 'tool' message (or inside an
- * assistant→tool pair), we back up so the recent window starts at the
- * assistant message that initiated the tool call.
+ * same context, so the cutoff must not split an assistant→tool pair.
  */
 function snapToSafeMessageBoundary({ messages, rawCutoff }: {
     messages: ModelMessage[]
@@ -118,14 +115,11 @@ function buildCompactedPayload({ messages, summary, summarizedUpToIndex, provide
     }
 
     const recentMessages = messages.slice(summarizedUpToIndex)
-    const summaryMessage: ModelMessage = {
-        role: 'user',
-        content: `[Previous conversation summary]\n${summary}\n[End of summary — conversation continues below]`,
-    }
+    const summaryText = `[Previous conversation summary]\n${summary}\n[End of summary — conversation continues below]`
 
     const maxContext = aiProviderUtils.getMaxContextTokens({ provider })
     const threshold = maxContext * COMPACTION_THRESHOLD
-    const summaryCharLen = JSON.stringify(summaryMessage).length
+    const summaryCharLen = JSON.stringify(summaryText).length
     const recentLengths = recentMessages.map((m) => JSON.stringify(m).length)
 
     let runningCharLen = summaryCharLen + recentLengths.reduce((a, b) => a + b, 0)
@@ -140,24 +134,20 @@ function buildCompactedPayload({ messages, summary, summarizedUpToIndex, provide
     }
 
     const trimmedRecent = recentMessages.slice(startIdx)
-    const summaryText = `[Previous conversation summary]\n${summary}\n[End of summary — conversation continues below]`
 
-    // Anthropic rejects consecutive same-role messages. If the first recent
-    // message is also 'user', merge the summary into it instead of prepending
-    // a separate user message.
-    let finalPayload: ModelMessage[]
-    if (trimmedRecent[0]?.role === 'user') {
-        const mergedFirst: ModelMessage = {
-            ...trimmedRecent[0],
-            content: typeof trimmedRecent[0].content === 'string'
-                ? `${summaryText}\n\n${trimmedRecent[0].content}`
-                : summaryText,
-        }
-        finalPayload = [mergedFirst, ...trimmedRecent.slice(1)]
-    }
-    else {
-        finalPayload = [summaryMessage, ...trimmedRecent]
-    }
+    // Anthropic rejects consecutive same-role messages, so merge the summary
+    // into the first message when it is already a 'user' turn.
+    const finalPayload: ModelMessage[] = trimmedRecent[0]?.role === 'user'
+        ? [
+            {
+                ...trimmedRecent[0],
+                content: typeof trimmedRecent[0].content === 'string'
+                    ? `${summaryText}\n\n${trimmedRecent[0].content}`
+                    : summaryText,
+            },
+            ...trimmedRecent.slice(1),
+        ]
+        : [{ role: 'user', content: summaryText }, ...trimmedRecent]
     const finalEstimate = Math.ceil(runningCharLen / CHARS_PER_TOKEN_ESTIMATE)
 
     if (finalEstimate > maxContext) {

--- a/packages/server/api/src/app/chat/chat-conversation-entity.ts
+++ b/packages/server/api/src/app/chat/chat-conversation-entity.ts
@@ -33,7 +33,7 @@ export const ChatConversationEntity = new EntitySchema<ChatConversationWithRelat
             default: '[]',
         },
         summary: {
-            type: String,
+            type: 'text',
             nullable: true,
         },
         summarizedUpToIndex: {

--- a/packages/server/api/src/app/chat/chat-conversation-entity.ts
+++ b/packages/server/api/src/app/chat/chat-conversation-entity.ts
@@ -32,6 +32,14 @@ export const ChatConversationEntity = new EntitySchema<ChatConversationWithRelat
             nullable: false,
             default: '[]',
         },
+        summary: {
+            type: String,
+            nullable: true,
+        },
+        summarizedUpToIndex: {
+            type: Number,
+            nullable: true,
+        },
     },
     indices: [
         {

--- a/packages/server/api/src/app/chat/chat-service.ts
+++ b/packages/server/api/src/app/chat/chat-service.ts
@@ -20,7 +20,7 @@ import {
     UpdateChatConversationRequest,
 } from '@activepieces/shared'
 import { createMCPClient } from '@ai-sdk/mcp'
-import { ModelMessage, stepCountIs, streamText } from 'ai'
+import { LanguageModel, ModelMessage, stepCountIs, streamText } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { aiProviderService } from '../ai/ai-provider-service'
 import { repoFactory } from '../core/db/repo-factory'
@@ -31,6 +31,7 @@ import { system } from '../helper/system/system'
 import { AppSystemProp } from '../helper/system/system-props'
 import { mcpServerService } from '../mcp/mcp-service'
 import { projectService } from '../project/project-service'
+import { chatCompaction } from './chat-compaction'
 import { ChatConversationEntity } from './chat-conversation-entity'
 import { buildUserContentWithFiles } from './chat-file-utils'
 import { createChatModel } from './chat-model-factory'
@@ -142,6 +143,23 @@ export const chatService = (log: FastifyBaseLogger) => ({
         const newUserMessage: ModelMessage = { role: 'user' as const, content: userContent }
         const allMessages = [...previousMessages, newUserMessage]
 
+        const compactionState = await resolveCompactionState({
+            conversation,
+            allMessages,
+            systemPromptLength: systemPrompt.length,
+            provider: providerConfig.provider,
+            model,
+            conversationId,
+            log,
+        })
+
+        const messagesForLlm = chatCompaction.buildCompactedPayload({
+            messages: allMessages,
+            summary: compactionState.summary,
+            summarizedUpToIndex: compactionState.summarizedUpToIndex,
+            provider: providerConfig.provider,
+        })
+
         let pendingTitle = ''
         const localTools = createChatTools({
             onSessionTitle: (title) => {
@@ -162,7 +180,7 @@ export const chatService = (log: FastifyBaseLogger) => ({
             const result = streamText({
                 model,
                 system: systemPrompt,
-                messages: allMessages,
+                messages: messagesForLlm,
                 tools,
                 stopWhen: stepCountIs(MAX_STEPS),
                 onStepFinish: ({ finishReason, usage }) => {
@@ -232,6 +250,45 @@ async function resolveDefaultChatModel({ platformId, provider, log }: {
         code: ErrorCode.ENTITY_NOT_FOUND,
         params: { entityId: provider, entityType: 'AIProviderTextModel' },
     })
+}
+
+async function resolveCompactionState({ conversation, allMessages, systemPromptLength, provider, model, conversationId, log }: {
+    conversation: ChatConversation
+    allMessages: ModelMessage[]
+    systemPromptLength: number
+    provider: AIProviderName
+    model: LanguageModel
+    conversationId: string
+    log: FastifyBaseLogger
+}): Promise<{ summary: string | null, summarizedUpToIndex: number | null }> {
+    const summary = conversation.summary ?? null
+    const summarizedUpToIndex = conversation.summarizedUpToIndex ?? null
+
+    const estimatedTokens = chatCompaction.estimateTokenCount({
+        messages: allMessages,
+        systemPromptLength,
+    })
+
+    if (!chatCompaction.shouldCompact({ estimatedTokens, provider, messageCount: allMessages.length })) {
+        return { summary, summarizedUpToIndex }
+    }
+
+    const result = await chatCompaction.compactMessages({
+        messages: allMessages,
+        existingSummary: summary,
+        summarizedUpToIndex,
+        provider,
+        model,
+        log,
+    })
+
+    await conversationRepo().update(conversationId, {
+        summary: result.summary,
+        summarizedUpToIndex: result.summarizedUpToIndex,
+    })
+    log.info({ conversationId, summarizedUpToIndex: result.summarizedUpToIndex }, 'Chat compaction completed')
+
+    return result
 }
 
 async function connectMcpClient({ mcpCredentials, log }: {

--- a/packages/server/api/src/app/database/migration/postgres/1786000000000-AddChatCompactionColumns.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1786000000000-AddChatCompactionColumns.ts
@@ -1,0 +1,25 @@
+import { QueryRunner } from 'typeorm'
+import { Migration } from '../../migration'
+
+export class AddChatCompactionColumns1786000000000 implements Migration {
+    name = 'AddChatCompactionColumns1786000000000'
+    breaking = false
+    release = '0.85.0'
+    transaction = true
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "chat_conversation"
+            ADD COLUMN "summary" text,
+            ADD COLUMN "summarizedUpToIndex" integer
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "chat_conversation"
+            DROP COLUMN IF EXISTS "summary",
+            DROP COLUMN IF EXISTS "summarizedUpToIndex"
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -366,6 +366,7 @@ import { AddLastLoggedInPlatformIdToUserIdentity1777491000474 } from './migratio
 import { DropChatTokenColumns1782000000000 } from './migration/postgres/1782000000000-DropChatTokenColumns'
 import { AddUserSandboxTable1784000000000 } from './migration/postgres/1784000000000-AddUserSandboxTable'
 import { ReplacesSandboxWithVercelAiSdk1785000000000 } from './migration/postgres/1785000000000-ReplacesSandboxWithVercelAiSdk'
+import { AddChatCompactionColumns1786000000000 } from './migration/postgres/1786000000000-AddChatCompactionColumns'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -747,6 +748,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         AddUserSandboxTable1784000000000,
         AddLastLoggedInPlatformIdToUserIdentity1777491000474,
         ReplacesSandboxWithVercelAiSdk1785000000000,
+        AddChatCompactionColumns1786000000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -44,6 +44,7 @@ export const errorHandler = async (
             [ErrorCode.DOES_NOT_MEET_BUSINESS_REQUIREMENTS]: StatusCodes.UNPROCESSABLE_ENTITY,
             [ErrorCode.FLOW_RUN_RETRY_OUTSIDE_RETENTION]: StatusCodes.GONE,
             [ErrorCode.SANDBOX_CAPACITY_EXCEEDED]: StatusCodes.TOO_MANY_REQUESTS,
+            [ErrorCode.CHAT_CONTEXT_LIMIT_EXCEEDED]: StatusCodes.BAD_REQUEST,
         }
         const statusCode =
       statusCodeMap[error.error.code] ?? StatusCodes.BAD_REQUEST

--- a/packages/server/api/src/assets/prompts/chat-compaction-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-compaction-prompt.md
@@ -1,0 +1,8 @@
+You are a conversation summarizer. Summarize the conversation below for context continuity. You MUST preserve:
+- All user-stated facts, preferences, and decisions
+- Names of entities, flows, pieces, and connections referenced
+- Results of any tool calls (what was called and what it returned)
+- The current task or question being worked on
+- Any errors or issues encountered
+
+Output a concise context block using bullet points. Do NOT include pleasantries, greetings, or filler. Do NOT use narrative form.

--- a/packages/server/api/test/unit/app/chat/chat-compaction.test.ts
+++ b/packages/server/api/test/unit/app/chat/chat-compaction.test.ts
@@ -62,10 +62,10 @@ describe('chatCompaction.shouldCompact', () => {
     })
 
     it('uses correct limits per provider', () => {
-        // OpenAI has 1M context. 70% = 700K
+        // Google has 1M context. 70% = ~700K. 150K is well below threshold.
         const result = chatCompaction.shouldCompact({
             estimatedTokens: 150_000,
-            provider: AIProviderName.OPENAI,
+            provider: AIProviderName.GOOGLE,
             messageCount: 20,
         })
         expect(result).toBe(false)

--- a/packages/server/api/test/unit/app/chat/chat-compaction.test.ts
+++ b/packages/server/api/test/unit/app/chat/chat-compaction.test.ts
@@ -1,0 +1,185 @@
+import { AIProviderName, ErrorCode } from '@activepieces/shared'
+import { ModelMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+import { chatCompaction } from '../../../../src/app/chat/chat-compaction'
+
+function makeMessages(count: number, charsPer = 100): ModelMessage[] {
+    return Array.from({ length: count }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' as const : 'assistant' as const,
+        content: `Message ${i}: ${'x'.repeat(charsPer)}`,
+    }))
+}
+
+describe('chatCompaction.estimateTokenCount', () => {
+    it('estimates tokens from message character length', () => {
+        const messages = makeMessages(2, 100)
+        const result = chatCompaction.estimateTokenCount({ messages, systemPromptLength: 0 })
+        expect(result).toBeGreaterThan(0)
+        expect(result).toBe(Math.ceil(JSON.stringify(messages).length / 4))
+    })
+
+    it('includes system prompt length in estimate', () => {
+        const messages = makeMessages(1)
+        const withoutSystem = chatCompaction.estimateTokenCount({ messages, systemPromptLength: 0 })
+        const withSystem = chatCompaction.estimateTokenCount({ messages, systemPromptLength: 400 })
+        expect(withSystem - withoutSystem).toBe(100)
+    })
+
+    it('returns 1 for empty messages with no system prompt', () => {
+        const result = chatCompaction.estimateTokenCount({ messages: [], systemPromptLength: 0 })
+        expect(result).toBe(Math.ceil('[]'.length / 4))
+    })
+})
+
+describe('chatCompaction.shouldCompact', () => {
+    it('returns false when message count is below minimum', () => {
+        const result = chatCompaction.shouldCompact({
+            estimatedTokens: 999_999,
+            provider: AIProviderName.ANTHROPIC,
+            messageCount: 5,
+        })
+        expect(result).toBe(false)
+    })
+
+    it('returns false when tokens are below 70% of provider limit', () => {
+        // Anthropic has 200K context. 70% = 140K
+        const result = chatCompaction.shouldCompact({
+            estimatedTokens: 100_000,
+            provider: AIProviderName.ANTHROPIC,
+            messageCount: 20,
+        })
+        expect(result).toBe(false)
+    })
+
+    it('returns true when tokens exceed 70% of provider limit', () => {
+        // Anthropic has 200K context. 70% = 140K
+        const result = chatCompaction.shouldCompact({
+            estimatedTokens: 150_000,
+            provider: AIProviderName.ANTHROPIC,
+            messageCount: 20,
+        })
+        expect(result).toBe(true)
+    })
+
+    it('uses correct limits per provider', () => {
+        // OpenAI has 1M context. 70% = 700K
+        const result = chatCompaction.shouldCompact({
+            estimatedTokens: 150_000,
+            provider: AIProviderName.OPENAI,
+            messageCount: 20,
+        })
+        expect(result).toBe(false)
+    })
+})
+
+describe('chatCompaction.buildCompactedPayload', () => {
+    it('returns messages as-is when no summary exists', () => {
+        const messages = makeMessages(10)
+        const result = chatCompaction.buildCompactedPayload({
+            messages,
+            summary: null,
+            summarizedUpToIndex: null,
+            provider: AIProviderName.ANTHROPIC,
+        })
+        expect(result).toBe(messages)
+    })
+
+    it('prepends summary and keeps only recent messages', () => {
+        const messages = makeMessages(10, 50)
+        const result = chatCompaction.buildCompactedPayload({
+            messages,
+            summary: 'User discussed flow creation.',
+            summarizedUpToIndex: 7,
+            provider: AIProviderName.ANTHROPIC,
+        })
+
+        expect(result.length).toBe(4) // 1 summary + 3 recent (index 7,8,9)
+        expect(result[0].role).toBe('user')
+        expect(result[0].content).toContain('[Previous conversation summary]')
+        expect(result[0].content).toContain('User discussed flow creation.')
+        expect(result[1]).toBe(messages[7])
+        expect(result[2]).toBe(messages[8])
+        expect(result[3]).toBe(messages[9])
+    })
+
+    it('trims recent messages if compacted payload still exceeds threshold', () => {
+        // Create messages with very large content so payload exceeds threshold
+        // Anthropic: 200K * 0.7 = 140K tokens = 560K chars
+        const largeMessages = Array.from({ length: 10 }, (_, i) => ({
+            role: i % 2 === 0 ? 'user' as const : 'assistant' as const,
+            content: `Message ${i}: ${'x'.repeat(200_000)}`,
+        }))
+
+        const result = chatCompaction.buildCompactedPayload({
+            messages: largeMessages,
+            summary: 'Short summary.',
+            summarizedUpToIndex: 5,
+            provider: AIProviderName.ANTHROPIC,
+        })
+
+        // Should have trimmed some recent messages
+        expect(result.length).toBeLessThan(6) // less than 1 summary + 5 recent
+        expect(result[0].content).toContain('[Previous conversation summary]')
+    })
+
+    it('throws CHAT_CONTEXT_LIMIT_EXCEEDED when even minimal payload is too large', () => {
+        // Single message larger than the entire context window
+        const hugeMessages: ModelMessage[] = [{
+            role: 'user',
+            content: 'x'.repeat(2_000_000),
+        }]
+
+        expect(() => chatCompaction.buildCompactedPayload({
+            messages: hugeMessages,
+            summary: 'Summary',
+            summarizedUpToIndex: 0,
+            provider: AIProviderName.ANTHROPIC,
+        })).toThrow(expect.objectContaining({
+            error: expect.objectContaining({
+                code: ErrorCode.CHAT_CONTEXT_LIMIT_EXCEEDED,
+            }),
+        }))
+    })
+
+    it('skips orphaned tool messages when trimming the recent window', () => {
+        const messages: ModelMessage[] = [
+            { role: 'user', content: 'msg 0' },
+            { role: 'assistant', content: 'msg 1' },
+            { role: 'user', content: 'msg 2' },
+            { role: 'assistant', content: [{ type: 'tool-call', toolCallId: 't1', toolName: 'myTool', args: {} }] },
+            { role: 'tool', content: [{ type: 'tool-result', toolCallId: 't1', result: 'done' }] },
+            { role: 'assistant', content: 'msg 5' },
+            { role: 'user', content: 'msg 6' },
+            { role: 'assistant', content: 'msg 7' },
+        ]
+
+        // summarizedUpToIndex=4 means recent window starts at the tool message
+        const result = chatCompaction.buildCompactedPayload({
+            messages,
+            summary: 'Summary of earlier messages.',
+            summarizedUpToIndex: 4,
+            provider: AIProviderName.ANTHROPIC,
+        })
+
+        // First message should be summary, second should NOT be a tool message
+        expect(result[0].content).toContain('[Previous conversation summary]')
+        for (let i = 1; i < result.length; i++) {
+            if (i === 1) {
+                expect(result[i].role).not.toBe('tool')
+            }
+        }
+    })
+
+    it('does not trim when compacted payload fits within threshold', () => {
+        const messages = makeMessages(20, 50)
+        const result = chatCompaction.buildCompactedPayload({
+            messages,
+            summary: 'Brief summary.',
+            summarizedUpToIndex: 15,
+            provider: AIProviderName.ANTHROPIC,
+        })
+
+        // 1 summary + 5 recent messages (index 15-19)
+        expect(result.length).toBe(6)
+    })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.68.5",
+  "version": "0.68.6",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/automation/chat/index.ts
+++ b/packages/shared/src/lib/automation/chat/index.ts
@@ -30,6 +30,8 @@ export const ChatConversation = z.object({
     title: Nullable(z.string()),
     modelName: Nullable(z.string()),
     messages: z.array(z.record(z.string(), z.unknown())).default([]),
+    summary: Nullable(z.string()),
+    summarizedUpToIndex: Nullable(z.number().int()),
 })
 export type ChatConversation = z.infer<typeof ChatConversation>
 

--- a/packages/shared/src/lib/core/common/activepieces-error.ts
+++ b/packages/shared/src/lib/core/common/activepieces-error.ts
@@ -68,6 +68,7 @@ export type ApErrorParams =
     | SessionExpiredParams
     | InvalidLicenseKeyParams
     | NoChatResponseParams
+    | ChatContextLimitExceededParams
     | InvalidSmtpCredentialsErrorParams
     | InvalidGitCredentialsParams
     | InvalidReleaseTypeParams
@@ -143,6 +144,8 @@ export type SessionExpiredParams = BaseErrorParams<ErrorCode.SESSION_EXPIRED, {
 }>
 
 export type NoChatResponseParams = BaseErrorParams<ErrorCode.NO_CHAT_RESPONSE, Record<string, never>>
+
+export type ChatContextLimitExceededParams = BaseErrorParams<ErrorCode.CHAT_CONTEXT_LIMIT_EXCEEDED, Record<string, never>>
 
 export type EmailAuthIsDisabledParams = BaseErrorParams<ErrorCode.EMAIL_AUTH_DISABLED, Record<string, never>>
 
@@ -496,6 +499,7 @@ export enum ErrorCode {
     MACHINE_NOT_AVAILABLE = 'MACHINE_NOT_AVAILABLE',
     INVALID_CUSTOM_DOMAIN = 'INVALID_CUSTOM_DOMAIN',
     NO_CHAT_RESPONSE = 'NO_CHAT_RESPONSE',
+    CHAT_CONTEXT_LIMIT_EXCEEDED = 'CHAT_CONTEXT_LIMIT_EXCEEDED',
     ERROR_UPDATING_SUBSCRIPTION = 'ERROR_UPDATING_SUBSCRIPTION',
     AUTHENTICATION = 'AUTHENTICATION',
     AUTHORIZATION = 'AUTHORIZATION',

--- a/packages/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/shared/src/lib/management/ai-providers/index.ts
@@ -354,3 +354,24 @@ export function splitCloudflareGatewayModelId(modelId: string): {
         publisher: undefined,
     }
 }
+
+const DEFAULT_MAX_CONTEXT_TOKENS = 128_000
+
+const PROVIDER_MAX_CONTEXT_TOKENS: Partial<Record<AIProviderName, number>> = {
+    [AIProviderName.OPENAI]: 1_048_576,
+    [AIProviderName.ANTHROPIC]: 200_000,
+    [AIProviderName.GOOGLE]: 1_048_576,
+    [AIProviderName.BEDROCK]: 200_000,
+    [AIProviderName.AZURE]: 1_048_576,
+    [AIProviderName.OPENROUTER]: 200_000,
+    [AIProviderName.ACTIVEPIECES]: 200_000,
+}
+
+function getMaxContextTokens({ provider }: { provider: AIProviderName | undefined }): number {
+    if (!provider) return DEFAULT_MAX_CONTEXT_TOKENS
+    return PROVIDER_MAX_CONTEXT_TOKENS[provider] ?? DEFAULT_MAX_CONTEXT_TOKENS
+}
+
+export const aiProviderUtils = {
+    getMaxContextTokens,
+}

--- a/packages/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/shared/src/lib/management/ai-providers/index.ts
@@ -363,7 +363,7 @@ const PROVIDER_MAX_CONTEXT_TOKENS: Partial<Record<AIProviderName, number>> = {
     [AIProviderName.GOOGLE]: 1_048_576,
     [AIProviderName.BEDROCK]: 200_000,
     [AIProviderName.AZURE]: 128_000,
-    [AIProviderName.OPENROUTER]: 200_000,
+    [AIProviderName.OPENROUTER]: 128_000,
     [AIProviderName.ACTIVEPIECES]: 200_000,
 }
 

--- a/packages/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/shared/src/lib/management/ai-providers/index.ts
@@ -358,11 +358,11 @@ export function splitCloudflareGatewayModelId(modelId: string): {
 const DEFAULT_MAX_CONTEXT_TOKENS = 128_000
 
 const PROVIDER_MAX_CONTEXT_TOKENS: Partial<Record<AIProviderName, number>> = {
-    [AIProviderName.OPENAI]: 1_048_576,
+    [AIProviderName.OPENAI]: 128_000,
     [AIProviderName.ANTHROPIC]: 200_000,
     [AIProviderName.GOOGLE]: 1_048_576,
     [AIProviderName.BEDROCK]: 200_000,
-    [AIProviderName.AZURE]: 1_048_576,
+    [AIProviderName.AZURE]: 128_000,
     [AIProviderName.OPENROUTER]: 200_000,
     [AIProviderName.ACTIVEPIECES]: 200_000,
 }


### PR DESCRIPTION
## Summary
Adds server-side chat compaction that automatically summarizes older conversation messages when the context window is running out of space. This prevents provider 400 errors on long conversations and reduces token costs.

## How It Works

### Problem
The chat feature stores the entire conversation history in a JSONB `messages` column and sends **all messages** to the LLM on every request. When conversations grow beyond the model's context window, the provider returns a 400 error and the conversation breaks with no recovery.

### Solution — Hybrid Compaction (Summary + Recent Window)
Before each `streamText()` call, the server estimates the token count and checks if it exceeds 70% of the provider's context limit. When triggered:

1. **Summarize** — Calls `generateText()` with a structured prompt that preserves user decisions, entity names, tool call results, and the current task
2. **Split** — Keeps recent messages verbatim (the "recent window") and replaces older messages with the summary
3. **Store** — Saves the summary in new `summary` and `summarizedUpToIndex` columns; the full `messages` array is preserved for UI rendering
4. **Send** — Passes `[summary_message, ...recent_messages]` to the LLM instead of the full history

The compaction is **fully transparent** — the user sees the complete message history in the UI, and the model retains context about earlier messages via the summary.

### Key Design Decisions
| Decision | Choice |
|---|---|
| Trigger | Lazy — only at 70% of provider context limit |
| Token estimation | Character heuristic (~4 chars/token) |
| Context limits | Per-provider map (OpenAI: 1M, Anthropic: 200K, Google: 1M, etc.) with 128K default |
| Summarization model | Same model as the conversation |
| Storage | Separate `summary` + `summarizedUpToIndex` columns; `messages` untouched |
| Tool call safety | Respects assistant→tool message pairs to avoid orphaned `tool_result` errors |
| Overflow fallback | Progressively shrinks recent window; throws `CHAT_CONTEXT_LIMIT_EXCEEDED` if even minimal payload is too large |

## Changes

### New Files
- `packages/server/api/src/app/chat/chat-compaction.ts` — Compaction module (estimateTokenCount, shouldCompact, compactMessages, buildCompactedPayload)
- `packages/server/api/src/app/database/migration/postgres/1786000000000-AddChatCompactionColumns.ts` — Migration adding `summary` and `summarizedUpToIndex` columns
- `packages/server/api/test/unit/app/chat/chat-compaction.test.ts` — 13 unit tests

### Modified Files
- `chat-service.ts` — Integrated compaction into `sendMessage()` via `resolveCompactionState` helper
- `chat-conversation-entity.ts` — Added `summary` (String, nullable) and `summarizedUpToIndex` (Number, nullable) columns
- `ai-providers/index.ts` — Added `PROVIDER_MAX_CONTEXT_TOKENS` map and `aiProviderUtils.getMaxContextTokens()`
- `activepieces-error.ts` — Added `CHAT_CONTEXT_LIMIT_EXCEEDED` error code
- `error-handler.ts` — Mapped new error code to 400
- `chat/index.ts` (shared) — Added fields to `ChatConversation` schema
- `shared/package.json` — Bumped to 0.68.6

## Test plan
- [x] Unit tests for `estimateTokenCount`, `shouldCompact`, `buildCompactedPayload` including tool boundary edge cases (13 tests)
- [x] End-to-end manual test: compaction triggered on real conversation, summary stored in DB, model retained context from summarized messages
- [x] Verified tool call boundary handling prevents Anthropic `tool_result` pairing errors
- [ ] Verify on OpenAI and Google providers
- [ ] Verify re-compaction (extending an existing summary with more messages)
- [x] `npm run lint-dev` passes with 0 errors
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)