### PR TITLE
chore: bump github action versions off node 20 across all workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,7 +67,7 @@ jobs:
           echo "Flow ID: $FLOW_ID"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.22'
           cache: false
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-results-${{ matrix.label }}
           path: |
@@ -128,7 +128,7 @@ jobs:
     if: always()
     steps:
       - name: Download all benchmark artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: benchmark-results-*
           path: /tmp/results

--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo RELEASE=$(node --print "require('./package.json').version") >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -27,7 +27,7 @@ jobs:
       - run: bun install
 
       - name: Turbo Cache
-        uses: rharkor/caching-for-turbo@v2.2.1
+        uses: rharkor/caching-for-turbo@v2.4.2
         with:
           provider: s3
           s3-bucket: ${{ secrets.TURBO_CACHE_S3_BUCKET }}

--- a/.github/workflows/continuous-delivery-canary.yml
+++ b/.github/workflows/continuous-delivery-canary.yml
@@ -27,7 +27,7 @@ jobs:
           RELEASE=$(node --print "require('./package.json').version")
           echo "image_tag=${RELEASE}.${{ github.sha }}.canary" >> $GITHUB_OUTPUT
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/continuous-delivery-cloud.yml
+++ b/.github/workflows/continuous-delivery-cloud.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           RELEASE=$(node --print "require('./package.json').version")
           echo "image_tag=${RELEASE}.${{ github.sha }}.beta" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/continuous-delivery-release.yml
+++ b/.github/workflows/continuous-delivery-release.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
           ref: release-candidate
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -40,13 +40,13 @@ jobs:
           echo "release=$RELEASE" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/continuous-delivery-rollback-canary.yml
+++ b/.github/workflows/continuous-delivery-rollback-canary.yml
@@ -50,7 +50,7 @@ jobs:
           echo "image_tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/continuous-delivery-rollback.yml
+++ b/.github/workflows/continuous-delivery-rollback.yml
@@ -34,7 +34,7 @@ jobs:
           SSH_HOST: ${{ secrets.DEV_OPS_HOST }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/continuous-delivery-stg.yml
+++ b/.github/workflows/continuous-delivery-stg.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           RELEASE=$(node --print "require('./package.json').version")
           echo "image_tag=${RELEASE}.${{ github.sha }}.beta" >> $GITHUB_OUTPUT
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -171,7 +171,7 @@ jobs:
           echo "Staging tag: $CURRENT (SHA: $SHA)"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/crowdin-pr-merger.yml
+++ b/.github/workflows/crowdin-pr-merger.yml
@@ -20,14 +20,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ hashFiles('bun.lock', 'package.json') }}
           restore-keys: bun-
 
       - name: Setup nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -40,7 +40,7 @@ jobs:
         run: bun install
       
       - name: Add label to PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.addLabels({
@@ -95,7 +95,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update PR branch from base
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.CROWDIN_PRS }}
           script: |
@@ -115,7 +115,7 @@ jobs:
             }
 
       - name: Wait until PR is mergeable
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.CROWDIN_PRS }}
           script: |
@@ -143,7 +143,7 @@ jobs:
             core.setFailed('PR did not become up-to-date in time');
 
       - name: Merge PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.CROWDIN_PRS }}
           script: |
@@ -155,7 +155,7 @@ jobs:
             });
 
       - name: Delete branch after merge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: success()
         with:
           github-token: ${{ secrets.CROWDIN_PRS }}

--- a/.github/workflows/e2e-tests-checkly.yml
+++ b/.github/workflows/e2e-tests-checkly.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Check if PR exists with ready-for-e2e label for this SHA
         id: check-if-pr-has-label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Always run on manual workflow dispatch
@@ -77,14 +77,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./artifacts
           pattern: "*"
           merge-multiple: false
 
       - name: Re-upload consolidated artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: e2e-test-artifacts-all
@@ -93,7 +93,7 @@ jobs:
 
       - name: Comment on PR with test results
         if: always() && github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Determine which tests failed

