### PR TITLE
fix(e2e): open test panel before clicking test-trigger-button

### DIFF
--- a/packages/tests-e2e/pages/builder.page.ts
+++ b/packages/tests-e2e/pages/builder.page.ts
@@ -31,6 +31,7 @@ export class BuilderPage extends BasePage {
   }
 
   async testTrigger() {
+    await this.page.getByRole('button', { name: 'Test Step Ctrl + G' }).click();
     await this.page.getByTestId('test-trigger-button').click();
     await this.page.waitForTimeout(5000);
   }


### PR DESCRIPTION
The testing-UX redesign made the test panel start closed by default, so testTrigger() needs to click the Test Step CTA before the test-trigger-button mounts.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
