### PR TITLE
fix(workers): honor BullMQ deferredFailure to drain zombie jobs (cherry-pick #13110)

### DIFF
--- a/packages/server/api/src/app/workers/job-queue/job-broker.ts
+++ b/packages/server/api/src/app/workers/job-queue/job-broker.ts
@@ -89,6 +89,22 @@ async function tryDequeue(worker: BullMQWorker, queueName: string, log: FastifyB
     if (isNil(job)) {
         return null  // waiting list empty — drainDelay provided backpressure
     }
+
+    if (job.deferredFailure) {
+        log.warn(
+            { queueName, jobId: job.id, jobName: job.name, deferredFailure: job.deferredFailure },
+            '[jobBroker#tryDequeue] Failing job with deferred failure (BullMQ stalled limit exceeded)',
+        )
+        const { error: failError } = await tryCatch(() => job.moveToFailed(new Error(job.deferredFailure), token, false))
+        if (failError) {
+            log.error(
+                { queueName, jobId: job.id, error: String(failError) },
+                '[jobBroker#tryDequeue] Failed to fail deferred-failure job',
+            )
+        }
+        return tryDequeue(worker, queueName, log)
+    }
+
     log.info({ queueName, jobId: job.id, jobName: job.name }, '[jobBroker#tryDequeue] Dequeued job')
 
     const originalSchemaVersion = (job.data as Record<string, unknown>).schemaVersion

--- a/packages/server/api/test/integration/ce/workers/job-broker-seed-cause.test.ts
+++ b/packages/server/api/test/integration/ce/workers/job-broker-seed-cause.test.ts
@@ -1,0 +1,205 @@
+import { FastifyInstance } from 'fastify'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+import { mockAndSaveBasicSetup } from '../../../helpers/mocks'
+import { jobBroker } from '../../../../src/app/workers/job-queue/job-broker'
+import { jobQueue, JobType } from '../../../../src/app/workers/job-queue/job-queue'
+import { redisConnections } from '../../../../src/app/database/redis-connections'
+import { QueueName } from '../../../../src/app/workers/job'
+import {
+    apId,
+    EngineResponseStatus,
+    LATEST_JOB_DATA_SCHEMA_VERSION,
+    TriggerHookType,
+    WorkerJobType,
+} from '@activepieces/shared'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+    await jobBroker(app.log).init()
+})
+
+afterAll(async () => {
+    await jobBroker(app.log).close()
+    await teardownTestEnvironment()
+})
+
+const jobKey = (jobId: string): string => `bull:${QueueName.WORKER_JOBS}:${jobId}`
+const lockKey = (jobId: string): string => `${jobKey(jobId)}:lock`
+const activeKey = (): string => `bull:${QueueName.WORKER_JOBS}:active`
+const completedKey = (): string => `bull:${QueueName.WORKER_JOBS}:completed`
+const failedKey = (): string => `bull:${QueueName.WORKER_JOBS}:failed`
+
+/**
+ * Reproduces the seed cause behind the production "stuck-active" zombies:
+ *   provisionFlowPieces (or any work between getNextJob and completeJob) takes
+ *   longer than `lockDuration` (120s in prod). The Redis lock for the job
+ *   expires. By the time the worker calls completeJob with its original token,
+ *   BullMQ's moveToFinished Lua script returns `-2 Missing lock`, which the
+ *   broker classifies as a "stalled job error" and silently swallows. The job
+ *   never receives an LREM from the active list, attemptsMade never increments,
+ *   and the job becomes a zombie that the BullMQ 5.61 stalled-scan loop
+ *   recycles forever (until our fix in tryDequeue).
+ *
+ *   This test simulates the > 120s gap by directly DELing the lock key after
+ *   the dequeue, then calling completeJob with the (now stale) token.
+ */
+describe('jobBroker.completeJob — seed cause for stuck-active zombies', () => {
+    it('SEED: silently swallows "Missing lock" on moveToCompleted, leaving job in active', async () => {
+        const { mockPlatform, mockProject } = await mockAndSaveBasicSetup()
+        const requestId = apId()
+
+        const jobData = {
+            jobType: WorkerJobType.EXECUTE_TRIGGER_HOOK,
+            platformId: mockPlatform.id,
+            projectId: mockProject.id,
+            schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
+            flowId: apId(),
+            flowVersionId: apId(),
+            test: false,
+            hookType: TriggerHookType.ON_ENABLE,
+            requestId,
+            webserverId: 'seed-cause-test',
+        }
+
+        const jobId = apId()
+        await jobQueue(app.log).add({
+            type: JobType.ONE_TIME,
+            id: jobId,
+            data: jobData,
+        })
+
+        const polledJob = await jobBroker(app.log).poll()
+        expect(polledJob).not.toBeNull()
+        expect(polledJob!.jobId).toBe(jobId)
+
+        const redis = await redisConnections.useExisting()
+
+        const lockBefore = await redis.get(lockKey(jobId))
+        expect(lockBefore).toBe(polledJob!.token)
+        const activeBefore = await redis.lrange(activeKey(), 0, -1)
+        expect(activeBefore).toContain(jobId)
+
+        // Simulate cold-cache provisioning (or any > lockDuration delay) that lets
+        // the lock TTL expire before completeJob runs.
+        const deleted = await redis.del(lockKey(jobId))
+        expect(deleted).toBe(1)
+
+        await expect(
+            jobBroker(app.log).completeJob({
+                jobId,
+                token: polledJob!.token,
+                queueName: polledJob!.queueName,
+                status: EngineResponseStatus.LOG_SIZE_EXCEEDED,
+                logs: 'simulated large logs',
+            }),
+        ).resolves.toBeUndefined()
+
+        const activeAfter = await redis.lrange(activeKey(), 0, -1)
+        const completedAfter = await redis.zrange(completedKey(), 0, -1)
+        const failedAfter = await redis.zrange(failedKey(), 0, -1)
+        const atm = await redis.hget(jobKey(jobId), 'atm')
+
+        expect(activeAfter).toContain(jobId)
+        expect(completedAfter).not.toContain(jobId)
+        expect(failedAfter).not.toContain(jobId)
+        expect(atm == null || atm === '0').toBe(true)
+
+        await redis.lrem(activeKey(), 0, jobId)
+        await redis.del(jobKey(jobId))
+    })
+
+    it('SEED: same swallow happens on the INTERNAL_ERROR -> moveToFailed path', async () => {
+        const { mockPlatform, mockProject } = await mockAndSaveBasicSetup()
+        const requestId = apId()
+
+        const jobData = {
+            jobType: WorkerJobType.EXECUTE_TRIGGER_HOOK,
+            platformId: mockPlatform.id,
+            projectId: mockProject.id,
+            schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
+            flowId: apId(),
+            flowVersionId: apId(),
+            test: false,
+            hookType: TriggerHookType.ON_ENABLE,
+            requestId,
+            webserverId: 'seed-cause-test-2',
+        }
+
+        const jobId = apId()
+        await jobQueue(app.log).add({
+            type: JobType.ONE_TIME,
+            id: jobId,
+            data: jobData,
+        })
+
+        const polledJob = await jobBroker(app.log).poll()
+        expect(polledJob).not.toBeNull()
+
+        const redis = await redisConnections.useExisting()
+        await redis.del(lockKey(jobId))
+
+        await expect(
+            jobBroker(app.log).completeJob({
+                jobId,
+                token: polledJob!.token,
+                queueName: polledJob!.queueName,
+                status: EngineResponseStatus.INTERNAL_ERROR,
+                errorMessage: 'sandbox died during cold-cache provision',
+            }),
+        ).resolves.toBeUndefined()
+
+        const activeAfter = await redis.lrange(activeKey(), 0, -1)
+        const failedAfter = await redis.zrange(failedKey(), 0, -1)
+        const atm = await redis.hget(jobKey(jobId), 'atm')
+
+        expect(activeAfter).toContain(jobId)
+        expect(failedAfter).not.toContain(jobId)
+        expect(atm == null || atm === '0').toBe(true)
+
+        await redis.lrem(activeKey(), 0, jobId)
+        await redis.del(jobKey(jobId))
+    })
+
+    it('CONTROL: when the lock IS still valid, completeJob removes the job from active and increments atm', async () => {
+        const { mockPlatform, mockProject } = await mockAndSaveBasicSetup()
+        const requestId = apId()
+
+        const jobData = {
+            jobType: WorkerJobType.EXECUTE_TRIGGER_HOOK,
+            platformId: mockPlatform.id,
+            projectId: mockProject.id,
+            schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
+            flowId: apId(),
+            flowVersionId: apId(),
+            test: false,
+            hookType: TriggerHookType.ON_ENABLE,
+            requestId,
+            webserverId: 'seed-cause-control',
+        }
+
+        const jobId = apId()
+        await jobQueue(app.log).add({
+            type: JobType.ONE_TIME,
+            id: jobId,
+            data: jobData,
+        })
+
+        const polledJob = await jobBroker(app.log).poll()
+        expect(polledJob).not.toBeNull()
+
+        const redis = await redisConnections.useExisting()
+
+        await jobBroker(app.log).completeJob({
+            jobId,
+            token: polledJob!.token,
+            queueName: polledJob!.queueName,
+            status: EngineResponseStatus.OK,
+            response: { ok: true },
+        })
+
+        const activeAfter = await redis.lrange(activeKey(), 0, -1)
+        expect(activeAfter).not.toContain(jobId)
+    })
+})

