### PR TITLE
fix(engine): subflow failure overwriting sibling waitpoint-based steps outputs on resume

### DIFF
--- a/.agents/features/flow-runs.md
+++ b/.agents/features/flow-runs.md
@@ -32,6 +32,7 @@ Flow Runs records every execution of a flow, tracking its full lifecycle from qu
 - **Waitpoint**: Row in the `waitpoint` table representing one paused step on a run. Fields: `type` (DELAY|WEBHOOK), `version` (V0|V1 — V1 is the current API), `status` (PENDING|COMPLETED), `stepName`, `resumeDateTime`, `responseToSend`, `resumePayload`, `workerHandlerId`, `httpRequestId`. Unique on `(flow_run_id, step_name)`.
 - **PauseMetadata** *(legacy/V0)*: JSONB column on `flow_run` distinguishing DELAY vs WEBHOOK pauses. Deprecated 2026-04-13 (0.82.0); still read for in-flight V0 runs, scheduled for removal. V1 runs store this information on the `waitpoint` row instead.
 - **Retry Strategy**: FROM_FAILED_STEP (resume from exact failure point, keeping prior outputs) or ON_LATEST_VERSION (fresh run on current published version).
+- **ResumeReason**: `WAITPOINT` | `RETRY`. Set on every `ExecutionType.RESUME` engine operation and threaded through `ExecuteFlowJobData`. Determines whether the engine restores FAILED steps from the journal — waitpoint resumes preserve them, retry resumes drop them so the failed step re-executes. The two resume paths share the same `ExecutionType`, so this field is the only discriminator.
 - **Subflow**: A child run linked via `parentRunId`, created when a flow calls another flow as a step.
 - **failedStep**: JSONB snapshot of `{ name, displayName, message? }` for the step that caused failure. Enables filtered retries, the runs-table error-message search, the failure email's "Reason" line, and the builder's jump-to-failed-step affordance. `message` is truncated via `truncateString` from `@activepieces/shared` before being persisted, and the engine populates `failedStep` for every status in `FAILED_STATES` (FAILED, TIMEOUT, INTERNAL_ERROR, QUOTA_EXCEEDED, MEMORY_LIMIT_EXCEEDED) — not just `FAILED`.
 
@@ -60,7 +61,7 @@ Flow Runs records every execution of a flow, tracking its full lifecycle from qu
 
 ## Retry Strategies
 
-- **FROM_FAILED_STEP**: Fetches execution state from zstd-compressed logs file, rebuilds FlowExecutorContext, re-runs from failed step. Previous step outputs preserved.
+- **FROM_FAILED_STEP**: Fetches execution state from zstd-compressed logs file, rebuilds FlowExecutorContext, re-runs from failed step. Previous step outputs preserved. Enqueued with `resumeReason: RETRY` so the engine drops the FAILED step from the restored journal — without this, the failed step would be treated as already-complete and the retry would be a no-op.
 - **ON_LATEST_VERSION**: Starts fresh from trigger on latest published version.
 - Constraint: only terminal states, within retention window (EXECUTION_DATA_RETENTION_DAYS).
 
@@ -77,7 +78,7 @@ Flow Runs records every execution of a flow, tracking its full lifecycle from qu
   - `DELAY` waitpoint: server upserts a `SystemJobName.RESUME_DELAY_WAITPOINT` BullMQ job scheduled at `resumeDateTime`. When it fires, `resumeService.resumeFromWaitpoint` enqueues the resume.
   - `WEBHOOK` waitpoint: resume signal arrives as an HTTP call on `/:id/waitpoints/:waitpointId[/sync]`. Optional `responseToSend` is replied immediately to the original webhook trigger.
 - **Pre-completion (resume-before-pause race):** `waitpoint-service.complete()` takes a pessimistic write lock on the PENDING row. If no row yet, it inserts a COMPLETED row with the `resumePayload`. When the flow then transitions to PAUSED, `flow-runs-queue.ts` sees the COMPLETED waitpoint and enqueues the resume immediately. Prevents dropped early callbacks.
-- **On resume:** fetch state from logs file → rebuild `FlowExecutorContext` → re-run the paused step with `ExecutionType.RESUME` and `ctx.resumePayload = waitpoint.resumePayload`.
+- **On resume:** fetch state from logs file → rebuild `FlowExecutorContext` → re-run the paused step with `ExecutionType.RESUME` and `ctx.resumePayload = waitpoint.resumePayload`. When rebuilding `flowContext` in `flow.operation.ts#getFlowExecutionState`, steps in `SUCCEEDED` / `PAUSED` are always restored; `FAILED` steps are restored iff `resumeReason === WAITPOINT`. Dropping a FAILED step kept alive by `continueOnFailure` would re-execute it from BEGIN — re-firing its waitpoint (e.g. re-invoking a subflow) and letting the global `constants.resumePayload` pollute the new output. The retry path needs the opposite behavior, hence the discriminator.
 - **Limits:** `AP_PAUSED_FLOW_TIMEOUT_DAYS` caps DELAY `resumeDateTime`; engine throws `PausedFlowTimeoutError` beyond that.
 - **Legacy (V0) path:** `pauseMetadata` on `flow_run` + `ctx.run.pause({ pauseMetadata })` + `ctx.generateResumeUrl()` + `/requests/:requestId[/sync]` routes. Still functional for in-flight runs; scheduled for removal.
 - **On server restart:** `refill-paused-jobs` migration re-queues legacy paused runs. Waitpoint DELAYs are BullMQ delayed jobs and survive restarts natively.

--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -174,7 +174,6 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
                     flowRun: updatedFlowRun,
                     platformId,
                     streamStepProgress: StreamStepProgress.NONE,
-                    executeTrigger: false,
                     executionType: ExecutionType.RESUME,
                     resumeReason: ResumeReason.RETRY,
                     workerHandlerId: undefined,
