### PR TITLE
fix(auth): prevent OAuth code leak to cross-origin opener

### DIFF
--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -291,11 +291,12 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
             if (!code) {
                 return reply.type('text/plain').send('The code is missing in url')
             }
+            const frontendOrigin = new URL(system.getOrThrow(AppSystemProp.FRONTEND_URL)).origin
             return reply
                 .type('text/html')
                 .header('Content-Security-Policy', 'default-src \'none\'; script-src \'unsafe-inline\'')
                 .header('X-Content-Type-Options', 'nosniff')
-                .send(Mustache.render(REDIRECT_HTML_TEMPLATE, { code }))
+                .send(Mustache.render(REDIRECT_HTML_TEMPLATE, { code, frontendOrigin }))
         },
     )
 
@@ -524,7 +525,7 @@ Redirect successful, this window should close now.
     var el = document.getElementById('ap-oauth-code');
     var code = el ? el.getAttribute('content') : null;
     if (window.opener && code) {
-        window.opener.postMessage({ code: code }, '*');
+        window.opener.postMessage({ code: code }, '{{{frontendOrigin}}}');
     }
 })();
 </script>

--- a/packages/server/api/test/integration/ce/redirect/redirect.test.ts
+++ b/packages/server/api/test/integration/ce/redirect/redirect.test.ts
@@ -1,0 +1,68 @@
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { system } from '../../../../src/app/helper/system/system'
+import { AppSystemProp } from '../../../../src/app/helper/system/system-props'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('GET /api/redirect', () => {
+    it('should post the code only to the configured frontend origin', async () => {
+        const expectedOrigin = new URL(system.getOrThrow(AppSystemProp.FRONTEND_URL)).origin
+
+        const response = await app?.inject({
+            method: 'GET',
+            url: '/api/redirect',
+            query: { code: 'oauth_code_123' },
+        })
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        expect(response?.headers['content-type']).toContain('text/html')
+
+        const body = response?.body ?? ''
+        expect(body).toContain(`window.opener.postMessage({ code: code }, '${expectedOrigin}')`)
+    })
+
+    it('should not HTML-escape the slashes in the target origin', async () => {
+        const response = await app?.inject({
+            method: 'GET',
+            url: '/api/redirect',
+            query: { code: 'oauth_code_123' },
+        })
+
+        const body = response?.body ?? ''
+        expect(body).not.toContain('&#x2F;')
+        expect(body).not.toContain('postMessage({ code: code }, \'*\'')
+    })
+
+    it('should HTML-escape the code inside the meta attribute', async () => {
+        const response = await app?.inject({
+            method: 'GET',
+            url: '/api/redirect',
+            query: { code: 'abc"><script>alert(1)</script>' },
+        })
+
+        const body = response?.body ?? ''
+        expect(body).not.toContain('abc"><script>alert(1)')
+        expect(body).toContain('&quot;')
+    })
+
+    it('should return a plain-text error when the code is missing', async () => {
+        const response = await app?.inject({
+            method: 'GET',
+            url: '/api/redirect',
+        })
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        expect(response?.headers['content-type']).toContain('text/plain')
+        expect(response?.body).toBe('The code is missing in url')
+    })
+})

--- a/packages/web/src/app/routes/redirect.tsx
+++ b/packages/web/src/app/routes/redirect.tsx
@@ -71,7 +71,7 @@ const RedirectPage: React.FC = React.memo(() => {
         {
           code: code,
         },
-        '*',
+        window.location.origin,
       );
     }
     if (!window.opener && !code) {


### PR DESCRIPTION
## Summary
Hardens the OAuth sign-in flow so the temporary login code can no longer be picked up by an unrelated site.

## Test plan
- [ ] Sign in with a third-party provider.
- [ ] Create a new OAuth connection (any piece).
- [ ] Reconnect an existing OAuth connection.