### PR TITLE
feat(api): expose single user read endpoint

### DIFF
--- a/packages/server/api/src/app/ee/users/users-controller.ts
+++ b/packages/server/api/src/app/ee/users/users-controller.ts
@@ -6,6 +6,7 @@ import {
     isNil,
     PrincipalType,
     PROFILE_PICTURE_ALLOWED_TYPES,
+    SERVICE_KEY_SECURITY_OPENAPI,
     UpdateMeResponse,
     UserWithBadges,
 } from '@activepieces/shared'
@@ -60,6 +61,9 @@ export const usersController: FastifyPluginAsyncZod = async (app) => {
 
 const GetUserByIdRequest = {
     schema: {
+        tags: ['users'],
+        description: 'Get a user by id',
+        security: [SERVICE_KEY_SECURITY_OPENAPI],
         params: z.object({
             id: ApId,
         }),
@@ -68,7 +72,7 @@ const GetUserByIdRequest = {
         },
     },
     config: {
-        security: securityAccess.publicPlatform([PrincipalType.USER]),
+        security: securityAccess.publicPlatform([PrincipalType.USER, PrincipalType.SERVICE]),
     },
 }
 

--- a/packages/server/api/test/integration/ee/users/user-profile.test.ts
+++ b/packages/server/api/test/integration/ee/users/user-profile.test.ts
@@ -4,7 +4,7 @@ import {
 } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
-import { createTestContext } from '../../../helpers/test-context'
+import { createServiceContext, createTestContext } from '../../../helpers/test-context'
 
 let app: FastifyInstance | null = null
 
@@ -45,6 +45,29 @@ describe('User Profile API', () => {
             const ctx2 = await createTestContext(app!)
 
             const response = await ctx2.get(`/v1/users/${ctx1.user.id}`)
+
+            expect(response?.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+
+        it('should allow API-key (SERVICE) callers to fetch a user on their platform', async () => {
+            const ctx = await createTestContext(app!)
+            const serviceCtx = await createServiceContext(app!, ctx)
+
+            const response = await serviceCtx.get(`/v1/users/${ctx.user.id}`)
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const body = response?.json()
+            expect(body.id).toBe(ctx.user.id)
+            expect(body.platformId).toBe(ctx.platform.id)
+            expect(body.email).toBe(ctx.userIdentity.email)
+        })
+
+        it('should return 404 when an API-key tries to fetch a user on a different platform', async () => {
+            const ctx1 = await createTestContext(app!)
+            const ctx2 = await createTestContext(app!)
+            const serviceCtx2 = await createServiceContext(app!, ctx2)
+
+            const response = await serviceCtx2.get(`/v1/users/${ctx1.user.id}`)
 
             expect(response?.statusCode).toBe(StatusCodes.NOT_FOUND)
         })


### PR DESCRIPTION
## What does this PR do?

`GET /v1/users/<id>` was not publicly exposed / could not be used with an API key

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
