### PR TITLE
fix(platform): serve user profile pictures from platforms assets

### DIFF
--- a/packages/server/api/src/app/file/file.service.ts
+++ b/packages/server/api/src/app/file/file.service.ts
@@ -84,7 +84,7 @@ export const fileService = (log: FastifyBaseLogger) => ({
         const file = await fileRepo().findOneBy({
             projectId: params.projectId,
             id: params.fileId,
-            type: params.type,
+            type: normalizeTypeFilter(params.type),
         })
         return !isNil(file)
     },
@@ -92,7 +92,7 @@ export const fileService = (log: FastifyBaseLogger) => ({
         const file = await fileRepo().findOneBy({
             projectId,
             id: fileId,
-            type,
+            type: normalizeTypeFilter(type),
         })
         return file
     },
@@ -126,7 +126,7 @@ export const fileService = (log: FastifyBaseLogger) => ({
         const file = await fileRepo().findOneBy({
             projectId,
             id: fileId,
-            type,
+            type: normalizeTypeFilter(type),
         })
         if (isNil(file)) {
             throw new ActivepiecesError({
@@ -295,6 +295,10 @@ type GetDataResponse = {
     fileName?: string
 }
 
+function normalizeTypeFilter(type: FileType | FileType[] | undefined) {
+    return Array.isArray(type) ? In(type) : type
+}
+
 export function getLocationForFile(type: FileType) {
     const FILE_LOCATION = system.getOrThrow<FileLocation>(AppSystemProp.FILE_STORAGE_LOCATION)
     if (isExecutionDataFileThatExpires(type)) {
@@ -341,7 +345,7 @@ type SaveParams = {
 type GetOneParams = {
     fileId?: FileId
     projectId?: ProjectId
-    type?: FileType
+    type?: FileType | FileType[]
 }
 
 type FileToken = {

--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -113,18 +113,19 @@ export const platformController: FastifyPluginAsyncZod = async (app) => {
     })
 
     app.get('/assets/:id', GetAssetRequest, async (req, reply) => {
-        const [file, data] = await Promise.all([
-            fileService(app.log).getFileOrThrow({ fileId: req.params.id, type: FileType.PLATFORM_ASSET }),
-            fileService(app.log).getDataOrThrow({ fileId: req.params.id, type: FileType.PLATFORM_ASSET })])
+        const { fileName, metadata, data } = await fileService(app.log).getDataOrThrow({
+            fileId: req.params.id,
+            type: [FileType.PLATFORM_ASSET, FileType.USER_PROFILE_PICTURE],
+        })
 
         return reply
             .header(
                 'Content-Disposition',
-                `attachment; filename="${encodeURI(file.fileName ?? '')}"`,
+                `attachment; filename="${encodeURI(fileName ?? '')}"`,
             )
-            .type(file.metadata?.mimetype ?? 'application/octet-stream')
+            .type(metadata?.mimetype ?? 'application/octet-stream')
             .status(StatusCodes.OK)
-            .send(data.data)
+            .send(data)
     })
 
 

--- a/packages/server/api/test/integration/cloud/platform/platform.test.ts
+++ b/packages/server/api/test/integration/cloud/platform/platform.test.ts
@@ -790,6 +790,34 @@ describe('Platform API', () => {
             expect(response?.rawPayload.equals(assetData)).toBe(true)
         })
 
+        it('serves a public user profile picture', async () => {
+            // arrange
+            const { mockPlatform } = await mockAndSaveBasicSetup()
+            const pictureData = Buffer.from('user-profile-picture-bytes')
+            const pictureFile = createMockFile({
+                platformId: mockPlatform.id,
+                projectId: null,
+                type: FileType.USER_PROFILE_PICTURE,
+                compression: FileCompression.NONE,
+                location: FileLocation.DB,
+                data: pictureData,
+                fileName: 'avatar.png',
+                metadata: { mimetype: 'image/png' },
+            })
+            await db.save('file', pictureFile)
+
+            // act — public endpoint, no auth
+            const response = await app?.inject({
+                method: 'GET',
+                url: `/api/v1/platforms/assets/${pictureFile.id}`,
+            })
+
+            // assert
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(response?.headers['content-type']).toContain('image/png')
+            expect(response?.rawPayload.equals(pictureData)).toBe(true)
+        })
+
         it('rejects access to non-PLATFORM_ASSET files (IDOR via public asset endpoint)', async () => {
             // arrange — a sensitive flow run log file stored under a project
             const { mockProject } = await mockAndSaveBasicSetup()


### PR DESCRIPTION
## Summary

- Profile pictures 404'd after #13177 restricted `/platforms/assets/:id` to `PLATFORM_ASSET`, because `uploadPublicAsset` also writes `USER_PROFILE_PICTURE` to the same URL path.
- Endpoint now whitelists `[PLATFORM_ASSET, USER_PROFILE_PICTURE]` .
- Collapsed the redundant `getFileOrThrow` + `getDataOrThrow` pair into a single `getDataOrThrow` call (halves DB hits on the logo/avatar hot path).

## Test plan

- [x] `vitest run test/integration/cloud/platform/platform.test.ts` — 21/21 pass, including:
- [x] `npx turbo run lint --filter=api` — 0 errors
- [ ] Manually verify a user avatar URL loads on cloud after deploy
