### PR TITLE
feat(worker): add requiresFreshSandbox piece-metadata flag

### DIFF
--- a/packages/pieces/community/oracle-database/package.json
+++ b/packages/pieces/community/oracle-database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-oracle-database",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/oracle-database/src/index.ts
+++ b/packages/pieces/community/oracle-database/src/index.ts
@@ -17,6 +17,10 @@ export const oracleDatabase = createPiece({
   logoUrl: 'https://cdn.activepieces.com/pieces/oracle-database.png',
   categories: [PieceCategory.DEVELOPER_TOOLS],
   authors: ['Prabhukiran161', 'onyedikachi-david', 'sanket-a11y'],
+  // node-oracledb locks each Node.js process to Thin or Thick mode on first successful
+  // connection. Reusing a Thin-locked worker process for a Thick init throws NJS-118.
+  // This flag tells the sandbox manager to give every Oracle job a fresh forked process.
+  requiresFreshSandbox: true,
   actions: [
     insertRowAction,
     insertRowsAction,

--- a/packages/pieces/framework/src/lib/piece-metadata.ts
+++ b/packages/pieces/framework/src/lib/piece-metadata.ts
@@ -23,6 +23,7 @@ export const PieceBase = z.object({
   minimumSupportedRelease: z.string().optional(),
   maximumSupportedRelease: z.string().optional(),
   i18n: I18nForPiece,
+  requiresFreshSandbox: z.boolean().optional(),
 })
 
 export type PieceBase = {
@@ -40,6 +41,10 @@ export type PieceBase = {
   minimumSupportedRelease?: string;
   maximumSupportedRelease?: string;
   i18n?: Partial<Record<LocalesEnum, Record<string, string>>>
+  // When true, every worker job running this piece gets a freshly-forked Node.js process
+  // and the sandbox is invalidated after release. Use for pieces with process-global state
+  // that cannot safely be shared across jobs (e.g. node-oracledb's one-way Thin/Thick lock).
+  requiresFreshSandbox?: boolean;
   // this method didn't exist in older version
   getContextInfo: (() => { version: ContextVersion }) | undefined;
 }

--- a/packages/pieces/framework/src/lib/piece.ts
+++ b/packages/pieces/framework/src/lib/piece.ts
@@ -31,6 +31,7 @@ export class Piece<PieceAuth extends PieceAuthProperty | PieceAuthProperty[] | u
     public readonly minimumSupportedRelease: string = MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION,
     public readonly maximumSupportedRelease?: string,
     public readonly description = '',
+    public readonly requiresFreshSandbox?: boolean,
   ) {
     if (!isValidSimpleSemver(minimumSupportedRelease) || isSemverLessThan(minimumSupportedRelease, MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION)) {
       this.minimumSupportedRelease = MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION;
@@ -52,6 +53,7 @@ export class Piece<PieceAuth extends PieceAuthProperty | PieceAuthProperty[] | u
       auth: this.auth,
       minimumSupportedRelease: this.minimumSupportedRelease,
       maximumSupportedRelease: this.maximumSupportedRelease,
+      requiresFreshSandbox: this.requiresFreshSandbox,
       contextInfo: this.getContextInfo?.()
     };
   }
@@ -96,6 +98,7 @@ export const createPiece = <PieceAuth extends PieceAuthProperty | PieceAuthPrope
     params.minimumSupportedRelease,
     params.maximumSupportedRelease,
     params.description,
+    params.requiresFreshSandbox,
   );
 };
 
@@ -113,6 +116,10 @@ type CreatePieceParams<
   actions: Action[];
   triggers: Trigger[];
   categories?: PieceCategory[];
+  // When true, every worker job running this piece gets a freshly-forked Node.js process
+  // and the sandbox is invalidated after the job finishes. Use for pieces with
+  // process-global state that cannot safely be shared across jobs.
+  requiresFreshSandbox?: boolean;
 };
 
 type PieceEventProcessors = {

--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -524,6 +524,7 @@ const engineValidateAuth = async (
         platformId,
         connectionValue: auth,
         jobType: WorkerJobType.EXECUTE_VALIDATION,
+        requiresFreshSandbox: pieceMetadata.requiresFreshSandbox === true,
     }, log)
 
     if (engineResponse.status !== EngineResponseStatus.OK) {

--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -5,6 +5,7 @@ import {
     Cursor,
     ErrorCode,
     ExecutionType,
+    FlowActionType,
     FlowId,
     FlowRetryStrategy,
     FlowRun,
@@ -12,6 +13,9 @@ import {
     FlowRunId,
     FlowRunStatus,
     FlowRunWithRetryError,
+    flowStructureUtil,
+    FlowTriggerType,
+    FlowVersion,
     FlowVersionId,
     isFlowRunStateTerminal,
     isNil,
@@ -26,6 +30,7 @@ import {
     UploadLogsBehavior,
     WorkerJobType,
 } from '@activepieces/shared'
+import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { context, propagation, trace } from '@opentelemetry/api'
 import { FastifyBaseLogger } from 'fastify'
 import pLimit from 'p-limit'
@@ -567,6 +572,12 @@ export async function addToQueue(params: AddToQueueParams, log: FastifyBaseLogge
         jobPayload = await payloadOffloader.maybeOffloadPayload(log, params.payload, params.flowRun.projectId, params.platformId)
     }
 
+    const requiresFreshSandbox = await flowRequiresFreshSandbox({
+        flowVersionId: params.flowRun.flowVersionId,
+        platformId: params.platformId,
+        log,
+    })
+
     await jobQueue(log).add({
         id: params.flowRun.id,
         type: JobType.ONE_TIME,
@@ -590,9 +601,42 @@ export async function addToQueue(params: AddToQueueParams, log: FastifyBaseLogge
             logsUploadUrl,
             logsFileId,
             traceContext,
+            requiresFreshSandbox,
         },
     })
     return params.flowRun
+}
+
+async function flowRequiresFreshSandbox({ flowVersionId, platformId, log }: { flowVersionId: FlowVersionId, platformId: PlatformId, log: FastifyBaseLogger }): Promise<boolean> {
+    const flowVersion = await flowVersionService(log).getOne(flowVersionId)
+    if (isNil(flowVersion)) {
+        return false
+    }
+    const pieceRefs = extractPieceReferences(flowVersion)
+    if (pieceRefs.length === 0) {
+        return false
+    }
+    const metadataResults = await Promise.all(
+        pieceRefs.map((ref) =>
+            pieceMetadataService(log).getOrThrow({
+                name: ref.name,
+                version: ref.version,
+                platformId,
+            }),
+        ),
+    )
+    return metadataResults.some((m) => m.requiresFreshSandbox === true)
+}
+
+function extractPieceReferences(flowVersion: FlowVersion): Array<{ name: string, version: string }> {
+    const refs = new Map<string, { name: string, version: string }>()
+    for (const step of flowStructureUtil.getAllSteps(flowVersion.trigger)) {
+        if (step.type === FlowActionType.PIECE || step.type === FlowTriggerType.PIECE) {
+            const { pieceName, pieceVersion } = step.settings
+            refs.set(`${pieceName}@${pieceVersion}`, { name: pieceName, version: pieceVersion })
+        }
+    }
+    return [...refs.values()]
 }
 
 export async function findFlowRunOrThrow(flowRunId: FlowRunId): Promise<FlowRun> {

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -51,7 +51,11 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResu
             }, 'logsFileId is missing for RESUME operation')
         }
 