@@ -593,7 +592,7 @@ export async function addToQueue(params: AddToQueueParams, log: FastifyBaseLogge
         ? {
             ...commonJobData,
             executionType: ExecutionType.RESUME,
-            resumeReason: params.resumeReason ?? ResumeReason.WAITPOINT,
+            resumeReason: params.resumeReason,
         }
         : {
             ...commonJobData,
@@ -705,18 +704,20 @@ type GetOneParams = {
     projectId: ProjectId | undefined
 }
 
-export type AddToQueueParams = {
+type AddToQueueParamsCommon = {
     flowRun: FlowRun
     platformId: PlatformId
     payload?: unknown
-    executeTrigger: boolean
-    executionType: ExecutionType
-    resumeReason?: ResumeReason
     workerHandlerId: string | undefined
     httpRequestId: string | undefined
     streamStepProgress: StreamStepProgress
     sampleData?: Record<string, unknown>
 }
+
+export type AddToQueueParams = AddToQueueParamsCommon & (
+    | { executionType: ExecutionType.BEGIN, executeTrigger: boolean }
+    | { executionType: ExecutionType.RESUME, resumeReason: ResumeReason }
+)
 
 
 type StartParams = {
@@ -730,7 +731,7 @@ type StartParams = {
     failParentOnFailure: boolean | undefined
     stepNameToTest?: string
     executeTrigger: boolean
-    executionType: ExecutionType
+    executionType: ExecutionType.BEGIN
     workerHandlerId: string | undefined
     httpRequestId: string | undefined
     streamStepProgress: StreamStepProgress

--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -4,6 +4,7 @@ import {
     apId,
     Cursor,
     ErrorCode,
+    ExecuteFlowJobData,
     ExecutionType,
     ExecutioOutputFile,
     FileType,
@@ -570,32 +571,39 @@ export async function addToQueue(params: AddToQueueParams, log: FastifyBaseLogge
         jobPayload = await payloadOffloader.maybeOffloadPayload(log, params.payload, params.flowRun.projectId, params.platformId)
     }
 
+    const commonJobData = {
+        schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
+        workerHandlerId: params.workerHandlerId ?? null,
+        projectId: params.flowRun.projectId,
+        platformId: params.platformId,
+        environment: params.flowRun.environment,
+        flowId: params.flowRun.flowId,
+        runId: params.flowRun.id,
+        jobType: WorkerJobType.EXECUTE_FLOW as const,
+        flowVersionId: params.flowRun.flowVersionId,
+        payload: jobPayload,
+        httpRequestId: params.httpRequestId,
+        streamStepProgress: params.streamStepProgress,
+        stepNameToTest: params.flowRun.stepNameToTest ?? undefined,
+        sampleData: params.sampleData,
+        logsFileId,
+        traceContext,
+    }
+    const data: ExecuteFlowJobData = params.executionType === ExecutionType.RESUME
+        ? {
+            ...commonJobData,
+            executionType: ExecutionType.RESUME,
+            resumeReason: params.resumeReason ?? ResumeReason.WAITPOINT,
+        }
+        : {
+            ...commonJobData,
+            executionType: ExecutionType.BEGIN,
+            executeTrigger: params.executeTrigger,
+        }
     await jobQueue(log).add({
         id: params.flowRun.id,
         type: JobType.ONE_TIME,
-        data: {
-            schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
-            workerHandlerId: params.workerHandlerId ?? null,
-            projectId: params.flowRun.projectId,
-            platformId: params.platformId,
-            environment: params.flowRun.environment,
-            flowId: params.flowRun.flowId,
-            runId: params.flowRun.id,
-            jobType: WorkerJobType.EXECUTE_FLOW,
-            flowVersionId: params.flowRun.flowVersionId,
-            payload: jobPayload,
-            executeTrigger: params.executeTrigger,
-            httpRequestId: params.httpRequestId,
-            executionType: params.executionType,
-            resumeReason: params.executionType === ExecutionType.RESUME
-                ? (params.resumeReason ?? ResumeReason.WAITPOINT)
-                : undefined,
-            streamStepProgress: params.streamStepProgress,
-            stepNameToTest: params.flowRun.stepNameToTest ?? undefined,
-            sampleData: params.sampleData,
-            logsFileId,
-            traceContext,
-        },
+        data,
     })
     return params.flowRun
 }

--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -21,6 +21,7 @@ import {
     LATEST_JOB_DATA_SCHEMA_VERSION,
     PlatformId,
     ProjectId,
+    ResumeReason,
     RunEnvironment,
     SampleDataFileType,
     SeekPage,
@@ -174,6 +175,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
                     streamStepProgress: StreamStepProgress.NONE,
                     executeTrigger: false,
                     executionType: ExecutionType.RESUME,
+                    resumeReason: ResumeReason.RETRY,
                     workerHandlerId: undefined,
                     httpRequestId: undefined,
                 }, log)
@@ -585,6 +587,9 @@ export async function addToQueue(params: AddToQueueParams, log: FastifyBaseLogge
             executeTrigger: params.executeTrigger,
             httpRequestId: params.httpRequestId,
             executionType: params.executionType,
+            resumeReason: params.executionType === ExecutionType.RESUME
+                ? (params.resumeReason ?? ResumeReason.WAITPOINT)
+                : undefined,
             streamStepProgress: params.streamStepProgress,
             stepNameToTest: params.flowRun.stepNameToTest ?? undefined,
             sampleData: params.sampleData,
@@ -698,6 +703,7 @@ export type AddToQueueParams = {
     payload?: unknown
     executeTrigger: boolean
     executionType: ExecutionType
+    resumeReason?: ResumeReason
     workerHandlerId: string | undefined
     httpRequestId: string | undefined
     streamStepProgress: StreamStepProgress

--- a/packages/server/api/src/app/flows/flow-run/waitpoint/resume-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/waitpoint/resume-service.ts
@@ -6,6 +6,7 @@ import {
     FlowRunId,
     FlowRunStatus,
     isFlowRunStateTerminal,
+    ResumeReason,
     RunEnvironment,
     StreamStepProgress,
 } from '@activepieces/shared'
@@ -121,6 +122,7 @@ async function enqueueResume(params: EnqueueResumeParams, log: FastifyBaseLogger
             : StreamStepProgress.NONE,
         executeTrigger: false,
         executionType: ExecutionType.RESUME,
+        resumeReason: ResumeReason.WAITPOINT,
     }, log)
     await flowRunSideEffects(log).onResume(flowRun)
 }

--- a/packages/server/api/src/app/flows/flow-run/waitpoint/resume-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/waitpoint/resume-service.ts
@@ -120,7 +120,6 @@ async function enqueueResume(params: EnqueueResumeParams, log: FastifyBaseLogger
         streamStepProgress: flowRun.environment === RunEnvironment.TESTING
             ? StreamStepProgress.WEBSOCKET
             : StreamStepProgress.NONE,
-        executeTrigger: false,
         executionType: ExecutionType.RESUME,
         resumeReason: ResumeReason.WAITPOINT,
     }, log)

--- a/packages/server/api/src/app/workers/migrations/job-data-migrations.ts
+++ b/packages/server/api/src/app/workers/migrations/job-data-migrations.ts
@@ -1,4 +1,4 @@
-import { apId, JobData, StreamStepProgress, WorkerJobType } from '@activepieces/shared'
+import { apId, ExecutionType, isNil, JobData, ResumeReason, StreamStepProgress, WorkerJobType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { flowVersionService } from '../../flows/flow-version/flow-version.service'
@@ -91,8 +91,26 @@ function createMigrations(log: FastifyBaseLogger): JobMigration[] {
             }
         },
     }
+    const bridgeV8ToV9: JobMigration = {
+        runAtSchemaVersion: 8,
+        migrate: async (job: JobData) => ({ ...job, schemaVersion: 9 }),
+    }
+    const addResumeReason: JobMigration = {
+        runAtSchemaVersion: 9,
+        migrate: async (job: JobData) => {
+            if (job.jobType !== WorkerJobType.EXECUTE_FLOW || job.executionType !== ExecutionType.RESUME) {
+                return { ...job, schemaVersion: 10 }
+            }
+            const isLegacyRetry = job.payload.type === 'inline' && isNil(job.payload.value)
+            return {
+                ...job,
+                schemaVersion: 10,
+                resumeReason: isLegacyRetry ? ResumeReason.RETRY : ResumeReason.WAITPOINT,
+            }
+        },
+    }
 
-    return [enrichFlowId, migratePayloadToUnion, renameProgressAndHandlerFields, dropLogsUploadUrl, backfillRequiredExecuteFlowFields]
+    return [enrichFlowId, migratePayloadToUnion, renameProgressAndHandlerFields, dropLogsUploadUrl, backfillRequiredExecuteFlowFields, bridgeV8ToV9, addResumeReason]
 }
 
 function migrateProgressUpdateType(progressUpdateType: string | undefined): StreamStepProgress {

--- a/packages/server/api/src/app/workers/migrations/unify-old-queues-to-one.ts
+++ b/packages/server/api/src/app/workers/migrations/unify-old-queues-to-one.ts
@@ -1,4 +1,4 @@
-import { ExecuteFlowJobData, isNil, LATEST_JOB_DATA_SCHEMA_VERSION, StreamStepProgress, WebhookJobData, WorkerJobType } from '@activepieces/shared'
+import { BeginExecuteFlowJobData, ExecuteFlowJobData, isNil, LATEST_JOB_DATA_SCHEMA_VERSION, StreamStepProgress, WebhookJobData, WorkerJobType } from '@activepieces/shared'
 import { Job, Queue } from 'bullmq'
 import { FastifyBaseLogger } from 'fastify'
 import { redisConnections } from '../../database/redis-connections'
@@ -6,7 +6,7 @@ import { flowVersionRepo } from '../../flows/flow-version/flow-version.service'
 import { projectService } from '../../project/project-service'
 import { jobQueue, JobType } from '../job-queue/job-queue'
 
-type LegacyOneTimeJobData = Pick<ExecuteFlowJobData, 'runId' | 'projectId' | 'flowVersionId' | 'environment' | 'workerHandlerId' | 'httpRequestId' | 'payload' | 'executeTrigger' | 'executionType' | 'stepNameToTest' | 'sampleData'> & { progressUpdateType: string }
+type LegacyOneTimeJobData = Pick<BeginExecuteFlowJobData, 'runId' | 'projectId' | 'flowVersionId' | 'environment' | 'workerHandlerId' | 'httpRequestId' | 'payload' | 'executeTrigger' | 'executionType' | 'stepNameToTest' | 'sampleData'> & { progressUpdateType: string }
 type LegacyWebhookJobData = Pick<WebhookJobData, 'projectId' | 'schemaVersion' | 'requestId' | 'payload' | 'runEnvironment' | 'flowId' | 'saveSampleData' | 'flowVersionIdToRun' | 'execute' | 'parentRunId' | 'failParentOnFailure'>
 const migratedKey = 'unified_queue_migrated'
 

--- a/packages/server/api/test/unit/app/workers/migrations/job-data-migrations.test.ts
+++ b/packages/server/api/test/unit/app/workers/migrations/job-data-migrations.test.ts
@@ -1,4 +1,4 @@
-import { ExecuteFlowJobData, ExecutionType, FlowTriggerType, PollingJobData, RunEnvironment, StreamStepProgress, WorkerJobType } from '@activepieces/shared'
+import { ExecuteFlowJobData, ExecutionType, FlowTriggerType, PollingJobData, ResumeReason, RunEnvironment, StreamStepProgress, WorkerJobType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -23,7 +23,7 @@ const mockLog: FastifyBaseLogger = {
     level: 'info',
 } as unknown as FastifyBaseLogger
 
-const LATEST = 8
+const LATEST = 10
 
 function baseFlowJob(overrides: Partial<ExecuteFlowJobData> = {}): ExecuteFlowJobData {
     return {
@@ -170,5 +170,70 @@ describe('jobMigrations v7 → v8 (backfillRequiredExecuteFlowFields)', () => {
 
         expect(migrated.schemaVersion).toBe(LATEST)
         expect(migrated.jobType).toBe(WorkerJobType.EXECUTE_POLLING)
+    })
+})
+
+describe('jobMigrations v9 → v10 (addResumeReason)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('classifies inline-null payload as RETRY (the only legacy producer of that shape)', async () => {
+        const job = baseFlowJob({
+            schemaVersion: 9,
+            executionType: ExecutionType.RESUME,
+            payload: { type: 'inline', value: null },
+        })
+
+        const migrated = await jobMigrations(mockLog).apply(job) as ExecuteFlowJobData
+
+        expect(migrated.schemaVersion).toBe(LATEST)
+        expect(migrated.resumeReason).toBe(ResumeReason.RETRY)
+    })
+
+    it('classifies inline payload with a real body as WAITPOINT', async () => {
+        const job = baseFlowJob({
+            schemaVersion: 9,
+            executionType: ExecutionType.RESUME,
+            payload: { type: 'inline', value: { body: { action: 'approve' }, headers: {}, queryParams: {} } },
+        })
+
+        const migrated = await jobMigrations(mockLog).apply(job) as ExecuteFlowJobData
+
+        expect(migrated.resumeReason).toBe(ResumeReason.WAITPOINT)
+    })
+
+    it('classifies ref payload as WAITPOINT (offloaded payloads were never produced by retry)', async () => {
+        const job = baseFlowJob({
+            schemaVersion: 9,
+            executionType: ExecutionType.RESUME,
+            payload: { type: 'ref', fileId: 'offloaded-payload-1' },
+        })
+
+        const migrated = await jobMigrations(mockLog).apply(job) as ExecuteFlowJobData
+
+        expect(migrated.resumeReason).toBe(ResumeReason.WAITPOINT)
+    })
+
+    it('only bumps schemaVersion for BEGIN execution (resumeReason is meaningless for BEGIN)', async () => {
+        const job = baseFlowJob({
+            schemaVersion: 9,
+            executionType: ExecutionType.BEGIN,
+        })
+
+        const migrated = await jobMigrations(mockLog).apply(job) as ExecuteFlowJobData
+
+        expect(migrated.schemaVersion).toBe(LATEST)
+        expect(migrated.resumeReason).toBeUndefined()
+    })
+
+    it('only bumps schemaVersion for non-EXECUTE_FLOW jobs at v9', async () => {
+        const job = basePollingJob({ schemaVersion: 9 })
+
+        const migrated = await jobMigrations(mockLog).apply(job)
+
+        expect(migrated.schemaVersion).toBe(LATEST)
+        expect(migrated.jobType).toBe(WorkerJobType.EXECUTE_POLLING)
+        expect('resumeReason' in migrated).toBe(false)
     })
 })

