### PR TITLE
fix(webhooks): exclude rawBody from payload size check

### DIFF
--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -127,7 +127,10 @@ export const webhookService = {
 
                 const resolvedPayload = payload ?? await data(flow.projectId)
 
-                const payloadSize = payloadOffloader.getPayloadSizeInBytes(resolvedPayload)
+                // rawBody is a string copy of body added by convertRequest — exclude it
+                // from size measurement so the same content isn't counted twice.
+                const { rawBody: _rawBody, ...sizePayload } = resolvedPayload as Record<string, unknown>
+                const payloadSize = payloadOffloader.getPayloadSizeInBytes(sizePayload)
                 if (payloadSize > MAX_PAYLOAD_SIZE_BYTES) {
                     pinoLogger.warn({ payloadSize, maxPayloadSizeBytes: MAX_PAYLOAD_SIZE_BYTES }, 'Webhook payload too large')
                     span.setAttribute('webhook.payloadTooLarge', true)


### PR DESCRIPTION
## Problem

`convertRequest` in `webhook-request-converter.ts` builds the resolved webhook payload with both `body` (the parsed JSON object) and `rawBody` (the original request string):

```ts
return {
    method: request.method,
    headers: request.headers,
    body: await convertBody(request, projectId, flowId),
    queryParams: request.query,
    rawBody: isBinary ? undefined : request.rawBody,  // ← string copy of body
}
```

In `webhook.service.ts`, the size check runs `getPayloadSizeInBytes` on the **entire** resolved payload, which internally does `JSON.stringify(payload)`. Since `body` and `rawBody` carry the same content in different forms, the request data is counted **twice**.

### Real-world impact

We hit this in production with a webhook pushing ~13.5 MB of JSON (a batch of CRM leads). The actual request body is well under the 25 MB `AP_MAX_WEBHOOK_PAYLOAD_SIZE_MB` default, but once `rawBody` is included in the serialization the measured size balloons to ~27 MB → 413.

| What | Size |
|---|---|
| Actual request body | 13.5 MB |
| `body` (parsed object) serialized | ~13.5 MB |
| `rawBody` (string) serialized | ~13.5 MB |
| **Total measured by `getPayloadSizeInBytes`** | **~27 MB** |
| `MAX_WEBHOOK_PAYLOAD_SIZE_MB` default | 25 MB |

The effective limit is halved for any text-based webhook because of the duplication.

### How `rawBody` gets there

`rawBody` was added to `EventPayload` for pieces that need the original request bytes (e.g. HMAC signature verification on Stripe/GitHub webhooks). It's only set for non-binary content types. The field is necessary for flow execution — it just shouldn't inflate the size gate that decides whether the payload is accepted at all.

## Fix

One-line change in `webhook.service.ts` — destructure out `rawBody` before passing to `getPayloadSizeInBytes`:

```ts
const { rawBody: _rawBody, ...sizePayload } = resolvedPayload as Record<string, unknown>
const payloadSize = payloadOffloader.getPayloadSizeInBytes(sizePayload)
```

The full `resolvedPayload` (including `rawBody`) is still passed downstream to flow execution unchanged, so pieces that rely on `rawBody` are unaffected.

### Why not fix it in `getPayloadSizeInBytes`?

`getPayloadSizeInBytes` is a generic utility — it shouldn't have webhook-specific knowledge about which keys to skip. The webhook service is the right place since it knows the payload shape and why `rawBody` is redundant for sizing purposes.

## Notes

- This is related to #13158 which fixed Buffer-specific inflation in `getPayloadSizeInBytes`. That PR handled binary `rawBody` blowing up during JSON serialization. This PR handles the remaining case: text-based `rawBody` that silently doubles the measured size even with correct serialization.
- No changes to `rawBody` handling in flow execution, offloading, or storage — only the size gate is affected.
- Workaround for anyone hitting this before the fix ships: set `AP_MAX_WEBHOOK_PAYLOAD_SIZE_MB` to 2x your actual limit (e.g. 50 for a real 25 MB cap).

cc @abuaboud @AbdulTheActivePiecer