### PR TITLE
fix(subflows): clarify Call Flow dropdown hides unpublished/disabled subflows

### DIFF
--- a/packages/pieces/core/subflows/package.json
+++ b/packages/pieces/core/subflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-subflows",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/subflows/src/i18n/translation.json
+++ b/packages/pieces/core/subflows/src/i18n/translation.json
@@ -8,7 +8,7 @@
   "Mode": "Mode",
   "Wait for Response": "Wait for Response",
   "Response": "Response",
-  "The flow to execute": "The flow to execute",
+  "The flow to execute. Only published flows with a \"Callable Flow\" trigger appear here — unpublished or disabled subflows are hidden.": "The flow to execute. Only published flows with a \"Callable Flow\" trigger appear here — unpublished or disabled subflows are hidden.",
   "Choose Simple for key-value or Advanced for JSON.": "Choose Simple for key-value or Advanced for JSON.",
   "Simple": "Simple",
   "Advanced": "Advanced",

--- a/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
+++ b/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
@@ -21,7 +21,7 @@ export const callFlow = createAction({
     flow: Property.Dropdown<FlowValue>({
       auth: PieceAuth.None(),
       displayName: 'Flow',
-      description: 'The flow to execute',
+      description: 'The flow to execute. Only published flows with a "Callable Flow" trigger appear here — unpublished or disabled subflows are hidden.',
       required: true,
       options: async (_, context) => {
         const flows = await listEnabledFlowsWithSubflowTrigger({


### PR DESCRIPTION
## Summary
- Updated the `Flow` dropdown description on the **Call Flow** action in the Subflows piece so it explicitly tells the user that only published flows with a "Callable Flow" trigger appear — unpublished or disabled subflows are hidden.
- Updated the i18n English source key in `translation.json` to match the new description (identity-mapped).
- Bumped `@activepieces/piece-subflows` patch version (0.4.12 → 0.4.13).

## Test plan
- [ ] Open a flow, add the **Subflows → Call Flow** action, and confirm the new description text appears under the `Flow` dropdown.
- [ ] Confirm the dropdown still only lists published flows whose trigger is `Callable Flow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)