### PR TITLE
feat: add Wayfront piece

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7274,6 +7274,16 @@
         "tslib": "^2.3.0",
       },
     },
+    "packages/pieces/community/wayfront": {
+      "name": "@activepieces/piece-wayfront",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/wealthbox": {
       "name": "@activepieces/piece-wealthbox",
       "version": "0.1.3",
@@ -9804,6 +9814,8 @@
     "@activepieces/piece-wafeq": ["@activepieces/piece-wafeq@workspace:packages/pieces/community/wafeq"],
 
     "@activepieces/piece-waitwhile": ["@activepieces/piece-waitwhile@workspace:packages/pieces/community/waitwhile"],
+
+    "@activepieces/piece-wayfront": ["@activepieces/piece-wayfront@workspace:packages/pieces/community/wayfront"],
 
     "@activepieces/piece-wealthbox": ["@activepieces/piece-wealthbox@workspace:packages/pieces/community/wealthbox"],
 

--- a/packages/pieces/community/wayfront/.eslintrc.json
+++ b/packages/pieces/community/wayfront/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/wayfront/package.json
+++ b/packages/pieces/community/wayfront/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-wayfront",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/wayfront/src/index.ts
+++ b/packages/pieces/community/wayfront/src/index.ts
@@ -1,0 +1,36 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { wayfrontAuth } from './lib/auth';
+import { createClientAction } from './lib/actions/create-client';
+import { updateClientAction } from './lib/actions/update-client';
+import { createActivityAction } from './lib/actions/create-activity';
+import { updateActivityAction } from './lib/actions/update-activity';
+import { completeActivityAction } from './lib/actions/complete-activity';
+import { createTicketAction } from './lib/actions/create-ticket';
+import { listTicketsAction } from './lib/actions/list-tickets';
+import { updateTicketAction } from './lib/actions/update-ticket';
+import { listOrdersAction } from './lib/actions/list-orders';
+import { createOrderAction } from './lib/actions/create-order';
+import { updateOrderAction } from './lib/actions/update-order';
+
+export const wayfront = createPiece({
+  displayName: 'Wayfront',
+  description: 'Unify your process, automate steps, and help clients find what they need.',
+  auth: wayfrontAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/wayfront.png',
+  authors: ['onyedikachi-david'],
+  actions: [
+    createClientAction,
+    updateClientAction,
+    createActivityAction,
+    updateActivityAction,
+    completeActivityAction,
+    createTicketAction,
+    listTicketsAction,
+    updateTicketAction,
+    listOrdersAction,
+    createOrderAction,
+    updateOrderAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/complete-activity.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/complete-activity.ts
@@ -1,0 +1,31 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { wayfrontAuth } from '../auth';
+import {
+  activitiesDropdown,
+  clientsDropdown,
+  flattenActivity,
+  wayfrontApiClient,
+  WayfrontActivity,
+  WayfrontAuthType,
+} from '../common';
+
+export const completeActivityAction = createAction({
+  auth: wayfrontAuth,
+  name: 'complete_activity',
+  displayName: 'Complete Activity',
+  description: 'Marks a scheduled activity as complete for a client in Wayfront.',
+  props: {
+    user_id: clientsDropdown,
+    activity_id: activitiesDropdown,
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).post<WayfrontActivity>(
+      `/clients/${p.user_id}/activities/${p.activity_id}/complete`,
+    );
+
+    return flattenActivity(response.body);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/create-activity.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/create-activity.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { wayfrontAuth } from '../auth';
+import {
+  clientsDropdown,
+  flattenActivity,
+  teamMembersDropdown,
+  wayfrontApiClient,
+  WayfrontActivity,
+  WayfrontAuthType,
+} from '../common';
+
+export const createActivityAction = createAction({
+  auth: wayfrontAuth,
+  name: 'create_activity',
+  displayName: 'Create Activity',
+  description: 'Creates a new activity log entry for a client in Wayfront.',
+  props: {
+    user_id: clientsDropdown,
+    content: Property.LongText({
+      displayName: 'Content',
+      description: 'The activity note or description (max 10,000 characters).',
+      required: true,
+    }),
+    scheduled_at: Property.ShortText({
+      displayName: 'Scheduled At',
+      description:
+        'Schedule this activity for a future date and time. Format: 2026-04-15T14:00:00Z (ISO 8601). Leave empty to log it immediately.',
+      required: false,
+    }),
+    assigned_to: teamMembersDropdown,
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const body: Record<string, unknown> = { content: p.content };
+    if (p.scheduled_at) body['scheduled_at'] = p.scheduled_at;
+    if (p.assigned_to) body['assigned_to'] = p.assigned_to;
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).post<WayfrontActivity>(
+      `/clients/${p.user_id}/activities`,
+      body,
+    );
+
+    return flattenActivity(response.body);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/create-client.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/create-client.ts
@@ -1,0 +1,143 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { isNil } from '@activepieces/shared';
+import { wayfrontAuth } from '../auth';
+import { flattenUser, wayfrontApiClient, WayfrontAuthType, WayfrontUser } from '../common';
+
+export const createClientAction = createAction({
+  auth: wayfrontAuth,
+  name: 'create_client',
+  displayName: 'Create Client',
+  description: 'Creates a new client in your Wayfront workspace.',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'The email address of the client.',
+      required: false,
+    }),
+    name_f: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+    }),
+    name_l: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      required: false,
+    }),
+    note: Property.LongText({
+      displayName: 'Note',
+      required: false,
+    }),
+    status_id: Property.Number({
+      displayName: 'Status ID',
+      description: 'Numeric ID of the client status. Find status IDs in your Wayfront workspace settings.',
+      required: false,
+    }),
+    referrer_user_id: Property.Number({
+      displayName: 'Referrer Team Member ID',
+      description: 'ID of the team member who referred this client.',
+      required: false,
+    }),
+    tax_id: Property.ShortText({
+      displayName: 'Tax ID',
+      required: false,
+    }),
+    balance: Property.Number({
+      displayName: 'Balance',
+      description: 'Starting account balance for the client.',
+      required: false,
+    }),
+    optin: Property.ShortText({
+      displayName: 'Opt-in',
+      description: 'Opt-in status for the client, e.g. "Yes" or "No".',
+      required: false,
+    }),
+    stripe_id: Property.ShortText({
+      displayName: 'Stripe Customer ID',
+      description: 'The Stripe customer ID to link to this client.',
+      required: false,
+    }),
+    created_at: Property.ShortText({
+      displayName: 'Created Date',
+      description:
+        'Override the creation date. Format: 2021-09-01T00:00:00+00:00. Leave empty to use the current date.',
+      required: false,
+    }),
+    address_line_1: Property.ShortText({
+      displayName: 'Address Line 1',
+      required: false,
+    }),
+    address_city: Property.ShortText({
+      displayName: 'City',
+      required: false,
+    }),
+    address_state: Property.ShortText({
+      displayName: 'State / Province',
+      required: false,
+    }),
+    address_postcode: Property.ShortText({
+      displayName: 'Postcode / ZIP',
+      required: false,
+    }),
+    address_country: Property.ShortText({
+      displayName: 'Country',
+      description: 'Two-letter country code, e.g. US or GB.',
+      required: false,
+    }),
+    custom_fields: Property.Object({
+      displayName: 'Custom Fields',
+      description: 'Additional custom fields as key-value pairs.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const hasAddress =
+      !isNil(p.address_line_1) ||
+      !isNil(p.address_city) ||
+      !isNil(p.address_state) ||
+      !isNil(p.address_postcode) ||
+      !isNil(p.address_country);
+
+    const body = {
+      ...(!isNil(p.email) && { email: p.email }),
+      ...(!isNil(p.name_f) && { name_f: p.name_f }),
+      ...(!isNil(p.name_l) && { name_l: p.name_l }),
+      ...(!isNil(p.company) && { company: p.company }),
+      ...(!isNil(p.phone) && { phone: p.phone }),
+      ...(!isNil(p.note) && { note: p.note }),
+      ...(!isNil(p.status_id) && { status_id: p.status_id }),
+      ...(!isNil(p.referrer_user_id) && { referrer_user_id: p.referrer_user_id }),
+      ...(!isNil(p.tax_id) && { tax_id: p.tax_id }),
+      ...(!isNil(p.balance) && { balance: p.balance }),
+      ...(!isNil(p.optin) && { optin: p.optin }),
+      ...(!isNil(p.stripe_id) && { stripe_id: p.stripe_id }),
+      ...(!isNil(p.created_at) && { created_at: p.created_at }),
+      ...(!isNil(p.custom_fields) && { custom_fields: p.custom_fields }),
+      ...(hasAddress && {
+        address: {
+          ...(!isNil(p.address_line_1) && { line_1: p.address_line_1 }),
+          ...(!isNil(p.address_city) && { city: p.address_city }),
+          ...(!isNil(p.address_state) && { state: p.address_state }),
+          ...(!isNil(p.address_postcode) && { postcode: p.address_postcode }),
+          ...(!isNil(p.address_country) && { country: p.address_country }),
+        },
+      }),
+    };
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).post<WayfrontUser>(
+      '/clients',
+      body,
+    );
+
+    return flattenUser(response.body);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/create-order.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/create-order.ts
@@ -1,0 +1,131 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { isNil } from '@activepieces/shared';
+import { wayfrontAuth } from '../auth';
+import {
+  clientsDropdown,
+  flattenOrder,
+  wayfrontApiClient,
+  WayfrontAuthType,
+  WayfrontIndexOrder,
+} from '../common';
+
+export const createOrderAction = createAction({
+  auth: wayfrontAuth,
+  name: 'create_order',
+  displayName: 'Create Order',
+  description: 'Creates a new order for a client in Wayfront.',
+  props: {
+    user_id: clientsDropdown,
+    service: Property.ShortText({
+      displayName: 'Service / Order Title',
+      description:
+        'The name of the service or title for this order (e.g. "Instagram Followers"). Required if no Service ID is provided.',
+      required: false,
+    }),
+    service_id: Property.Number({
+      displayName: 'Service ID',
+      description:
+        'ID of an existing service in Wayfront to attach to this order. Required if no Service / Order Title is provided.',
+      required: false,
+    }),
+    note: Property.LongText({
+      displayName: 'Note',
+      description: 'An internal note to attach to the order.',
+      required: false,
+    }),
+    status: Property.Number({
+      displayName: 'Status ID',
+      description: 'Numeric ID of the order status. Find status IDs in your Wayfront workspace settings.',
+      required: false,
+    }),
+    number: Property.ShortText({
+      displayName: 'Order Number',
+      description: 'Custom order reference number (e.g. B1C2D3E4F5). Leave empty to auto-generate.',
+      required: false,
+    }),
+    date_due: Property.ShortText({
+      displayName: 'Due Date',
+      description: 'Due date for the order. Format: 2021-09-01T00:00:00+00:00 (ISO 8601).',
+      required: false,
+    }),
+    date_started: Property.ShortText({
+      displayName: 'Start Date',
+      description: 'Date the order was started. Format: 2021-09-01T00:00:00+00:00 (ISO 8601).',
+      required: false,
+    }),
+    date_completed: Property.ShortText({
+      displayName: 'Completion Date',
+      description: 'Date the order was completed. Format: 2021-09-01T00:00:00+00:00 (ISO 8601).',
+      required: false,
+    }),
+    created_at: Property.ShortText({
+      displayName: 'Created Date',
+      description: 'Override the creation date. Format: 2021-09-01T00:00:00+00:00. Leave empty to use now.',
+      required: false,
+    }),
+    employees: Property.ShortText({
+      displayName: 'Assigned Employee IDs',
+      description: 'Comma-separated IDs of employees to assign to this order (e.g. 1,2,3).',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma-separated list of tags to apply to the order (e.g. vip,rush).',
+      required: false,
+    }),
+    linked_orders: Property.ShortText({
+      displayName: 'Linked Order Numbers',
+      description: 'Comma-separated order numbers to link to this order (e.g. B1C2D3,E4F5G6).',
+      required: false,
+    }),
+    metadata: Property.ShortText({
+      displayName: 'Metadata',
+      description: 'Comma-separated metadata values to attach to the order.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const employeeIds = p.employees
+      ? p.employees.split(',').map((s) => parseInt(s.trim(), 10)).filter((n) => !isNaN(n))
+      : undefined;
+
+    const tags = p.tags
+      ? p.tags.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const linkedOrders = p.linked_orders
+      ? p.linked_orders.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const metadata = p.metadata
+      ? p.metadata.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const body = {
+      user_id: p.user_id,
+      ...(!isNil(p.service) && { service: p.service }),
+      ...(!isNil(p.service_id) && { service_id: p.service_id }),
+      ...(!isNil(p.note) && { note: p.note }),
+      ...(!isNil(p.status) && { status: p.status }),
+      ...(!isNil(p.number) && { number: p.number }),
+      ...(!isNil(p.date_due) && { date_due: p.date_due }),
+      ...(!isNil(p.date_started) && { date_started: p.date_started }),
+      ...(!isNil(p.date_completed) && { date_completed: p.date_completed }),
+      ...(!isNil(p.created_at) && { created_at: p.created_at }),
+      ...(employeeIds !== undefined && { 'employees[]': employeeIds }),
+      ...(tags !== undefined && { 'tags[]': tags }),
+      ...(linkedOrders !== undefined && { 'linked_orders[]': linkedOrders }),
+      ...(metadata !== undefined && { 'metadata[]': metadata }),
+    };
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).post<WayfrontIndexOrder>(
+      '/orders',
+      body,
+    );
+
+    return flattenOrder(response.body);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/create-ticket.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/create-ticket.ts
@@ -1,0 +1,92 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { isNil } from '@activepieces/shared';
+import { wayfrontAuth } from '../auth';
+import {
+  clientsDropdown,
+  flattenTicket,
+  wayfrontApiClient,
+  WayfrontAuthType,
+  WayfrontTicket,
+} from '../common';
+
+export const createTicketAction = createAction({
+  auth: wayfrontAuth,
+  name: 'create_ticket',
+  displayName: 'Create Ticket',
+  description: 'Creates a new support ticket for a client in Wayfront.',
+  props: {
+    user_id: clientsDropdown,
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'The subject line of the ticket.',
+      required: true,
+    }),
+    note: Property.LongText({
+      displayName: 'Note',
+      description: 'An internal note to attach to the ticket.',
+      required: false,
+    }),
+    status: Property.Number({
+      displayName: 'Status ID',
+      description: 'Numeric ID of the ticket status. Find status IDs in your Wayfront workspace settings.',
+      required: false,
+    }),
+    employees: Property.ShortText({
+      displayName: 'Assigned Employee IDs',
+      description: 'Comma-separated IDs of employees to assign to this ticket (e.g. 1,2,3).',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma-separated list of tags to apply to the ticket (e.g. billing,urgent).',
+      required: false,
+    }),
+    order: Property.ShortText({
+      displayName: 'Order Reference',
+      description: 'The order number or reference to link to this ticket.',
+      required: false,
+    }),
+    metadata: Property.ShortText({
+      displayName: 'Metadata',
+      description: 'Comma-separated metadata values to attach to the ticket.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const employeeIds = p.employees
+      ? p.employees
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => !isNaN(n))
+      : undefined;
+
+    const tags = p.tags
+      ? p.tags.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const metadata = p.metadata
+      ? p.metadata.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const body = {
+      user_id: p.user_id,
+      subject: p.subject,
+      ...(!isNil(p.note) && { note: p.note }),
+      ...(!isNil(p.status) && { status: p.status }),
+      ...(employeeIds !== undefined && { 'employees[]': employeeIds }),
+      ...(tags !== undefined && { 'tags[]': tags }),
+      ...(!isNil(p.order) && { order: p.order }),
+      ...(metadata !== undefined && { 'metadata[]': metadata }),
+    };
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).post<WayfrontTicket>(
+      '/tickets',
+      body,
+    );
+
+    return flattenTicket(response.body);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/list-orders.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/list-orders.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { wayfrontAuth } from '../auth';
+import {
+  flattenOrder,
+  wayfrontApiClient,
+  WayfrontAuthType,
+  WayfrontIndexOrder,
+  WayfrontListResponse,
+} from '../common';
+
+export const listOrdersAction = createAction({
+  auth: wayfrontAuth,
+  name: 'list_orders',
+  displayName: 'List Orders',
+  description: 'Returns a list of orders from your Wayfront workspace, sorted by most recent first.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of orders to return per page. Defaults to 20.',
+      required: false,
+      defaultValue: 20,
+    }),
+    page: Property.Number({
+      displayName: 'Page',
+      description: 'Page number to retrieve when results span multiple pages. Starts at 1.',
+      required: false,
+      defaultValue: 1,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).get<
+      WayfrontListResponse<WayfrontIndexOrder>
+    >('/orders', {
+      limit: String(p.limit ?? 20),
+      page: String(p.page ?? 1),
+    });
+
+    return response.body.data.map(flattenOrder);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/list-tickets.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/list-tickets.ts
@@ -1,0 +1,45 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { wayfrontAuth } from '../auth';
+import {
+  flattenTicket,
+  wayfrontApiClient,
+  WayfrontAuthType,
+  WayfrontListResponse,
+  WayfrontTicket,
+} from '../common';
+
+export const listTicketsAction = createAction({
+  auth: wayfrontAuth,
+  name: 'list_tickets',
+  displayName: 'List Tickets',
+  description: 'Returns a list of tickets from your Wayfront workspace, sorted by most recent first.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of tickets to return per page. Defaults to 20.',
+      required: false,
+      defaultValue: 20,
+    }),
+    page: Property.Number({
+      displayName: 'Page',
+      description: 'Page number to retrieve when results span multiple pages. Starts at 1.',
+      required: false,
+      defaultValue: 1,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const queryParams: Record<string, string> = {
+      limit: String(p.limit ?? 20),
+      page: String(p.page ?? 1),
+    };
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).get<
+      WayfrontListResponse<WayfrontTicket>
+    >('/tickets', queryParams);
+
+    return response.body.data.map(flattenTicket);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/update-activity.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/update-activity.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { wayfrontAuth } from '../auth';
+import {
+  activitiesDropdown,
+  clientsDropdown,
+  flattenActivity,
+  teamMembersDropdown,
+  wayfrontApiClient,
+  WayfrontActivity,
+  WayfrontAuthType,
+} from '../common';
+
+export const updateActivityAction = createAction({
+  auth: wayfrontAuth,
+  name: 'update_activity',
+  displayName: 'Update Activity',
+  description: 'Updates an existing activity for a client in Wayfront.',
+  props: {
+    user_id: clientsDropdown,
+    activity_id: activitiesDropdown,
+    content: Property.LongText({
+      displayName: 'Content',
+      description: 'The updated activity note or description (max 10,000 characters).',
+      required: true,
+    }),
+    scheduled_at: Property.ShortText({
+      displayName: 'Scheduled At',
+      description:
+        'Reschedule the activity. Format: 2026-05-01T14:00:00Z (ISO 8601). Only applies to already-scheduled activities.',
+      required: false,
+    }),
+    assigned_to: teamMembersDropdown,
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const body: Record<string, unknown> = { content: p.content };
+    if (p.scheduled_at) body['scheduled_at'] = p.scheduled_at;
+    if (p.assigned_to) body['assigned_to'] = p.assigned_to;
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).put<WayfrontActivity>(
+      `/clients/${p.user_id}/activities/${p.activity_id}`,
+      body,
+    );
+
+    return flattenActivity(response.body);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/update-client.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/update-client.ts
@@ -1,0 +1,161 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { isNil } from '@activepieces/shared';
+import { wayfrontAuth } from '../auth';
+import {
+  clientsDropdown,
+  flattenUser,
+  wayfrontApiClient,
+  WayfrontAuthType,
+  WayfrontUser,
+} from '../common';
+
+export const updateClientAction = createAction({
+  auth: wayfrontAuth,
+  name: 'update_client',
+  displayName: 'Update Client',
+  description: 'Updates a client in your Wayfront workspace. Only provided fields are changed.',
+  props: {
+    user_id: clientsDropdown,
+    email: Property.ShortText({
+      displayName: 'Email',
+      required: false,
+    }),
+    name_f: Property.ShortText({
+      displayName: 'First Name',
+      required: false,
+    }),
+    name_l: Property.ShortText({
+      displayName: 'Last Name',
+      required: false,
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      required: false,
+    }),
+    note: Property.LongText({
+      displayName: 'Note',
+      required: false,
+    }),
+    status_id: Property.Number({
+      displayName: 'Status ID',
+      description: 'Numeric ID of the client status. Find status IDs in your Wayfront workspace settings.',
+      required: false,
+    }),
+    referrer_user_id: Property.Number({
+      displayName: 'Referrer Team Member ID',
+      description: 'ID of the team member who referred this client.',
+      required: false,
+    }),
+    employee_id: Property.ShortText({
+      displayName: 'Employee IDs',
+      description: 'Comma-separated IDs of employees to assign to this client (e.g. 1,2,3).',
+      required: false,
+    }),
+    tax_id: Property.ShortText({
+      displayName: 'Tax ID',
+      required: false,
+    }),
+    balance: Property.Number({
+      displayName: 'Balance',
+      description: 'Updated account balance for the client.',
+      required: false,
+    }),
+    optin: Property.ShortText({
+      displayName: 'Opt-in',
+      description: 'Opt-in status, e.g. "Yes" or "No".',
+      required: false,
+    }),
+    stripe_id: Property.ShortText({
+      displayName: 'Stripe Customer ID',
+      description: 'The Stripe customer ID linked to this client.',
+      required: false,
+    }),
+    created_at: Property.ShortText({
+      displayName: 'Created Date',
+      description: 'Override the creation date. Format: 2021-09-01T00:00:00+00:00.',
+      required: false,
+    }),
+    address_line_1: Property.ShortText({
+      displayName: 'Address Line 1',
+      required: false,
+    }),
+    address_city: Property.ShortText({
+      displayName: 'City',
+      required: false,
+    }),
+    address_state: Property.ShortText({
+      displayName: 'State / Province',
+      required: false,
+    }),
+    address_postcode: Property.ShortText({
+      displayName: 'Postcode / ZIP',
+      required: false,
+    }),
+    address_country: Property.ShortText({
+      displayName: 'Country',
+      description: 'Two-letter country code, e.g. US or GB.',
+      required: false,
+    }),
+    custom_fields: Property.Object({
+      displayName: 'Custom Fields',
+      description: 'Additional custom fields as key-value pairs.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const employeeIds = p.employee_id
+      ? p.employee_id
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => !isNaN(n))
+      : undefined;
+
+    const hasAddress =
+      !isNil(p.address_line_1) ||
+      !isNil(p.address_city) ||
+      !isNil(p.address_state) ||
+      !isNil(p.address_postcode) ||
+      !isNil(p.address_country);
+
+    const body = {
+      ...(!isNil(p.email) && { email: p.email }),
+      ...(!isNil(p.name_f) && { name_f: p.name_f }),
+      ...(!isNil(p.name_l) && { name_l: p.name_l }),
+      ...(!isNil(p.company) && { company: p.company }),
+      ...(!isNil(p.phone) && { phone: p.phone }),
+      ...(!isNil(p.note) && { note: p.note }),
+      ...(!isNil(p.status_id) && { status_id: p.status_id }),
+      ...(!isNil(p.referrer_user_id) && { referrer_user_id: p.referrer_user_id }),
+      ...(employeeIds !== undefined && { employee_id: employeeIds }),
+      ...(!isNil(p.tax_id) && { tax_id: p.tax_id }),
+      ...(!isNil(p.balance) && { balance: p.balance }),
+      ...(!isNil(p.optin) && { optin: p.optin }),
+      ...(!isNil(p.stripe_id) && { stripe_id: p.stripe_id }),
+      ...(!isNil(p.created_at) && { created_at: p.created_at }),
+      ...(!isNil(p.custom_fields) && { custom_fields: p.custom_fields }),
+      ...(hasAddress && {
+        address: {
+          ...(!isNil(p.address_line_1) && { line_1: p.address_line_1 }),
+          ...(!isNil(p.address_city) && { city: p.address_city }),
+          ...(!isNil(p.address_state) && { state: p.address_state }),
+          ...(!isNil(p.address_postcode) && { postcode: p.address_postcode }),
+          ...(!isNil(p.address_country) && { country: p.address_country }),
+        },
+      }),
+    };
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).put<WayfrontUser>(
+      `/clients/${p.user_id}`,
+      body,
+    );
+
+    return flattenUser(response.body);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/update-order.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/update-order.ts
@@ -1,0 +1,126 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { isNil } from '@activepieces/shared';
+import { wayfrontAuth } from '../auth';
+import {
+  flattenOrder,
+  ordersDropdown,
+  wayfrontApiClient,
+  WayfrontAuthType,
+  WayfrontIndexOrder,
+} from '../common';
+
+export const updateOrderAction = createAction({
+  auth: wayfrontAuth,
+  name: 'update_order',
+  displayName: 'Update Order',
+  description: 'Updates an order in Wayfront. Only the fields you provide will be changed.',
+  props: {
+    order_ref: ordersDropdown,
+    note: Property.LongText({
+      displayName: 'Note',
+      description: 'Updated internal note for the order.',
+      required: false,
+    }),
+    status: Property.Number({
+      displayName: 'Status ID',
+      description: 'Numeric ID of the order status. Find status IDs in your Wayfront workspace settings.',
+      required: false,
+    }),
+    service_id: Property.Number({
+      displayName: 'Service ID',
+      description: 'ID of the service to attach to this order.',
+      required: false,
+    }),
+    date_due: Property.ShortText({
+      displayName: 'Due Date',
+      description: 'Updated due date. Format: 2021-09-01T00:00:00+00:00 (ISO 8601).',
+      required: false,
+    }),
+    date_started: Property.ShortText({
+      displayName: 'Start Date',
+      description: 'Updated start date. Format: 2021-09-01T00:00:00+00:00 (ISO 8601).',
+      required: false,
+    }),
+    date_completed: Property.ShortText({
+      displayName: 'Completion Date',
+      description: 'Updated completion date. Format: 2021-09-01T00:00:00+00:00 (ISO 8601).',
+      required: false,
+    }),
+    created_at: Property.ShortText({
+      displayName: 'Created Date',
+      description: 'Override the creation date. Format: 2021-09-01T00:00:00+00:00 (ISO 8601).',
+      required: false,
+    }),
+    employees: Property.ShortText({
+      displayName: 'Assigned Employee IDs',
+      description: 'Comma-separated IDs of employees to assign to this order (e.g. 1,2,3).',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma-separated list of tags (e.g. vip,rush). Replaces all existing tags.',
+      required: false,
+    }),
+    linked_orders: Property.ShortText({
+      displayName: 'Linked Order Numbers',
+      description: 'Comma-separated order numbers to link (e.g. B1C2D3,E4F5G6). Replaces existing links.',
+      required: false,
+    }),
+    form_data: Property.ShortText({
+      displayName: 'Form Data',
+      description: 'Comma-separated form data values to attach to the order.',
+      required: false,
+    }),
+    metadata: Property.ShortText({
+      displayName: 'Metadata',
+      description: 'Comma-separated metadata values to attach to the order.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const employeeIds = p.employees
+      ? p.employees.split(',').map((s) => parseInt(s.trim(), 10)).filter((n) => !isNaN(n))
+      : undefined;
+
+    const tags = p.tags
+      ? p.tags.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const linkedOrders = p.linked_orders
+      ? p.linked_orders.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const formData = p.form_data
+      ? p.form_data.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const metadata = p.metadata
+      ? p.metadata.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const body = {
+      ...(!isNil(p.note) && { note: p.note }),
+      ...(!isNil(p.status) && { status: p.status }),
+      ...(!isNil(p.service_id) && { service_id: p.service_id }),
+      ...(!isNil(p.date_due) && { date_due: p.date_due }),
+      ...(!isNil(p.date_started) && { date_started: p.date_started }),
+      ...(!isNil(p.date_completed) && { date_completed: p.date_completed }),
+      ...(!isNil(p.created_at) && { created_at: p.created_at }),
+      ...(employeeIds !== undefined && { 'employees[]': employeeIds }),
+      ...(tags !== undefined && { 'tags[]': tags }),
+      ...(linkedOrders !== undefined && { 'linked_orders[]': linkedOrders }),
+      ...(formData !== undefined && { 'form_data[]': formData }),
+      ...(metadata !== undefined && { 'metadata[]': metadata }),
+    };
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).put<WayfrontIndexOrder>(
+      `/orders/${p.order_ref}`,
+      body,
+    );
+
+    return flattenOrder(response.body);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/actions/update-ticket.ts
+++ b/packages/pieces/community/wayfront/src/lib/actions/update-ticket.ts
@@ -1,0 +1,85 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { isNil } from '@activepieces/shared';
+import { wayfrontAuth } from '../auth';
+import {
+  flattenTicket,
+  ticketsDropdown,
+  wayfrontApiClient,
+  WayfrontAuthType,
+  WayfrontTicket,
+} from '../common';
+
+export const updateTicketAction = createAction({
+  auth: wayfrontAuth,
+  name: 'update_ticket',
+  displayName: 'Update Ticket',
+  description: 'Updates a ticket in Wayfront. Only the fields you provide will be changed.',
+  props: {
+    ticket_ref: ticketsDropdown,
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'Updated subject line for the ticket.',
+      required: false,
+    }),
+    status: Property.Number({
+      displayName: 'Status ID',
+      description: 'Numeric ID of the ticket status. Find status IDs in your Wayfront workspace settings.',
+      required: false,
+    }),
+    employees: Property.ShortText({
+      displayName: 'Assigned Employee IDs',
+      description: 'Comma-separated IDs of employees to assign to this ticket (e.g. 1,2,3).',
+      required: false,
+    }),
+    tags: Property.ShortText({
+      displayName: 'Tags',
+      description: 'Comma-separated list of tags (e.g. billing,urgent). Replaces all existing tags.',
+      required: false,
+    }),
+    order: Property.ShortText({
+      displayName: 'Order Reference',
+      description: 'The order number or reference to link to this ticket.',
+      required: false,
+    }),
+    metadata: Property.ShortText({
+      displayName: 'Metadata',
+      description: 'Comma-separated metadata values to attach to the ticket.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as unknown as WayfrontAuthType;
+    const p = context.propsValue;
+
+    const employeeIds = p.employees
+      ? p.employees
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => !isNaN(n))
+      : undefined;
+
+    const tags = p.tags
+      ? p.tags.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const metadata = p.metadata
+      ? p.metadata.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    const body = {
+      ...(!isNil(p.subject) && { subject: p.subject }),
+      ...(!isNil(p.status) && { status: p.status }),
+      ...(employeeIds !== undefined && { 'employees[]': employeeIds }),
+      ...(tags !== undefined && { 'tags[]': tags }),
+      ...(!isNil(p.order) && { order: p.order }),
+      ...(metadata !== undefined && { 'metadata[]': metadata }),
+    };
+
+    const response = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).put<WayfrontTicket>(
+      `/tickets/${p.ticket_ref}`,
+      body,
+    );
+
+    return flattenTicket(response.body);
+  },
+});

--- a/packages/pieces/community/wayfront/src/lib/auth.ts
+++ b/packages/pieces/community/wayfront/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import { wayfrontApiClient } from './common';
+
+export const wayfrontAuth = PieceAuth.CustomAuth({
+  description: 'Provide your Wayfront workspace URL and bearer token.',
+  props: {
+    workspaceUrl: Property.ShortText({
+      displayName: 'Workspace URL',
+      description: 'Your Wayfront workspace URL (e.g. example.wayfront.com)',
+      required: true,
+    }),
+    apiToken: PieceAuth.SecretText({
+      displayName: 'API Token',
+      description: 'Your Wayfront bearer token',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    const { success, error } = await wayfrontApiClient(auth.workspaceUrl, auth.apiToken).validateAuth();
+    return success ? { valid: true } : { valid: false, error: error ?? 'Authentication failed.' };
+  },
+  required: true,
+});
+

--- a/packages/pieces/community/wayfront/src/lib/common/index.ts
+++ b/packages/pieces/community/wayfront/src/lib/common/index.ts
@@ -1,0 +1,482 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { Property } from '@activepieces/pieces-framework';
+import { wayfrontAuth } from '../auth';
+
+function buildBaseUrl(workspaceUrl: string) {
+  const host = workspaceUrl.replace(/^https?:\/\//, '').replace(/\/$/, '');
+  return `https://${host}/api`;
+}
+
+async function makeRequest<T>({
+  workspaceUrl,
+  apiToken,
+  method,
+  path,
+  body,
+  queryParams,
+}: {
+  workspaceUrl: string;
+  apiToken: string;
+  method: HttpMethod;
+  path: string;
+  body?: unknown;
+  queryParams?: Record<string, string>;
+}) {
+  const baseUrl = buildBaseUrl(workspaceUrl);
+  return httpClient.sendRequest<T>({
+    method,
+    url: `${baseUrl}${path}`,
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: body as Record<string, unknown>,
+    queryParams,
+  });
+}
+
+async function validateAuth(
+  workspaceUrl: string,
+  apiToken: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await makeRequest<unknown>({
+      workspaceUrl,
+      apiToken,
+      method: HttpMethod.GET,
+      path: '/team',
+      queryParams: { limit: '1' },
+    });
+    return { success: true };
+  } catch {
+    return { success: false, error: 'Invalid workspace URL or API token.' };
+  }
+}
+
+export function wayfrontApiClient(workspaceUrl: string, apiToken: string) {
+  return {
+    get: <T>(path: string, queryParams?: Record<string, string>) =>
+      makeRequest<T>({ workspaceUrl, apiToken, method: HttpMethod.GET, path, queryParams }),
+    post: <T>(path: string, body?: unknown) =>
+      makeRequest<T>({ workspaceUrl, apiToken, method: HttpMethod.POST, path, body }),
+    put: <T>(path: string, body?: unknown) =>
+      makeRequest<T>({ workspaceUrl, apiToken, method: HttpMethod.PUT, path, body }),
+    delete: <T>(path: string) =>
+      makeRequest<T>({ workspaceUrl, apiToken, method: HttpMethod.DELETE, path }),
+    validateAuth: () => validateAuth(workspaceUrl, apiToken),
+  };
+}
+
+export const teamMembersDropdown = Property.Dropdown({
+  displayName: 'Assigned To',
+  description: 'Select a team member to assign this activity to.',
+  refreshers: [],
+  auth: wayfrontAuth,
+  required: false,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return { disabled: true, options: [], placeholder: 'Please connect your account first.' };
+    }
+    const { workspaceUrl, apiToken } = auth as unknown as WayfrontAuthType;
+    try {
+      const response = await wayfrontApiClient(workspaceUrl, apiToken).get<
+        WayfrontListResponse<WayfrontUser>
+      >('/team', { limit: '100' });
+      return {
+        disabled: false,
+        options: response.body.data.map((member) => ({
+          label: member.name ? `${member.name} (${member.email})` : member.email,
+          value: member.id,
+        })),
+      };
+    } catch {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load team members. Check your connection.',
+      };
+    }
+  },
+});
+
+export const clientsDropdown = Property.Dropdown({
+  displayName: 'Client',
+  description: 'Select a client from your Wayfront workspace.',
+  refreshers: [],
+  auth: wayfrontAuth,
+  required: true,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return { disabled: true, options: [], placeholder: 'Please connect your account first.' };
+    }
+    const { workspaceUrl, apiToken } = auth as unknown as WayfrontAuthType;
+    try {
+      const response = await wayfrontApiClient(workspaceUrl, apiToken).get<
+        WayfrontListResponse<WayfrontUser>
+      >('/clients', { limit: '100' });
+      return {
+        disabled: false,
+        options: response.body.data.map((client) => ({
+          label: client.name ? `${client.name} (${client.email})` : client.email,
+          value: client.id,
+        })),
+      };
+    } catch {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load clients. Check your connection.',
+      };
+    }
+  },
+});
+
+export const activitiesDropdown = Property.Dropdown({
+  displayName: 'Activity',
+  description: 'Select an activity for the chosen client.',
+  refreshers: ['user_id'],
+  auth: wayfrontAuth,
+  required: true,
+  options: async ({ auth, user_id }) => {
+    if (!auth) {
+      return { disabled: true, options: [], placeholder: 'Please connect your account first.' };
+    }
+    if (!user_id) {
+      return { disabled: true, options: [], placeholder: 'Please select a client first.' };
+    }
+    const { workspaceUrl, apiToken } = auth as unknown as WayfrontAuthType;
+    try {
+      const response = await wayfrontApiClient(workspaceUrl, apiToken).get<
+        WayfrontListResponse<WayfrontActivity>
+      >(`/clients/${user_id}/activities`, { limit: '100' });
+      return {
+        disabled: false,
+        options: response.body.data.map((activity) => ({
+          label: `#${activity.id}: ${activity.content.length > 60 ? activity.content.slice(0, 60) + '…' : activity.content}`,
+          value: activity.id,
+        })),
+      };
+    } catch {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load activities. Check your connection.',
+      };
+    }
+  },
+});
+
+export const ticketsDropdown = Property.Dropdown({
+  displayName: 'Ticket',
+  description: 'Select a ticket from your Wayfront workspace.',
+  refreshers: [],
+  auth: wayfrontAuth,
+  required: true,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return { disabled: true, options: [], placeholder: 'Please connect your account first.' };
+    }
+    const { workspaceUrl, apiToken } = auth as unknown as WayfrontAuthType;
+    try {
+      const response = await wayfrontApiClient(workspaceUrl, apiToken).get<
+        WayfrontListResponse<WayfrontTicket>
+      >('/tickets', { limit: '100' });
+      return {
+        disabled: false,
+        options: response.body.data.map((ticket) => ({
+          label: `#${ticket.number ?? ticket.id}: ${ticket.subject}`,
+          value: ticket.number ?? String(ticket.id),
+        })),
+      };
+    } catch {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load tickets. Check your connection.',
+      };
+    }
+  },
+});
+
+export function flattenUser(user: WayfrontUser) {
+  return {
+    id: user.id,
+    name: user.name,
+    first_name: user.name_f,
+    last_name: user.name_l,
+    email: user.email,
+    company: user.company ?? null,
+    phone: user.phone ?? null,
+    tax_id: user.tax_id ?? null,
+    affiliate_link: user.aff_link ?? null,
+    note: user.note ?? null,
+    balance: user.balance ?? null,
+    optin: user.optin ?? null,
+    stripe_id: user.stripe_id ?? null,
+    status: user.status ?? null,
+    status_id: user.status_id ?? null,
+    role_id: user.role_id ?? null,
+    referrer_user_id: user.referrer_user_id ?? null,
+    employee_id: user.employee_id ?? null,
+    spent: user.spent ?? null,
+    address_line_1: user.address?.line_1 ?? null,
+    address_line_2: user.address?.line_2 ?? null,
+    address_city: user.address?.city ?? null,
+    address_state: user.address?.state ?? null,
+    address_postcode: user.address?.postcode ?? null,
+    address_country: user.address?.country ?? null,
+    team_member_ids: Array.isArray(user.team_member_ids)
+      ? user.team_member_ids.join(', ')
+      : null,
+    team_owner_ids: Array.isArray(user.team_owner_ids)
+      ? user.team_owner_ids.join(', ')
+      : null,
+    created_at: user.created_at,
+  };
+}
+
+export type WayfrontAuthType = {
+  workspaceUrl: string;
+  apiToken: string;
+};
+
+export type WayfrontAddress = {
+  line_1: string;
+  line_2: string;
+  city: string;
+  country: string;
+  state: string;
+  postcode: string;
+  name_f: string;
+  name_l: string;
+  tax_id: string;
+  company_name: string;
+  company_vat: string;
+};
+
+export type WayfrontUser = {
+  id: number;
+  referrer_user_id: number | null;
+  aff_link: string;
+  created_at: string;
+  name_f: string;
+  name_l: string;
+  email: string;
+  company: string;
+  tax_id: string;
+  phone: string;
+  address: WayfrontAddress;
+  note: string;
+  balance: number;
+  optin: string;
+  stripe_id: string;
+  custom_fields: Record<string, unknown>;
+  status: number;
+  status_id: number;
+  role_id: number;
+  name: string;
+  spent: string | null;
+  employee_id: number;
+  team_owner_ids: number[];
+  team_member_ids: number[];
+};
+
+export type WayfrontActivityParticipant = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+export type WayfrontActivity = {
+  id: number;
+  content: string;
+  scheduled_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+  author: WayfrontActivityParticipant | null;
+  assignee: WayfrontActivityParticipant | null;
+};
+
+export function flattenActivity(activity: WayfrontActivity) {
+  return {
+    id: activity.id,
+    content: activity.content,
+    scheduled_at: activity.scheduled_at ?? null,
+    completed_at: activity.completed_at ?? null,
+    created_at: activity.created_at,
+    updated_at: activity.updated_at,
+    author_id: activity.author?.id ?? null,
+    author_name: activity.author?.name ?? null,
+    author_email: activity.author?.email ?? null,
+    assignee_id: activity.assignee?.id ?? null,
+    assignee_name: activity.assignee?.name ?? null,
+    assignee_email: activity.assignee?.email ?? null,
+  };
+}
+
+export type WayfrontTicketEmployee = {
+  id: number;
+  name_f: string;
+  name_l: string;
+  group_id: number;
+  role_id: number;
+};
+
+export type WayfrontTicket = {
+  id: number;
+  number?: string;
+  created_at: string;
+  updated_at: string;
+  last_message_at: string;
+  date_closed: string;
+  subject: string;
+  user_id: number;
+  client?: WayfrontUser;
+  form_data: Record<string, unknown>;
+  tags: string[];
+  note: string;
+  employees: WayfrontTicketEmployee[];
+  status: string;
+  status_id: number;
+  source: string;
+  order_id: number;
+  metadata: Record<string, unknown>;
+};
+
+export function flattenTicket(ticket: WayfrontTicket) {
+  return {
+    id: ticket.id,
+    number: ticket.number ?? null,
+    subject: ticket.subject,
+    user_id: ticket.user_id,
+    client_name: ticket.client?.name ?? null,
+    client_email: ticket.client?.email ?? null,
+    status: ticket.status ?? null,
+    status_id: ticket.status_id ?? null,
+    source: ticket.source ?? null,
+    order_id: ticket.order_id ?? null,
+    note: ticket.note ?? null,
+    tags: Array.isArray(ticket.tags) ? ticket.tags.join(', ') : null,
+    employees: Array.isArray(ticket.employees)
+      ? ticket.employees
+          .map((e) => [e.name_f, e.name_l].filter(Boolean).join(' ') || String(e.id))
+          .join(', ')
+      : null,
+    last_message_at: ticket.last_message_at ?? null,
+    date_closed: ticket.date_closed ?? null,
+    created_at: ticket.created_at,
+    updated_at: ticket.updated_at,
+  };
+}
+
+export type WayfrontIndexOrder = {
+  id: number;
+  number?: string;
+  created_at: string;
+  updated_at: string;
+  last_message_at: string;
+  date_started: string;
+  date_completed: string;
+  date_due: string;
+  client?: WayfrontUser;
+  tags: string[];
+  status: string;
+  status_id: number;
+  price: number;
+  quantity: number;
+  invoice_id: number;
+  service: string;
+  service_id: number;
+  user_id: number;
+  employees: WayfrontTicketEmployee[];
+  note: string;
+  form_data: Record<string, unknown>;
+  paysys: string;
+  currency?: string;
+  metadata?: Record<string, unknown>;
+  linked_orders?: string[];
+};
+
+export function flattenOrder(order: WayfrontIndexOrder) {
+  return {
+    id: order.id,
+    number: order.number ?? null,
+    service: order.service ?? null,
+    service_id: order.service_id ?? null,
+    user_id: order.user_id,
+    client_name: order.client?.name ?? null,
+    client_email: order.client?.email ?? null,
+    status: order.status ?? null,
+    status_id: order.status_id ?? null,
+    price: order.price ?? null,
+    quantity: order.quantity ?? null,
+    invoice_id: order.invoice_id ?? null,
+    note: order.note ?? null,
+    paysys: order.paysys ?? null,
+    currency: order.currency ?? null,
+    tags: Array.isArray(order.tags) ? order.tags.join(', ') : null,
+    employees: Array.isArray(order.employees)
+      ? order.employees
+          .map((e) => [e.name_f, e.name_l].filter(Boolean).join(' ') || String(e.id))
+          .join(', ')
+      : null,
+    linked_orders: Array.isArray(order.linked_orders) ? order.linked_orders.join(', ') : null,
+    date_started: order.date_started ?? null,
+    date_completed: order.date_completed ?? null,
+    date_due: order.date_due ?? null,
+    last_message_at: order.last_message_at ?? null,
+    created_at: order.created_at,
+    updated_at: order.updated_at,
+  };
+}
+
+export const ordersDropdown = Property.Dropdown({
+  displayName: 'Order',
+  description: 'Select an order from your Wayfront workspace.',
+  refreshers: [],
+  auth: wayfrontAuth,
+  required: true,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return { disabled: true, options: [], placeholder: 'Please connect your account first.' };
+    }
+    const { workspaceUrl, apiToken } = auth as unknown as WayfrontAuthType;
+    try {
+      const response = await wayfrontApiClient(workspaceUrl, apiToken).get<
+        WayfrontListResponse<WayfrontIndexOrder>
+      >('/orders', { limit: '100' });
+      return {
+        disabled: false,
+        options: response.body.data.map((order) => ({
+          label: `#${order.number ?? order.id}: ${order.service}`,
+          value: order.number ?? String(order.id),
+        })),
+      };
+    } catch {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load orders. Check your connection.',
+      };
+    }
+  },
+});
+
+export type WayfrontListResponse<T> = {
+  data: T[];
+  links: {
+    first: string;
+    last: string;
+    prev: string | null;
+    next: string | null;
+  };
+  meta: {
+    current_page: number;
+    from: number;
+    last_page: number;
+    per_page: number;
+    to: number;
+    total: number;
+  };
+};

--- a/packages/pieces/community/wayfront/tsconfig.json
+++ b/packages/pieces/community/wayfront/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/wayfront/tsconfig.lib.json
+++ b/packages/pieces/community/wayfront/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
Adds a new community piece for Wayfront — a client management and service delivery platform.

Actions included:
- Create Client / Update Client
- Create Activity / Update Activity / Complete Activity
- Create Ticket / List Tickets / Update Ticket
- Create Order / List Orders / Update Order

Auth: CustomAuth with workspace URL + bearer token, validated against GET /team.

Common utilities (wayfrontApiClient, shared types, flatten helpers, and reusable dropdowns for clients, team members, activities, tickets, and orders) live in src/lib/common/.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
