### PR TITLE
fix(mcp): derive authorize redirect URL from request host

### DIFF
--- a/packages/server/api/src/app/mcp/oauth/code/mcp-oauth-authorize.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/code/mcp-oauth-authorize.controller.ts
@@ -3,8 +3,7 @@ import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { z } from 'zod'
 import { securityAccess } from '../../../core/security/authorization/fastify-security'
 import { JwtAudience, jwtUtils } from '../../../helper/jwt-utils'
-import { system } from '../../../helper/system/system'
-import { AppSystemProp } from '../../../helper/system/system-props'
+import { networkUtils } from '../../../helper/network-utils'
 import { mcpOAuthClientService } from '../client/mcp-oauth-client.service'
 
 const AUTH_REQUEST_TTL_10_MINUTES_SECONDS = 10 * 60
@@ -49,8 +48,7 @@ export const mcpOAuthAuthorizeController: FastifyPluginAsyncZod = async (app) =>
             audience: JwtAudience.MCP_OAUTH_AUTH_REQUEST,
         })
 
-        const frontendUrl = system.getOrThrow(AppSystemProp.FRONTEND_URL)
-        const authorizePageUrl = new URL('/mcp-authorize', frontendUrl)
+        const authorizePageUrl = new URL('/mcp-authorize', networkUtils.getRequestBaseUrl(req))
         authorizePageUrl.searchParams.set('authRequestId', authRequestToken)
 
         return reply.redirect(authorizePageUrl.toString())


### PR DESCRIPTION
## Summary
- The `/authorize` endpoint redirected to `AP_FRONTEND_URL` for the MCP consent page, ignoring custom domains
- Now uses `networkUtils.getRequestBaseUrl(req)` so users on `flix.activepieces.com` stay on `flix.activepieces.com` instead of being redirected to `cloud.activepieces.com`

## Test plan
- [x] Verified `/authorize` redirect uses request host instead of static env var
- [ ] Verify MCP OAuth flow end-to-end with a custom domain on staging/production