### PR TITLE
feat(pieces): add Canva integration piece

### DIFF
--- a/packages/pieces/community/canva/README.md
+++ b/packages/pieces/community/canva/README.md
@@ -1,0 +1,5 @@
+# pieces-canva
+
+## Building
+
+Run `turbo run build --filter=@activepieces/piece-canva` to build the library.

--- a/packages/pieces/community/canva/package.json
+++ b/packages/pieces/community/canva/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-canva",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/canva/src/i18n/translation.json
+++ b/packages/pieces/community/canva/src/i18n/translation.json
@@ -1,0 +1,10 @@
+{
+  "Upload Asset": "Upload Asset",
+  "Create Design": "Create Design",
+  "Export Design": "Export Design",
+  "Import Design": "Import Design",
+  "Move Folder Item": "Move Folder Item",
+  "Find Design": "Find Design",
+  "Get Folder": "Get Folder",
+  "Get Asset": "Get Asset"
+}

--- a/packages/pieces/community/canva/src/index.ts
+++ b/packages/pieces/community/canva/src/index.ts
@@ -1,0 +1,41 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { canvaAuth } from './lib/auth';
+import { createDesignAction } from './lib/actions/create-design';
+import { exportDesignAction } from './lib/actions/export-design';
+import { findDesignAction } from './lib/actions/find-design';
+import { getAssetAction } from './lib/actions/get-asset';
+import { getFolderAction } from './lib/actions/get-folder';
+import { importDesignAction } from './lib/actions/import-design';
+import { moveFolderItemAction } from './lib/actions/move-folder-item';
+import { uploadAssetAction } from './lib/actions/upload-asset';
+
+export const canva = createPiece({
+  displayName: 'Canva',
+  description:
+    'Online design platform for creating visual content like graphics, presentations, and posters.',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/canva.png',
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  authors: ['doublesilver'],
+  auth: canvaAuth,
+  actions: [
+    createDesignAction,
+    findDesignAction,
+    exportDesignAction,
+    importDesignAction,
+    uploadAssetAction,
+    moveFolderItemAction,
+    getFolderAction,
+    getAssetAction,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.canva.com/rest/v1',
+      auth: canvaAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${auth.access_token}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/canva/src/lib/actions/create-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/create-design.ts
@@ -1,0 +1,65 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaApiCall } from '../common';
+import { canvaAuth } from '../auth';
+
+export const createDesignAction = createAction({
+  auth: canvaAuth,
+  name: 'create_design',
+  displayName: 'Create Design',
+  description: 'Creates a new Canva design.',
+  props: {
+    design_type: Property.StaticDropdown({
+      displayName: 'Design Type',
+      description: 'The type of design to create.',
+      required: false,
+      defaultValue: 'CUSTOM',
+      options: {
+        options: [
+          { label: 'Custom Size', value: 'CUSTOM' },
+          { label: 'Document', value: 'DOCUMENT' },
+          { label: 'Presentation', value: 'PRESENTATION' },
+          { label: 'Whiteboard', value: 'WHITEBOARD' },
+        ],
+      },
+    }),
+    width: Property.Number({
+      displayName: 'Width (px)',
+      description: 'Width in pixels. Required when Design Type is "Custom Size".',
+      required: false,
+    }),
+    height: Property.Number({
+      displayName: 'Height (px)',
+      description: 'Height in pixels. Required when Design Type is "Custom Size".',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The title of the new design.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { design_type, width, height, title } = context.propsValue;
+    const accessToken = context.auth.access_token;
+
+    const body: Record<string, unknown> = {};
+
+    if (design_type === 'CUSTOM' && width && height) {
+      body['design_type'] = { type: 'CUSTOM', width, height };
+    } else if (design_type && design_type !== 'CUSTOM') {
+      body['design_type'] = { type: design_type };
+    }
+
+    if (title) {
+      body['title'] = title;
+    }
+
+    return canvaApiCall({
+      accessToken,
+      method: HttpMethod.POST,
+      path: '/designs',
+      body,
+    });
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/create-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/create-design.ts
@@ -45,9 +45,12 @@ export const createDesignAction = createAction({
 
     const body: Record<string, unknown> = {};
 
-    if (design_type === 'CUSTOM' && width && height) {
+    if (design_type === 'CUSTOM') {
+      if (!width || !height) {
+        throw new Error('Width and Height are required when Design Type is "Custom Size".');
+      }
       body['design_type'] = { type: 'CUSTOM', width, height };
-    } else if (design_type && design_type !== 'CUSTOM') {
+    } else if (design_type) {
       body['design_type'] = { type: design_type };
     }
 

--- a/packages/pieces/community/canva/src/lib/actions/export-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/export-design.ts
@@ -1,0 +1,76 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaApiCall } from '../common';
+import { canvaAuth } from '../auth';
+
+export const exportDesignAction = createAction({
+  auth: canvaAuth,
+  name: 'export_design',
+  displayName: 'Export Design',
+  description: 'Exports a Canva design to a file format (PDF, PNG, JPG, etc.).',
+  props: {
+    design_id: Property.ShortText({
+      displayName: 'Design ID',
+      description: 'The ID of the design to export.',
+      required: true,
+    }),
+    format: Property.StaticDropdown({
+      displayName: 'Export Format',
+      description: 'The file format to export the design to.',
+      required: true,
+      defaultValue: 'pdf',
+      options: {
+        options: [
+          { label: 'PDF', value: 'pdf' },
+          { label: 'PNG', value: 'png' },
+          { label: 'JPG', value: 'jpg' },
+          { label: 'GIF', value: 'gif' },
+          { label: 'PPTX', value: 'pptx' },
+          { label: 'MP4', value: 'mp4' },
+          { label: 'SVG', value: 'svg' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { design_id, format } = context.propsValue;
+    const accessToken = context.auth.access_token;
+
+    const exportJob = await canvaApiCall<{ job: { id: string; status: string } }>({
+      accessToken,
+      method: HttpMethod.POST,
+      path: '/exports',
+      body: {
+        design_id,
+        format: { type: format },
+      },
+    });
+
+    const jobId = exportJob.job.id;
+    const maxAttempts = 20;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const statusResponse = await canvaApiCall<{
+        job: { id: string; status: string; urls?: string[] };
+      }>({
+        accessToken,
+        method: HttpMethod.GET,
+        path: `/exports/${jobId}`,
+      });
+
+      const { status } = statusResponse.job;
+
+      if (status === 'success') {
+        return statusResponse;
+      }
+
+      if (status === 'failed') {
+        throw new Error(`Export job ${jobId} failed.`);
+      }
+    }
+
+    throw new Error(`Export job ${jobId} timed out after ${maxAttempts} attempts.`);
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/export-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/export-design.ts
@@ -50,8 +50,6 @@ export const exportDesignAction = createAction({
     const maxAttempts = 20;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-
       const statusResponse = await canvaApiCall<{
         job: { id: string; status: string; urls?: string[] };
       }>({
@@ -69,6 +67,8 @@ export const exportDesignAction = createAction({
       if (status === 'failed') {
         throw new Error(`Export job ${jobId} failed.`);
       }
+
+      await new Promise((resolve) => setTimeout(resolve, 3000));
     }
 
     throw new Error(`Export job ${jobId} timed out after ${maxAttempts} attempts.`);

--- a/packages/pieces/community/canva/src/lib/actions/find-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/find-design.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaApiCall } from '../common';
+import { canvaAuth } from '../auth';
+
+export const findDesignAction = createAction({
+  auth: canvaAuth,
+  name: 'find_design',
+  displayName: 'Find Design',
+  description: 'Searches for designs by query string.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'Keywords to search for in design titles.',
+      required: true,
+    }),
+    ownership: Property.StaticDropdown({
+      displayName: 'Ownership',
+      description: 'Filter designs by ownership.',
+      required: false,
+      defaultValue: 'ANY',
+      options: {
+        options: [
+          { label: 'Any', value: 'ANY' },
+          { label: 'Owned', value: 'OWNED' },
+          { label: 'Shared', value: 'SHARED' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { query, ownership } = context.propsValue;
+    const accessToken = context.auth.access_token;
+
+    const queryParams: Record<string, string> = { query };
+    if (ownership && ownership !== 'ANY') {
+      queryParams['ownership'] = ownership;
+    }
+
+    return canvaApiCall({
+      accessToken,
+      method: HttpMethod.GET,
+      path: '/designs',
+      queryParams,
+    });
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-asset.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaApiCall } from '../common';
+import { canvaAuth } from '../auth';
+
+export const getAssetAction = createAction({
+  auth: canvaAuth,
+  name: 'get_asset',
+  displayName: 'Get Asset',
+  description: 'Retrieves details about an existing Canva asset (image) by its ID.',
+  props: {
+    asset_id: Property.ShortText({
+      displayName: 'Asset ID',
+      description: 'The ID of the asset to retrieve.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { asset_id } = context.propsValue;
+    const accessToken = context.auth.access_token;
+
+    return canvaApiCall({
+      accessToken,
+      method: HttpMethod.GET,
+      path: `/assets/${encodeURIComponent(asset_id)}`,
+    });
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-folder.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-folder.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaApiCall } from '../common';
+import { canvaAuth } from '../auth';
+
+export const getFolderAction = createAction({
+  auth: canvaAuth,
+  name: 'get_folder',
+  displayName: 'Get Folder',
+  description: 'Retrieves details about a Canva folder by its ID.',
+  props: {
+    folder_id: Property.ShortText({
+      displayName: 'Folder ID',
+      description: 'The ID of the folder to retrieve.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { folder_id } = context.propsValue;
+    const accessToken = context.auth.access_token;
+
+    return canvaApiCall({
+      accessToken,
+      method: HttpMethod.GET,
+      path: `/folders/${encodeURIComponent(folder_id)}`,
+    });
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/import-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/import-design.ts
@@ -1,0 +1,81 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaApiCall } from '../common';
+import { canvaAuth } from '../auth';
+
+export const importDesignAction = createAction({
+  auth: canvaAuth,
+  name: 'import_design',
+  displayName: 'Import Design',
+  description: 'Imports an external file (e.g., PDF or PPTX) as an editable Canva design.',
+  props: {
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The title of the imported design.',
+      required: true,
+    }),
+    url: Property.ShortText({
+      displayName: 'File URL',
+      description: 'A publicly accessible URL to the file to import (PDF, PPTX, etc.).',
+      required: true,
+    }),
+    mime_type: Property.StaticDropdown({
+      displayName: 'File Type',
+      description: 'The MIME type of the file being imported.',
+      required: true,
+      defaultValue: 'application/pdf',
+      options: {
+        options: [
+          { label: 'PDF', value: 'application/pdf' },
+          {
+            label: 'PowerPoint (PPTX)',
+            value:
+              'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+          },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { title, url, mime_type } = context.propsValue;
+    const accessToken = context.auth.access_token;
+
+    const importJob = await canvaApiCall<{ job: { id: string; status: string } }>({
+      accessToken,
+      method: HttpMethod.POST,
+      path: '/imports',
+      body: {
+        title,
+        url,
+        mime_type,
+      },
+    });
+
+    const jobId = importJob.job.id;
+    const maxAttempts = 20;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const statusResponse = await canvaApiCall<{
+        job: { id: string; status: string; design?: unknown };
+      }>({
+        accessToken,
+        method: HttpMethod.GET,
+        path: `/imports/${jobId}`,
+      });
+
+      const { status } = statusResponse.job;
+
+      if (status === 'success') {
+        return statusResponse;
+      }
+
+      if (status === 'failed') {
+        throw new Error(`Import job ${jobId} failed.`);
+      }
+    }
+
+    throw new Error(`Import job ${jobId} timed out after ${maxAttempts} attempts.`);
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/import-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/import-design.ts
@@ -55,8 +55,6 @@ export const importDesignAction = createAction({
     const maxAttempts = 20;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-
       const statusResponse = await canvaApiCall<{
         job: { id: string; status: string; design?: unknown };
       }>({
@@ -74,6 +72,8 @@ export const importDesignAction = createAction({
       if (status === 'failed') {
         throw new Error(`Import job ${jobId} failed.`);
       }
+
+      await new Promise((resolve) => setTimeout(resolve, 3000));
     }
 
     throw new Error(`Import job ${jobId} timed out after ${maxAttempts} attempts.`);

--- a/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
+++ b/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { canvaApiCall } from '../common';
+import { canvaAuth } from '../auth';
+
+export const moveFolderItemAction = createAction({
+  auth: canvaAuth,
+  name: 'move_folder_item',
+  displayName: 'Move Folder Item',
+  description: 'Moves a design or asset into a specific Canva folder.',
+  props: {
+    folder_id: Property.ShortText({
+      displayName: 'Destination Folder ID',
+      description: 'The ID of the folder to move the item into.',
+      required: true,
+    }),
+    item_id: Property.ShortText({
+      displayName: 'Item ID',
+      description: 'The ID of the design or asset to move.',
+      required: true,
+    }),
+    item_type: Property.StaticDropdown({
+      displayName: 'Item Type',
+      description: 'The type of item to move.',
+      required: true,
+      defaultValue: 'DESIGN',
+      options: {
+        options: [
+          { label: 'Design', value: 'DESIGN' },
+          { label: 'Image', value: 'IMAGE' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { folder_id, item_id, item_type } = context.propsValue;
+    const accessToken = context.auth.access_token;
+
+    return canvaApiCall({
+      accessToken,
+      method: HttpMethod.POST,
+      path: `/folders/${encodeURIComponent(folder_id)}/items/move`,
+      body: {
+        items: [{ type: item_type, id: item_id }],
+      },
+    });
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
@@ -1,0 +1,61 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { CANVA_API_BASE_URL } from '../common';
+import { canvaAuth } from '../auth';
+
+const MIME_TYPES: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  pdf: 'application/pdf',
+};
+
+export const uploadAssetAction = createAction({
+  auth: canvaAuth,
+  name: 'upload_asset',
+  displayName: 'Upload Asset',
+  description: 'Uploads an image or other asset file to your Canva media library.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Asset Name',
+      description: 'A name for the uploaded asset.',
+      required: true,
+    }),
+    file: Property.File({
+      displayName: 'File',
+      description: 'The image or file to upload to Canva.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { name, file } = context.propsValue;
+    const accessToken = context.auth.access_token;
+
+    const extension = (file.extension ?? '').toLowerCase();
+    const contentType = MIME_TYPES[extension] ?? 'application/octet-stream';
+
+    const metadata = {
+      name_base64: Buffer.from(name).toString('base64'),
+    };
+    const encodedMetadata = Buffer.from(JSON.stringify(metadata)).toString('base64');
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${CANVA_API_BASE_URL}/assets/upload`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: accessToken,
+      },
+      headers: {
+        'Content-Type': contentType,
+        'Asset-Upload-Metadata': encodedMetadata,
+      },
+      body: file.data,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/auth.ts
+++ b/packages/pieces/community/canva/src/lib/auth.ts
@@ -1,0 +1,20 @@
+import { OAuth2AuthorizationMethod, PieceAuth } from '@activepieces/pieces-framework';
+
+export const canvaAuth = PieceAuth.OAuth2({
+  description: '',
+  authUrl: 'https://www.canva.com/api/oauth/authorize',
+  tokenUrl: 'https://api.canva.com/rest/v1/oauth/token',
+  required: true,
+  scope: [
+    'asset:read',
+    'asset:write',
+    'design:content:read',
+    'design:content:write',
+    'design:meta:read',
+    'folder:read',
+    'folder:write',
+    'folder:content:read',
+    'folder:content:write',
+  ],
+  authorizationMethod: OAuth2AuthorizationMethod.BODY,
+});

--- a/packages/pieces/community/canva/src/lib/common/index.ts
+++ b/packages/pieces/community/canva/src/lib/common/index.ts
@@ -1,0 +1,33 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+
+export async function canvaApiCall<T>({
+  accessToken,
+  method,
+  path,
+  body,
+  queryParams,
+}: {
+  accessToken: string;
+  method: HttpMethod;
+  path: string;
+  body?: Record<string, unknown>;
+  queryParams?: Record<string, string>;
+}): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url: `${CANVA_API_BASE_URL}${path}`,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: accessToken,
+    },
+    body,
+    queryParams,
+  });
+  return response.body;
+}
+
+export const CANVA_API_BASE_URL = 'https://api.canva.com/rest/v1';

--- a/packages/pieces/community/canva/tsconfig.json
+++ b/packages/pieces/community/canva/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/canva/tsconfig.lib.json
+++ b/packages/pieces/community/canva/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -210,6 +210,9 @@
       "@activepieces/piece-campaign-monitor": [
         "packages/pieces/community/campaign-monitor/src/index.ts"
       ],
+      "@activepieces/piece-canva": [
+        "packages/pieces/community/canva/src/index.ts"
+      ],
       "@activepieces/piece-capsule-crm": [
         "packages/pieces/community/capsule-crm/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Adds a new Canva community piece that integrates with the [Canva Connect API](https://www.canva.dev/docs/connect/api-reference/designs/create-design/), enabling automation builders to create, manage, and export Canva designs directly from their workflows.

### Explain How the Feature Works

The piece uses OAuth2 authentication with the Canva Connect API. It covers all the actions specified in the issue:

**Write Actions:**
- **Create Design** — Creates a new Canva design with configurable type (Custom Size, Document, Presentation, Whiteboard) and optional title
- **Import Design** — Imports an external PDF or PPTX file from a URL as an editable Canva design (with async job polling)
- **Export Design** — Exports a design to PDF, PNG, JPG, GIF, PPTX, MP4, or SVG format (with async job polling)
- **Move Folder Item** — Moves a design or asset into a specified folder

**Search Actions:**
- **Find Design** — Searches designs by keyword with optional ownership filter (Any/Owned/Shared)

**Read Actions:**
- **Get Folder** — Retrieves details about a folder by ID
- **Get Asset** — Retrieves details about an asset/image by ID

**Asset Management:**
- **Upload Asset** — Uploads an image or file to the Canva media library using binary upload with the `Asset-Upload-Metadata` header

**Custom API Call** — Allows making arbitrary requests to any Canva REST API endpoint.

### Relevant User Scenarios

- Auto-upload brand assets when a campaign starts
- Automatically generate design templates on new blog posts
- Convert user-submitted PDFs into editable Canva designs
- Export a brochure as a PDF and save it to cloud storage
- Organize completed designs into an "Archive" folder

Fixes #8135

/claim #8135