### PR TITLE
fix: some pieces were failing to reconnect in the UI for older versions like MS Excel 365 on piece version 0.5.3

### DIFF
--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -72,6 +72,7 @@ export const appConnectionService = (log: FastifyBaseLogger) => ({
         const validatedConnectionValue = await validateConnectionValue({
             value: await secretManagersService(log).resolveObject({ value, platformId, projectIds }),
             pieceName,
+            pieceVersion,
             projectId: projectIds[0],
             platformId,
         }, log)
@@ -405,12 +406,13 @@ const validateConnectionValue = async (
     params: ValidateConnectionValueParams,
     log: FastifyBaseLogger,
 ): Promise<AppConnectionValue> => {
-    const { value, pieceName, projectId, platformId } = params
+    const { value, pieceName, pieceVersion, projectId, platformId } = params
 
     switch (value.type) {
         case AppConnectionType.PLATFORM_OAUTH2: {
             const tokenUrl = await oauth2Util(log).getOAuth2TokenUrl({
                 pieceName,
+                pieceVersion,
                 platformId,
                 props: value.props,
             })
@@ -433,6 +435,7 @@ const validateConnectionValue = async (
         case AppConnectionType.CLOUD_OAUTH2: {
             const tokenUrl = await oauth2Util(log).getOAuth2TokenUrl({
                 pieceName,
+                pieceVersion,
                 platformId,
                 props: value.props,
             })
@@ -454,6 +457,7 @@ const validateConnectionValue = async (
         case AppConnectionType.OAUTH2: {
             const tokenUrl = await oauth2Util(log).getOAuth2TokenUrl({
                 pieceName,
+                pieceVersion,
                 platformId,
                 props: value.props,
             })
@@ -667,6 +671,7 @@ type DeleteParams = {
 type ValidateConnectionValueParams = {
     value: UpsertAppConnectionRequestBody['value']
     pieceName: string
+    pieceVersion: string
     projectId: ProjectId | undefined
     platformId: string
 }

--- a/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
@@ -71,12 +71,13 @@ export const oauth2Util = (log: FastifyBaseLogger) => ({
     getOAuth2TokenUrl: async ({
         platformId,
         pieceName,
+        pieceVersion,
         props,
     }: OAuth2TokenUrlParams): Promise<string> => {
         const pieceMetadata = await pieceMetadataService(log).getOrThrow({
             name: pieceName,
             platformId,
-            version: undefined,
+            version: pieceVersion,
         })
         const pieceAuth = Array.isArray(pieceMetadata.auth) ? pieceMetadata.auth.find(auth => auth.type === PropertyType.OAUTH2) : pieceMetadata.auth
         assertNotNullOrUndefined(pieceAuth, 'auth')
@@ -190,6 +191,7 @@ export const oauth2Util = (log: FastifyBaseLogger) => ({
 type OAuth2TokenUrlParams = {
     platformId: PlatformId
     pieceName: string
+    pieceVersion?: string
     props?: Record<string, unknown>
 }
 


### PR DESCRIPTION
**Title:** `fix: align piece version between connection upsert and OAuth2 token URL generation`

---

## What does this PR do?

Fixes a regression introduced by #12447 (Azure Government / GCC High support for 14 Microsoft pieces) where reconnecting an existing Microsoft 365 connection — or creating a new connection from a flow step pinned to a pre-0.6.0 piece version via the version dialog — fails with `INVALID_CLOUD_CLAIM` and the surface error "Could not claim the authorization code, make sure you have correct settings and try again."

Affected pieces: Excel 365, Outlook, Outlook Calendar, OneDrive, Teams, SharePoint, Power BI, OneNote, Todo, 365 People, 365 Planner, Copilot, Dynamics CRM, Dynamics 365 Business Central.


### Explain How the Feature Works

#12447 replaced the Microsoft pieces' hardcoded `authUrl: 'https://login.microsoftonline.com/...'` / `tokenUrl: 'https://login.microsoftonline.com/...'` with templated `https://{cloud}/...` URLs that get resolved against a new `microsoftCloudProperty` auth prop (`cloud`) via `resolveValueFromProps`.

The server was resolving piece metadata asymmetrically across the OAuth flow:

| Server-side call | Piece version used |
|---|---|
| `buildAuthorizationUrl` — auth popup URL | **requested** `pieceVersion` ✓ |
| `getOAuth2TokenUrl` — token exchange in `validateConnectionValue` | hardcoded `version: undefined` → always **latest** ✗ |

That was harmless while every Microsoft piece had hardcoded URLs, but the templating in #12447 makes it surface:

1. Form rendered against piece 0.5.3 has no `cloud` dropdown → submits `value.props = {}`.
2. Backend resolves the token URL against piece **0.6.1** (latest) → templated `https://{cloud}/.../token`.
3. `resolveValueFromProps({}, ...)` finds no `cloud` key → leaves the literal placeholder.
4. `https://{cloud}/.../token` is POSTed to `secrets.activepieces.com/claim` → upstream 500 → caught and wrapped as `INVALID_CLOUD_CLAIM` in `cloud-oauth2-service.ts`.

The patch threads `pieceVersion` through `appConnectionService.upsert` → `validateConnectionValue` → `getOAuth2TokenUrl` → `pieceMetadataService.getOrThrow`, mirroring what `buildAuthorizationUrl` already does. Both halves of the OAuth round-trip now resolve against the same piece version, so `{cloud}` always pairs with a `props` schema that actually carries the value — or with a piece version (e.g. 0.5.3) that uses the hardcoded URL and doesn't need substitution at all.

No behavior change for any path that already worked: the only caller of `validateConnectionValue` (`appConnectionService.upsert`) already had `pieceVersion` available — it was being dropped on the floor.

### Relevant User Scenarios

- **Reconnecting Microsoft 365 connections after upgrading to a release containing #12447.** Connections created before #12447 have `pieceVersion < 0.6.0`. The reconnect dialog loads the old piece schema (no `cloud` prop), submits `props: {}`, and the backend's token-URL resolution falls through to the latest templated piece. Reported in Pylon #4780 (MoneyGram, prod 0.82.1 — Excel/Outlook reconnect failing with this exact error).
- **Creating a new Microsoft 365 connection from a flow step pinned to an older piece version** via the per-step Update Piece Version dialog on cloud.activepieces.com. Same asymmetric path.
- **Any future piece that adds a templated auth URL + a new required `auth.props` entry in a minor bump.** Templating only works when both halves of the OAuth flow resolve to the same piece version; without this fix, the same regression would recur for any subsequent piece following the GCC High pattern.

Fixes # (issue)
