### PR TITLE
fix(run-details): render download UI for sliced step outputs missing discriminant

### DIFF
--- a/packages/web/src/app/builder/run-details/flow-step-input-output.tsx
+++ b/packages/web/src/app/builder/run-details/flow-step-input-output.tsx
@@ -8,6 +8,7 @@ import {
   isNil,
   ApFlagId,
   LogSliceRef,
+  StepOutput,
   StepOutputType,
 } from '@activepieces/shared';
 import { t } from 'i18next';
@@ -52,12 +53,8 @@ export const FlowStepInputOutput = () => {
   }, [run, selectedStep?.name, loopsIndexes, flowVersion.trigger]);
   const isAgent = isRunAgent(selectedStep);
   const isStepRunning = selectedStepOutput?.status === StepOutputStatus.RUNNING;
-  const isSlicedOutput =
-    selectedStepOutput?.outputType === StepOutputType.SLICE;
-  const slicedOutputRef = isSlicedOutput
-    ? (selectedStepOutput?.output as LogSliceRef | undefined)
-    : undefined;
-  const parsedOutput = isSlicedOutput
+  const slicedOutputRef = extractSlicedOutputRef(selectedStepOutput);
+  const parsedOutput = slicedOutputRef
     ? undefined
     : selectedStepOutput?.errorMessage ??
       selectedStepOutput?.output ??
@@ -187,6 +184,40 @@ export const FlowStepInputOutput = () => {
     </ScrollArea>
   );
 };
+
+function extractSlicedOutputRef(
+  stepOutput: StepOutput | null | undefined,
+): LogSliceRef | undefined {
+  if (isNil(stepOutput)) {
+    return undefined;
+  }
+  const discriminant =
+    stepOutput.outputType ??
+    (stepOutput as unknown as { kind?: StepOutputType }).kind;
+  if (
+    discriminant === StepOutputType.SLICE &&
+    isLogSliceRef(stepOutput.output)
+  ) {
+    return stepOutput.output;
+  }
+  if (isLogSliceRef(stepOutput.output)) {
+    return stepOutput.output;
+  }
+  return undefined;
+}
+
+function isLogSliceRef(value: unknown): value is LogSliceRef {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const ref = value as Record<string, unknown>;
+  return (
+    typeof ref.fileId === 'string' &&
+    typeof ref.size === 'number' &&
+    typeof ref.url === 'string' &&
+    Object.keys(ref).length === 3
+  );
+}
 
 function handleRunFailureOrEmptyLog(
   run: FlowRun | null,


### PR DESCRIPTION
## Summary

Sliced step outputs were being shown as raw JSON (`{ fileId, size, url }`) instead of the "Download output" prompt because slice detection in `flow-step-input-output.tsx` relied solely on `stepOutput.outputType === SLICE`. Step outputs written before the `kind → outputType` rename — or any payload where the discriminant fails to propagate — fell through to the inline JSON viewer.

Extract slice detection into a helper that:
- prefers `outputType`,
- falls back to the legacy `kind` field,
- structurally recognizes the `LogSliceRef` shape (exact `fileId | size | url`).

## Test plan

- [ ] Visit a flow run whose step output was uploaded as a slice with `outputType: SLICE` → "Download output" button renders.
- [ ] Visit an older run where the discriminant is missing/legacy → "Download output" button still renders.
- [ ] A step whose normal output happens to include `fileId`/`size`/`url` plus other keys → still rendered as JSON (structural check requires exact 3-key shape).