### PR TITLE
feat(mcp): add structuredContent to MCP tool responses

### DIFF
--- a/packages/server/api/src/app/ee/chat/mcp/chat-mcp.ts
+++ b/packages/server/api/src/app/ee/chat/mcp/chat-mcp.ts
@@ -52,6 +52,7 @@ async function connectMcpClient({ mcpCredentials, log }: {
 }
 
 const AP_TOOLS_REQUIRING_APPROVAL = new Set([
+    'ap_delete_flow',
     'ap_delete_table',
     'ap_delete_step',
     'ap_delete_branch',

--- a/packages/server/api/src/app/mcp/mcp-server-builder.ts
+++ b/packages/server/api/src/app/mcp/mcp-server-builder.ts
@@ -1,4 +1,4 @@
-import { FlowStatus, isNil, McpProperty, McpPropertyType, mcpToolNameUtils, McpTrigger, Permission, PopulatedMcpServer, ProjectScopedMcpServer, TelemetryEventName } from '@activepieces/shared'
+import { FlowStatus, isNil, McpProperty, McpPropertyType, McpToolDefinition, mcpToolNameUtils, McpTrigger, Permission, PopulatedMcpServer, ProjectScopedMcpServer, TelemetryEventName } from '@activepieces/shared'
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
@@ -84,12 +84,7 @@ function registerPlatformTools({ server, mcp, platformId, userId, resolveProject
     log: FastifyBaseLogger
 }): void {
     const contextTool = apSetProjectContextTool({ platformId, userId, log })
-    server.registerTool(contextTool.title, {
-        title: contextTool.title,
-        description: contextTool.description,
-        inputSchema: contextTool.inputSchema,
-        annotations: contextTool.annotations,
-    }, (args: Record<string, unknown>) => contextTool.execute(args))
+    server.registerTool(contextTool.title, buildToolConfig(contextTool), (args: Record<string, unknown>) => contextTool.execute(args))
 
     const templateMcp: ProjectScopedMcpServer = { ...mcp, projectId: platformId }
     const allTools = activepiecesTools(templateMcp, log)
@@ -97,12 +92,7 @@ function registerPlatformTools({ server, mcp, platformId, userId, resolveProject
     const tools = allTools.filter(t => LOCKED_TOOL_NAMES.includes(t.title) || enabledControllable.has(t.title))
 
     tools.forEach((tool) => {
-        server.registerTool(tool.title, {
-            title: tool.title,
-            description: tool.description,
-            inputSchema: tool.inputSchema,
-            annotations: tool.annotations,
-        }, async (args: Record<string, unknown>) => {
+        server.registerTool(tool.title, buildToolConfig(tool), async (args: Record<string, unknown>) => {
             const selectedProjectId = mcpProjectSelection.get({ platformId, userId })
             if (isNil(selectedProjectId)) {
                 return {
@@ -185,7 +175,7 @@ function registerStaticTools({ server, mcp, projectId, permissionChecker, log }:
 
     tools.forEach((tool) => {
         const execute = permissionChecker.wrapExecute({ execute: tool.execute, permission: tool.permission, toolTitle: tool.title })
-        server.registerTool(tool.title, { title: tool.title, description: tool.description, inputSchema: tool.inputSchema, annotations: tool.annotations }, (args: Record<string, unknown>) => execute(args))
+        server.registerTool(tool.title, buildToolConfig(tool), (args: Record<string, unknown>) => execute(args))
     })
 }
 
@@ -233,6 +223,16 @@ function registerEmptyResourcesAndPrompts(server: McpServer): void {
         async () => ({ contents: [] }),
     )
     server.registerPrompt('_', {}, () => ({ messages: [] }))
+}
+
+function buildToolConfig(tool: McpToolDefinition): Record<string, unknown> {
+    return {
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        annotations: tool.annotations,
+        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+    }
 }
 
 type RegisterToolsParams = {

--- a/packages/server/api/src/app/mcp/mcp-server-builder.ts
+++ b/packages/server/api/src/app/mcp/mcp-server-builder.ts
@@ -231,7 +231,6 @@ function buildToolConfig(tool: McpToolDefinition): Record<string, unknown> {
         description: tool.description,
         inputSchema: tool.inputSchema,
         annotations: tool.annotations,
-        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
     }
 }
 

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -56,11 +56,6 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
             packageJson: z.string().optional().describe('For CODE steps: package.json as JSON string. Defaults to "{}".'),
             loopItems: z.string().optional().describe('For LOOP steps: expression for items to iterate (e.g. "{{step_1.items}}").'),
         },
-        outputSchema: {
-            stepName: z.string(),
-            displayName: z.string(),
-            valid: z.boolean(),
-        },
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             const { flowId, parentStepName, stepLocationRelativeToParent, branchIndex, stepType, displayName, pieceName, pieceVersion, actionName, input, auth, sourceCode, packageJson, loopItems } = addStepInput.parse(args)

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -56,7 +56,12 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
             packageJson: z.string().optional().describe('For CODE steps: package.json as JSON string. Defaults to "{}".'),
             loopItems: z.string().optional().describe('For LOOP steps: expression for items to iterate (e.g. "{{step_1.items}}").'),
         },
-        annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
+        outputSchema: {
+            stepName: z.string(),
+            displayName: z.string(),
+            valid: z.boolean(),
+        },
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             const { flowId, parentStepName, stepLocationRelativeToParent, branchIndex, stepType, displayName, pieceName, pieceVersion, actionName, input, auth, sourceCode, packageJson, loopItems } = addStepInput.parse(args)
 
@@ -195,12 +200,15 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
                 const draftWarning = mcpUtils.publishedFlowWarning(flow.publishedVersionId)
                 const hasConfig = input !== undefined || auth !== undefined || sourceCode !== undefined || loopItems !== undefined
                 const addedStep = flowStructureUtil.getStep(stepName, updatedFlow.version.trigger)
+                const stepValid = hasConfig && addedStep ? addedStep.valid : false
+                const structured = { stepName, displayName, valid: stepValid }
                 if (hasConfig && addedStep && !addedStep.valid) {
                     return {
                         content: [{
                             type: 'text',
                             text: `⚠️ Step "${displayName}" (${stepName}) added but still invalid. Use ap_get_piece_props to check required fields, then ap_update_step to fix.${draftWarning}`,
                         }],
+                        structuredContent: structured,
                     }
                 }
                 if (hasConfig) {
@@ -209,6 +217,7 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
                             type: 'text',
                             text: `✅ Step "${displayName}" (${stepName}) added and configured.${draftWarning}`,
                         }],
+                        structuredContent: { ...structured, valid: true },
                     }
                 }
                 return {
@@ -216,6 +225,7 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
                         type: 'text',
                         text: `✅ Step "${displayName}" (${stepName}) added. Now use ap_update_step with stepName="${stepName}" to configure its settings.${draftWarning}`,
                     }],
+                    structuredContent: structured,
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -59,14 +59,6 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
             }).describe('Trigger configuration'),
             steps: z.array(stepSpec).describe('Array of steps added sequentially after trigger. Each step supports: PIECE (pieceName+actionName+input), CODE (sourceCode+input), LOOP_ON_ITEMS (loopItems), ROUTER.'),
         },
-        outputSchema: {
-            flowId: z.string(),
-            displayName: z.string(),
-            stepCount: z.number(),
-            validCount: z.number(),
-            invalidSteps: z.array(z.string()),
-            skippedSteps: z.array(z.string()),
-        },
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             let flowId: string | undefined

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -59,7 +59,15 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
             }).describe('Trigger configuration'),
             steps: z.array(stepSpec).describe('Array of steps added sequentially after trigger. Each step supports: PIECE (pieceName+actionName+input), CODE (sourceCode+input), LOOP_ON_ITEMS (loopItems), ROUTER.'),
         },
-        annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
+        outputSchema: {
+            flowId: z.string(),
+            displayName: z.string(),
+            stepCount: z.number(),
+            validCount: z.number(),
+            invalidSteps: z.array(z.string()),
+            skippedSteps: z.array(z.string()),
+        },
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             let flowId: string | undefined
             const projectId = mcp.projectId
@@ -141,10 +149,18 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                 const stepWord = allSteps.length === 1 ? 'step' : 'steps'
 
                 const skippedHint = skippedSteps.length > 0 ? ` Skipped: ${skippedSteps.join(', ')}.` : ''
-                if (invalidSteps.length === 0 && skippedSteps.length === 0) {
-                    return { content: [{ type: 'text', text: `✅ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} ${stepWord}, all valid.` }] }
+                const structured = {
+                    flowId: flowId!,
+                    displayName: flowName,
+                    stepCount: allSteps.length,
+                    validCount,
+                    invalidSteps,
+                    skippedSteps,
                 }
-                return { content: [{ type: 'text', text: `⚠️ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} ${stepWord} (${validCount} valid, ${invalidSteps.length} invalid: ${invalidSteps.join(', ')}).${skippedHint} Use ap_update_step or ap_update_trigger to fix.` }] }
+                if (invalidSteps.length === 0 && skippedSteps.length === 0) {
+                    return { content: [{ type: 'text', text: `✅ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} ${stepWord}, all valid.` }], structuredContent: structured }
+                }
+                return { content: [{ type: 'text', text: `⚠️ Flow "${flowName}" created (id: ${flowId}) with ${allSteps.length} ${stepWord} (${validCount} valid, ${invalidSteps.length} invalid: ${invalidSteps.join(', ')}).${skippedHint} Use ap_update_step or ap_update_trigger to fix.` }], structuredContent: structured }
             }
             catch (err) {
                 if (flowId) {

--- a/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
@@ -12,7 +12,11 @@ export const apCreateFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
         inputSchema: {
             flowName: z.string().trim().min(1, 'Flow name cannot be empty').max(255, 'Flow name must be 255 characters or less').describe('The name of the flow'),
         },
-        annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
+        outputSchema: {
+            flowId: z.string(),
+            displayName: z.string(),
+        },
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             const { flowName } = z.object({ flowName: z.string().trim().min(1).max(255) }).parse(args)
             try {
@@ -28,6 +32,7 @@ export const apCreateFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                         type: 'text',
                         text: `✅ Created flow "${flow.version.displayName}" (id: ${flow.id}). The flow has an empty trigger. Next steps:\n1. Use ap_update_trigger to set the trigger (e.g. webhook, schedule, or a piece trigger)\n2. Use ap_add_step to add action steps after the trigger\n3. Use ap_update_step to configure each step's inputs`,
                     }],
+                    structuredContent: { flowId: flow.id, displayName: flow.version.displayName },
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-create-flow.ts
@@ -12,10 +12,6 @@ export const apCreateFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
         inputSchema: {
             flowName: z.string().trim().min(1, 'Flow name cannot be empty').max(255, 'Flow name must be 255 characters or less').describe('The name of the flow'),
         },
-        outputSchema: {
-            flowId: z.string(),
-            displayName: z.string(),
-        },
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             const { flowName } = z.object({ flowName: z.string().trim().min(1).max(255) }).parse(args)

--- a/packages/server/api/src/app/mcp/tools/ap-delete-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-flow.ts
@@ -12,10 +12,6 @@ export const apDeleteFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
         inputSchema: {
             flowId: z.string().describe('The ID of the flow to delete'),
         },
-        outputSchema: {
-            flowId: z.string(),
-            deleted: z.boolean(),
-        },
         annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             const { flowId } = z.object({ flowId: z.string() }).parse(args)

--- a/packages/server/api/src/app/mcp/tools/ap-delete-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-flow.ts
@@ -12,7 +12,11 @@ export const apDeleteFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
         inputSchema: {
             flowId: z.string().describe('The ID of the flow to delete'),
         },
-        annotations: { destructiveHint: true, idempotentHint: false, openWorldHint: false },
+        outputSchema: {
+            flowId: z.string(),
+            deleted: z.boolean(),
+        },
+        annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
             const { flowId } = z.object({ flowId: z.string() }).parse(args)
             try {
@@ -27,6 +31,7 @@ export const apDeleteFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                         type: 'text',
                         text: `✅ Flow "${displayName}" has been permanently deleted.`,
                     }],
+                    structuredContent: { flowId, deleted: true },
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-find-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-find-records.ts
@@ -88,7 +88,7 @@ export const apFindRecordsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
                     records: result.data.map(r => ({
                         id: r.id,
                         cells: Object.fromEntries(
-                            Object.values(r.cells).map(c => [c.fieldName ?? c.fieldId, c.value]),
+                            Object.entries(r.cells).map(([fieldId, c]) => [c.fieldName ?? fieldId, c.value]),
                         ),
                     })),
                     count: result.data.length,

--- a/packages/server/api/src/app/mcp/tools/ap-find-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-find-records.ts
@@ -35,7 +35,14 @@ export const apFindRecordsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
         permission: Permission.READ_TABLE,
         description: 'Query records from a table with optional filtering. Operators: eq, neq, gt, gte, lt, lte, co, exists, not_exists.',
         inputSchema: findRecordsInput.shape,
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            records: z.array(z.object({
+                id: z.string(),
+                cells: z.record(z.string(), z.unknown()),
+            })),
+            count: z.number(),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const { tableId, filters, limit } = findRecordsInput.parse(args)
@@ -77,15 +84,28 @@ export const apFindRecordsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
                 })
 
                 if (result.data.length === 0) {
-                    return { content: [{ type: 'text', text: 'No records found.' }] }
+                    return {
+                        content: [{ type: 'text', text: 'No records found.' }],
+                        structuredContent: { records: [], count: 0 },
+                    }
                 }
 
                 const formatted = result.data.map(r => formatPopulatedRecord(r)).join('\n\n')
