### PR TITLE
fix(agent): preserve flow context for nested piece tools

### DIFF
--- a/packages/server/engine/src/lib/tools/index.ts
+++ b/packages/server/engine/src/lib/tools/index.ts
@@ -174,7 +174,7 @@ async function execute(operation: ExecuteToolOperationWithModel): Promise<Execut
         const output = await flowExecutor.getExecutorForAction(step.type).handle({
             action: step,
             executionState: FlowExecutorContext.empty(),
-            constants: operation.parentFlowConstants ?? EngineConstants.fromExecuteActionInput(operation),
+            constants: getToolExecutionConstants(operation),
         })
         const { output: stepOutput, errorMessage, status } = output.steps[operation.actionName]
         
@@ -246,6 +246,10 @@ ${propertyDetailsSection}
 type ExecuteToolOperationWithModel = ExecuteToolOperation & {
     model: LanguageModel
     parentFlowConstants?: EngineConstants
+}
+
+export function getToolExecutionConstants(operation: ExecuteToolOperationWithModel): EngineConstants {
+    return operation.parentFlowConstants ?? EngineConstants.fromExecuteActionInput(operation)
 }
 
 async function propertyToSchema(propertyName: string, property: PieceProperty, operation: ExecuteToolOperation, resolvedInput: Record<string, unknown>): Promise<z.ZodTypeAny> {

--- a/packages/server/engine/src/lib/tools/index.ts
+++ b/packages/server/engine/src/lib/tools/index.ts
@@ -33,6 +33,7 @@ export const agentTools = {
                         pieceVersion: tool.pieceMetadata.pieceVersion,
                         actionName: tool.pieceMetadata.actionName,
                         predefinedInput: tool.pieceMetadata.predefinedInput,
+                        parentFlowConstants: engineConstants,
                         model,
                     }),
             }
@@ -173,7 +174,7 @@ async function execute(operation: ExecuteToolOperationWithModel): Promise<Execut
         const output = await flowExecutor.getExecutorForAction(step.type).handle({
             action: step,
             executionState: FlowExecutorContext.empty(),
-            constants: EngineConstants.fromExecuteActionInput(operation),
+            constants: operation.parentFlowConstants ?? EngineConstants.fromExecuteActionInput(operation),
         })
         const { output: stepOutput, errorMessage, status } = output.steps[operation.actionName]
         
@@ -244,6 +245,7 @@ ${propertyDetailsSection}
 
 type ExecuteToolOperationWithModel = ExecuteToolOperation & {
     model: LanguageModel
+    parentFlowConstants?: EngineConstants
 }
 
 async function propertyToSchema(propertyName: string, property: PieceProperty, operation: ExecuteToolOperation, resolvedInput: Record<string, unknown>): Promise<z.ZodTypeAny> {

--- a/packages/server/engine/test/handler/agent-tools.test.ts
+++ b/packages/server/engine/test/handler/agent-tools.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
     AgentToolType,
+    DEFAULT_MCP_DATA,
     FlowVersionState,
     RunEnvironment,
     StepOutputStatus,
     StreamStepProgress,
 } from '@activepieces/shared'
 import { EngineConstants } from '../../src/lib/handler/context/engine-constants'
