### PR TITLE
fix(webhook): handle undefined auth fields without crashing engine

### DIFF
--- a/packages/pieces/core/webhook/package.json
+++ b/packages/pieces/core/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-webhook",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/webhook/src/lib/triggers/catch-hook.ts
+++ b/packages/pieces/core/webhook/src/lib/triggers/catch-hook.ts
@@ -239,18 +239,24 @@ function verifyAuth(
 
 function verifyHeaderAuth(
   headers: Record<string, string>,
-  headerName: string,
-  headerSecret: string
+  headerName: string | undefined,
+  headerSecret: string | undefined
 ) {
+  if (!headerName || !headerSecret) {
+    return false;
+  }
   const headerValue = headers[headerName.toLocaleLowerCase()];
   return headerValue === headerSecret;
 }
 
 function verifyBasicAuth(
-  headerValue: string,
-  username: string,
-  password: string
+  headerValue: string | undefined,
+  username: string | undefined,
+  password: string | undefined
 ) {
+  if (!headerValue || !username || !password) {
+    return false;
+  }
   if (!headerValue.toLocaleLowerCase().startsWith('basic ')) {
     return false;
   }
@@ -263,12 +269,15 @@ function verifyBasicAuth(
 export function verifyHmacAuth(
   headers: Record<string, string>,
   rawBody: unknown,
-  headerName: string,
-  secret: string,
+  headerName: string | undefined,
+  secret: string | undefined,
   algorithm: string,
   encoding: 'hex' | 'base64',
   signaturePrefix: string
 ): boolean {
+  if (!headerName || !secret) {
+    return false;
+  }
   // Get signature from header
   const headerValue = headers[headerName.toLowerCase()];
   if (!headerValue) {


### PR DESCRIPTION
## Summary

- `verifyHeaderAuth`, `verifyBasicAuth`, and `verifyHmacAuth` in the Catch Webhook trigger assumed their required fields were always defined and called `.toLocaleLowerCase()` / `.toLowerCase()` on them directly.
- When any required field was missing (e.g. Header auth with no `headerName` configured, or Basic auth on a request without an `Authorization` header), the call crashed the engine subprocess (`uncaughtException` → `exit 3`), surfacing as a flow run with `INTERNAL_ERROR` and noise in worker logs.
- Treat missing required fields as a failed verification (`return false`) so the trigger rejects the request cleanly instead of crashing.

## How it manifested in prod

Crawler traffic (ThinkBot) hitting a sync webhook (`/sync`) of a flow with auth configured but a missing field. Stack trace pointed at `job-broker.ts:235:40`, but that was the engine bundle's minified/source-mapped misattribution — the real crash was in `verifyHeaderAuth` / `verifyBasicAuth` inside the engine subprocess.

## Test plan

- [ ] Configure Catch Webhook with Header auth (set `headerName` then clear it in the JSON) or Basic auth, hit the `/sync` URL with no `Authorization` header.
- [ ] Confirm the request is rejected cleanly (trigger returns `[]`, no `INTERNAL_ERROR`, no engine crash in worker logs).
- [ ] Confirm a correctly-authenticated request still fires the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)