### PR TITLE
fix(chat): default to personal project and show Personal Project label

### DIFF
--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -1,8 +1,8 @@
-import { AIProviderName } from '@activepieces/shared';
+import { AIProviderName, ProjectType } from '@activepieces/shared';
 import { t } from 'i18next';
 import { AlertTriangle, RefreshCw, Square } from 'lucide-react';
 import { motion } from 'motion/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   ChatContainerContent,
@@ -98,11 +98,20 @@ function ChatBoxContent({
     new Set(),
   );
 
+  const didAutoSelectProjectRef = useRef(false);
   useEffect(() => {
-    if (selectedProjectId !== null || initialConversationId) return;
-    const firstProject = projects[0];
-    if (firstProject) {
-      void setProjectContext(firstProject.id);
+    if (
+      didAutoSelectProjectRef.current ||
+      selectedProjectId !== null ||
+      initialConversationId
+    )
+      return;
+    const personalProject = projects.find(
+      (p) => p.type === ProjectType.PERSONAL,
+    );
+    if (personalProject) {
+      didAutoSelectProjectRef.current = true;
+      void setProjectContext(personalProject.id);
     }
   }, [projects, selectedProjectId, initialConversationId, setProjectContext]);
 

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -99,6 +99,14 @@ function ChatBoxContent({
   );
 
   useEffect(() => {
+    if (selectedProjectId !== null || initialConversationId) return;
+    const firstProject = projects[0];
+    if (firstProject) {
+      void setProjectContext(firstProject.id);
+    }
+  }, [projects, selectedProjectId, initialConversationId, setProjectContext]);
+
+  useEffect(() => {
     if (initialConversationId) {
       void setConversationId(initialConversationId);
     }

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-project-selector.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-project-selector.tsx
@@ -16,6 +16,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { getProjectName } from '@/features/projects';
 import { cn } from '@/lib/utils';
 
 export function ChatProjectSelector({
@@ -55,10 +56,10 @@ export function ChatProjectSelector({
                   color: selectedColor?.textColor,
                 }}
               >
-                {selectedProject.displayName.charAt(0).toUpperCase()}
+                {getProjectName(selectedProject).charAt(0).toUpperCase()}
               </span>
               <span className="max-w-[120px] truncate">
-                {selectedProject.displayName}
+                {getProjectName(selectedProject)}
               </span>
               <button
                 type="button"
@@ -92,7 +93,7 @@ export function ChatProjectSelector({
               return (
                 <CommandItem
                   key={project.id}
-                  value={project.displayName}
+                  value={getProjectName(project)}
                   onSelect={() => {
                     onProjectChange(project.id);
                     setOpen(false);
@@ -106,9 +107,11 @@ export function ChatProjectSelector({
                       color: color.textColor,
                     }}
                   >
-                    {project.displayName.charAt(0).toUpperCase()}
+                    {getProjectName(project).charAt(0).toUpperCase()}
                   </span>
-                  <span className="flex-1 truncate">{project.displayName}</span>
+                  <span className="flex-1 truncate">
+                    {getProjectName(project)}
+                  </span>
                   <Check
                     className={cn(
                       'ml-auto size-4',

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-project-selector.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-project-selector.tsx
@@ -1,4 +1,4 @@
-import { PROJECT_COLOR_PALETTE, Project } from '@activepieces/shared';
+import { Project, ProjectType } from '@activepieces/shared';
 import { t } from 'i18next';
 import { Check, ChevronDown, FolderOpen, X } from 'lucide-react';
 import { useState } from 'react';
@@ -16,8 +16,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import { getProjectName } from '@/features/projects';
+import { ApProjectDisplay } from '@/features/projects';
 import { cn } from '@/lib/utils';
+
+function projectName(project: Project): string {
+  return project.type === ProjectType.PERSONAL
+    ? t('Personal Project')
+    : project.displayName;
+}
 
 export function ChatProjectSelector({
   projects,
@@ -28,10 +34,6 @@ export function ChatProjectSelector({
 
   const selectedProject = selectedProjectId
     ? projects.find((p) => p.id === selectedProjectId)
-    : null;
-
-  const selectedColor = selectedProject
-    ? PROJECT_COLOR_PALETTE[selectedProject.icon.color]
     : null;
 
   return (
@@ -49,18 +51,13 @@ export function ChatProjectSelector({
         >
           {selectedProject ? (
             <>
-              <span
-                className="inline-flex items-center justify-center h-3.5 w-3.5 rounded-sm shrink-0 text-[8px] font-bold"
-                style={{
-                  backgroundColor: selectedColor?.color,
-                  color: selectedColor?.textColor,
-                }}
-              >
-                {getProjectName(selectedProject).charAt(0).toUpperCase()}
-              </span>
-              <span className="max-w-[120px] truncate">
-                {getProjectName(selectedProject)}
-              </span>
+              <ApProjectDisplay
+                title={projectName(selectedProject)}
+                icon={selectedProject.icon}
+                projectType={selectedProject.type}
+                iconClassName="size-3.5"
+                titleClassName="max-w-[120px] truncate text-xs"
+              />
               <button
                 type="button"
                 className="ml-0.5 rounded-full p-0.5 hover:bg-muted transition-colors"
@@ -88,41 +85,32 @@ export function ChatProjectSelector({
           )}
           <CommandEmpty>{t('No project found.')}</CommandEmpty>
           <CommandGroup className="max-h-64 overflow-auto">
-            {projects.map((project) => {
-              const color = PROJECT_COLOR_PALETTE[project.icon.color];
-              return (
-                <CommandItem
-                  key={project.id}
-                  value={getProjectName(project)}
-                  onSelect={() => {
-                    onProjectChange(project.id);
-                    setOpen(false);
-                  }}
-                  className="cursor-pointer gap-2"
-                >
-                  <span
-                    className="inline-flex items-center justify-center h-5 w-5 rounded-sm shrink-0 text-[10px] font-bold"
-                    style={{
-                      backgroundColor: color.color,
-                      color: color.textColor,
-                    }}
-                  >
-                    {getProjectName(project).charAt(0).toUpperCase()}
-                  </span>
-                  <span className="flex-1 truncate">
-                    {getProjectName(project)}
-                  </span>
-                  <Check
-                    className={cn(
-                      'ml-auto size-4',
-                      selectedProjectId === project.id
-                        ? 'opacity-100'
-                        : 'opacity-0',
-                    )}
-                  />
-                </CommandItem>
-              );
-            })}
+            {projects.map((project) => (
+              <CommandItem
+                key={project.id}
+                value={projectName(project)}
+                onSelect={() => {
+                  onProjectChange(project.id);
+                  setOpen(false);
+                }}
+                className="cursor-pointer gap-2"
+              >
+                <ApProjectDisplay
+                  title={projectName(project)}
+                  icon={project.icon}
+                  projectType={project.type}
+                  iconClassName="size-4"
+                />
+                <Check
+                  className={cn(
+                    'ml-auto size-4',
+                    selectedProjectId === project.id
+                      ? 'opacity-100'
+                      : 'opacity-0',
+                  )}
+                />
+              </CommandItem>
+            ))}
           </CommandGroup>
         </Command>
       </PopoverContent>

--- a/packages/web/src/components/ui/sidebar-shadcn.tsx
+++ b/packages/web/src/components/ui/sidebar-shadcn.tsx
@@ -819,6 +819,7 @@ export {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  SidebarContext,
   SidebarProvider,
   SidebarRail,
   SidebarSeparator,

--- a/packages/web/src/features/projects/components/ap-project-display.tsx
+++ b/packages/web/src/features/projects/components/ap-project-display.tsx
@@ -5,9 +5,10 @@ import {
   ProjectType,
 } from '@activepieces/shared';
 import { User } from 'lucide-react';
+import { useContext } from 'react';
 
 import { Avatar } from '@/components/ui/avatar';
-import { useSidebar } from '@/components/ui/sidebar-shadcn';
+import { SidebarContext } from '@/components/ui/sidebar-shadcn';
 import {
   Tooltip,
   TooltipContent,
@@ -16,11 +17,17 @@ import {
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
+function useSidebarSafe(): string {
+  const context = useContext(SidebarContext);
+  return context?.state ?? 'expanded';
+}
+
 type ApProjectDisplayProps = {
   title: string;
   icon?: ProjectIcon;
   containerClassName?: string;
   titleClassName?: string;
+  iconClassName?: string;
   maxLengthToNotShowTooltip?: number;
   projectType: ProjectType;
   inSidebar?: boolean;
@@ -31,15 +38,19 @@ export const ApProjectDisplay = ({
   icon,
   containerClassName = '',
   titleClassName = '',
+  iconClassName,
   maxLengthToNotShowTooltip = 30,
   projectType,
   inSidebar = false,
 }: ApProjectDisplayProps) => {
-  const { state } = useSidebar();
+  const sidebarState = useSidebarSafe();
   const projectAvatar = isNil(icon) ? null : projectType ===
     ProjectType.TEAM ? (
     <Avatar
-      className="size-6 flex items-center justify-center rounded-sm"
+      className={cn(
+        'size-6 flex items-center justify-center rounded-sm',
+        iconClassName,
+      )}
       style={{
         backgroundColor: PROJECT_COLOR_PALETTE[icon.color].color,
         color: PROJECT_COLOR_PALETTE[icon.color].textColor,
@@ -48,7 +59,9 @@ export const ApProjectDisplay = ({
       {title.charAt(0).toUpperCase()}
     </Avatar>
   ) : (
-    <User className="size-5 flex items-center justify-center" />
+    <User
+      className={cn('size-5 flex items-center justify-center', iconClassName)}
+    />
   );
 
   const shouldShowTooltip = title.length > maxLengthToNotShowTooltip;
@@ -59,7 +72,7 @@ export const ApProjectDisplay = ({
   const content = (
     <div className={`flex items-center gap-2 ${containerClassName}`}>
       {projectAvatar}
-      {((inSidebar && state === 'expanded') || !inSidebar) && (
+      {((inSidebar && sidebarState === 'expanded') || !inSidebar) && (
         <span className={cn(titleClassName, 'truncate')}>{displayText}</span>
       )}
     </div>


### PR DESCRIPTION
## Summary
- New conversations now auto-select the user's personal project instead of starting with no project
- The project selector displays "Personal Project" for personal projects instead of the raw `displayName`

## What changed

**`ai-chat-box.tsx`** — Added a `useEffect` that sets the first available project (personal, since the query orders PERSONAL first) when no project is selected and no existing conversation is being loaded.

**`chat-project-selector.tsx`** — Replaced `project.displayName` with `getProjectName(project)` from `@/features/projects`, which returns "Personal Project" for `ProjectType.PERSONAL`.

## Test plan
- [ ] Open a new chat → personal project is pre-selected in the project dropdown
- [ ] The selector shows "Personal Project" (not the raw display name)
- [ ] Open an existing conversation with a different project → that project stays selected (not overridden)
- [ ] Users with multiple projects see all projects in the dropdown with correct names
- [ ] Clearing the project selection (X button) still works