### PR TITLE
fix(tables): map cell unique-violation to 409 (was 500)

### DIFF
--- a/packages/server/api/src/app/tables/record/record.service.ts
+++ b/packages/server/api/src/app/tables/record/record.service.ts
@@ -16,7 +16,7 @@ import {
     UpdateRecordRequest,
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { EntityManager, In } from 'typeorm'
+import { EntityManager, In, QueryFailedError } from 'typeorm'
 import { repoFactory } from '../../core/db/repo-factory'
 import { transaction } from '../../core/db/transaction'
 import { system } from '../../helper/system/system'
@@ -52,24 +52,35 @@ export const recordService = {
         )
 
         let insertedRecordIds: string[] = []
-        insertedRecordIds = await transaction(async (entityManager: EntityManager) => {
-            const batches = chunk(validRecords, MAX_BATCH_SIZE)
-            const records: RecordSchema[] = []
-            const insertedRecordIds: string[] = []
+        try {
+            insertedRecordIds = await transaction(async (entityManager: EntityManager) => {
+                const batches = chunk(validRecords, MAX_BATCH_SIZE)
+                const records: RecordSchema[] = []
+                const insertedRecordIds: string[] = []
 
-            for (const batch of batches) {
-                const now = new Date(new Date().getTime() + records.length)
-                const recordInsertions = prepareRecordInsertions(batch, request.tableId, projectId, now)
-                await entityManager.getRepository(RecordEntity).insert(recordInsertions)
+                for (const batch of batches) {
+                    const now = new Date(new Date().getTime() + records.length)
+                    const recordInsertions = prepareRecordInsertions(batch, request.tableId, projectId, now)
+                    await entityManager.getRepository(RecordEntity).insert(recordInsertions)
 
-                const cellInsertions = prepareCellInsertions(batch, recordInsertions, projectId)
-                await entityManager.getRepository(CellEntity).insert(cellInsertions)
+                    const cellInsertions = prepareCellInsertions(batch, recordInsertions, projectId)
+                    await entityManager.getRepository(CellEntity).insert(cellInsertions)
 
-                insertedRecordIds.push(...recordInsertions.map((r) => r.id))
+                    insertedRecordIds.push(...recordInsertions.map((r) => r.id))
+                }
+
+                return insertedRecordIds
+            })
+        }
+        catch (e) {
+            if (e instanceof QueryFailedError && isUniqueViolation(e)) {
+                throw new ActivepiecesError({
+                    code: ErrorCode.VALIDATION,
+                    params: { message: 'Record or cell already exists for the given (projectId, tableId, fieldId, recordId)' },
+                })
             }
-
-            return insertedRecordIds
-        })
+            throw e
+        }
 
         const insertedRecords = await recordRepo().find({
             where: { id: In(insertedRecordIds), tableId: request.tableId, projectId },
@@ -424,6 +435,15 @@ type CellInsertion = {
     fieldId: string
     projectId: string
     value: string
+}
+
+function isUniqueViolation(error: QueryFailedError): boolean {
+    // Postgres: 23505 (unique_violation). Sqlite: SQLITE_CONSTRAINT_UNIQUE / SQLITE_CONSTRAINT.
+    const driverError = (error as QueryFailedError & { driverError?: { code?: string } }).driverError
+    const code = driverError?.code
+    return code === '23505'
+        || code === 'SQLITE_CONSTRAINT_UNIQUE'
+        || code === 'SQLITE_CONSTRAINT'
 }
 
 function prepareRecordInsertions(

--- a/packages/server/api/src/app/tables/record/record.service.ts
+++ b/packages/server/api/src/app/tables/record/record.service.ts
@@ -438,12 +438,14 @@ type CellInsertion = {
 }
 
 function isUniqueViolation(error: QueryFailedError): boolean {
-    // Postgres: 23505 (unique_violation). Sqlite: SQLITE_CONSTRAINT_UNIQUE / SQLITE_CONSTRAINT.
+    // Postgres: 23505 (unique_violation). Sqlite: SQLITE_CONSTRAINT_UNIQUE (extended code — available
+    // since 3.7.17, exposed by both node-sqlite3 and better-sqlite3). The generic SQLITE_CONSTRAINT
+    // fallback is intentionally omitted: it also fires for NOT NULL / CHECK / FOREIGN KEY violations,
+    // which should surface as 500s, not be silently translated to 409.
     const driverError = (error as QueryFailedError & { driverError?: { code?: string } }).driverError
     const code = driverError?.code
     return code === '23505'
         || code === 'SQLITE_CONSTRAINT_UNIQUE'
-        || code === 'SQLITE_CONSTRAINT'
 }
 
 function prepareRecordInsertions(

--- a/packages/server/api/test/integration/ce/tables/record.test.ts
+++ b/packages/server/api/test/integration/ce/tables/record.test.ts
@@ -115,6 +115,28 @@ describe('Record API', () => {
             expect(body.length).toBe(1)
             expect(body[0].cells[field.id].value).toBe('valid')
         })
+
+        it('should return 409 (not 500) when a unique-violation hits the cell index', async () => {
+            // Two cells with the same fieldId in one record → identical (projectId, fieldId, recordId)
+            // → fires idx_cell_project_id_field_id_record_id_unique → QueryFailedError → caught and
+            // translated to ActivepiecesError(VALIDATION) → mapped to CONFLICT by error-handler.
+            const ctx = await setup()
+            const { table, field } = await createTableWithField(ctx)
+
+            const response = await ctx.post('/v1/records', {
+                tableId: table.id,
+                records: [
+                    [
+                        { fieldId: field.id, value: 'first' },
+                        { fieldId: field.id, value: 'second' },
+                    ],
+                ],
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.CONFLICT)
+            const body = response?.json()
+            expect(body.code).toBe('VALIDATION')
+        })
     })
 
     describeWithAuth('GET /v1/records (List)', () => app!, (setup) => {


### PR DESCRIPTION
## What does this PR do?

`recordService.create()` inserts cell rows inside a TypeORM `transaction(...)` without a catch handler. When the cell unique index `idx_cell_project_id_field_id_record_id_unique` (on `projectId`, `fieldId`, `recordId`) fires, the resulting `QueryFailedError` bubbles past the wrapper and the API returns **HTTP 500** instead of a recoverable **HTTP 409 Conflict**.

This PR wraps the transaction, detects unique-violation errors (postgres `23505` / sqlite `SQLITE_CONSTRAINT_UNIQUE`), and translates them into `ActivepiecesError({ code: ErrorCode.VALIDATION })` — which `helper/error-handler.ts:37` already maps to `StatusCodes.CONFLICT` (409). All other errors propagate unchanged.

### Explain How the Feature Works

1. `transaction(...)` in `recordService.create()` is now wrapped in `try { ... } catch (e) { ... }`.
2. The catch checks `e instanceof QueryFailedError` AND `e.driverError.code` matches a unique-violation code for the active driver (postgres `23505` or sqlite `SQLITE_CONSTRAINT_UNIQUE` / `SQLITE_CONSTRAINT`).
3. On match, throw `ActivepiecesError({ code: ErrorCode.VALIDATION })`. The centralised `error-handler.ts` routes `VALIDATION` to `StatusCodes.CONFLICT`.
4. Non-unique-violation errors are re-thrown unchanged (preserves existing observability — `exceptionHandler` still receives them).

This mirrors the convention of `project-service.ts:assertExternalIdIsUnique` (pre-check → throw `PROJECT_EXTERNAL_ID_ALREADY_EXISTS` → CONFLICT). The pre-check pattern guards happy-path collisions but cannot catch transaction-level errors after the insert; this PR adds the post-error path.

### Relevant User Scenarios

- **Duplicate cell entries in one request.** A client that POSTs two cells with the same `fieldId` for a single record (buggy form serializer, JSON merge that doesn't dedupe) currently gets an opaque 500. With this fix, they get a clean 409 with `code: 'VALIDATION'` and can correct the request.
- **Idempotent automation flows.** A flow step that re-fires `Create Record` after a partial failure can branch on 409 (e.g. switch to upsert) instead of treating opaque 500s as fatal.

### Testing

- **New integration test** in `packages/server/api/test/integration/ce/tables/record.test.ts`: POSTs `/v1/records` with two cells sharing the same `fieldId` (`prepareCellInsertions` doesn't dedupe, so both reach the cell insert and trip `idx_cell_project_id_field_id_record_id_unique`). Asserts `StatusCodes.CONFLICT` + `body.code === 'VALIDATION'`. Passes under both `[USER]` and `[SERVICE]` auth contexts via `describeWithAuth`.
- Full `bun run --cwd packages/server/api test-ce-command` — **41 test files / 497 tests, all green** locally.
- `bun run lint-core` — 0 errors.
- `bun run --cwd packages/server/api build` — clean `tsc`.
- *Note:* `bun run test-unit` has 5 unrelated pre-existing failures in `packages/server/engine/test/handler/flow-with-delay.test.ts` (`PieceNotFoundError: @activepieces/piece-delay`). Confirmed reproducible on `main` without this change.

Fixes # (no existing issue — happy to file one if preferred)

## Loom video

https://www.loom.com/share/8d4ab2501dfe4231ac205270350e6773