### PR TITLE
fix(chat): custom API call support, build card fixes, and action name suggestions

### DIFF
--- a/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
+++ b/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
@@ -1,4 +1,4 @@
-import { FlowRunStatus, FlowStatus, isNil, Project, RunEnvironment } from '@activepieces/shared'
+import { FlowRunStatus, FlowStatus, isNil, parseToJsonIfPossible, Project, RunEnvironment } from '@activepieces/shared'
 import { SharedV3ProviderOptions } from '@ai-sdk/provider'
 import { LanguageModel, tool, ToolSet } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
@@ -78,11 +78,14 @@ function createChatTools({ onSessionTitle, onSetProjectContext, projects, platfo
                 if (!availableProjectIds.includes(input.projectId)) {
                     return { content: [{ type: 'text', text: `❌ Project ${input.projectId} is not accessible.` }] }
                 }
+                const parsedInput = typeof input.input === 'string'
+                    ? parseToJsonIfPossible(input.input) as Record<string, unknown>
+                    : input.input
                 return executeAdhocAction({
                     projectId: input.projectId,
                     pieceName: input.pieceName,
                     actionName: input.actionName,
-                    input: input.input,
+                    input: parsedInput,
                     connectionExternalId: input.connectionExternalId,
                     log,
                 })

--- a/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
+++ b/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
@@ -78,9 +78,13 @@ function createChatTools({ onSessionTitle, onSetProjectContext, projects, platfo
                 if (!availableProjectIds.includes(input.projectId)) {
                     return { content: [{ type: 'text', text: `❌ Project ${input.projectId} is not accessible.` }] }
                 }
-                const parsedInput = typeof input.input === 'string'
-                    ? parseToJsonIfPossible(input.input) as Record<string, unknown>
-                    : input.input
+                let parsedInput = input.input
+                if (typeof parsedInput === 'string') {
+                    const parsed = parseToJsonIfPossible(parsedInput)
+                    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+                        parsedInput = parsed as Record<string, unknown>
+                    }
+                }
                 return executeAdhocAction({
                     projectId: input.projectId,
                     pieceName: input.pieceName,

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -139,7 +139,7 @@ export async function executeAdhocAction({
         ...(connectionExternalId !== undefined && { auth: `{{connections['${connectionExternalId}']}}` }),
     }
 
-    // custom_api_call expects url as nested { url: string } from DynamicProperties
+    // createCustomApiCallAction wraps url in DynamicProperties, expecting { url: string } not a flat string
     if (actionName === 'custom_api_call' && typeof resolvedInput.url === 'string') {
         resolvedInput.url = { url: resolvedInput.url }
     }

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -139,6 +139,11 @@ export async function executeAdhocAction({
         ...(connectionExternalId !== undefined && { auth: `{{connections['${connectionExternalId}']}}` }),
     }
 
+    // custom_api_call expects url as nested { url: string } from DynamicProperties
+    if (actionName === 'custom_api_call' && typeof resolvedInput.url === 'string') {
+        resolvedInput.url = { url: resolvedInput.url }
+    }
+
     const diagnosis = mcpUtils.diagnosePieceProps({
         props: action.props,
         input: resolvedInput,

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -174,7 +174,10 @@ async function lookupPieceComponent({ pieceName, componentName, componentType, p
     const label = componentType === 'action' ? 'Action' : 'Trigger'
     const component = componentMap[componentName]
     if (isNil(component)) {
-        return { error: { content: [{ type: 'text', text: `❌ ${label} "${componentName}" not found in "${normalized}". Available: ${Object.keys(componentMap).join(', ')}` }] } }
+        const available = Object.keys(componentMap)
+        const suggestion = available.find((name) => name.includes(componentName) || componentName.includes(name))
+        const hint = suggestion ? ` Did you mean "${suggestion}"?` : ''
+        return { error: { content: [{ type: 'text', text: `❌ ${label} "${componentName}" not found in "${normalized}".${hint} Available: ${available.join(', ')}` }] } }
     }
     return { piece, component, pieceName: normalized }
 }

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -175,7 +175,7 @@ async function lookupPieceComponent({ pieceName, componentName, componentType, p
     const component = componentMap[componentName]
     if (isNil(component)) {
         const available = Object.keys(componentMap)
-        const suggestion = available.find((name) => name.includes(componentName) || componentName.includes(name))
+        const suggestion = available.find((name) => name.includes(componentName))
         const hint = suggestion ? ` Did you mean "${suggestion}"?` : ''
         return { error: { content: [{ type: 'text', text: `❌ ${label} "${componentName}" not found in "${normalized}".${hint} Available: ${available.join(', ')}` }] } }
     }

--- a/packages/server/api/src/assets/prompts/chat-builder-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-builder-prompt.md
@@ -65,3 +65,21 @@ c. If any fields couldn't be resolved or tests failed, add an **orange** note li
 
 Resolve parent fields before dependent children (e.g., select Spreadsheet before Sheet).
 </property_filling_guide>
+
+<custom_api_call>
+When a piece does not have a built-in action for what the user needs, use that piece's `custom_api_call` action instead.
+
+How to configure:
+1. **URL**: Use a **relative path** — the piece's base URL is prepended automatically.
+   - Each piece has a base URL (e.g. Gmail: `https://gmail.googleapis.com/gmail/v1`, Slack: `https://slack.com/api`).
+   - Set only the path: `/users/me/messages/{{trigger.message.id}}/modify` — the system builds the full URL.
+   - A full URL starting with `https://` is also accepted but used as-is without prepending — only use this when calling a completely different service.
+2. **Method**: Set to the correct HTTP method (GET, POST, PUT, PATCH, DELETE).
+3. **Headers**: Not needed — the piece injects auth headers automatically from the connection.
+4. **Query params**: Pass as key-value pairs if the endpoint needs query parameters.
+5. **Body**: For POST/PUT/PATCH, pass the request body as JSON. Use step references like `{{trigger.field}}` for dynamic values.
+
+When to use custom_api_call:
+- The user asks for an action that the piece doesn't have as a named action (e.g. "mark as spam" in Gmail, "archive a card" in Trello).
+- You searched with `ap_get_piece_props` and the specific action doesn't exist.
+</custom_api_call>

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -67,6 +67,8 @@ When building an automation, follow these steps in order:
 **Step 1 — GATHER REQUIREMENTS**
 If the request already names specific apps and actions, skip to Step 2. Otherwise, ask ONE clarifying question via `multi-question` block. Stop and wait.
 
+If the user needs an action that a piece doesn't have built-in (e.g. "mark Gmail as spam", "archive a Trello card"), plan to use that piece's `custom_api_call` action with the correct API path. The builder knows how to configure it.
+
 **Step 2 — PROPOSE**
 Show an `automation-proposal` block based on the user's request. STOP — nothing else in this message. Do NOT call any tools or select a project. Wait for "Build this automation".
 

--- a/packages/web/src/app/routes/chat-with-ai/components/build-progress-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/build-progress-card.tsx
@@ -336,7 +336,8 @@ function useAnimatedStatuses({
 
   useEffect(() => {
     if (!isStreaming) {
-      setDisplayed(targetStatuses);
+      const changed = targetStatuses.some((s, i) => s !== displayed[i]);
+      if (changed) setDisplayed(targetStatuses);
       return;
     }
 

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-message.tsx
@@ -18,7 +18,11 @@ import { ChatUIMessage, DynamicToolPart } from '@/features/chat/lib/chat-types';
 import { chatUtils } from '@/features/chat/lib/chat-utils';
 import { cn } from '@/lib/utils';
 
-import { getTextFromParts, parseBuildProgress } from '../lib/message-parsers';
+import {
+  getTextFromParts,
+  parseAllBuildProgress,
+  parseBuildProgress,
+} from '../lib/message-parsers';
 
 import { ThinkingBlock } from './activity-accordion';
 import { BuildProgressCard } from './build-progress-card';
@@ -315,24 +319,28 @@ function renderTextParts({
   }>;
 }): React.ReactNode[] {
   const fullText = parts.map((p) => p.text).join('');
-  const { progress: buildProgress } = parseBuildProgress(fullText);
+  const { progressList } = parseAllBuildProgress(fullText);
 
   const nodes: React.ReactNode[] = [];
 
-  if (buildProgress) {
+  if (progressList.length > 0) {
     const toolParts =
       allConversationToolParts ??
       allParts.filter((p) => p.type === 'dynamic-tool');
-    nodes.push(
-      <BuildProgressCard
-        key="build-progress"
-        progress={buildProgress}
-        toolParts={toolParts}
-        allParts={allParts}
-        buildStepUpdates={buildProgressUpdates}
-        isStreaming={isStreaming}
-      />,
-    );
+    for (let idx = 0; idx < progressList.length; idx++) {
+      nodes.push(
+        <BuildProgressCard
+          key={`build-progress-${idx}`}
+          progress={progressList[idx]}
+          toolParts={toolParts}
+          allParts={allParts}
+          buildStepUpdates={
+            idx === progressList.length - 1 ? buildProgressUpdates : undefined
+          }
+          isStreaming={isStreaming}
+        />,
+      );
+    }
   }
 
   for (let i = 0; i < parts.length; i++) {

--- a/packages/web/src/app/routes/chat-with-ai/lib/message-parsers.ts
+++ b/packages/web/src/app/routes/chat-with-ai/lib/message-parsers.ts
@@ -362,12 +362,39 @@ export function parseBuildProgress(content: string): {
   progress: BuildProgressData | null;
   cleanContent: string;
 } {
-  const { block, cleanContent } = parseCodeBlock(content, 'build-progress');
-  if (!block) return { progress: null, cleanContent: content };
+  const result = parseAllBuildProgress(content);
+  return {
+    progress: result.progressList[0] ?? null,
+    cleanContent: result.cleanContent,
+  };
+}
 
+export function parseAllBuildProgress(content: string): {
+  progressList: BuildProgressData[];
+  cleanContent: string;
+} {
+  const regex = /```\s*build-progress\s*\r?\n([\s\S]*?)\r?\n?\s*```/g;
+  const progressList: BuildProgressData[] = [];
+  let cleanContent = content;
+  let match;
+
+  while ((match = regex.exec(content)) !== null) {
+    const block = match[1];
+    const parsed = parseBuildBlock(block);
+    if (parsed) progressList.push(parsed);
+    cleanContent = cleanContent
+      .replace(match[0], '')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
+  }
+
+  return { progressList, cleanContent };
+}
+
+function parseBuildBlock(block: string): BuildProgressData | null {
   const titleMatch = /^title:\s*(.+)$/m.exec(block);
+  if (!titleMatch) return null;
   const projectMatch = /^project:\s*(.+)$/m.exec(block);
-  if (!titleMatch) return { progress: null, cleanContent: content };
 
   const steps: BuildProgressData['steps'] = [];
   const stepBlocks = block.split(/^-\s+type:\s*/m).slice(1);
@@ -388,15 +415,12 @@ export function parseBuildProgress(content: string): {
     });
   }
 
-  if (steps.length === 0) return { progress: null, cleanContent: content };
+  if (steps.length === 0) return null;
 
   return {
-    progress: {
-      title: titleMatch[1].trim(),
-      project: projectMatch?.[1].trim() ?? '',
-      steps,
-    },
-    cleanContent,
+    title: titleMatch[1].trim(),
+    project: projectMatch?.[1].trim() ?? '',
+    steps,
   };
 }
 


### PR DESCRIPTION
## Summary
- Parse stringified JSON input in `ap_run_one_time_action` using `parseToJsonIfPossible` from shared
- Wrap `url` field for `custom_api_call` actions in `executeAdhocAction` (DynamicProperties nesting)
- Add fuzzy "Did you mean?" suggestion when action name lookup fails
- Fix build-progress card infinite re-render loop with equality check in `useAnimatedStatuses`
- Support multiple build-progress cards in a single message
- Clear `buildProgressUpdates` on conversation switch
- Add `custom_api_call` guidance to builder and system prompts

## Test plan
- [x] Run one-time Gmail search action — input parsed correctly, action name suggestion works
- [ ] Build a flow with custom_api_call step — URL set as relative path
- [ ] Build-progress card shows multiple cards when model outputs two flows
- [ ] No React error #185 when loading conversation history with build messages