### PR TITLE
ci: generate SBOMs and Grype scans for all image builds

### DIFF
--- a/.github/actions/sbom/action.yml
+++ b/.github/actions/sbom/action.yml
@@ -1,0 +1,71 @@
+name: SBOM
+description: Generates CycloneDX + SPDX SBOMs for a Docker image, scans them with Grype, and conditionally uploads to GitHub Releases and the Security tab.
+
+inputs:
+  image:
+    description: Full image reference with tag (e.g. ghcr.io/activepieces/activepieces:0.83.0).
+    required: true
+  version:
+    description: Version string used to name the SBOM files and as the Grype SARIF category.
+    required: true
+  upload-release:
+    description: If 'true', attach both SBOMs as assets to the GitHub Release named after `version`.
+    required: false
+    default: 'false'
+  upload-sarif:
+    description: "If 'true', upload the Grype SARIF report to the GitHub Security tab. Requires security-events write permission on the calling job."
+    required: false
+    default: 'false'
+  github-token:
+    description: Token used for `gh release upload`. Required when `upload-release` is true.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+    - name: Generate SBOMs (CycloneDX + SPDX)
+      shell: bash
+      run: |
+        syft "${{ inputs.image }}" \
+          -o "cyclonedx-json=activepieces-${{ inputs.version }}.cdx.json" \
+          -o "spdx-json=activepieces-${{ inputs.version }}.spdx.json"
+
+    - name: Scan SBOM with Grype
+      id: grype
+      uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6.5.1
+      with:
+        sbom: activepieces-${{ inputs.version }}.cdx.json
+        output-format: sarif
+        fail-build: false
+        severity-cutoff: high
+
+    - name: Upload SARIF to GitHub Security tab
+      if: inputs.upload-sarif == 'true'
+      uses: github/codeql-action/upload-sarif@1521896cd211af95be3f02edf6f436e10b819c27 # v3.35.4
+      with:
+        sarif_file: ${{ steps.grype.outputs.sarif }}
+        category: grype-${{ inputs.version }}
+
+    - name: Attach SBOMs to GitHub Release
+      if: inputs.upload-release == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        gh release upload "${{ inputs.version }}" \
+          "activepieces-${{ inputs.version }}.cdx.json" \
+          "activepieces-${{ inputs.version }}.spdx.json"
+
+    - name: Upload SBOMs + SARIF as workflow artifact
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: sbom-${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt }}
+        path: |
+          activepieces-${{ inputs.version }}.cdx.json
+          activepieces-${{ inputs.version }}.spdx.json
+          ${{ steps.grype.outputs.sarif }}
+        retention-days: 30
+        if-no-files-found: error

--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -35,3 +35,8 @@ jobs:
           push: true
           tags: |
             ghcr.io/activepieces/activepieces-cloud:${{ env.RELEASE }}.${{ github.sha }}.beta
+
+      - uses: ./.github/actions/sbom
+        with:
+          image: ghcr.io/activepieces/activepieces-cloud:${{ env.RELEASE }}.${{ github.sha }}.beta
+          version: ${{ env.RELEASE }}.${{ github.sha }}.beta

--- a/.github/workflows/continuous-delivery-canary.yml
+++ b/.github/workflows/continuous-delivery-canary.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build-image:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
     concurrency:
       group: canary-deploy
       cancel-in-progress: true
@@ -43,6 +47,12 @@ jobs:
           push: true
           no-cache: true
           tags: ghcr.io/activepieces/activepieces-cloud:${{ steps.set-tag.outputs.image_tag }}
+
+      - uses: ./.github/actions/sbom
+        with:
+          image: ghcr.io/activepieces/activepieces-cloud:${{ steps.set-tag.outputs.image_tag }}
+          version: ${{ steps.set-tag.outputs.image_tag }}
+          upload-sarif: 'true'
 
   check-migrations:
     needs: build-image

--- a/.github/workflows/continuous-delivery-release.yml
+++ b/.github/workflows/continuous-delivery-release.yml
@@ -100,6 +100,15 @@ jobs:
             --tag ghcr.io/activepieces/activepieces:latest \
             ghcr.io/activepieces/activepieces-cloud:release-candidate
 
+      # Internal-only for now.
+      # To expose them on the GitHub Release for supply-chain audits,
+      # set upload-release: 'true'
+      # and pass github-token: ${{ secrets.GITHUB_TOKEN }}.
+      - uses: ./.github/actions/sbom
+        with:
+          image: ghcr.io/activepieces/activepieces:${{ steps.version.outputs.release }}
+          version: ${{ steps.version.outputs.release }}
+
       - name: Add breaking migration note to release
         if: steps.migration-check.outputs.has_breaking == 'true'
         run: |

--- a/.github/workflows/release-self-hosted.yml
+++ b/.github/workflows/release-self-hosted.yml
@@ -64,3 +64,12 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Internal-only for now.
+      # To expose them on the GitHub Release for supply-chain audits,
+      # set upload-release: 'true'
+      # and pass github-token: ${{ secrets.GITHUB_TOKEN }}.
+      - uses: ./.github/actions/sbom
+        with:
+          image: ghcr.io/activepieces/activepieces:${{ inputs.tag }}
+          version: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary
- New `.github/actions/sbom` composite action: Syft (CycloneDX + SPDX) SBOMs, Grype (SARIF)
- Wired into all 4 image-producing workflows: build-cloud-image, continuous-delivery-canary, continuous-delivery-release, release-self-hosted
- Canary uploads SARIF to the Security tab (Code scanning alerts). the others store it as a workflow artifact

## Test plan
- [ ] Manually dispatch `Release Self-Hosted` with tag `0.83.0-sbom-test`. confirm the `sbom-<tag>-...` artifact appears on the run
- [ ] Download the artifact; verify it contains `*.cdx.json`, `*.spdx.json`, and `results.sarif`
- [ ] Verify next canary build posts findings to Security -> Code scanning under category `grype-<canary-tag>`