--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -14,6 +14,7 @@ import {
     JobPayload,
     LoopStepOutput,
     ResumePayload,
+    ResumeReason,
     StepOutput,
     StepOutputStatus,
     TriggerHookType,
@@ -89,7 +90,7 @@ async function getFlowExecutionState(input: ResolvedExecuteFlowOperation, consta
             }).setOutput(newPayload))
     }
     flowContext = flowContext.addTags(input.executionState.tags)
-    const isWaitpointResume = !isNil(input.resumePayload)
+    const isWaitpointResume = input.resumeReason === ResumeReason.WAITPOINT
     for (const [step, output] of Object.entries(input.executionState.steps)) {
         if (isStepRestorable({ status: output.status, isWaitpointResume })) {
             const newOutput = await insertSuccessStepsOrPausedRecursively({ stepOutput: output, isWaitpointResume })
@@ -191,7 +192,8 @@ async function fetchExecutionStateFromLogs(logsFileId: string | undefined, opera
 // Waitpoint resumes preserve FAILED so a `continueOnFailure` step isn't replayed,
 // which would re-fire its waitpoint and let the global `constants.resumePayload`
 // pollute the new output. Retry resumes (FlowRetryStrategy.FROM_FAILED_STEP) drop
-// FAILED so the engine re-executes the failed step.
+// FAILED so the engine re-executes the failed step. The discriminator is the
+// explicit `resumeReason` set when the run is enqueued.
 function isStepRestorable({ status, isWaitpointResume }: IsStepRestorableParams): boolean {
     if (status === StepOutputStatus.SUCCEEDED || status === StepOutputStatus.PAUSED) {
         return true

--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -89,9 +89,10 @@ async function getFlowExecutionState(input: ResolvedExecuteFlowOperation, consta
             }).setOutput(newPayload))
     }
     flowContext = flowContext.addTags(input.executionState.tags)
+    const isWaitpointResume = !isNil(input.resumePayload)
     for (const [step, output] of Object.entries(input.executionState.steps)) {
-        if ([StepOutputStatus.SUCCEEDED, StepOutputStatus.PAUSED].includes(output.status)) {
-            const newOutput = await insertSuccessStepsOrPausedRecursively(output)
+        if (isStepRestorable({ status: output.status, isWaitpointResume })) {
+            const newOutput = await insertSuccessStepsOrPausedRecursively({ stepOutput: output, isWaitpointResume })
             if (!isNil(newOutput)) {
                 flowContext = await flowContext.upsertStep(step, newOutput)
             }
@@ -118,8 +119,8 @@ async function runOrReturnPayload(input: ResolvedBeginExecuteFlowOperation, cons
 }
 
 
-async function insertSuccessStepsOrPausedRecursively(stepOutput: StepOutput): Promise<StepOutput | null> {
-    if (![StepOutputStatus.SUCCEEDED, StepOutputStatus.PAUSED].includes(stepOutput.status)) {
+async function insertSuccessStepsOrPausedRecursively({ stepOutput, isWaitpointResume }: InsertStepsParams): Promise<StepOutput | null> {
+    if (!isStepRestorable({ status: stepOutput.status, isWaitpointResume })) {
         return null
     }
     if (stepOutput.type === FlowActionType.LOOP_ON_ITEMS) {
@@ -129,7 +130,7 @@ async function insertSuccessStepsOrPausedRecursively(stepOutput: StepOutput): Pr
         for (const iteration of iterations) {
             const newSteps: Record<string, StepOutput> = {}
             for (const [step, output] of Object.entries(iteration)) {
-                const newOutput = await insertSuccessStepsOrPausedRecursively(output)
+                const newOutput = await insertSuccessStepsOrPausedRecursively({ stepOutput: output, isWaitpointResume })
                 if (!isNil(newOutput)) {
                     newSteps[step] = newOutput
                 }
@@ -187,3 +188,23 @@ async function fetchExecutionStateFromLogs(logsFileId: string | undefined, opera
     return parsed.executionState as ExecutionState
 }
 
+// Waitpoint resumes preserve FAILED so a `continueOnFailure` step isn't replayed,
+// which would re-fire its waitpoint and let the global `constants.resumePayload`
+// pollute the new output. Retry resumes (FlowRetryStrategy.FROM_FAILED_STEP) drop
+// FAILED so the engine re-executes the failed step.
+function isStepRestorable({ status, isWaitpointResume }: IsStepRestorableParams): boolean {
+    if (status === StepOutputStatus.SUCCEEDED || status === StepOutputStatus.PAUSED) {
+        return true
+    }
+    return isWaitpointResume && status === StepOutputStatus.FAILED
+}
+
+type IsStepRestorableParams = {
+    status: StepOutputStatus
+    isWaitpointResume: boolean
+}
+
+type InsertStepsParams = {
+    stepOutput: StepOutput
+    isWaitpointResume: boolean
+}

--- a/packages/server/engine/test/operations/flow-operation-invariants.test.ts
+++ b/packages/server/engine/test/operations/flow-operation-invariants.test.ts
@@ -5,6 +5,7 @@ import {
     FlowActionType,
     FlowTriggerType,
     FlowVersionState,
+    ResumeReason,
     StreamStepProgress,
     RunEnvironment,
     StepOutputStatus,
@@ -152,6 +153,7 @@ function makeResumeOperation(overrides?: Partial<ResumeExecuteFlowOperation>): R
         streamStepProgress: StreamStepProgress.NONE,
         stepNameToTest: null,
         resumePayload: { type: 'inline', value: { data: {} } },
+        resumeReason: ResumeReason.WAITPOINT,
         logsFileId: 'logs-file-1',
         ...overrides,
     }
@@ -281,11 +283,11 @@ describe('flow operation invariants', () => {
             expect(mockCreateWaitpoint).not.toHaveBeenCalled()
         })
 
-        it('drops FAILED steps on a retry resume (resumePayload absent — FlowRetryStrategy.FROM_FAILED_STEP)', async () => {
+        it('drops FAILED steps on a retry resume (resumeReason=RETRY — FlowRetryStrategy.FROM_FAILED_STEP)', async () => {
             // The retry-from-failed-step feature (flow-run-service.ts FlowRetryStrategy.FROM_FAILED_STEP)
-            // re-enqueues the run as executionType=RESUME with NO payload, expecting the engine to
-            // replay the failed step. Preserving FAILED on this path would silently turn retry into
-            // a no-op. The discriminator is `isNil(resumePayload)`.
+            // re-enqueues the run as executionType=RESUME with resumeReason=RETRY, expecting the
+            // engine to replay the failed step. Preserving FAILED on this path would silently turn
+            // retry into a no-op. The discriminator is the explicit `resumeReason` field.
             mockDownload.mockReset()
             mockCreateWaitpoint.mockReset()
             mockCreateWaitpoint.mockResolvedValue({
@@ -319,11 +321,12 @@ describe('flow operation invariants', () => {
                 ...makeResumeOperation(),
                 flowVersion: makeFlowVersionWithTwoApprovals(),
                 resumePayload: { type: 'inline', value: null },
+                resumeReason: ResumeReason.RETRY,
             }
 
             await flowOperation.execute(operation)
 
-            // step_1 (FAILED) was dropped because no resumePayload → engine replayed it from
+            // step_1 (FAILED) was dropped because resumeReason=RETRY → engine replayed it from
             // BEGIN, which creates a waitpoint via the approval piece.
             expect(mockCreateWaitpoint).toHaveBeenCalled()
         })
@@ -379,6 +382,59 @@ describe('flow operation invariants', () => {
             await flowOperation.execute(operation)
 
             expect(mockCreateWaitpoint).toHaveBeenCalledTimes(1)
+        })
+
+        it('preserves FAILED steps on a delay-piece waitpoint resume even though resumePayload is null', async () => {
+            // The Delay piece's scheduled resume (`flow-run-module.ts` RESUME_DELAY_WAITPOINT
+            // handler) calls `resumeFromWaitpoint` with `resumePayload: null`. Prior to the
+            // explicit `resumeReason` field this looked indistinguishable from a retry, and the
+            // engine would drop FAILED — replaying any `continueOnFailure` step that preceded
+            // the delay. With `resumeReason: WAITPOINT`, FAILED is preserved correctly.
+            mockDownload.mockReset()
+            mockCreateWaitpoint.mockReset()
+            mockCreateWaitpoint.mockResolvedValue({
+                id: 'wp-delay',
+                resumeUrl: 'http://localhost:4200/api/v1/flow-runs/run-1/waitpoints/wp-delay',
+            })
+
+            mockDownload.mockResolvedValue(
+                new TextEncoder().encode(JSON.stringify({
+                    executionState: {
+                        steps: {
+                            trigger_1: {
+                                type: FlowTriggerType.EMPTY,
+                                status: StepOutputStatus.SUCCEEDED,
+                                input: {},
+                                output: {},
+                            },
+                            step_1: {
+                                type: FlowActionType.PIECE,
+                                status: StepOutputStatus.FAILED,
+                                input: {},
+                                errorMessage: 'Subflow execution failed',
+                            },
+                            step_2: {
+                                type: FlowActionType.PIECE,
+                                status: StepOutputStatus.PAUSED,
+                                input: {},
+                                output: {},
+                            },
+                        },
+                        tags: [],
+                    },
+                })),
+            )
+
+            const operation: ResumeExecuteFlowOperation = {
+                ...makeResumeOperation(),
+                flowVersion: makeFlowVersionWithTwoApprovals(),
+                resumePayload: { type: 'inline', value: null },
+                resumeReason: ResumeReason.WAITPOINT,
+            }
+
+            await flowOperation.execute(operation)
+
+            expect(mockCreateWaitpoint).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/server/engine/test/operations/flow-operation-invariants.test.ts
+++ b/packages/server/engine/test/operations/flow-operation-invariants.test.ts
@@ -2,18 +2,20 @@ import { describe, it, expect, vi } from 'vitest'
 import {
     EngineGenericError,
     ExecutionType,
+    FlowActionType,
     FlowTriggerType,
     FlowVersionState,
     StreamStepProgress,
     RunEnvironment,
     StepOutputStatus,
 } from '@activepieces/shared'
-import type { BeginExecuteFlowOperation, FlowVersion, ResumeExecuteFlowOperation } from '@activepieces/shared'
+import type { BeginExecuteFlowOperation, FlowAction, FlowVersion, ResumeExecuteFlowOperation } from '@activepieces/shared'
 
 vi.mock('../../src/lib/helper/flow-run-progress-reporter', () => ({
     flowRunProgressReporter: {
         sendUpdate: vi.fn().mockResolvedValue(undefined),
         backup: vi.fn().mockResolvedValue(undefined),
+        createOutputContext: vi.fn().mockReturnValue({ update: vi.fn().mockResolvedValue(undefined) }),
     },
 }))
 
@@ -25,6 +27,15 @@ vi.mock('../../src/lib/engine-file-api', () => ({
     engineFileApi: {
         download: mockDownload,
         upload: mockUpload,
+    },
+}))
+
+const { mockCreateWaitpoint } = vi.hoisted(() => ({
+    mockCreateWaitpoint: vi.fn(),
+}))
+vi.mock('../../src/lib/piece-context/waitpoint-client', () => ({
+    waitpointClient: {
+        create: mockCreateWaitpoint,
     },
 }))
 
@@ -74,6 +85,53 @@ function makeBeginOperation(overrides?: Partial<BeginExecuteFlowOperation>): Beg
         triggerPayload: { type: 'inline', value: {} },
         executeTrigger: false,
         ...overrides,
+    }
+}
+
+function makeFlowVersionWithTwoApprovals(): FlowVersion {
+    const step2: FlowAction = {
+        name: 'step_2',
+        displayName: 'Step 2 — Wait for Approval',
+        type: FlowActionType.PIECE,
+        skip: false,
+        valid: true,
+        settings: {
+            input: {},
+            pieceName: '@activepieces/piece-approval',
+            pieceVersion: '1.0.0',
+            actionName: 'wait_for_approval',
+            propertySettings: {},
+        },
+    }
+    const step1: FlowAction = {
+        name: 'step_1',
+        displayName: 'Step 1 — Wait for Approval',
+        type: FlowActionType.PIECE,
+        skip: false,
+        valid: true,
+        settings: {
+            input: {},
+            pieceName: '@activepieces/piece-approval',
+            pieceVersion: '1.0.0',
+            actionName: 'wait_for_approval',
+            propertySettings: {},
+            errorHandlingOptions: {
+                continueOnFailure: { value: true },
+                retryOnFailure: { value: false },
+            },
+        },
+        nextAction: step2,
+    }
+    return {
+        ...makeFlowVersion(),
+        trigger: {
+            name: 'trigger_1',
+            valid: true,
+            displayName: 'Test Trigger',
+            type: FlowTriggerType.EMPTY,
+            settings: {},
+            nextAction: step1,
+        },
     }
 }
 
@@ -159,6 +217,168 @@ describe('flow operation invariants', () => {
                 expect((e as Error).message).not.toContain('logsFileId is missing')
                 expect((e as Error).message).not.toContain('executionState is missing')
             }
+        })
+    })
+
+    describe('RESUME step-restoration semantics', () => {
+        it('preserves FAILED steps on a waitpoint resume (resumePayload present)', async () => {
+            // Regression for the Slack/webhook-resume bug: a FAILED step preserved by
+            // `continueOnFailure` was being dropped from the restored journal on resume.
+            // The engine then re-executed it from BEGIN, creating a fresh waitpoint and
+            // (for Call Flow) re-invoking the subflow. That cascade is what eventually
+            // let the global resumePayload pollute downstream paused steps.
+            //
+            // Setup: trigger → step_1 (FAILED with continueOnFailure) → step_2 (PAUSED waiting
+            // for a webhook click). Resume is fired for step_2 with a non-null resumePayload
+            // (waitpoint path). With the fix, step_1 stays FAILED in the restored state,
+            // `isCompleted` short-circuits piece-executor, and no new waitpoint is created.
+            mockDownload.mockReset()
+            mockCreateWaitpoint.mockReset()
+            mockCreateWaitpoint.mockResolvedValue({
+                id: 'wp-new',
+                resumeUrl: 'http://localhost:4200/api/v1/flow-runs/run-1/waitpoints/wp-new',
+            })
+
+            mockDownload.mockResolvedValue(
+                new TextEncoder().encode(JSON.stringify({
+                    executionState: {
+                        steps: {
+                            trigger_1: {
+                                type: FlowTriggerType.EMPTY,
+                                status: StepOutputStatus.SUCCEEDED,
+                                input: {},
+                                output: {},
+                            },
+                            step_1: {
+                                type: FlowActionType.PIECE,
+                                status: StepOutputStatus.FAILED,
+                                input: {},
+                                errorMessage: 'Subflow execution failed',
+                            },
+                            step_2: {
+                                type: FlowActionType.PIECE,
+                                status: StepOutputStatus.PAUSED,
+                                input: {},
+                                output: { approved: true },
+                            },
+                        },
+                        tags: [],
+                    },
+                })),
+            )
+
+            const operation: ResumeExecuteFlowOperation = {
+                ...makeResumeOperation(),
+                flowVersion: makeFlowVersionWithTwoApprovals(),
+                resumePayload: {
+                    type: 'inline',
+                    value: { queryParams: { action: 'approve' }, body: {}, headers: {} },
+                },
+            }
+
+            await flowOperation.execute(operation)
+
+            expect(mockCreateWaitpoint).not.toHaveBeenCalled()
+        })
+
+        it('drops FAILED steps on a retry resume (resumePayload absent — FlowRetryStrategy.FROM_FAILED_STEP)', async () => {
+            // The retry-from-failed-step feature (flow-run-service.ts FlowRetryStrategy.FROM_FAILED_STEP)
+            // re-enqueues the run as executionType=RESUME with NO payload, expecting the engine to
+            // replay the failed step. Preserving FAILED on this path would silently turn retry into
+            // a no-op. The discriminator is `isNil(resumePayload)`.
+            mockDownload.mockReset()
+            mockCreateWaitpoint.mockReset()
+            mockCreateWaitpoint.mockResolvedValue({
+                id: 'wp-retry',
+                resumeUrl: 'http://localhost:4200/api/v1/flow-runs/run-1/waitpoints/wp-retry',
+            })
+
+            mockDownload.mockResolvedValue(
+                new TextEncoder().encode(JSON.stringify({
+                    executionState: {
+                        steps: {
+                            trigger_1: {
+                                type: FlowTriggerType.EMPTY,
+                                status: StepOutputStatus.SUCCEEDED,
+                                input: {},
+                                output: {},
+                            },
+                            step_1: {
+                                type: FlowActionType.PIECE,
+                                status: StepOutputStatus.FAILED,
+                                input: {},
+                                errorMessage: 'transient error',
+                            },
+                        },
+                        tags: [],
+                    },
+                })),
+            )
+
+            const operation: ResumeExecuteFlowOperation = {
+                ...makeResumeOperation(),
+                flowVersion: makeFlowVersionWithTwoApprovals(),
+                resumePayload: { type: 'inline', value: null },
+            }
+
+            await flowOperation.execute(operation)
+
+            // step_1 (FAILED) was dropped because no resumePayload → engine replayed it from
+            // BEGIN, which creates a waitpoint via the approval piece.
+            expect(mockCreateWaitpoint).toHaveBeenCalled()
+        })
+
+        it('drops non-terminal statuses (e.g. RUNNING from a mid-step crash) on any resume', async () => {
+            // Sanity check on the inverse direction: a step left in RUNNING (engine crash mid-step,
+            // never reached a terminal status) should still be replayed on resume, regardless of
+            // whether resumePayload is present. Only SUCCEEDED, PAUSED, and FAILED (the last
+            // conditionally) survive restoration.
+            mockDownload.mockReset()
+            mockCreateWaitpoint.mockReset()
+            mockCreateWaitpoint.mockResolvedValue({
+                id: 'wp-replay',
+                resumeUrl: 'http://localhost:4200/api/v1/flow-runs/run-1/waitpoints/wp-replay',
+            })
+
+            mockDownload.mockResolvedValue(
+                new TextEncoder().encode(JSON.stringify({
+                    executionState: {
+                        steps: {
+                            trigger_1: {
+                                type: FlowTriggerType.EMPTY,
+                                status: StepOutputStatus.SUCCEEDED,
+                                input: {},
+                                output: {},
+                            },
+                            step_1: {
+                                type: FlowActionType.PIECE,
+                                status: StepOutputStatus.RUNNING,
+                                input: {},
+                            },
+                            step_2: {
+                                type: FlowActionType.PIECE,
+                                status: StepOutputStatus.PAUSED,
+                                input: {},
+                                output: { approved: true },
+                            },
+                        },
+                        tags: [],
+                    },
+                })),
+            )
+
+            const operation: ResumeExecuteFlowOperation = {
+                ...makeResumeOperation(),
+                flowVersion: makeFlowVersionWithTwoApprovals(),
+                resumePayload: {
+                    type: 'inline',
+                    value: { queryParams: { action: 'approve' }, body: {}, headers: {} },
+                },
+            }
+
+            await flowOperation.execute(operation)
+
+            expect(mockCreateWaitpoint).toHaveBeenCalledTimes(1)
         })
     })
 

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -132,11 +132,7 @@ function buildFlowOperation(
             ...base,
             executionType: ExecutionType.RESUME,
             resumePayload: data.payload,
-            // Pre-existing in-flight jobs lack this field; default to WAITPOINT so the
-            // engine preserves FAILED steps (the safe behavior — retries are user-driven
-            // and rare, so the worst case here is a one-off "retry didn't replay" that
-            // resolves on next deploy when all in-flight jobs carry the field).
-            resumeReason: data.resumeReason ?? ResumeReason.WAITPOINT,
+            resumeReason: data.resumeReason ?? legacyResumeReason(data),
         }
     }
 
@@ -173,4 +169,14 @@ async function reportFlowStatus(
 
 function isDedicatedWorker(): boolean {
     return !isNil(system.get(WorkerSystemProp.WORKER_GROUP_ID))
+}
+
+// Resolves resumeReason for jobs queued before schemaVersion 10. The retry path is
+// the only producer of an inline-null payload; every other resume signal (HTTP
+// callback, markParentRunAsFailed) carries a real body. Pre-existing delay-piece
+// resumes are misclassified here as RETRY — same buggy behavior they had pre-fix,
+// limited to the brief deploy window before legacy jobs drain.
+function legacyResumeReason(data: ExecuteFlowJobData): ResumeReason {
+    const isLegacyRetry = data.payload.type === 'inline' && isNil(data.payload.value)
+    return isLegacyRetry ? ResumeReason.RETRY : ResumeReason.WAITPOINT
 }

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -12,6 +12,7 @@ import {
     FlowVersion,
     isNil,
     ResumeExecuteFlowOperation,
+    ResumeReason,
     tryCatch,
     WorkerJobType,
 } from '@activepieces/shared'
@@ -131,6 +132,11 @@ function buildFlowOperation(
             ...base,
             executionType: ExecutionType.RESUME,
             resumePayload: data.payload,
+            // Pre-existing in-flight jobs lack this field; default to WAITPOINT so the
+            // engine preserves FAILED steps (the safe behavior — retries are user-driven
+            // and rare, so the worst case here is a one-off "retry didn't replay" that
+            // resolves on next deploy when all in-flight jobs carry the field).
+            resumeReason: data.resumeReason ?? ResumeReason.WAITPOINT,
         }
     }
 

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -12,7 +12,6 @@ import {
     FlowVersion,
     isNil,
     ResumeExecuteFlowOperation,
-    ResumeReason,
     tryCatch,
     WorkerJobType,
 } from '@activepieces/shared'
@@ -132,7 +131,7 @@ function buildFlowOperation(
             ...base,
             executionType: ExecutionType.RESUME,
             resumePayload: data.payload,
-            resumeReason: data.resumeReason ?? legacyResumeReason(data),
+            resumeReason: data.resumeReason,
         }
     }
 
@@ -169,14 +168,4 @@ async function reportFlowStatus(
 
 function isDedicatedWorker(): boolean {
     return !isNil(system.get(WorkerSystemProp.WORKER_GROUP_ID))
-}
-
-// Resolves resumeReason for jobs queued before schemaVersion 10. The retry path is
-// the only producer of an inline-null payload; every other resume signal (HTTP
-// callback, markParentRunAsFailed) carries a real body. Pre-existing delay-piece
-// resumes are misclassified here as RETRY — same buggy behavior they had pre-fix,
-// limited to the brief deploy window before legacy jobs drain.
-function legacyResumeReason(data: ExecuteFlowJobData): ResumeReason {
-    const isLegacyRetry = data.payload.type === 'inline' && isNil(data.payload.value)
-    return isLegacyRetry ? ResumeReason.RETRY : ResumeReason.WAITPOINT
 }

--- a/packages/shared/src/lib/automation/engine/engine-operation.ts
+++ b/packages/shared/src/lib/automation/engine/engine-operation.ts
@@ -110,9 +110,19 @@ export type BeginExecuteFlowOperation = BaseExecuteFlowOperation<ExecutionType.B
 
 export type ResumeExecuteFlowOperation = BaseExecuteFlowOperation<ExecutionType.RESUME> & {
     resumePayload: JobPayload
+    resumeReason: ResumeReason
 }
 
 export type ExecuteFlowOperation = BeginExecuteFlowOperation | ResumeExecuteFlowOperation
+
+export enum ResumeReason {
+    // A waitpoint produced a resume signal: HTTP callback (Slack click, subflow Return Response),
+    // delay timer firing, scheduled job, or `markParentRunAsFailed` completing a parent waitpoint.
+    WAITPOINT = 'WAITPOINT',
+    // User-triggered retry of a terminated run via `FlowRetryStrategy.FROM_FAILED_STEP`.
+    // Carries no payload; the engine must re-execute the originally-failed step.
+    RETRY = 'RETRY',
+}
 
 
 export type ExecuteTriggerOperation<HT extends TriggerHookType> = BaseEngineOperation & {

--- a/packages/shared/src/lib/automation/engine/engine-operation.ts
+++ b/packages/shared/src/lib/automation/engine/engine-operation.ts
@@ -116,11 +116,7 @@ export type ResumeExecuteFlowOperation = BaseExecuteFlowOperation<ExecutionType.
 export type ExecuteFlowOperation = BeginExecuteFlowOperation | ResumeExecuteFlowOperation
 
 export enum ResumeReason {
-    // A waitpoint produced a resume signal: HTTP callback (Slack click, subflow Return Response),
-    // delay timer firing, scheduled job, or `markParentRunAsFailed` completing a parent waitpoint.
     WAITPOINT = 'WAITPOINT',
-    // User-triggered retry of a terminated run via `FlowRetryStrategy.FROM_FAILED_STEP`.
-    // Carries no payload; the engine must re-execute the originally-failed step.
     RETRY = 'RETRY',
 }
 

--- a/packages/shared/src/lib/automation/workers/job-data.ts
+++ b/packages/shared/src/lib/automation/workers/job-data.ts
@@ -9,7 +9,7 @@ import { FlowVersion } from '../flows/flow-version'
 import { FlowTriggerType } from '../flows/triggers/trigger'
 import { PiecePackage } from '../pieces/piece'
 
-export const LATEST_JOB_DATA_SCHEMA_VERSION = 9
+export const LATEST_JOB_DATA_SCHEMA_VERSION = 10
 
 export const InlineJobPayload = z.object({
     type: z.literal('inline'),
@@ -124,8 +124,6 @@ export const ExecuteFlowJobData = z.object({
     payload: JobPayload,
     executeTrigger: z.boolean().optional(),
     executionType: z.nativeEnum(ExecutionType),
-    // Only meaningful when executionType === RESUME. Optional for backward compat with
-    // jobs queued before this field existed; the worker defaults missing values to WAITPOINT.
     resumeReason: z.nativeEnum(ResumeReason).optional(),
     streamStepProgress: z.nativeEnum(StreamStepProgress),
     stepNameToTest: z.string().optional(),

--- a/packages/shared/src/lib/automation/workers/job-data.ts
+++ b/packages/shared/src/lib/automation/workers/job-data.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod'
 import { isNil } from '../../core/common'
 import { ApplicationEvent } from '../../ee/audit-events'
-import { StreamStepProgress, TriggerHookType, TriggerPayload } from '../engine'
+import { ResumeReason, StreamStepProgress, TriggerHookType, TriggerPayload } from '../engine'
 import { ExecutionType } from '../flow-run/execution/execution-output'
 import { RunEnvironment } from '../flow-run/flow-run'
 import { FlowVersion } from '../flows/flow-version'
@@ -124,6 +124,9 @@ export const ExecuteFlowJobData = z.object({
     payload: JobPayload,
     executeTrigger: z.boolean().optional(),
     executionType: z.nativeEnum(ExecutionType),
+    // Only meaningful when executionType === RESUME. Optional for backward compat with
+    // jobs queued before this field existed; the worker defaults missing values to WAITPOINT.
+    resumeReason: z.nativeEnum(ResumeReason).optional(),
     streamStepProgress: z.nativeEnum(StreamStepProgress),
     stepNameToTest: z.string().optional(),
     sampleData: z.record(z.string(), z.unknown()).optional(),

--- a/packages/shared/src/lib/automation/workers/job-data.ts
+++ b/packages/shared/src/lib/automation/workers/job-data.ts
@@ -110,7 +110,7 @@ export const PollingJobData = z.object({
 })
 export type PollingJobData = z.infer<typeof PollingJobData>
 
-export const ExecuteFlowJobData = z.object({
+const ExecuteFlowJobDataCommon = z.object({
     projectId: z.string(),
     platformId: z.string(),
     jobType: z.literal(WorkerJobType.EXECUTE_FLOW),
@@ -122,15 +122,26 @@ export const ExecuteFlowJobData = z.object({
     workerHandlerId: z.union([z.string(), z.null()]).optional(),
     httpRequestId: z.string().optional(),
     payload: JobPayload,
-    executeTrigger: z.boolean().optional(),
-    executionType: z.nativeEnum(ExecutionType),
-    resumeReason: z.nativeEnum(ResumeReason).optional(),
     streamStepProgress: z.nativeEnum(StreamStepProgress),
     stepNameToTest: z.string().optional(),
     sampleData: z.record(z.string(), z.unknown()).optional(),
     logsFileId: z.string(),
     traceContext: z.record(z.string(), z.string()).optional(),
 })
+
+export const BeginExecuteFlowJobData = ExecuteFlowJobDataCommon.extend({
+    executionType: z.literal(ExecutionType.BEGIN),
+    executeTrigger: z.boolean().optional(),
+})
+export type BeginExecuteFlowJobData = z.infer<typeof BeginExecuteFlowJobData>
+
+export const ResumeExecuteFlowJobData = ExecuteFlowJobDataCommon.extend({
+    executionType: z.literal(ExecutionType.RESUME),
+    resumeReason: z.nativeEnum(ResumeReason),
+})
+export type ResumeExecuteFlowJobData = z.infer<typeof ResumeExecuteFlowJobData>
+
+export const ExecuteFlowJobData = z.discriminatedUnion('executionType', [BeginExecuteFlowJobData, ResumeExecuteFlowJobData])
 export type ExecuteFlowJobData = z.infer<typeof ExecuteFlowJobData>
 
 export const WebhookJobData = z.object({


### PR DESCRIPTION
## Summary

Fixes a payload pollution bug where a Call Flow step with **Wait for Response + Continue on Failure** caused subsequent waitpoint steps to surface the wrong output — typically the failing subflow's error message in place of the actual payload.

Customer report: master flow with 4 subflows under a router, subflow 1's failure message overrode subflow 2 / 3 / 4's `Return Response` outputs.

## Root cause

`getFlowExecutionState` rebuilt `flowContext` from the persisted step journal but only restored `SUCCEEDED` / `PAUSED` steps — a `FAILED` step kept alive by `continueOnFailure` was silently dropped. The actual pollution lands **one resume cycle after** the drop, through a transient "two paused steps at once" journal state:

1. **Resume #1** (subflow 1 fails): journal goes `{ Call Flow 1: FAILED, Call Flow 2: PAUSED }`.
2. **Resume #2** (subflow 2's `Return Response`): the FAILED Call Flow 1 is dropped → engine re-walks → Call Flow 1 not in journal → executes as `BEGIN` → `call-flow.ts` BEGIN branch creates a fresh waitpoint `W_1_new` and re-invokes subflow 1. Master pauses *on Call Flow 1 again*. Call Flow 2 never executes this cycle. Journal saved as `{ Call Flow 1: PAUSED W_1_new, Call Flow 2: PAUSED W_2 }` — **two coexisting paused steps**, a state a healthy sequential run never produces.
3. **Resume #3** (subflow 1's new invocation responds with `P_1_new`): `constants.resumePayload = P_1_new` set globally. Engine walks: Call Flow 1 → RESUME, reads global, output = `P_1_new.data` (correct). Call Flow 2 → also RESUME (still PAUSED in journal), reads the **same global**, output = `P_1_new.data` (**pollution**). Same for any other paused siblings.

The drop doesn't pollute directly. It triggers a BEGIN re-execution that creates a duplicate waitpoint, which gives the *next* resume a journal with multiple PAUSED steps all reading one global payload.

## Fix

Preserve `FAILED` steps on waitpoint resumes; keep dropping them on retry resumes (`FlowRetryStrategy.FROM_FAILED_STEP` depends on re-execution). Both paths share `ExecutionType.RESUME`, so a discriminator is needed.

Five commits:

1. **`fe8b5d6139`** — preserve FAILED, initial fix using `!isNil(resumePayload)` as discriminator.
2. **`8a748e348d`** — explicit `ResumeReason` enum (`WAITPOINT` | `RETRY`). The payload-presence heuristic misclassified the Delay piece's scheduled resume, which legitimately passes `resumePayload: null`. Plumbed through `ExecuteFlowJobData`, `addToQueue`, `enqueueResume`, retry path, worker → engine.
3. **`b95568fbc2`** — bumps `LATEST_JOB_DATA_SCHEMA_VERSION` 9 → 10 (first pass at legacy-job handling, superseded by commit 5).
4. **`4cb29f4120`** — updates `.agents/features/flow-runs.md` with the `ResumeReason` domain term and FAILED-preservation invariant.
5. **`d7d72a3cc9`** — proper migration + discriminated union (details below). **`f28c872070`** is a follow-up fixing `unify-old-queues-to-one.ts` whose `Pick<ExecuteFlowJobData, ...>` broke after the union split.

## Why a real `JobMigration` instead of a worker-side fallback

Commit 3 put the v9 → v10 transition in the worker (`data.resumeReason ?? legacyResumeReason(data)`). It worked but encoded migration intent in a fallback expression and the legacy branch would live in the worker forever.

The codebase already has a proper job-data migration system (`job-data-migrations.ts`, invoked at every dequeue in `job-broker.ts:111`, writes back via `job.updateData()`). Commit 5 uses it correctly:

- **`addResumeReason`** (`runAtSchemaVersion: 9`): applies the inline-null → RETRY / anything-else → WAITPOINT heuristic for legacy v9 jobs and rewrites them to v10 in Redis. After v9 jobs drain (seconds–minutes), the heuristic branch becomes unreachable.
- **`bridgeV8ToV9`** (`runAtSchemaVersion: 8`): structural no-op closing a pre-existing gap from PR #13219 (commit `b6af396bca`), which bumped the version constant but never added a migration entry — so the chain was ending at v8. There was an abandoned fix on `fix/canary-skip-system-jobs` (commit `c99a49cd6f`) that this mirrors.

The info that distinguishes waitpoint from retry isn't in the queued job data — it's owned by the call site. Legacy jobs still need a heuristic, but it now lives in the right layer.

## Why a discriminated union on `ExecuteFlowJobData`

After the migration, every v10 RESUME job has `resumeReason` set — but the type system didn't know that. Commit 5 splits the schema:

```ts
const BeginExecuteFlowJobData = ExecuteFlowJobDataCommon.extend({
    executionType: z.literal(ExecutionType.BEGIN),
    executeTrigger: z.boolean().optional(),
})
const ResumeExecuteFlowJobData = ExecuteFlowJobDataCommon.extend({
    executionType: z.literal(ExecutionType.RESUME),
    resumeReason: z.nativeEnum(ResumeReason),  // required
})
export const ExecuteFlowJobData = z.discriminatedUnion('executionType', [BeginExecuteFlowJobData, ResumeExecuteFlowJobData])
```

The worker becomes `resumeReason: data.resumeReason` with no fallback — narrowing on `executionType` gives the required field. Any new enqueue path that forgets `resumeReason` fails at compile time. Zod also rejects a malformed v10 RESUME job at `job-broker.ts:118`. The bug we tracked down was "invariant assumed but not enforced" — the union pushes this specific invariant into the layer that can enforce it.

## Test plan

- [x] Engine unit: 308/308 (4 new regression tests in `flow-operation-invariants.test.ts`).
- [x] Migration unit: 14/14 (5 new tests in `job-data-migrations.test.ts`).
- [x] Lint: 0 errors across 20 packages.
- [x] Build: passes after `f28c872070`.
- [ ] Manual: 4 Call Flows in router, branch 1's subflow fails — all 4 outputs distinct, Call Flow 1 stays FAILED with its real error.
- [ ] Manual: retry-from-failed-step on a terminated FAILED run still replays the failed step.
- [ ] Manual: `Call Flow A (continueOnFailure, fails) → Delay 5s` — Call Flow A stays FAILED across the delay resume, no subflow re-invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)