### PR TITLE
fix(web): make system theme follow OS dark/light preference

### DIFF
--- a/packages/web/src/components/providers/theme-provider.tsx
+++ b/packages/web/src/components/providers/theme-provider.tsx
@@ -5,6 +5,7 @@ import { flagsHooks } from '@/hooks/flags-hooks';
 import { colorsUtils } from '@/lib/color-utils';
 
 type Theme = 'dark' | 'light' | 'system';
+type ResolvedTheme = 'dark' | 'light';
 
 type ThemeProviderProps = {
   children: React.ReactNode;
@@ -28,6 +29,14 @@ const initialState: ThemeProviderState = {
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
+
+const getSystemTheme = (): ResolvedTheme =>
+  typeof window !== 'undefined' &&
+  window.matchMedia(SYSTEM_DARK_QUERY).matches
+    ? 'dark'
+    : 'light';
+
 const setFavicon = (url: string) => {
   document.querySelectorAll("link[rel*='icon']").forEach((el) => el.remove());
   const link = document.createElement('link');
@@ -45,8 +54,19 @@ export function ThemeProvider({
   const [theme, setTheme] = useState<Theme>(
     () => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
   );
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(getSystemTheme);
   const [forceLightMode, setForceLightMode] = useState(false);
   const branding = flagsHooks.useWebsiteBranding();
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(SYSTEM_DARK_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? 'dark' : 'light');
+    };
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
   useEffect(() => {
     if (!branding) {
       console.warn('Website brand is not defined');
@@ -54,10 +74,10 @@ export function ThemeProvider({
     }
     const root = window.document.documentElement;
 
-    const resolvedTheme = forceLightMode
+    const resolvedTheme: ResolvedTheme = forceLightMode
       ? 'light'
       : theme === 'system'
-      ? 'light'
+      ? systemTheme
       : theme;
     root.classList.remove('light', 'dark');
     document.title = branding.websiteName;
@@ -95,7 +115,7 @@ export function ThemeProvider({
     }
 
     root.classList.add(resolvedTheme);
-  }, [theme, branding, forceLightMode]);
+  }, [theme, branding, forceLightMode, systemTheme]);
 
   const value = {
     theme,


### PR DESCRIPTION
## Problem

Fixes #13163.

When the theme is set to **System** in Appearance settings, the UI does not react to OS-level dark/light mode changes — it always renders in light mode regardless of the OS preference, and never updates when the OS switches modes.

Root cause is in `packages/web/src/components/providers/theme-provider.tsx`:

```ts
const resolvedTheme = forceLightMode
  ? 'light'
  : theme === 'system'
  ? 'light'         // ← unconditionally light when theme === 'system'
  : theme;
```

The `'system'` branch hard-codes `'light'` instead of resolving against `prefers-color-scheme`, and there is no listener on `matchMedia` to re-render when the OS preference changes at runtime.

## Solution

- Resolve `'system'` against `window.matchMedia('(prefers-color-scheme: dark)')` instead of hard-coding `'light'`.
- Track the system preference in a `systemTheme` state and subscribe to the `MediaQueryList` `change` event, so the UI updates live when the OS toggles dark/light mode.
- Keep `forceLightMode` (used by the auth screens) as the highest-priority override — unchanged behaviour.

The change is scoped to the resolver and a new `useEffect` that adds/removes the `matchMedia` listener. Manual `'light'` / `'dark'` selections are unaffected.

## Testing

1. Settings → Appearance → **System**.
2. Toggle OS dark/light mode (macOS: System Settings → Appearance; Windows: Settings → Personalization → Colors).
3. Activepieces UI now switches between light and dark in sync with the OS.
4. Set **Light** or **Dark** explicitly → toggling OS mode has no effect (expected).
5. Sign-out flow (which sets `forceLightMode=true` via `auth-form-template.tsx`) still renders light regardless of OS preference (expected).