-        const sandbox = ctx.sandboxManager.acquire({ log: ctx.log, apiClient: ctx.apiClient })
+        const sandbox = ctx.sandboxManager.acquire({
+            log: ctx.log,
+            apiClient: ctx.apiClient,
+            requiresFreshSandbox: data.requiresFreshSandbox,
+        })
         try {
             await sandbox.start({
                 flowVersionId: flowVersion.id,
@@ -98,7 +102,9 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResu
             throw e
         }
         finally {
-            await ctx.sandboxManager.release(ctx.log)
+            await ctx.sandboxManager.release(ctx.log, {
+                invalidateAfter: data.requiresFreshSandbox === true,
+            })
         }
     },
 }

--- a/packages/server/worker/src/lib/execute/jobs/execute-validation.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-validation.ts
@@ -21,7 +21,11 @@ export const executeValidationJob: JobHandler<ExecuteValidateAuthJobData, Synchr
             codeSteps: [],
         })
 
-        const sandbox = ctx.sandboxManager.acquire({ log: ctx.log, apiClient: ctx.apiClient })
+        const sandbox = ctx.sandboxManager.acquire({
+            log: ctx.log,
+            apiClient: ctx.apiClient,
+            requiresFreshSandbox: data.requiresFreshSandbox,
+        })
         try {
             await sandbox.start({
                 flowVersionId: undefined,
@@ -63,7 +67,9 @@ export const executeValidationJob: JobHandler<ExecuteValidateAuthJobData, Synchr
             throw e
         }
         finally {
-            await ctx.sandboxManager.release(ctx.log)
+            await ctx.sandboxManager.release(ctx.log, {
+                invalidateAfter: data.requiresFreshSandbox === true,
+            })
         }
     },
 }

