### PR TITLE
feat: update API to allow creation of connection placeholders

### DIFF
--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -69,6 +69,20 @@ export const appConnectionService = (log: FastifyBaseLogger) => ({
         })).version
         validatePieceVersion(pieceVersion)
         await assertProjectIds(projectIds, platformId)
+
+        if (status === AppConnectionStatus.MISSING) {
+            const existingForPlaceholder = await appConnectionsRepo().findOneBy({
+                externalId,
+                scope,
+                platformId,
+                ...(projectIds ? { projectIds: ArrayContains(projectIds) } : {}),
+            })
+            if (!isNil(existingForPlaceholder) && existingForPlaceholder.status !== AppConnectionStatus.MISSING) {
+                log.info({ connectionId: existingForPlaceholder.id, pieceName, platformId, existingStatus: existingForPlaceholder.status }, 'Placeholder upsert skipped — non-missing connection already exists')
+                return this.removeSensitiveData(existingForPlaceholder)
+            }
+        }
+
         const validatedConnectionValue = await validateConnectionValue({
             value: await secretManagersService(log).resolveObject({ value, platformId, projectIds }),
             pieceName,
@@ -630,7 +644,7 @@ type UpsertParams = {
     platformId: string
     scope: AppConnectionScope
     externalId: string
-    value: UpsertAppConnectionRequestBody['value']
+    value: Extract<UpsertAppConnectionRequestBody, { value: unknown }>['value']
     displayName: string
     type: AppConnectionType
     status?: AppConnectionStatus
@@ -665,7 +679,7 @@ type DeleteParams = {
 }
 
 type ValidateConnectionValueParams = {
-    value: UpsertAppConnectionRequestBody['value']
+    value: Extract<UpsertAppConnectionRequestBody, { value: unknown }>['value']
     pieceName: string
     projectId: ProjectId | undefined
     platformId: string

--- a/packages/server/api/src/app/app-connection/app-connection.controller.ts
+++ b/packages/server/api/src/app/app-connection/app-connection.controller.ts
@@ -1,6 +1,8 @@
 import { ApId,
     AppConnectionOwners,
     AppConnectionScope,
+    AppConnectionStatus,
+    AppConnectionType,
     AppConnectionWithoutSensitiveData,
     ApplicationEventName,
     GetOAuth2AuthorizationUrlRequestBody,
@@ -8,6 +10,7 @@ import { ApId,
     ListAppConnectionOwnersRequestQuery,
     ListAppConnectionsRequestQuery,
     Permission,
+    PLACEHOLDER_CONNECTION_TYPE,
     PrincipalType,
     ReplaceAppConnectionsRequestBody,
     SeekPage,
@@ -28,19 +31,30 @@ import { AppConnectionEntity } from './app-connection.entity'
 
 export const appConnectionController: FastifyPluginCallbackZod = (app, _opts, done) => {
     app.post('/', UpsertAppConnectionRequest, async (request, reply) => {
-        const appConnection = await appConnectionService(request.log).upsert({
+        const ownerId = await securityHelper.getUserIdFromRequest(request)
+        const baseUpsert = {
             platformId: request.principal.platform.id,
             projectIds: [request.projectId],
-            type: request.body.type,
             externalId: request.body.externalId,
-            value: request.body.value,
             displayName: request.body.displayName,
             pieceName: request.body.pieceName,
-            ownerId: await securityHelper.getUserIdFromRequest(request),
+            ownerId,
             scope: AppConnectionScope.PROJECT,
             metadata: request.body.metadata,
             pieceVersion: request.body.pieceVersion,
-        })
+        }
+        const appConnection = request.body.type === PLACEHOLDER_CONNECTION_TYPE
+            ? await appConnectionService(request.log).upsert({
+                ...baseUpsert,
+                type: AppConnectionType.NO_AUTH,
+                value: { type: AppConnectionType.NO_AUTH },
+                status: AppConnectionStatus.MISSING,
+            })
+            : await appConnectionService(request.log).upsert({
+                ...baseUpsert,
+                type: request.body.type,
+                value: request.body.value,
+            })
         applicationEvents(request.log).sendUserEvent(request, {
             action: ApplicationEventName.CONNECTION_UPSERTED,
             data: {

--- a/packages/server/api/test/integration/ce/app-connection/app-connection.test.ts
+++ b/packages/server/api/test/integration/ce/app-connection/app-connection.test.ts
@@ -1,9 +1,11 @@
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 import {
     apId,
+    AppConnectionStatus,
     AppConnectionType,
     PackageType,
     PieceType,
+    PLACEHOLDER_CONNECTION_TYPE,
 } from '@activepieces/shared'
 import { FastifyBaseLogger, FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
@@ -87,6 +89,121 @@ describe('AppConnection CE API', () => {
             expect(response?.statusCode).toBe(StatusCodes.CREATED)
             const body = response?.json()
             expect(body.displayName).toBe('Test No Auth')
+        })
+
+        it('should create a placeholder connection with status MISSING', async () => {
+            const ctx = await setup()
+
+            const mockPiece = createMockPieceMetadata({
+                platformId: ctx.platform.id,
+                packageType: PackageType.REGISTRY,
+                pieceType: PieceType.OFFICIAL,
+            })
+            await db.save('piece_metadata', mockPiece)
+            pieceMetadataService(mockLog).getOrThrow = vi.fn().mockResolvedValue(mockPiece)
+
+            const response = await ctx.post('/v1/app-connections', {
+                externalId: 'test-placeholder-connection',
+                displayName: 'Placeholder Slack',
+                pieceName: mockPiece.name,
+                projectId: ctx.project.id,
+                type: PLACEHOLDER_CONNECTION_TYPE,
+                pieceVersion: mockPiece.version,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.CREATED)
+            const body = response?.json()
+            expect(body.displayName).toBe('Placeholder Slack')
+            expect(body.type).toBe(AppConnectionType.NO_AUTH)
+            expect(body.status).toBe(AppConnectionStatus.MISSING)
+            expect(body.pieceName).toBe(mockPiece.name)
+            expect(body.externalId).toBe('test-placeholder-connection')
+        })
+
+        it('should not overwrite an active connection with a placeholder', async () => {
+            const ctx = await setup()
+
+            const mockPiece = createMockPieceMetadata({
+                platformId: ctx.platform.id,
+                packageType: PackageType.REGISTRY,
+                pieceType: PieceType.OFFICIAL,
+            })
+            await db.save('piece_metadata', mockPiece)
+            pieceMetadataService(mockLog).getOrThrow = vi.fn().mockResolvedValue(mockPiece)
+
+            const active = await ctx.post('/v1/app-connections', {
+                externalId: 'placeholder-no-clobber',
+                displayName: 'Active Secret',
+                pieceName: mockPiece.name,
+                projectId: ctx.project.id,
+                type: AppConnectionType.SECRET_TEXT,
+                value: {
+                    type: AppConnectionType.SECRET_TEXT,
+                    secret_text: 'real-secret',
+                },
+                pieceVersion: mockPiece.version,
+            })
+            expect(active?.statusCode).toBe(StatusCodes.CREATED)
+            const activeBody = active?.json()
+            expect(activeBody.status).toBe(AppConnectionStatus.ACTIVE)
+            expect(activeBody.type).toBe(AppConnectionType.SECRET_TEXT)
+
+            const placeholder = await ctx.post('/v1/app-connections', {
+                externalId: 'placeholder-no-clobber',
+                displayName: 'Should Not Win',
+                pieceName: mockPiece.name,
+                projectId: ctx.project.id,
+                type: PLACEHOLDER_CONNECTION_TYPE,
+                pieceVersion: mockPiece.version,
+            })
+            expect(placeholder?.statusCode).toBe(StatusCodes.CREATED)
+            const placeholderBody = placeholder?.json()
+            expect(placeholderBody.id).toBe(activeBody.id)
+            expect(placeholderBody.status).toBe(AppConnectionStatus.ACTIVE)
+            expect(placeholderBody.type).toBe(AppConnectionType.SECRET_TEXT)
+            expect(placeholderBody.displayName).toBe('Active Secret')
+        })
+
+        it('should transition a placeholder to ACTIVE on real upsert', async () => {
+            const ctx = await setup()
+
+            const mockPiece = createMockPieceMetadata({
+                platformId: ctx.platform.id,
+                packageType: PackageType.REGISTRY,
+                pieceType: PieceType.OFFICIAL,
+            })
+            await db.save('piece_metadata', mockPiece)
+            pieceMetadataService(mockLog).getOrThrow = vi.fn().mockResolvedValue(mockPiece)
+
+            const placeholder = await ctx.post('/v1/app-connections', {
+                externalId: 'placeholder-fill-in',
+                displayName: 'Pending',
+                pieceName: mockPiece.name,
+                projectId: ctx.project.id,
+                type: PLACEHOLDER_CONNECTION_TYPE,
+                pieceVersion: mockPiece.version,
+            })
+            expect(placeholder?.statusCode).toBe(StatusCodes.CREATED)
+            const placeholderId = placeholder?.json().id
+
+            const filled = await ctx.post('/v1/app-connections', {
+                externalId: 'placeholder-fill-in',
+                displayName: 'Filled In',
+                pieceName: mockPiece.name,
+                projectId: ctx.project.id,
+                type: AppConnectionType.SECRET_TEXT,
+                value: {
+                    type: AppConnectionType.SECRET_TEXT,
+                    secret_text: 'real-secret',
+                },
+                pieceVersion: mockPiece.version,
+            })
+            expect(filled?.statusCode).toBe(StatusCodes.CREATED)
+            const filledBody = filled?.json()
+            expect(filledBody.id).toBe(placeholderId)
+            expect(filledBody.type).toBe(AppConnectionType.SECRET_TEXT)
+            expect(filledBody.status).toBe(AppConnectionStatus.ACTIVE)
+            expect(filledBody.displayName).toBe('Filled In')
         })
 
         it('should upsert on duplicate externalId', async () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/automation/app-connection/dto/upsert-app-connection-request.ts
+++ b/packages/shared/src/lib/automation/app-connection/dto/upsert-app-connection-request.ts
@@ -15,6 +15,8 @@ const commonAuthProps = {
 
 export const BOTH_CLIENT_CREDENTIALS_AND_AUTHORIZATION_CODE = 'both_client_credentials_and_authorization_code'
 
+export const PLACEHOLDER_CONNECTION_TYPE = 'PLACEHOLDER'
+
 export enum OAuth2GrantType {
     AUTHORIZATION_CODE = 'authorization_code',
     CLIENT_CREDENTIALS = 'client_credentials',
@@ -37,6 +39,11 @@ export const UpsertNoAuthRequest = z.object({
         type: z.literal(AppConnectionType.NO_AUTH),
     }),
 }).describe('No Auth')
+
+export const UpsertPlaceholderConnectionRequest = z.object({
+    ...commonAuthProps,
+    type: z.literal(PLACEHOLDER_CONNECTION_TYPE),
+}).describe('Placeholder')
 
 const commonOAuth2ValueProps = {
     client_id: z.string().min(1),
@@ -109,6 +116,7 @@ export const UpsertAppConnectionRequestBody = z.union([
     UpsertBasicAuthRequest,
     UpsertCustomAuthRequest,
     UpsertNoAuthRequest,
+    UpsertPlaceholderConnectionRequest,
 ])
 
 export type UpsertCloudOAuth2Request = z.infer<typeof UpsertCloudOAuth2Request>
@@ -118,6 +126,7 @@ export type UpsertSecretTextRequest = z.infer<typeof UpsertSecretTextRequest>
 export type UpsertBasicAuthRequest = z.infer<typeof UpsertBasicAuthRequest>
 export type UpsertCustomAuthRequest = z.infer<typeof UpsertCustomAuthRequest>
 export type UpsertNoAuthRequest = z.infer<typeof UpsertNoAuthRequest>
+export type UpsertPlaceholderConnectionRequest = z.infer<typeof UpsertPlaceholderConnectionRequest>
 export type UpsertAppConnectionRequestBody = z.infer<typeof UpsertAppConnectionRequestBody>
 
 


### PR DESCRIPTION
## What does this PR do?

We want to be able to create "placeholder" connections via the API (shown as status "missing" in the UI)
Today it's only possible via project releases - it's not exposed to external systems.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