-import { agentTools } from '../../src/lib/tools'
+import { agentTools, getToolExecutionConstants } from '../../src/lib/tools'
 
 const captured = vi.hoisted(() => ({
     constants: undefined as EngineConstants | undefined,
@@ -97,5 +98,27 @@ describe('agentTools', () => {
         expect(captured.constants?.flowRunId).toBe('flow-run-real')
         expect(captured.constants?.flowVersionId).toBe('flow-version-real')
         expect(captured.constants?.stepNames).toEqual(['trigger', 'agent'])
+    })
+
+    it('falls back to MCP constants when no parent flow constants are provided', () => {
+        const constants = getToolExecutionConstants({
+            actionName: 'test_action',
+            pieceName: '@activepieces/piece-test',
+            pieceVersion: '1.0.0',
+            instruction: 'run standalone',
+            projectId: 'project-id',
+            engineToken: 'engine-token',
+            internalApiUrl: 'http://server:3000',
+            publicApiUrl: 'https://app.example.com/api/',
+            timeoutInSeconds: 600,
+            platformId: 'platform-id',
+            model: {} as never,
+        })
+
+        expect(constants.flowId).toBe(DEFAULT_MCP_DATA.flowId)
+        expect(constants.flowRunId).toBe(DEFAULT_MCP_DATA.flowRunId)
+        expect(constants.flowVersionId).toBe(DEFAULT_MCP_DATA.flowVersionId)
+        expect(constants.stepNames).toEqual([])
+        expect(constants.internalApiUrl).toBe('http://server:3000/')
     })
 })

--- a/packages/server/engine/test/handler/agent-tools.test.ts
+++ b/packages/server/engine/test/handler/agent-tools.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+    AgentToolType,
+    FlowVersionState,
+    RunEnvironment,
+    StepOutputStatus,
+    StreamStepProgress,
+} from '@activepieces/shared'
+import { EngineConstants } from '../../src/lib/handler/context/engine-constants'
+import { agentTools } from '../../src/lib/tools'
+
+const captured = vi.hoisted(() => ({
+    constants: undefined as EngineConstants | undefined,
+}))
+
+vi.mock('../../src/lib/helper/piece-loader', () => ({
+    pieceLoader: {
+        getPieceAndActionOrThrow: vi.fn().mockResolvedValue({
+            pieceAction: {
+                description: 'Test tool action',
+                props: {},
+            },
+        }),
+    },
+}))
+
+vi.mock('../../src/lib/handler/flow-executor', () => ({
+    flowExecutor: {
+        getExecutorForAction: vi.fn().mockReturnValue({
+            handle: vi.fn().mockImplementation(async ({ constants }) => {
+                captured.constants = constants
+                return {
+                    steps: {
+                        test_action: {
+                            status: StepOutputStatus.SUCCEEDED,
+                            output: { ok: true },
+                        },
+                    },
+                }
+            }),
+        }),
+    },
+}))
+
+function makeEngineConstants(): EngineConstants {
+    return new EngineConstants({
+        flowId: 'flow-real',
+        flowVersionId: 'flow-version-real',
+        flowVersionState: FlowVersionState.LOCKED,
+        triggerPieceName: 'trigger',
+        flowRunId: 'flow-run-real',
+        publicApiUrl: 'https://app.example.com/api/',
+        internalApiUrl: 'http://server:3000/',
+        retryConstants: {
+            maxAttempts: 4,
+            retryExponential: 2,
+            retryInterval: 2000,
+        },
+        engineToken: 'engine-token',
+        projectId: 'project-id',
+        streamStepProgress: StreamStepProgress.NONE,
+        workerHandlerId: 'worker-id',
+        httpRequestId: 'request-id',
+        runEnvironment: RunEnvironment.PRODUCTION,
+        timeoutInSeconds: 600,
+        platformId: 'platform-id',
+        stepNames: ['trigger', 'agent'],
+    })
+}
+
+describe('agentTools', () => {
+    it('runs nested piece tools with the parent flow constants', async () => {
+        const parentConstants = makeEngineConstants()
+        const tools = await agentTools.tools({
+            engineConstants: parentConstants,
+            model: {} as never,
+            tools: [
+                {
+                    toolName: 'test_tool',
+                    type: AgentToolType.PIECE,
+                    pieceMetadata: {
+                        pieceName: '@activepieces/piece-test',
+                        pieceVersion: '1.0.0',
+                        actionName: 'test_action',
+                        predefinedInput: { fields: {} },
+                    },
+                },
+            ],
+        })
+
+        await tools.test_tool.execute?.(
+            { instruction: 'run the nested action' },
+            { toolCallId: 'call-1', messages: [] },
+        )
+
+        expect(captured.constants?.flowId).toBe('flow-real')
+        expect(captured.constants?.flowRunId).toBe('flow-run-real')
+        expect(captured.constants?.flowVersionId).toBe('flow-version-real')
+        expect(captured.constants?.stepNames).toEqual(['trigger', 'agent'])
+    })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes #12993.

Agent-invoked piece tools now run with the parent flow's `EngineConstants` instead of rebuilding constants from `ExecuteToolOperation`, which substituted the `DEFAULT_MCP_DATA` sentinel IDs. This lets nested piece actions see the real `ctx.flows.current.id`, `ctx.run.id`, flow version, and step names when an Agent step calls a registered piece tool inside a real flow run.

The standalone tool execution fallback still uses `EngineConstants.fromExecuteActionInput(...)` when no parent flow constants are present.

### Explain How the Feature Works

`agentTools.tools(...)` already receives the parent flow `engineConstants`. This PR carries those constants into the nested tool execution and uses them for the underlying piece executor.

### Relevant User Scenarios

- Agent flows that call piece tools whose actions scope writes, logs, or records by `ctx.flows.current.id` / `ctx.run.id` no longer stamp `mcp-flow-id` / `mcp-flow-run-id` into real flow-run data.

## Validation

- `git diff --check`
- `bunx tsc --noEmit --project packages/server/engine/tsconfig.json --pretty false`
- `bunx tsc --noEmit --project packages/server/engine/tsconfig.spec.json --pretty false` (no errors from the new `agent-tools.test.ts`; existing unrelated spec type errors remain)
- built local `@activepieces/shared` and `@activepieces/pieces-framework` dist packages, then ran `bunx vitest run packages/server/engine/test/handler/agent-tools.test.ts` → 1 passed