### PR TITLE
fix(platform): restrict /platforms/assets/:id to PLATFORM_ASSET files

### DIFF
--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -114,8 +114,8 @@ export const platformController: FastifyPluginAsyncZod = async (app) => {
 
     app.get('/assets/:id', GetAssetRequest, async (req, reply) => {
         const [file, data] = await Promise.all([
-            fileService(app.log).getFileOrThrow({ fileId: req.params.id }),
-            fileService(app.log).getDataOrThrow({ fileId: req.params.id })])
+            fileService(app.log).getFileOrThrow({ fileId: req.params.id, type: FileType.PLATFORM_ASSET }),
+            fileService(app.log).getDataOrThrow({ fileId: req.params.id, type: FileType.PLATFORM_ASSET })])
 
         return reply
             .header(

--- a/packages/server/api/test/helpers/mocks/index.ts
+++ b/packages/server/api/test/helpers/mocks/index.ts
@@ -737,16 +737,22 @@ export const mockAndSaveBasicSetupWithApiKey = async (params?: MockBasicSetupPar
 }
 
 export const createMockFile = (file?: Partial<File>): File => {
+    const hasExplicitProjectId = file !== undefined && 'projectId' in file
+    const hasExplicitPlatformId = file !== undefined && 'platformId' in file
     return {
         id: file?.id ?? apId(),
         created: file?.created ?? faker.date.recent().toISOString(),
         updated: file?.updated ?? faker.date.recent().toISOString(),
-        platformId: file?.platformId ?? apId(),
-        projectId: file?.projectId ?? apId(),
+        platformId: hasExplicitPlatformId ? (file?.platformId ?? null) : apId(),
+        projectId: hasExplicitProjectId ? (file?.projectId ?? null) : apId(),
         location: file?.location ?? FileLocation.DB,
         compression: file?.compression ?? faker.helpers.enumValue(FileCompression),
         data: file?.data ?? Buffer.from(faker.lorem.paragraphs()),
         type: file?.type ?? faker.helpers.enumValue(FileType),
+        fileName: file?.fileName ?? null,
+        metadata: file?.metadata ?? null,
+        s3Key: file?.s3Key ?? null,
+        size: file?.size ?? null,
     }
 }
 

--- a/packages/server/api/test/integration/cloud/platform/platform.test.ts
+++ b/packages/server/api/test/integration/cloud/platform/platform.test.ts
@@ -1,5 +1,5 @@
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
-import { apId, ApEdition, FilteredPieceBehavior,
+import { apId, ApEdition, FileCompression, FileLocation, FileType, FilteredPieceBehavior,
     FlowOperationStatus,
     FlowStatus,
     PlanName,
@@ -16,7 +16,7 @@ import { system } from '../../../../src/app/helper/system/system'
 import { systemJobsQueue } from '../../../../src/app/helper/system-jobs/system-job'
 import { db } from '../../../helpers/db'
 import { generateMockToken } from '../../../helpers/auth'
-import { checkIfSolutionExistsInDb, createMockConnection, createMockFlow, createMockFlowRun, createMockFlowVersion, createMockSolutionAndSave, createMockUser, mockAndSaveBasicSetup, mockBasicUser } from '../../../helpers/mocks'
+import { checkIfSolutionExistsInDb, createMockConnection, createMockFile, createMockFlow, createMockFlowRun, createMockFlowVersion, createMockSolutionAndSave, createMockUser, mockAndSaveBasicSetup, mockBasicUser } from '../../../helpers/mocks'
 
 let app: FastifyInstance | null = null
 
@@ -759,5 +759,69 @@ describe('Platform API', () => {
         })
         // assert
         expect(response?.statusCode).toBe(StatusCodes.OK)
+    })
+
+    describe('get platform asset endpoint', () => {
+        it('serves a public platform asset', async () => {
+            // arrange
+            const { mockPlatform } = await mockAndSaveBasicSetup()
+            const assetData = Buffer.from('public-logo-bytes')
+            const assetFile = createMockFile({
+                platformId: mockPlatform.id,
+                projectId: null,
+                type: FileType.PLATFORM_ASSET,
+                compression: FileCompression.NONE,
+                location: FileLocation.DB,
+                data: assetData,
+                fileName: 'logo.png',
+                metadata: { mimetype: 'image/png' },
+            })
+            await db.save('file', assetFile)
+
+            // act — public endpoint, no auth
+            const response = await app?.inject({
+                method: 'GET',
+                url: `/api/v1/platforms/assets/${assetFile.id}`,
+            })
+
+            // assert
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(response?.headers['content-type']).toContain('image/png')
+            expect(response?.rawPayload.equals(assetData)).toBe(true)
+        })
+
+        it('rejects access to non-PLATFORM_ASSET files (IDOR via public asset endpoint)', async () => {
+            // arrange — a sensitive flow run log file stored under a project
+            const { mockProject } = await mockAndSaveBasicSetup()
+            const sensitiveData = Buffer.from(JSON.stringify({ secret: 'super-secret-api-key' }))
+            const sensitiveFile = createMockFile({
+                projectId: mockProject.id,
+                type: FileType.FLOW_RUN_LOG,
+                compression: FileCompression.NONE,
+                location: FileLocation.DB,
+                data: sensitiveData,
+                fileName: 'flow-run.json',
+                metadata: { mimetype: 'application/json' },
+            })
+            await db.save('file', sensitiveFile)
+
+            // act — unauthenticated attacker hits the public asset endpoint
+            const response = await app?.inject({
+                method: 'GET',
+                url: `/api/v1/platforms/assets/${sensitiveFile.id}`,
+            })
+
+            // assert — non-asset file types must NOT be served by this endpoint
+            expect(response?.statusCode).toBe(StatusCodes.NOT_FOUND)
+            expect(response?.rawPayload.includes(sensitiveData)).toBe(false)
+        })
+
+        it('returns 404 for unknown asset ids', async () => {
+            const response = await app?.inject({
+                method: 'GET',
+                url: `/api/v1/platforms/assets/${apId()}`,
+            })
+            expect(response?.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
     })
 })


### PR DESCRIPTION
## Summary

- The public asset endpoint looked up files by id only — `getFileOrThrow({ fileId })` and `getDataOrThrow({ fileId })` were called without a `type` filter, so the query matched any file row by id regardless of file type.
- This change pins both lookups to `type: FileType.PLATFORM_ASSET`, matching the endpoint's intent. Non-asset files now return 404 from this route.

## Test plan

Added integration tests in `packages/server/api/test/integration/cloud/platform/platform.test.ts`:

- [x] `serves a public platform asset` — legitimate `PLATFORM_ASSET` is still served (positive case)
- [x] `rejects access to non-PLATFORM_ASSET files via public asset endpoint` — saves a `FLOW_RUN_LOG` and asserts the endpoint returns 404 (regression guard)
- [x] `returns 404 for unknown asset ids`

Validation:
- [x] All 3 tests pass with the fix; the regression test fails without it.
- [x] `npx turbo run lint --filter=api --force -- --fix` — 0 errors.

## Notes

- `createMockFile` helper updated to (a) preserve explicit `null`/`undefined` for `projectId` / `platformId` and (b) round out optional `File` fields (`fileName`, `metadata`, `s3Key`, `size`). Existing call sites are unaffected.