### PR TITLE
feat(mcp): auto-resolve piece versions and improve tool UX

### DIFF
--- a/.agents/features/mcp.md
+++ b/.agents/features/mcp.md
@@ -44,6 +44,7 @@ Exposes an Activepieces project as a Model Context Protocol (MCP) server so that
 **Locked tools** (always enabled if MCP is on):
 - `ap_list_flows` — list all flows in project
 - `ap_flow_structure` — get flow definition and structure
+- `ap_read_step_code` — read full source code of a CODE step
 - `ap_list_pieces` — browse available pieces
 - `ap_list_connections` — list app connections
 

--- a/docs/mcp/tools.mdx
+++ b/docs/mcp/tools.mdx
@@ -26,6 +26,19 @@ Get the full structure of a flow: step tree, configuration status, step input va
 |-------|------|----------|-------------|
 | `flowId` | string | Yes | The flow ID |
 
+### ap_read_step_code
+
+Read the full source code, package.json, and input mappings of a CODE step. Returns untruncated content — unlike `ap_flow_structure` which truncates code to 300 characters.
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `flowId` | string | Yes | The flow ID |
+| `stepName` | string | Yes | The name of the CODE step (e.g., `step_1`) |
+
+<Tip>
+Use this tool when you need to read or edit a CODE step's full source. `ap_flow_structure` truncates code for overview purposes, so always call `ap_read_step_code` before modifying a code step.
+</Tip>
+
 ### ap_validate_flow
 
 Validate a flow for structural issues without publishing. Checks step validity, template references, and empty branches.
@@ -231,12 +244,12 @@ Create a complete flow in one call — trigger plus any number of steps. Steps a
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
 | `flowName` | string | Yes | Name for the new flow |
-| `trigger` | object | Yes | `{pieceName, pieceVersion, triggerName, input?, auth?}` |
+| `trigger` | object | Yes | `{pieceName, triggerName, input?, auth?}` |
 | `steps` | array | Yes | Array of step specs, each with `type`, `displayName`, and type-specific fields |
 
 **Step types in the array:**
-- **PIECE**: `pieceName`, `pieceVersion`, `actionName`, `input`, `auth`
-- **CODE**: `sourceCode`, `input`
+- **PIECE**: `pieceName`, `actionName`, `input`, `auth`, `continueOnFailure`, `retryOnFailure`
+- **CODE**: `sourceCode`, `input`, `continueOnFailure`, `retryOnFailure`
 - **LOOP_ON_ITEMS**: `loopItems`
 - **ROUTER**: creates a router with Branch 1 + Otherwise
 
@@ -248,7 +261,6 @@ Set or update the trigger for a flow.
 |-------|------|----------|-------------|
 | `flowId` | string | Yes | The flow ID |
 | `pieceName` | string | Yes | Piece name (e.g., `@activepieces/piece-gmail`) |
-| `pieceVersion` | string | Yes | Piece version (e.g., `~0.11.6`) |
 | `triggerName` | string | Yes | Trigger name from the piece |
 | `input` | object | No | Trigger configuration |
 | `auth` | string | No | Connection externalId |
@@ -266,7 +278,6 @@ Add a new step to a flow. Optionally configure it in the same call by providing 
 | `stepType` | string | Yes | `CODE`, `PIECE`, `LOOP_ON_ITEMS`, or `ROUTER` |
 | `displayName` | string | Yes | Step display name |
 | `pieceName` | string | No | For PIECE steps |
-| `pieceVersion` | string | No | For PIECE steps |
 | `actionName` | string | No | For PIECE steps |
 | `branchIndex` | number | No | For INSIDE_BRANCH |
 | `input` | object | No | Step input config (key-value pairs) |
@@ -274,6 +285,8 @@ Add a new step to a flow. Optionally configure it in the same call by providing 
 | `sourceCode` | string | No | For CODE steps: JavaScript/TypeScript source |
 | `packageJson` | string | No | For CODE steps: npm dependencies |
 | `loopItems` | string | No | For LOOP steps: items expression |
+| `continueOnFailure` | boolean | No | For CODE/PIECE steps: continue flow if this step fails (default: false) |
+| `retryOnFailure` | boolean | No | For CODE/PIECE steps: retry this step on failure (default: false) |
 
 ### ap_update_step
 
@@ -291,6 +304,8 @@ Update an existing step's settings. Auto-fills default values for optional prope
 | `sourceCode` | string | No | For CODE steps: JavaScript/TypeScript source code |
 | `packageJson` | string | No | For CODE steps: npm dependencies as JSON string |
 | `skip` | boolean | No | Skip this step |
+| `continueOnFailure` | boolean | No | For CODE/PIECE steps: continue flow if this step fails |
+| `retryOnFailure` | boolean | No | For CODE/PIECE steps: retry this step on failure |
 
 <Tip>
 Use `{{stepName.field}}` syntax in input values to reference data from previous steps (e.g., `{{trigger.body.email}}`, `{{step_1.id}}`). Do NOT include `.output.` in the path.
@@ -488,7 +503,6 @@ Execute a single piece action once without building or saving a flow. Designed f
 | `actionName` | string | Yes | Action to run (e.g. `send_channel_message`). Use `ap_get_piece_props` for the input shape. |
 | `input` | object | No | Fully-resolved input for the action. Keys must match the piece action's props. Pass raw values — do **not** wrap them in `{{…}}`. Omit entirely if the action has no props. |
 | `connectionExternalId` | string | No | `externalId` from `ap_list_connections`. Required if the piece needs auth. Auto-wrapped server-side as `{{connections['externalId']}}`. Must be a plain ID — special characters are rejected. |
