### PR TITLE
fix(apify): remove deprecated crawler option and validate dataset pagination

### DIFF
--- a/packages/pieces/community/apify/package.json
+++ b/packages/pieces/community/apify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-apify",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/apify/src/lib/actions/get-dataset-items.ts
+++ b/packages/pieces/community/apify/src/lib/actions/get-dataset-items.ts
@@ -27,7 +27,7 @@ export const getDatasetItems = createAction({
     limit: Property.Number({
       required: false,
       displayName: 'Limit',
-      description: 'Maximum number of results to return.',
+      description: 'Maximum number of results to return. Must be greater than 0.',
       defaultValue: 50
     })
   },
@@ -36,6 +36,12 @@ export const getDatasetItems = createAction({
     const { datasetId, offset, limit } = context.propsValue;
 
     const client = createApifyClient(apifyToken);
+    if (offset !== undefined && offset !== null && offset < 0) {
+      throw new Error('Offset must be greater than or equal to 0.');
+    }
+    if (limit !== undefined && limit !== null && limit <= 0) {
+      throw new Error('Limit must be greater than 0.');
+    }
 
     const response = await client.dataset(datasetId).listItems({
       limit,

--- a/packages/pieces/community/apify/src/lib/actions/scrape-single-url.ts
+++ b/packages/pieces/community/apify/src/lib/actions/scrape-single-url.ts
@@ -28,10 +28,6 @@ export const scrapeSingleUrl = createAction({
             value: 'cheerio',
           },
           {
-            label: 'JSDOM',
-            value: 'jsdom',
-          },
-          {
             label: 'Playwright Adaptive',
             value: 'playwright:adaptive',
           },

--- a/packages/pieces/community/apify/src/lib/common/index.ts
+++ b/packages/pieces/community/apify/src/lib/common/index.ts
@@ -293,7 +293,7 @@ export const createBuildProperty = () => Property.ShortText({
 });
 
 export const createMemoryProperty = (runType: RunType) => Property.StaticDropdown({
-  displayName: 'Memory',
+  displayName: 'Memory (MB)',
   description: `Memory limit for the run, in megabytes. The amount of memory can be set to one of the available options. By default, the run uses a memory limit specified in the ${runType === RunType.ACTOR ? 'default run configuration for the Actor' : 'task settings'}.`,
   required: false,
   options: {


### PR DESCRIPTION
## What does this PR do?

This PR updates the Apify piece with small usability and reliability fixes:

- Removes deprecated **JSDOM** from the **Scrape Single URL** crawler options.
- Adds input validation in **Get Dataset Items**:
  - `limit` must be greater than `0`
  - `offset` must be greater than or equal to `0`
- Updates memory field wording in **Run Actor** / **Run Task** for clearer unit context.

It also bumps the Apify piece version from **0.2.1** to **0.2.2**.

### Explain How the Feature Works

- In `Scrape Single URL`, the deprecated JSDOM crawler option is removed from the static dropdown list, so users only see supported crawler types.
- In `Get Dataset Items`, runtime guards validate pagination inputs before calling Apify:
  - negative offsets are rejected
  - zero/negative limits are rejected
  - clear error messages are returned for invalid values
- In run actions, the memory field label text is adjusted for clarity while keeping the same dropdown values.

### Relevant User Scenarios

- Users configuring **Scrape Single URL** no longer select a deprecated crawler mode.
- Users passing dynamic values into **Get Dataset Items** avoid silent failures from invalid pagination values.
- Users configuring actor/task runs get slightly clearer memory configuration wording.

Fixes # (issue)