### PR TITLE
fix(chat): persist user message before streaming to survive page refresh

### DIFF
--- a/packages/server/api/src/app/chat/chat-service.ts
+++ b/packages/server/api/src/app/chat/chat-service.ts
@@ -163,6 +163,8 @@ export const chatService = (log: FastifyBaseLogger) => ({
         const newUserMessage: ModelMessage = { role: 'user' as const, content: userContent }
         const allMessages = [...previousMessages, newUserMessage]
 
+        await conversationRepo().update(conversationId, { messages: allMessages })
+
         const compactionState = await resolveCompactionState({
             conversation,
             allMessages,


### PR DESCRIPTION
## Summary
- User messages are now saved to the DB **before** `streamText` starts, not after it finishes
- Previously, refreshing the page during streaming (e.g., while waiting for tool approval) lost the user's message entirely

## What changed
One line added in `chat-service.ts` — `conversationRepo().update(conversationId, { messages: allMessages })` before the `streamText` call.

The `onFinish` callback still saves the full conversation (user message + assistant response) when streaming completes. This early save is a safety net for interrupted streams.

## Test plan
- [ ] Send a message → refresh immediately while AI is responding → reload shows your message
- [ ] Send a message → let AI finish → conversation has both user message and assistant response
- [ ] Normal chat flow is unaffected (no duplicate messages, no performance regression)