### PR TITLE
fix(engine): stream SUCCEEDED for steps neighbouring skipped steps

### DIFF
--- a/packages/server/engine/src/lib/handler/flow-executor.ts
+++ b/packages/server/engine/src/lib/handler/flow-executor.ts
@@ -77,7 +77,6 @@ export const flowExecutor = {
 
         while (!isNil(currentAction)) {
             if (currentAction.skip && !testSingleStepMode) {
-                previousAction = currentAction
                 currentAction = currentAction.nextAction
                 continue
             }

--- a/packages/server/engine/test/handler/flow-skip-progress.test.ts
+++ b/packages/server/engine/test/handler/flow-skip-progress.test.ts
@@ -1,0 +1,100 @@
+import { FlowAction, FlowRunStatus, StepOutputStatus, StreamStepProgress, UpdateRunProgressRequest } from '@activepieces/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FlowExecutorContext } from '../../src/lib/handler/context/flow-execution-context'
+import { buildPieceAction, generateMockEngineConstants } from './test-helper'
+
+const { updateRunProgressMock } = vi.hoisted(() => ({
+    updateRunProgressMock: vi.fn<(request: UpdateRunProgressRequest) => Promise<void>>().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../src/lib/worker-socket', () => ({
+    workerSocket: {
+        getWorkerClient: () => ({
+            updateRunProgress: updateRunProgressMock,
+            updateStepProgress: vi.fn(),
+            uploadRunLog: vi.fn(),
+            sendFlowResponse: vi.fn(),
+        }),
+    },
+}))
+
+import { flowExecutor } from '../../src/lib/handler/flow-executor'
+
+describe('flowExecutor — progress events with skipped neighbours', () => {
+    beforeEach(() => {
+        updateRunProgressMock.mockClear()
+    })
+
+    it('streams SUCCEEDED for the step preceding skipped steps before the next executed step runs', async () => {
+        const flow = buildMapper({
+            name: 'first',
+            mapping: { key: '{{ 1 + 2 }}' },
+            nextAction: buildMapper({
+                name: 'skipped_a',
+                skip: true,
+                nextAction: buildMapper({
+                    name: 'skipped_b',
+                    skip: true,
+                    nextAction: buildMapper({
+                        name: 'second',
+                        mapping: { doubled: '{{ 2 + 2 }}' },
+                    }),
+                }),
+            }),
+        })
+
+        const result = await flowExecutor.execute({
+            action: flow,
+            executionState: FlowExecutorContext.empty(),
+            constants: generateMockEngineConstants({ streamStepProgress: StreamStepProgress.WEBSOCKET }),
+        })
+
+        expect(result.verdict).toStrictEqual({ status: FlowRunStatus.RUNNING })
+
+        const finalStatus = lastStatusByStep()
+        expect(finalStatus.first).toBe(StepOutputStatus.SUCCEEDED)
+        expect(finalStatus.second).toBe(StepOutputStatus.SUCCEEDED)
+    })
+
+    it('streams SUCCEEDED for the last executed step even when it is followed by skipped steps', async () => {
+        const flow = buildMapper({
+            name: 'only',
+            mapping: { key: '{{ 7 + 3 }}' },
+            nextAction: buildMapper({ name: 'trailing_skip', skip: true }),
+        })
+
+        await flowExecutor.execute({
+            action: flow,
+            executionState: FlowExecutorContext.empty(),
+            constants: generateMockEngineConstants({ streamStepProgress: StreamStepProgress.WEBSOCKET }),
+        })
+
+        expect(lastStatusByStep().only).toBe(StepOutputStatus.SUCCEEDED)
+    })
+})
+
+const lastStatusByStep = (): Record<string, StepOutputStatus> => {
+    const result: Record<string, StepOutputStatus> = {}
+    for (const [request] of updateRunProgressMock.mock.calls) {
+        if (request.step) {
+            result[request.step.name] = request.step.output.status
+        }
+    }
+    return result
+}
+
+const buildMapper = ({ name, mapping, skip, nextAction }: {
+    name: string
+    mapping?: Record<string, unknown>
+    skip?: boolean
+    nextAction?: FlowAction
+}): FlowAction => ({
+    ...buildPieceAction({
+        name,
+        input: { mapping: mapping ?? {} },
+        skip,
+        pieceName: '@activepieces/piece-data-mapper',
+        actionName: 'advanced_mapping',
+    }),
+    nextAction,
+})


### PR DESCRIPTION
## Summary

- Steps in a test-flow run stayed on `Running` (with `0 ms` duration) whenever they were adjacent to skipped steps, even though the actions had completed successfully.
- `flow-executor`'s loop tracks `previousAction` so each iteration's `sendUpdate` flushes the just-completed step's `SUCCEEDED` event. The skip branch was overwriting `previousAction` with a skipped step, which never lives in `flowExecutionContext.steps` — so the next `sendUpdate` short-circuited and the executed step's `SUCCEEDED` event was lost. Same mechanic strands the *last* executed step on `Running` when it is followed by a trailing skip.
- Fix is a one-liner: stop advancing `previousAction` when the current action is skipped, so it keeps pointing at the last executed step across skip runs.

## Repro (before this PR)

Build a flow like `Webhook → Run → Skip → Skip → Run → Skip`. On Test Flow, the two executed pieces stay on `Running`, `0 ms` even though they finished — the action side effects (e.g. row created) confirm the run actually completed.

## Test plan

- [x] Added `packages/server/engine/test/handler/flow-skip-progress.test.ts` with two cases:
  - Step preceding skipped steps before another executed step (`first → skip → skip → second`)
  - Last executed step followed by a trailing skip (`only → skip → end`)
- [x] Both new tests **fail on `main`** (`Expected SUCCEEDED / Received RUNNING`) and **pass on this branch** — verified by stashing the fix and re-running.
- [x] Existing `flow-piece.test.ts` skip tests still pass (they assert final `result.steps` / `verdict`, which were never affected by the bug).
- [x] `turbo run lint --filter=@activepieces/engine` clean (0 errors).
- [ ] Manual UI check: run the repro flow and confirm the executed steps now flip to `Succeeded` with real durations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)