### PR TITLE
fix: Update telemetry code link in documentation

### DIFF
--- a/docs/install/configuration/telemetry.mdx
+++ b/docs/install/configuration/telemetry.mdx
@@ -17,7 +17,7 @@ We have implemented a minimal tracking plan and provide a detailed list of the m
 
 We value transparency in data collection and assure you that we do not collect any personal information. The following events are currently being collected:
 
-[Exact Code](https://github.com/activepieces/activepieces/blob/main/packages/shared/src/lib/common/telemetry.ts)
+[Exact Code](https://github.com/activepieces/activepieces/blob/main/packages/shared/src/lib/core/common/telemetry.ts)
 
 
 # Opting out?


### PR DESCRIPTION
## What does this PR do?

Update the link to the exact code of telemetry.
