### PR TITLE
feat(chat): enable prompt caching for all AI providers

### DIFF
--- a/packages/server/api/src/app/ee/chat/chat-service.ts
+++ b/packages/server/api/src/app/ee/chat/chat-service.ts
@@ -18,7 +18,7 @@ import {
     UpdateChatConversationRequest,
 } from '@activepieces/shared'
 import { SharedV3ProviderOptions } from '@ai-sdk/provider'
-import { createUIMessageStream, LanguageModel, ModelMessage, stepCountIs, streamText } from 'ai'
+import { createUIMessageStream, LanguageModel, ModelMessage, stepCountIs, streamText, SystemModelMessage } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { aiProviderService } from '../../ai/ai-provider-service'
 import { repoFactory } from '../../core/db/repo-factory'
@@ -220,10 +220,10 @@ export const chatService = (log: FastifyBaseLogger) => ({
                 const sanitizedMessages = stripThinkingBlocks(messagesForLlm)
                 const textStream = streamText({
                     model,
-                    system: systemPrompt,
+                    system: buildSystemPromptWithCaching({ systemPrompt, provider: providerConfig.provider }),
                     messages: sanitizedMessages,
                     tools,
-                    providerOptions: buildThinkingOptions({ provider: providerConfig.provider, modelId: modelName }),
+                    providerOptions: buildProviderOptions({ provider: providerConfig.provider, modelId: modelName }),
                     stopWhen: stepCountIs(MAX_STEPS),
                     onStepFinish: ({ finishReason, usage }) => {
                         log.debug({ conversationId, finishReason, usage }, 'Chat step finished')
@@ -245,6 +245,8 @@ export const chatService = (log: FastifyBaseLogger) => ({
                             conversationId,
                             inputTokens: usage.inputTokens,
                             outputTokens: usage.outputTokens,
+                            cacheReadTokens: usage.inputTokenDetails.cacheReadTokens,
+                            cacheWriteTokens: usage.inputTokenDetails.cacheWriteTokens,
                             provider: providerConfig.provider,
                         }, 'Chat message completed')
                     },
@@ -415,25 +417,44 @@ function supportsThinking({ modelId }: { modelId: string }): boolean {
     return THINKING_CAPABLE_MODELS.has(bareModel)
 }
 
-function buildThinkingOptions({ provider, modelId }: { provider: AIProviderName, modelId: string }): SharedV3ProviderOptions {
-    if (!supportsThinking({ modelId })) return {}
-    const effort = resolveEffort({ modelId })
+function buildProviderOptions({ provider, modelId }: { provider: AIProviderName, modelId: string }): SharedV3ProviderOptions {
+    const effort = supportsThinking({ modelId }) ? resolveEffort({ modelId }) : null
+
     switch (provider) {
         case AIProviderName.ANTHROPIC:
+        case AIProviderName.BEDROCK:
             return {
                 anthropic: {
-                    thinking: { type: 'enabled', budgetTokens: effort.anthropicBudget },
+                    ...(effort ? { thinking: { type: 'enabled', budgetTokens: effort.anthropicBudget } } : {}),
                 },
             }
         case AIProviderName.ACTIVEPIECES:
         case AIProviderName.OPENROUTER:
             return {
                 openrouter: {
-                    reasoning: { effort: effort.openrouterEffort },
+                    cache_control: { type: 'ephemeral' },
+                    ...(effort ? { reasoning: { effort: effort.openrouterEffort } } : {}),
                 },
             }
         default:
             return {}
+    }
+}
+
+function buildSystemPromptWithCaching({ systemPrompt, provider }: {
+    systemPrompt: string
+    provider: AIProviderName
+}): string | SystemModelMessage {
+    switch (provider) {
+        case AIProviderName.ANTHROPIC:
+        case AIProviderName.BEDROCK:
+            return {
+                role: 'system',
+                content: systemPrompt,
+                providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+            }
+        default:
+            return systemPrompt
     }
 }
 

--- a/packages/server/api/src/app/ee/chat/chat-service.ts
+++ b/packages/server/api/src/app/ee/chat/chat-service.ts
@@ -245,8 +245,8 @@ export const chatService = (log: FastifyBaseLogger) => ({
                             conversationId,
                             inputTokens: usage.inputTokens,
                             outputTokens: usage.outputTokens,
-                            cacheReadTokens: usage.inputTokenDetails.cacheReadTokens,
-                            cacheWriteTokens: usage.inputTokenDetails.cacheWriteTokens,
+                            ...spreadIfDefined('cacheReadTokens', usage.inputTokenDetails.cacheReadTokens),
+                            ...spreadIfDefined('cacheWriteTokens', usage.inputTokenDetails.cacheWriteTokens),
                             provider: providerConfig.provider,
                         }, 'Chat message completed')
                     },


### PR DESCRIPTION
## Summary
- Enable prompt caching to reduce input token costs across all AI providers
- OpenRouter/Activepieces: top-level `cache_control` for automatic caching
- Anthropic/Bedrock: per-message `cacheControl` on system prompt via `SystemModelMessage`
- OpenAI/Google/Azure: no config needed (implicit caching)
- Log `cacheReadTokens` and `cacheWriteTokens` for monitoring cache hit rates
- Rename `buildThinkingOptions` → `buildProviderOptions` to consolidate thinking + caching config

## Test plan
- [ ] Send a message with smart tier (Claude Sonnet via OpenRouter), check logs for `cacheWriteTokens` on first turn
- [ ] Send follow-up message within 5 min, check logs for `cacheReadTokens` (cache hit)
- [ ] Test with fast tier (DeepSeek) — should work normally
- [ ] Verify no regressions in chat functionality across providers