### PR TITLE
feat: add external IDs to flow.* events

### DIFF
--- a/packages/server/api/src/app/flows/flow/flow.controller.ts
+++ b/packages/server/api/src/app/flows/flow/flow.controller.ts
@@ -120,6 +120,7 @@ export const flowController: FastifyPluginAsyncZod = async (app) => {
         applicationEvents(request.log).sendUserEvent(request, {
             action: ApplicationEventName.FLOW_UPDATED,
             data: {
+                flow,
                 request: request.body,
                 flowVersion: flow.version,
             },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.72.1",
+  "version": "0.72.2",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/ee/audit-events/index.ts
+++ b/packages/shared/src/lib/ee/audit-events/index.ts
@@ -129,9 +129,10 @@ export const FlowCreatedEvent = z.object({
     ...BaseAuditEventProps,
     action: z.literal(ApplicationEventName.FLOW_CREATED),
     data: z.object({
-        flow: Flow.pick({ id: true, created: true, updated: true }),
+        flow: Flow.pick({ id: true, externalId: true, created: true, updated: true }),
         project: z.object({
             displayName: z.string(),
+            externalId: Nullable(z.string()),
         }).optional(),
     }),
 })
@@ -142,7 +143,7 @@ export const FlowDeletedEvent = z.object({
     ...BaseAuditEventProps,
     action: z.literal(ApplicationEventName.FLOW_DELETED),
     data: z.object({
-        flow: Flow.pick({ id: true, created: true, updated: true }),
+        flow: Flow.pick({ id: true, externalId: true, created: true, updated: true }),
         flowVersion: FlowVersion.pick({
             id: true,
             displayName: true,
@@ -152,6 +153,7 @@ export const FlowDeletedEvent = z.object({
         }),
         project: z.object({
             displayName: z.string(),
+            externalId: Nullable(z.string()),
         }).optional(),
     }),
 })
@@ -162,6 +164,7 @@ export const FlowUpdatedEvent = z.object({
     ...BaseAuditEventProps,
     action: z.literal(ApplicationEventName.FLOW_UPDATED),
     data: z.object({
+        flow: Flow.pick({ id: true, externalId: true }),
         flowVersion: FlowVersion.pick({
             id: true,
             displayName: true,
@@ -172,6 +175,7 @@ export const FlowUpdatedEvent = z.object({
         request: FlowOperationRequest,
         project: z.object({
             displayName: z.string(),
+            externalId: Nullable(z.string()),
         }).optional(),
     }),
 })


### PR DESCRIPTION
## What does this PR do?

Add external ID of flows and projects in `flow.*` events

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