+                const structured = {
+                    records: result.data.map(r => ({
+                        id: r.id,
+                        cells: Object.fromEntries(
+                            r.cells.map(c => [c.fieldName ?? c.fieldId, c.value]),
+                        ),
+                    })),
+                    count: result.data.length,
+                }
                 return {
                     content: [{
                         type: 'text',
                         text: `Found ${result.data.length} record(s):\n\n${formatted}`,
                     }],
+                    structuredContent: structured,
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-find-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-find-records.ts
@@ -35,13 +35,6 @@ export const apFindRecordsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
         permission: Permission.READ_TABLE,
         description: 'Query records from a table with optional filtering. Operators: eq, neq, gt, gte, lt, lte, co, exists, not_exists.',
         inputSchema: findRecordsInput.shape,
-        outputSchema: {
-            records: z.array(z.object({
-                id: z.string(),
-                cells: z.record(z.string(), z.unknown()),
-            })),
-            count: z.number(),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-find-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-find-records.ts
@@ -88,7 +88,7 @@ export const apFindRecordsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
                     records: result.data.map(r => ({
                         id: r.id,
                         cells: Object.fromEntries(
-                            r.cells.map(c => [c.fieldName ?? c.fieldId, c.value]),
+                            Object.values(r.cells).map(c => [c.fieldName ?? c.fieldId, c.value]),
                         ),
                     })),
                     count: result.data.length,

--- a/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
@@ -288,22 +288,6 @@ export const apFlowStructureTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
         },
-        outputSchema: {
-            flowId: z.string(),
-            displayName: z.string(),
-            steps: z.array(z.object({
-                name: z.string(),
-                type: z.string(),
-                displayName: z.string(),
-                parentName: z.string().nullable(),
-                relationship: z.string(),
-                branchIndex: z.number().optional(),
-                branchName: z.string().optional(),
-                valid: z.boolean(),
-                configStatus: z.string(),
-            })),
-            stepCount: z.number(),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async ({ flowId }) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-flow-structure.ts
@@ -288,7 +288,23 @@ export const apFlowStructureTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
         },
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            flowId: z.string(),
+            displayName: z.string(),
+            steps: z.array(z.object({
+                name: z.string(),
+                type: z.string(),
+                displayName: z.string(),
+                parentName: z.string().nullable(),
+                relationship: z.string(),
+                branchIndex: z.number().optional(),
+                branchName: z.string().optional(),
+                valid: z.boolean(),
+                configStatus: z.string(),
+            })),
+            stepCount: z.number(),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async ({ flowId }) => {
             try {
                 const flow = await flowService(log).getOnePopulated({
@@ -301,7 +317,25 @@ export const apFlowStructureTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                 const { structure, stepByName } = buildFlowStructure(flow.version.trigger)
                 const positions = flowCanvasUtils.computeStepPositions(flow.version.trigger)
                 const text = formatFlowStructure(flow.version.displayName, flow.id, structure, stepByName, positions, flow.version.notes ?? [])
-                return { content: [{ type: 'text', text }] }
+                return {
+                    content: [{ type: 'text', text }],
+                    structuredContent: {
+                        flowId: flow.id,
+                        displayName: flow.version.displayName,
+                        steps: structure.map(s => ({
+                            name: s.name,
+                            type: s.type,
+                            displayName: s.displayName,
+                            parentName: s.parentName,
+                            relationship: s.relationship,
+                            ...(s.branchIndex !== undefined ? { branchIndex: s.branchIndex } : {}),
+                            ...(s.branchName !== undefined ? { branchName: s.branchName } : {}),
+                            valid: s.valid,
+                            configStatus: s.configStatus,
+                        })),
+                        stepCount: structure.length,
+                    },
+                }
             }
             catch (err) {
                 return mcpUtils.mcpToolError('Failed to get flow structure', err)

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -26,23 +26,6 @@ export const apGetPiecePropsTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
         title: 'ap_get_piece_props',
         description: 'Get the input property schema for a piece action or trigger. Returns field names, types, required/optional, defaults, and options. Pass auth to resolve dynamic dropdowns and dynamic property sub-fields (e.g. Custom API Call url/body fields).',
         inputSchema: getPiecePropsInput.shape,
-        outputSchema: {
-            piece: z.string(),
-            name: z.string(),
-            displayName: z.string(),
-            description: z.string(),
-            requiresAuth: z.boolean(),
-            props: z.array(z.object({
-                name: z.string(),
-                type: z.string(),
-                required: z.boolean(),
-                displayName: z.string(),
-                description: z.string().optional(),
-                defaultValue: z.unknown().optional(),
-                options: z.array(z.object({ label: z.string(), value: z.unknown() })).optional(),
-                note: z.string().optional(),
-            })),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -71,7 +71,7 @@ export const apGetPiecePropsTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                     log,
                 })
 
-                const result = {
+                const textResult = {
                     piece: normalized,
                     name: component.name,
                     displayName: component.displayName,
@@ -80,11 +80,19 @@ export const apGetPiecePropsTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                     ...(authHint && { authHint }),
                     props,
                 }
+                const structured = {
+                    piece: normalized,
+                    name: component.name,
+                    displayName: component.displayName,
+                    description: component.description,
+                    requiresAuth,
+                    props,
+                }
 
                 const descLine = component.description ? `\nDescription: ${component.description}\n` : ''
                 return {
-                    content: [{ type: 'text', text: `✅ ${label} schema for "${normalized}/${actionOrTriggerName}":${descLine}\n${JSON.stringify(result, null, 2)}` }],
-                    structuredContent: result,
+                    content: [{ type: 'text', text: `✅ ${label} schema for "${normalized}/${actionOrTriggerName}":${descLine}\n${JSON.stringify(textResult, null, 2)}` }],
+                    structuredContent: structured,
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -26,7 +26,24 @@ export const apGetPiecePropsTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
         title: 'ap_get_piece_props',
         description: 'Get the input property schema for a piece action or trigger. Returns field names, types, required/optional, defaults, and options. Pass auth to resolve dynamic dropdowns and dynamic property sub-fields (e.g. Custom API Call url/body fields).',
         inputSchema: getPiecePropsInput.shape,
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            piece: z.string(),
+            name: z.string(),
+            displayName: z.string(),
+            description: z.string(),
+            requiresAuth: z.boolean(),
+            props: z.array(z.object({
+                name: z.string(),
+                type: z.string(),
+                required: z.boolean(),
+                displayName: z.string(),
+                description: z.string().optional(),
+                defaultValue: z.unknown().optional(),
+                options: z.array(z.object({ label: z.string(), value: z.unknown() })).optional(),
+                note: z.string().optional(),
+            })),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const { pieceName, actionOrTriggerName, type, auth, flowId, input: providedInput } = getPiecePropsInput.parse(args)
@@ -84,6 +101,7 @@ export const apGetPiecePropsTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                 const descLine = component.description ? `\nDescription: ${component.description}\n` : ''
                 return {
                     content: [{ type: 'text', text: `✅ ${label} schema for "${normalized}/${actionOrTriggerName}":${descLine}\n${JSON.stringify(result, null, 2)}` }],
+                    structuredContent: result,
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-get-run.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-run.ts
@@ -1,4 +1,4 @@
-import { McpToolDefinition, Permission, ProjectScopedMcpServer } from '@activepieces/shared'
+import { isNil, McpToolDefinition, Permission, ProjectScopedMcpServer } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowRunService } from '../../flows/flow-run/flow-run-service'
@@ -15,7 +15,23 @@ export const apGetRunTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger
         permission: Permission.READ_RUN,
         description: 'Get detailed results of a flow run including step-by-step outputs, errors, and durations.',
         inputSchema: getRunInput.shape,
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            id: z.string(),
+            flowId: z.string(),
+            status: z.string(),
+            environment: z.string(),
+            created: z.string(),
+            duration: z.string().nullable(),
+            failedStepName: z.string().nullable(),
+            steps: z.array(z.object({
+                name: z.string(),
+                status: z.string(),
+                duration: z.number().nullable(),
+                output: z.unknown(),
+                errorMessage: z.unknown(),
+            })),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const { flowRunId } = getRunInput.parse(args)
@@ -25,11 +41,35 @@ export const apGetRunTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger
                     projectId: mcp.projectId,
                 })
 
+                const stepEntries = !isNil(run.steps) && typeof run.steps === 'object'
+                    ? Object.entries(run.steps as Record<string, Record<string, unknown>>)
+                    : []
+
+                const structured = {
+                    id: run.id,
+                    flowId: run.flowId,
+                    status: run.status,
+                    environment: run.environment,
+                    created: run.created,
+                    duration: run.startTime && run.finishTime
+                        ? `${((new Date(run.finishTime).getTime() - new Date(run.startTime).getTime()) / 1000).toFixed(1)}s`
+                        : null,
+                    failedStepName: run.failedStep?.name ?? null,
+                    steps: stepEntries.map(([name, step]) => ({
+                        name,
+                        status: String(step.status ?? 'UNKNOWN'),
+                        duration: typeof step.duration === 'number' ? step.duration : null,
+                        output: step.output ?? null,
+                        errorMessage: step.errorMessage ?? null,
+                    })),
+                }
+
                 return {
                     content: [{
                         type: 'text',
                         text: formatRunResult(run),
                     }],
+                    structuredContent: structured,
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-get-run.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-run.ts
@@ -15,22 +15,6 @@ export const apGetRunTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger
         permission: Permission.READ_RUN,
         description: 'Get detailed results of a flow run including step-by-step outputs, errors, and durations.',
         inputSchema: getRunInput.shape,
-        outputSchema: {
-            id: z.string(),
-            flowId: z.string(),
-            status: z.string(),
-            environment: z.string(),
-            created: z.string(),
-            duration: z.string().nullable(),
-            failedStepName: z.string().nullable(),
-            steps: z.array(z.object({
-                name: z.string(),
-                status: z.string(),
-                duration: z.number().nullable(),
-                output: z.unknown(),
-                errorMessage: z.unknown(),
-            })),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-list-ai-models.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-ai-models.ts
@@ -16,7 +16,17 @@ export const apListAiModelsTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
         title: 'ap_list_ai_models',
         description: 'List configured AI providers and their available models. Use this to discover valid provider and model values for configuring Run Agent steps. The output shows provider names and model IDs needed for the aiProviderModel input.',
         inputSchema: listAiModelsInput.shape,
-        annotations: { readOnlyHint: true, openWorldHint: true },
+        outputSchema: {
+            providers: z.array(z.object({
+                provider: z.string(),
+                displayName: z.string(),
+                models: z.array(z.object({
+                    id: z.string(),
+                    name: z.string(),
+                })),
+            })),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
         execute: async (args) => {
             try {
                 const { provider: filterProvider } = listAiModelsInput.parse(args)
@@ -26,7 +36,10 @@ export const apListAiModelsTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                 const providers = await service.listProviders(project.platformId)
 
                 if (providers.length === 0) {
-                    return { content: [{ type: 'text', text: 'No AI providers configured. Ask a platform admin to add one in Settings → AI Providers.' }] }
+                    return {
+                        content: [{ type: 'text', text: 'No AI providers configured. Ask a platform admin to add one in Settings → AI Providers.' }],
+                        structuredContent: { providers: [] },
+                    }
                 }
 
                 const filteredProviders = filterProvider
@@ -35,16 +48,25 @@ export const apListAiModelsTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
 
                 if (filteredProviders.length === 0) {
                     const available = providers.map(p => p.provider).join(', ')
-                    return { content: [{ type: 'text', text: `Provider "${filterProvider}" is not configured. Available providers: ${available}` }] }
+                    return {
+                        content: [{ type: 'text', text: `Provider "${filterProvider}" is not configured. Available providers: ${available}` }],
+                        structuredContent: { providers: [] },
+                    }
                 }
 
                 const MAX_MODELS_PER_PROVIDER = 20
+                const structuredProviders: Array<{ provider: string, displayName: string, models: Array<{ id: string, name: string }> }> = []
                 const sections = await Promise.all(
                     filteredProviders.map(async (p) => {
                         try {
                             const models = await service.listModels(project.platformId, p.provider)
                             const textModels = models.filter(m => m.type === AIProviderModelType.TEXT)
                             const capped = textModels.slice(0, MAX_MODELS_PER_PROVIDER)
+                            structuredProviders.push({
+                                provider: p.provider,
+                                displayName: p.name,
+                                models: capped.map(m => ({ id: m.id, name: m.name })),
+                            })
                             const modelLines = capped.length > 0
                                 ? capped.map(m => `    - ${m.name} (id: ${m.id})`).join('\n')
                                 : '    (no text models available)'
@@ -55,6 +77,7 @@ export const apListAiModelsTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                         }
                         catch (err) {
                             log.warn({ err, provider: p.provider }, 'ap_list_ai_models: failed to fetch models for provider')
+                            structuredProviders.push({ provider: p.provider, displayName: p.name, models: [] })
                             return `- ${p.provider} (${p.name})\n  (failed to fetch models)`
                         }
                     }),
@@ -65,6 +88,7 @@ export const apListAiModelsTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                         type: 'text',
                         text: `Configured AI Providers:\n\n${sections.join('\n\n')}\n\nUsage: Set aiProviderModel to {"provider": "<provider>", "model": "<model id>"} when configuring a Run Agent step.`,
                     }],
+                    structuredContent: { providers: structuredProviders },
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-list-ai-models.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-ai-models.ts
@@ -16,16 +16,6 @@ export const apListAiModelsTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
         title: 'ap_list_ai_models',
         description: 'List configured AI providers and their available models. Use this to discover valid provider and model values for configuring Run Agent steps. The output shows provider names and model IDs needed for the aiProviderModel input.',
         inputSchema: listAiModelsInput.shape,
-        outputSchema: {
-            providers: z.array(z.object({
-                provider: z.string(),
-                displayName: z.string(),
-                models: z.array(z.object({
-                    id: z.string(),
-                    name: z.string(),
-                })),
-            })),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
@@ -44,16 +44,6 @@ export const apListConnectionsTool = (mcp: ProjectScopedMcpServer, log: FastifyB
             displayName: listConnectionsSchema.shape.displayName,
             status: listConnectionsSchema.shape.status,
         },
-        outputSchema: {
-            connections: z.array(z.object({
-                externalId: z.string(),
-                displayName: z.string(),
-                pieceName: z.string(),
-                status: z.string(),
-                scope: z.string(),
-            })),
-            count: z.number(),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-connections.ts
@@ -44,7 +44,17 @@ export const apListConnectionsTool = (mcp: ProjectScopedMcpServer, log: FastifyB
             displayName: listConnectionsSchema.shape.displayName,
             status: listConnectionsSchema.shape.status,
         },
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            connections: z.array(z.object({
+                externalId: z.string(),
+                displayName: z.string(),
+                pieceName: z.string(),
+                status: z.string(),
+                scope: z.string(),
+            })),
+            count: z.number(),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const params = listConnectionsSchema.parse(args ?? {})
@@ -61,11 +71,22 @@ export const apListConnectionsTool = (mcp: ProjectScopedMcpServer, log: FastifyB
                     externalIds: undefined,
                 })
                 const lines = connections.data.map(c => `- externalId: ${c.externalId} | displayName: "${c.displayName}" | piece: ${c.pieceName} | status: ${c.status} | scope: ${c.scope}`)
+                const structured = {
+                    connections: connections.data.map(c => ({
+                        externalId: c.externalId,
+                        displayName: c.displayName,
+                        pieceName: c.pieceName,
+                        status: c.status,
+                        scope: c.scope,
+                    })),
+                    count: connections.data.length,
+                }
                 return {
                     content: [{
                         type: 'text',
                         text: `✅ Listed ${lines.length} connection(s):\n${lines.join('\n')}`,
                     }],
+                    structuredContent: structured,
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
@@ -23,7 +23,17 @@ export const apListFlowsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
             status: z.enum(Object.values(FlowStatus) as [FlowStatus, ...FlowStatus[]]).optional().describe('Filter by status: ENABLED or DISABLED.'),
             name: z.string().optional().describe('Filter by flow name (partial match).'),
         },
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            flows: z.array(z.object({
+                id: z.string(),
+                displayName: z.string(),
+                status: z.string(),
+                published: z.boolean(),
+                triggerType: z.string(),
+            })),
+            count: z.number(),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const { limit, status, name } = listFlowsInput.parse(args)
@@ -36,11 +46,24 @@ export const apListFlowsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                 })
                 const lines = flows.data.map((flow) => formatFlowLine(flow))
                 const filterNote = (status || name) ? ' (filtered)' : ''
+                const structured = {
+                    flows: flows.data.map((flow) => ({
+                        id: flow.id,
+                        displayName: flow.version.displayName,
+                        status: flow.status,
+                        published: !isNil(flow.publishedVersionId),
+                        triggerType: flow.version.trigger.type === FlowTriggerType.PIECE
+                            ? (flow.version.trigger.settings.pieceName ?? 'piece (unconfigured)')
+                            : flow.version.trigger.type,
+                    })),
+                    count: flows.data.length,
+                }
                 return {
                     content: [{
                         type: 'text',
                         text: `✅ Listed ${lines.length} flow(s)${filterNote}:\n${lines.join('\n')}`,
                     }],
+                    structuredContent: structured,
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-flows.ts
@@ -23,16 +23,6 @@ export const apListFlowsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
             status: z.enum(Object.values(FlowStatus) as [FlowStatus, ...FlowStatus[]]).optional().describe('Filter by status: ENABLED or DISABLED.'),
             name: z.string().optional().describe('Filter by flow name (partial match).'),
         },
-        outputSchema: {
-            flows: z.array(z.object({
-                id: z.string(),
-                displayName: z.string(),
-                status: z.string(),
-                published: z.boolean(),
-                triggerType: z.string(),
-            })),
-            count: z.number(),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
@@ -34,7 +34,17 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
             includeActions: z.boolean().optional().describe('When true, include action names and descriptions for each piece'),
             includeTriggers: z.boolean().optional().describe('When true, include trigger names and descriptions for each piece'),
         },
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            pieces: z.array(z.object({
+                name: z.string(),
+                displayName: z.string(),
+                version: z.string(),
+                description: z.string(),
+            })),
+            count: z.number(),
+            totalCount: z.number(),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const params = listPiecesSchema.parse(args ?? {})
@@ -66,6 +76,11 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                     const hint = totalCount > LIST_CAP ? ` (showing ${LIST_CAP} of ${totalCount} — use searchQuery to narrow results)` : ''
                     return {
                         content: [{ type: 'text', text: `✅ Successfully listed pieces${hint}:\n${JSON.stringify(capped)}` }],
+                        structuredContent: {
+                            pieces: capped.map(p => ({ name: p.name, displayName: p.displayName, version: p.version, description: p.description })),
+                            count: capped.length,
+                            totalCount,
+                        },
                     }
                 }
 
@@ -111,6 +126,16 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                     : ''
                 return {
                     content: [{ type: 'text', text: `✅ Successfully listed pieces${overflowHint}:\n${JSON.stringify(enrichedPieces)}` }],
+                    structuredContent: {
+                        pieces: enrichedPieces.map(p => ({
+                            name: String(p.name),
+                            displayName: String(p.displayName),
+                            version: String(p.version),
+                            description: String(p.description),
+                        })),
+                        count: enrichedPieces.length,
+                        totalCount,
+                    },
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
@@ -34,16 +34,6 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
             includeActions: z.boolean().optional().describe('When true, include action names and descriptions for each piece'),
             includeTriggers: z.boolean().optional().describe('When true, include trigger names and descriptions for each piece'),
         },
-        outputSchema: {
-            pieces: z.array(z.object({
-                name: z.string(),
-                displayName: z.string(),
-                version: z.string(),
-                description: z.string(),
-            })),
-            count: z.number(),
-            totalCount: z.number(),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
@@ -21,7 +21,19 @@ export const apListRunsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
         permission: Permission.READ_RUN,
         description: 'List recent flow runs with optional filters. Returns run ID, status, timestamps, and failed step info.',
         inputSchema: listRunsInput.shape,
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            runs: z.array(z.object({
+                id: z.string(),
+                flowId: z.string(),
+                status: z.string(),
+                environment: z.string(),
+                created: z.string(),
+                duration: z.string().nullable(),
+                failedStepName: z.string().nullable(),
+            })),
+            count: z.number(),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const { flowId, status, environment, limit } = listRunsInput.parse(args)
@@ -41,15 +53,33 @@ export const apListRunsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
                 })
 
                 if (result.data.length === 0) {
-                    return { content: [{ type: 'text', text: 'No flow runs found matching the criteria.' }] }
+                    return {
+                        content: [{ type: 'text', text: 'No flow runs found matching the criteria.' }],
+                        structuredContent: { runs: [], count: 0 },
+                    }
                 }
 
                 const lines = result.data.map(run => formatRunSummary(run))
+                const structured = {
+                    runs: result.data.map(run => ({
+                        id: run.id,
+                        flowId: run.flowId,
+                        status: run.status,
+                        environment: run.environment,
+                        created: run.created,
+                        duration: run.startTime && run.finishTime
+                            ? `${((new Date(run.finishTime).getTime() - new Date(run.startTime).getTime()) / 1000).toFixed(1)}s`
+                            : null,
+                        failedStepName: run.failedStep?.name ?? null,
+                    })),
+                    count: result.data.length,
+                }
                 return {
                     content: [{
                         type: 'text',
                         text: `Flow runs (${result.data.length}):\n\n${lines.join('\n')}`,
                     }],
+                    structuredContent: structured,
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
@@ -21,18 +21,6 @@ export const apListRunsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
         permission: Permission.READ_RUN,
         description: 'List recent flow runs with optional filters. Returns run ID, status, timestamps, and failed step info.',
         inputSchema: listRunsInput.shape,
-        outputSchema: {
-            runs: z.array(z.object({
-                id: z.string(),
-                flowId: z.string(),
-                status: z.string(),
-                environment: z.string(),
-                created: z.string(),
-                duration: z.string().nullable(),
-                failedStepName: z.string().nullable(),
-            })),
-            count: z.number(),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-list-tables.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-tables.ts
@@ -1,6 +1,5 @@
 import { McpToolDefinition, Permission, ProjectScopedMcpServer } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { z } from 'zod'
 import { fieldService } from '../../tables/field/field.service'
 import { tableService } from '../../tables/table/table.service'
 import { mcpUtils } from './mcp-utils'
@@ -12,19 +11,6 @@ export const apListTablesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
         permission: Permission.READ_TABLE,
         description: 'List all tables in the current project with their fields (name, type, id) and row counts. Use this to discover available tables before querying or modifying data. Returns table IDs needed by other table tools.',
         inputSchema: {},
-        outputSchema: {
-            tables: z.array(z.object({
-                id: z.string(),
-                name: z.string(),
-                rowCount: z.number(),
-                fields: z.array(z.object({
-                    id: z.string(),
-                    name: z.string(),
-                    type: z.string(),
-                })),
-            })),
-            count: z.number(),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async () => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-list-tables.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-tables.ts
@@ -1,5 +1,6 @@
 import { McpToolDefinition, Permission, ProjectScopedMcpServer } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
 import { fieldService } from '../../tables/field/field.service'
 import { tableService } from '../../tables/table/table.service'
 import { mcpUtils } from './mcp-utils'
@@ -11,7 +12,20 @@ export const apListTablesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
         permission: Permission.READ_TABLE,
         description: 'List all tables in the current project with their fields (name, type, id) and row counts. Use this to discover available tables before querying or modifying data. Returns table IDs needed by other table tools.',
         inputSchema: {},
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            tables: z.array(z.object({
+                id: z.string(),
+                name: z.string(),
+                rowCount: z.number(),
+                fields: z.array(z.object({
+                    id: z.string(),
+                    name: z.string(),
+                    type: z.string(),
+                })),
+            })),
+            count: z.number(),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async () => {
             try {
                 const result = await tableService.list({
@@ -25,7 +39,10 @@ export const apListTablesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                 })
 
                 if (result.data.length === 0) {
-                    return { content: [{ type: 'text', text: 'No tables found in this project.' }] }
+                    return {
+                        content: [{ type: 'text', text: 'No tables found in this project.' }],
+                        structuredContent: { tables: [], count: 0 },
+                    }
                 }
 
                 const tableIds = result.data.map(t => t.id)
@@ -41,6 +58,19 @@ export const apListTablesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                     return `- ${table.name} (id: ${table.id}) — ${rowCount} records\n  Fields:\n${fieldLines}`
                 })
 
+                const structured = {
+                    tables: result.data.map((table) => {
+                        const fields = fieldsByTable.get(table.id) ?? []
+                        return {
+                            id: table.id,
+                            name: table.name,
+                            rowCount: table.rowCount ?? 0,
+                            fields: fields.map(f => ({ id: f.id, name: f.name, type: f.type })),
+                        }
+                    }),
+                    count: result.data.length,
+                }
+
                 const output = tableDetails.join('\n\n')
                 const truncationNote = result.data.length >= 100
                     ? '\n\n⚠️ Showing first 100 tables. There may be more in this project.'
@@ -50,6 +80,7 @@ export const apListTablesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                         type: 'text',
                         text: output + truncationNote,
                     }],
+                    structuredContent: structured,
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/ap-resolve-property-options.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-resolve-property-options.ts
@@ -23,14 +23,6 @@ export const apResolvePropertyOptionsTool = (mcp: ProjectScopedMcpServer, log: F
         title: 'ap_resolve_property_options',
         description: 'Resolve dropdown options for a single piece property. Returns the available options with labels and values (IDs). Use this to discover valid values for DROPDOWN fields (e.g. Slack channels, Google Sheets, email labels). Always use the `value` from the returned options, not the `label`.',
         inputSchema: resolvePropertyOptionsInput.shape,
-        outputSchema: {
-            propertyName: z.string(),
-            options: z.array(z.object({
-                label: z.string(),
-                value: z.unknown(),
-            })),
-            count: z.number(),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-resolve-property-options.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-resolve-property-options.ts
@@ -23,7 +23,15 @@ export const apResolvePropertyOptionsTool = (mcp: ProjectScopedMcpServer, log: F
         title: 'ap_resolve_property_options',
         description: 'Resolve dropdown options for a single piece property. Returns the available options with labels and values (IDs). Use this to discover valid values for DROPDOWN fields (e.g. Slack channels, Google Sheets, email labels). Always use the `value` from the returned options, not the `label`.',
         inputSchema: resolvePropertyOptionsInput.shape,
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            propertyName: z.string(),
+            options: z.array(z.object({
+                label: z.string(),
+                value: z.unknown(),
+            })),
+            count: z.number(),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const { pieceName, actionOrTriggerName, type, propertyName, auth, input: providedInput, searchValue } = resolvePropertyOptionsInput.parse(args)
@@ -87,6 +95,7 @@ export const apResolvePropertyOptionsTool = (mcp: ProjectScopedMcpServer, log: F
                     const dynamicFields = mcpUtils.buildPropSummaries(options as PiecePropertyMap)
                     return {
                         content: [{ type: 'text', text: `✅ Dynamic fields for "${propertyName}":\n${JSON.stringify(dynamicFields, null, 2)}` }],
+                        structuredContent: { propertyName, options: dynamicFields, count: dynamicFields.length },
                     }
                 }
 
@@ -97,10 +106,12 @@ export const apResolvePropertyOptionsTool = (mcp: ProjectScopedMcpServer, log: F
                     if (mapped.length === 0) {
                         return {
                             content: [{ type: 'text', text: `⚠️ No options found for "${propertyName}". The account may have no items. You may use the value the user provided directly, but the dropdown in the flow editor will appear unset.` }],
+                            structuredContent: { propertyName, options: [], count: 0 },
                         }
                     }
                     return {
                         content: [{ type: 'text', text: `✅ Options for "${propertyName}" (${mapped.length} found). IMPORTANT: Use the "value" field (the ID), NOT the "label", when setting this property.\n${JSON.stringify(mapped, null, 2)}` }],
+                        structuredContent: { propertyName, options: mapped, count: mapped.length },
                     }
                 }
 

--- a/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
@@ -19,7 +19,19 @@ export const apValidateFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
         permission: Permission.READ_FLOW,
         description: 'Validate a flow for structural issues without publishing. Checks step validity, template references, and empty branches. Returns a detailed report with all issues found. Use this before ap_lock_and_publish to catch problems early.',
         inputSchema: validateFlowInput.shape,
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            valid: z.boolean(),
+            totalSteps: z.number(),
+            validSteps: z.number(),
+            invalidSteps: z.number(),
+            skippedSteps: z.number(),
+            issues: z.array(z.object({
+                category: z.string(),
+                stepName: z.string(),
+                message: z.string(),
+            })),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const { flowId } = validateFlowInput.parse(args)
@@ -30,7 +42,17 @@ export const apValidateFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                 }
 
                 const result = validateFlow({ trigger: flow.version.trigger })
-                return { content: [{ type: 'text', text: formatValidationResult({ result, flowDisplayName: flow.version.displayName }) }] }
+                return {
+                    content: [{ type: 'text', text: formatValidationResult({ result, flowDisplayName: flow.version.displayName }) }],
+                    structuredContent: {
+                        valid: result.issues.length === 0 && result.validSteps > 0,
+                        totalSteps: result.totalSteps,
+                        validSteps: result.validSteps,
+                        invalidSteps: result.invalidSteps,
+                        skippedSteps: result.skippedSteps,
+                        issues: result.issues.map(i => ({ category: i.category, stepName: i.stepName, message: i.message })),
+                    },
+                }
             }
             catch (err) {
                 return mcpUtils.mcpToolError('Flow validation failed', err)

--- a/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-flow.ts
@@ -19,18 +19,6 @@ export const apValidateFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
         permission: Permission.READ_FLOW,
         description: 'Validate a flow for structural issues without publishing. Checks step validity, template references, and empty branches. Returns a detailed report with all issues found. Use this before ap_lock_and_publish to catch problems early.',
         inputSchema: validateFlowInput.shape,
-        outputSchema: {
-            valid: z.boolean(),
-            totalSteps: z.number(),
-            validSteps: z.number(),
-            invalidSteps: z.number(),
-            skippedSteps: z.number(),
-            issues: z.array(z.object({
-                category: z.string(),
-                stepName: z.string(),
-                message: z.string(),
-            })),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
@@ -16,10 +16,6 @@ export const apValidateStepConfigTool = (mcp: ProjectScopedMcpServer, log: Fasti
         title: 'ap_validate_step_config',
         description: 'Validate a step configuration before applying it. Returns field-level errors without modifying any flow. Use this to check your config is correct before calling ap_update_step or ap_update_trigger.',
         inputSchema: validateStepConfigInput.shape,
-        outputSchema: {
-            valid: z.boolean(),
-            errors: z.array(z.string()),
-        },
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {

--- a/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-validate-step-config.ts
@@ -1,6 +1,7 @@
 import {
     BranchExecutionType,
     McpToolDefinition,
+    McpToolResult,
     ProjectScopedMcpServer,
     RouterActionSettingsWithValidation,
     RouterExecutionType,
@@ -15,7 +16,11 @@ export const apValidateStepConfigTool = (mcp: ProjectScopedMcpServer, log: Fasti
         title: 'ap_validate_step_config',
         description: 'Validate a step configuration before applying it. Returns field-level errors without modifying any flow. Use this to check your config is correct before calling ap_update_step or ap_update_trigger.',
         inputSchema: validateStepConfigInput.shape,
-        annotations: { readOnlyHint: true, openWorldHint: false },
+        outputSchema: {
+            valid: z.boolean(),
+            errors: z.array(z.string()),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
             try {
                 const params = validateStepConfigInput.parse(args)
@@ -69,7 +74,7 @@ const validateStepConfigInput = z.object({
         .describe('For ROUTER: raw router settings including branches and executionType.'),
 })
 
-async function validatePieceComponent({ pieceName, componentName, componentType, input, auth, projectId, log }: ValidatePieceParams): Promise<McpResult> {
+async function validatePieceComponent({ pieceName, componentName, componentType, input, auth, projectId, log }: ValidatePieceParams): Promise<McpToolResult> {
     const lookup = await mcpUtils.lookupPieceComponent({ pieceName, componentName, componentType, projectId, log })
     if (lookup.error) {
         return lookup.error
@@ -89,19 +94,31 @@ async function validatePieceComponent({ pieceName, componentName, componentType,
         const uiHint = diagnosis.uiRequired.length > 0
             ? `\nNote: these fields require configuration in the Activepieces UI: ${diagnosis.uiRequired.join(', ')}.`
             : ''
-        return { content: [{ type: 'text', text: `✅ Valid configuration for ${componentType.toUpperCase()} "${normalized}/${componentName}".${uiHint}` }] }
+        return {
+            content: [{ type: 'text', text: `✅ Valid configuration for ${componentType.toUpperCase()} "${normalized}/${componentName}".${uiHint}` }],
+            structuredContent: { valid: true, errors: [] },
+        }
     }
 
-    return { content: [{ type: 'text', text: `⚠️ Invalid configuration:\n${diagnosis.parts.join('\n')}` }] }
+    return {
+        content: [{ type: 'text', text: `⚠️ Invalid configuration:\n${diagnosis.parts.join('\n')}` }],
+        structuredContent: { valid: false, errors: diagnosis.parts },
+    }
 }
 
-function validateWithSchema({ schema, data, label }: { schema: z.ZodType, data: unknown, label: string }): McpResult {
+function validateWithSchema({ schema, data, label }: { schema: z.ZodType, data: unknown, label: string }): McpToolResult {
     const result = schema.safeParse(data)
     if (result.success) {
-        return { content: [{ type: 'text', text: `✅ Valid ${label} configuration.` }] }
+        return {
+            content: [{ type: 'text', text: `✅ Valid ${label} configuration.` }],
+            structuredContent: { valid: true, errors: [] },
+        }
     }
     const errors = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`)
-    return { content: [{ type: 'text', text: `⚠️ Invalid ${label} configuration:\n${errors.join('\n')}` }] }
+    return {
+        content: [{ type: 'text', text: `⚠️ Invalid ${label} configuration:\n${errors.join('\n')}` }],
+        structuredContent: { valid: false, errors },
+    }
 }
 
 const codeValidator = z.object({
@@ -120,7 +137,7 @@ function routerEnumHint(): string {
     return `Valid executionType values: ${Object.values(RouterExecutionType).join(', ')}\nBranch types: ${Object.values(BranchExecutionType).join(', ')}`
 }
 
-function validateRouter(settings: Record<string, unknown> | undefined): McpResult {
+function validateRouter(settings: Record<string, unknown> | undefined): McpToolResult {
     if (!settings || !settings.branches || !settings.executionType || (Array.isArray(settings.branches) && settings.branches.length === 0)) {
         const example = JSON.stringify({
             branches: [
@@ -142,11 +159,15 @@ function validateRouter(settings: Record<string, unknown> | undefined): McpResul
                 type: 'text',
                 text: `⚠️ Invalid ROUTER configuration: settings must include branches and executionType.\n\n${routerEnumHint()}\n\nExample:\n${example}`,
             }],
+            structuredContent: { valid: false, errors: ['settings must include branches and executionType'] },
         }
     }
     const result = RouterActionSettingsWithValidation.safeParse(settings)
     if (result.success) {
-        return { content: [{ type: 'text', text: '✅ Valid ROUTER configuration.' }] }
+        return {
+            content: [{ type: 'text', text: '✅ Valid ROUTER configuration.' }],
+            structuredContent: { valid: true, errors: [] },
+        }
     }
     const errors = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`)
     return {
@@ -154,10 +175,9 @@ function validateRouter(settings: Record<string, unknown> | undefined): McpResul
             type: 'text',
             text: `⚠️ Invalid ROUTER configuration:\n${errors.join('\n')}\n\n${routerEnumHint()}`,
         }],
+        structuredContent: { valid: false, errors },
     }
 }
-
-type McpResult = { content: [{ type: 'text', text: string }] }
 
 type ValidatePieceParams = {
     pieceName: string

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -1,4 +1,4 @@
-import { apId, FlowActionType, FlowOperationType, FlowRun, FlowRunStatus, flowStructureUtil, FlowTriggerType, isFlowRunStateTerminal, isNil, RunEnvironment, SampleDataFileType, StepLocationRelativeToParent, StepOutputStatus, tryCatch, UpdateActionRequest } from '@activepieces/shared'
+import { apId, FlowActionType, FlowOperationType, FlowRun, FlowRunStatus, flowStructureUtil, FlowTriggerType, isFlowRunStateTerminal, isNil, McpToolResult, RunEnvironment, SampleDataFileType, StepLocationRelativeToParent, StepOutputStatus, tryCatch, UpdateActionRequest } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { flowService } from '../../flows/flow/flow.service'
 import { flowRunService, isOutsideRetentionWindow } from '../../flows/flow-run/flow-run-service'
@@ -17,7 +17,7 @@ export async function executeFlowTest({ flowId, projectId, stepName, triggerTest
     stepName?: string
     triggerTestData?: Record<string, unknown>
     log: FastifyBaseLogger
-}): Promise<{ content: [{ type: 'text', text: string }] }> {
+}): Promise<McpToolResult> {
     let flow = await flowService(log).getOnePopulated({ id: flowId, projectId })
     if (isNil(flow)) {
         return { content: [{ type: 'text', text: '❌ Flow not found' }] }
@@ -111,7 +111,7 @@ export async function executeAdhocAction({
     input?: Record<string, unknown>
     connectionExternalId?: string
     log: FastifyBaseLogger
-}): Promise<{ content: [{ type: 'text', text: string }] }> {
+}): Promise<McpToolResult> {
     const authError = mcpUtils.validateAuth(connectionExternalId)
     if (authError) {
         return authError

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -1,5 +1,5 @@
 import { PieceMetadataModel, PiecePropertyMap, PropertyType } from '@activepieces/pieces-framework'
-import { BranchOperator, FlowActionType, flowStructureUtil, isNil, isObject, singleValueConditions } from '@activepieces/shared'
+import { BranchOperator, FlowActionType, flowStructureUtil, isNil, isObject, McpToolResult, singleValueConditions } from '@activepieces/shared'
 import type { RouterAction, Step } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
@@ -22,14 +22,14 @@ const RESOLVABLE_PROP_TYPES = new Set<PropertyType>([
 
 const STEP_REFERENCE_HINT = 'Use {{stepName.field}} to reference prior steps (no .output. in path).'
 
-function mcpToolError(prefix: string, err: unknown): { content: [{ type: 'text', text: string }] } {
+function mcpToolError(prefix: string, err: unknown): McpToolResult {
     const entityDetail = extractEntityNotFoundDetail(err)
     if (entityDetail) {
-        return { content: [{ type: 'text', text: `❌ ${prefix}: ${entityDetail} not found. Check the ID or name and try again.` }] }
+        return { content: [{ type: 'text', text: `❌ ${prefix}: ${entityDetail} not found. Check the ID or name and try again.` }], isError: true }
     }
     const raw = err instanceof Error ? err.message : String(err)
     const message = sanitizeErrorMessage(raw)
-    return { content: [{ type: 'text', text: `❌ ${prefix}: ${message}` }] }
+    return { content: [{ type: 'text', text: `❌ ${prefix}: ${message}` }], isError: true }
 }
 
 function extractEntityNotFoundDetail(err: unknown): string | null {
@@ -370,9 +370,7 @@ type LookupPieceComponentParams = {
 
 type LookupPieceComponentResult =
     | { piece: PieceMetadataModel, component: { props: PiecePropertyMap, requireAuth: boolean, name: string, displayName: string, description: string }, pieceName: string, error?: never }
-    | { error: { content: [{ type: 'text', text: string }] }, piece?: never, component?: never, pieceName?: never }
-
-type McpToolResult = { content: [{ type: 'text', text: string }] }
+    | { error: McpToolResult, piece?: never, component?: never, pieceName?: never }
 
 type ResolveRouterStepResult =
     | { routerStep: RouterAction, error?: never }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.71.7",
+  "version": "0.72.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.72.1",
+  "version": "0.72.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/automation/mcp/mcp.ts
+++ b/packages/shared/src/lib/automation/mcp/mcp.ts
@@ -37,12 +37,11 @@ export const UpdateMcpServerRequest = z.object({
 
 export type UpdateMcpServerRequest = z.infer<typeof UpdateMcpServerRequest>
 
-/** Tool definition for MCP: inputSchema/outputSchema are raw Zod shapes (same as MCP expects). */
+/** Tool definition for MCP: inputSchema is a raw Zod shape (same as MCP expects). */
 export type McpToolDefinition = {
     title: string
     description: string
     inputSchema: Record<string, z.ZodTypeAny>
-    outputSchema?: Record<string, z.ZodTypeAny>
     annotations?: {
         readOnlyHint?: boolean
         destructiveHint?: boolean

--- a/packages/shared/src/lib/automation/mcp/mcp.ts
+++ b/packages/shared/src/lib/automation/mcp/mcp.ts
@@ -37,11 +37,12 @@ export const UpdateMcpServerRequest = z.object({
 
 export type UpdateMcpServerRequest = z.infer<typeof UpdateMcpServerRequest>
 
-/** Tool definition for MCP: inputSchema is a raw Zod shape (same as MCP expects). */
+/** Tool definition for MCP: inputSchema/outputSchema are raw Zod shapes (same as MCP expects). */
 export type McpToolDefinition = {
     title: string
     description: string
     inputSchema: Record<string, z.ZodTypeAny>
+    outputSchema?: Record<string, z.ZodTypeAny>
     annotations?: {
         readOnlyHint?: boolean
         destructiveHint?: boolean
@@ -49,5 +50,11 @@ export type McpToolDefinition = {
         openWorldHint?: boolean
     }
     permission?: Permission
-    execute: (args: Record<string, unknown>) => Promise<{ content: Array<{ type: 'text', text: string }> }>
+    execute: (args: Record<string, unknown>) => Promise<McpToolResult>
+}
+
+export type McpToolResult = {
+    content: Array<{ type: 'text', text: string }>
+    structuredContent?: Record<string, unknown>
+    isError?: boolean
 }


### PR DESCRIPTION
## Summary
- Add `structuredContent` to MCP tool responses so clients can programmatically parse results instead of text parsing
- 18 tools updated: all 14 read/list tools + 4 key write tools (`ap_create_flow`, `ap_build_flow`, `ap_add_step`, `ap_delete_flow`)
- Success responses return both `content` (text for display) and `structuredContent` (JSON for programmatic use)
- Error responses return text-only `content` with `isError: true` — no `structuredContent` on errors to avoid SDK validation issues
- Complete all tool annotations (all 4 fields: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)

## Test plan
- [x] Verify MCP server starts and tools are registered correctly
- [x] Test read tools (`ap_list_flows`, `ap_flow_structure`, `ap_validate_flow`, etc.) return structured JSON
- [x] Test write tools (`ap_create_flow`, `ap_build_flow`, `ap_add_step`) return entity IDs in structured JSON
- [x] Test error responses (nonexistent flow/piece) return text gracefully without SDK crash
- [x] Verify existing text-based responses are unchanged (backward compatible)
- [ ] Verify chat agent integration still works (approval gates, tool execution)