### PR TITLE
feat: add llmDescription to pieces and their actions and triggers

### DIFF
--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.28.2",
+  "version": "0.29.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.29.0",
+  "version": "0.28.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/framework/src/lib/action/action.ts
+++ b/packages/pieces/framework/src/lib/action/action.ts
@@ -30,6 +30,13 @@ type CreateActionParams<PieceAuth extends PieceAuthProperty | PieceAuthProperty[
   auth?: PieceAuth
   displayName: string
   description: string
+  /**
+   * Optional alternate description shown to LLMs (chat / MCP).
+   * Use this for tool-selection guidance, anti-patterns, disambiguation,
+   * and parameter pitfalls that would be noise in the human UI description.
+   * Falls back to {@code description} when omitted.
+   */
+  llmDescription?: string
   props: ActionProps
   run: ActionRunner<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, ActionProps>
   test?: ActionRunner<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, ActionProps>
@@ -48,6 +55,7 @@ export class IAction<PieceAuth extends PieceAuthProperty | PieceAuthProperty[] |
     public readonly test: ActionRunner<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, ActionProps>,
     public readonly requireAuth: boolean,
     public readonly errorHandlingOptions: ErrorHandlingOptionsParam,
+    public readonly llmDescription?: string,
   ) { }
 }
 
@@ -80,5 +88,6 @@ export const createAction = <
         defaultValue: false,
       }
     },
+    params.llmDescription,
   )
 }

