### PR TITLE
fix(chat): enforce project scoping during build and fix progress card

### DIFF
--- a/packages/web/src/app/connections/create-edit-connection-dialog.tsx
+++ b/packages/web/src/app/connections/create-edit-connection-dialog.tsx
@@ -70,6 +70,7 @@ function CreateOrEditConnectionSection({
   selectedAuth,
   onTryAnotherMethodButtonClicked,
   showTryAnotherMethodButton,
+  projectId: projectIdOverride,
 }: CreateOrEditConnectionSectionProps) {
   const formSchema = formUtils.buildConnectionSchema(
     selectedAuth.authProperty,
@@ -100,6 +101,7 @@ function CreateOrEditConnectionSection({
           redirectUrl: redirectUrl ?? '',
         }),
         ...(isGlobalConnection ? { scope: AppConnectionScope.PLATFORM } : {}),
+        ...(projectIdOverride ? { projectId: projectIdOverride } : {}),
         projectIds: reconnectConnection?.projectIds ?? [],
         preSelectForNewProjects: false,
         pieceVersion: piece.version,
@@ -357,6 +359,7 @@ function CreateOrEditConnectionDialog({
   reconnectConnection,
   isGlobalConnection,
   externalIdComingFromSdk,
+  projectId: projectIdOverride,
 }: ConnectionDialogProps) {
   const { data: piecesOAuth2AppsMap, isPending: loadingPiecesOAuth2AppsMap } =
     oauthAppsQueries.usePiecesOAuth2AppsMap();
@@ -391,6 +394,7 @@ function CreateOrEditConnectionDialog({
             reconnectConnection={reconnectConnection}
             isGlobalConnection={isGlobalConnection}
             externalIdComingFromSdk={externalIdComingFromSdk}
+            projectId={projectIdOverride}
           />
         )}
       </DialogContent>
@@ -481,6 +485,7 @@ type ConnectionDialogProps = {
   reconnectConnection: AppConnectionWithoutSensitiveData | null;
   isGlobalConnection: boolean;
   externalIdComingFromSdk?: string | null;
+  projectId?: string | null;
 };
 
 type CreateOrEditConnectionDialogContentProps = {
@@ -493,6 +498,7 @@ type CreateOrEditConnectionDialogContentProps = {
     open: boolean,
     connection?: AppConnectionWithoutSensitiveData,
   ) => void;
+  projectId?: string | null;
 };
 
 type CreateOrEditConnectionSectionProps =

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/prompt-kit/chat-container';
 import { ScrollButton } from '@/components/prompt-kit/scroll-button';
 import { Button } from '@/components/ui/button';
+import { ChatUIMessage, DynamicToolPart } from '@/features/chat/lib/chat-types';
 import { useAgentChat } from '@/features/chat/lib/use-chat';
 import { useToolApproval } from '@/features/chat/lib/use-tool-approval';
 import { aiProviderQueries } from '@/features/platform-admin';
@@ -157,6 +158,14 @@ function ChatBoxContent({
     dismiss: dismissApproval,
   } = useToolApproval({ pendingApprovalRequest });
 
+  const allConversationToolParts = useMemo(
+    () =>
+      messages.flatMap((m: ChatUIMessage) =>
+        m.parts.filter((p): p is DynamicToolPart => p.type === 'dynamic-tool'),
+      ),
+    [messages],
+  );
+
   const isEmpty = messages.length === 0 && !isLoadingHistory && !isStreaming;
 
   if (isEmpty) {
@@ -217,6 +226,7 @@ function ChatBoxContent({
                 onRetry={handleRetry}
                 selectedProjectId={selectedProjectId}
                 onSelectProject={handleProjectChange}
+                allConversationToolParts={allConversationToolParts}
               />
             );
           })}

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-message.tsx
@@ -32,6 +32,7 @@ export function ChatMessage({
   onSend,
   selectedProjectId,
   onSelectProject,
+  allConversationToolParts,
 }: {
   message: ChatUIMessage;
   isStreaming: boolean;
@@ -40,6 +41,7 @@ export function ChatMessage({
   onSend: (text: string, files?: File[]) => void;
   selectedProjectId?: string | null;
   onSelectProject?: (projectId: string) => void;
+  allConversationToolParts?: DynamicToolPart[];
 }) {
   if (message.role === 'user') {
     return <UserMessage message={message} isLastMessage={isLastMessage} />;
@@ -54,6 +56,7 @@ export function ChatMessage({
       onSend={onSend}
       selectedProjectId={selectedProjectId}
       onSelectProject={onSelectProject}
+      allConversationToolParts={allConversationToolParts}
     />
   );
 }
@@ -133,6 +136,7 @@ function AssistantMessage({
   onSend,
   selectedProjectId,
   onSelectProject,
+  allConversationToolParts,
 }: {
   message: ChatUIMessage;
   isStreaming: boolean;
@@ -141,6 +145,7 @@ function AssistantMessage({
   onSend: (text: string, files?: File[]) => void;
   selectedProjectId?: string | null;
   onSelectProject?: (projectId: string) => void;
+  allConversationToolParts?: DynamicToolPart[];
 }) {
   const allToolParts = useMemo(
     () =>
@@ -231,6 +236,7 @@ function AssistantMessage({
                   selectedProjectId,
                   onSelectProject,
                   allParts: message.parts,
+                  allConversationToolParts,
                 })}
               </motion.div>
             )}
@@ -279,6 +285,7 @@ function renderTextParts({
   onSelectProject,
   isLastMessage,
   allParts,
+  allConversationToolParts,
 }: {
   parts: Array<{ type: 'text'; text: string }>;
   isStreaming: boolean;
@@ -287,6 +294,7 @@ function renderTextParts({
   selectedProjectId?: string | null;
   onSelectProject?: (projectId: string) => void;
   allParts: ChatUIMessage['parts'];
+  allConversationToolParts?: DynamicToolPart[];
 }): React.ReactNode[] {
   const fullText = parts.map((p) => p.text).join('');
   const { progress: buildProgress } = parseBuildProgress(fullText);
@@ -294,7 +302,9 @@ function renderTextParts({
   const nodes: React.ReactNode[] = [];
 
   if (buildProgress) {
-    const toolParts = allParts.filter((p) => p.type === 'dynamic-tool');
+    const toolParts =
+      allConversationToolParts ??
+      allParts.filter((p) => p.type === 'dynamic-tool');
     nodes.push(
       <BuildProgressCard
         key="build-progress"

--- a/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
@@ -145,9 +145,17 @@ export function ConnectionPickerCard({
   picker,
   onSelect,
   isInteractive = true,
+  selectedProjectId,
 }: ConnectionPickerCardProps) {
   const queryClient = useQueryClient();
   const pieceName = normalizePieceName(picker.piece);
+  const filteredPicker = useMemo(() => {
+    if (!selectedProjectId) return picker;
+    const filtered = picker.connections.filter(
+      (c) => c.projectId === selectedProjectId,
+    );
+    return { ...picker, connections: filtered };
+  }, [picker, selectedProjectId]);
   const { pieceModel, isLoading: isPieceLoading } = piecesHooks.usePiece({
     name: pieceName,
   });
@@ -163,7 +171,7 @@ export function ConnectionPickerCard({
     fullConnections,
     isLoading: isLoadingStatuses,
   } = useLiveConnections({
-    connections: picker.connections,
+    connections: filteredPicker.connections,
     pieceName,
     enabled: isInteractive && !selectedConnection,
   });
@@ -201,7 +209,9 @@ export function ConnectionPickerCard({
             </div>
           </div>
           <div className="flex-1 min-w-0">
-            <div className="text-sm font-semibold">{picker.displayName}</div>
+            <div className="text-sm font-semibold">
+              {filteredPicker.displayName}
+            </div>
             <div className="text-xs text-muted-foreground">
               {t('Connected')}
             </div>
@@ -216,7 +226,7 @@ export function ConnectionPickerCard({
       <SelectedState
         pieceName={pieceName}
         connection={selectedConnection}
-        displayName={picker.displayName}
+        displayName={filteredPicker.displayName}
       />
     );
   }
@@ -237,13 +247,13 @@ export function ConnectionPickerCard({
         <div className="p-4 pb-3">
           <h3 className="font-semibold text-base">
             {t('Which {name} account should I use?', {
-              name: picker.displayName,
+              name: filteredPicker.displayName,
             })}
           </h3>
         </div>
 
         <div className="max-h-64 overflow-auto">
-          {picker.connections.map((conn) => {
+          {filteredPicker.connections.map((conn) => {
             const status = liveStatuses[conn.externalId] ?? conn.status;
             const healthy = isConnectionHealthy(status);
             return (
@@ -316,7 +326,7 @@ export function ConnectionPickerCard({
             </div>
             <div className="text-xs text-muted-foreground">
               {t('Connect a new {name} account', {
-                name: picker.displayName,
+                name: filteredPicker.displayName,
               })}
             </div>
           </div>
@@ -336,6 +346,7 @@ export function ConnectionPickerCard({
         <CreateOrEditConnectionDialog
           piece={pieceModel}
           open={connectDialogOpen}
+          projectId={selectedProjectId}
           setOpen={(open, createdConnection) => {
             setConnectDialogOpen(open);
             if (createdConnection) {
@@ -364,4 +375,5 @@ type ConnectionPickerCardProps = {
   picker: ConnectionPickerData;
   onSelect: (text: string) => void;
   isInteractive?: boolean;
+  selectedProjectId?: string | null;
 };

--- a/packages/web/src/app/routes/chat-with-ai/components/message-content.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/message-content.tsx
@@ -128,6 +128,7 @@ export function MessageContentWithAuth({
           picker={connectionPicker}
           onSelect={(text) => onSend?.(text)}
           isInteractive={isLastMessage}
+          selectedProjectId={selectedProjectId}
         />
       )}
       {projectPicker && (
@@ -397,6 +398,7 @@ function ConnectionsRequiredCard({
           key={activeConnection.piece}
           piece={pieceModel}
           open={true}
+          projectId={selectedProjectId}
           setOpen={(open, createdConnection) => {
             if (!open) {
               if (createdConnection) {

--- a/packages/web/src/app/routes/chat-with-ai/components/project-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/project-picker-card.tsx
@@ -36,10 +36,11 @@ export function ProjectPickerCard({
   const { data: currentUser } = userHooks.useCurrentUser();
   const projects = useMemo(() => {
     const all = allProjects ?? [];
+    if (!currentUser) return all;
     return all.filter(
-      (p) => p.type !== ProjectType.PERSONAL || p.ownerId === currentUser?.id,
+      (p) => p.type !== ProjectType.PERSONAL || p.ownerId === currentUser.id,
     );
-  }, [allProjects, currentUser?.id]);
+  }, [allProjects, currentUser]);
   const [selected, setSelected] = useState<string | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 

--- a/packages/web/src/app/routes/chat-with-ai/components/project-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/project-picker-card.tsx
@@ -1,7 +1,8 @@
+import { ProjectType } from '@activepieces/shared';
 import { t } from 'i18next';
 import { Check, Ellipsis } from 'lucide-react';
 import { motion } from 'motion/react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   Command,
@@ -20,6 +21,7 @@ import {
   getProjectName,
   projectCollectionUtils,
 } from '@/features/projects';
+import { userHooks } from '@/hooks/user-hooks';
 import { cn } from '@/lib/utils';
 
 import { ProjectPickerData } from '../lib/message-parsers';
@@ -31,7 +33,13 @@ export function ProjectPickerCard({
   selectedProjectId,
 }: ProjectPickerCardProps) {
   const { data: allProjects } = projectCollectionUtils.useAll();
-  const projects = allProjects ?? [];
+  const { data: currentUser } = userHooks.useCurrentUser();
+  const projects = useMemo(() => {
+    const all = allProjects ?? [];
+    return all.filter(
+      (p) => p.type !== ProjectType.PERSONAL || p.ownerId === currentUser?.id,
+    );
+  }, [allProjects, currentUser?.id]);
   const [selected, setSelected] = useState<string | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
@@ -82,39 +90,41 @@ export function ProjectPickerCard({
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
     >
-      {picker.suggestedProjects.map((suggested, i) => {
-        const resolvedProject = projects.find((p) => p.id === suggested.id);
-        return (
-          <motion.button
-            key={suggested.id}
-            type="button"
-            onClick={() =>
-              handleSelect(
-                suggested.id,
-                resolvedProject
-                  ? getProjectName(resolvedProject)
-                  : suggested.name,
-              )
-            }
-            className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm hover:bg-muted transition-colors cursor-pointer"
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.2, delay: i * 0.04 }}
-          >
-            {resolvedProject ? (
-              <ApProjectDisplay
-                title={getProjectName(resolvedProject)}
-                icon={resolvedProject.icon}
-                projectType={resolvedProject.type}
-                iconClassName="size-4"
-                titleClassName="text-sm"
-              />
-            ) : (
-              <span>{suggested.name}</span>
-            )}
-          </motion.button>
-        );
-      })}
+      {picker.suggestedProjects
+        .filter((s) => projects.some((p) => p.id === s.id))
+        .map((suggested, i) => {
+          const resolvedProject = projects.find((p) => p.id === suggested.id);
+          return (
+            <motion.button
+              key={suggested.id}
+              type="button"
+              onClick={() =>
+                handleSelect(
+                  suggested.id,
+                  resolvedProject
+                    ? getProjectName(resolvedProject)
+                    : suggested.name,
+                )
+              }
+              className="inline-flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm hover:bg-muted transition-colors cursor-pointer"
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.2, delay: i * 0.04 }}
+            >
+              {resolvedProject ? (
+                <ApProjectDisplay
+                  title={getProjectName(resolvedProject)}
+                  icon={resolvedProject.icon}
+                  projectType={resolvedProject.type}
+                  iconClassName="size-4"
+                  titleClassName="text-sm"
+                />
+              ) : (
+                <span>{suggested.name}</span>
+              )}
+            </motion.button>
+          );
+        })}
 
       <Popover open={dropdownOpen} onOpenChange={setDropdownOpen}>
         <PopoverTrigger asChild>

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -372,14 +372,19 @@ export function useAgentChat({
     const isNowIdle = status === 'ready' || status === 'error';
     prevStatusRef.current = status;
     if (wasStreaming && isNowIdle && conversationIdRef.current) {
-      if (buildCompleteRef.current) {
+      const wasBuildComplete = buildCompleteRef.current;
+      if (wasBuildComplete) {
         setProjectSetInSession(false);
         buildCompleteRef.current = false;
       }
       void chatApi
         .getConversation(conversationIdRef.current)
         .then((conv) => {
-          updateSelectedProjectId(conv.projectId ?? null);
+          const projectId = conv.projectId ?? null;
+          updateSelectedProjectId(projectId);
+          if (projectId && !wasBuildComplete) {
+            setProjectSetInSession(true);
+          }
         })
         .catch(() => undefined);
     }

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -330,6 +330,10 @@ export function useAgentChat({
     return [...withoutEmptyAssistant, createPendingAssistantMessage()];
   }, [hasPending, uiMessages, pendingMessages]);
 
+  // Tracks whether the conversation was loaded from history (resumed).
+  // When true, the server sync should NOT re-enable the project label.
+  const loadedFromHistoryRef = useRef(false);
+
   // Detect project context changes from AI tool calls
   const buildCompleteRef = useRef(false);
   useEffect(() => {
@@ -360,6 +364,7 @@ export function useAgentChat({
     if (newProjectId !== undefined) {
       updateSelectedProjectId(newProjectId);
       setProjectSetInSession(true);
+      loadedFromHistoryRef.current = false;
     }
   }, [uiMessages]);
 
@@ -382,7 +387,7 @@ export function useAgentChat({
         .then((conv) => {
           const projectId = conv.projectId ?? null;
           updateSelectedProjectId(projectId);
-          if (projectId && !wasBuildComplete) {
+          if (projectId && !wasBuildComplete && !loadedFromHistoryRef.current) {
             setProjectSetInSession(true);
           }
         })
@@ -407,6 +412,7 @@ export function useAgentChat({
     setModelNameState(null);
     updateSelectedProjectId(null);
     setProjectSetInSession(false);
+    loadedFromHistoryRef.current = false;
     setUiMessages([]);
     setLocalError(null);
     setWasCancelled(false);
@@ -527,6 +533,7 @@ export function useAgentChat({
         // Set project for backend tool scoping, but don't show it visually (projectSetInSession stays false)
         updateSelectedProjectId(convResult.data.projectId ?? null);
         setProjectSetInSession(false);
+        loadedFromHistoryRef.current = true;
       }
       setIsLoadingHistory(false);
     },
@@ -549,6 +556,7 @@ export function useAgentChat({
     updateSelectedProjectId(projectId);
     if (projectId) {
       setProjectSetInSession(true);
+      loadedFromHistoryRef.current = false;
     }
     const convId = conversationIdRef.current;
     if (!convId) return;


### PR DESCRIPTION
## Summary
- Build progress card now uses all conversation tool parts instead of only current message's, fixing intermittent "all Queued" status when tools and build-progress text land in different messages
- Connection picker filters connections to only show those from the active project, preventing cross-project connection selection during builds
- Connection create/reconnect dialog receives the chat's selected projectId so connections are created in the correct project instead of the session's default
- Project picker excludes other users' personal projects
- Project label lifecycle: server sync now sets projectSetInSession when a project context exists and build isn't complete

## Test plan
- [ ] Start a build in a non-default project — verify build card progresses through statuses (not stuck on Queued)
- [ ] During build, verify connection picker only shows connections from the selected project
- [ ] Reconnect a connection from the picker — verify it updates in the correct project
- [ ] Open project picker — verify other users' personal projects are not shown
- [ ] Select a project from AI question — verify chat input shows colored project label
- [ ] After build completes — verify project label disappears