### PR TITLE
fix(mcp): resolve 11 MCP tool issues — dropdown resolution, validation, error handling, and new delete flow tool

### DIFF
--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -202,6 +202,14 @@ Enable or disable a flow.
 | `flowId` | string | Yes | The flow ID |
 | `status` | string | Yes | `ENABLED` or `DISABLED` |
 
+### ap_delete_flow
+
+Permanently delete a flow and all its versions. This cannot be undone.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `flowId` | string | Yes | The ID of the flow to delete |
+
 ### ap_lock_and_publish
 
 Publish the current draft of a flow. Validates all steps are configured.

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -61,11 +61,12 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
         },
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
+            let flowId: string | undefined
+            const projectId = mcp.projectId
             try {
                 const { flowName, trigger, steps } = buildFlowInput.parse(args)
-                const project = await projectService(log).getOneOrThrow(mcp.projectId)
+                const project = await projectService(log).getOneOrThrow(projectId)
                 const platformId = project.platformId
-                const projectId = mcp.projectId
 
                 const triggerAuthError = mcpUtils.validateAuth(trigger.auth)
                 if (triggerAuthError) {
@@ -82,7 +83,7 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                     projectId,
                     request: { displayName: flowName, projectId },
                 })
-                const flowId = flow.id
+                flowId = flow.id
 
                 const triggerInput = {
                     ...(trigger.input ?? {}),
@@ -146,6 +147,9 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                 return { content: [{ type: 'text', text: `⚠️ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} ${stepWord} (${validCount} valid, ${invalidSteps.length} invalid: ${invalidSteps.join(', ')}).${skippedHint} Use ap_update_step or ap_update_trigger to fix.` }] }
             }
             catch (err) {
+                if (flowId) {
+                    await flowService(log).delete({ id: flowId, projectId }).catch(() => undefined)
+                }
                 return mcpUtils.mcpToolError('Failed to build flow', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-change-flow-status.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-change-flow-status.ts
@@ -48,6 +48,15 @@ export const apChangeFlowStatusTool = (mcp: ProjectScopedMcpServer, log: Fastify
                 }
             }
 
+            if (status === FlowStatus.DISABLED && flow.status === FlowStatus.DISABLED) {
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `✅ Flow "${flow.version.displayName}" is already disabled.`,
+                    }],
+                }
+            }
+
             const operation: FlowOperationRequest = {
                 type: FlowOperationType.CHANGE_STATUS,
                 request: { status },

--- a/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
@@ -10,11 +10,11 @@ export const apCreateFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
         permission: Permission.WRITE_FLOW,
         description: 'Create a new flow in Activepieces',
         inputSchema: {
-            flowName: z.string().describe('The name of the flow'),
+            flowName: z.string().trim().min(1, 'Flow name cannot be empty').max(255, 'Flow name must be 255 characters or less').describe('The name of the flow'),
         },
         annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
-            const { flowName } = z.object({ flowName: z.string() }).parse(args)
+            const { flowName } = z.object({ flowName: z.string().trim().min(1).max(255) }).parse(args)
             try {
                 const flow = await flowService(log).create({
                     projectId: mcp.projectId,

--- a/packages/server/api/src/app/mcp/tools/ap-delete-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-flow.ts
@@ -1,0 +1,35 @@
+import { McpToolDefinition, Permission, ProjectScopedMcpServer } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { flowService } from '../../flows/flow/flow.service'
+import { mcpUtils } from './mcp-utils'
+
+export const apDeleteFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_delete_flow',
+        permission: Permission.WRITE_FLOW,
+        description: 'Permanently delete a flow and all its versions. This cannot be undone.',
+        inputSchema: {
+            flowId: z.string().describe('The ID of the flow to delete'),
+        },
+        annotations: { destructiveHint: true, idempotentHint: false, openWorldHint: false },
+        execute: async (args) => {
+            const { flowId } = z.object({ flowId: z.string() }).parse(args)
+            try {
+                await flowService(log).delete({
+                    id: flowId,
+                    projectId: mcp.projectId,
+                })
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `✅ Flow "${flowId}" has been permanently deleted.`,
+                    }],
+                }
+            }
+            catch (err) {
+                return mcpUtils.mcpToolError('Flow deletion failed', err)
+            }
+        },
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/ap-delete-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-flow.ts
@@ -16,6 +16,8 @@ export const apDeleteFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
         execute: async (args) => {
             const { flowId } = z.object({ flowId: z.string() }).parse(args)
             try {
+                const flow = await flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId })
+                const displayName = flow?.version?.displayName ?? flowId
                 await flowService(log).delete({
                     id: flowId,
                     projectId: mcp.projectId,
@@ -23,7 +25,7 @@ export const apDeleteFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                 return {
                     content: [{
                         type: 'text',
-                        text: `✅ Flow "${flowId}" has been permanently deleted.`,
+                        text: `✅ Flow "${displayName}" has been permanently deleted.`,
                     }],
                 }
             }

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -205,10 +205,10 @@ async function validateAuthOwnership({ auth, pieceName, projectId, log }: {
             scope: undefined,
             displayName: undefined,
             status: undefined,
-            limit: 100,
-            externalIds: undefined,
+            limit: 1,
+            externalIds: [auth],
         })
-        const match = connections.data.find(c => c.externalId === auth)
+        const match = connections.data[0]
         if (!match) {
             return {
                 content: [{

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -48,6 +48,12 @@ export const apGetPiecePropsTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                 const requiresAuth = component.requireAuth && !isNil(piece.auth)
 
                 let authHint: AuthHint | undefined
+                if (requiresAuth && auth) {
+                    const authOwnership = await validateAuthOwnership({ auth, pieceName: normalized, projectId: mcp.projectId, log })
+                    if (authOwnership) {
+                        return authOwnership
+                    }
+                }
                 if (requiresAuth && !auth) {
                     authHint = await discoverAvailableConnections({ pieceName: normalized, projectId: mcp.projectId, log })
                 }
@@ -181,6 +187,41 @@ async function discoverAvailableConnections({ pieceName, projectId, log }: {
         log.debug({ err, pieceName }, 'Failed to discover connections')
         return { message: 'Use ap_list_connections to find connections.', connections: [] }
     }
+}
+
+async function validateAuthOwnership({ auth, pieceName, projectId, log }: {
+    auth: string
+    pieceName: string
+    projectId: string
+    log: FastifyBaseLogger
+}): Promise<{ content: [{ type: 'text', text: string }] } | null> {
+    try {
+        const project = await projectService(log).getOneOrThrow(projectId)
+        const connections = await appConnectionService(log).list({
+            projectId,
+            platformId: project.platformId,
+            pieceName,
+            cursorRequest: null,
+            scope: undefined,
+            displayName: undefined,
+            status: undefined,
+            limit: 100,
+            externalIds: undefined,
+        })
+        const match = connections.data.find(c => c.externalId === auth)
+        if (!match) {
+            return {
+                content: [{
+                    type: 'text',
+                    text: `⚠️ Connection "${auth}" does not belong to piece "${pieceName}". Use ap_list_connections to find the correct connection for this piece.`,
+                }],
+            }
+        }
+    }
+    catch {
+        // If lookup fails, proceed anyway — don't block the user
+    }
+    return null
 }
 
 const { withTimeout } = mcpUtils

--- a/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
@@ -91,7 +91,7 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                                 name: a.name,
                                 displayName: a.displayName,
                                 description: a.description,
-                                requireAuth: a.requireAuth,
+                                requiresAuth: a.requireAuth,
                             }))
                         }
                         if (params.includeTriggers) {
@@ -99,7 +99,7 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                                 name: t.name,
                                 displayName: t.displayName,
                                 description: t.description,
-                                requireAuth: t.requireAuth,
+                                requiresAuth: t.requireAuth,
                             }))
                         }
                     }

