### PR TITLE
fix(google-sheets): extract row number correctly for multi-letter columns

### DIFF
--- a/packages/pieces/community/google-sheets/src/lib/actions/insert-row.action.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/insert-row.action.ts
@@ -73,7 +73,9 @@ export const insertRowAction = createAction({
 
 function extractRowNumber(updatedRange: string): number {
 	const rowRange = updatedRange.split('!')[1];
-	return parseInt(rowRange.split(':')[0].substring(1), 10);
+	const match = rowRange.split(':')[0].match(/\d+/);
+	const rowNumber = match ? parseInt(match[0], 10) : 0;
+	return rowNumber;
 }
 
 async function appendGoogleSheetValues(params: AppendGoogleSheetValuesParams) {

--- a/packages/pieces/community/google-sheets/src/lib/actions/update-row.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/update-row.ts
@@ -77,10 +77,8 @@ export const updateRowAction = createAction({
         '!'
       );
       const updatedRowRange = updatedRangeParts?.[1];
-      const updatedRowNumber = parseInt(
-        updatedRowRange?.split(':')[0].substring(1) ?? '0',
-        10
-      );
+      const match = updatedRowRange?.split(':')[0].match(/\d+/);
+      const updatedRowNumber = match ? parseInt(match[0], 10) : 0;
 
       return { updates: { ...response.data }, row: updatedRowNumber };
     } else {


### PR DESCRIPTION
Fixes the NaN row number bug by using regex to extract row numbers instead of hardcoded substring(1). This ensures support for multi-letter columns like AA, AB, etc.