### PR TITLE
fix(worker): key sandbox network env off proxyPort, not live settings

### DIFF
--- a/packages/server/worker/src/lib/execute/create-sandbox-for-job.ts
+++ b/packages/server/worker/src/lib/execute/create-sandbox-for-job.ts
@@ -79,22 +79,32 @@ function buildSandboxEnv({ settings, proxyPort }: {
     settings: WorkerSettings
     proxyPort: number | null
 }): Record<string, string> {
+    // `proxyPort` reflects what the egress stack actually started at worker boot:
+    // non-null means the proxy is listening AND the iptables UID-owner REJECT chain is
+    // armed. `settings.NETWORK_MODE` is refreshed on every socket reconnect, so reading
+    // it here can drift away from the firewall the worker already armed. If the
+    // platform flips STRICT → UNRESTRICTED at reconnect, reading the live setting would
+    // drop AP_EGRESS_PROXY_URL from the sandbox env while iptables stays in place —
+    // user fetches then fall back to direct connect, hit the REJECT chain, and surface
+    // EHOSTUNREACH / "fetch failed". Keying the entire network env off proxyPort keeps
+    // the env var, the engine's ssrfGuard, and the kernel firewall on the same axis.
+    const networkMode = proxyPort === null ? NetworkMode.UNRESTRICTED : NetworkMode.STRICT
     return {
-        ...baseEnv(settings),
+        ...baseEnv({ settings, networkMode }),
         ...ssrfEnv(settings),
-        ...propagatedEnv(settings),
-        ...proxyEnv({ settings, proxyPort }),
+        ...propagatedEnv({ settings, networkMode }),
+        ...proxyEnv({ proxyPort }),
     }
 }
 
