### PR TITLE
fix(chat): default to Sonnet instead of Opus for chat model

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6007,7 +6007,7 @@
     },
     "packages/pieces/community/savvycal": {
       "name": "@activepieces/piece-savvycal",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -8213,7 +8213,6 @@
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
         "isolated-vm": "6.0.2",
-        "mime-types": "2.1.35",
         "nanoid": "3.3.8",
         "socket.io-client": "4.8.1",
         "tslib": "2.6.2",
@@ -8221,7 +8220,6 @@
         "zod": "4.3.6",
       },
       "devDependencies": {
-        "@types/mime-types": "2.1.1",
         "@types/node": "24.11.0",
         "vitest": "3.0.8",
       },
@@ -8280,7 +8278,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.71.1",
+      "version": "0.71.4",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.71.3",
+  "version": "0.71.4",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/shared/src/lib/management/ai-providers/index.ts
@@ -266,8 +266,8 @@ export const ALLOWED_CHAT_MODELS_BY_PROVIDER: Partial<Record<AIProviderName, rea
     [AIProviderName.ANTHROPIC]: ANTHROPIC_CHAT_MODELS,
     [AIProviderName.GOOGLE]: GOOGLE_CHAT_MODELS,
     [AIProviderName.ACTIVEPIECES]: [
-        ...OPENAI_CHAT_MODELS.map((m) => `${AIProviderName.OPENAI}/${m}`),
         ...ANTHROPIC_OPENROUTER_CHAT_MODELS.map((m) => `${AIProviderName.ANTHROPIC}/${m}`),
+        ...OPENAI_CHAT_MODELS.map((m) => `${AIProviderName.OPENAI}/${m}`),
         ...GOOGLE_CHAT_MODELS.map((m) => `${AIProviderName.GOOGLE}/${m}`),
         ...X_AI_OPENROUTER_CHAT_MODELS.map((m) => `x-ai/${m}`),
     ],

--- a/packages/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/shared/src/lib/management/ai-providers/index.ts
@@ -256,8 +256,8 @@ export type AIErrorResponse = z.infer<typeof AIErrorResponse>
  * wrong-but-confident answer.
  */
 const OPENAI_CHAT_MODELS = ['gpt-5.5', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-4.1', 'gpt-4.1-mini'] as const
-const ANTHROPIC_CHAT_MODELS = ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'] as const
-const ANTHROPIC_OPENROUTER_CHAT_MODELS = ['claude-opus-4.7', 'claude-sonnet-4.6', 'claude-haiku-4.5'] as const
+const ANTHROPIC_CHAT_MODELS = ['claude-sonnet-4-6', 'claude-opus-4-7', 'claude-haiku-4-5'] as const
+const ANTHROPIC_OPENROUTER_CHAT_MODELS = ['claude-sonnet-4.6', 'claude-opus-4.7', 'claude-haiku-4.5'] as const
 const GOOGLE_CHAT_MODELS = ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-3.1-pro-preview', 'gemini-3-flash-preview'] as const
 const X_AI_OPENROUTER_CHAT_MODELS = ['grok-4.20', 'grok-4.1-fast'] as const
 

--- a/packages/web/src/features/agents/ai-model/hooks.ts
+++ b/packages/web/src/features/agents/ai-model/hooks.ts
@@ -26,7 +26,14 @@ function getAllowedModelsForProvider(
 
       return allowedIds.includes(model.id);
     })
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) => {
+      if (isNil(allowedIds)) {
+        return a.name.localeCompare(b.name);
+      }
+      const aIndex = allowedIds.indexOf(a.id);
+      const bIndex = allowedIds.indexOf(b.id);
+      return aIndex - bIndex;
+    });
 }
 
 export const aiModelHooks = {


### PR DESCRIPTION
## Summary
- Reorder Anthropic allowed model arrays so Sonnet is first, making it the default when no model is explicitly selected
- Update frontend model list to sort by provider-defined priority order instead of alphabetically, so the preferred default appears first in the dropdown

## Test plan
- [ ] Open chat page — model selector should show Sonnet as the default
- [ ] Verify model dropdown order matches the priority: Sonnet → Opus → Haiku
- [ ] Start a new conversation without selecting a model — server should use Sonnet