### PR TITLE
feat: add new flow lifecycle events

### DIFF
--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -1,5 +1,5 @@
 import { PieceMetadata } from '@activepieces/pieces-framework'
-import { ApEdition, ApEnvironment, AppConnectionWithoutSensitiveData, ApplicationEventName, AuthenticationEvent, ConnectionEvent, Flow, FlowCreatedEvent, FlowDeletedEvent, FlowRun, FlowRunEvent, FlowUpdatedEvent, Folder, FolderEvent, GitRepoWithoutSensitiveData, isNil, ProjectMember, ProjectRelease, ProjectReleaseEvent, ProjectRoleEvent, ProjectWithLimits, SigningKeyEvent, SignUpEvent, Template, UserInvitation, UserWithMetaInformation } from '@activepieces/shared'
+import { ApEdition, ApEnvironment, AppConnectionWithoutSensitiveData, ApplicationEventName, AuthenticationEvent, ConnectionEvent, Flow, FlowCreatedEvent, FlowDeletedEvent, FlowLifecycleEvent, FlowRun, FlowRunEvent, FlowUpdatedEvent, Folder, FolderEvent, GitRepoWithoutSensitiveData, isNil, ProjectMember, ProjectRelease, ProjectReleaseEvent, ProjectRoleEvent, ProjectWithLimits, SigningKeyEvent, SignUpEvent, Template, UserInvitation, UserWithMetaInformation } from '@activepieces/shared'
 import replyFrom from '@fastify/reply-from'
 import swagger from '@fastify/swagger'
 import { createAdapter } from '@socket.io/redis-adapter'
@@ -124,6 +124,9 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
                     [ApplicationEventName.FLOW_CREATED]: FlowCreatedEvent,
                     [ApplicationEventName.FLOW_UPDATED]: FlowUpdatedEvent,
                     [ApplicationEventName.FLOW_DELETED]: FlowDeletedEvent,
+                    [ApplicationEventName.FLOW_PUBLISHED]: FlowLifecycleEvent,
+                    [ApplicationEventName.FLOW_ACTIVATED]: FlowLifecycleEvent,
+                    [ApplicationEventName.FLOW_DEACTIVATED]: FlowLifecycleEvent,
                     [ApplicationEventName.CONNECTION_UPSERTED]: ConnectionEvent,
                     [ApplicationEventName.CONNECTION_DELETED]: ConnectionEvent,
                     [ApplicationEventName.FOLDER_CREATED]: FolderEvent,

--- a/packages/server/api/src/app/flows/flow/flow.controller.ts
+++ b/packages/server/api/src/app/flows/flow/flow.controller.ts
@@ -124,6 +124,15 @@ export const flowController: FastifyPluginAsyncZod = async (app) => {
                 flowVersion: flow.version,
             },
         })
+        for (const action of pickLifecycleActions({ operation: request.body, previousStatus: flow.status })) {
+            applicationEvents(request.log).sendUserEvent(request, {
+                action,
+                data: {
+                    flow: updatedFlow,
+                    flowVersion: updatedFlow.version,
+                },
+            })
+        }
         return updatedFlow
     })
 
@@ -193,6 +202,32 @@ export const flowController: FastifyPluginAsyncZod = async (app) => {
         })
         return reply.status(StatusCodes.NO_CONTENT).send()
     })
+}
+
+function pickLifecycleActions({ operation, previousStatus }: PickLifecycleActionsParams): ApplicationEventName[] {
+    if (operation.type === FlowOperationType.LOCK_AND_PUBLISH) {
+        const actions: ApplicationEventName[] = [ApplicationEventName.FLOW_PUBLISHED]
+        const newStatus = operation.request.status ?? FlowStatus.ENABLED
+        const transitionAction = pickTransitionAction({ previousStatus, newStatus })
+        if (transitionAction) {
+            actions.push(transitionAction)
+        }
+        return actions
+    }
+    if (operation.type === FlowOperationType.CHANGE_STATUS) {
+        const transitionAction = pickTransitionAction({ previousStatus, newStatus: operation.request.status })
+        return transitionAction ? [transitionAction] : []
+    }
+    return []
+}
+
+function pickTransitionAction({ previousStatus, newStatus }: PickTransitionActionParams): ApplicationEventName | undefined {
+    if (newStatus === previousStatus) {
+        return undefined
+    }
+    return newStatus === FlowStatus.ENABLED
+        ? ApplicationEventName.FLOW_ACTIVATED
+        : ApplicationEventName.FLOW_DEACTIVATED
 }
 
 function cleanOperation(operation: FlowOperationRequest): FlowOperationRequest {
@@ -343,4 +378,12 @@ const DeleteFlowRequestOptions = {
     },
 }
 
+type PickLifecycleActionsParams = {
+    operation: FlowOperationRequest
+    previousStatus: FlowStatus
+}
 
