### PR TITLE
fix(chat): persist display tools, plan card, and thinking on reload

### DIFF
--- a/packages/server/api/src/app/ee/chat/history/chat-history.ts
+++ b/packages/server/api/src/app/ee/chat/history/chat-history.ts
@@ -40,14 +40,8 @@ function reconstructChatHistory(messages: ModelMessage[]): ChatHistoryMessage[] 
 
             if (text || toolCalls.length > 0 || thoughts) {
                 const lastResult = result[result.length - 1]
-                if (lastResult?.role === 'assistant') {
-                    // Merge consecutive assistant messages (agentic loop steps)
-                    // into a single ChatHistoryMessage to match streaming behavior
-                    if (text) {
-                        lastResult.content = lastResult.content
-                            ? lastResult.content + '\n' + text
-                            : text
-                    }
+                const hasText = text.length > 0
+                if (!hasText && lastResult?.role === 'assistant') {
                     if (toolCalls.length > 0) {
                         lastResult.toolCalls = [...(lastResult.toolCalls ?? []), ...toolCalls]
                     }

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -19,11 +19,18 @@ Hard rules — follow these in every response, no exceptions.
 5. If a tool fails, retry ONCE silently. If it fails again, tell the user in 1-2 sentences.
 6. Never call the same tool twice for the same data in a single response. Call `ap_list_connections` ONCE, then filter locally.
 7. After every step mutation (ap_add_step, ap_update_trigger, ap_update_step), call `ap_validate_step_config` immediately. Fix and re-validate if it fails.
-8. Use display tools for interactive UI — never ask questions in prose text. Use `ap_show_questions` for questions, `ap_show_project_picker` for project selection, `ap_show_connection_picker` or `ap_show_connection_required` for connections.
+8. Use display tools for interactive UI — never ask questions in prose text. Before calling `ap_show_questions`, write a brief intro such as "I need a few details:". Use `ap_show_project_picker` for project selection, `ap_show_connection_picker` or `ap_show_connection_required` for connections.
 9. When no other display tool is needed, end your response with `ap_show_quick_replies` (2-4 relevant next actions). Skip quick replies if you already called another display tool in this response.
 10. One-time tasks use `ap_run_one_time_action` (local tool), never `ap_run_action` (MCP tool).
 11. Projects are invisible to the user. Don't mention projects unless building an automation or the user asks.
 12. After completing a task, summarize in 1-2 sentences with resource links.
+13. **Never duplicate display-tool content in text.** When calling a display tool (`ap_show_questions`, `ap_show_connection_picker`, `ap_show_project_picker`, `ap_request_plan_approval`, `ap_show_quick_replies`), write at most one short intro sentence before the call. Do NOT list the same information (plan steps, connection names, project options, question fields) in your text — the UI card already shows it. After the user responds to a display tool or after completing an action, write 1-2 sentences summarizing the outcome or next step.
+
+Good: "Here's the plan:" → call `ap_request_plan_approval`
+Bad:  "Here's the plan:\n\nFlow: Gmail → Slack\nTrigger: New Email\nAction: Send Message" → call `ap_request_plan_approval` (duplicates the card)
+
+Good: call `ap_show_connection_picker` (the card already asks "Which account?")
+Bad:  "I found 2 Gmail accounts: Hazem Adel and Work Account." → call `ap_show_connection_picker` (duplicates the card)
 </rules>
 
 <project_scope>
@@ -53,6 +60,7 @@ Classify every user message and follow the corresponding action:
 |----------|----------|--------|
 | **General question** | "What is Activepieces?" | Answer directly |
 | **Information request** | "List my flows", "Show connections" | Call tools, present results in a table |
+| **Vague automation** | "Automate a task", "Build me something", "Help me automate" | The user hasn't named a trigger or action — show `ap_show_quick_replies` with 2-4 category suggestions (e.g. "Email automation", "CRM sync", "Notifications", "Data entry"). Once the user picks a category, proceed to the automation build process. |
 | **Automation request** | "When I get a Gmail, send to Slack" | Follow `<automation_build_process>` |
 | **Troubleshooting** | "My flow is broken", "Why did it fail?" | `ap_list_runs` + `ap_get_run` → explain → suggest fix |
 | **Greeting** | "Hi", "What can you do?" | Reply briefly with quick replies |
@@ -60,6 +68,8 @@ Classify every user message and follow the corresponding action:
 | **Discovery** | "What CRM integrations exist?" | `ap_list_pieces` → `ap_get_piece_props` → present |
 
 Disambiguation:
+- "Automate a task" or "Build something" (no trigger/action specified) = vague automation → quick replies.
+- "When I get emails, send Slack message" (trigger or action specified) = automation request → build process.
 - "list my emails" or "check my Stripe" = one-time task.
 - "What can Gmail do?" = discovery.
 - "Connect X to Y" = create a flow, not an OAuth connection.
@@ -92,7 +102,7 @@ c. **Configuration**: For unspecified fields you cannot infer:
    - TEXT fields → include in same `ap_show_questions` with `type: text`.
 
 **Step 3 — PLAN & APPROVE**
-Present the plan via `ap_request_plan_approval` with summary and steps. The steps array must include ALL actions: creating the flow, configuring each step, validating, testing, and adding notes. Example:
+Write one sentence like "Here's the plan:" then call `ap_request_plan_approval` with summary and steps. Do NOT write the plan details as text — the plan card displays them. The steps array must include ALL actions: creating the flow, configuring each step, validating, testing, and adding notes. Example:
 ```
 steps:
   - "Create flow: Gmail to Slack Forwarder"

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -198,7 +198,7 @@ function ChatBoxContent({
                 onRetry={handleRetry}
                 onSend={handleSend}
                 lastAssistantMessage={
-                  isLastAssistant ? lastAssistantMessage : undefined
+                  isLastAssistant ? lastAssistantMessage : msg
                 }
               />
             );

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -1,3 +1,4 @@
+import { PlanStepUpdate } from '@activepieces/shared';
 import { t } from 'i18next';
 import { RefreshCw } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -75,26 +76,22 @@ export const AssistantMessage = memo(function AssistantMessage({
           if (chatPartUtils.isDisplayTool(toolName)) {
             rendered.push({ kind: 'display-tool', part: p });
           } else if (toolName === 'ap_request_plan_approval') {
-            rendered.push({ kind: 'plan-marker' });
+            rendered.push({ kind: 'plan-marker', part: p });
           } else {
             thinkingTools.push(p);
           }
         }
       }
 
-      const planMarkerIdx = rendered.findIndex((r) => r.kind === 'plan-marker');
-      if (planMarkerIdx > -1) {
-        const [marker] = rendered.splice(planMarkerIdx, 1);
-        rendered.unshift(marker);
-      }
-
-      const lastDisplayIdx = rendered.findLastIndex(
-        (r) => r.kind === 'display-tool',
-      );
-      if (lastDisplayIdx > -1) {
-        for (let j = rendered.length - 1; j >= 0; j--) {
-          if (rendered[j].kind === 'display-tool' && j !== lastDisplayIdx) {
-            rendered.splice(j, 1);
+      if (isStreaming) {
+        const lastDisplayIdx = rendered.findLastIndex(
+          (r) => r.kind === 'display-tool',
+        );
+        if (lastDisplayIdx > -1) {
+          for (let j = rendered.length - 1; j >= 0; j--) {
+            if (rendered[j].kind === 'display-tool' && j !== lastDisplayIdx) {
+              rendered.splice(j, 1);
+            }
           }
         }
       }
@@ -113,31 +110,24 @@ export const AssistantMessage = memo(function AssistantMessage({
   );
 
   const openThinkingDetails = useChatStoreContext((s) => s.openThinkingDetails);
-  const showPlanCard = useChatStoreContext((s) =>
-    chatStoreSelectors.shouldShowPlan({
-      state: s,
-      isStreaming,
-      isLastAssistant: isLastMessage,
-      lastAssistantMessage,
-    }),
-  );
-  const planProgress = useChatStoreContext((s) =>
-    chatStoreSelectors.planProgress({ state: s, lastAssistantMessage }),
-  );
-  const planProgressUpdates = useChatStoreContext((s) =>
-    chatStoreSelectors.effectivePlanUpdates({ state: s, lastAssistantMessage }),
-  );
 
+  const hasPlanMarker = renderedParts.some((p) => p.kind === 'plan-marker');
   const hasRenderedContent = renderedParts.some(
     (p) => p.kind !== 'plan-marker',
   );
-  if (!hasContent && !hasRenderedContent && !isStreaming && !showPlanCard) {
+  const hasThinkingContent =
+    thinkingToolParts.length > 0 || reasoningText.length > 0;
+  const showThinking = isStreaming || hasThinkingContent;
+
+  if (
+    !hasContent &&
+    !hasRenderedContent &&
+    !isStreaming &&
+    !hasPlanMarker &&
+    !hasThinkingContent
+  ) {
     return null;
   }
-
-  const showThinking =
-    isStreaming ||
-    ((thinkingToolParts.length > 0 || reasoningText.length > 0) && hasContent);
 
   return (
     <motion.div
@@ -166,23 +156,24 @@ export const AssistantMessage = memo(function AssistantMessage({
                   </div>
                 );
               case 'display-tool':
-                return isLastMessage ? (
+                return (
                   <DisplayToolCard
                     key={part.part.toolCallId}
                     part={part.part}
                     onSend={onSend}
-                    isInteractive={true}
+                    isInteractive={isLastMessage}
                   />
-                ) : null;
+                );
               case 'plan-marker':
-                return showPlanCard && planProgress ? (
-                  <PlanProgressCard
+                return (
+                  <InlinePlanCard
                     key={`plan-${i}`}
-                    progress={planProgress}
-                    updates={planProgressUpdates ?? []}
+                    planPart={part.part}
+                    message={message}
+                    lastAssistantMessage={lastAssistantMessage}
                     isStreaming={isStreaming}
                   />
-                ) : null;
+                );
               default:
                 return null;
             }
@@ -218,6 +209,59 @@ export const AssistantMessage = memo(function AssistantMessage({
     </motion.div>
   );
 });
+
+function InlinePlanCard({
+  planPart,
+  message,
+  lastAssistantMessage,
+  isStreaming,
+}: {
+  planPart: AnyToolPart;
+  message: ChatUIMessage;
+  lastAssistantMessage?: ChatUIMessage;
+  isStreaming: boolean;
+}) {
+  const storePlanProgress = useChatStoreContext((s) =>
+    chatStoreSelectors.planProgress({ state: s, lastAssistantMessage }),
+  );
+  const storePlanUpdates = useChatStoreContext((s) =>
+    chatStoreSelectors.effectivePlanUpdates({ state: s, lastAssistantMessage }),
+  );
+
+  const input = planPart.input as
+    | { planSummary?: string; steps?: string[] }
+    | undefined;
+  const steps = input?.steps ?? [];
+  const localPlan =
+    steps.length > 0 ? { title: input?.planSummary ?? '', steps } : null;
+
+  const progress = storePlanProgress ?? localPlan;
+
+  const updates = useMemo(() => {
+    if (storePlanUpdates.length > 0) return storePlanUpdates;
+    if (!progress) return [];
+    const toolParts = message.parts.filter((p): p is AnyToolPart =>
+      chatPartUtils.isAnyToolPart(p),
+    );
+    if (toolParts.length === 0) return [];
+    return progress.steps.map(
+      (stepText, i): PlanStepUpdate => ({
+        stepIndex: i,
+        status: chatStoreSelectors.deriveStepStatus({ stepText, toolParts }),
+      }),
+    );
+  }, [storePlanUpdates, progress, message.parts]);
+
+  if (!progress) return null;
+
+  return (
+    <PlanProgressCard
+      progress={progress}
+      updates={updates}
+      isStreaming={isStreaming}
+    />
+  );
+}
 
 function DisplayToolCard({
   part,
@@ -266,4 +310,4 @@ function DisplayToolCard({
 type RenderedPart =
   | { kind: 'text'; text: string }
   | { kind: 'display-tool'; part: AnyToolPart }
-  | { kind: 'plan-marker' };
+  | { kind: 'plan-marker'; part: AnyToolPart };

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -228,12 +228,19 @@ function InlinePlanCard({
     chatStoreSelectors.effectivePlanUpdates({ state: s, lastAssistantMessage }),
   );
 
-  const input = planPart.input as
-    | { planSummary?: string; steps?: string[] }
-    | undefined;
-  const steps = input?.steps ?? [];
-  const localPlan =
-    steps.length > 0 ? { title: input?.planSummary ?? '', steps } : null;
+  const localPlan = (() => {
+    const toolOutput = chatPartUtils.parseTypedToolOutput(
+      planPart,
+      'ap_request_plan_approval',
+    );
+    if (toolOutput.state === 'success' && !toolOutput.data.success) return null;
+    const input = planPart.input as
+      | { planSummary?: string; steps?: string[] }
+      | undefined;
+    const steps = input?.steps ?? [];
+    if (steps.length === 0) return null;
+    return { title: input?.planSummary ?? '', steps };
+  })();
 
   const progress = storePlanProgress ?? localPlan;
 

--- a/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
@@ -210,7 +210,9 @@ export function ConnectionPickerCard({
           </div>
           <div className="flex-1 min-w-0">
             <div className="text-sm font-semibold">
-              {filteredPicker.displayName}
+              {t('Which {name} account should I use?', {
+                name: filteredPicker.displayName,
+              })}
             </div>
             <div className="text-xs text-muted-foreground">
               {t('Connected')}

--- a/packages/web/src/app/routes/chat-with-ai/components/project-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/project-picker-card.tsx
@@ -61,24 +61,32 @@ export function ProjectPickerCard({
       : picker.suggestedProjects[0]?.name ?? '';
     return (
       <motion.div
-        className="flex flex-wrap gap-2 my-2"
+        className="rounded-xl border bg-background overflow-hidden my-2"
         initial={{ opacity: 0, scale: 0.98 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.2 }}
       >
-        <div className="inline-flex items-center gap-2 rounded-full border bg-muted/60 px-3 py-1.5 text-sm">
-          {resolvedProject ? (
-            <ApProjectDisplay
-              title={getProjectName(resolvedProject)}
-              icon={resolvedProject.icon}
-              projectType={resolvedProject.type}
-              iconClassName="size-4"
-              titleClassName="text-sm"
-            />
-          ) : (
-            displayName && <span className="text-sm">{displayName}</span>
-          )}
-          <Check className="size-3.5 text-green-600 dark:text-green-400" />
+        <div className="p-4 flex items-center gap-3">
+          <div className="relative">
+            {resolvedProject ? (
+              <ApProjectDisplay
+                title={getProjectName(resolvedProject)}
+                icon={resolvedProject.icon}
+                projectType={resolvedProject.type}
+                iconClassName="size-5"
+                titleClassName="text-sm font-semibold"
+              />
+            ) : (
+              displayName && (
+                <span className="text-sm font-semibold">{displayName}</span>
+              )
+            )}
+          </div>
+          <div className="ml-auto">
+            <div className="bg-green-100 dark:bg-green-500/20 rounded-full p-1">
+              <Check className="h-3 w-3 text-green-600 dark:text-green-400" />
+            </div>
+          </div>
         </div>
       </motion.div>
     );

--- a/packages/web/src/features/chat/lib/chat-store.ts
+++ b/packages/web/src/features/chat/lib/chat-store.ts
@@ -336,11 +336,16 @@ function selectShouldShowPlan({
   lastAssistantMessage: ChatUIMessage | undefined;
 }): boolean {
   const progress = selectPlanProgress({ state, lastAssistantMessage });
+  if (progress === null) return false;
+
   const planWasExecuted =
     selectEffectivePlanUpdates({ state, lastAssistantMessage }).length > 0;
+
+  if (!isLastAssistant) {
+    return !isStreaming && planWasExecuted;
+  }
+
   return (
-    isLastAssistant &&
-    progress !== null &&
     !selectHasPlanApproval(state) &&
     !state.planRejected &&
     (!isStreaming || planWasExecuted)
@@ -356,6 +361,7 @@ export const chatStoreSelectors = {
   planProgress: selectPlanProgress,
   effectivePlanUpdates: selectEffectivePlanUpdates,
   shouldShowPlan: selectShouldShowPlan,
+  deriveStepStatus,
 };
 
 export type SetChatStore = StoreApi<ChatStoreState>['setState'];

--- a/packages/web/src/features/chat/lib/chat-utils.ts
+++ b/packages/web/src/features/chat/lib/chat-utils.ts
@@ -118,6 +118,25 @@ function mapHistoryToUIMessages(data: ChatHistoryMessage[]): ChatUIMessage[] {
   });
 }
 
+function extractQuickRepliesFromHistory(messages: ChatUIMessage[]): string[] {
+  const lastMessage = messages[messages.length - 1];
+  if (!lastMessage || lastMessage.role !== 'assistant') return [];
+
+  for (let i = lastMessage.parts.length - 1; i >= 0; i--) {
+    const p = lastMessage.parts[i];
+    if (
+      chatPartUtils.isAnyToolPart(p) &&
+      chatPartUtils.getToolPartName(p) === 'ap_show_quick_replies'
+    ) {
+      const input = p.input as { replies?: string[] } | undefined;
+      if (input?.replies) {
+        return input.replies;
+      }
+    }
+  }
+  return [];
+}
+
 export const chatUtils = {
   formatToolLabel: ({ part }: { part: AnyToolPart }) =>
     formatToolName({ part }),
@@ -127,4 +146,5 @@ export const chatUtils = {
   stripPiecePrefix,
   humanizePieceName,
   mapHistoryToUIMessages,
+  extractQuickRepliesFromHistory,
 };

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -447,9 +447,15 @@ export function useAgentChat({
           message: 'Failed to load conversation history',
         });
       } else {
-        setUiMessages(
-          chatUtils.mapHistoryToUIMessages(historyResult.data.data),
+        const uiMessages = chatUtils.mapHistoryToUIMessages(
+          historyResult.data.data,
         );
+        setUiMessages(uiMessages);
+        const restoredReplies =
+          chatUtils.extractQuickRepliesFromHistory(uiMessages);
+        if (restoredReplies.length > 0) {
+          store.setState({ quickReplies: restoredReplies });
+        }
       }
       if (convResult.data) {
         modelNameRef.current = convResult.data.modelName ?? null;


### PR DESCRIPTION
## Summary
- Show thinking blocks on reload regardless of text content
- Render display tools (connection/project pickers) for all messages with read-only state for historical ones
- Plan card renders inline via self-contained `InlinePlanCard` component that extracts data directly from tool parts
- Restore quick replies from history on conversation load
- Smart merge in chat history: only merge tool-call-only agentic steps, keep text-bearing steps as separate messages to preserve correct ordering
- System prompt: prioritize quick replies for vague requests, add intro before questions, prevent content duplication with display tools

## Test plan
- [ ] Start a new chat, say "Automate a task" → should see quick reply category suggestions
- [ ] Build a flow end-to-end → plan card renders inline after "Here's the plan:" text
- [ ] Reload the conversation → plan card, connection picker, project picker, quick replies, and thinking all persist
- [ ] During streaming, display tools from previous turns remain visible
- [ ] Rejected plans do not show the plan card on reload