### PR TITLE
fix(jotform): parse and flatten new submission trigger output

### DIFF
--- a/packages/pieces/community/jotform/package.json
+++ b/packages/pieces/community/jotform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jotform",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/jotform/src/lib/triggers/new-submission.ts
+++ b/packages/pieces/community/jotform/src/lib/triggers/new-submission.ts
@@ -6,13 +6,21 @@ export const newSubmission = createTrigger({
   auth: jotformAuth,
   name: 'new_submission',
   displayName: 'New Submission',
-  description: 'Triggers when a new submission is submitted',
+  description:
+    'Triggers when someone submits a response to your form. Each form field is returned as a separate field using the question label as the key.',
   type: TriggerStrategy.WEBHOOK,
-  sampleData: {},
+  sampleData: {
+    form_id: '31751954731962',
+    submission_id: '237955080346633702',
+    ip: '123.123.123.123',
+    type: 'WEB',
+    pretty: 'Name: Bart Simpson\nYour Message: ¡Ay, caramba!',
+    name: 'Bart Simpson',
+    your_message: '¡Ay, caramba!',
+  },
   props: {
     formId: jotformCommon.form,
   },
-  //Set the webhook URL in Jotform and save the webhook URL in store for disable behavior
   async onEnable(context) {
     await jotformCommon.subscribeWebhook(
       context.propsValue['formId'],
@@ -22,12 +30,9 @@ export const newSubmission = createTrigger({
 
     await context.store?.put<WebhookInformation>(
       '_new_jotform_submission_trigger',
-      {
-        jotformWebhook: context.webhookUrl,
-      }
+      { jotformWebhook: context.webhookUrl }
     );
   },
-  //Delete the webhook URL from Jotform
   async onDisable(context) {
     const response = await context.store?.get<WebhookInformation>(
       '_new_jotform_submission_trigger'
@@ -41,8 +46,78 @@ export const newSubmission = createTrigger({
       );
     }
   },
-  //Return new submission
   async run(context) {
-    return [context.payload.body];
+    const body = context.payload.body as Record<string, unknown>;
+
+    const answers = parseAnswers(body['rawRequest']);
+
+    return [
+      {
+        form_id: body['formID'] ?? null,
+        submission_id: body['submissionID'] ?? null,
+        ip: body['ip'] ?? null,
+        type: body['type'] ?? null,
+        pretty: body['pretty'] ?? null,
+        ...answers,
+      },
+    ];
   },
 });
+
+type JotFormField = {
+  text: string;
+  type: string;
+  answer: unknown;
+  prettyFormat?: string;
+};
+
+function parseAnswers(rawRequest: unknown): Record<string, unknown> {
+  let parsed: Record<string, JotFormField> | null = null;
+
+  if (typeof rawRequest === 'string') {
+    try {
+      parsed = JSON.parse(rawRequest) as Record<string, JotFormField>;
+    } catch {
+      return {};
+    }
+  } else if (rawRequest !== null && typeof rawRequest === 'object') {
+    parsed = rawRequest as Record<string, JotFormField>;
+  }
+
+  if (!parsed) return {};
+
+  const result: Record<string, unknown> = {};
+
+  for (const field of Object.values(parsed)) {
+    if (!field.text) continue;
+    const key = toSnakeCase(field.text);
+    const { answer, prettyFormat } = field;
+
+    if (prettyFormat) {
+      result[key] = prettyFormat;
+    } else if (
+      typeof answer === 'string' ||
+      typeof answer === 'number' ||
+      typeof answer === 'boolean'
+    ) {
+      result[key] = answer;
+    } else if (Array.isArray(answer)) {
+      result[key] = answer.join(', ');
+    } else if (answer !== null && answer !== undefined) {
+      result[key] = Object.values(answer as Record<string, string>)
+        .filter(Boolean)
+        .join(' ');
+    } else {
+      result[key] = null;
+    }
+  }
+
+  return result;
+}
+
+function toSnakeCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}

--- a/packages/pieces/community/jotform/src/lib/triggers/new-submission.ts
+++ b/packages/pieces/community/jotform/src/lib/triggers/new-submission.ts
@@ -53,12 +53,12 @@ export const newSubmission = createTrigger({
 
     return [
       {
+        ...answers,
         form_id: body['formID'] ?? null,
         submission_id: body['submissionID'] ?? null,
         ip: body['ip'] ?? null,
         type: body['type'] ?? null,
         pretty: body['pretty'] ?? null,
-        ...answers,
       },
     ];
   },
@@ -91,6 +91,7 @@ function parseAnswers(rawRequest: unknown): Record<string, unknown> {
   for (const field of Object.values(parsed)) {
     if (!field.text) continue;
     const key = toSnakeCase(field.text);
+    if (!key) continue;
     const { answer, prettyFormat } = field;
 
     if (prettyFormat) {


### PR DESCRIPTION
rawRequest was returned as a raw string. Now parses answers and flattens them into top-level fields using question labels as keys, alongside form_id, submission_id, ip, type, and pretty.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
