### PR TITLE
release: v0.82.3 - hotfix worker-group Redlock contention on submitPayloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.82.2",
+  "version": "0.82.3",
   "packageManager": "bun@1.3.3",
   "scripts": {
     "prebuild": "node tools/scripts/install-bun.js",

--- a/packages/server/api/src/app/ee/platform/platform-plan/worker-group.service.ts
+++ b/packages/server/api/src/app/ee/platform/platform-plan/worker-group.service.ts
@@ -1,42 +1,30 @@
 import { isNil } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { distributedLock, distributedStore } from '../../../database/redis-connections'
+import { distributedStore } from '../../../database/redis-connections'
 import { getWorkerGroupQueueName, QueueName } from '../../../workers/job'
 import { platformQueueMigrationService } from '../../../workers/platform-queue-migration.service'
 import { platformPlanRepo } from './platform-plan.service'
 
 export const CANARY_WORKER_GROUP_ID = 'canary'
 
+const NO_WORKER_GROUP_SENTINEL = '__none__'
 const getWorkerGroupCacheKey = (platformId: string): string => `platform:${platformId}:worker_group_id`
 
 export const workerGroupService = (log: FastifyBaseLogger) => ({
     async getWorkerGroupId({ platformId }: { platformId: string }): Promise<string | null> {
         const cached = await distributedStore.get<string>(getWorkerGroupCacheKey(platformId))
         if (!isNil(cached)) {
-            return cached
+            return cached === NO_WORKER_GROUP_SENTINEL ? null : cached
         }
 
-        return distributedLock(log).runExclusive({
-            key: `worker_group_lock:${platformId}`,
-            timeoutInSeconds: 10,
-            fn: async () => {
-                const cachedAfterLock = await distributedStore.get<string>(getWorkerGroupCacheKey(platformId))
-                if (!isNil(cachedAfterLock)) {
-                    return cachedAfterLock
-                }
-
-                const plan = await platformPlanRepo().findOne({
-                    select: ['workerGroupId'],
-                    where: { platformId },
-                })
-
-                const groupId = plan?.workerGroupId ?? null
-                if (!isNil(groupId)) {
-                    await distributedStore.put(getWorkerGroupCacheKey(platformId), groupId)
-                }
-                return groupId
-            },
+        const plan = await platformPlanRepo().findOne({
+            select: ['workerGroupId'],
+            where: { platformId },
         })
+
+        const groupId = plan?.workerGroupId ?? null
+        await distributedStore.put(getWorkerGroupCacheKey(platformId), groupId ?? NO_WORKER_GROUP_SENTINEL)
+        return groupId
     },
 
     async isCanaryPlatform({ platformId }: { platformId: string }): Promise<boolean> {

--- a/packages/server/api/src/app/ee/platform/platform-plan/worker-group.service.ts
+++ b/packages/server/api/src/app/ee/platform/platform-plan/worker-group.service.ts
@@ -1,3 +1,4 @@
+import { apDayjsDuration } from '@activepieces/server-utils'
 import { isNil } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { distributedStore } from '../../../database/redis-connections'
@@ -8,6 +9,7 @@ import { platformPlanRepo } from './platform-plan.service'
 export const CANARY_WORKER_GROUP_ID = 'canary'
 
 const NO_WORKER_GROUP_SENTINEL = '__none__'
+const CACHE_TTL_SECONDS = apDayjsDuration(7, 'day').asSeconds()
 const getWorkerGroupCacheKey = (platformId: string): string => `platform:${platformId}:worker_group_id`
 
 export const workerGroupService = (log: FastifyBaseLogger) => ({
@@ -23,7 +25,7 @@ export const workerGroupService = (log: FastifyBaseLogger) => ({
         })
 
         const groupId = plan?.workerGroupId ?? null
-        await distributedStore.put(getWorkerGroupCacheKey(platformId), groupId ?? NO_WORKER_GROUP_SENTINEL)
+        await distributedStore.put(getWorkerGroupCacheKey(platformId), groupId ?? NO_WORKER_GROUP_SENTINEL, CACHE_TTL_SECONDS)
         return groupId
     },
 

--- a/packages/server/api/test/unit/app/core/canary/worker-group.service.test.ts
+++ b/packages/server/api/test/unit/app/core/canary/worker-group.service.test.ts
@@ -61,7 +61,7 @@ describe('workerGroupService', () => {
             const result = await service.getWorkerGroupId({ platformId: 'p1' })
 
             expect(result).toBe('canary')
-            expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p1:worker_group_id', 'canary')
+            expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p1:worker_group_id', 'canary', expect.any(Number))
         })
 
         it('returns null and caches sentinel when platform has no worker group', async () => {
@@ -71,7 +71,7 @@ describe('workerGroupService', () => {
             const result = await service.getWorkerGroupId({ platformId: 'p2' })
 
             expect(result).toBeNull()
-            expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p2:worker_group_id', '__none__')
+            expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p2:worker_group_id', '__none__', expect.any(Number))
         })
 
         it('returns null without hitting DB when sentinel is cached', async () => {

--- a/packages/server/api/test/unit/app/core/canary/worker-group.service.test.ts
+++ b/packages/server/api/test/unit/app/core/canary/worker-group.service.test.ts
@@ -64,14 +64,23 @@ describe('workerGroupService', () => {
             expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p1:worker_group_id', 'canary')
         })
 
-        it('returns null when platform has no worker group', async () => {
+        it('returns null and caches sentinel when platform has no worker group', async () => {
             mockDistributedStoreGet.mockResolvedValue(null)
             mockFindOne.mockResolvedValue({ workerGroupId: null })
 
             const result = await service.getWorkerGroupId({ platformId: 'p2' })
 
             expect(result).toBeNull()
-            expect(mockDistributedStorePut).not.toHaveBeenCalled()
+            expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p2:worker_group_id', '__none__')
+        })
+
+        it('returns null without hitting DB when sentinel is cached', async () => {
+            mockDistributedStoreGet.mockResolvedValue('__none__')
+
+            const result = await service.getWorkerGroupId({ platformId: 'p3' })
+
+            expect(result).toBeNull()
+            expect(mockFindOne).not.toHaveBeenCalled()
         })
 
         it('returns cached value without hitting DB', async () => {


### PR DESCRIPTION
## Summary

Hotfix release for the 0.82.x line. Eliminates a Redlock acquisition on the `submitPayloads` RPC hot path that was failing webhook BullMQ jobs under contention.

## Symptom

Webhook BullMQ jobs were appearing as failed in the board with `failedReason`:

```
RPC [submitPayloads] handler threw: The operation was unable to achieve a quorum during its retry window.
```

The inner string is verbatim from `redlock@5.0.0-beta.2/dist/esm/index.js:290` (`ExecutionError` thrown when retry budget is exhausted). The outer wrapper is the RPC client envelope from `packages/shared/src/lib/automation/engine/rpc.ts:23`.

## Root cause

`submitPayloads` ultimately calls `workerGroupService.getWorkerGroupId({ platformId })` via:

```
submitPayloads
 -> flowRunService.start
 -> addToQueue
 -> jobQueue.add
 -> getQueueName(platformId, log)
 -> workerGroupService.getWorkerGroupId
```

That function wrapped its DB lookup in `distributedLock(log).runExclusive({ key: 'worker_group_lock:${platformId}', timeoutInSeconds: 10 })` and **only cached positive results** (`if (!isNil(groupId))`). For any platform with `platformPlan.workerGroupId IS NULL` (the default — only canary platforms have one), the cache was never populated, so every `submitPayloads` call cache-missed and contended on the same Redis key for that platform.

`projectService.getPlatformId` throws when null, so the `if (!platformId) return WORKER_JOBS` short-circuit in `getQueueName` never fires on the webhook path — the lock is always entered.

When Redlock can't acquire after 50 × 200 ms retries, it throws; the RPC handler surfaces the error verbatim; the worker reports `INTERNAL_ERROR` to `completeJob`; `jobBroker.completeJob` calls `job.moveToFailed(new Error(failedReason), token)` and the message lands on the BullMQ board.

## Fix

`packages/server/api/src/app/ee/platform/platform-plan/worker-group.service.ts`

- Drop the `distributedLock.runExclusive(...)` wrapper. The work it protected is a single indexed `findOne` against `platform_plan` — idempotent under concurrent callers, no stampede risk worth a Redlock.
- Always write the cache, using a `__none__` sentinel for the null case so subsequent calls short-circuit at the read.
- Cache invalidation (`updateWorkerGroup` / `updateCanary`) already deletes the key; sentinel goes through the same delete path.

Tests (`packages/server/api/test/unit/app/core/canary/worker-group.service.test.ts`):
- Flipped the "do not cache null" assertion to "caches sentinel".
- Added a read-side test asserting the sentinel short-circuits the DB call.

Root `package.json` bumped `0.82.2` -> `0.82.3`.

## Test plan

- [x] `npx turbo run lint --filter=api` — 0 errors (pre-existing warnings only).
- [x] `npm run lint-dev` — 0 errors across the repo.
- [x] `npx vitest run packages/server/api/test/unit/app/core/canary/worker-group.service.test.ts` — all new and modified tests in the `getWorkerGroupId` describe pass. (Five pre-existing failures in the `isCanaryPlatform`/`disableAllCanary` blocks remain — they reference `mockFind`/`disableAllCanary` that don't match the current service surface; these failures exist verbatim on the base `release/v0.82.2` and are out of scope for this hotfix.)
- [ ] Post-deploy verification: no `worker_group_lock:*` keys observed in Redis on the `submitPayloads` path; webhook BullMQ jobs stop showing the "achieve a quorum" `failedReason` for non-canary platforms.

## Pre-push hook note

The repo's pre-push hook also runs `api:check-migrations`, which fails on a pre-existing `mcp_server` foreign-key schema drift on `release/v0.82.2` — entirely unrelated to this diff. Push was performed with `SKIP_CHECK=1` after explicit confirmation. The migration drift should be tracked separately.