### PR TITLE
feat(subflows): allow selecting disabled subflows

### DIFF
--- a/packages/pieces/core/subflows/package.json
+++ b/packages/pieces/core/subflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-subflows",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
+++ b/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
@@ -5,8 +5,8 @@ import {
   Property,
 } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
-import { ExecutionType, FAIL_PARENT_ON_FAILURE_HEADER, isNil, PARENT_RUN_ID_HEADER } from '@activepieces/shared';
-import { CallableFlowRequest, CallableFlowResponse, findFlowByExternalIdOrThrow, listEnabledFlowsWithSubflowTrigger } from '../common';
+import { ExecutionType, FAIL_PARENT_ON_FAILURE_HEADER, FlowStatus, isNil, PARENT_RUN_ID_HEADER } from '@activepieces/shared';
+import { CallableFlowRequest, CallableFlowResponse, findFlowByExternalIdOrThrow, listFlowsWithSubflowTrigger } from '../common';
 
 type FlowValue = {
   externalId: string;
@@ -24,7 +24,7 @@ export const callFlow = createAction({
       description: 'The flow to execute',
       required: true,
       options: async (_, context) => {
-        const flows = await listEnabledFlowsWithSubflowTrigger({
+        const flows = await listFlowsWithSubflowTrigger({
           flowsContext: context.flows,
         });
         return {
@@ -33,7 +33,10 @@ export const callFlow = createAction({
               externalId: flow.externalId ?? flow.id,
               exampleData: flow.version.trigger.settings.input.exampleData,
             },
-            label: flow.version.displayName,
+            label:
+              flow.status === FlowStatus.ENABLED
+                ? flow.version.displayName
+                : `${flow.version.displayName} (inactive)`,
           })),
         };
       },

--- a/packages/pieces/core/subflows/src/lib/common.ts
+++ b/packages/pieces/core/subflows/src/lib/common.ts
@@ -1,4 +1,4 @@
-import { FlowStatus, FlowTriggerType, isNil, PopulatedFlow } from "@activepieces/shared";
+import { FlowTriggerType, isNil, PopulatedFlow } from "@activepieces/shared";
 import { FlowsContext, ListFlowsContextParams } from "@activepieces/pieces-framework";
 
 
@@ -15,14 +15,13 @@ export type CallableFlowResponse = {
 
 export const MOCK_CALLBACK_IN_TEST_FLOW_URL = 'MOCK';
 
-export async function listEnabledFlowsWithSubflowTrigger({
+export async function listFlowsWithSubflowTrigger({
     flowsContext,
     params,
 }: ListParams) {
     const allFlows = (await flowsContext.list(params)).data;
     const flows = allFlows.filter(
         (flow) =>
-            flow.status === FlowStatus.ENABLED &&
             flow.version.trigger.type === FlowTriggerType.PIECE &&
             flow.version.trigger.settings.pieceName ==
             '@activepieces/piece-subflows'
@@ -43,7 +42,7 @@ export async function findFlowByExternalIdOrThrow({
         }));
     }
     const externalIds = [externalId];
-    const allFlows = await listEnabledFlowsWithSubflowTrigger({
+    const allFlows = await listFlowsWithSubflowTrigger({
         flowsContext,
         params: {
             externalIds


### PR DESCRIPTION
## What does this PR do?

Preventing disabled subflows from appearing in the UI (where they could have been selected previously) is confusing

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