-function baseEnv(settings: WorkerSettings): Record<string, string> {
+function baseEnv({ settings, networkMode }: { settings: WorkerSettings, networkMode: NetworkMode }): Record<string, string> {
     return {
         HOME: '/tmp/',
         AP_EXECUTION_MODE: settings.EXECUTION_MODE,
         AP_MAX_FLOW_RUN_LOG_SIZE_MB: String(settings.MAX_FLOW_RUN_LOG_SIZE_MB),
         AP_MAX_FILE_SIZE_MB: String(settings.MAX_FILE_SIZE_MB),
         NODE_PATH: '/usr/src/node_modules',
-        AP_NETWORK_MODE: settings.NETWORK_MODE,
+        AP_NETWORK_MODE: networkMode,
     }
 }
 
@@ -109,11 +119,8 @@ function ssrfEnv(settings: WorkerSettings): Record<string, string> {
     return env
 }
 
-function proxyEnv({ settings, proxyPort }: {
-    settings: WorkerSettings
-    proxyPort: number | null
-}): Record<string, string> {
-    if (settings.NETWORK_MODE !== NetworkMode.STRICT || proxyPort === null) {
+function proxyEnv({ proxyPort }: { proxyPort: number | null }): Record<string, string> {
+    if (proxyPort === null) {
         return {}
     }
     // Never export standard HTTP_PROXY / HTTPS_PROXY env vars: axios's built-in
@@ -126,10 +133,10 @@ function proxyEnv({ settings, proxyPort }: {
     }
 }
 
-function propagatedEnv(settings: WorkerSettings): Record<string, string> {
+function propagatedEnv({ settings, networkMode }: { settings: WorkerSettings, networkMode: NetworkMode }): Record<string, string> {
     const env: Record<string, string> = {}
     for (const key of settings.SANDBOX_PROPAGATED_ENV_VARS) {
-        if (STRICT_MODE_BLOCKED_PROPAGATED_KEYS.has(key) && settings.NETWORK_MODE === NetworkMode.STRICT) {
+        if (STRICT_MODE_BLOCKED_PROPAGATED_KEYS.has(key) && networkMode === NetworkMode.STRICT) {
             continue
         }
         if (process.env[key]) {

--- a/packages/server/worker/test/e2e/fixtures/egress-probe.js
+++ b/packages/server/worker/test/e2e/fixtures/egress-probe.js
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 // Minimal probe that runs inside an isolate sandbox.
 // Reads AP_PROBE_PLAN from env (JSON array of actions) and writes a JSON summary to stdout.
-// Uses only Node core modules so it does not need any mounted node_modules.
+// Most actions use only Node core modules; the `fetch-via-undici` action additionally
+// requires undici from a mounted location (set via AP_UNDICI_REQUIRE_PATH) to exercise
+// the *exact* production code path that real user code-pieces hit:
+// globalThis.fetch -> undici global dispatcher -> ProxyAgent -> CONNECT to egress proxy.
 
 const dns = require('node:dns')
 const http = require('node:http')
@@ -39,6 +42,9 @@ async function main() {
             }
             else if (action.type === 'https-head-via-proxy') {
                 results.push(await httpsHeadViaProxy(action))
+            }
+            else if (action.type === 'fetch-via-undici') {
+                results.push(await fetchViaUndici(action))
             }
             else {
                 results.push({ action, error: 'unknown action type' })
@@ -196,6 +202,45 @@ function httpsHeadViaProxy(action) {
         })
         connectReq.end()
     })
+}
+
+// fetch-via-undici reproduces the exact data path a real user code-piece traverses
+// under STRICT mode: globalThis.fetch reads the undici global dispatcher (a ProxyAgent
+// installed by ssrf-guard's installEnvProxyDispatcher in engine main.ts), opens a
+// keep-alive client to the egress proxy, sends CONNECT for HTTPS targets, then sends
+// the request over the tunneled TLS socket. The existing https-head-via-proxy action
+// bypasses undici and the global dispatcher entirely, so it cannot detect bugs in:
+//  - ProxyAgent install / setGlobalDispatcher / Symbol-keyed state sharing with Node's
+//    built-in fetch
+//  - undici's CONNECT handling, connection pooling, redirect re-CONNECT, TLS negotiation
+//  - the AP_EGRESS_PROXY_URL env propagation chain (engine reads it; missing → fetch
+//    falls back to direct connect → iptables REJECT → EHOSTUNREACH "fetch failed")
+// AP_UNDICI_REQUIRE_PATH must point at a directory the sandbox can require the undici
+// package from (e.g. an additional mount the test sets up).
+async function fetchViaUndici(action) {
+    const started = Date.now()
+    const settle = (payload) => ({ ...payload, action, elapsedMs: Date.now() - started })
+    try {
+        const undiciPath = process.env.AP_UNDICI_REQUIRE_PATH
+        if (!undiciPath) return settle({ status: 'ERR', code: 'AP_UNDICI_REQUIRE_PATH_MISSING' })
+        const undici = require(undiciPath)
+        const proxyUrl = process.env.AP_EGRESS_PROXY_URL
+        if (proxyUrl) undici.setGlobalDispatcher(new undici.ProxyAgent(proxyUrl))
+        const res = await fetch(action.url, {
+            method: action.method || 'HEAD',
+            signal: AbortSignal.timeout(action.timeoutMs || 8000),
+        })
+        return settle({ status: 'OK', statusCode: res.status })
+    }
+    catch (err) {
+        const cause = err && err.cause
+        return settle({
+            status: 'ERR',
+            code: (err && err.code) || (cause && cause.code) || 'FETCH_ERR',
+            message: (err && err.message) || 'fetch failed',
+            causeMessage: cause && cause.message,
+        })
+    }
 }
 
 main().catch((err) => {

--- a/packages/server/worker/test/e2e/sandbox-real-third-party.e2e.test.ts
+++ b/packages/server/worker/test/e2e/sandbox-real-third-party.e2e.test.ts
@@ -1,4 +1,5 @@
-import { chmod, copyFile, mkdtemp } from 'node:fs/promises'
+import { spawnSync } from 'node:child_process'
+import { chmod, copyFile, mkdtemp, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -58,6 +59,10 @@ describe.skipIf(PRIVILEGE_SKIP)('sandbox real third-party connectivity (SANDBOX_
         await copyFile(path.resolve(__dirname, 'fixtures/egress-probe.js'), probeDst)
         await chmod(commonDir, 0o755)
         await chmod(probeDst, 0o644)
+        // Mirror undici into the common dir so the sandbox can require it. Node has no
+        // node:undici built-in; the bundled engine ships its own copy at runtime, but
+        // this probe is a standalone JS fixture that has none.
+        await mirrorUndiciInto(commonDir)
     }, 60_000)
 
     afterAll(async () => {
@@ -97,6 +102,49 @@ describe.skipIf(PRIVILEGE_SKIP)('sandbox real third-party connectivity (SANDBOX_
         const result = await runProbeInSandbox({ commonDir, plan, proxyPort: proxy.port })
         const successes = countConnectivitySuccesses({ results: result.results, hosts: GROUP_B_HOSTS })
         expect(successes, summarizeFailures({ results: result.results, hosts: GROUP_B_HOSTS })).toBeGreaterThanOrEqual(GROUP_B_HOSTS.length - 1)
+    }, 60_000)
+
+    it.skipIf(PRIVILEGE_SKIP)('Group E — globalThis.fetch via undici ProxyAgent reaches the same hosts (real code-piece path)', async (ctx) => {
+        if (internetSkip) ctx.skip()
+        // Smaller curated set: keeps the test deterministic while still exercising
+        // multi-IP / IPv6-fronted / single-A-record DNS shapes.
+        const plan: ProbeAction[] = GROUP_E_HOSTS.map((host) => ({
+            type: 'fetch-via-undici', url: `https://${host}/`, method: 'HEAD', timeoutMs: 8000, tag: `${host}:fetch`,
+        }))
+        const result = await runProbeInSandbox({ commonDir, plan, proxyPort: proxy.port })
+        const fetchResults = result.results.filter((r) => r.action.type === 'fetch-via-undici')
+        const okCount = fetchResults.filter((r) => r.status === 'OK').length
+        const summary = fetchResults
+            .filter((r) => r.status !== 'OK')
+            .map((r) => `  ${r.action.tag} → code=${r.code} cause=${r.causeMessage ?? r.message}`)
+            .join('\n')
+        expect(
+            okCount >= Math.ceil(GROUP_E_HOSTS.length * 0.8),
+            `expected >= 80% of hosts reachable via globalThis.fetch+ProxyAgent; got ${okCount}/${GROUP_E_HOSTS.length}.\n${summary}`,
+        ).toBe(true)
+    }, 90_000)
+
+    it.skipIf(PRIVILEGE_SKIP)('Group F — bug repro: STRICT iptables WITHOUT AP_EGRESS_PROXY_URL → fetch fails with EHOSTUNREACH on every host', async (ctx) => {
+        if (internetSkip) ctx.skip()
+        // Reproduces the exact symptom users see when STRICT-mode iptables is in effect
+        // but the engine never installed undici's ProxyAgent — typically because
+        // AP_EGRESS_PROXY_URL didn't reach the sandbox env. fetch falls back to direct
+        // connect; iptables REJECTs with icmp-host-prohibited; userland reports
+        // EHOSTUNREACH wrapped in "fetch failed". Locking this failure mode in keeps
+        // any future regression that drops the env var while iptables stays armed
+        // failing LOUD against the real kernel + proxy + undici stack.
+        const plan: ProbeAction[] = GROUP_E_HOSTS.map((host) => ({
+            type: 'fetch-via-undici', url: `https://${host}/`, method: 'HEAD', timeoutMs: 4000, tag: `${host}:fetch-noproxy`,
+        }))
+        const result = await runProbeInSandbox({ commonDir, plan, proxyPort: proxy.port, omitProxyUrl: true })
+        const failures = result.results.filter((r) => r.action.type === 'fetch-via-undici')
+        for (const r of failures) {
+            expect(r.status, `${r.action.tag} unexpectedly succeeded with no ProxyAgent: ${JSON.stringify(r)}`).toBe('ERR')
+            expect(
+                r.code === 'EHOSTUNREACH' || r.code === 'ENETUNREACH' || r.code === 'FETCH_ERR',
+                `${r.action.tag} expected EHOSTUNREACH-class failure (iptables REJECT → icmp-host-prohibited), got: ${JSON.stringify(r)}`,
+            ).toBe(true)
+        }
     }, 60_000)
 
     it.skipIf(PRIVILEGE_SKIP)('Group D — SSRF defense-in-depth: cloud-metadata and loopback are blocked', async (ctx) => {
@@ -150,31 +198,34 @@ function summarizeFailures({ results, hosts }: { results: ProbeResult[], hosts: 
     return lines.length > 0 ? `failures:\n${lines.join('\n')}` : 'all hosts succeeded'
 }
 
-async function runProbeInSandbox({ commonDir, plan, proxyPort }: {
+async function runProbeInSandbox({ commonDir, plan, proxyPort, omitProxyUrl }: {
     commonDir: string
     plan: ProbeAction[]
     proxyPort: number
+    omitProxyUrl?: boolean
 }): Promise<{ results: ProbeResult[] }> {
     const logger = silentLogger()
     const maker = isolateProcess(logger, path.join(commonDir, 'egress-probe.js'), commonDir, BOX_ID)
     const proxyUrl = `http://127.0.0.1:${proxyPort}`
+    const baseEnv: Record<string, string> = {
+        HOME: '/tmp/',
+        NODE_PATH: '/usr/src/node_modules',
+        AP_EXECUTION_MODE: 'SANDBOX_PROCESS',
+        AP_SANDBOX_WS_PORT: '0',
+        AP_BASE_CODE_DIRECTORY: '/root/codes',
+        SANDBOX_ID: 'e2e-real-3p',
+        AP_NETWORK_MODE: 'STRICT',
+        AP_UNDICI_REQUIRE_PATH: '/root/common/undici',
+        AP_PROBE_PLAN: JSON.stringify(plan),
+    }
+    if (!omitProxyUrl) baseEnv.AP_EGRESS_PROXY_URL = proxyUrl
     const child = await maker.create({
         sandboxId: 'e2e-real-3p',
         command: [],
         mounts: [
             { hostPath: commonDir, sandboxPath: '/root/common' },
         ],
-        env: {
-            HOME: '/tmp/',
-            NODE_PATH: '/usr/src/node_modules',
-            AP_EXECUTION_MODE: 'SANDBOX_PROCESS',
-            AP_SANDBOX_WS_PORT: '0',
-            AP_BASE_CODE_DIRECTORY: '/root/codes',
-            SANDBOX_ID: 'e2e-real-3p',
-            AP_NETWORK_MODE: 'STRICT',
-            AP_EGRESS_PROXY_URL: proxyUrl,
-            AP_PROBE_PLAN: JSON.stringify(plan),
-        },
+        env: baseEnv,
         resourceLimits: { memoryLimitMb: 256, cpuMsPerSec: 4000, timeLimitSeconds: 90 },
     })
 
@@ -232,13 +283,56 @@ const GROUP_B_HOSTS = [
     'www.figma.com',
 ] as const
 
+// Curated for the fetch-via-undici suite: diverse DNS shapes (multi-A only,
+// Cloudflare-fronted v6+v4, AWS v6+v4, Google Cloud-front) so a regression in
+// any one DNS family is visible without being host-specific.
+const GROUP_E_HOSTS = [
+    'api.airtable.com',
+    'api.github.com',
+    'api.stripe.com',
+    'api.openai.com',
+    'hooks.slack.com',
+    'graph.microsoft.com',
+] as const
+
 const MIN_GROUP_A_SUCCESSES = Math.ceil(GROUP_A_HOSTS.length * 0.8)
+
+async function mirrorUndiciInto(commonDir: string): Promise<void> {
+    const undiciRoot = await locateUndiciRoot()
+    const dest = path.join(commonDir, 'undici')
+    // -L so any symlinks (bun's symlink farm) are dereferenced — the sandbox mount
+    // must hold real files, not links into the worker host's /usr/src/app/node_modules.
+    const r = spawnSync('cp', ['-RL', undiciRoot + '/.', dest], { encoding: 'utf8' })
+    if (r.status !== 0) throw new Error(`failed to copy undici from ${undiciRoot} → ${dest}: ${r.stderr}`)
+    spawnSync('chmod', ['-R', 'a+rX', dest])
+}
+
+async function locateUndiciRoot(): Promise<string> {
+    // Engine ships undici 7.x, bundled at build time. Inside the e2e docker image,
+    // bun installs each package version under node_modules/.bun/<name>@<ver>/.../<name>.
+    // Try the engine version first (matches what real code-pieces use), then any version.
+    const candidates = [
+        '/usr/src/app/node_modules/.bun/undici@7.24.6/node_modules/undici',
+    ]
+    const globResult = spawnSync('bash', ['-c', 'ls -d /usr/src/app/node_modules/.bun/undici@*/node_modules/undici 2>/dev/null | head -1'], { encoding: 'utf8' })
+    if (globResult.stdout.trim()) candidates.push(globResult.stdout.trim())
+    for (const c of candidates) {
+        const { error } = await tryStat(path.join(c, 'package.json'))
+        if (!error) return c
+    }
+    throw new Error(`undici package not found in any of: ${candidates.join(', ')} — ensure the worker test image has bun-installed undici`)
+}
+
+async function tryStat(p: string): Promise<{ error?: Error }> {
+    try { await stat(p); return {} } catch (e) { return { error: e as Error } }
+}
 
 type ProbeAction =
     | { type: 'dns-lookup', hostname: string, tag: string }
     | { type: 'dns-lookup-v6', hostname: string, tag: string }
     | { type: 'https-head-via-proxy', url: string, timeoutMs: number, tag: string }
     | { type: 'direct-tcp-connect', host: string, port: number, tag: string }
+    | { type: 'fetch-via-undici', url: string, method?: string, timeoutMs?: number, tag: string }
 
 type ProbeResult = {
     action: ProbeAction
@@ -246,6 +340,7 @@ type ProbeResult = {
     statusCode?: number
     code?: string
     message?: string
+    causeMessage?: string
     address?: string
     elapsedMs?: number
 }

--- a/packages/server/worker/test/lib/execute/create-sandbox-for-job.test.ts
+++ b/packages/server/worker/test/lib/execute/create-sandbox-for-job.test.ts
@@ -102,7 +102,7 @@ describe('createSandboxForJob', () => {
     describe('baseMounts', () => {
         it('contains exactly /root/common → getGlobalCacheCommonPath()', () => {
             getSettingsMock.mockReturnValue(buildSettings())
-            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: null })
 
             const options = createSandboxMock.mock.calls[0][2]
             expect(options.baseMounts).toEqual([
@@ -112,7 +112,7 @@ describe('createSandboxForJob', () => {
 
         it('never leaks host / or /etc into baseMounts', () => {
             getSettingsMock.mockReturnValue(buildSettings())
-            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: null })
 
             const options = createSandboxMock.mock.calls[0][2]
             for (const mount of options.baseMounts) {
@@ -150,14 +150,14 @@ describe('createSandboxForJob', () => {
     })
 
     describe('buildSandboxEnv', () => {
-        it('emits all required keys including NODE_PATH', () => {
+        it('emits all required keys including NODE_PATH (STRICT when proxyPort is set)', () => {
             getSettingsMock.mockReturnValue(buildSettings({
                 EXECUTION_MODE: ExecutionMode.SANDBOX_PROCESS,
                 MAX_FLOW_RUN_LOG_SIZE_MB: 25,
                 MAX_FILE_SIZE_MB: 50,
                 NETWORK_MODE: NetworkMode.STRICT,
             }))
-            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: 49321 })
 
             const env = createSandboxMock.mock.calls[0][2].env
             expect(env).toMatchObject({
@@ -167,12 +167,13 @@ describe('createSandboxForJob', () => {
                 AP_MAX_FILE_SIZE_MB: '50',
                 NODE_PATH: '/usr/src/node_modules',
                 AP_NETWORK_MODE: NetworkMode.STRICT,
+                AP_EGRESS_PROXY_URL: 'http://127.0.0.1:49321',
             })
         })
 
         it('omits AP_DEV_PIECES when DEV_PIECES is empty', () => {
             getSettingsMock.mockReturnValue(buildSettings({ DEV_PIECES: [] }))
-            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: null })
 
             const env = createSandboxMock.mock.calls[0][2].env
             expect(env.AP_DEV_PIECES).toBeUndefined()
@@ -180,7 +181,7 @@ describe('createSandboxForJob', () => {
 
         it('joins DEV_PIECES with comma', () => {
             getSettingsMock.mockReturnValue(buildSettings({ DEV_PIECES: ['a', 'b', 'c'] }))
-            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: null })
 
             const env = createSandboxMock.mock.calls[0][2].env
             expect(env.AP_DEV_PIECES).toBe('a,b,c')
@@ -194,7 +195,7 @@ describe('createSandboxForJob', () => {
                 getSettingsMock.mockReturnValue(buildSettings({
                     SANDBOX_PROPAGATED_ENV_VARS: ['PROPAGATED_YES', 'PROPAGATED_NO'],
                 }))
-                createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+                createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: null })
 
                 const env = createSandboxMock.mock.calls[0][2].env
                 expect(env.PROPAGATED_YES).toBe('forwarded')
@@ -209,14 +210,14 @@ describe('createSandboxForJob', () => {
     describe('parseMemoryLimit', () => {
         it('converts KB string to MB', () => {
             getSettingsMock.mockReturnValue(buildSettings({ SANDBOX_MEMORY_LIMIT: '524288' }))
-            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: null })
 
             expect(createSandboxMock.mock.calls[0][2].memoryLimitMb).toBe(512)
         })
 
         it('defaults to 1024 MB on invalid input', () => {
             getSettingsMock.mockReturnValue(buildSettings({ SANDBOX_MEMORY_LIMIT: 'not-a-number' }))
-            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false })
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: null })
 
             expect(createSandboxMock.mock.calls[0][2].memoryLimitMb).toBe(1024)
         })
@@ -224,8 +225,59 @@ describe('createSandboxForJob', () => {
 
     it('forwards reusable flag into createSandbox options', () => {
         getSettingsMock.mockReturnValue(buildSettings())
-        createSandboxForJob({ log, apiClient, boxId: 1, reusable: true })
+        createSandboxForJob({ log, apiClient, boxId: 1, reusable: true, proxyPort: null })
 
         expect(createSandboxMock.mock.calls[0][2].reusable).toBe(true)
+    })
+
+    // The sandbox network env follows the egress stack's runtime state (proxyPort),
+    // not the live workerSettings.NETWORK_MODE. The stack starts once at worker boot;
+    // settings refresh on every reconnect. Keying off proxyPort prevents the
+    // STRICT iptables + missing AP_EGRESS_PROXY_URL drift that surfaces as
+    // EHOSTUNREACH ("fetch failed") in user code-pieces.
+    describe('sandbox network env follows proxyPort, not live settings', () => {
+        it('proxyPort=null + NETWORK_MODE=STRICT in settings → engine sees UNRESTRICTED, no proxy URL', () => {
+            // Drift scenario: settings flipped STRICT after boot but the egress stack
+            // was never (re)started, so the firewall isn't actually armed. Telling the
+            // engine it is would install ProxyAgent pointed at nothing.
+            getSettingsMock.mockReturnValue(buildSettings({ NETWORK_MODE: NetworkMode.STRICT }))
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: null })
+
+            const env = createSandboxMock.mock.calls[0][2].env
+            expect(env.AP_NETWORK_MODE).toBe(NetworkMode.UNRESTRICTED)
+            expect('AP_EGRESS_PROXY_URL' in env).toBe(false)
+        })
+
+        it('proxyPort=<port> + NETWORK_MODE=UNRESTRICTED in settings → engine sees STRICT, proxy URL set', () => {
+            // Drift scenario users actually hit: settings flipped UNRESTRICTED after
+            // boot, but iptables is still armed and the proxy is still listening.
+            // Engine MUST install ProxyAgent or every fetch fails with EHOSTUNREACH.
+            getSettingsMock.mockReturnValue(buildSettings({ NETWORK_MODE: NetworkMode.UNRESTRICTED }))
+            createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: 49322 })
+
+            const env = createSandboxMock.mock.calls[0][2].env
+            expect(env.AP_NETWORK_MODE).toBe(NetworkMode.STRICT)
+            expect(env.AP_EGRESS_PROXY_URL).toBe('http://127.0.0.1:49322')
+        })
+
+        it('blocks HTTP_PROXY-style propagated env vars when STRICT is derived from proxyPort, not settings', () => {
+            const originalProcessEnv = { ...process.env }
+            try {
+                process.env.HTTP_PROXY = 'http://leak:3128'
+                process.env.HTTPS_PROXY = 'http://leak:3128'
+                getSettingsMock.mockReturnValue(buildSettings({
+                    NETWORK_MODE: NetworkMode.UNRESTRICTED,
+                    SANDBOX_PROPAGATED_ENV_VARS: ['HTTP_PROXY', 'HTTPS_PROXY'],
+                }))
+                createSandboxForJob({ log, apiClient, boxId: 1, reusable: false, proxyPort: 49323 })
+
+                const env = createSandboxMock.mock.calls[0][2].env
+                expect('HTTP_PROXY' in env).toBe(false)
+                expect('HTTPS_PROXY' in env).toBe(false)
+            }
+            finally {
+                process.env = originalProcessEnv
+            }
+        })
     })
 })


### PR DESCRIPTION
## Summary

User code-pieces in STRICT-mode workers intermittently fail with `fetch failed` + `cause.code = EHOSTUNREACH` on *every* outbound host. The symptom is not specific to any third-party API — it's the kernel firewall rejecting direct egress because the sandbox engine never installed undici's `ProxyAgent`.

## Root cause

The egress stack (proxy + iptables UID-owner REJECT chain) is initialized **once** on first socket connect (`worker.ts:62`, guarded by `if (!egressStack)`), but `settings.NETWORK_MODE` is refreshed on **every** reconnect via `fetchAndStoreSettings`. `proxyEnv()` in `create-sandbox-for-job.ts` read the live setting; when it flipped STRICT → UNRESTRICTED after boot, `AP_EGRESS_PROXY_URL` got dropped from new sandbox envs while iptables stayed armed (only torn down on `egressStack.shutdown`).

Result inside the sandbox: engine's `ssrfGuard` sees no proxy URL → no `ProxyAgent` → `fetch` falls back to direct connect → iptables `REJECT --reject-with icmp-host-prohibited` → kernel returns `EHOSTUNREACH` → undici surfaces `"fetch failed"`.

## Fix

Derive `AP_NETWORK_MODE` and `AP_EGRESS_PROXY_URL` from `proxyPort` — the runtime state of the egress stack at boot — not from re-readable settings. `proxyPort` being non-null is now the single source of truth for "firewall armed". Env var, `ssrfGuard`, and iptables all stay on the same axis regardless of settings drift mid-life.

## Tests

- **Unit** (`create-sandbox-for-job.test.ts`): new invariant locked in — `proxyPort=null` → `UNRESTRICTED` env even if settings say STRICT; `proxyPort=N` → STRICT + proxy URL even if settings say UNRESTRICTED. HTTP_PROXY-style propagated env blocking is now keyed on the derived mode.
- **e2e Group E** (`sandbox-real-third-party.e2e.test.ts`): `globalThis.fetch` via `undici.ProxyAgent` reaches 6 hosts of varied DNS shapes (AWS v6+v4, Cloudflare v6+v4, multi-A v4-only, MS). Closes the gap left by `https-head-via-proxy`, which bypassed undici and the global dispatcher entirely.
- **e2e Group F** (regression repro): STRICT iptables in place but `AP_EGRESS_PROXY_URL` omitted → every fetch must fail with `EHOSTUNREACH`/`ENETUNREACH`. Any future regression that loses the env var while iptables stays armed will fail loud against the real kernel + proxy + undici stack.

## Test plan

- [x] `npx vitest run packages/server/worker/test/lib/execute/create-sandbox-for-job.test.ts` — 16/16 pass
- [x] `npx turbo run lint --filter=worker` — 0 errors
- [x] `npm run test:sandbox-e2e` (privileged Docker) — Groups A, B, D, E, F all pass
- [x] Pre-push lint + unit-test gate green (14/14 tasks)