### PR TITLE
feat(chat): persist UI messages for reliable reload rendering

### DIFF
--- a/packages/server/api/src/app/database/migration/common/1760500000000-AddUiMessagesToChatConversation.ts
+++ b/packages/server/api/src/app/database/migration/common/1760500000000-AddUiMessagesToChatConversation.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddUiMessagesToChatConversation1760500000000 implements MigrationInterface {
+    name = 'AddUiMessagesToChatConversation1760500000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "chat_conversation" ADD COLUMN "uiMessages" jsonb
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "chat_conversation" DROP COLUMN "uiMessages"
+        `)
+    }
+
+}

--- a/packages/server/api/src/app/database/migration/common/1778983371000-AddUiMessagesToChatConversation.ts
+++ b/packages/server/api/src/app/database/migration/common/1778983371000-AddUiMessagesToChatConversation.ts
@@ -1,7 +1,11 @@
-import { MigrationInterface, QueryRunner } from 'typeorm'
+import { QueryRunner } from 'typeorm'
+import { Migration } from '../../migration'
 
-export class AddUiMessagesToChatConversation1778983371000 implements MigrationInterface {
+export class AddUiMessagesToChatConversation1778983371000 implements Migration {
     name = 'AddUiMessagesToChatConversation1778983371000'
+    breaking = false
+    release = '0.83.0'
+    transaction = true
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`

--- a/packages/server/api/src/app/database/migration/common/1778983371000-AddUiMessagesToChatConversation.ts
+++ b/packages/server/api/src/app/database/migration/common/1778983371000-AddUiMessagesToChatConversation.ts
@@ -1,11 +1,11 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class AddUiMessagesToChatConversation1760500000000 implements MigrationInterface {
-    name = 'AddUiMessagesToChatConversation1760500000000'
+export class AddUiMessagesToChatConversation1778983371000 implements MigrationInterface {
+    name = 'AddUiMessagesToChatConversation1778983371000'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            ALTER TABLE "chat_conversation" ADD COLUMN "uiMessages" jsonb
+            ALTER TABLE "chat_conversation" ADD COLUMN IF NOT EXISTS "uiMessages" jsonb
         `)
     }
 

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -49,7 +49,7 @@ import { SplitUpPieceMetadataIntoTools1752004202722 } from './migration/common/1
 import { AddIndexToIssues1756775080449 } from './migration/common/1756775080449-AddIndexToIssues'
 import { AddFlowIndexToTriggerSource1757555419075 } from './migration/common/1757555283659-AddFlowIndexToTriggerSource'
 import { AddIndexForAppEvents1759392852559 } from './migration/common/1759392852559-AddIndexForAppEvents'
-import { AddUiMessagesToChatConversation1760500000000 } from './migration/common/1760500000000-AddUiMessagesToChatConversation'
+import { AddUiMessagesToChatConversation1778983371000 } from './migration/common/1778983371000-AddUiMessagesToChatConversation'
 import { AddAuthToPiecesMetadata1688922241747 } from './migration/postgres//1688922241747-AddAuthToPiecesMetadata'
 import { FlowAndFileProjectId1674788714498 } from './migration/postgres/1674788714498-FlowAndFileProjectId'
 import { initializeSchema1676238396411 } from './migration/postgres/1676238396411-initialize-schema'
@@ -766,7 +766,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         RemoveMcpServerStatus1790000000000,
         RenameEnabledToolsToDisabledTools1791000000000,
         AddTriggerSourceFlowVersionIdIndex1792000000000,
-        AddUiMessagesToChatConversation1760500000000,
+        AddUiMessagesToChatConversation1778983371000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -49,6 +49,7 @@ import { SplitUpPieceMetadataIntoTools1752004202722 } from './migration/common/1
 import { AddIndexToIssues1756775080449 } from './migration/common/1756775080449-AddIndexToIssues'
 import { AddFlowIndexToTriggerSource1757555419075 } from './migration/common/1757555283659-AddFlowIndexToTriggerSource'
 import { AddIndexForAppEvents1759392852559 } from './migration/common/1759392852559-AddIndexForAppEvents'
+import { AddUiMessagesToChatConversation1760500000000 } from './migration/common/1760500000000-AddUiMessagesToChatConversation'
 import { AddAuthToPiecesMetadata1688922241747 } from './migration/postgres//1688922241747-AddAuthToPiecesMetadata'
 import { FlowAndFileProjectId1674788714498 } from './migration/postgres/1674788714498-FlowAndFileProjectId'
 import { initializeSchema1676238396411 } from './migration/postgres/1676238396411-initialize-schema'
@@ -765,6 +766,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         RemoveMcpServerStatus1790000000000,
         RenameEnabledToolsToDisabledTools1791000000000,
         AddTriggerSourceFlowVersionIdIndex1792000000000,
+        AddUiMessagesToChatConversation1760500000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/ee/chat/chat-conversation-entity.ts
+++ b/packages/server/api/src/app/ee/chat/chat-conversation-entity.ts
@@ -1,11 +1,11 @@
-import { ChatConversation, Platform, Project } from '@activepieces/shared'
+import { ChatConversation, Platform, Project, User } from '@activepieces/shared'
 import { EntitySchema } from 'typeorm'
 import { ApIdSchema, BaseColumnSchemaPart } from '../../database/database-common'
 
 type ChatConversationWithRelations = ChatConversation & {
     platform: Platform
     project: Project
-    user: unknown
+    user: User
 }
 
 export const ChatConversationEntity = new EntitySchema<ChatConversationWithRelations>({
@@ -36,6 +36,10 @@ export const ChatConversationEntity = new EntitySchema<ChatConversationWithRelat
             type: 'jsonb',
             nullable: false,
             default: '[]',
+        },
+        uiMessages: {
+            type: 'jsonb',
+            nullable: true,
         },
         summary: {
             type: 'text',

--- a/packages/server/api/src/app/ee/chat/chat-service.ts
+++ b/packages/server/api/src/app/ee/chat/chat-service.ts
@@ -6,12 +6,18 @@ import {
     apId,
     ChatConversation,
     ChatHistoryMessage,
+    chatPersistenceUtils,
     ChatStreamWriter,
     CreateChatConversationRequest,
     DEFAULT_CHAT_TIER_ID,
     ErrorCode,
     GetProviderConfigResponse,
     isNil,
+    PersistedChatMessage,
+    PersistedChatPart,
+    PersistedChatPartType,
+    PersistedChatRole,
+    PersistedToolCallStatus,
     Project,
     ProjectType,
     SeekPage,
@@ -111,8 +117,11 @@ export const chatService = (log: FastifyBaseLogger) => ({
         await conversationRepo().delete(conversation.id)
     },
 
-    async getMessages({ id, platformId, userId }: ConversationIdentifier): Promise<{ data: ChatHistoryMessage[] }> {
+    async getMessages({ id, platformId, userId }: ConversationIdentifier): Promise<{ data: PersistedChatMessage[] | ChatHistoryMessage[] }> {
         const conversation = await this.getConversationOrThrow({ id, platformId, userId })
+        if (conversation.uiMessages) {
+            return { data: conversation.uiMessages }
+        }
         const messages = chatHistory.reconstruct(conversation.messages as ModelMessage[])
         return { data: messages }
     },
@@ -199,6 +208,8 @@ export const chatService = (log: FastifyBaseLogger) => ({
 
         const planApproved = { approved: false }
         const planStepCounter = { current: 0 }
+        const uiParts: PersistedChatPart[] = []
+        const previousUiMessages = conversation.uiMessages ?? []
         const stream = createUIMessageStream({
             execute: ({ writer }) => {
                 const localTools = createChatTools({
@@ -230,14 +241,21 @@ export const chatService = (log: FastifyBaseLogger) => ({
                     providerOptions: currentProviderOptions,
                     prepareStep: chatPrepareStep.createPrepareStep({ log }),
                     stopWhen: stepCountIs(MAX_STEPS),
-                    onStepFinish: ({ finishReason, usage }) => {
+                    onStepFinish: ({ text, reasoning, toolCalls, toolResults, finishReason, usage }) => {
+                        uiParts.push(...buildStepParts({ text, reasoning, toolCalls, toolResults }))
                         log.debug({ conversationId, finishReason, usage }, 'Chat step finished')
                     },
                     onFinish: async ({ response, usage }) => {
                         const updatedMessages = [...allMessages, ...response.messages]
+                        const updatedUiMessages: PersistedChatMessage[] = [
+                            ...previousUiMessages,
+                            { role: PersistedChatRole.USER, parts: [{ type: PersistedChatPartType.TEXT, text: content }] },
+                            { role: PersistedChatRole.ASSISTANT, parts: uiParts },
+                        ]
                         try {
                             await conversationRepo().update(conversationId, {
                                 messages: updatedMessages,
+                                uiMessages: JSON.parse(JSON.stringify(updatedUiMessages)),
                                 ...(pendingTitle ? { title: pendingTitle } : {}),
                                 ...(isNil(conversation.modelName) ? { modelName: tier.id } : {}),
                             })
@@ -448,6 +466,41 @@ function buildSystemPromptWithCaching({ systemPrompt, provider }: {
         default:
             return systemPrompt
     }
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function buildStepParts({ text, reasoning, toolCalls, toolResults }: {
+    text: string
+    reasoning: Array<{ text: string }>
+    toolCalls: Array<{ toolCallId: string, toolName: string, input: unknown }>
+    toolResults: Array<{ toolCallId: string, output: unknown }>
+}): PersistedChatPart[] {
+    const parts: PersistedChatPart[] = []
+    for (const r of reasoning) {
+        if (r.text) {
+            parts.push({ type: PersistedChatPartType.REASONING, text: r.text })
+        }
+    }
+    if (text) {
+        parts.push({ type: PersistedChatPartType.TEXT, text })
+    }
+    const resultMap = new Map(toolResults.map((tr) => [tr.toolCallId, tr]))
+    for (const tc of toolCalls) {
+        const result = resultMap.get(tc.toolCallId)
+        const rawOutput = result ? chatPersistenceUtils.unwrapToolOutput(result.output) : undefined
+        parts.push({
+            type: PersistedChatPartType.TOOL_CALL,
+            toolCallId: tc.toolCallId,
+            toolName: tc.toolName,
+            input: toRecord(tc.input),
+            output: rawOutput,
+            status: PersistedToolCallStatus.COMPLETED,
+        })
+    }
+    return parts
 }
 
 type CreateConversationParams = {

--- a/packages/server/api/src/app/ee/chat/chat-service.ts
+++ b/packages/server/api/src/app/ee/chat/chat-service.ts
@@ -497,7 +497,7 @@ function buildStepParts({ text, reasoning, toolCalls, toolResults }: {
             toolName: tc.toolName,
             input: toRecord(tc.input),
             output: rawOutput,
-            status: PersistedToolCallStatus.COMPLETED,
+            status: result ? PersistedToolCallStatus.COMPLETED : PersistedToolCallStatus.ERROR,
         })
     }
     return parts

--- a/packages/server/api/src/app/ee/chat/history/chat-history.ts
+++ b/packages/server/api/src/app/ee/chat/history/chat-history.ts
@@ -1,4 +1,4 @@
-import { ChatHistoryMessage, ChatHistoryToolCall } from '@activepieces/shared'
+import { ChatHistoryMessage, ChatHistoryToolCall, chatPersistenceUtils } from '@activepieces/shared'
 import { ModelMessage } from 'ai'
 
 function reconstructChatHistory(messages: ModelMessage[]): ChatHistoryMessage[] {
@@ -70,9 +70,10 @@ function reconstructChatHistory(messages: ModelMessage[]): ChatHistoryMessage[] 
                         const tr = toolResult as { toolCallId: string, output: unknown }
                         const existing = lastAssistant.toolCalls.find((tc) => tc.toolCallId === tr.toolCallId)
                         if (existing) {
-                            existing.output = typeof tr.output === 'string'
-                                ? tr.output
-                                : JSON.stringify(tr.output)
+                            const unwrapped = chatPersistenceUtils.unwrapToolOutput(tr.output)
+                            existing.output = typeof unwrapped === 'string'
+                                ? unwrapped
+                                : JSON.stringify(unwrapped)
                             existing.status = 'completed'
                         }
                     }

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -26,7 +26,9 @@ Hard rules — follow these in every response, no exceptions.
 12. After completing a task, summarize in 1-2 sentences with resource links.
 13. **Never duplicate display-tool content in text.** When calling a display tool (`ap_show_questions`, `ap_show_connection_picker`, `ap_show_project_picker`, `ap_request_plan_approval`, `ap_show_quick_replies`), write at most one short intro sentence before the call. Do NOT list the same information (plan steps, connection names, project options, question fields) in your text — the UI card already shows it. After the user responds to a display tool or after completing an action, write 1-2 sentences summarizing the outcome or next step.
 
-Good: "Here's the plan:" → call `ap_request_plan_approval`
+14. **Always include 1-2 sentences of visible text in your final response to the user.** After tool calls resolve, write a brief summary of what you found or what happens next. The user sees a "Thinking..." indicator during tool calls — the text gives them context once it resolves.
+
+Good: call `ap_request_plan_approval` (the plan card is self-explanatory)
 Bad:  "Here's the plan:\n\nFlow: Gmail → Slack\nTrigger: New Email\nAction: Send Message" → call `ap_request_plan_approval` (duplicates the card)
 
 Good: call `ap_show_connection_picker` (the card already asks "Which account?")
@@ -86,7 +88,7 @@ Silently verify assumptions in a single call:
 **Step 2 — GATHER INFORMATION**
 Resolve all unknowns BEFORE the plan. Each sub-step may require waiting for user input.
 
-a. **Project**: One project → select silently. Multiple → use `ap_show_questions` with choices, then `ap_select_project`.
+a. **Project**: One project → select silently. Multiple → use `ap_show_project_picker`. After the user picks, call `ap_select_project` with their choice.
 
 b. **Connections**: Call `ap_list_connections` ONCE. For each piece needing auth:
    - One active connection → note its externalId, continue.
@@ -100,7 +102,7 @@ c. **Configuration**: For unspecified fields you cannot infer:
    - TEXT fields → include in same `ap_show_questions` with `type: text`.
 
 **Step 3 — PLAN & APPROVE**
-Write one sentence like "Here's the plan:" then call `ap_request_plan_approval` with summary and steps. Do NOT write the plan details as text — the plan card displays them. The steps array must include ALL actions: creating the flow, configuring each step, validating, testing, and adding notes. Example:
+Call `ap_request_plan_approval` with summary and steps — no intro text needed, the plan card is self-explanatory. Do NOT write the plan details as text — the plan card displays them. The steps array must include ALL actions: creating the flow, configuring each step, validating, testing, and adding notes. Example:
 ```
 steps:
   - "Create flow: Gmail to Slack Forwarder"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.76.3",
+  "version": "0.76.4",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/ee/chat/index.ts
+++ b/packages/shared/src/lib/ee/chat/index.ts
@@ -23,6 +23,59 @@ const ChatMessageFile = z.object({
     data: z.string().max(MAX_FILE_BASE64_CHARS),
 })
 
+export enum PersistedChatPartType {
+    TEXT = 'text',
+    REASONING = 'reasoning',
+    TOOL_CALL = 'tool-call',
+}
+
+export enum PersistedToolCallStatus {
+    COMPLETED = 'completed',
+    ERROR = 'error',
+}
+
+export enum PersistedChatRole {
+    USER = 'user',
+    ASSISTANT = 'assistant',
+}
+
+const PersistedTextPartSchema = z.object({
+    type: z.literal(PersistedChatPartType.TEXT),
+    text: z.string(),
+})
+
+const PersistedReasoningPartSchema = z.object({
+    type: z.literal(PersistedChatPartType.REASONING),
+    text: z.string(),
+})
+
+const PersistedToolCallPartSchema = z.object({
+    type: z.literal(PersistedChatPartType.TOOL_CALL),
+    toolCallId: z.string(),
+    toolName: z.string(),
+    input: z.record(z.string(), z.unknown()),
+    output: z.unknown().optional(),
+    status: z.enum([PersistedToolCallStatus.COMPLETED, PersistedToolCallStatus.ERROR]),
+    errorText: z.string().optional(),
+})
+
+const PersistedChatPartSchema = z.discriminatedUnion('type', [
+    PersistedTextPartSchema,
+    PersistedReasoningPartSchema,
+    PersistedToolCallPartSchema,
+])
+
+export const PersistedChatMessageSchema = z.object({
+    role: z.enum([PersistedChatRole.USER, PersistedChatRole.ASSISTANT]),
+    parts: z.array(PersistedChatPartSchema),
+})
+
+export type PersistedTextPart = z.infer<typeof PersistedTextPartSchema>
+export type PersistedReasoningPart = z.infer<typeof PersistedReasoningPartSchema>
+export type PersistedToolCallPart = z.infer<typeof PersistedToolCallPartSchema>
+export type PersistedChatPart = z.infer<typeof PersistedChatPartSchema>
+export type PersistedChatMessage = z.infer<typeof PersistedChatMessageSchema>
+
 export const ChatConversation = z.object({
     ...BaseModelSchema,
     platformId: z.string(),
@@ -31,6 +84,7 @@ export const ChatConversation = z.object({
     title: Nullable(z.string()),
     modelName: Nullable(z.string()),
     messages: z.array(z.record(z.string(), z.unknown())).default([]),
+    uiMessages: z.array(PersistedChatMessageSchema).nullable().default(null),
     summary: Nullable(z.string()),
     summarizedUpToIndex: Nullable(z.number().int()),
 })
@@ -121,6 +175,20 @@ export type ConnectionOption = {
 }
 
 export type ChatToolName = keyof ChatToolOutputs
+
+function unwrapToolOutput(output: unknown): unknown {
+    if (typeof output !== 'object' || output === null) return output
+    if (!('type' in output) || !('value' in output)) return output
+    const record = output as Record<string, unknown>
+    if (record['type'] === 'json') {
+        return record['value']
+    }
+    return output
+}
+
+export const chatPersistenceUtils = {
+    unwrapToolOutput,
+}
 
 export type ChatAllowedMimeType = typeof CHAT_ALLOWED_MIME_TYPES[number]
 export { CHAT_ALLOWED_MIME_TYPES }

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -269,9 +269,24 @@ function InlinePlanCard({
 
   const progress = storePlanProgress ?? localPlan;
 
+  const planCompleted =
+    !isStreaming &&
+    (() => {
+      const output = chatPartUtils.parseTypedToolOutput(
+        planPart,
+        'ap_request_plan_approval',
+      );
+      return output.state === 'success' && output.data.success;
+    })();
+
   const updates = useMemo(() => {
-    if (storePlanUpdates.length > 0) return storePlanUpdates;
     if (!progress) return [];
+    if (planCompleted) {
+      return progress.steps.map(
+        (_stepText, i): PlanStepUpdate => ({ stepIndex: i, status: 'done' }),
+      );
+    }
+    if (storePlanUpdates.length > 0) return storePlanUpdates;
     const toolParts = message.parts.filter((p): p is AnyToolPart =>
       chatPartUtils.isAnyToolPart(p),
     );
@@ -282,7 +297,7 @@ function InlinePlanCard({
         status: chatStoreSelectors.deriveStepStatus({ stepText, toolParts }),
       }),
     );
-  }, [storePlanUpdates, progress, message.parts]);
+  }, [storePlanUpdates, progress, message.parts, planCompleted]);
 
   if (!progress) return null;
 

--- a/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
@@ -188,6 +188,16 @@ export function ConnectionPickerCard({
     setConnectDialogOpen(true);
   };
 
+  if (selectedConnection) {
+    return (
+      <SelectedState
+        pieceName={pieceName}
+        connection={selectedConnection}
+        displayName={filteredPicker.displayName}
+      />
+    );
+  }
+
   if (!isInteractive) {
     return (
       <motion.div
@@ -220,16 +230,6 @@ export function ConnectionPickerCard({
           </div>
         </div>
       </motion.div>
-    );
-  }
-
-  if (selectedConnection) {
-    return (
-      <SelectedState
-        pieceName={pieceName}
-        connection={selectedConnection}
-        displayName={filteredPicker.displayName}
-      />
     );
   }
 

--- a/packages/web/src/app/routes/chat-with-ai/components/multi-question-form.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/multi-question-form.tsx
@@ -259,10 +259,9 @@ export function MultiQuestionForm({
                             />
                           </div>
                         )}
-                        <Label
-                          htmlFor={id}
-                          onClick={(e) => {
-                            if (e.detail >= 1) handleNext(option);
+                        <div
+                          onClick={() => {
+                            handleNext(option);
                           }}
                           onMouseEnter={() => setHoveredRow(i)}
                           onMouseLeave={() =>
@@ -321,7 +320,7 @@ export function MultiQuestionForm({
                             {i + 1}
                           </span>
                           <span className="flex-1 leading-snug">{option}</span>
-                        </Label>
+                        </div>
                       </Fragment>
                     );
                   })}

--- a/packages/web/src/app/routes/chat-with-ai/components/thinking-details-panel.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/thinking-details-panel.tsx
@@ -64,12 +64,26 @@ export function ThinkingDetailsPanel({
   messageParts: ChatUIMessage['parts'];
   onClose: () => void;
 }) {
-  const steps: ThinkingStep[] = [];
+  const lastThinkingIndex = messageParts.findLastIndex((p) => {
+    if (p.type === 'reasoning' && p.text.length > 0) return true;
+    if (!chatPartUtils.isAnyToolPart(p)) return false;
+    const name = chatPartUtils.getToolPartName(p);
+    return (
+      !chatPartUtils.HIDDEN_TOOL_NAMES.has(name) &&
+      !chatPartUtils.isDisplayTool(name)
+    );
+  });
 
-  for (const p of messageParts) {
+  const steps: ThinkingStep[] = [];
+  for (let i = 0; i < messageParts.length; i++) {
+    const p = messageParts[i];
     if (p.type === 'reasoning' && p.text.length > 0) {
       steps.push({ kind: 'reasoning', text: p.text });
-    } else if (p.type === 'text' && p.text.length > 0) {
+    } else if (
+      p.type === 'text' &&
+      p.text.length > 0 &&
+      i < lastThinkingIndex
+    ) {
       steps.push({ kind: 'text', text: p.text });
     } else if (chatPartUtils.isAnyToolPart(p)) {
       const name = chatPartUtils.getToolPartName(p);

--- a/packages/web/src/features/chat/lib/chat-api.ts
+++ b/packages/web/src/features/chat/lib/chat-api.ts
@@ -1,5 +1,6 @@
 import {
   type ChatHistoryMessage,
+  type PersistedChatMessage,
   ChatConversation,
   CreateChatConversationRequest,
   SeekPage,
@@ -33,8 +34,8 @@ async function getConversation(id: string): Promise<ChatConversation> {
 
 async function getMessages(
   conversationId: string,
-): Promise<{ data: ChatHistoryMessage[] }> {
-  return api.get<{ data: ChatHistoryMessage[] }>(
+): Promise<{ data: PersistedChatMessage[] | ChatHistoryMessage[] }> {
+  return api.get<{ data: PersistedChatMessage[] | ChatHistoryMessage[] }>(
     `/v1/chat/conversations/${conversationId}/messages`,
   );
 }

--- a/packages/web/src/features/chat/lib/chat-utils.ts
+++ b/packages/web/src/features/chat/lib/chat-utils.ts
@@ -1,4 +1,11 @@
-import { ChatHistoryMessage, isObject } from '@activepieces/shared';
+import {
+  ChatHistoryMessage,
+  isObject,
+  PersistedChatMessage,
+  PersistedChatPart,
+  PersistedChatPartType,
+  PersistedToolCallStatus,
+} from '@activepieces/shared';
 
 import { formatUtils } from '@/lib/format-utils';
 
@@ -74,48 +81,121 @@ function extractToolContext({
   return parts.length > 0 ? parts.join(' ') : null;
 }
 
-function mapHistoryToUIMessages(data: ChatHistoryMessage[]): ChatUIMessage[] {
-  return data.map((msg, idx) => {
-    const parts: ChatUIMessage['parts'] = [];
-    if (msg.thoughts) {
-      parts.push({ type: 'reasoning', text: msg.thoughts });
-    }
-    if (msg.content) {
-      parts.push({ type: 'text', text: msg.content });
-    }
-    if (msg.toolCalls) {
-      for (const tc of msg.toolCalls) {
-        if (tc.status === 'completed') {
-          parts.push({
-            type: 'dynamic-tool',
-            toolCallId: tc.toolCallId,
-            toolName: tc.title,
-            title: tc.title,
-            state: 'output-available',
-            input: tc.input ?? {},
-            output: tc.output,
-          });
-        } else {
-          parts.push({
-            type: 'dynamic-tool',
-            toolCallId: tc.toolCallId,
-            toolName: tc.title,
-            title: tc.title,
-            state: 'output-error',
-            input: tc.input ?? {},
-            errorText:
-              typeof tc.output === 'string' ? tc.output : 'Tool call failed',
-          });
-        }
+function historyMsgToParts(msg: ChatHistoryMessage): ChatUIMessage['parts'] {
+  const parts: ChatUIMessage['parts'] = [];
+  if (msg.thoughts) {
+    parts.push({ type: 'reasoning', text: msg.thoughts });
+  }
+  if (msg.content) {
+    parts.push({ type: 'text', text: msg.content });
+  }
+  if (msg.toolCalls) {
+    for (const tc of msg.toolCalls) {
+      if (tc.status === 'completed') {
+        parts.push({
+          type: 'dynamic-tool',
+          toolCallId: tc.toolCallId,
+          toolName: tc.title,
+          title: tc.title,
+          state: 'output-available',
+          input: tc.input ?? {},
+          output: tc.output,
+        });
+      } else {
+        parts.push({
+          type: 'dynamic-tool',
+          toolCallId: tc.toolCallId,
+          toolName: tc.title,
+          title: tc.title,
+          state: 'output-error',
+          input: tc.input ?? {},
+          errorText:
+            typeof tc.output === 'string' ? tc.output : 'Tool call failed',
+        });
       }
     }
+  }
+  return parts;
+}
 
-    return {
-      id: `hist-${idx}`,
-      role: msg.role,
-      parts,
-    };
-  });
+function isPersistedFormat(data: unknown[]): data is PersistedChatMessage[] {
+  if (data.length === 0) return false;
+  const first = data[0] as Record<string, unknown>;
+  return Array.isArray(first.parts) && !('content' in first);
+}
+
+function persistedPartToUIPart(
+  part: PersistedChatPart,
+): ChatUIMessage['parts'][number] {
+  switch (part.type) {
+    case PersistedChatPartType.TEXT:
+      return { type: 'text', text: part.text };
+    case PersistedChatPartType.REASONING:
+      return { type: 'reasoning', text: part.text };
+    case PersistedChatPartType.TOOL_CALL:
+      if (part.status === PersistedToolCallStatus.COMPLETED) {
+        return {
+          type: 'dynamic-tool',
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          title: part.toolName,
+          state: 'output-available',
+          input: part.input,
+          output:
+            typeof part.output === 'string'
+              ? part.output
+              : JSON.stringify(part.output),
+        };
+      }
+      return {
+        type: 'dynamic-tool',
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        title: part.toolName,
+        state: 'output-error',
+        input: part.input,
+        errorText: part.errorText ?? 'Tool call failed',
+      };
+    default: {
+      const _exhaustive: never = part;
+      throw new Error(
+        `Unknown persisted part type: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+function mapPersistedToUIMessages(
+  data: PersistedChatMessage[],
+): ChatUIMessage[] {
+  return data.map((msg, idx) => ({
+    id: `hist-${idx}`,
+    role: msg.role,
+    parts: msg.parts.map(persistedPartToUIPart),
+  }));
+}
+
+function mapHistoryToUIMessages(
+  data: PersistedChatMessage[] | ChatHistoryMessage[],
+): ChatUIMessage[] {
+  if (data.length === 0) return [];
+  if (isPersistedFormat(data)) {
+    return mapPersistedToUIMessages(data);
+  }
+
+  const legacyData = data as ChatHistoryMessage[];
+  const result: ChatUIMessage[] = [];
+  for (let i = 0; i < legacyData.length; i++) {
+    const msg = legacyData[i];
+    const parts = historyMsgToParts(msg);
+    const lastResult = result[result.length - 1];
+    if (msg.role === 'assistant' && lastResult?.role === 'assistant') {
+      lastResult.parts.push(...parts);
+    } else {
+      result.push({ id: `hist-${i}`, role: msg.role, parts });
+    }
+  }
+  return result;
 }
 
 function extractQuickRepliesFromHistory(messages: ChatUIMessage[]): string[] {

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -171,15 +171,24 @@ export function useAgentChat({
 
         case 'data-plan-progress':
           if (typeof d.stepIndex === 'number' && typeof d.status === 'string') {
-            store.setState((prev) => ({
-              planProgressUpdates: [
-                ...prev.planProgressUpdates,
-                {
-                  stepIndex: d.stepIndex as number,
-                  status: d.status as PlanStepUpdate['status'],
-                },
-              ],
-            }));
+            store.setState((prev) => {
+              const stepIndex = d.stepIndex as number;
+              const status = d.status as PlanStepUpdate['status'];
+              const existing = prev.planProgressUpdates.findIndex(
+                (u) => u.stepIndex === stepIndex,
+              );
+              if (existing >= 0) {
+                const updated = [...prev.planProgressUpdates];
+                updated[existing] = { stepIndex, status };
+                return { planProgressUpdates: updated };
+              }
+              return {
+                planProgressUpdates: [
+                  ...prev.planProgressUpdates,
+                  { stepIndex, status },
+                ],
+              };
+            });
           }
           break;
 


### PR DESCRIPTION
## Summary

- **New `uiMessages` column** stores chat parts in exact rendering order via `onStepFinish` accumulation, fixing plan cards/display tools disappearing or appearing at wrong position on page reload
- **Unwraps AI SDK `{type:'json',value:...}` envelope** from tool outputs — root cause of plan cards not rendering on reload (`data.success` was undefined due to wrapping)
- **Fixes multi-question form** option click not working (Radix Label → div), connection picker rerender flash on selection, plan progress dedup, thinking details showing duplicate summary text
- **New `PersistedChatMessage` types** with Zod schemas, enums (`PersistedChatPartType`, `PersistedChatRole`, `PersistedToolCallStatus`), and shared `chatPersistenceUtils.unwrapToolOutput`
- **Marks all plan steps as done** when streaming completes (eliminates fragile keyword matching for completed messages)

## Test plan

- [x] New conversation: build a flow → plan card renders inline during streaming
- [x] Reload page → plan card appears in correct position with all steps marked done
- [x] Old conversation (before migration) → falls back to legacy reconstruction
- [x] Multi-question form → clicking options advances/submits correctly
- [x] Connection picker → selecting connection shows stable SelectedState without rerender flash
- [x] Thinking details → final summary text excluded (no duplication)
- [x] `npm run lint-dev` passes