--- a/.github/workflows/emergency-cloud-deploy.yml
+++ b/.github/workflows/emergency-cloud-deploy.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo RELEASE=$(node --print "require('./package.json').version") >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/release-pieces.yml
+++ b/.github/workflows/release-pieces.yml
@@ -24,14 +24,14 @@ jobs:
           fetch-depth: 0
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ hashFiles('bun.lock', 'package.json') }}
           restore-keys: bun-
 
       - name: Setup nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/release-self-hosted.yml
+++ b/.github/workflows/release-self-hosted.yml
@@ -18,13 +18,13 @@ jobs:
         run: '! docker manifest inspect activepieces/activepieces:${{ inputs.tag }}'
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/reusable-finalize-translations-pr.yml
+++ b/.github/workflows/reusable-finalize-translations-pr.yml
@@ -18,14 +18,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ hashFiles('bun.lock', 'package.json') }}
           restore-keys: bun-
 
       - name: Setup nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.ahead.outputs.changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.CROWDIN_PRS }}
           script: |

--- a/.github/workflows/reusable-generate-translations-shard.yml
+++ b/.github/workflows/reusable-generate-translations-shard.yml
@@ -26,14 +26,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ hashFiles('bun.lock', 'package.json') }}
           restore-keys: bun-
 
       - name: Setup nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/setup-environment.yml
+++ b/.github/workflows/setup-environment.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Check if PR has preview label
         id: check-label
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const isManualTrigger = context.eventName === 'workflow_dispatch';
@@ -67,7 +67,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.check-label.outputs.should-setup == 'true' && github.event_name != 'workflow_dispatch'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/tag-release-candidate.yml
+++ b/.github/workflows/tag-release-candidate.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Promoting: $IMAGE_TAG (SHA: $SHA)"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/tests-e2e-ce.yml
+++ b/.github/workflows/tests-e2e-ce.yml
@@ -64,14 +64,14 @@ jobs:
           fetch-depth: 2
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ hashFiles('bun.lock', 'package.json') }}
           restore-keys: bun-
 
       - name: Setup nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -93,7 +93,7 @@ jobs:
           CI: true
           
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report-ce
@@ -101,7 +101,7 @@ jobs:
           retention-days: 10
           
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-results-ce

--- a/.github/workflows/tests-e2e-ee.yml
+++ b/.github/workflows/tests-e2e-ee.yml
@@ -64,14 +64,14 @@ jobs:
           fetch-depth: 2
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ hashFiles('bun.lock', 'package.json') }}
           restore-keys: bun-
 
       - name: Setup nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -93,7 +93,7 @@ jobs:
           CI: true
           
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report-ee
@@ -101,7 +101,7 @@ jobs:
           retention-days: 30
           
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-results-ee

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -15,6 +15,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-publishable-packages.yml
+++ b/.github/workflows/validate-publishable-packages.yml
@@ -18,14 +18,14 @@ jobs:
           fetch-depth: 0
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ hashFiles('bun.lock', 'package.json') }}
           restore-keys: bun-
 
       - name: Setup nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 


### PR DESCRIPTION
Audits every uses: tag in .github/workflows and bumps any action that still runs on Node 16 or 20 to its latest Node 24-compatible major. Several actions kept Node 20 across multiple recent majors (upload-artifact through v5, download-artifact through v6, setup-go v6.0/v6.1, amannn/action-semantic-pull-request v5) so the bumps target the first major that ships Node 24:

- actions/cache v4 -> v5
- actions/setup-node v4 -> v6
- actions/upload-artifact v4 -> v6
- actions/download-artifact v4 -> v7
- actions/github-script v6/v7 -> v8 (avoids v9's @actions/github ESM-only break)
- actions/setup-go v5 -> v6
- docker/login-action v2/v3 -> v4
- amannn/action-semantic-pull-request v5.2.0 -> v6.1.1
- rharkor/caching-for-turbo v2.2.1 -> v2.4.2

Avoids GitHub's forced switch to Node 24 on 2026-06-02 and the runner removal of Node 20 on 2026-09-16.
