### PR TITLE
fix: propagate flowId and flowRunId to agent tool calls (#12993)

### DIFF
--- a/packages/server/engine/src/lib/handler/context/engine-constants.ts
+++ b/packages/server/engine/src/lib/handler/context/engine-constants.ts
@@ -140,13 +140,13 @@ export class EngineConstants {
         })
     }
 
-    public static fromExecuteActionInput(input: ExecuteToolOperation): EngineConstants {
+    public static fromExecuteActionInput(input: ExecuteToolOperation, overrides?: { flowId?: string, flowRunId?: string }): EngineConstants {
         return new EngineConstants({
-            flowId: DEFAULT_MCP_DATA.flowId,
+            flowId: overrides?.flowId ?? DEFAULT_MCP_DATA.flowId,
             flowVersionId: DEFAULT_MCP_DATA.flowVersionId,
             flowVersionState: DEFAULT_MCP_DATA.flowVersionState,
             triggerPieceName: DEFAULT_MCP_DATA.triggerPieceName,
-            flowRunId: DEFAULT_MCP_DATA.flowRunId,
+            flowRunId: overrides?.flowRunId ?? DEFAULT_MCP_DATA.flowRunId,
             publicApiUrl: input.publicApiUrl,
             internalApiUrl: addTrailingSlashIfMissing(input.internalApiUrl),
             retryConstants: DEFAULT_RETRY_CONSTANTS,

--- a/packages/server/engine/src/lib/tools/index.ts
+++ b/packages/server/engine/src/lib/tools/index.ts
@@ -173,7 +173,10 @@ async function execute(operation: ExecuteToolOperationWithModel): Promise<Execut
         const output = await flowExecutor.getExecutorForAction(step.type).handle({
             action: step,
             executionState: FlowExecutorContext.empty(),
-            constants: EngineConstants.fromExecuteActionInput(operation),
+            constants: EngineConstants.fromExecuteActionInput(operation, {
+                flowId: operation.flowId,
+                flowRunId: operation.flowRunId,
+            }),
         })
         const { output: stepOutput, errorMessage, status } = output.steps[operation.actionName]
         

--- a/packages/shared/src/lib/automation/engine/engine-operation.ts
+++ b/packages/shared/src/lib/automation/engine/engine-operation.ts
@@ -73,6 +73,8 @@ export type ExecuteToolOperation = BaseEngineOperation & {
     pieceVersion: string
     predefinedInput?: PredefinedInputsStructure
     instruction: string
+    flowId?: string
+    flowRunId?: string
 }
 
 export type ExecutePropsOptions = BaseEngineOperation & {


### PR DESCRIPTION
This PR ensures that agent tool calls (piece actions) inherit the actual parent flow context (flowId and flowRunId) instead of using placeholders. This fix includes the necessary TypeScript type updates in the shared engine-operation definitions to ensure a clean build. Closes #12993.