### PR TITLE
fix: restore insert button on step roots and fix broken e2e tests

### DIFF
--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -1645,6 +1645,7 @@
   "Reviewing runs": "Reviewing runs",
   "Found setup instructions.": "Found setup instructions.",
   "Getting setup guide": "Getting setup guide",
+  "Get started with {brandName}": "Get started with {brandName}",
   "Added flow documentation.": "Added flow documentation.",
   "Adding notes": "Adding notes",
   "Resolved configuration options.": "Resolved configuration options.",

--- a/packages/web/src/app/builder/data-selector/data-selector-node-content.tsx
+++ b/packages/web/src/app/builder/data-selector/data-selector-node-content.tsx
@@ -60,7 +60,7 @@ const DataSelectorNodeContent = ({
     !isExpandable && node.data.type === 'value' && !isStepRoot;
   const isInsertable =
     node.data.type === 'value' && node.data.insertable && !node.isLoopStepNode;
-  const showInsertButton = isInsertable && (!isStepRoot || isPrimitiveStepRoot);
+  const showInsertButton = isInsertable;
 
   const arrayValue =
     node.data.type === 'value' && Array.isArray(node.data.value)


### PR DESCRIPTION
…translation

- data picker: show Insert button on step header rows (and step-root arrays) again so users can insert the whole step `{{step_1}}`, not only nested fields. Loop roots and chunk separators stay excluded.
- automations empty state: add the missing `Get started with {brandName}` key to en/translation.json so the heading renders the brand name instead of the literal placeholder; fixes the e2e selector that waits for "Get started with Activepieces".

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