--- a/packages/pieces/framework/src/lib/piece-metadata.ts
+++ b/packages/pieces/framework/src/lib/piece-metadata.ts
@@ -88,13 +88,11 @@ export type TriggerBase = ActionBase & {
 
 export const PieceMetadata = z.object({
   ...PieceBase.shape,
-  llmDescription: z.string().optional(),
   actions: z.record(z.string(), ActionBase),
   triggers: z.record(z.string(), TriggerBase),
 })
 
 export type PieceMetadata = Omit<PieceBase, 'getContextInfo'> & {
-  llmDescription?: string;
   actions: Record<string, ActionBase>;
   triggers: Record<string, TriggerBase>;
   // this property didn't exist in older version

--- a/packages/pieces/framework/src/lib/piece-metadata.ts
+++ b/packages/pieces/framework/src/lib/piece-metadata.ts
@@ -88,11 +88,13 @@ export type TriggerBase = ActionBase & {
 
 export const PieceMetadata = z.object({
   ...PieceBase.shape,
+  llmDescription: z.string().optional(),
   actions: z.record(z.string(), ActionBase),
   triggers: z.record(z.string(), TriggerBase),
 })
 
 export type PieceMetadata = Omit<PieceBase, 'getContextInfo'> & {
+  llmDescription?: string;
   actions: Record<string, ActionBase>;
   triggers: Record<string, TriggerBase>;
   // this property didn't exist in older version

--- a/packages/pieces/framework/src/lib/piece-metadata.ts
+++ b/packages/pieces/framework/src/lib/piece-metadata.ts
@@ -49,6 +49,7 @@ export const ActionBase = z.object({
   name: z.string(),
   displayName: z.string(),
   description: z.string(),
+  llmDescription: z.string().optional(),
   props: PiecePropertyMap,
   requireAuth: z.boolean(),
   errorHandlingOptions: ErrorHandlingOptionsParam.optional(),
@@ -58,6 +59,7 @@ export type ActionBase = {
   name: string,
   displayName: string,
   description: string,
+  llmDescription?: string,
   props: PiecePropertyMap,
   requireAuth: boolean;
   errorHandlingOptions?: ErrorHandlingOptionsParam;
@@ -67,6 +69,7 @@ export const TriggerBase = z.object({
   name: z.string(),
   displayName: z.string(),
   description: z.string(),
+  llmDescription: z.string().optional(),
   props: PiecePropertyMap,
   errorHandlingOptions: ErrorHandlingOptionsParam.optional(),
   type: z.nativeEnum(TriggerStrategy),

--- a/packages/pieces/framework/src/lib/piece.ts
+++ b/packages/pieces/framework/src/lib/piece.ts
@@ -31,7 +31,6 @@ export class Piece<PieceAuth extends PieceAuthProperty | PieceAuthProperty[] | u
     public readonly minimumSupportedRelease: string = MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION,
     public readonly maximumSupportedRelease?: string,
     public readonly description = '',
-    public readonly llmDescription?: string,
   ) {
     if (!isValidSimpleSemver(minimumSupportedRelease) || isSemverLessThan(minimumSupportedRelease, MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION)) {
       this.minimumSupportedRelease = MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION;
@@ -49,7 +48,6 @@ export class Piece<PieceAuth extends PieceAuthProperty | PieceAuthProperty[] | u
       triggers: this._triggers,
       categories: this.categories,
       description: this.description,
-      llmDescription: this.llmDescription,
       authors: this.authors,
       auth: this.auth,
       minimumSupportedRelease: this.minimumSupportedRelease,
@@ -98,7 +96,6 @@ export const createPiece = <PieceAuth extends PieceAuthProperty | PieceAuthPrope
     params.minimumSupportedRelease,
     params.maximumSupportedRelease,
     params.description,
-    params.llmDescription,
   );
 };
 
@@ -109,13 +106,6 @@ type CreatePieceParams<
   logoUrl: string;
   authors: string[];
   description?: string;
-  /**
-   * Optional alternate description shown to LLMs (chat / MCP).
-   * Use this for tool-selection guidance, anti-patterns, disambiguation,
-   * and parameter pitfalls that would be noise in the human UI description.
-   * Falls back to {@code description} when omitted.
-   */
-  llmDescription?: string;
   auth: PieceAuth | undefined;
   events?: PieceEventProcessors;
   minimumSupportedRelease?: string;

--- a/packages/pieces/framework/src/lib/piece.ts
+++ b/packages/pieces/framework/src/lib/piece.ts
@@ -31,6 +31,7 @@ export class Piece<PieceAuth extends PieceAuthProperty | PieceAuthProperty[] | u
     public readonly minimumSupportedRelease: string = MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION,
     public readonly maximumSupportedRelease?: string,
     public readonly description = '',
+    public readonly llmDescription?: string,
   ) {
     if (!isValidSimpleSemver(minimumSupportedRelease) || isSemverLessThan(minimumSupportedRelease, MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION)) {
       this.minimumSupportedRelease = MINIMUM_SUPPORTED_RELEASE_AFTER_LATEST_CONTEXT_VERSION;
@@ -48,6 +49,7 @@ export class Piece<PieceAuth extends PieceAuthProperty | PieceAuthProperty[] | u
       triggers: this._triggers,
       categories: this.categories,
       description: this.description,
+      llmDescription: this.llmDescription,
       authors: this.authors,
       auth: this.auth,
       minimumSupportedRelease: this.minimumSupportedRelease,
@@ -96,6 +98,7 @@ export const createPiece = <PieceAuth extends PieceAuthProperty | PieceAuthPrope
     params.minimumSupportedRelease,
     params.maximumSupportedRelease,
     params.description,
+    params.llmDescription,
   );
 };
 
@@ -106,6 +109,13 @@ type CreatePieceParams<
   logoUrl: string;
   authors: string[];
   description?: string;
+  /**
+   * Optional alternate description shown to LLMs (chat / MCP).
+   * Use this for tool-selection guidance, anti-patterns, disambiguation,
+   * and parameter pitfalls that would be noise in the human UI description.
+   * Falls back to {@code description} when omitted.
+   */
+  llmDescription?: string;
   auth: PieceAuth | undefined;
   events?: PieceEventProcessors;
   minimumSupportedRelease?: string;

--- a/packages/pieces/framework/src/lib/trigger/trigger.ts
+++ b/packages/pieces/framework/src/lib/trigger/trigger.ts
@@ -44,6 +44,13 @@ type BaseTriggerParams<
   name: string
   displayName: string
   description: string
+  /**
+   * Optional alternate description shown to LLMs (chat / MCP).
+   * Use this for tool-selection guidance, anti-patterns, disambiguation,
+   * and parameter pitfalls that would be noise in the human UI description.
+   * Falls back to {@code description} when omitted.
+   */
+  llmDescription?: string
   requireAuth?: boolean
   auth?: PieceAuth
   props: TriggerProps
@@ -98,6 +105,7 @@ export class ITrigger<
     public readonly test: (ctx: TestOrRunHookContext<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, TriggerProps, TS>) => Promise<unknown[]>,
     public readonly sampleData: unknown,
     public readonly testStrategy: TriggerTestStrategy,
+    public readonly llmDescription?: string,
   ) { }
 }
 
@@ -134,6 +142,7 @@ export const createTrigger = <
         params.test ?? (() => Promise.resolve([params.sampleData])),
         params.sampleData,
         params.test ? TriggerTestStrategy.TEST_FUNCTION : TriggerTestStrategy.SIMULATION,
+        params.llmDescription,
       )
     case TriggerStrategy.POLLING:
       return new ITrigger(
@@ -154,6 +163,7 @@ export const createTrigger = <
         params.test ?? (() => Promise.resolve([params.sampleData])),
         params.sampleData,
         TriggerTestStrategy.TEST_FUNCTION,
+        params.llmDescription,
       )
     case TriggerStrategy.MANUAL:
       return new ITrigger(
@@ -174,6 +184,7 @@ export const createTrigger = <
         params.test ?? (() => Promise.resolve([params.sampleData])),
         params.sampleData,
         TriggerTestStrategy.TEST_FUNCTION,
+        params.llmDescription,
       )
     case TriggerStrategy.APP_WEBHOOK:
       return new ITrigger(
@@ -194,6 +205,7 @@ export const createTrigger = <
         params.test ?? (() => Promise.resolve([params.sampleData])),
         params.sampleData,
         (isNil(params.sampleData) && isNil(params.test)) ? TriggerTestStrategy.SIMULATION : TriggerTestStrategy.TEST_FUNCTION,
+        params.llmDescription,
       )
   }
 }


### PR DESCRIPTION
## What does this PR do?

Adds a new optional `llmDescription` field to pieces, actions, and triggers in the framework. It sits alongside the existing `description` field but is intended for LLM consumers (chat / MCP), so piece authors can give models tool-selection guidance, anti-patterns, and parameter pitfalls without polluting the human-facing UI description. When `llmDescription` is omitted, consumers fall back to `description`.


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

Piece authors can now optionally pass `llmDescription` to `createAction` / `createTrigger`. The field is threaded through the framework into `ActionBase` / `TriggerBase` metadata (both the Zod schemas and the TS types). Downstream LLM consumers can prefer `llmDescription ?? description`. Pieces that don't set it behave exactly as before.

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->

- Disambiguating similar actions for LLMs (e.g. "send email" vs "reply to email") without making the human description noisy.
- Documenting anti-patterns and parameter pitfalls that only the model needs to know.
- Improving MCP tool selection accuracy for pieces with many similar actions/triggers.



Fixes # (issue)
