### PR TITLE
fix: prevent duplicate CORS headers on webhook sync endpoint

### DIFF
--- a/packages/server/api/src/app/webhooks/webhook-controller.ts
+++ b/packages/server/api/src/app/webhooks/webhook-controller.ts
@@ -14,6 +14,23 @@ import { WebhookFlowVersionToRun, webhookService } from './webhook.service'
 
 const tracer = trace.getTracer('webhook-controller')
 
+const FLOW_HEADERS_SKIP_GLOBAL_CORS = new Set([
+    'access-control-allow-origin',
+    'access-control-allow-methods',
+    'access-control-allow-headers',
+])
+
+function webhookReplyHeaders(flowHeaders: Record<string, string>): Record<string, string> {
+    const result: Record<string, string> = {}
+    for (const [key, value] of Object.entries(flowHeaders)) {
+        if (FLOW_HEADERS_SKIP_GLOBAL_CORS.has(key.toLowerCase())) {
+            continue
+        }
+        result[key] = value
+    }
+    return result
+}
+
 export const webhookController: FastifyPluginAsyncZod = async (app) => {
 
     app.all(
@@ -46,7 +63,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
                     span.setAttribute('webhook.response.status', response.status)
                     await reply
                         .status(response.status)
-                        .headers(response.headers)
+                        .headers(webhookReplyHeaders(response.headers))
                         .send(response.body)
                 }
                 finally {
@@ -86,7 +103,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
                     span.setAttribute('webhook.response.status', response.status)
                     await reply
                         .status(response.status)
-                        .headers(response.headers)
+                        .headers(webhookReplyHeaders(response.headers))
                         .send(response.body)
                 }
                 finally {
@@ -112,7 +129,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
         })
         await reply
             .status(response.status)
-            .headers(response.headers)
+            .headers(webhookReplyHeaders(response.headers))
             .send(response.body)
     })
 
@@ -129,7 +146,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
         })
         await reply
             .status(response.status)
-            .headers(response.headers)
+            .headers(webhookReplyHeaders(response.headers))
             .send(response.body)
     })
 
@@ -146,7 +163,7 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
         })
         await reply
             .status(response.status)
-            .headers(response.headers)
+            .headers(webhookReplyHeaders(response.headers))
             .send(response.body)
     })
 

--- a/packages/server/api/src/app/webhooks/webhook-controller.ts
+++ b/packages/server/api/src/app/webhooks/webhook-controller.ts
@@ -18,6 +18,8 @@ const FLOW_HEADERS_SKIP_GLOBAL_CORS = new Set([
     'access-control-allow-origin',
     'access-control-allow-methods',
     'access-control-allow-headers',
+    'access-control-allow-credentials',
+    'access-control-max-age',
 ])
 
 function webhookReplyHeaders(flowHeaders: Record<string, string>): Record<string, string> {


### PR DESCRIPTION
Fixes #12577.

Synchronous (and other) webhook handlers forward flow HTTP headers onto the Fastify reply. The app already applies CORS via Fastify; when the flow response also contained Access-Control-Allow-* headers, clients saw duplicated values such as \`Access-Control-Allow-Origin: *, *\`.

Forwarded webhook replies now omit \`Access-Control-Allow-Origin\`, \`Access-Control-Allow-Methods\`, and \`Access-Control-Allow-Headers\` so only the global CORS plugin applies those headers.

Made with [Cursor](https://cursor.com)