### PR TITLE
fix(server): bump worker-group cache key to v2 to isolate rolling-deploy reads

### DIFF
--- a/packages/server/api/src/app/ee/platform/platform-plan/worker-group.service.ts
+++ b/packages/server/api/src/app/ee/platform/platform-plan/worker-group.service.ts
@@ -10,7 +10,7 @@ export const CANARY_WORKER_GROUP_ID = 'canary'
 
 const NO_WORKER_GROUP_SENTINEL = '__none__'
 const CACHE_TTL_SECONDS = apDayjsDuration(5, 'minute').asSeconds()
-const getWorkerGroupCacheKey = (platformId: string): string => `platform:${platformId}:worker_group_id`
+const getWorkerGroupCacheKey = (platformId: string): string => `platform:${platformId}:worker_group_id:v2`
 
 export const workerGroupService = (log: FastifyBaseLogger) => ({
     async getWorkerGroupId({ platformId }: { platformId: string }): Promise<string | null> {

--- a/packages/server/api/src/app/workers/migrations/delete-legacy-redis-keys.ts
+++ b/packages/server/api/src/app/workers/migrations/delete-legacy-redis-keys.ts
@@ -4,13 +4,14 @@ import { FastifyBaseLogger } from 'fastify'
 import { redisHelper } from '../../database/redis'
 import { redisConnections } from '../../database/redis-connections'
 
-const DELETE_LEGACY_REDIS_KEYS_KEY = 'delete_legacy_redis_keys'
+const DELETE_LEGACY_REDIS_KEYS_KEY = 'delete_legacy_redis_keys_v2'
 
 const LEGACY_PATTERNS = [
     'tasks:project:*',
     'tasks:platform:*',
     'project-usage:*',
     'project-*-usage-tasks:*',
+    'platform:*:worker_group_id',
 ]
 
 export const deleteLegacyRedisKeys = (log: FastifyBaseLogger) => ({

--- a/packages/server/api/test/unit/app/core/canary/worker-group.service.test.ts
+++ b/packages/server/api/test/unit/app/core/canary/worker-group.service.test.ts
@@ -61,7 +61,7 @@ describe('workerGroupService', () => {
             const result = await service.getWorkerGroupId({ platformId: 'p1' })
 
             expect(result).toBe('canary')
-            expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p1:worker_group_id', 'canary', expect.any(Number))
+            expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p1:worker_group_id:v2', 'canary', expect.any(Number))
         })
 
         it('returns null and caches sentinel when platform has no worker group', async () => {
@@ -71,7 +71,7 @@ describe('workerGroupService', () => {
             const result = await service.getWorkerGroupId({ platformId: 'p2' })
 
             expect(result).toBeNull()
-            expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p2:worker_group_id', '__none__', expect.any(Number))
+            expect(mockDistributedStorePut).toHaveBeenCalledWith('platform:p2:worker_group_id:v2', '__none__', expect.any(Number))
         })
 
         it('returns null without hitting DB when sentinel is cached', async () => {


### PR DESCRIPTION
## Summary

- Bumps the worker-group Redis cache key from `platform:<id>:worker_group_id` to `platform:<id>:worker_group_id:v2` so the pre- and post-#13199 read paths are isolated during a rolling deploy.
- Adds the legacy pattern `platform:*:worker_group_id` to the existing startup `deleteLegacyRedisKeys` migration and bumps its version flag to `delete_legacy_redis_keys_v2` so a one-shot `SCAN`+`DEL` cleans out the orphaned legacy entries at boot.

## Bug

#13199 started caching a `"__none__"` sentinel under `platform:<id>:worker_group_id` to fix the Redlock stampede on null worker groups. During the rolling deploy that shipped #13199, pre-#13199 replicas were still running alongside new ones and reading the same Redis key. The old reader had no notion of the sentinel — it just did `if (!isNil(cached)) return cached`, so it returned the literal string `"__none__"` as a `workerGroupId`. That value flowed into:

```ts
const getWorkerGroupQueueName = (workerGroupId: string): string =>
    `platform-${workerGroupId}-jobs`
```

…producing `platform-__none__-jobs`, an orphan queue with no consumer. Every flow run enqueued by an old replica during the deploy window for a null-worker-group platform was silently stranded — real BullMQ jobs, persistent, just sitting on a queue nothing reads.

## Fix

**Versioned cache key.** Rename to `platform:<id>:worker_group_id:v2`. Old replicas keep reading the legacy key (which new code no longer writes to, so it only contains pre-#13199 positive worker group IDs — all safe values). New replicas read `:v2`, which old code doesn't know about. The two versions are isolated for the duration of any future rolling deploy. This is the same shape of mistake as changing the schema of a cached value without bumping the key.

**Startup cleanup, not per-request delete.** Rather than `DEL` the legacy key on every cache miss, the legacy pattern is added to the existing `deleteLegacyRedisKeys` startup migration (`packages/server/api/src/app/workers/migrations/delete-legacy-redis-keys.ts`). This runs once at boot under the existing `job_migration_lock` distributed lock, gated by a Redis flag that we bump to `delete_legacy_redis_keys_v2` so it re-runs. Benefits over the lazy approach:

- Runs once, deterministically — no per-request `DEL` chatter.
- Cleans idle platforms too (the lazy approach only touches platforms that get traffic).
- Naturally ordered: cleanup runs before the new code starts populating `:v2`, so we never race.
- Pre-#13199 entries had no TTL and would otherwise live forever for idle platforms.

The dangerous `"__none__"` strings written to the legacy key by #13199-era code have a 5-min TTL and self-evict; the migration's `SCAN`+`DEL` on a presumably-clean Redis is harmless.

## Separate concern — orphan jobs

This PR does **not** clean up the BullMQ jobs already stranded on `platform-__none__-jobs`. Those are real flow-run jobs sitting on a queue with no consumer. They need to be either:
- Moved to `workerJobs` via `platformQueueMigrationService`, or
- Inspected and dropped manually if data loss is acceptable.

Tracking that separately — happy to follow up with a script.

## Test plan

- [x] `npx turbo run lint --filter=api` — 0 errors (pre-existing warnings only).
- [x] `npx vitest run packages/server/api/test/unit/app/core/canary/worker-group.service.test.ts` — all 5 tests in the `getWorkerGroupId` describe pass (the 5 unrelated pre-existing failures called out in #13199 still exist verbatim, out of scope).
- [ ] Post-deploy: API boot logs show `[deleteLegacyRedisKeys] Found legacy keys { pattern: 'platform:*:worker_group_id' }`, then no `platform:*:worker_group_id` keys remain in Redis; no new jobs landing on `platform-__none__-jobs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)