### PR TITLE
feat: add chat analytics telemetry push to console

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -19,6 +19,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - `packages/server/api/src/app/ee/chat/mcp/chat-mcp.ts` — connects to Activepieces MCP server for project-scoped tools with approval wrapping
 - `packages/server/api/src/app/ee/chat/history/chat-history.ts` — reconstructs chat history from AI SDK `ModelMessage` format
 - `packages/server/api/src/app/ee/chat/prompt/chat-prompt.ts` — builds system prompt from markdown templates in `src/assets/prompts/`
+- `packages/server/api/src/app/ee/chat/chat-sync-job.ts` — fire-and-forget telemetry sync to console.activepieces.com (cloud-only); also exposes `chatAnalyticsBulkSync` for admin bulk sync
 - `packages/shared/src/lib/ee/chat/index.ts` — shared Zod schemas, types (ChatConversation, request DTOs, ChatHistoryMessage), and typed tool outputs (`ChatToolOutputs`)
 - `packages/web/src/app/routes/chat-with-ai/index.tsx` — main chat page component
 - `packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx` — chat interface with provider check, message streaming, Zustand store provider
@@ -89,7 +90,9 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - `POST /v1/chat/conversations/:id/messages` — send message (streaming response)
 - `POST /v1/chat/tool-approvals/:gateId` — approve or deny a tool execution
 
-All endpoints require `PrincipalType.USER` authentication at the platform level.
+- `POST /v1/admin/chat/sync-all` — bulk historical sync of all conversations to console analytics (admin API key required)
+
+All chat endpoints require `PrincipalType.USER` authentication at the platform level. The admin sync endpoint uses `api-key` header auth.
 
 ## Message Flow
 1. User sends message via `POST /conversations/:id/messages`
@@ -99,3 +102,4 @@ All endpoints require `PrincipalType.USER` authentication at the platform level.
 5. Destructive MCP tool calls pause and emit an approval request to the UI via the stream
 6. User approves/denies via `POST /tool-approvals/:gateId`, unblocking the gate via Redis pub/sub
 7. On stream completion, assistant messages are appended to the stored conversation
+8. On cloud, `chatAnalyticsTelemetry` pushes the updated conversation to `console.activepieces.com` for monitoring (fire-and-forget, skipped when `CONSOLE_API_SECRET_KEY` is unset)

--- a/packages/server/api/src/app/ee/chat/chat-service.ts
+++ b/packages/server/api/src/app/ee/chat/chat-service.ts
@@ -42,6 +42,7 @@ import { ChatConversationEntity } from './chat-conversation-entity'
 import { buildUserContentWithFiles } from './chat-file-utils'
 import { createChatModel } from './chat-model-factory'
 import { chatPrepareStep } from './chat-prepare-step'
+import { chatAnalyticsTelemetry } from './chat-sync-job'
 import { chatHistory } from './history/chat-history'
 import { chatMcp, PlanExecution } from './mcp/chat-mcp'
 import { chatPrompt } from './prompt/chat-prompt'
@@ -272,6 +273,17 @@ export const chatService = (log: FastifyBaseLogger) => ({
                             ...spreadIfDefined('cacheWriteTokens', usage.inputTokenDetails.cacheWriteTokens),
                             provider: providerConfig.provider,
                         }, 'Chat message completed')
