### PR TITLE
fix(builder): notify user when trigger test returns no events

### DIFF
--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -264,6 +264,7 @@
   "Action Required": "Action Required",
   "No sample data available": "No sample data available",
   "Old results were removed, retest for new sample data": "Old results were removed, retest for new sample data",
+  "We didn't find any data in {pieceName} yet. Do something there that should start this flow, then test again.": "We didn't find any data in {pieceName} yet. Do something there that should start this flow, then test again.",
   "Result #": "Result #",
   "The sample data can be used in the next steps.": "The sample data can be used in the next steps.",
   "There is no sample data available found for this trigger.": "There is no sample data available found for this trigger.",

--- a/packages/web/src/app/builder/test-step/test-trigger-section/index.tsx
+++ b/packages/web/src/app/builder/test-step/test-trigger-section/index.tsx
@@ -1,9 +1,11 @@
 import { FlowTrigger, flowStructureUtil, isNil } from '@activepieces/shared';
 import { t } from 'i18next';
+import { Info } from 'lucide-react';
 import React, { useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { ChatDrawerSource } from '@/app/builder/types';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { triggerEventHooks } from '@/features/flows';
 import { piecesHooks } from '@/features/pieces';
 
@@ -42,6 +44,9 @@ const TestTriggerSection = React.memo(
       pieceModel?.triggers?.[formValues.settings.triggerName]?.sampleData;
 
     const [errorMessage, setErrorMessage] = useState<string | undefined>(
+      undefined,
+    );
+    const [infoMessage, setInfoMessage] = useState<string | undefined>(
       undefined,
     );
 
@@ -86,6 +91,9 @@ const TestTriggerSection = React.memo(
     const { mutate: pollTrigger, isPending: isPollingTesting } =
       testStepHooks.usePollTrigger({
         setErrorMessage,
+        setInfoMessage,
+        pieceDisplayName:
+          pieceModel?.displayName ?? formValues.settings.pieceName,
         onSuccess: onTestSuccess,
       });
 
@@ -162,25 +170,37 @@ const TestTriggerSection = React.memo(
       }
     };
 
+    const emptyResultNotice = infoMessage ? (
+      <Alert className="mb-3">
+        <Info className="h-4 w-4" />
+        <AlertDescription>{infoMessage}</AlertDescription>
+      </Alert>
+    ) : null;
+
     return (
       <div>
         {showFirstTimeTestingSection && !errorMessage && (
-          <FirstTimeTestingSection
-            isValid={isValid}
-            testType={testType}
-            isTesting={isPollingTesting || isSimulating || isTestingDialogOpen}
-            mockData={mockData}
-            isSaving={isSaving || isSavingMockdata}
-            onSimulateTrigger={() => {
-              if (testType === 'chat-trigger') {
-                setChatDrawerOpenSource(ChatDrawerSource.TEST_STEP);
+          <>
+            {emptyResultNotice}
+            <FirstTimeTestingSection
+              isValid={isValid}
+              testType={testType}
+              isTesting={
+                isPollingTesting || isSimulating || isTestingDialogOpen
               }
-              simulateTrigger(abortControllerRef.current.signal);
-            }}
-            onPollTrigger={pollTrigger}
-            onMcpToolTesting={() => setIsTestingDialogOpen(true)}
-            onSaveMockAsSampleData={saveMockAsSampleData}
-          />
+              mockData={mockData}
+              isSaving={isSaving || isSavingMockdata}
+              onSimulateTrigger={() => {
+                if (testType === 'chat-trigger') {
+                  setChatDrawerOpenSource(ChatDrawerSource.TEST_STEP);
+                }
+                simulateTrigger(abortControllerRef.current.signal);
+              }}
+              onPollTrigger={pollTrigger}
+              onMcpToolTesting={() => setIsTestingDialogOpen(true)}
+              onSaveMockAsSampleData={saveMockAsSampleData}
+            />
+          </>
         )}
         {(!showFirstTimeTestingSection || errorMessage) && (
           <>
@@ -197,6 +217,7 @@ const TestTriggerSection = React.memo(
                 lastTestDate={lastTestDate}
                 isSaving={isSaving}
               >
+                {emptyResultNotice}
                 {pollResults?.data && !errorMessage && (
                   <TriggerEventSelect
                     pollResults={pollResults}

--- a/packages/web/src/app/builder/test-step/utils/test-step-hooks.ts
+++ b/packages/web/src/app/builder/test-step/utils/test-step-hooks.ts
@@ -118,9 +118,13 @@ export const testStepHooks = {
   },
   usePollTrigger: ({
     setErrorMessage,
+    setInfoMessage,
+    pieceDisplayName,
     onSuccess,
   }: {
     setErrorMessage: (msg: string | undefined) => void;
+    setInfoMessage: (msg: string | undefined) => void;
+    pieceDisplayName: string;
     onSuccess: () => void;
   }) => {
     const { form, builderState } = useRequiredStateToTestSteps();
@@ -131,6 +135,7 @@ export const testStepHooks = {
     return useMutation<TriggerEventWithPayload[], Error, void>({
       mutationFn: async () => {
         setErrorMessage(undefined);
+        setInfoMessage(undefined);
         const { data } = await triggerEventsApi.test({
           projectId: authenticationSession.getProjectId()!,
           flowId,
@@ -142,6 +147,13 @@ export const testStepHooks = {
             stepName,
             output: data[0].payload,
           });
+        } else {
+          setInfoMessage(
+            t(
+              "We didn't find any data in {pieceName} yet. Do something there that should start this flow, then test again.",
+              { pieceName: pieceDisplayName },
+            ),
+          );
         }
         return data;
       },


### PR DESCRIPTION
## What does this PR do?

When a polling-style trigger's test function succeeds with an empty result (e.g., a freshly-connected Telegram bot whose owner hasn't sent any messages yet), **Generate Sample Data** previously did nothing visible, leaving users to wonder what went wrong. This PR surfaces that state with an inline notice that names the connected piece and tells the user how to proceed.

### Explain How the Feature Works

`usePollTrigger` now accepts a `setInfoMessage` setter and the piece's display name. When `POST /api/v1/test-trigger` returns `{ data: [] }` — a successful-but-empty test — the hook sets a translated, ICU-interpolated message:

> We didn't find any data in {pieceName} yet. Do something there that should start this flow, then test again.

`TestTriggerSection` owns the `infoMessage` state and renders it as an inline `<Alert>` with an info icon in two places:
- Above `FirstTimeTestingSection` for users who have never tested this trigger.
- Inside `TestSampleDataViewer` for users retesting; the previous sample stays visible while the notice explains why nothing changed.

The notice is cleared at the start of every test attempt and on error, so it never co-renders with an error message. No backend changes; no piece-framework changes.

### Relevant User Scenarios

- **Newly-connected bot/integration with no events yet.** A user connects a Telegram bot via BotFather, clicks **Generate Sample Data** before any message has been sent to the bot, and gets clear guidance instead of a silent no-op.
- **Retesting after a quiet period.** A user who tested successfully earlier retests later when no new events have come in; the notice tells them why no new sample data appeared, while their prior sample stays usable.
- **Generalizes beyond Telegram.** Affects every polling-style test trigger (`testStrategy: TEST_FUNCTION`) — Slack, Gmail, calendar, etc. — that can legitimately return zero events from its `test()` hook.


### Screenshots/recording
#### Before

https://github.com/user-attachments/assets/0d1d057c-2262-40c1-8286-619dbcda6115



#### After

https://github.com/user-attachments/assets/305a5e52-f05e-45fd-9ed0-798b7939e6f7



Closes https://github.com/activepieces/activepieces/issues/13166