### PR TITLE
fix: health check uses >= for minimum CPU/RAM/disk thresholds

### DIFF
--- a/docs/install/configuration/hardware.mdx
+++ b/docs/install/configuration/hardware.mdx
@@ -14,8 +14,8 @@ Activepieces is designed to be memory-intensive rather than CPU-intensive. A mod
 | ---------- | ------------ | --------- | ---------- | ---------------------------------- |
 | PostgreSQL | 1 GB         | 1         | —          |                                    |
 | Redis      | 1 GB         | 1         | —          |                                    |
-| App        | 2 GB         | 1         | 30 GB      | API server, UI, webhook routing    |
-| Worker     | 1 GB         | 0.5       | —          | Per replica; add replicas to scale |
+| App        | 4 GB         | 1         | 30 GB      | API server, UI, webhook routing    |
+| Worker     | 4 GB         | 1         | —          | Per replica; add replicas to scale |
 
 <Tip>
 The above recommendations are designed to meet the needs of the majority of use cases.

--- a/packages/server/api/src/app/health/health.service.ts
+++ b/packages/server/api/src/app/health/health.service.ts
@@ -39,14 +39,14 @@ export const healthStatusService = (log: FastifyBaseLogger) => ({
     },
     getSystemHealthChecks: async (platformId: string): Promise<GetSystemHealthChecksResponse> => {
         const workers = await machineService(log).list(platformId)
-        const allWorkersPassedHealthcheck = workers.every(worker => worker.information.totalCpuCores > 1)
-        const allWorkersHaveEnoughRam = workers.every(worker => worker.information.totalAvailableRamInBytes > gigaBytes(4))
+        const allWorkersPassedHealthcheck = workers.every(worker => worker.information.totalCpuCores >= 1)
+        const allWorkersHaveEnoughRam = workers.every(worker => worker.information.totalAvailableRamInBytes >= gigaBytes(4))
         const databaseHealthy = await healthStatusService(log).checkDatabaseHealth()
-        
+
         return {
             cpu: await systemUsage.getCpuCores() >= 1 && allWorkersPassedHealthcheck,
-            disk: (await systemUsage.getDiskInfo()).total > gigaBytes(30),
-            ram: (await systemUsage.getContainerMemoryUsage()).totalRamInBytes > gigaBytes(4) && allWorkersHaveEnoughRam,
+            disk: (await systemUsage.getDiskInfo()).total >= gigaBytes(30),
+            ram: (await systemUsage.getContainerMemoryUsage()).totalRamInBytes >= gigaBytes(4) && allWorkersHaveEnoughRam,
             database: databaseHealthy,
         }
     },


### PR DESCRIPTION
## What does this PR do?

The system health checks in `packages/server/api/src/app/health/health.service.ts` compared RAM, CPU, and disk with strict `>`. Containers and workers allocated **exactly** the documented minimums (4 GiB RAM = `gigaBytes(4)`, 1 CPU core, 30 GB disk) failed the check even though they meet the minimum.

Switched the comparisons to `>=`:

- Per-worker CPU cores: `> 1` → `>= 1`
- Per-worker RAM: `> gigaBytes(4)` → `>= gigaBytes(4)`
- Container RAM: `> gigaBytes(4)` → `>= gigaBytes(4)`
- Disk: `> gigaBytes(30)` → `>= gigaBytes(30)`

`4096 MiB = 4 * 1024 * 1024 * 1024` is exactly `gigaBytes(4)`, so with `>` the RAM check was always false for a container limited to 4 GiB. Similarly a worker provisioned with exactly 1 vCPU failed `> 1`.

### Explain How the Feature Works

`getSystemHealthChecks` reports CPU/RAM/disk/database readiness for a platform. Allocating exactly the minimum (e.g. `mem_limit: 4g` in Docker Compose, or a 1-vCPU container) now reports healthy, matching the documented requirements.

### Relevant User Scenarios

- Self-hosted users provisioning containers at the documented minimums seeing the health endpoint report unhealthy.
- The hardware docs at https://www.activepieces.com/docs/install/configuration/hardware#technical-specifications listed App at 2 GB and Worker at 1 GB / 0.5 CPU, which would always fail the in-code check. Updated the table to match the thresholds the health check actually enforces (4 GB / 1 CPU for both App and Worker).

Fixes # (issue)