### PR TITLE
fix(event-destinations): align trigger payload with test payload

### DIFF
--- a/packages/server/api/src/app/event-destinations/event-destinations.service.ts
+++ b/packages/server/api/src/app/event-destinations/event-destinations.service.ts
@@ -32,14 +32,12 @@ export const eventDestinationService = (log: FastifyBaseLogger) => ({
         applicationEvents(log).registerListeners(log, {
             userEvent: () => async (event) => {
                 await eventDestinationService(log).trigger({
-                    platformId: event.platformId,
                     projectId: event.projectId,
                     event,
                 })
             },
             workerEvent: () => async (projectId, event) => {
                 await eventDestinationService(log).trigger({
-                    platformId: event.platformId,
                     projectId,
                     event,
                 })
@@ -98,7 +96,8 @@ export const eventDestinationService = (log: FastifyBaseLogger) => ({
 
         return paginationHelper.createPage<EventDestination>(data, cursor)
     },
-    trigger: async ({ platformId, projectId, event }: TriggerParams): Promise<void> => {
+    trigger: async ({ projectId, event }: TriggerParams): Promise<void> => {
+        const platformId = event.platformId
         const conditions: FindOptionsWhere<EventDestinationSchema>[] = [{
             platformId,
             events: ArrayContains([event.action]),
@@ -199,7 +198,6 @@ type ListParams = {
 }
 
 type TriggerParams = {
-    platformId: PlatformId
     projectId?: ProjectId
     event: ApplicationEvent
 }

--- a/packages/server/api/src/app/event-destinations/event-destinations.service.ts
+++ b/packages/server/api/src/app/event-destinations/event-destinations.service.ts
@@ -123,7 +123,7 @@ export const eventDestinationService = (log: FastifyBaseLogger) => ({
                     projectId,
                     webhookId: destination.id,
                     webhookUrl: destination.url,
-                    payload: event.data,
+                    payload: event,
                     jobType: WorkerJobType.EVENT_DESTINATION,
                 },
             }),
@@ -201,7 +201,7 @@ type ListParams = {
 type TriggerParams = {
     platformId: PlatformId
     projectId?: ProjectId
-    event: Pick<ApplicationEvent, 'action' | 'data'>
+    event: ApplicationEvent
 }
 
 type TestParams = {

--- a/packages/server/api/test/integration/cloud/event-destinations/event-destination-trigger.test.ts
+++ b/packages/server/api/test/integration/cloud/event-destinations/event-destination-trigger.test.ts
@@ -1,5 +1,6 @@
 import {
     apId,
+    ApplicationEvent,
     ApplicationEventName,
     EventDestinationScope,
     WorkerJobType,
@@ -51,24 +52,17 @@ describe('Event Destination Trigger', () => {
         })
         await db.save('event_destination', destination)
 
-        await eventDestinationService(app.log).trigger({
-            platformId: ctx.platform.id,
-            event: {
-                id: apId(),
-                created: new Date().toISOString(),
-                updated: new Date().toISOString(),
-                platformId: ctx.platform.id,
-                action: ApplicationEventName.FLOW_CREATED,
-                data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
-            },
-        })
+        const event = buildFlowEvent(ApplicationEventName.FLOW_CREATED, ctx.platform.id)
+        await eventDestinationService(app.log).trigger({ event })
 
         expect(addSpy).toHaveBeenCalledTimes(1)
         expect(addSpy).toHaveBeenCalledWith(
             expect.objectContaining({
                 data: expect.objectContaining({
+                    platformId: ctx.platform.id,
                     webhookUrl: destination.url,
                     jobType: WorkerJobType.EVENT_DESTINATION,
+                    payload: event,
                 }),
             }),
         )
@@ -84,15 +78,7 @@ describe('Event Destination Trigger', () => {
         await db.save('event_destination', destination)
 
         await eventDestinationService(app.log).trigger({
-            platformId: ctx.platform.id,
-            event: {
-                id: apId(),
-                created: new Date().toISOString(),
-                updated: new Date().toISOString(),
-                platformId: ctx.platform.id,
-                action: ApplicationEventName.FLOW_DELETED,
-                data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
-            },
+            event: buildFlowEvent(ApplicationEventName.FLOW_DELETED, ctx.platform.id),
         })
 
         expect(addSpy).not.toHaveBeenCalled()
@@ -109,15 +95,7 @@ describe('Event Destination Trigger', () => {
         await db.save('event_destination', destination)
 
         await eventDestinationService(app.log).trigger({
-            platformId: ctx2.platform.id,
-            event: {
-                id: apId(),
-                created: new Date().toISOString(),
-                updated: new Date().toISOString(),
-                platformId: ctx2.platform.id,
-                action: ApplicationEventName.FLOW_CREATED,
-                data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
-            },
+            event: buildFlowEvent(ApplicationEventName.FLOW_CREATED, ctx2.platform.id),
         })
 
         expect(addSpy).not.toHaveBeenCalled()
@@ -139,22 +117,15 @@ describe('Event Destination Trigger', () => {
         })
         await db.save('event_destination', [dest1, dest2])
 
-        await eventDestinationService(app.log).trigger({
-            platformId: ctx.platform.id,
-            event: {
-                id: apId(),
-                created: new Date().toISOString(),
-                updated: new Date().toISOString(),
-                platformId: ctx.platform.id,
-                action: ApplicationEventName.FLOW_CREATED,
-                data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
-            },
-        })
+        const event = buildFlowEvent(ApplicationEventName.FLOW_CREATED, ctx.platform.id)
+        await eventDestinationService(app.log).trigger({ event })
 
         expect(addSpy).toHaveBeenCalledTimes(2)
-        const urls = addSpy.mock.calls.map((call: unknown[]) => (call[0] as Record<string, Record<string, string>>).data.webhookUrl)
-        expect(urls).toContain('https://example.com/hook1')
-        expect(urls).toContain('https://example.com/hook2')
+        const queuedJobs = addSpy.mock.calls.map((call: unknown[]) => (call[0] as { data: { webhookUrl: string, payload: unknown } }).data)
+        expect(queuedJobs.map(j => j.webhookUrl)).toEqual(expect.arrayContaining(['https://example.com/hook1', 'https://example.com/hook2']))
+        for (const job of queuedJobs) {
+            expect(job.payload).toEqual(event)
+        }
     })
 
     it('should match destination when events array has multiple entries', async () => {
@@ -166,26 +137,31 @@ describe('Event Destination Trigger', () => {
         })
         await db.save('event_destination', destination)
 
-        await eventDestinationService(app.log).trigger({
-            platformId: ctx.platform.id,
-            event: {
-                id: apId(),
-                created: new Date().toISOString(),
-                updated: new Date().toISOString(),
-                platformId: ctx.platform.id,
-                action: ApplicationEventName.FLOW_DELETED,
-                data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
-            },
-        })
+        const event = buildFlowEvent(ApplicationEventName.FLOW_DELETED, ctx.platform.id)
+        await eventDestinationService(app.log).trigger({ event })
 
         expect(addSpy).toHaveBeenCalledTimes(1)
         expect(addSpy).toHaveBeenCalledWith(
             expect.objectContaining({
                 data: expect.objectContaining({
+                    platformId: ctx.platform.id,
                     webhookUrl: destination.url,
                     jobType: WorkerJobType.EVENT_DESTINATION,
+                    payload: event,
                 }),
             }),
         )
     })
+})
+
+const buildFlowEvent = (action: ApplicationEventName.FLOW_CREATED | ApplicationEventName.FLOW_DELETED, platformId: string): ApplicationEvent => ({
+    id: apId(),
+    created: new Date().toISOString(),
+    updated: new Date().toISOString(),
+    platformId,
+    action,
+    data: {
+        flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() },
+        project: { displayName: 'Test' },
+    },
 })

--- a/packages/server/api/test/integration/cloud/event-destinations/event-destination-trigger.test.ts
+++ b/packages/server/api/test/integration/cloud/event-destinations/event-destination-trigger.test.ts
@@ -5,12 +5,12 @@ import {
     WorkerJobType,
 } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
-import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
-import { createTestContext } from '../../../helpers/test-context'
-import { createMockEventDestination } from '../../../helpers/mocks'
-import { db } from '../../../helpers/db'
 import { eventDestinationService } from '../../../../src/app/event-destinations/event-destinations.service'
 import * as jobQueueModule from '../../../../src/app/workers/job-queue/job-queue'
+import { db } from '../../../helpers/db'
+import { createMockEventDestination } from '../../../helpers/mocks'
+import { createTestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
 let app: FastifyInstance
 
@@ -54,6 +54,10 @@ describe('Event Destination Trigger', () => {
         await eventDestinationService(app.log).trigger({
             platformId: ctx.platform.id,
             event: {
+                id: apId(),
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+                platformId: ctx.platform.id,
                 action: ApplicationEventName.FLOW_CREATED,
                 data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
             },
@@ -82,6 +86,10 @@ describe('Event Destination Trigger', () => {
         await eventDestinationService(app.log).trigger({
             platformId: ctx.platform.id,
             event: {
+                id: apId(),
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+                platformId: ctx.platform.id,
                 action: ApplicationEventName.FLOW_DELETED,
                 data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
             },
@@ -103,6 +111,10 @@ describe('Event Destination Trigger', () => {
         await eventDestinationService(app.log).trigger({
             platformId: ctx2.platform.id,
             event: {
+                id: apId(),
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+                platformId: ctx2.platform.id,
                 action: ApplicationEventName.FLOW_CREATED,
                 data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
             },
@@ -130,6 +142,10 @@ describe('Event Destination Trigger', () => {
         await eventDestinationService(app.log).trigger({
             platformId: ctx.platform.id,
             event: {
+                id: apId(),
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+                platformId: ctx.platform.id,
                 action: ApplicationEventName.FLOW_CREATED,
                 data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
             },
@@ -153,6 +169,10 @@ describe('Event Destination Trigger', () => {
         await eventDestinationService(app.log).trigger({
             platformId: ctx.platform.id,
             event: {
+                id: apId(),
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+                platformId: ctx.platform.id,
                 action: ApplicationEventName.FLOW_DELETED,
                 data: { flow: { id: apId(), created: new Date().toISOString(), updated: new Date().toISOString() }, project: { displayName: 'Test' } },
             },


### PR DESCRIPTION
## Summary

- The test endpoint sent the full ApplicationEvent envelope (id, created, updated, ip, platformId, projectId, userId, action, data) to the destination URL, while trigger only sent event.data. Receivers previewing via the test button got a richer payload than they would in production.
- Widen TriggerParams.event to ApplicationEvent and send the full envelope so live deliveries match what the test preview produces — receivers can now reliably switch on action and use platformId/projectId/userId for context.
- Update the 5 trigger integration test call sites to provide the envelope fields the widened type now requires.

## Test plan

- [ ] Configure a platform event destination pointing at a request bin
- [ ] Click "Test" — confirm payload contains the envelope fields
- [ ] Trigger a real event (e.g. create a flow) — confirm the live payload now has the same envelope shape as the test payload
- [ ] `npm run test-api` passes the event-destinations trigger suite