-| `pieceVersion` | string | No | Defaults to the latest installed version. Use `~X.Y.Z` to pin the minor version. |
 
 <Info>
 When to pick this vs. `ap_build_flow`:

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -26,13 +26,14 @@ const addStepInput = z.object({
     stepType: z.enum([FlowActionType.CODE, FlowActionType.PIECE, FlowActionType.LOOP_ON_ITEMS, FlowActionType.ROUTER]),
     displayName: z.string(),
     pieceName: z.string().optional(),
-    pieceVersion: z.string().optional(),
     actionName: z.string().optional(),
     input: z.record(z.string(), z.unknown()).optional(),
     auth: z.string().optional(),
     sourceCode: z.string().optional(),
     packageJson: z.string().optional(),
     loopItems: z.string().optional(),
+    continueOnFailure: z.boolean().optional(),
+    retryOnFailure: z.boolean().optional(),
 })
 
 export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger): McpToolDefinition => {
@@ -48,17 +49,18 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
             stepType: z.enum([FlowActionType.CODE, FlowActionType.PIECE, FlowActionType.LOOP_ON_ITEMS, FlowActionType.ROUTER]).describe('The type of step to add. Prefer PIECE over CODE — only use CODE when no piece exists for the task.'),
             displayName: z.string().describe('Display name for the step'),
             pieceName: z.string().optional().describe('For PIECE steps: the piece name (e.g. "@activepieces/piece-gmail"). Use ap_list_pieces to get valid values.'),
-            pieceVersion: z.string().optional().describe('For PIECE steps: the piece version (e.g. "~0.1.0"). Use ap_list_pieces to get valid values.'),
             actionName: z.string().optional().describe('For PIECE steps: the action name within the piece. Use ap_list_pieces with includeActions=true to get valid values.'),
             input: z.record(z.string(), z.unknown()).optional().describe(`For PIECE/CODE steps: input config (key-value pairs). ${mcpUtils.STEP_REFERENCE_HINT}`),
             auth: z.string().optional().describe('Connection externalId from ap_list_connections. Auto-wrapped as {{connections[\'externalId\']}}.'),
             sourceCode: z.string().optional().describe('For CODE steps: JavaScript/TypeScript source. Must export a `code` function.'),
             packageJson: z.string().optional().describe('For CODE steps: package.json as JSON string. Defaults to "{}".'),
             loopItems: z.string().optional().describe('For LOOP steps: expression for items to iterate (e.g. "{{step_1.items}}").'),
+            continueOnFailure: z.boolean().optional().describe('For CODE/PIECE steps: whether to continue the flow if this step fails. Defaults to false.'),
+            retryOnFailure: z.boolean().optional().describe('For CODE/PIECE steps: whether to retry this step on failure. Defaults to false.'),
         },
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
-            const { flowId, parentStepName, stepLocationRelativeToParent, branchIndex, stepType, displayName, pieceName, pieceVersion, actionName, input, auth, sourceCode, packageJson, loopItems } = addStepInput.parse(args)
+            const { flowId, parentStepName, stepLocationRelativeToParent, branchIndex, stepType, displayName, pieceName, actionName, input, auth, sourceCode, packageJson, loopItems, continueOnFailure, retryOnFailure } = addStepInput.parse(args)
 
             const [flow, project] = await Promise.all([
                 flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
@@ -94,26 +96,30 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
                                 packageJson: packageJson ?? '{}',
                             },
                             input: resolvedInput,
-                            errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
+                            errorHandlingOptions: mcpUtils.buildErrorHandlingOptions({ continueOnFailure, retryOnFailure }),
                         },
                     }
                     break
                 case FlowActionType.PIECE: {
-                    if (!pieceName || !pieceVersion) {
+                    if (!pieceName) {
                         return {
                             content: [{
                                 type: 'text',
-                                text: '❌ pieceName and pieceVersion are required for PIECE steps. Use ap_list_pieces to get valid values.',
+                                text: '❌ pieceName is required for PIECE steps. Use ap_list_pieces to get valid values.',
                             }],
                         }
                     }
+                    const versionResult = await mcpUtils.resolveLatestPieceVersion({ pieceName, projectId: mcp.projectId, platformId: project.platformId, log })
+                    if (versionResult.error) {
+                        return versionResult.error
+                    }
                     const pieceSettings: Record<string, unknown> = {
-                        pieceName,
-                        pieceVersion,
+                        pieceName: versionResult.normalizedPieceName,
+                        pieceVersion: versionResult.pieceVersion,
                         actionName: actionName ?? '',
                         input: resolvedInput,
                         propertySettings: {},
-                        errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
+                        errorHandlingOptions: mcpUtils.buildErrorHandlingOptions({ continueOnFailure, retryOnFailure }),
                     }
                     if (input !== undefined) {
                         await mcpUtils.fillDefaultsForMissingOptionalProps({ settings: pieceSettings, platformId: project.platformId, log })

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -22,20 +22,20 @@ const stepSpec = z.object({
     type: z.enum([FlowActionType.CODE, FlowActionType.PIECE, FlowActionType.LOOP_ON_ITEMS, FlowActionType.ROUTER]),
     displayName: z.string(),
     pieceName: z.string().optional(),
-    pieceVersion: z.string().optional(),
     actionName: z.string().optional(),
     input: z.record(z.string(), z.unknown()).optional(),
     auth: z.string().optional(),
     sourceCode: z.string().optional(),
     packageJson: z.string().optional(),
     loopItems: z.string().optional(),
+    continueOnFailure: z.boolean().optional(),
+    retryOnFailure: z.boolean().optional(),
 })
 
 const buildFlowInput = z.object({
     flowName: z.string(),
     trigger: z.object({
         pieceName: z.string(),
-        pieceVersion: z.string(),
         triggerName: z.string(),
         input: z.record(z.string(), z.unknown()).optional(),
         auth: z.string().optional(),
@@ -52,7 +52,6 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
             flowName: z.string().describe('Name for the new flow'),
             trigger: z.object({
                 pieceName: z.string().describe('Trigger piece name (e.g. "@activepieces/piece-webhook")'),
-                pieceVersion: z.string().describe('Piece version (e.g. "~0.1.32")'),
                 triggerName: z.string().describe('Trigger name (e.g. "catch_webhook")'),
                 input: z.record(z.string(), z.unknown()).optional().describe('Trigger input config'),
                 auth: z.string().optional().describe('Connection externalId for trigger auth'),
@@ -65,9 +64,6 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
             const projectId = mcp.projectId
             try {
                 const { flowName, trigger, steps } = buildFlowInput.parse(args)
-                const project = await projectService(log).getOneOrThrow(projectId)
-                const platformId = project.platformId
-
                 const triggerAuthError = mcpUtils.validateAuth(trigger.auth)
                 if (triggerAuthError) {
                     return triggerAuthError
@@ -79,11 +75,18 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                     }
                 }
 
-                const flow = await flowService(log).create({
-                    projectId,
-                    request: { displayName: flowName, projectId },
-                })
+                const [project, flow] = await Promise.all([
+                    projectService(log).getOneOrThrow(projectId),
+                    flowService(log).create({ projectId, request: { displayName: flowName, projectId } }),
+                ])
+                const platformId = project.platformId
                 flowId = flow.id
+
+                const triggerVersionResult = await mcpUtils.resolveLatestPieceVersion({ pieceName: trigger.pieceName, projectId, platformId, log })
+                if (triggerVersionResult.error) {
+                    await flowService(log).delete({ id: flowId, projectId }).catch(() => undefined)
+                    return triggerVersionResult.error
+                }
 
                 const triggerInput = {
                     ...(trigger.input ?? {}),
@@ -96,8 +99,8 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                     lastUpdatedDate: new Date().toISOString(),
                     type: FlowTriggerType.PIECE,
                     settings: {
-                        pieceName: trigger.pieceName,
-                        pieceVersion: trigger.pieceVersion,
+                        pieceName: triggerVersionResult.normalizedPieceName,
+                        pieceVersion: triggerVersionResult.pieceVersion,
                         triggerName: trigger.triggerName,
                         input: triggerInput,
                         propertySettings: {},
@@ -115,7 +118,19 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                     const allSteps = flowStructureUtil.getAllSteps(latestTrigger)
                     const lastStep = allSteps[allSteps.length - 1]
 
-                    const skeleton = buildSkeleton({ step, name: stepName })
+                    let resolvedPieceVersion: string | undefined
+                    let resolvedPieceName: string | undefined
+                    if (step.type === FlowActionType.PIECE && step.pieceName) {
+                        const versionResult = await mcpUtils.resolveLatestPieceVersion({ pieceName: step.pieceName, projectId, platformId, log })
+                        if (versionResult.error) {
+                            skippedSteps.push(step.displayName)
+                            continue
+                        }
+                        resolvedPieceVersion = versionResult.pieceVersion
+                        resolvedPieceName = versionResult.normalizedPieceName
+                    }
+
+                    const skeleton = buildSkeleton({ step, name: stepName, resolvedPieceVersion, resolvedPieceName })
                     const parseResult = UpdateActionRequest.safeParse(skeleton)
                     if (!parseResult.success) {
                         skippedSteps.push(step.displayName)
@@ -164,9 +179,11 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
     }
 }
 
-function buildSkeleton({ step, name }: {
+function buildSkeleton({ step, name, resolvedPieceVersion, resolvedPieceName }: {
     step: z.infer<typeof stepSpec>
     name: string
+    resolvedPieceVersion?: string
+    resolvedPieceName?: string
 }): Record<string, unknown> {
     const resolvedInput = {
         ...(step.input ?? {}),
@@ -186,7 +203,7 @@ function buildSkeleton({ step, name }: {
                         packageJson: step.packageJson ?? '{}',
                     },
                     input: step.input ?? {},
-                    errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
+                    errorHandlingOptions: mcpUtils.buildErrorHandlingOptions({ continueOnFailure: step.continueOnFailure, retryOnFailure: step.retryOnFailure }),
                 },
             }
         case FlowActionType.PIECE:
@@ -196,12 +213,12 @@ function buildSkeleton({ step, name }: {
                 displayName: step.displayName,
                 valid: false,
                 settings: {
-                    pieceName: step.pieceName ?? '',
-                    pieceVersion: step.pieceVersion ?? '',
+                    pieceName: resolvedPieceName ?? step.pieceName ?? '',
+                    pieceVersion: resolvedPieceVersion ?? '',
                     actionName: step.actionName ?? '',
                     input: resolvedInput,
                     propertySettings: {},
-                    errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
+                    errorHandlingOptions: mcpUtils.buildErrorHandlingOptions({ continueOnFailure: step.continueOnFailure, retryOnFailure: step.retryOnFailure }),
                 },
             }
         case FlowActionType.LOOP_ON_ITEMS:

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -84,7 +84,9 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
 
                 const triggerVersionResult = await mcpUtils.resolveLatestPieceVersion({ pieceName: trigger.pieceName, projectId, platformId, log })
                 if (triggerVersionResult.error) {
-                    await flowService(log).delete({ id: flowId, projectId }).catch(() => undefined)
+                    await flowService(log).delete({ id: flowId, projectId }).catch((deleteErr) => {
+                        log.warn({ err: deleteErr, flowId }, 'Failed to clean up orphaned flow after trigger version resolution error')
+                    })
                     return triggerVersionResult.error
                 }
 
@@ -120,7 +122,11 @@ export const apBuildFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
 
                     let resolvedPieceVersion: string | undefined
                     let resolvedPieceName: string | undefined
-                    if (step.type === FlowActionType.PIECE && step.pieceName) {
+                    if (step.type === FlowActionType.PIECE) {
+                        if (!step.pieceName) {
+                            skippedSteps.push(step.displayName)
+                            continue
+                        }
                         const versionResult = await mcpUtils.resolveLatestPieceVersion({ pieceName: step.pieceName, projectId, platformId, log })
                         if (versionResult.error) {
                             skippedSteps.push(step.displayName)

--- a/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-pieces.ts
@@ -58,7 +58,6 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                     const capped = pieces.slice(0, LIST_CAP).map(p => ({
                         name: p.name,
                         displayName: p.displayName,
-                        version: p.version,
                         description: p.description,
                         actions: p.actions,
                         triggers: p.triggers,
@@ -67,7 +66,7 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                     return {
                         content: [{ type: 'text', text: `✅ Successfully listed pieces${hint}:\n${JSON.stringify(capped)}` }],
                         structuredContent: {
-                            pieces: capped.map(p => ({ name: p.name, displayName: p.displayName, version: p.version, description: p.description })),
+                            pieces: capped.map(p => ({ name: p.name, displayName: p.displayName, description: p.description })),
                             count: capped.length,
                             totalCount,
                         },
@@ -81,7 +80,6 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                     const base: Record<string, unknown> = {
                         name: piece.name,
                         displayName: piece.displayName,
-                        version: piece.version,
                         description: piece.description,
                     }
                     const fullPiece = await pieceMetadataService(log).get({
@@ -120,7 +118,6 @@ export const apListPiecesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                         pieces: enrichedPieces.map(p => ({
                             name: String(p.name),
                             displayName: String(p.displayName),
-                            version: String(p.version),
                             description: String(p.description),
                         })),
                         count: enrichedPieces.length,

--- a/packages/server/api/src/app/mcp/tools/ap-read-step-code.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-read-step-code.ts
@@ -1,0 +1,66 @@
+import {
+    FlowActionType,
+    flowStructureUtil,
+    isNil,
+    McpToolDefinition,
+    Permission,
+    ProjectScopedMcpServer,
+} from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { flowService } from '../../flows/flow/flow.service'
+import { mcpUtils } from './mcp-utils'
+
+const readStepCodeInput = z.object({
+    flowId: z.string(),
+    stepName: z.string(),
+})
+
+export const apReadStepCodeTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_read_step_code',
+        permission: Permission.READ_FLOW,
+        description: 'Read the full source code, package.json, and input of a CODE step. Returns untruncated content (unlike ap_flow_structure which truncates).',
+        inputSchema: {
+            flowId: z.string().describe('The id of the flow'),
+            stepName: z.string().describe('The name of the CODE step (e.g. "step_1"). Use ap_flow_structure to get valid values.'),
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        execute: async (args) => {
+            try {
+                const { flowId, stepName } = readStepCodeInput.parse(args)
+
+                const flow = await flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId })
+                if (isNil(flow)) {
+                    return { content: [{ type: 'text', text: '❌ Flow not found' }] }
+                }
+
+                const step = flowStructureUtil.getStep(stepName, flow.version.trigger)
+                if (isNil(step)) {
+                    const allSteps = flowStructureUtil.getAllSteps(flow.version.trigger).map(s => s.name).join(', ')
+                    return { content: [{ type: 'text', text: `❌ Step "${stepName}" not found. Available steps: ${allSteps}` }] }
+                }
+
+                if (step.type !== FlowActionType.CODE) {
+                    return { content: [{ type: 'text', text: `❌ Step "${stepName}" is type ${step.type}, not CODE. This tool only works with CODE steps.` }] }
+                }
+
+                const settings = step.settings as { sourceCode?: { code?: string, packageJson?: string }, input?: Record<string, unknown> }
+                const code = settings.sourceCode?.code ?? ''
+                const packageJson = settings.sourceCode?.packageJson ?? '{}'
+                const input = settings.input ?? {}
+
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `Source code for step "${stepName}":\n\n### Source Code\n\`\`\`typescript\n${code}\n\`\`\`\n\n### package.json\n\`\`\`json\n${packageJson}\n\`\`\`\n\n### Input\n${JSON.stringify(input, null, 2)}`,
+                    }],
+                    structuredContent: { stepName, code, packageJson, input },
+                }
+            }
+            catch (err) {
+                return mcpUtils.mcpToolError('Failed to read step code', err)
+            }
+        },
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/ap-run-action.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-run-action.ts
@@ -9,7 +9,6 @@ const runActionInput = z.object({
     actionName: z.string().describe('Action to run, e.g. "send_channel_message". Use ap_get_piece_props for the input shape.'),
     input: z.record(z.string(), z.unknown()).optional().describe('Fully-resolved input for the action. Keys must match the piece action\'s props. Pass raw values — do NOT wrap in {{...}}. Omit if the action has no props.'),
     connectionExternalId: z.string().optional().describe('externalId from ap_list_connections. Required if the piece needs auth. Auto-wrapped as {{connections[\'externalId\']}}.'),
-    pieceVersion: z.string().optional().describe('Defaults to the latest installed version. Use "~X.Y.Z" for minor-version pinning.'),
 })
 
 export const apRunActionTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger): McpToolDefinition => {
@@ -21,11 +20,10 @@ export const apRunActionTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
         annotations: { destructiveHint: true, idempotentHint: false, openWorldHint: true },
         execute: async (args) => {
             try {
-                const { pieceName, actionName, input, connectionExternalId, pieceVersion } = runActionInput.parse(args)
+                const { pieceName, actionName, input, connectionExternalId } = runActionInput.parse(args)
                 return await executeAdhocAction({
                     projectId: mcp.projectId,
                     pieceName,
-                    pieceVersion,
                     actionName,
                     input,
                     connectionExternalId,

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -28,6 +28,8 @@ const updateStepInput = z.object({
     skip: z.boolean().optional(),
     sourceCode: z.string().optional(),
     packageJson: z.string().optional(),
+    continueOnFailure: z.boolean().optional(),
+    retryOnFailure: z.boolean().optional(),
 })
 
 export const apUpdateStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger): McpToolDefinition => {
@@ -46,10 +48,12 @@ export const apUpdateStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
             skip: z.boolean().optional().describe('Whether to skip this step during execution'),
             sourceCode: z.string().optional().describe('For CODE steps only: the JavaScript/TypeScript source code. Must export a `code` function: `export const code = async (inputs) => { ... }`.'),
             packageJson: z.string().optional().describe('For CODE steps only: package.json content as a JSON string for npm dependencies. Defaults to "{}".'),
+            continueOnFailure: z.boolean().optional().describe('For CODE/PIECE steps: whether to continue the flow if this step fails.'),
+            retryOnFailure: z.boolean().optional().describe('For CODE/PIECE steps: whether to retry this step on failure.'),
         },
         annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
-            const { flowId, stepName, displayName, input, auth, actionName, loopItems, skip, sourceCode, packageJson } = updateStepInput.parse(args)
+            const { flowId, stepName, displayName, input, auth, actionName, loopItems, skip, sourceCode, packageJson, continueOnFailure, retryOnFailure } = updateStepInput.parse(args)
 
             const [flow, project] = await Promise.all([
                 flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
@@ -117,6 +121,17 @@ export const apUpdateStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                     code: sourceCode ?? existingCode,
                     packageJson: packageJson ?? existingPkg,
                 }
+            }
+
+            if (continueOnFailure !== undefined || retryOnFailure !== undefined) {
+                if (step.type !== FlowActionType.CODE && step.type !== FlowActionType.PIECE) {
+                    return { content: [{ type: 'text', text: `❌ continueOnFailure/retryOnFailure can only be set on CODE or PIECE steps, but "${stepName}" is type ${step.type}.` }] }
+                }
+                const currentErrorHandling = (currentSettings.errorHandlingOptions as { continueOnFailure?: { value?: boolean }, retryOnFailure?: { value?: boolean } }) ?? {}
+                updatedSettings.errorHandlingOptions = mcpUtils.buildErrorHandlingOptions({
+                    continueOnFailure: continueOnFailure ?? currentErrorHandling.continueOnFailure?.value,
+                    retryOnFailure: retryOnFailure ?? currentErrorHandling.retryOnFailure?.value,
+                })
             }
 
             if (step.type === FlowActionType.PIECE && input !== undefined) {

--- a/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
@@ -18,7 +18,6 @@ import { mcpUtils } from './mcp-utils'
 const updateTriggerInput = z.object({
     flowId: z.string(),
     pieceName: z.string(),
-    pieceVersion: z.string(),
     triggerName: z.string(),
     input: z.record(z.string(), z.unknown()).optional(),
     auth: z.string().optional(),
@@ -33,7 +32,6 @@ export const apUpdateTriggerTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             pieceName: z.string().describe('The piece name for the trigger (e.g. "@activepieces/piece-gmail"). Use ap_list_pieces to get valid values.'),
-            pieceVersion: z.string().describe('The piece version (e.g. "~0.1.0"). Use ap_list_pieces to get valid values.'),
             triggerName: z.string().describe('The trigger name within the piece (e.g. "new_email"). Use ap_list_pieces with includeTriggers=true to get valid values.'),
             input: z.record(z.string(), z.unknown()).optional().describe(`Input settings for the trigger (key-value pairs). ${mcpUtils.STEP_REFERENCE_HINT}`),
             auth: z.string().optional().describe('Connection `externalId` from `ap_list_connections`. The tool wraps it automatically as `{{connections[\'externalId\']}}`.'),
@@ -41,7 +39,7 @@ export const apUpdateTriggerTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
         },
         annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
-            const { flowId, pieceName, pieceVersion, triggerName, input: rawInput, auth, displayName: rawDisplayName } = updateTriggerInput.parse(args)
+            const { flowId, pieceName, triggerName, input: rawInput, auth, displayName: rawDisplayName } = updateTriggerInput.parse(args)
 
             const authError = mcpUtils.validateAuth(auth)
             if (authError) {
@@ -58,9 +56,16 @@ export const apUpdateTriggerTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                 return { content: [{ type: 'text', text: '❌ Flow not found' }] }
             }
 
+            const versionResult = await mcpUtils.resolveLatestPieceVersion({ pieceName, projectId: mcp.projectId, platformId: project.platformId, log })
+            if (versionResult.error) {
+                return versionResult.error
+            }
+            const pieceVersion = versionResult.pieceVersion
+            const resolvedPieceName = versionResult.normalizedPieceName
+
             const existingTrigger = flow.version.trigger
             const existingPieceSettings = existingTrigger.type === FlowTriggerType.PIECE
-                && existingTrigger.settings.pieceName === pieceName
+                && existingTrigger.settings.pieceName === resolvedPieceName
                 && existingTrigger.settings.triggerName === triggerName
                 ? existingTrigger.settings
                 : null
@@ -79,7 +84,7 @@ export const apUpdateTriggerTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                 lastUpdatedDate: new Date().toISOString(),
                 type: FlowTriggerType.PIECE,
                 settings: {
-                    pieceName,
+                    pieceName: resolvedPieceName,
                     pieceVersion,
                     triggerName,
                     input,
@@ -111,7 +116,7 @@ export const apUpdateTriggerTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                 const trigger = updatedFlow.version.trigger
                 const draftWarning = mcpUtils.publishedFlowWarning(flow.publishedVersionId)
                 if (!trigger.valid) {
-                    const diagnosis = await diagnoseMissingTriggerInputs({ pieceName, pieceVersion, triggerName, input, platformId: project.platformId, log })
+                    const diagnosis = await diagnoseMissingTriggerInputs({ pieceName: resolvedPieceName, pieceVersion, triggerName, input, platformId: project.platformId, log })
                     const hint = diagnosis ?? 'Check that triggerName is correct and all required inputs are provided. Use ap_list_connections to get a valid connection externalId for auth.'
                     return {
                         content: [{
@@ -121,7 +126,7 @@ export const apUpdateTriggerTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                     }
                 }
                 return {
-                    content: [{ type: 'text', text: `✅ Successfully updated trigger to "${pieceName}/${triggerName}".${draftWarning}` }],
+                    content: [{ type: 'text', text: `✅ Successfully updated trigger to "${resolvedPieceName}/${triggerName}".${draftWarning}` }],
                 }
             }
             catch (err) {

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -197,7 +197,7 @@ export async function executeAdhocAction({
             actionName: action.name,
             input: resolvedInput,
             propertySettings: {},
-            errorHandlingOptions: { continueOnFailure: { value: false }, retryOnFailure: { value: false } },
+            errorHandlingOptions: mcpUtils.buildErrorHandlingOptions({}),
         }
         await mcpUtils.fillDefaultsForMissingOptionalProps({ settings: pieceSettings, platformId: project.platformId, log })
 
@@ -300,7 +300,7 @@ function formatAdhocActionResult(run: FlowRun, stepName: string, displayName: st
         const outStr = output === undefined
             ? '(no output)'
             : typeof output === 'string' ? output : JSON.stringify(output)
-        const base = `✅ ${displayName} completed (run ${run.id}).\n\n${mcpUtils.truncate(outStr, 4000)}`
+        const base = `✅ ${displayName} completed (run ${run.id}).\n\n${outStr}`
         if (looksEmpty(output)) {
             return `${base}\n\nNote: No results matched. If the user expected data, try broader parameters (e.g., wider date range, fewer filters).`
         }
@@ -309,7 +309,7 @@ function formatAdhocActionResult(run: FlowRun, stepName: string, displayName: st
     const errStr = errorMessage === undefined
         ? `status: ${String(status)}`
         : typeof errorMessage === 'string' ? errorMessage : JSON.stringify(errorMessage)
-    return `❌ ${displayName} failed (run ${run.id}): ${mcpUtils.truncate(errStr, 2000)}\n\nRetry suggestion: Check the error above. If it mentions missing criteria, try adding a broad filter (e.g., after_date with a recent date, or a common search term). If it mentions auth, verify the connection.`
+    return `❌ ${displayName} failed (run ${run.id}): ${errStr}\n\nRetry suggestion: Check the error above. If it mentions missing criteria, try adding a broad filter (e.g., after_date with a recent date, or a common search term). If it mentions auth, verify the connection.`
 }
 
 export async function pollForRunCompletion(log: FastifyBaseLogger, runId: string, projectId: string): Promise<FlowRun> {
@@ -388,11 +388,11 @@ function formatStepOutput(name: string, step: unknown): string {
 
     if (status === StepOutputStatus.FAILED && errorMessage !== undefined) {
         const errStr = typeof errorMessage === 'string' ? errorMessage : JSON.stringify(errorMessage)
-        parts.push(`    Error: ${mcpUtils.truncate(errStr, 300)}`)
+        parts.push(`    Error: ${errStr}`)
     }
     else if (output !== undefined) {
         const outStr = typeof output === 'string' ? output : JSON.stringify(output)
-        parts.push(`    Output: ${mcpUtils.truncate(outStr, 500)}`)
+        parts.push(`    Output: ${outStr}`)
     }
 
     return parts.join('\n')

--- a/packages/server/api/src/app/mcp/tools/index.ts
+++ b/packages/server/api/src/app/mcp/tools/index.ts
@@ -26,6 +26,7 @@ import { apListTablesTool } from './ap-list-tables'
 import { apLockAndPublishTool } from './ap-lock-and-publish'
 import { apManageFieldsTool } from './ap-manage-fields'
 import { apManageNotesTool } from './ap-manage-notes'
+import { apReadStepCodeTool } from './ap-read-step-code'
 import { apRenameFlowTool } from './ap-rename-flow'
 import { apResolvePropertyOptionsTool } from './ap-resolve-property-options'
 import { apRetryRunTool } from './ap-retry-run'
@@ -43,6 +44,7 @@ import { apValidateStepConfigTool } from './ap-validate-step-config'
 export const LOCKED_TOOL_NAMES: string[] = [
     'ap_list_flows',
     'ap_flow_structure',
+    'ap_read_step_code',
     'ap_validate_flow',
     'ap_list_pieces',
     'ap_get_piece_props',
@@ -95,6 +97,7 @@ export const activepiecesTools = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
     apRenameFlowTool(mcp, log),
     apListFlowsTool(mcp, log),
     apFlowStructureTool(mcp, log),
+    apReadStepCodeTool(mcp, log),
     apValidateFlowTool(mcp, log),
     apListPiecesTool(mcp, log),
     apGetPiecePropsTool(mcp, log),

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -295,6 +295,33 @@ async function fillDefaultsForMissingOptionalProps({ settings, platformId, log }
     }
 }
 
+function buildErrorHandlingOptions({ continueOnFailure, retryOnFailure }: {
+    continueOnFailure?: boolean
+    retryOnFailure?: boolean
+}): { continueOnFailure: { value: boolean }, retryOnFailure: { value: boolean } } {
+    return {
+        continueOnFailure: { value: continueOnFailure ?? false },
+        retryOnFailure: { value: retryOnFailure ?? false },
+    }
+}
+
+async function resolveLatestPieceVersion({ pieceName, projectId, platformId, log }: {
+    pieceName: string
+    projectId: string
+    platformId: string
+    log: FastifyBaseLogger
+}): Promise<ResolveLatestPieceVersionResult> {
+    const normalized = normalizePieceName(pieceName)
+    if (isNil(normalized)) {
+        return { error: mcpToolError('Validation failed', new Error('pieceName is required')) }
+    }
+    const piece = await pieceMetadataService(log).get({ name: normalized, projectId, platformId })
+    if (isNil(piece)) {
+        return { error: { content: [{ type: 'text', text: `❌ Piece "${normalized}" not found. Use ap_list_pieces to get valid piece names.` }] } }
+    }
+    return { pieceVersion: `~${piece.version}`, normalizedPieceName: normalized }
+}
+
 function withTimeout<T>({ promise, ms }: { promise: Promise<T>, ms: number }): Promise<T> {
     let timer: ReturnType<typeof setTimeout>
     return Promise.race([
@@ -318,6 +345,8 @@ export const mcpUtils = {
     findResolvableProps,
     validateAuth,
     fillDefaultsForMissingOptionalProps,
+    buildErrorHandlingOptions,
+    resolveLatestPieceVersion,
     withTimeout,
     STEP_REFERENCE_HINT,
     BRANCH_CONDITIONS_INPUT_SCHEMA,
@@ -375,3 +404,7 @@ type LookupPieceComponentResult =
 type ResolveRouterStepResult =
     | { routerStep: RouterAction, error?: never }
     | { error: McpToolResult, routerStep?: never }
+
+type ResolveLatestPieceVersionResult =
+    | { pieceVersion: string, normalizedPieceName: string, error?: never }
+    | { error: McpToolResult, pieceVersion?: never, normalizedPieceName?: never }

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -32,7 +32,7 @@ Hard rules — follow these in every response, no exceptions:
 </project_scope>
 
 <tool_risk_levels>
-- **Read-only** (ap_list_flows, ap_list_connections, ap_find_records, ap_flow_structure, ap_list_runs, ap_get_run, ap_resolve_property_options): Use freely.
+- **Read-only** (ap_list_flows, ap_list_connections, ap_find_records, ap_flow_structure, ap_read_step_code, ap_list_runs, ap_get_run, ap_resolve_property_options): Use freely.
 - **Cross-project** (ap_list_across_projects): Use when the user asks about resources across projects.
 - **Write** (ap_create_flow, ap_add_step, ap_update_trigger, ap_insert_records, ap_manage_fields): Only after user approval.
 - **Destructive** (ap_delete_flow, ap_delete_step, ap_delete_table, ap_delete_records, ap_change_flow_status): System prompts user for approval automatically — just call the tool.

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -231,7 +231,6 @@ describe('MCP Tools integration', () => {
             stepType: FlowActionType.PIECE,
             displayName: 'Send Email',
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
         })
 
         expect(text(result)).toContain('✅')
@@ -254,7 +253,6 @@ describe('MCP Tools integration', () => {
             stepType: FlowActionType.PIECE,
             displayName: 'Send Email',
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
         })
 
         // Update the step: set skip=true. The step is still invalid (no actionName configured)
@@ -479,7 +477,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -514,7 +511,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -525,7 +521,6 @@ describe('MCP Tools integration', () => {
             stepType: FlowActionType.PIECE,
             displayName: 'Unconfigured Piece',
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
         })
 
         const result = await apValidateFlowTool(mcp, mockLog).execute({ flowId })
@@ -545,7 +540,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -703,7 +697,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -739,7 +732,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -749,7 +741,6 @@ describe('MCP Tools integration', () => {
         const renameResult = await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
             displayName: 'Renamed Trigger',
         })
@@ -768,7 +759,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
             input: { customField: 'should-be-discarded' },
         })
@@ -776,7 +766,6 @@ describe('MCP Tools integration', () => {
         const switchResult = await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_attachment',
         })
         expect(text(switchResult)).toContain('✅')
@@ -794,14 +783,12 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
         const addFieldResult = await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
             input: { extraField: 'value' },
         })
@@ -864,7 +851,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -896,7 +882,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -957,7 +942,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1041,7 +1025,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1123,7 +1106,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1131,7 +1113,6 @@ describe('MCP Tools integration', () => {
             await apUpdateTriggerTool(mcp, mockLog).execute({
                 flowId,
                 pieceName: '@activepieces/piece-test-email',
-                pieceVersion: '~0.1.0',
                 triggerName: 'new_email',
                 displayName: `Attempt ${i + 1}`,
             })
@@ -1155,7 +1136,6 @@ describe('MCP Tools integration', () => {
             flowName: 'Build Test 1',
             trigger: {
                 pieceName: '@activepieces/piece-test-email',
-                pieceVersion: '~0.1.0',
                 triggerName: 'new_email',
             },
             steps: [
@@ -1181,7 +1161,6 @@ describe('MCP Tools integration', () => {
             flowName: 'Build Test 2',
             trigger: {
                 pieceName: '@activepieces/piece-test-email',
-                pieceVersion: '~0.1.0',
                 triggerName: 'new_email',
             },
             steps: [
@@ -1229,7 +1208,6 @@ describe('MCP Tools integration', () => {
             flowName: 'Build Test Partial',
             trigger: {
                 pieceName: '@activepieces/piece-test-email',
-                pieceVersion: '~0.1.0',
                 triggerName: 'new_email',
             },
             steps: [
@@ -1243,7 +1221,6 @@ describe('MCP Tools integration', () => {
                     type: FlowActionType.PIECE,
                     displayName: 'Invalid Piece',
                     pieceName: '@activepieces/piece-test-email',
-                    pieceVersion: '~0.1.0',
                 },
             ],
         })
@@ -1261,7 +1238,6 @@ describe('MCP Tools integration', () => {
             flowName: 'Build Test Empty',
             trigger: {
                 pieceName: '@activepieces/piece-test-email',
-                pieceVersion: '~0.1.0',
                 triggerName: 'new_email',
             },
             steps: [],
@@ -1279,7 +1255,6 @@ describe('MCP Tools integration', () => {
             flowName: 'Build Test Lifecycle',
             trigger: {
                 pieceName: '@activepieces/piece-test-email',
-                pieceVersion: '~0.1.0',
                 triggerName: 'new_email',
             },
             steps: [
@@ -1311,7 +1286,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1347,7 +1321,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1379,7 +1352,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1422,7 +1394,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1490,7 +1461,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1512,7 +1482,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1562,7 +1531,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1605,7 +1573,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1639,7 +1606,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1671,7 +1637,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1702,7 +1667,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1733,7 +1697,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1764,7 +1727,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1794,7 +1756,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1853,7 +1814,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 
@@ -1994,7 +1954,6 @@ describe('MCP Tools integration', () => {
         await apUpdateTriggerTool(mcp, mockLog).execute({
             flowId,
             pieceName: '@activepieces/piece-test-email',
-            pieceVersion: '~0.1.0',
             triggerName: 'new_email',
         })
 

--- a/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
+++ b/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
@@ -23,6 +23,11 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
           'Get the structure of a flow: step tree, configuration status, and valid insert locations',
       },
       {
+        name: 'ap_read_step_code',
+        description:
+          'Read full source code, package.json, and input of a CODE step',
+      },
+      {
         name: 'ap_validate_flow',
         description:
           'Validate a flow for structural issues without publishing — checks step validity, template references, and empty branches',


### PR DESCRIPTION
## Summary
- **Auto-resolve latest piece version**: Removed `pieceVersion` from `ap_add_step`, `ap_build_flow`, `ap_update_trigger`, `ap_run_action` schemas and `ap_list_pieces` response. Server now auto-resolves the latest version as a tilde range (`~X.Y.Z`), preventing Claude from using old/buggy versions (e.g. subflow at 0.1.0).
- **New `ap_read_step_code` tool**: Returns full untruncated source code, package.json, and input mappings for CODE steps — `ap_flow_structure` truncates code to 300 chars, so this gives Claude full access when editing code steps.
- **Error handling via MCP**: Added `continueOnFailure` and `retryOnFailure` optional boolean params to `ap_add_step`, `ap_update_step`, and `ap_build_flow` (per-step). Previously hardcoded to `false` with no way to change via MCP.
- **Remove output truncation**: Removed 4000/2000/500/300 char truncation limits from action results and run outputs so the LLM sees full data (e.g. all 5 Gmail emails instead of 1).

## Test plan
- [x] Verify `ap_list_pieces` no longer returns `version` field
- [x] Verify `ap_add_step` with PIECE type resolves latest version without `pieceVersion` param
- [x] Verify `ap_build_flow` creates flows with latest piece versions (trigger + steps)
- [x] Verify `ap_update_trigger` works without `pieceVersion`
- [x] Verify `ap_read_step_code` returns full untruncated code for CODE steps
- [x] Verify `ap_read_step_code` rejects non-CODE steps with clear error
- [x] Verify `continueOnFailure`/`retryOnFailure` work on `ap_add_step` and `ap_build_flow`
- [x] Verify `ap_update_step` can toggle error handling on existing steps
- [x] Verify error handling rejected on LOOP/ROUTER step types
- [x] Verify full action output returned (no truncation) when running actions via chat