### PR TITLE
fix(snowflake): drop invalid session:role-any scope from OAuth flow

### DIFF
--- a/packages/pieces/community/snowflake/package.json
+++ b/packages/pieces/community/snowflake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-snowflake",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/snowflake/src/lib/auth.ts
+++ b/packages/pieces/community/snowflake/src/lib/auth.ts
@@ -54,10 +54,13 @@ CREATE SECURITY INTEGRATION "activepieces"
   OAUTH_CLIENT_TYPE = 'CONFIDENTIAL'
   OAUTH_REDIRECT_URI = 'https://cloud.activepieces.com/redirect'
   ENABLED = TRUE
-  OAUTH_ISSUE_REFRESH_TOKENS = TRUE;
+  OAUTH_ISSUE_REFRESH_TOKENS = TRUE
+  OAUTH_USE_SECONDARY_ROLES = IMPLICIT;
 \`\`\`
 
 > Replace the redirect URI with the one shown on your Activepieces OAuth connection page.
+>
+> \`OAUTH_USE_SECONDARY_ROLES = IMPLICIT\` lets the access token use any role granted to the user. Without it, the token is bound to the user's default Snowflake role and the **Default Role** field below will be ignored.
 
 ---
 
@@ -85,7 +88,7 @@ Copy the **Account Identifier** (e.g. \`xy12345.us-east-1\` or \`orgname-account
 Enter the **Client ID** and **Client Secret** in the Activepieces OAuth2 settings for this connection, fill in the **Account Identifier** below, then click **Connect**.`,
   authUrl: 'https://{account}.snowflakecomputing.com/oauth/authorize',
   tokenUrl: 'https://{account}.snowflakecomputing.com/oauth/token-request',
-  scope: ['session:role-any', 'refresh_token'],
+  scope: ['refresh_token'],
   pkce: false,
   authorizationMethod: OAuth2AuthorizationMethod.BODY,
   required: true,


### PR DESCRIPTION
## What does this PR do?

Fixes the Snowflake OAuth connection flow, which was failing for every customer with `The requested scope is invalid` before they could even authenticate.

The piece was sending `session:role-any refresh_token` as the OAuth scope. Per Snowflake's [custom OAuth docs](https://docs.snowflake.com/en/user-guide/oauth-custom), `session:role-any` is only valid for **External OAuth** integrations (where another IdP like Okta or Azure issues the token). For the **custom client integration** that the piece's setup SQL creates (`OAUTH_CLIENT = CUSTOM`), the only accepted scope values are `refresh_token` and `session:role:<ROLE_NAME>`. Snowflake therefore rejected the request at `/oauth/authorize` before the user was shown the sign-in screen.

This PR:

- Drops `session:role-any` from the requested OAuth scope, leaving `refresh_token`.
- Adds `OAUTH_USE_SECONDARY_ROLES = IMPLICIT` to the setup SQL so the **Default Role** field still works for switching to any role granted to the user after the token is issued.
- Bumps the piece version `0.3.1 → 0.3.2`.


### Explain How the Feature Works

After the change, the OAuth flow looks like this:

1. The user runs the updated `CREATE SECURITY INTEGRATION` SQL in Snowflake (now including `OAUTH_USE_SECONDARY_ROLES = IMPLICIT`).
2. The piece redirects the browser to `https://<account>.snowflakecomputing.com/oauth/authorize?…&scope=refresh_token`.
3. Snowflake accepts the scope, the user signs in, and the token is issued for the user's default Snowflake role.
4. When a query runs, `snowflake.createConnection({ role })` switches the session to the role configured in the **Default Role** field. `OAUTH_USE_SECONDARY_ROLES = IMPLICIT` is what lets the token use any role granted to the user, so the Default Role field is no longer silently ignored.

Verified end-to-end against a fresh Snowflake trial account: the previous `scope=session:role-any+refresh_token` URL reproduces the customer's "The requested scope is invalid" error, and the patched `scope=refresh_token` URL passes through to the sign-in screen and issues a working token.

<!-- [Insert the video link here] -->


### Relevant User Scenarios

- **Any customer setting up a new Snowflake OAuth connection.** The integration was effectively broken for new connections — the authorize step rejected the request before authentication, so no one could complete OAuth without falling back to the username/password or key-pair auth path.
- **Customers who want to use a non-default Snowflake role at query time.** The added `OAUTH_USE_SECONDARY_ROLES = IMPLICIT` keeps the **Default Role** field on the connection form functional after the scope change; without it, the OAuth token would be bound to the user's default role and the field would be silently ignored.

<!-- [Insert Pylon tickets or community posts here if possible] -->


Fixes # (issue)