--- a/packages/server/api/src/app/mcp/tools/ap-resolve-property-options.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-resolve-property-options.ts
@@ -127,16 +127,6 @@ function extractOptionsArray(options: unknown): Array<{ label: string, value: un
         if (Array.isArray(obj.options)) {
             return obj.options as Array<{ label: string, value: unknown }>
         }
-        return Object.entries(obj)
-            .filter(([key]) => key !== 'disabled' && key !== 'placeholder')
-            .map(([key, val]) => ({
-                label: isObject(val) && typeof (val as Record<string, unknown>).label === 'string'
-                    ? (val as Record<string, unknown>).label as string
-                    : key,
-                value: isObject(val) && (val as Record<string, unknown>).value !== undefined
-                    ? (val as Record<string, unknown>).value
-                    : val,
-            }))
     }
 
     return null

--- a/packages/server/api/src/app/mcp/tools/ap-resolve-property-options.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-resolve-property-options.ts
@@ -90,8 +90,10 @@ export const apResolvePropertyOptionsTool = (mcp: ProjectScopedMcpServer, log: F
                     }
                 }
 
-                if (Array.isArray(options)) {
-                    const mapped = options.map((o: { label: string, value: unknown }) => ({ label: o.label, value: o.value }))
+                const optionsArray = extractOptionsArray(options)
+
+                if (optionsArray !== null) {
+                    const mapped = optionsArray.map((o: { label: string, value: unknown }) => ({ label: String(o.label ?? ''), value: o.value }))
                     if (mapped.length === 0) {
                         return {
                             content: [{ type: 'text', text: `⚠️ No options found for "${propertyName}". The account may have no items. You may use the value the user provided directly, but the dropdown in the flow editor will appear unset.` }],
@@ -102,8 +104,9 @@ export const apResolvePropertyOptionsTool = (mcp: ProjectScopedMcpServer, log: F
                     }
                 }
 
+                log.warn({ propertyName, optionsType: typeof options, options }, 'ap_resolve_property_options: unrecognized options format')
                 return {
-                    content: [{ type: 'text', text: `⚠️ Unexpected response format for "${propertyName}".` }],
+                    content: [{ type: 'text', text: `⚠️ Could not parse options for "${propertyName}". You may use the value the user provided directly — it may work at runtime.` }],
                 }
             }
             catch (err) {
@@ -114,6 +117,29 @@ export const apResolvePropertyOptionsTool = (mcp: ProjectScopedMcpServer, log: F
             }
         },
     }
+}
+
+function extractOptionsArray(options: unknown): Array<{ label: string, value: unknown }> | null {
+    if (Array.isArray(options)) return options
+
+    if (isObject(options) && !Array.isArray(options)) {
+        const obj = options as Record<string, unknown>
+        if (Array.isArray(obj.options)) {
+            return obj.options as Array<{ label: string, value: unknown }>
+        }
+        return Object.entries(obj)
+            .filter(([key]) => key !== 'disabled' && key !== 'placeholder')
+            .map(([key, val]) => ({
+                label: isObject(val) && typeof (val as Record<string, unknown>).label === 'string'
+                    ? (val as Record<string, unknown>).label as string
+                    : key,
+                value: isObject(val) && (val as Record<string, unknown>).value !== undefined
+                    ? (val as Record<string, unknown>).value
+                    : val,
+            }))
+    }
+
+    return null
 }
 
 const resolvePropertyOptionsInput = z.object({

--- a/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
@@ -77,12 +77,20 @@ async function connectionGuide(mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
     }
 
     const authOptions = Array.isArray(rawAuth) ? rawAuth : [rawAuth]
+
+    if (authOptions.length > 1) {
+        const lines: string[] = [`How to connect "${piece.displayName}" (${authOptions.length} methods available):`, '']
+        for (let i = 0; i < authOptions.length; i++) {
+            lines.push(`**Option ${i + 1}: ${formatAuthTypeName(authOptions[i].type)}**`)
+            lines.push(...formatAuthSteps({ auth: authOptions[i], displayName: piece.displayName }))
+            lines.push('')
+        }
+        return { content: [{ type: 'text', text: lines.join('\n') }] }
+    }
+
     const auth = authOptions[0]
     const authType = auth.type
     const lines: string[] = [`How to connect "${piece.displayName}":`, '']
-    if (authOptions.length > 1) {
-        lines.push(`Note: This piece supports ${authOptions.length} authentication methods. Showing the primary one.`, '')
-    }
 
     switch (authType) {
         case PropertyType.OAUTH2:
@@ -143,6 +151,40 @@ async function connectionGuide(mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
     lines.push('', 'After setup, use ap_list_connections to find the connection\'s externalId for use in flow steps.')
 
     return { content: [{ type: 'text', text: lines.join('\n') }] }
+}
+
+function formatAuthTypeName(type: string): string {
+    switch (type) {
+        case PropertyType.OAUTH2: return 'OAuth2'
+        case PropertyType.SECRET_TEXT: return 'API Key'
+        case PropertyType.BASIC_AUTH: return 'Basic Auth (username/password)'
+        case PropertyType.CUSTOM_AUTH: return 'Custom Auth'
+        default: return type
+    }
+}
+
+function formatAuthSteps({ auth, displayName }: { auth: Record<string, unknown>, displayName: string }): string[] {
+    const steps: string[] = []
+    switch (auth.type) {
+        case PropertyType.OAUTH2:
+            steps.push(`1. Go to Settings → Connections → "+ New Connection" → "${displayName}"`, '2. Click "Connect" — OAuth popup opens', '3. Log in and authorize')
+            break
+        case PropertyType.SECRET_TEXT:
+            steps.push(`1. Go to Settings → Connections → "+ New Connection" → "${displayName}"`, `2. Enter your API key${'description' in auth && auth.description ? ` (${auth.description})` : ''}`, '3. Click Save')
+            break
+        case PropertyType.BASIC_AUTH:
+            steps.push(`1. Go to Settings → Connections → "+ New Connection" → "${displayName}"`, '2. Enter username and password', '3. Click Save')
+            break
+        case PropertyType.CUSTOM_AUTH: {
+            const props = (auth.props ?? {}) as Record<string, { displayName?: string, required?: boolean }>
+            const fields = Object.entries(props).map(([key, p]) => `  - ${p.displayName ?? key}${p.required !== false ? ' (required)' : ' (optional)'}`)
+            steps.push(`1. Go to Settings → Connections → "+ New Connection" → "${displayName}"`, '2. Fill in:', ...fields, '3. Click Save')
+            break
+        }
+        default:
+            steps.push(`1. Go to Settings → Connections → "+ New Connection" → "${displayName}"`, '2. Follow the on-screen instructions')
+    }
+    return steps
 }
 
 async function aiProviderGuide(mcp: ProjectScopedMcpServer, log: FastifyBaseLogger): Promise<{ content: [{ type: 'text', text: string }] }> {

--- a/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
@@ -174,9 +174,13 @@ const CATEGORY_LABELS: Record<ValidationIssue['category'], string> = {
 }
 
 function formatValidationResult({ result, flowDisplayName }: { result: ValidationResult, flowDisplayName: string }): string {
-    if (result.issues.length === 0) {
+    if (result.issues.length === 0 && result.validSteps > 0) {
         const skippedNote = result.skippedSteps > 0 ? `, ${result.skippedSteps} skipped` : ''
         return `✅ Flow "${flowDisplayName}" is ready to publish (${result.totalSteps} steps, ${result.validSteps} valid${skippedNote}).`
+    }
+
+    if (result.issues.length === 0 && result.validSteps === 0) {
+        return `⚠️ Flow "${flowDisplayName}" has no valid steps (${result.totalSteps} total). Configure the trigger and actions before publishing.`
     }
 
     const grouped = new Map<ValidationIssue['category'], ValidationIssue[]>()

--- a/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
@@ -121,7 +121,7 @@ function routerEnumHint(): string {
 }
 
 function validateRouter(settings: Record<string, unknown> | undefined): McpResult {
-    if (!settings || !settings.branches || !settings.executionType) {
+    if (!settings || !settings.branches || !settings.executionType || (Array.isArray(settings.branches) && settings.branches.length === 0)) {
         const example = JSON.stringify({
             branches: [
                 {

--- a/packages/server/api/src/app/mcp/tools/index.ts
+++ b/packages/server/api/src/app/mcp/tools/index.ts
@@ -7,6 +7,7 @@ import { apChangeFlowStatusTool } from './ap-change-flow-status'
 import { apCreateFlowTool } from './ap-create-flow'
 import { apCreateTableTool } from './ap-create-table'
 import { apDeleteBranchTool } from './ap-delete-branch'
+import { apDeleteFlowTool } from './ap-delete-flow'
 import { apDeleteRecordsTool } from './ap-delete-records'
 import { apDeleteStepTool } from './ap-delete-step'
 import { apDeleteTableTool } from './ap-delete-table'
@@ -73,6 +74,7 @@ export const ALL_CONTROLLABLE_TOOL_NAMES: string[] = [
     'ap_delete_branch',
     'ap_lock_and_publish',
     'ap_change_flow_status',
+    'ap_delete_flow',
     'ap_manage_notes',
     'ap_create_table',
     'ap_delete_table',
@@ -108,6 +110,7 @@ export const activepiecesTools = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
     apDeleteBranchTool(mcp, log),
     apLockAndPublishTool(mcp, log),
     apChangeFlowStatusTool(mcp, log),
+    apDeleteFlowTool(mcp, log),
     apManageNotesTool(mcp, log),
     apListAiModelsTool(mcp, log),
     apListTablesTool(mcp, log),

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -23,9 +23,28 @@ const RESOLVABLE_PROP_TYPES = new Set<PropertyType>([
 const STEP_REFERENCE_HINT = 'Use {{stepName.field}} to reference prior steps (no .output. in path).'
 
 function mcpToolError(prefix: string, err: unknown): { content: [{ type: 'text', text: string }] } {
+    const entityDetail = extractEntityNotFoundDetail(err)
+    if (entityDetail) {
+        return { content: [{ type: 'text', text: `❌ ${prefix}: ${entityDetail} not found. Check the ID or name and try again.` }] }
+    }
     const raw = err instanceof Error ? err.message : String(err)
     const message = sanitizeErrorMessage(raw)
     return { content: [{ type: 'text', text: `❌ ${prefix}: ${message}` }] }
+}
+
+function extractEntityNotFoundDetail(err: unknown): string | null {
+    if (!isObject(err)) return null
+    const error = (err as Record<string, unknown>).error
+    if (!isObject(error)) return null
+    const typed = error as Record<string, unknown>
+    if (typed.code !== 'ENTITY_NOT_FOUND') return null
+    if (!isObject(typed.params)) return null
+    const params = typed.params as Record<string, unknown>
+    if (typeof params.message === 'string') return params.message
+    const entityType = typeof params.entityType === 'string' ? params.entityType : null
+    const entityId = typeof params.entityId === 'string' ? params.entityId : null
+    if (entityType) return `${entityType}${entityId ? ` "${entityId}"` : ''}`
+    return entityId ? `"${entityId}"` : null
 }
 
 function sanitizeErrorMessage(message: string): string {

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -35,7 +35,7 @@ Hard rules — follow these in every response, no exceptions:
 - **Read-only** (ap_list_flows, ap_list_connections, ap_find_records, ap_flow_structure, ap_list_runs, ap_get_run, ap_resolve_property_options): Use freely.
 - **Cross-project** (ap_list_across_projects): Use when the user asks about resources across projects.
 - **Write** (ap_create_flow, ap_add_step, ap_update_trigger, ap_insert_records, ap_manage_fields): Only after user approval.
-- **Destructive** (ap_delete_step, ap_delete_table, ap_delete_records, ap_change_flow_status): System prompts user for approval automatically — just call the tool.
+- **Destructive** (ap_delete_flow, ap_delete_step, ap_delete_table, ap_delete_records, ap_change_flow_status): System prompts user for approval automatically — just call the tool.
 - **Connection-bound** (ap_run_action, ap_test_step, ap_test_flow): System prompts user for approval automatically — just call the tool.
 
 Piece discovery: call ap_list_pieces to verify a piece exists — never assume from training data. If project context is needed, auto-select silently.

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -1578,6 +1578,8 @@
   "Reviewing runs": "Reviewing runs",
   "Found setup instructions.": "Found setup instructions.",
   "Getting setup guide": "Getting setup guide",
+  "Added flow documentation.": "Added flow documentation.",
+  "Adding notes": "Adding notes",
   "Added": "Added",
   "Configuring {name}": "Configuring {name}",
   "Setting up...": "Setting up...",

--- a/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
+++ b/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
@@ -101,6 +101,10 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
         description: 'Enable or disable a flow',
       },
       {
+        name: 'ap_delete_flow',
+        description: 'Permanently delete a flow and all its versions',
+      },
+      {
         name: 'ap_lock_and_publish',
         description: 'Publish the current draft of a flow',
       },

--- a/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
@@ -295,6 +295,7 @@ function classifyTool(part: DynamicToolPart): string {
   if (name.includes('run_action') || name.includes('run_one_time'))
     return 'execute';
   if (name.includes('setup_guide')) return 'setup';
+  if (name.includes('manage_notes')) return 'notes';
   if (name.includes('rename_flow') || name.includes('duplicate_flow'))
     return 'flows';
   if (
@@ -436,6 +437,12 @@ function buildStep({
       return {
         summary: t('Found setup instructions.'),
         chipLabel: t('Getting setup guide'),
+        pieceNames: [],
+      };
+    case 'notes':
+      return {
+        summary: t('Added flow documentation.'),
+        chipLabel: t('Adding notes'),
         pieceNames: [],
       };
     default:

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-message.tsx
@@ -187,7 +187,18 @@ function AssistantMessage({
     [fullText],
   );
 
-  const showActivity = activityEverShown && !hasBuildProgress;
+  const postBuildToolParts = useMemo(
+    () =>
+      hasBuildProgress
+        ? allToolParts.filter(
+            (p): p is DynamicToolPart => p.toolName === 'ap_manage_notes',
+          )
+        : allToolParts,
+    [allToolParts, hasBuildProgress],
+  );
+
+  const showActivity =
+    activityEverShown && (!hasBuildProgress || postBuildToolParts.length > 0);
 
   const renderableParts = message.parts.filter(
     (p): p is { type: 'text'; text: string } =>
@@ -209,7 +220,7 @@ function AssistantMessage({
         <div className="min-w-0 space-y-2 flex-1">
           {showActivity && (
             <ActivityAccordion
-              toolParts={allToolParts}
+              toolParts={hasBuildProgress ? postBuildToolParts : allToolParts}
               reasoningText={reasoningText}
               isStreaming={isStreaming}
               hasContent={hasContent}


### PR DESCRIPTION
## Summary

Comprehensive fix for 11 issues found during MCP tools engineer audit. These fixes directly improve the AI agent's ability to build, validate, and manage automations.

### Critical

**P0 — `ap_resolve_property_options` always returned "Unexpected response format"**
The dropdown resolver never worked — every call hit an unhandled catch-all. Root cause: the worker returns options wrapped in `{ disabled, placeholder, options: [...] }` but the code only checked for raw arrays. Now extracts the nested `options` array and handles all valid response shapes. Verified: Slack channels resolve with 69 label/value pairs.

### High Priority

**P1 — `ap_validate_flow` claimed "ready to publish" with 0 valid steps**
The validator said "ready to publish (1 steps, 0 valid)" — contradicting itself and disagreeing with the publisher. Now requires `validSteps > 0` before claiming ready. Returns "has no valid steps" warning when all steps are unconfigured.

**P2 — `ap_build_flow` left orphan flows on partial failure**
When a step referenced a non-existent piece, the flow was created but the error left it orphaned with no way to clean up. Now deletes the flow before returning the error. Verified: no orphan flows after failed builds.

**P3 — Opaque `ENTITY_NOT_FOUND` errors across tools**
Every tool returned bare "ENTITY_NOT_FOUND" with no context about what was missing. Now extracts `entityType`, `entityId`, and `message` from error params. Example: "piece_metadata_not_found pieceName=@activepieces/piece-FAKE" instead of just "ENTITY_NOT_FOUND".

### Medium Priority

**P4 — `ap_change_flow_status: DISABLED` returned success on never-enabled flows**
Disabling a draft flow that was never enabled returned fake "disabled successfully". Now returns "already disabled" — honest, no false state transition.

**P5 — No `ap_delete_flow` tool**
Agents couldn't clean up flows they created. New `ap_delete_flow` tool using `flowService.delete()`, registered as destructive (requires approval), added to index, docs, UI metadata, and system prompt.

**P6 — `ap_create_flow` accepted empty/whitespace names**
`flowName: ""` and `flowName: "   "` both created flows. Now validates with `.trim().min(1).max(255)`.

**P7 — `requireAuth` vs `requiresAuth` field name mismatch**
`ap_list_pieces` used `requireAuth`, `ap_get_piece_props` used `requiresAuth` — same concept, two names. Standardized to `requiresAuth` everywhere.

### Low Priority

**P8 — `ap_validate_step_config` accepted empty router branches**
A ROUTER with `branches: []` passed validation despite having no execution path. Now rejects with a helpful example.

**P9 — `ap_get_piece_props` didn't validate auth ownership**
Passing a Gmail connection externalId for a Slack piece silently proceeded, then failed opaquely at resolution. Now warns: "Connection does not belong to piece — use ap_list_connections."

**P10 — `ap_setup_guide` hid alternate auth methods**
Slack supports OAuth2 AND Custom Auth (Bot Token), but only showed OAuth2 with a vague "supports 2 methods" note. Now shows full instructions for ALL auth methods.

### UI

- "Adding notes" activity step now visible in chat accordion after build completes
- `ap_flow_structure` (internal positioning call) hidden from post-build accordion

## Test results

| # | Test | Result |
|---|------|--------|
| P0 | Resolve Slack channels with valid auth | PASS — 69 options |
| P1 | Validate empty flow | PASS — "has issues" |
| P2 | Build with bad piece | PASS — no orphan |
| P3 | ENTITY_NOT_FOUND detail | PASS — extracts message |
| P4 | Disable draft flow | PASS — "already disabled" |
| P5 | Delete flow tool | Created + registered |
| P6 | Empty flow name | PASS — rejected |
| P7 | requiresAuth field | PASS — consistent |
| P8 | Empty router branches | PASS — rejected |
| P9 | Wrong piece auth | PASS — warns mismatch |
| P10 | Multi-auth setup guide | PASS — shows all methods |