### PR TITLE
fix(docs): clarify AP_DEV_PIECES must be set in .env.dev

### DIFF
--- a/docs/build-pieces/building-pieces/development-setup.mdx
+++ b/docs/build-pieces/building-pieces/development-setup.mdx
@@ -43,8 +43,14 @@ Password: `12345678`
 
 When [`AP_PIECES_SYNC_MODE`](https://github.com/activepieces/activepieces/blob/main/.env.dev#L14) is set to `OFFICIAL_AUTO`, all pieces are automatically loaded from the cloud API and synced to the database on first launch. This process may take a few seconds to several minutes depending on your internet connection.
 
-For local development, pieces are loaded from your local `dist` folder instead of the database. To enable this, set the [`AP_DEV_PIECES`](https://github.com/activepieces/activepieces/blob/main/.env.dev#L5) environment variable with a comma-separated list of pieces. For example, to develop with `google-sheets` and `cal-com`:
+For local development, pieces are loaded from your local `dist` folder instead of the database. Set [`AP_DEV_PIECES`](https://github.com/activepieces/activepieces/blob/main/.env.dev#L5) inside `.env.dev` as a comma-separated list of pieces. For example, to develop with `google-sheets` and `cal-com`, edit `.env.dev`:
 
 ```sh
-AP_DEV_PIECES=google-sheets,cal-com npm start
+AP_DEV_PIECES=google-sheets,cal-com
 ```
+
+Then run `npm start`.
+
+<Note>
+  Set this variable inside `.env.dev`, not on the command line. Inline shell variables (e.g. `AP_DEV_PIECES=... npm start`) are not picked up by the dev servers.
+</Note>


### PR DESCRIPTION
## What does this PR do?

Clarifies the development setup docs around `AP_DEV_PIECES`. The current example tells contributors to set the variable via an inline shell prefix (`AP_DEV_PIECES=... npm start`), but Turborepo's `serve` task does not forward shell-set environment variables to its spawned tasks, so the api/worker dev processes only ever read from `.env.dev`. Contributors who follow the docs verbatim see their pieces silently ignored.

This PR replaces the misleading example with an instruction to edit `.env.dev` directly, and adds a `<Note>` callout matching the existing doc style flagging the inline-shell pitfall.

### Explain How the Feature Works

No code change, documentation only. The new wording in `docs/build-pieces/building-pieces/development-setup.mdx`:

- Tells the reader to set `AP_DEV_PIECES` inside `.env.dev` rather than on the command line.
- Shows the env-file line (`AP_DEV_PIECES=google-sheets,cal-com`) followed by `npm start`, so the same end-to-end flow is preserved.
- Adds a `<Note>` clarifying that inline shell variables are not picked up by the dev servers, so future readers understand why.

### Relevant User Scenarios

- A new contributor follows the **Pieces Development** section, sets `AP_DEV_PIECES=foo,bar npm start`, and is confused when the editor doesn't reflect their local pieces. With this PR they're directed to the file that actually controls the runtime configuration.
- Same applies to `AP_PIECES_SYNC_MODE`, the `.env.dev`-as-source-of-truth rule is the same.

Closes https://github.com/activepieces/activepieces/issues/13168