+type PickTransitionActionParams = {
+    previousStatus: FlowStatus
+    newStatus: FlowStatus
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.71.6",
+  "version": "0.72.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/ee/audit-events/index.ts
+++ b/packages/shared/src/lib/ee/audit-events/index.ts
@@ -25,6 +25,9 @@ export enum ApplicationEventName {
     FLOW_CREATED = 'flow.created',
     FLOW_DELETED = 'flow.deleted',
     FLOW_UPDATED = 'flow.updated',
+    FLOW_PUBLISHED = 'flow.published',
+    FLOW_ACTIVATED = 'flow.activated',
+    FLOW_DEACTIVATED = 'flow.deactivated',
     FLOW_RUN_RESUMED = 'flow.run.resumed',
     FLOW_RUN_STARTED = 'flow.run.started',
     FLOW_RUN_FINISHED = 'flow.run.finished',
@@ -178,6 +181,30 @@ export const FlowUpdatedEvent = z.object({
 
 export type FlowUpdatedEvent = z.infer<typeof FlowUpdatedEvent>
 
+export const FlowLifecycleEvent = z.object({
+    ...BaseAuditEventProps,
+    action: z.union([
+        z.literal(ApplicationEventName.FLOW_PUBLISHED),
+        z.literal(ApplicationEventName.FLOW_ACTIVATED),
+        z.literal(ApplicationEventName.FLOW_DEACTIVATED),
+    ]),
+    data: z.object({
+        flow: Flow.pick({ id: true, created: true, updated: true }),
+        flowVersion: FlowVersion.pick({
+            id: true,
+            displayName: true,
+            flowId: true,
+            created: true,
+            updated: true,
+        }),
+        project: z.object({
+            displayName: z.string(),
+        }).optional(),
+    }),
+})
+
+export type FlowLifecycleEvent = z.infer<typeof FlowLifecycleEvent>
+
 export const AuthenticationEvent = z.object({
     ...BaseAuditEventProps,
     action: z.union([
@@ -276,6 +303,7 @@ export const ApplicationEvent = z.union([
     FlowCreatedEvent,
     FlowDeletedEvent,
     FlowUpdatedEvent,
+    FlowLifecycleEvent,
     FlowRunEvent,
     AuthenticationEvent,
     FolderEvent,
@@ -307,6 +335,12 @@ export function summarizeApplicationEvent(event: ApplicationEvent) {
             return `Flow ${event.data.flow.id} is created`
         case ApplicationEventName.FLOW_DELETED:
             return `Flow ${event.data.flow.id} (${event.data.flowVersion.displayName}) is deleted`
+        case ApplicationEventName.FLOW_PUBLISHED:
+            return `Flow "${event.data.flowVersion.displayName}" was published`
+        case ApplicationEventName.FLOW_ACTIVATED:
+            return `Flow "${event.data.flowVersion.displayName}" was activated`
+        case ApplicationEventName.FLOW_DEACTIVATED:
+            return `Flow "${event.data.flowVersion.displayName}" was deactivated`
         case ApplicationEventName.FOLDER_CREATED:
             return `${event.data.folder.displayName} is created`
         case ApplicationEventName.FOLDER_UPDATED:

--- a/packages/web/src/app/routes/platform/security/audit-logs/index.tsx
+++ b/packages/web/src/app/routes/platform/security/audit-logs/index.tsx
@@ -351,6 +351,9 @@ function convertToIcon(event: ApplicationEvent) {
     case ApplicationEventName.FLOW_CREATED:
     case ApplicationEventName.FLOW_DELETED:
     case ApplicationEventName.FLOW_UPDATED:
+    case ApplicationEventName.FLOW_PUBLISHED:
+    case ApplicationEventName.FLOW_ACTIVATED:
+    case ApplicationEventName.FLOW_DEACTIVATED:
       return {
         icon: <Workflow className="size-4" />,
         tooltip: t('Flow'),
@@ -454,6 +457,9 @@ function extractEventDetails(event: ApplicationEvent): EventDetailRow[] {
       return [];
     case ApplicationEventName.FLOW_DELETED:
     case ApplicationEventName.FLOW_UPDATED:
+    case ApplicationEventName.FLOW_PUBLISHED:
+    case ApplicationEventName.FLOW_ACTIVATED:
+    case ApplicationEventName.FLOW_DEACTIVATED:
       return [{ label: t('Flow'), value: event.data.flowVersion.displayName }];
     case ApplicationEventName.CONNECTION_UPSERTED:
     case ApplicationEventName.CONNECTION_DELETED: {


### PR DESCRIPTION
## What does this PR do?

Add more precise `flow.published`, `flow.activated` and `flow.deactivated` streaming events - `flow.updated` is still triggered in these cases for backward compatibility.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