--- a/packages/server/worker/src/lib/execute/sandbox-manager.ts
+++ b/packages/server/worker/src/lib/execute/sandbox-manager.ts
@@ -9,17 +9,25 @@ export function createSandboxManager({ boxId, proxyPort }: { boxId: number, prox
     let currentSandbox: Sandbox | null = null
 
     return {
-        acquire(params: { log: Logger, apiClient: WorkerToApiContract }): Sandbox {
-            if (canReuseSandbox() && currentSandbox && currentSandbox.isReady()) {
+        acquire(params: AcquireParams): Sandbox {
+            const needsFresh = params.requiresFreshSandbox === true
+
+            if (!needsFresh && canReuseSandbox() && currentSandbox && currentSandbox.isReady()) {
                 return currentSandbox
             }
             if (currentSandbox) {
-                params.log.info('Sandbox not ready or not reusable, creating fresh one')
+                params.log.info(
+                    { needsFresh },
+                    needsFresh
+                        ? 'Piece requires fresh sandbox; invalidating current and spawning new'
+                        : 'Sandbox not ready or not reusable, creating fresh one',
+                )
                 currentSandbox.shutdown().catch((err) =>
                     params.log.error({ err }, 'Error shutting down previous sandbox'),
                 )
             }
-            currentSandbox = createSandboxForJob({ ...params, boxId, reusable: canReuseSandbox(), proxyPort })
+            const reusable = canReuseSandbox() && !needsFresh
+            currentSandbox = createSandboxForJob({ ...params, boxId, reusable, proxyPort })
             return currentSandbox
         },
         async invalidate(log: Logger): Promise<void> {
@@ -30,8 +38,8 @@ export function createSandboxManager({ boxId, proxyPort }: { boxId: number, prox
                 await sb.shutdown()
             }
         },
-        async release(log: Logger): Promise<void> {
-            if (!canReuseSandbox()) {
+        async release(log: Logger, opts?: ReleaseOptions): Promise<void> {
+            if (!canReuseSandbox() || opts?.invalidateAfter === true) {
                 await this.invalidate(log)
             }
         },
@@ -57,9 +65,19 @@ function canReuseSandbox(): boolean {
     return false
 }
 
+type AcquireParams = {
+    log: Logger
+    apiClient: WorkerToApiContract
+    requiresFreshSandbox?: boolean
+}
+
+type ReleaseOptions = {
+    invalidateAfter?: boolean
+}
+
 export type SandboxManager = {
-    acquire(params: { log: Logger, apiClient: WorkerToApiContract }): Sandbox
+    acquire(params: AcquireParams): Sandbox
     invalidate(log: Logger): Promise<void>
-    release(log: Logger): Promise<void>
+    release(log: Logger, opts?: ReleaseOptions): Promise<void>
     shutdown(log: Logger): Promise<void>
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.72.0",
+  "version": "0.73.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/automation/workers/job-data.ts
+++ b/packages/shared/src/lib/automation/workers/job-data.ts
@@ -129,6 +129,7 @@ export const ExecuteFlowJobData = z.object({
     logsUploadUrl: z.string(),
     logsFileId: z.string(),
     traceContext: z.record(z.string(), z.string()).optional(),
+    requiresFreshSandbox: z.boolean().optional(),
 })
 export type ExecuteFlowJobData = z.infer<typeof ExecuteFlowJobData>
 
@@ -159,6 +160,7 @@ export const ExecuteValidateAuthJobData = z.object({
     connectionValue: z.unknown(),
     requestId: z.string(),
     webserverId: z.string(),
+    requiresFreshSandbox: z.boolean().optional(),
 })
 export type ExecuteValidateAuthJobData = z.infer<typeof ExecuteValidateAuthJobData>
 


### PR DESCRIPTION
## Summary

Adds an optional `requiresFreshSandbox: boolean` field to the piece manifest. When `true`, the sandbox manager:
- **On acquire** — invalidates any current sandbox and forks a fresh Node.js child process, regardless of `AP_EXECUTION_MODE` or `AP_REUSE_SANDBOX`.
- **On release** — kills the sandbox so the next job starts from scratch.

Backwards compatible — pieces without the flag behave exactly as today. The Oracle Database piece is the first user of the flag.

## Why

`node-oracledb` has a hard, one-way mode lock per Node.js process: once any Thin Mode connection successfully opens, the process cannot switch to Thick Mode (`NJS-118: Thick Mode cannot be activated...`). In reusable-sandbox modes (`SANDBOX_CODE_ONLY`, `UNSANDBOXED` — the recommended EE default), a slot's child process is kept alive across jobs. Any mixed Thin/Thick usage poisons slots over time.

For a customer with `AP_WORKER_CONCURRENCY=5` and 1 worker replica, this produces a ~20% NJS-118 failure rate per Thick connection save that climbs to near-100% as more slots get poisoned. Restarting the worker container is the only recovery.

The piece can't fix this on its own — `node-oracledb` controls the lock, not us. The clean fix is at the sandbox layer: give pieces a way to declare they need a fresh process per job, and have the worker honor it.


## Changes

| File | Change |
|---|---|
| `packages/pieces/framework/src/lib/piece-metadata.ts` | Add `requiresFreshSandbox?: boolean` to `PieceBase` schema + type |
| `packages/pieces/framework/src/lib/piece.ts` | Thread the field through the `Piece` class constructor, `metadata()`, and `createPiece` params |
| `packages/shared/src/lib/automation/workers/job-data.ts` | Add the field to `ExecuteValidateAuthJobData` and `ExecuteFlowJobData`. Bump `@activepieces/shared` to `0.73.0` |
| `packages/server/worker/src/lib/execute/sandbox-manager.ts` | `acquire()` honours the flag (force fresh); `release()` accepts `{ invalidateAfter }` |
| `packages/server/worker/src/lib/execute/jobs/execute-validation.ts` | Read flag from job data, pass to `acquire()` / `release()` |
| `packages/server/worker/src/lib/execute/jobs/execute-flow.ts` | Same as above |
| `packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts` | Look up flag from piece metadata; stamp onto auth-validation job |
| `packages/server/api/src/app/flows/flow-run/flow-run-service.ts` | Look up flag for every piece used in the flow; stamp onto flow-execution job if any piece needs it |
| `packages/pieces/community/oracle-database/src/index.ts` | Set `requiresFreshSandbox: true` |

## How it works at runtime

```
Job arrives at slot N
  ↓
sandboxManager.acquire({ requiresFreshSandbox: true })
  ↓
Kill existing process in slot N (if any)
  ↓
fork() a brand-new Node.js process
  ↓
Run job in fresh process — node-oracledb starts in default state, no inherited mode lock
  ↓
sandboxManager.release({ invalidateAfter: true })
  ↓
Kill the process — slot N is empty
```

## Performance

- Pieces **without** the flag: zero impact, identical behaviour.
- Pieces **with** the flag: ~100-300 ms cold-start added per BullMQ job (fork + Node startup + module load).
- Per-job, not per-action — all actions in a flow run share the same forked process.
- For typical Oracle workloads (saves, periodic syncs, scheduled flows) the latency is invisible end-to-end. Only meaningful concern is high-frequency triggers polling at sub-30-second intervals.

## What this does NOT solve

The flag forces fresh-at-acquire and kill-after-release per job. Within a single job (one flow run), the process is still shared across actions. So a flow with mixed Thin and Thick Oracle actions in one run would still hit NJS-118 on the second action. This is an unusual user pattern and not the symptom we've seen in production — flagging here as a known limitation, not a blocker for this PR.

## Test plan

- [ ] Lint/typecheck pass across all touched packages
- [ ] Existing pieces (no flag set) behave unchanged — sandbox reuse still works
- [ ] With `AP_EXECUTION_MODE=SANDBOX_CODE_ONLY` + `AP_WORKER_CONCURRENCY=5` + 1 replica: save Thin Oracle connection, then save Thick — both succeed
- [ ] Run a flow with multiple Oracle actions (same mode) — works end-to-end
- [ ] Run a flow with multiple Oracle actions (mixed Thin/Thick) — second action still fails with NJS-118 (documented limitation)
- [ ] Worker logs show "Piece requires fresh sandbox; invalidating current and spawning new" on each Oracle job

## Follow-ups (not in this PR)

- Document the flag in `docs/install/architecture/sandboxing.md` with native-binding piece guidance
- Audit other community pieces for native modules with similar process-global state issues (TLS contexts, native crypto, ML runtimes)
- Cache the per-flow `requiresFreshSandbox` lookup in `flow-run-service.ts` to avoid repeating piece metadata queries on every dispatch