+
+                        chatAnalyticsTelemetry(log).sendConversationUpdate({
+                            conversation: {
+                                ...conversation,
+                                messages: updatedMessages,
+                                uiMessages: updatedUiMessages,
+                                updated: new Date().toISOString(),
+                                ...(pendingTitle ? { title: pendingTitle } : {}),
+                                ...(isNil(conversation.modelName) ? { modelName: tier.id } : {}),
+                            },
+                        })
                     },
                     onError: ({ error }) => {
                         log.error({ err: error, conversationId }, 'Chat streamText error')

--- a/packages/server/api/src/app/ee/chat/chat-sync-job.ts
+++ b/packages/server/api/src/app/ee/chat/chat-sync-job.ts
@@ -1,0 +1,168 @@
+import { ACTIVEPIECES_CHAT_TIERS, ApEdition, ChatConversation, chunk, PersistedChatMessage, PersistedChatPartType, PersistedToolCallStatus, tryCatch } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { isNotOneOfTheseEditions } from '../../database/database-common'
+import { rejectedPromiseHandler } from '../../helper/promise-handler'
+import { system } from '../../helper/system/system'
+import { AppSystemProp } from '../../helper/system/system-props'
+import { platformService } from '../../platform/platform.service'
+import { userService } from '../../user/user-service'
+
+const CONSOLE_TELEMETRY_URL = 'https://console.activepieces.com/api/chat-analytics/external/sync'
+const CONSOLE_API_KEY = system.get(AppSystemProp.CONSOLE_API_SECRET_KEY)
+const BATCH_SIZE = 50
+
+export const chatAnalyticsTelemetry = (log: FastifyBaseLogger) => ({
+    sendConversationUpdate({ conversation }: {
+        conversation: ChatConversation
+    }): void {
+        if (isNotOneOfTheseEditions([ApEdition.CLOUD])) {
+            return
+        }
+
+        rejectedPromiseHandler(pushToConsole({ conversations: [conversation], log }), log)
+    },
+})
+
+export const chatAnalyticsBulkSync = (log: FastifyBaseLogger) => ({
+    async syncAll({ conversations }: {
+        conversations: ChatConversation[]
+    }): Promise<{ synced: number, failed: number }> {
+        const userCache = new Map<string, string | null>()
+        const platformCache = new Map<string, string | null>()
+
+        await preResolveLookups({ conversations, userCache, platformCache, log })
+
+        let synced = 0
+        let failed = 0
+
+        for (const batch of chunk(conversations, BATCH_SIZE)) {
+            const success = await pushToConsole({ conversations: batch, log, userCache, platformCache })
+            if (success) {
+                synced += batch.length
+            }
+            else {
+                failed += batch.length
+            }
+        }
+
+        return { synced, failed }
+    },
+})
+
+async function preResolveLookups({ conversations, userCache, platformCache, log }: {
+    conversations: ChatConversation[]
+    userCache: Map<string, string | null>
+    platformCache: Map<string, string | null>
+    log: FastifyBaseLogger
+}): Promise<void> {
+    const uniqueUserIds = [...new Set(conversations.map((c) => c.userId))]
+    const uniquePlatformIds = [...new Set(conversations.map((c) => c.platformId))]
+
+    await Promise.all([
+        ...uniqueUserIds.map(async (userId) => {
+            userCache.set(userId, await resolveUserEmail({ userId, log }))
+        }),
+        ...uniquePlatformIds.map(async (platformId) => {
+            platformCache.set(platformId, await resolvePlatformName({ platformId, log }))
+        }),
+    ])
+}
+
+async function pushToConsole({ conversations, log, userCache, platformCache }: {
+    conversations: ChatConversation[]
+    log: FastifyBaseLogger
+    userCache?: Map<string, string | null>
+    platformCache?: Map<string, string | null>
+}): Promise<boolean> {
+    if (!CONSOLE_API_KEY) {
+        return false
+    }
+
+    const payloads = await Promise.all(
+        conversations.map((conversation) => toSyncPayload({ conversation, log, userCache, platformCache })),
+    )
+
+    const result = await tryCatch(() => fetch(CONSOLE_TELEMETRY_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${CONSOLE_API_KEY}`,
+        },
+        body: JSON.stringify({ conversations: payloads }),
+        signal: AbortSignal.timeout(30000),
+    }))
+
+    if (result.error) {
+        log.error({ error: result.error }, 'Failed to push chat analytics telemetry')
+        return false
+    }
+    return true
+}
+
+async function toSyncPayload({ conversation, log, userCache, platformCache }: {
+    conversation: ChatConversation
+    log: FastifyBaseLogger
+    userCache?: Map<string, string | null>
+    platformCache?: Map<string, string | null>
+}): Promise<Record<string, unknown>> {
+    const userEmail = userCache?.get(conversation.userId) ?? await resolveUserEmail({ userId: conversation.userId, log })
+    const platformName = platformCache?.get(conversation.platformId) ?? await resolvePlatformName({ platformId: conversation.platformId, log })
+
+    return {
+        id: conversation.id,
+        platformId: conversation.platformId,
+        platformName,
+        userId: conversation.userId,
+        userEmail,
+        title: conversation.title,
+        modelName: resolveModelLabel(conversation.modelName ?? null),
+        messages: conversation.uiMessages ?? [],
+        messageCount: conversation.uiMessages?.length ?? 0,
+        toolCallsSummary: extractToolCallsSummary(conversation.uiMessages ?? []),
+        isActive: false,
+        createdAt: conversation.created,
+        updatedAt: conversation.updated,
+    }
+}
+
+function resolveModelLabel(tierId: string | null): string | null {
+    if (!tierId) return null
+    const tier = ACTIVEPIECES_CHAT_TIERS.find((t) => t.id === tierId)
+    if (!tier) return tierId
+    const modelShort = tier.modelId.split('/').pop() ?? tier.modelId
+    return `${tier.label} (${modelShort})`
+}
+
+function extractToolCallsSummary(messages: PersistedChatMessage[]): Array<{ name: string, successCount: number, failureCount: number }> | null {
+    const usage: Record<string, { successCount: number, failureCount: number }> = {}
+
+    for (const msg of messages) {
+        for (const part of msg.parts) {
+            if (part.type !== PersistedChatPartType.TOOL_CALL) continue
+
+            const name = part.toolName
+            if (!usage[name]) {
+                usage[name] = { successCount: 0, failureCount: 0 }
+            }
+            if (part.status === PersistedToolCallStatus.COMPLETED) {
+                usage[name].successCount++
+            }
+            else {
+                usage[name].failureCount++
+            }
+        }
+    }
+
+    const entries = Object.entries(usage).map(([name, counts]) => ({ name, ...counts }))
+    return entries.length > 0 ? entries : null
+}
+
+async function resolveUserEmail({ userId, log }: { userId: string, log: FastifyBaseLogger }): Promise<string | null> {
+    const result = await tryCatch(() => userService(log).getMetaInformation({ id: userId }))
+    return result.error ? null : result.data.email
+}
+
+async function resolvePlatformName({ platformId, log }: { platformId: string, log: FastifyBaseLogger }): Promise<string | null> {
+    const result = await tryCatch(() => platformService(log).getOneOrThrow(platformId))
+    return result.error ? null : result.data.name
+}

--- a/packages/server/api/src/app/ee/chat/chat-sync-job.ts
+++ b/packages/server/api/src/app/ee/chat/chat-sync-job.ts
@@ -96,6 +96,10 @@ async function pushToConsole({ conversations, log, userCache, platformCache }: {
         log.error({ error: result.error }, 'Failed to push chat analytics telemetry')
         return false
     }
+    if (!result.data.ok) {
+        log.error({ status: result.data.status }, 'Failed to push chat analytics telemetry: non-2xx response')
+        return false
+    }
     return true
 }
 

--- a/packages/server/api/src/app/ee/platform/admin/admin-platform.controller.ts
+++ b/packages/server/api/src/app/ee/platform/admin/admin-platform.controller.ts
@@ -1,13 +1,16 @@
 import { ErrorHandlingOptionsParam, PieceMetadata, PieceMetadataModel, WebhookRenewConfiguration } from '@activepieces/pieces-framework'
-import { AdminRetryRunsRequestBody, ApplyLicenseKeyByEmailRequestBody, ExactVersionType, IncreaseAICreditsForPlatformRequestBody, isNil, PackageType, PieceCategory, PieceType, TriggerStrategy, TriggerTestStrategy, WebhookHandshakeConfiguration } from '@activepieces/shared'
+import { AdminRetryRunsRequestBody, ApplyLicenseKeyByEmailRequestBody, ChatConversation, ExactVersionType, IncreaseAICreditsForPlatformRequestBody, isNil, PackageType, PieceCategory, PieceType, TriggerStrategy, TriggerTestStrategy, WebhookHandshakeConfiguration } from '@activepieces/shared'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
+import { repoFactory } from '../../../core/db/repo-factory'
 import { securityAccess } from '../../../core/security/authorization/fastify-security'
 import { system } from '../../../helper/system/system'
 import { AppSystemProp } from '../../../helper/system/system-props'
 import { pieceMetadataService } from '../../../pieces/metadata/piece-metadata-service'
+import { ChatConversationEntity } from '../../chat/chat-conversation-entity'
+import { chatAnalyticsBulkSync } from '../../chat/chat-sync-job'
 import { CANARY_WORKER_GROUP_ID, workerGroupService } from '../platform-plan/worker-group.service'
 import { adminPlatformService } from './admin-platform.service'
 
@@ -71,6 +74,32 @@ const adminPlatformController: FastifyPluginAsyncZod = async (
         await workerGroupService(req.log).moveJobsToTargetQueue({ platformId, workerGroupId: canary ? CANARY_WORKER_GROUP_ID : null })
         await workerGroupService(req.log).updateCanary({ platformId, canary })
         return res.status(StatusCodes.OK).send()
+    })
+
+    app.post('/chat/sync-all', SyncAllConversationsRequest, async (req, res) => {
+        const PAGE_SIZE = 100
+        const conversationRepo = repoFactory(ChatConversationEntity)
+        const totalCount = await conversationRepo().count()
+        const totalPages = Math.ceil(totalCount / PAGE_SIZE)
+
+        req.log.info({ totalCount, totalPages }, 'Starting bulk chat analytics sync')
+
+        let synced = 0
+        let failed = 0
+
+        for (let page = 0; page < totalPages; page++) {
+            const conversations: ChatConversation[] = await conversationRepo().find({
+                skip: page * PAGE_SIZE,
+                take: PAGE_SIZE,
+                order: { created: 'ASC' },
+            })
+            const result = await chatAnalyticsBulkSync(req.log).syncAll({ conversations })
+            synced += result.synced
+            failed += result.failed
+            req.log.info({ page: page + 1, totalPages, synced, failed }, 'Synced chat analytics page')
+        }
+
+        return res.status(StatusCodes.OK).send({ synced, failed, total: totalCount })
     })
 }
 
@@ -162,6 +191,12 @@ const CreatePieceRequest = {
             i18n: z.record(z.string(), z.record(z.string(), z.string())).optional(),
         }),
     },
+    config: {
+        security: securityAccess.public(),
+    },
+}
+
+const SyncAllConversationsRequest = {
     config: {
         security: securityAccess.public(),
     },

--- a/packages/server/api/src/app/helper/system-validator.ts
+++ b/packages/server/api/src/app/helper/system-validator.ts
@@ -192,6 +192,9 @@ const systemPropValidators: {
 
     // On-call
     [AppSystemProp.PAGE_ONCALL_WEBHOOK]: urlValidator,
+
+    // Console
+    [AppSystemProp.CONSOLE_API_SECRET_KEY]: stringValidator,
 }
 
 

--- a/packages/server/api/src/app/helper/system/system-props.ts
+++ b/packages/server/api/src/app/helper/system/system-props.ts
@@ -126,6 +126,7 @@ export enum AppSystemProp {
     CONTAINER_TYPE = 'CONTAINER_TYPE',
     FRONTEND_URL = 'FRONTEND_URL',
     PORT = 'PORT',
+    CONSOLE_API_SECRET_KEY = 'CONSOLE_API_SECRET_KEY',
 }
 
 export enum ContainerType {


### PR DESCRIPTION
## Summary
- Push conversation data to `console.activepieces.com` on every chat message completion (cloud-only, fire-and-forget)
- Add `chat-sync-job.ts` with transformation pipeline: resolves user email, platform name, model label, extracts tool calls summary
- Add admin endpoint `POST /v1/admin/chat/sync-all` for bulk historical sync (paginated, pre-resolves lookups, batches of 50)
- Add `CONSOLE_API_SECRET_KEY` system prop for console API authentication

## Test plan
- [ ] Send a chat message on cloud, verify conversation appears in console chat analytics
- [ ] Call `POST /v1/admin/chat/sync-all` with admin API key, verify all existing conversations sync to console
- [ ] Verify telemetry is skipped on CE/EE editions
- [ ] Verify telemetry is skipped when `CONSOLE_API_SECRET_KEY` is not set