### PR TITLE
feat(gmail): add label management, archive/delete actions, starred email and conversation triggers

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -4,11 +4,19 @@ import { PieceCategory } from '@activepieces/shared';
 import { gmailSendEmailAction } from './lib/actions/send-email-action';
 import { gmailReplyToEmailAction } from './lib/actions/reply-to-email-action';
 import { gmailCreateDraftReplyAction } from './lib/actions/create-draft-reply-action';
+import { gmailAddLabelAction } from './lib/actions/add-label-action';
+import { gmailRemoveLabelAction } from './lib/actions/remove-label-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
 import { gmailNewEmailTrigger } from './lib/triggers/new-email';
 import { gmailNewLabeledEmailTrigger } from './lib/triggers/new-labeled-email';
 import { requestApprovalInEmail } from './lib/actions/request-approval-in-email';
 import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
+import { gmailNewConversationTrigger } from './lib/triggers/new-conversation';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
 import { gmailAuth, getAccessToken, GmailAuthValue } from './lib/auth';
@@ -32,6 +40,12 @@ export const gmail = createPiece({
     requestApprovalInEmail,
     gmailReplyToEmailAction,
     gmailCreateDraftReplyAction,
+    gmailAddLabelAction,
+    gmailRemoveLabelAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
     createCustomApiCallAction({
@@ -58,12 +72,15 @@ export const gmail = createPiece({
     'AdamSelene',
     'sanket-a11y',
     'onyedikachi-david',
+    'doublesilver',
   ],
   triggers: [
     gmailNewEmailTrigger,
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewConversationTrigger,
+    gmailNewStarredEmailTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-action.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { google } from 'googleapis';
+import { GmailProps } from '../common/props';
+
+export const gmailAddLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'add_label_to_email',
+  displayName: 'Add Label to Email',
+  description: 'Attach a label to an individual email.',
+  props: {
+    message_id: GmailProps.message,
+    label_ids: Property.Array({
+      displayName: 'Labels',
+      description: 'One or more label IDs to add to the email.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        addLabelIds: context.propsValue.label_ids as string[],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,28 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { google } from 'googleapis';
+import { GmailProps } from '../common/props';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'archive_email',
+  displayName: 'Archive Email',
+  description: 'Archive an email by removing it from the inbox (moves to "All Mail").',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,60 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { google } from 'googleapis';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'create_label',
+  displayName: 'Create Label',
+  description: 'Create a new user label in Gmail.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'Name for the new label.',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Label List Visibility',
+      description: 'Visibility of the label in the label list.',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show in label list', value: 'labelShow' },
+          { label: 'Show if unread', value: 'labelShowIfUnread' },
+          { label: 'Hide from label list', value: 'labelHide' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Message List Visibility',
+      description: 'Visibility of messages with this label.',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show in message list', value: 'show' },
+          { label: 'Hide from message list', value: 'hide' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.labels.create({
+      userId: 'me',
+      requestBody: {
+        name: context.propsValue.name,
+        labelListVisibility: context.propsValue.label_list_visibility as string,
+        messageListVisibility:
+          context.propsValue.message_list_visibility as string,
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -6,8 +6,8 @@ import { GmailProps } from '../common/props';
 export const gmailDeleteEmailAction = createAction({
   auth: gmailAuth,
   name: 'delete_email',
-  displayName: 'Delete Email',
-  description: 'Permanently move an email to the Trash.',
+  displayName: 'Move Email to Trash',
+  description: 'Move an email to the Trash (can be recovered from Trash within 30 days).',
   props: {
     message_id: GmailProps.message,
   },

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,25 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { google } from 'googleapis';
+import { GmailProps } from '../common/props';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'delete_email',
+  displayName: 'Delete Email',
+  description: 'Permanently move an email to the Trash.',
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.trash({
+      userId: 'me',
+      id: context.propsValue.message_id,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-action.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { google } from 'googleapis';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_email',
+  displayName: 'Remove Label from Email',
+  description: 'Remove a specific label from an email.',
+  props: {
+    message_id: GmailProps.message,
+    label_ids: Property.Array({
+      displayName: 'Labels',
+      description: 'One or more label IDs to remove from the email.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: context.propsValue.label_ids as string[],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { google } from 'googleapis';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_thread',
+  displayName: 'Remove Label from Thread',
+  description: 'Strip a label from all emails in a thread.',
+  props: {
+    thread_id: GmailProps.thread,
+    label_ids: Property.Array({
+      displayName: 'Labels',
+      description: 'One or more label IDs to remove from the thread.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.threads.modify({
+      userId: 'me',
+      id: context.propsValue.thread_id,
+      requestBody: {
+        removeLabelIds: context.propsValue.label_ids as string[],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/auth.ts
+++ b/packages/pieces/community/gmail/src/lib/auth.ts
@@ -11,6 +11,7 @@ const gmailServiceAccountScopes = [
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/gmail.readonly',
   'https://www.googleapis.com/auth/gmail.compose',
+  'https://www.googleapis.com/auth/gmail.modify',
 ];
 
 export const gmailScopes = [...gmailServiceAccountScopes, 'email'];

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,162 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  FilesService,
+} from '@activepieces/pieces-framework';
+import { GmailProps } from '../common/props';
+import { gmailAuth, createGoogleClient, GmailAuthValue } from '../auth';
+import { google } from 'googleapis';
+import {
+  parseStream,
+  convertAttachment,
+  getFirstFiveOrAll,
+} from '../common/data';
+import { GmailLabel } from '../common/models';
+
+type Props = {
+  from?: string;
+  to?: string;
+  subject?: string;
+  label?: GmailLabel;
+};
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred (within the last 2 days).',
+  props: {
+    from: {
+      ...GmailProps.from,
+      description: 'Filter by sender email.',
+      displayName: 'From',
+      required: false,
+    },
+    to: {
+      ...GmailProps.to,
+      description: 'Filter by recipient email.',
+      displayName: 'To',
+      required: false,
+    },
+    subject: {
+      ...GmailProps.subject,
+      description: 'Filter by subject text.',
+      displayName: 'Subject Contains',
+      required: false,
+    },
+  },
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    await context.store.put('lastPoll', Date.now());
+  },
+  async onDisable() {
+    return;
+  },
+  async run(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      props: context.propsValue,
+      files: context.files,
+      lastFetchEpochMS,
+    });
+
+    const newLastEpochMilliSeconds = items.reduce(
+      (acc, item) => Math.max(acc, item.epochMilliSeconds),
+      lastFetchEpochMS
+    );
+    await context.store.put('lastPoll', newLastEpochMilliSeconds);
+    return items
+      .filter((f) => f.epochMilliSeconds > lastFetchEpochMS)
+      .map((item) => item.data);
+  },
+  async test(context) {
+    const lastFetchEpochMS = (await context.store.get<number>('lastPoll')) ?? 0;
+
+    const items = await pollStarredMessages({
+      auth: context.auth,
+      props: context.propsValue,
+      files: context.files,
+      lastFetchEpochMS,
+    });
+
+    return getFirstFiveOrAll(items.map((item) => item.data));
+  },
+});
+
+async function pollStarredMessages({
+  auth,
+  props,
+  files,
+  lastFetchEpochMS,
+}: {
+  auth: GmailAuthValue;
+  props: Props;
+  files: FilesService;
+  lastFetchEpochMS: number;
+}): Promise<{ epochMilliSeconds: number; data: unknown }[]> {
+  const authClient = await createGoogleClient(auth);
+  const gmail = google.gmail({ version: 'v1', auth: authClient });
+
+  const query = ['is:starred'];
+  const maxResults = lastFetchEpochMS === 0 ? 5 : 20;
+  const afterUnixSeconds = Math.floor(lastFetchEpochMS / 1000);
+
+  if (props.from) query.push(`from:(${props.from})`);
+  if (props.to) query.push(`to:(${props.to})`);
+  if (props.subject) query.push(`subject:(${props.subject})`);
+  if (afterUnixSeconds > 0) query.push(`after:${afterUnixSeconds}`);
+
+  const messagesResponse = await gmail.users.messages.list({
+    userId: 'me',
+    q: query.join(' '),
+    maxResults,
+  });
+
+  const messages = (messagesResponse.data.messages || []).slice().reverse();
+
+  const pollingResponse = [];
+  for (const message of messages) {
+    try {
+      const rawMailResponse = await gmail.users.messages.get({
+        userId: 'me',
+        id: message.id!,
+        format: 'raw',
+      });
+
+      const parsedMailResponse = await parseStream(
+        Buffer.from(rawMailResponse.data.raw as string, 'base64').toString(
+          'utf-8'
+        )
+      );
+
+      pollingResponse.push({
+        epochMilliSeconds: Number(rawMailResponse.data.internalDate),
+        data: {
+          message: {
+            id: message.id,
+            threadId: message.threadId,
+            ...parsedMailResponse,
+            attachments: await convertAttachment(
+              parsedMailResponse.attachments,
+              files
+            ),
+          },
+        },
+      });
+    } catch (error: unknown) {
+      const err = error as { status?: number; message?: string };
+      const isRateLimit =
+        err.status === 429 ||
+        (err.status === 403 && /quota|rate.?limit/i.test(err.message ?? ''));
+      if (isRateLimit) {
+        break;
+      }
+      throw error;
+    }
+  }
+
+  return pollingResponse;
+}

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -11,20 +11,18 @@ import {
   convertAttachment,
   getFirstFiveOrAll,
 } from '../common/data';
-import { GmailLabel } from '../common/models';
 
 type Props = {
   from?: string;
   to?: string;
   subject?: string;
-  label?: GmailLabel;
 };
 
 export const gmailNewStarredEmailTrigger = createTrigger({
   auth: gmailAuth,
   name: 'new_starred_email',
   displayName: 'New Starred Email',
-  description: 'Triggers when an email is starred (within the last 2 days).',
+  description: 'Triggers when a new email is starred.',
   props: {
     from: {
       ...GmailProps.from,


### PR DESCRIPTION
## What does this PR do?

Extends the Gmail piece with the actions and triggers outlined in issue #8072. All new features follow the existing coding patterns and reuse shared props, helpers, and the googleapis client.

### New Triggers

| Trigger | Description |
|---|---|
| **New Starred Email** | Polls Gmail for emails that have been starred, with optional filters for sender, recipient, and subject. Uses the `is:starred` query against the Gmail messages list API. |
| **New Conversation** | Registers the existing `new-conversation.ts` trigger that was implemented but never added to the piece index. |

### New Actions

| Action | Description |
|---|---|
| **Add Label to Email** | Calls `users.messages.modify` to apply one or more label IDs to a single message. |
| **Remove Label from Email** | Calls `users.messages.modify` to strip one or more label IDs from a single message. |
| **Create Label** | Calls `users.labels.create` to create a new user label with configurable list visibility. |
| **Archive Email** | Removes the `INBOX` label via `users.messages.modify`, moving the email to "All Mail". |
| **Delete Email** | Moves an email to Trash via `users.messages.trash`. |
| **Remove Label from Thread** | Calls `users.threads.modify` to strip label IDs from every message in a thread at once. |

### OAuth Scope Change

Added `https://www.googleapis.com/auth/gmail.modify` to the OAuth scope list. This scope is required by `messages.modify`, `messages.trash`, `labels.create`, and `threads.modify`. The New Starred Email trigger relies only on the already-present `gmail.readonly` scope.

### Explain How the Feature Works

Each label management action takes a message or thread ID (via the existing `GmailProps.message` / `GmailProps.thread` dropdowns) and an array of label IDs, then calls the corresponding Gmail API endpoint. The Archive and Delete actions are single-click — no label input needed. The New Starred Email trigger polls `users.messages.list` with `is:starred` and optional user-supplied filters, following the same polling pattern used by the existing New Attachment trigger.

### Relevant User Scenarios

- Automatically label customer-support emails arriving in a monitored inbox
- Archive processed invoices after a flow extracts the line items
- Delete spam that matches a pattern before it clutters the inbox
- Trigger a flow when an email is starred for follow-up
- Trigger a workflow when a new email thread is started by a key contact

Fixes #8072
/claim #8072