### PR TITLE
ci(sbom): scope Grype to Critical CVEs and stop SARIF upload

### DIFF
--- a/.github/actions/sbom/action.yml
+++ b/.github/actions/sbom/action.yml
@@ -40,7 +40,7 @@ runs:
         sbom: activepieces-${{ inputs.version }}.cdx.json
         output-format: sarif
         fail-build: false
-        severity-cutoff: high
+        severity-cutoff: critical
 
     - name: Upload SARIF to GitHub Security tab
       if: inputs.upload-sarif == 'true'

--- a/.github/workflows/continuous-delivery-canary.yml
+++ b/.github/workflows/continuous-delivery-canary.yml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      security-events: write
     concurrency:
       group: canary-deploy
       cancel-in-progress: true
@@ -52,7 +51,6 @@ jobs:
         with:
           image: ghcr.io/activepieces/activepieces-cloud:${{ steps.set-tag.outputs.image_tag }}
           version: ${{ steps.set-tag.outputs.image_tag }}
-          upload-sarif: 'true'
 
   check-migrations:
     needs: build-image


### PR DESCRIPTION
## Summary
- Bump Grype `severity-cutoff` from `high` to `critical` in the shared SBOM composite action.
- Drop `upload-sarif: 'true'` from the canary workflow.

SBOMs (CycloneDX + SPDX) and the filtered Grype SARIF are still attached to each run as workflow artifacts for ad-hoc inspection. Re-enabling SARIF upload later is a one-line change per workflow.

## Test plan
- [ ] Trigger the canary workflow and confirm the SBOM step succeeds.
- [ ] Confirm no new Grype alerts appear in the Security tab after the run.
- [ ] Download the workflow artifact and verify the SARIF only contains Critical findings.
