### PR TITLE
fix(lemlist): campaigns dropdown was broken 

### DIFF
--- a/packages/pieces/community/lemlist/package.json
+++ b/packages/pieces/community/lemlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-lemlist",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/lemlist/src/lib/common/constants.ts
+++ b/packages/pieces/community/lemlist/src/lib/common/constants.ts
@@ -6,7 +6,12 @@ export const BASE_URL = 'https://api.lemlist.com/api';
 
 export const lemlistAuth = PieceAuth.SecretText({
   displayName: 'Lemlist API Key',
-  description: 'Enter your Lemlist API key',
+  description: `
+  
+  1.Click on your profile picture in the bottom left-hand corner and click on Settings.
+  2.Go to the Integrations tab.
+  3.Click on Generate a new API key.
+  4.Store it securely because you won’t be able to see it again`,
   required: true,
   validate: async ({ auth }) => {
     try {

--- a/packages/pieces/community/lemlist/src/lib/common/props.ts
+++ b/packages/pieces/community/lemlist/src/lib/common/props.ts
@@ -17,7 +17,7 @@ export const campaignsDropdown = ({
       : 'Select a campaign (optional)',
     required,
     refreshers,
-    async options({ auth }: any) {
+    async options({ auth }) {
       if (!auth) {
         return {
           disabled: true,
@@ -27,7 +27,7 @@ export const campaignsDropdown = ({
       }
 
       try {
-        const campaigns = await lemlistApiService.fetchCampaigns(auth);
+        const campaigns = await lemlistApiService.fetchCampaigns(auth.secret_text);
 
         return {
           options: campaigns.map((c: any) => ({


### PR DESCRIPTION
- Pass `auth.secret_text` (string) instead of the full connection object to `fetchCampaigns` in the campaigns dropdown
- Remove unsafe `any` cast on the options `auth` parameter
- Improve API key description with step-by-step instructions for finding the key in Lemlist settings