--- a/packages/server/api/test/unit/app/workers/job-queue/job-broker.test.ts
+++ b/packages/server/api/test/unit/app/workers/job-queue/job-broker.test.ts
@@ -41,13 +41,15 @@ const mockLog: FastifyBaseLogger = {
     level: 'info',
 } as unknown as FastifyBaseLogger
 
-function createMockJob(id: string, data?: Record<string, unknown>): Job {
+function createMockJob(id: string, data?: Record<string, unknown>, deferredFailure?: string): Job {
     return {
         id,
         name: `job-name-${id}`,
         data: { projectId: 'proj-1', platformId: 'plat-1', ...data },
         attemptsMade: 0,
+        deferredFailure,
         moveToDelayed: vi.fn().mockResolvedValue(undefined),
+        moveToFailed: vi.fn().mockResolvedValue(undefined),
         changePriority: vi.fn().mockResolvedValue(undefined),
         updateData: vi.fn().mockResolvedValue(undefined),
     } as unknown as Job
@@ -155,6 +157,45 @@ describe('tryDequeue', () => {
 
         expect(result!.jobId).toBe('job-b')
         expect(jobA.changePriority).toHaveBeenCalledWith({ priority: 10 })
+    })
+
+    it('should fail job with deferredFailure and skip interceptors', async () => {
+        const zombieJob = createMockJob('zombie-1', undefined, 'job stalled more than allowable limit')
+
+        vi.mocked(mockWorker.getNextJob)
+            .mockResolvedValueOnce(zombieJob)
+            .mockResolvedValueOnce(undefined as unknown as Job)
+
+        const result = await tryDequeue(mockWorker, 'test-queue', mockLog)
+
+        expect(result).toBeNull()
+        expect(zombieJob.moveToFailed).toHaveBeenCalledTimes(1)
+        const moveToFailedCall = vi.mocked(zombieJob.moveToFailed).mock.calls[0]
+        expect(moveToFailedCall[0]).toBeInstanceOf(Error)
+        expect((moveToFailedCall[0] as Error).message).toBe('job stalled more than allowable limit')
+        expect(moveToFailedCall[1]).toMatch(/^token-/)
+        expect(moveToFailedCall[2]).toBe(false)
+        expect(mockPreDispatch).not.toHaveBeenCalled()
+        expect(mockOnJobFinished).not.toHaveBeenCalled()
+        expect(mockWorker.getNextJob).toHaveBeenCalledTimes(2)
+    })
+
+    it('should keep draining when moveToFailed throws on a deferred-failure job', async () => {
+        const zombieJob = createMockJob('zombie-2', undefined, 'job stalled more than allowable limit')
+        vi.mocked(zombieJob.moveToFailed).mockRejectedValueOnce(new Error('Missing lock'))
+        const liveJob = createMockJob('live-1')
+
+        vi.mocked(mockWorker.getNextJob)
+            .mockResolvedValueOnce(zombieJob)
+            .mockResolvedValueOnce(liveJob)
+
+        mockPreDispatch.mockResolvedValueOnce({ verdict: InterceptorVerdict.ALLOW })
+
+        const result = await tryDequeue(mockWorker, 'test-queue', mockLog)
+
+        expect(result).not.toBeNull()
+        expect(result!.jobId).toBe('live-1')
+        expect(mockWorker.getNextJob).toHaveBeenCalledTimes(2)
     })
 
     it('should return null when queue is empty (no jobs at all)', async () => {


### PR DESCRIPTION
## Summary

Cherry-picks #13110 onto `deploy/cloud/2026-05-03`.

- `fix(workers): honor BullMQ deferredFailure in custom dispatcher` — fail jobs immediately when BullMQ 5.61's stalled handler sets `deferredFailure`, instead of recycling zombies (~2,200/2,596 active jobs in production).
- `test(workers): reproduce stuck-active seed cause in job broker` — real-Redis integration test documenting how `moveToFinished` returning `-2 Missing lock` orphans jobs in the active list.

## Test plan

- [ ] CI green on cherry-pick branch
- [ ] Verify zombie active job count drains in cloud after deploy