### PR TITLE
feat(subflows): show disabled subflows with guard against execution

### DIFF
--- a/packages/pieces/core/subflows/package.json
+++ b/packages/pieces/core/subflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-subflows",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
+++ b/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
@@ -5,8 +5,8 @@ import {
   Property,
 } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
-import { ExecutionType, FAIL_PARENT_ON_FAILURE_HEADER, isNil, PARENT_RUN_ID_HEADER } from '@activepieces/shared';
-import { CallableFlowRequest, CallableFlowResponse, findFlowByExternalIdOrThrow, listEnabledFlowsWithSubflowTrigger } from '../common';
+import { ExecutionType, FAIL_PARENT_ON_FAILURE_HEADER, FlowStatus, isNil, PARENT_RUN_ID_HEADER } from '@activepieces/shared';
+import { CallableFlowRequest, CallableFlowResponse, findFlowByExternalIdOrThrow, listFlowsWithSubflowTrigger } from '../common';
 
 type FlowValue = {
   externalId: string;
@@ -21,10 +21,10 @@ export const callFlow = createAction({
     flow: Property.Dropdown<FlowValue>({
       auth: PieceAuth.None(),
       displayName: 'Flow',
-      description: 'The flow to execute. Only published flows with a "Callable Flow" trigger appear here — unpublished or disabled subflows are hidden.',
+      description: 'The flow to execute. Published flows with a "Callable Flow" trigger appear here; disabled flows are marked "(inactive)" and cannot be executed until they are enabled.',
       required: true,
       options: async (_, context) => {
-        const flows = await listEnabledFlowsWithSubflowTrigger({
+        const flows = await listFlowsWithSubflowTrigger({
           flowsContext: context.flows,
         });
         return {
@@ -33,7 +33,10 @@ export const callFlow = createAction({
               externalId: flow.externalId ?? flow.id,
               exampleData: flow.version.trigger.settings.input.exampleData,
             },
-            label: flow.version.displayName,
+            label:
+              flow.status === FlowStatus.ENABLED
+                ? flow.version.displayName
+                : `${flow.version.displayName} (inactive)`,
           })),
         };
       },
@@ -114,6 +117,14 @@ export const callFlow = createAction({
       flowsContext: context.flows,
       externalId: context.propsValue.flow?.externalId,
     });
+
+    if (flow.status !== FlowStatus.ENABLED) {
+      throw new Error(JSON.stringify({
+        message: 'The selected subflow is disabled. Enable it before calling it from a parent flow.',
+        externalId: context.propsValue.flow?.externalId,
+        flowName: flow.version.displayName,
+      }));
+    }
 
     let callbackUrl: string | undefined
     if (context.propsValue.waitForResponse) {

--- a/packages/pieces/core/subflows/src/lib/common.ts
+++ b/packages/pieces/core/subflows/src/lib/common.ts
@@ -1,4 +1,4 @@
-import { FlowStatus, FlowTriggerType, isNil, PopulatedFlow } from "@activepieces/shared";
+import { FlowTriggerType, isNil, PopulatedFlow } from "@activepieces/shared";
 import { FlowsContext, ListFlowsContextParams } from "@activepieces/pieces-framework";
 
 
@@ -15,14 +15,13 @@ export type CallableFlowResponse = {
 
 export const MOCK_CALLBACK_IN_TEST_FLOW_URL = 'MOCK';
 
-export async function listEnabledFlowsWithSubflowTrigger({
+export async function listFlowsWithSubflowTrigger({
     flowsContext,
     params,
-}: ListParams) {
+}: ListParams): Promise<PopulatedFlow[]> {
     const allFlows = (await flowsContext.list(params)).data;
     const flows = allFlows.filter(
         (flow) =>
-            flow.status === FlowStatus.ENABLED &&
             flow.version.trigger.type === FlowTriggerType.PIECE &&
             flow.version.trigger.settings.pieceName ==
             '@activepieces/piece-subflows'
@@ -43,7 +42,7 @@ export async function findFlowByExternalIdOrThrow({
         }));
     }
     const externalIds = [externalId];
-    const allFlows = await listEnabledFlowsWithSubflowTrigger({
+    const allFlows = await listFlowsWithSubflowTrigger({
         flowsContext,
         params: {
             externalIds


### PR DESCRIPTION
## Summary
- Re-applies the intent of #13165: disabled subflows appear in the Call Flow dropdown labeled "(inactive)" instead of being hidden.
- Adds the runtime guard the Greptile review on #13165 flagged as P1: if the selected subflow is not enabled, `run()` throws a clear error before POSTing to the webhook, preventing a confusing HTTP failure.
- Updates the dropdown description so users understand the new behavior.
- Bumps `@activepieces/piece-subflows` to `0.4.14`.

## Test plan
- [x] Disable a subflow → confirm it appears in the parent Call Flow dropdown with "(inactive)" suffix.
- [x] Select a disabled subflow and run the parent → confirm the error message reads "The selected subflow is disabled. Enable it before calling it from a parent flow." with externalId + flowName.
- [x] Enable the subflow → confirm the "(inactive)" label disappears and execution succeeds.