### PR TITLE
fix(agent): adding multiple flow tools to Run Agent causes the agent to not see any tools

### DIFF
--- a/packages/server/engine/src/lib/piece-context/flows.ts
+++ b/packages/server/engine/src/lib/piece-context/flows.ts
@@ -6,7 +6,9 @@ export const createFlowsContext = ({ engineToken, internalApiUrl, flowId, flowVe
         async list(params: ListFlowsContextParams): Promise<SeekPage<PopulatedFlow>> {
             const queryParams = new URLSearchParams()
             if (params?.externalIds) {
-                queryParams.set('externalIds', params.externalIds.join(','))
+                params.externalIds.forEach((externalId) => {
+                    queryParams.append('externalIds', externalId)
+                })
             }
             const url = `${internalApiUrl}v1/engine/populated-flows?${queryParams.toString()}`
             const response = await fetch(url, {

--- a/packages/server/engine/test/piece-context/flows.test.ts
+++ b/packages/server/engine/test/piece-context/flows.test.ts
@@ -1,0 +1,30 @@
+import { createFlowsContext } from '../../src/lib/piece-context/flows'
+
+const FLOWS_PARAMS = {
+    engineToken: 'test-token',
+    internalApiUrl: 'http://localhost:3000/',
+    flowId: 'flow-123',
+    flowVersionId: 'version-123',
+}
+
+describe('flows service', () => {
+
+    beforeEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('appends each external flow id as a separate query param', async () => {
+        const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(
+            JSON.stringify({ data: [], next: null, previous: null }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ))
+
+        const flows = createFlowsContext(FLOWS_PARAMS)
+        await flows.list({ externalIds: ['flow-a', 'flow-b'] })
+
+        const calledUrl = fetchSpy.mock.calls[0][0].toString()
+        expect(calledUrl).toContain('externalIds=flow-a')
+        expect(calledUrl).toContain('externalIds=flow-b')
+        expect(calledUrl).not.toContain('externalIds=flow-a%2Cflow-b')
+    })
+})


### PR DESCRIPTION
## Summary

Fixes a bug where adding 2 or more flow tools to the **Run Agent** step causes the agent to behave as if no tools are configured at all — it only sees `updateTaskStatus` and cannot execute any flow.

## Steps to Reproduce

1. Create two or more flows with an MCP trigger.
2. Add both as tools in a **Run Agent** step.
3. Run the agent and ask it to use either flow.
4. The agent responds that no tools are available, even though they are listed in the input.

> Adding only one flow tool works correctly. Both flows also work correctly when tested individually.

## Root Cause

When the engine fetches flow data for the configured tools, it serialises all external flow IDs as a single comma-joined query string value:

`GET /v1/engine/populated-flows?externalIds=id1,id2`

The server expects each ID as a separate repeated param:
`GET /v1/engine/populated-flows?externalIds=id1&externalIds=id2`

The comma-joined form is treated as one literal ID that never matches any row in the database, so **zero flows are returned**. The agent tools list is empty and the agent proceeds with no flow tools available.

## Impact
- Restores correct behavior when **multiple** flow tools are attached to Run Agent.
- No intentional behavior change for the single-flow case.
