### PR TITLE
fix(microsoft-teams): make dropdown loaders resilient to throttling a…

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4583,7 +4583,7 @@
     },
     "packages/pieces/community/microsoft-teams": {
       "name": "@activepieces/piece-microsoft-teams",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/community/microsoft-teams/package.json
+++ b/packages/pieces/community/microsoft-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-teams",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/microsoft-teams/src/lib/actions/send-channel-message.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/actions/send-channel-message.ts
@@ -3,7 +3,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { PageCollection } from '@microsoft/microsoft-graph-client';
 import { ConversationMember } from '@microsoft/microsoft-graph-types';
 import { microsoftTeamsCommon } from '../common';
-import { createGraphClient } from '../common/graph';
+import { createGraphClient, withGraphRetry } from '../common/graph';
 
 export const sendChannelMessageAction = createAction({
   auth: microsoftTeamsAuth,
@@ -73,15 +73,18 @@ export const sendChannelMessageAction = createAction({
       ]);
 
       const members: ConversationMember[] = [];
-      let response: PageCollection = await client
-        .api(`/teams/${teamId}/members`)
-        .filter(filterClauses.join(' or '))
-        .get();
+      let response: PageCollection = await withGraphRetry(() =>
+        client
+          .api(`/teams/${teamId}/members`)
+          .filter(filterClauses.join(' or '))
+          .get(),
+      );
 
-      while (response.value.length > 0) {
+      while (response.value && response.value.length > 0) {
         members.push(...(response.value as ConversationMember[]));
-        if (response['@odata.nextLink']) {
-          response = await client.api(response['@odata.nextLink']).get();
+        const nextLink = response['@odata.nextLink'];
+        if (nextLink) {
+          response = await withGraphRetry(() => client.api(nextLink).get());
         } else {
           break;
         }

--- a/packages/pieces/community/microsoft-teams/src/lib/common/graph.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/common/graph.ts
@@ -1,4 +1,5 @@
-import { Client } from '@microsoft/microsoft-graph-client';
+import { Client, PageCollection } from '@microsoft/microsoft-graph-client';
+import { tryCatch } from '@activepieces/shared';
 import { getGraphBaseUrl } from './microsoft-cloud';
 
 type GraphRetryOptions = {
@@ -47,8 +48,6 @@ const extractStatusCode = (error: any): number => {
 const shouldRetry = (statusCode: number, code?: string): boolean => {
 	// Retry on throttling and transient errors
 	if (statusCode === 429 || statusCode === 503 || statusCode === 504) return true;
-	// Some concurrency conflicts can be retried
-	if (statusCode === 409) return true;
 	// Optionally retry generic server errors
 	if (statusCode >= 500 && statusCode < 600) return true;
 	// Some SDKs surface codes like 'TooManyRequests'
@@ -117,6 +116,42 @@ export const withGraphRetry = async <T>(
 		}
 	}
 	throw new Error("Unexpected error occured");
+};
+
+// Walks a paginated Graph list endpoint with retry, an item cap, and graceful failure.
+// Returns whatever was collected before an error or the cap; the cap protects the 60s
+// dropdown sandbox timeout from runaway pagination on accounts with very large lists.
+export const paginateGraphList = async <T>(params: {
+	client: Client;
+	initialUrl: string;
+	// Omit on endpoints that don't support OData $top (e.g. /me/joinedTeams).
+	pageSize?: number;
+	maxItems: number;
+	expand?: string;
+}): Promise<{ items: T[]; truncated: boolean; error: Error | null }> => {
+	const { client, initialUrl, pageSize, maxItems, expand } = params;
+	const items: T[] = [];
+	const { error } = await tryCatch(async () => {
+		let firstRequest = client.api(initialUrl);
+		if (pageSize !== undefined) firstRequest = firstRequest.top(pageSize);
+		if (expand) firstRequest = firstRequest.expand(expand);
+		let response: PageCollection = await withGraphRetry(() => firstRequest.get());
+		while (response.value && response.value.length > 0) {
+			for (const item of response.value as T[]) {
+				items.push(item);
+				if (items.length >= maxItems) break;
+			}
+			if (items.length >= maxItems) break;
+			const nextLink = response['@odata.nextLink'];
+			if (!nextLink) break;
+			response = await withGraphRetry(() => client.api(nextLink).get());
+		}
+	});
+	return {
+		items,
+		truncated: items.length >= maxItems,
+		error,
+	};
 };
 
 

--- a/packages/pieces/community/microsoft-teams/src/lib/common/index.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/common/index.ts
@@ -3,7 +3,7 @@ import { DropdownOption, OAuth2PropertyValue, PiecePropValueSchema, Property } f
 import { PageCollection } from '@microsoft/microsoft-graph-client';
 import { Team, Channel, Chat, ConversationMember, CallTranscript, CallRecording } from '@microsoft/microsoft-graph-types';
 import { microsoftTeamsAuth } from '../auth';
-import { createGraphClient, resolveMeetingId } from './graph';
+import { createGraphClient, paginateGraphList, resolveMeetingId } from './graph';
 
 export const microsoftTeamsCommon = {
 	teamId: Property.Dropdown({
@@ -22,24 +22,26 @@ export const microsoftTeamsCommon = {
 			const authValue = auth as PiecePropValueSchema<typeof microsoftTeamsAuth>;
 			const cloud = (auth as OAuth2PropertyValue).props?.['cloud'] as string | undefined;
 			const client = createGraphClient(authValue.access_token, cloud);
-			const options: DropdownOption<string>[] = [];
 
-			// Pagination : https://learn.microsoft.com/en-us/graph/sdks/paging?view=graph-rest-1.0&tabs=typescript#manually-requesting-subsequent-pages
-			// List Joined Channels : https://learn.microsoft.com/en-us/graph/api/user-list-joinedteams?view=graph-rest-1.0&tabs=http
-			let response: PageCollection = await client.api('/me/joinedTeams').get();
-			while (response.value.length > 0) {
-				for (const team of response.value as Team[]) {
-					options.push({ label: team.displayName!, value: team.id! });
-				}
-				if (response['@odata.nextLink']) {
-					response = await client.api(response['@odata.nextLink']).get();
-				} else {
-					break;
-				}
+			// List Joined Teams : https://learn.microsoft.com/en-us/graph/api/user-list-joinedteams?view=graph-rest-1.0&tabs=http
+			// Note: this endpoint does not support OData $top — pageSize intentionally omitted.
+			const { items, error } = await paginateGraphList<Team>({
+				client,
+				initialUrl: '/me/joinedTeams',
+				maxItems: DROPDOWN_LIST_MAX,
+			});
+
+			if (error && items.length === 0) {
+				return {
+					disabled: true,
+					placeholder: "Couldn't load teams — please retry.",
+					options: [],
+				};
 			}
+
 			return {
 				disabled: false,
-				options: options,
+				options: items.map((team) => ({ label: team.displayName!, value: team.id! })),
 			};
 		},
 	}),
@@ -59,24 +61,26 @@ export const microsoftTeamsCommon = {
 			const authValue = auth as PiecePropValueSchema<typeof microsoftTeamsAuth>;
 			const cloud = (auth as OAuth2PropertyValue).props?.['cloud'] as string | undefined;
 			const client = createGraphClient(authValue.access_token, cloud);
-			const options: DropdownOption<string>[] = [];
 
-			// Pagination : https://learn.microsoft.com/en-us/graph/sdks/paging?view=graph-rest-1.0&tabs=typescript#manually-requesting-subsequent-pages
 			// List Channels : https://learn.microsoft.com/en-us/graph/api/channel-list?view=graph-rest-1.0&tabs=http
-			let response: PageCollection = await client.api(`/teams/${teamId}/channels`).get();
-			while (response.value.length > 0) {
-				for (const channel of response.value as Channel[]) {
-					options.push({ label: channel.displayName!, value: channel.id! });
-				}
-				if (response['@odata.nextLink']) {
-					response = await client.api(response['@odata.nextLink']).get();
-				} else {
-					break;
-				}
+			// Note: this endpoint does not support OData $top — pageSize intentionally omitted.
+			const { items, error } = await paginateGraphList<Channel>({
+				client,
+				initialUrl: `/teams/${teamId}/channels`,
+				maxItems: DROPDOWN_LIST_MAX,
+			});
+
+			if (error && items.length === 0) {
+				return {
+					disabled: true,
+					placeholder: "Couldn't load channels — please retry.",
+					options: [],
+				};
 			}
+
 			return {
 				disabled: false,
-				options: options,
+				options: items.map((channel) => ({ label: channel.displayName!, value: channel.id! })),
 			};
 		},
 	}),
@@ -96,22 +100,26 @@ export const microsoftTeamsCommon = {
 			const authValue = auth as PiecePropValueSchema<typeof microsoftTeamsAuth>;
 			const cloud = (auth as OAuth2PropertyValue).props?.['cloud'] as string | undefined;
 			const client = createGraphClient(authValue.access_token, cloud);
-			const options: DropdownOption<string>[] = [];
 
-			let response: PageCollection = await client.api(`/teams/${teamId}/members`).get();
-			while (response.value.length > 0) {
-				for (const member of response.value as ConversationMember[]) {
-					options.push({ label: member.displayName!, value: member.id! });
-				}
-				if (response['@odata.nextLink']) {
-					response = await client.api(response['@odata.nextLink']).get();
-				} else {
-					break;
-				}
+			// Default page size on /teams/{id}/members is 100; explicit top() is
+			// intentionally omitted to stay compatible with this endpoint's OData support.
+			const { items, error } = await paginateGraphList<ConversationMember>({
+				client,
+				initialUrl: `/teams/${teamId}/members`,
+				maxItems: DROPDOWN_LIST_MAX,
+			});
+
+			if (error && items.length === 0) {
+				return {
+					disabled: true,
+					placeholder: "Couldn't load members — please retry.",
+					options: [],
+				};
 			}
+
 			return {
 				disabled: false,
-				options: options,
+				options: items.map((member) => ({ label: member.displayName!, value: member.id! })),
 			};
 		},
 	}),
@@ -131,22 +139,26 @@ export const microsoftTeamsCommon = {
 			const authValue = auth as PiecePropValueSchema<typeof microsoftTeamsAuth>;
 			const cloud = (auth as OAuth2PropertyValue).props?.['cloud'] as string | undefined;
 			const client = createGraphClient(authValue.access_token, cloud);
-			const options: DropdownOption<string>[] = [];
 
-			let response: PageCollection = await client.api(`/teams/${teamId}/members`).get();
-			while (response.value.length > 0) {
-				for (const member of response.value as ConversationMember[]) {
-					options.push({ label: member.displayName!, value: member.id! });
-				}
-				if (response['@odata.nextLink']) {
-					response = await client.api(response['@odata.nextLink']).get();
-				} else {
-					break;
-				}
+			// Default page size on /teams/{id}/members is 100; explicit top() is
+			// intentionally omitted to stay compatible with this endpoint's OData support.
+			const { items, error } = await paginateGraphList<ConversationMember>({
+				client,
+				initialUrl: `/teams/${teamId}/members`,
+				maxItems: DROPDOWN_LIST_MAX,
+			});
+
+			if (error && items.length === 0) {
+				return {
+					disabled: true,
+					placeholder: "Couldn't load members — please retry.",
+					options: [],
+				};
 			}
+
 			return {
 				disabled: false,
-				options: options,
+				options: items.map((member) => ({ label: member.displayName!, value: member.id! })),
 			};
 		},
 	}),
@@ -269,33 +281,39 @@ export const microsoftTeamsCommon = {
 			const authValue = auth as PiecePropValueSchema<typeof microsoftTeamsAuth>;
 			const cloud = (auth as OAuth2PropertyValue).props?.['cloud'] as string | undefined;
 			const client = createGraphClient(authValue.access_token, cloud);
-			const options: DropdownOption<string>[] = [];
 
-			// Pagination : https://learn.microsoft.com/en-us/graph/sdks/paging?view=graph-rest-1.0&tabs=typescript#manually-requesting-subsequent-pages
 			// List Chats : https://learn.microsoft.com/en-us/graph/api/chat-list?view=graph-rest-1.0&tabs=http
-			let response: PageCollection = await client.api('/chats').expand('members').get();
-			while (response.value.length > 0) {
-				for (const chat of response.value as Chat[]) {
+			// Cap protects the 60s sandbox timeout and Graph throttling on /chats?$expand=members.
+			const { items, error } = await paginateGraphList<Chat>({
+				client,
+				initialUrl: '/chats',
+				expand: 'members',
+				pageSize: CHATS_PAGE_SIZE,
+				maxItems: DROPDOWN_LIST_MAX,
+			});
+
+			if (error && items.length === 0) {
+				return {
+					disabled: true,
+					placeholder: "Couldn't load chats — please retry.",
+					options: [],
+				};
+			}
+
+			return {
+				disabled: false,
+				options: items.map((chat) => {
 					const chatName =
 						chat.topic ??
 						chat.members
 							?.filter((member: ConversationMember) => member.displayName)
 							.map((member: ConversationMember) => member.displayName)
 							.join(',');
-					options.push({
+					return {
 						label: `(${CHAT_TYPE[chat.chatType! as keyof typeof CHAT_TYPE]} Chat) ${chatName || '(no title)'}`,
 						value: chat.id!,
-					});
-				}
-				if (response['@odata.nextLink']) {
-					response = await client.api(response['@odata.nextLink']).get();
-				} else {
-					break;
-				}
-			}
-			return {
-				disabled: false,
-				options: options,
+					};
+				}),
 			};
 		},
 	}),
@@ -307,3 +325,6 @@ const CHAT_TYPE = {
 	meeting: 'Meeting',
 	unknownFutureValue: 'Unknown',
 };
+
+const CHATS_PAGE_SIZE = 50;
+const DROPDOWN_LIST_MAX = 500;

--- a/packages/pieces/community/microsoft-teams/src/lib/triggers/new-channel-message.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/triggers/new-channel-message.ts
@@ -6,7 +6,7 @@ import {
 	TriggerStrategy,
 } from '@activepieces/pieces-framework';
 import { microsoftTeamsCommon } from '../common';
-import { createGraphClient } from '../common/graph';
+import { createGraphClient, withGraphRetry } from '../common/graph';
 import { PageCollection } from '@microsoft/microsoft-graph-client';
 import { ChatMessage } from '@microsoft/microsoft-graph-types';
 import dayjs from 'dayjs';
@@ -99,10 +99,9 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof microsoftTeamsAu
 		const messages: ChatMessage[] = [];
 
 		if (lastFetchEpochMS === 0) {
-			const response: PageCollection = await client
-				.api(`/teams/${teamId}/channels/${channelId}/messages`)
-				.top(5)
-				.get();
+			const response: PageCollection = await withGraphRetry(() =>
+				client.api(`/teams/${teamId}/channels/${channelId}/messages`).top(5).get(),
+			);
 
 			if (!isNil(response.value)) {
 				messages.push(...response.value);
@@ -115,7 +114,8 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof microsoftTeamsAu
 
 			// https://learn.microsoft.com/en-us/graph/api/chatmessage-delta?view=graph-rest-1.0&tabs=http
 			while (nextLink) {
-				const response: PageCollection = await client.api(nextLink).get();
+				const url = nextLink;
+				const response: PageCollection = await withGraphRetry(() => client.api(url).get());
 				const channelMessages = response.value as ChatMessage[];
 
 				if (Array.isArray(channelMessages)) {

--- a/packages/pieces/community/microsoft-teams/src/lib/triggers/new-channel.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/triggers/new-channel.ts
@@ -6,7 +6,7 @@ import {
 	TriggerStrategy,
 } from '@activepieces/pieces-framework';
 import { microsoftTeamsCommon } from '../common';
-import { createGraphClient } from '../common/graph';
+import { createGraphClient, withGraphRetry } from '../common/graph';
 import { PageCollection } from '@microsoft/microsoft-graph-client';
 import { Channel } from '@microsoft/microsoft-graph-types';
 import dayjs from 'dayjs';
@@ -67,7 +67,9 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof microsoftTeamsAu
 		const channels: Channel[] = [];
 		const filter = lastFetchEpochMS === 0 ? '' : `?$filter=createdDateTime gt ${lastFetchDate}`;
 
-		let response: PageCollection = await client.api(`/teams/${teamId}/channels${filter}`).get();
+		let response: PageCollection = await withGraphRetry(() =>
+			client.api(`/teams/${teamId}/channels${filter}`).get(),
+		);
 
 		while (response.value && response.value.length > 0) {
 			for (const channel of response.value as Channel[]) {
@@ -76,8 +78,9 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof microsoftTeamsAu
 				}
 				channels.push(channel);
 			}
-			if (lastFetchEpochMS !== 0 && response['@odata.nextLink']) {
-				response = await client.api(response['@odata.nextLink']).get();
+			const nextLink = response['@odata.nextLink'];
+			if (lastFetchEpochMS !== 0 && nextLink) {
+				response = await withGraphRetry(() => client.api(nextLink).get());
 			} else {
 				break;
 			}

--- a/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat-message.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat-message.ts
@@ -6,7 +6,7 @@ import {
 	TriggerStrategy,
 } from '@activepieces/pieces-framework';
 import { microsoftTeamsCommon } from '../common';
-import { createGraphClient } from '../common/graph';
+import { createGraphClient, withGraphRetry } from '../common/graph';
 import { PageCollection } from '@microsoft/microsoft-graph-client';
 import { ChatMessage } from '@microsoft/microsoft-graph-types';
 import dayjs from 'dayjs';
@@ -94,10 +94,9 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof microsoftTeamsAu
 		const messages: ChatMessage[] = [];
 
 		if (lastFetchEpochMS === 0) {
-			const response: PageCollection = await client
-				.api(`/chats/${chatId}/messages`)
-				.top(5)
-				.get();
+			const response: PageCollection = await withGraphRetry(() =>
+				client.api(`/chats/${chatId}/messages`).top(5).get(),
+			);
 
 			if (!isNil(response.value)) {
 				messages.push(...(response.value as ChatMessage[]));
@@ -109,7 +108,8 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof microsoftTeamsAu
 
 			// https://learn.microsoft.com/graph/api/chatmessage-delta?view=graph-rest-1.0&tabs=http
 			while (nextLink) {
-				const response: PageCollection = await client.api(nextLink).get();
+				const url = nextLink;
+				const response: PageCollection = await withGraphRetry(() => client.api(url).get());
 				const chatMessages = response.value as ChatMessage[];
 
 				if (Array.isArray(chatMessages)) {

--- a/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat.ts
@@ -6,7 +6,7 @@ import {
 	TriggerStrategy,
 } from '@activepieces/pieces-framework';
 import { isNil } from '@activepieces/shared';
-import { createGraphClient } from '../common/graph';
+import { createGraphClient, withGraphRetry } from '../common/graph';
 import { PageCollection } from '@microsoft/microsoft-graph-client';
 import { Chat, ChatType } from '@microsoft/microsoft-graph-types';
 import dayjs from 'dayjs';
@@ -65,10 +65,9 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof microsoftTeamsAu
 				? '$top=10'
 				: `$filter=createdDateTime gt ${lastFetchDate}`;
 
-		let response: PageCollection = await client.api(`/chats?${filter}`).get();
-
-		console.log('RESPONE');
-		console.log(JSON.stringify(response))
+		let response: PageCollection = await withGraphRetry(() =>
+			client.api(`/chats?${filter}`).get(),
+		);
 
 		while (response.value && response.value.length > 0) {
 			for (const channel of response.value as Chat[]) {
@@ -77,8 +76,9 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof microsoftTeamsAu
 				}
 				chats.push(channel);
 			}
-			if (lastFetchEpochMS !== 0 && response['@odata.nextLink']) {
-				response = await client.api(response['@odata.nextLink']).get();
+			const nextLink = response['@odata.nextLink'];
+			if (lastFetchEpochMS !== 0 && nextLink) {
+				response = await withGraphRetry(() => client.api(nextLink).get());
 			} else {
 				break;
 			}


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->

Hardens the Microsoft Teams piece against Microsoft Graph throttling and the engine's 60s sandbox timeout. Customers with large Teams accounts (hundreds of chats, or company-wide teams with thousands of members) were intermittently seeing `Unexpected error, please retry` on the **Chat ID** dropdown in **Send Chat Message**, and the same failure mode was latent on every other dynamic dropdown in the piece.

This PR introduces a `paginateGraphList` helper that combines retry-with-backoff, graceful error handling, and a per-dropdown item cap, then applies it to all five dynamic dropdowns. It also wraps every paginated Graph call in the four polling triggers and the **Send Channel Message** action with the same retry helper so transient throttling no longer fails entire flow runs.

### Explain How the Feature Works

<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

**Root cause.** The Chat ID dropdown loaded `/chats?$expand=members` and walked every page sequentially with no `$top`, no retry, no cap, and no error handling. For an account with ~700 chats this resulted in ~35 round-trips to a heavy `$expand=members` endpoint that Graph aggressively throttles. Total walltime exceeded the 60s `TRIGGER_TIMEOUT_SECONDS` cap on dropdown property execution. The worker killed the sandbox and returned an empty `response: {}`, the API forwarded it as-is, the frontend dropdown component couldn't render the malformed response, and the React error boundary surfaced `Unexpected error, please retry`.

**The fix has four pillars, all encapsulated in `paginateGraphList`:**

1. **Retry on transient errors** — wraps every Graph request in `withGraphRetry`, which retries 429 / 503 / 504 / 5xx with exponential backoff and honors `Retry-After`.
2. **Graceful failure** — wraps the entire pagination loop in `tryCatch`. If everything fails the dropdown returns a disabled state with a friendly placeholder. If a partial load succeeds before an error, those items are returned.
3. **Explicit page size where supported** — `/chats` supports `$top` (max 50) so the helper now requests 50 per page instead of Graph's default 20. This alone cuts the original 35 round-trips to ~10. Other endpoints (`/me/joinedTeams`, `/teams/{id}/channels`, `/teams/{id}/members`) don't support `$top` and rely on Graph defaults.
4. **Per-dropdown item cap of 500** — guarantees the load completes inside the sandbox budget regardless of account size. The 500 most recently active chats / first 500 channels / first 500 members are returned.

**Other resilience improvements:**

- Wrapped the four polling triggers (`new-chat`, `new-chat-message`, `new-channel`, `new-channel-message`) and the `Send Channel Message` action's mention-resolution pagination in `withGraphRetry`. A single 429 mid-poll no longer fails the entire trigger run.
- Removed `409` from the retry list — it's not a safe blanket retry on Graph delta endpoints, where it signals that the stored deltalink is stale and the sync state must restart.
- Removed two stray `console.log` debug statements from the New Chat trigger.

**Backward compatibility.** Verified end-to-end:

- All dropdown property names, value contracts (string IDs), label formats, and `displayName`/`description`/`required`/`refreshers` configurations are unchanged.
- Existing flows that already reference a chat / team / channel / member outside the new 500-item cap continue to resolve at runtime — the saved value is a string ID, the action passes it directly to Graph, and no dropdown loading happens at execution time.
- All retried errors fail in the same final state as before (just with up to ~7s of backoff first).

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->

- **Enterprise customers with large Teams tenants** — company-wide teams with thousands of members or accounts with hundreds of active chats can now configure **Send Chat Message**, **Create Chat & Send Message**, and **Send Channel Message** without the Chat ID / Team / Channel / Member dropdowns timing out.
- **Customers hitting Microsoft Graph throttling** — transient 429s during dropdown loads or trigger polls are now retried transparently with `Retry-After`-aware backoff instead of failing.
- **Customers running Teams triggers in production** — `New Chat`, `New Chat Message`, `New Channel`, `New Channel Message` no longer skip a poll cycle on a single transient Graph hiccup.
- **Customers seeing "Unexpected error, please retry" on dynamic dropdowns** — failures now degrade to a disabled-with-placeholder state ("Couldn't load X — please retry") instead of triggering the React error boundary.

Reproduction was verified locally by stubbing the Graph client to return 700 paginated chats with a 3s per-page delay, which reliably reproduces the 60s sandbox timeout against the broken code and loads cleanly against the fix.

Fixes # (issue)
