### PR TITLE
fix(trigger-source): add missing flowVersionId index

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1792000000000-AddTriggerSourceFlowVersionIdIndex.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1792000000000-AddTriggerSourceFlowVersionIdIndex.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { system } from '../../../helper/system/system'
+import { AppSystemProp } from '../../../helper/system/system-props'
+import { DatabaseType } from '../../database-type'
+
+const databaseType = system.get(AppSystemProp.DB_TYPE)
+const isPGlite = databaseType === DatabaseType.PGLITE
+
+export class AddTriggerSourceFlowVersionIdIndex1792000000000 implements MigrationInterface {
+    name = 'AddTriggerSourceFlowVersionIdIndex1792000000000'
+    release = '0.83.0'
+    breaking = false
+    transaction = false
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (isPGlite) {
+            await queryRunner.query(`
+                CREATE INDEX IF NOT EXISTS "idx_trigger_flow_version_id"
+                ON "trigger_source" ("flowVersionId")
+                WHERE "deleted" IS NULL
+            `)
+        }
+        else {
+            await queryRunner.query(`
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_trigger_flow_version_id"
+                ON "trigger_source" ("flowVersionId")
+                WHERE "deleted" IS NULL
+            `)
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP INDEX IF EXISTS "idx_trigger_flow_version_id"')
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -373,6 +373,7 @@ import { AddPlatformMcpServer1788000000000 } from './migration/postgres/17880000
 import { MakeMcpOAuthProjectIdNullable1789000000000 } from './migration/postgres/1789000000000-MakeMcpOAuthProjectIdNullable'
 import { RemoveMcpServerStatus1790000000000 } from './migration/postgres/1790000000000-RemoveMcpServerStatus'
 import { RenameEnabledToolsToDisabledTools1791000000000 } from './migration/postgres/1791000000000-RenameEnabledToolsToDisabledTools'
+import { AddTriggerSourceFlowVersionIdIndex1792000000000 } from './migration/postgres/1792000000000-AddTriggerSourceFlowVersionIdIndex'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -761,6 +762,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         MakeChatConversationPlatformWide1787000000000,
         RemoveMcpServerStatus1790000000000,
         RenameEnabledToolsToDisabledTools1791000000000,
+        AddTriggerSourceFlowVersionIdIndex1792000000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-source-entity.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-source-entity.ts
@@ -76,6 +76,12 @@ export const TriggerSourceEntity = new EntitySchema<TriggerSourceSchema>({
             name: 'idx_trigger_project_id',
             unique: false,
         },
+        {
+            columns: ['flowVersionId'],
+            name: 'idx_trigger_flow_version_id',
+            where: 'deleted IS NULL',
+            unique: false,
+        },
     ],
     relations: {
         flow: {


### PR DESCRIPTION
## Summary

- Cherry-picked from the main-targeted PR so the index ships with the in-flight cloud release.
- Adds a partial btree index `idx_trigger_flow_version_id` on `trigger_source(flowVersionId) WHERE deleted IS NULL` to back the per-job lookup that runs inside the zombie-polling interceptor.
- Migration uses `CREATE INDEX CONCURRENTLY` with `transaction = false` so the index is created online without blocking writes; PGlite path falls back to a regular `CREATE INDEX IF NOT EXISTS`.

## Why

`zombie-polling-interceptor.ts` runs `triggerSourceRepo().findOneBy({ flowVersionId })` in `preDispatch` for **every** `EXECUTE_POLLING` and `RENEW_WEBHOOK` job. No existing index on `trigger_source` has `flowVersionId` as the leading column, so each call falls back to a sequential scan of the table (~274k rows in EU prod). `pg_stat_statements` shows this single query at **~84% of total cumulative DB time** on EU prod — the dominant driver of CPU pressure. With the partial index the plan flips to an index scan and mean time drops from ~30 ms to <1 ms.

## Test plan
- [ ] Migration runs cleanly on a fresh CE DB
- [ ] `npx turbo run check-migrations --filter=api` passes (schema drift check)
- [ ] After migration, `EXPLAIN (ANALYZE, BUFFERS) SELECT id FROM trigger_source WHERE "flowVersionId" = '<id>' AND deleted IS NULL LIMIT 1` shows `Index Scan using idx_trigger_flow_version_id`
- [ ] DB CPU on EU prod drops after rollout