### PR TITLE
fix: reconstruct messages for old conversations without uiMessages

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -19,7 +19,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - `packages/server/api/src/app/ee/chat/mcp/chat-mcp.ts` — connects to Activepieces MCP server for project-scoped tools with approval wrapping
 - `packages/server/api/src/app/ee/chat/history/chat-history.ts` — reconstructs chat history from AI SDK `ModelMessage` format
 - `packages/server/api/src/app/ee/chat/prompt/chat-prompt.ts` — builds system prompt from markdown templates in `src/assets/prompts/`
-- `packages/server/api/src/app/ee/chat/chat-sync-job.ts` — fire-and-forget telemetry sync to console.activepieces.com (cloud-only); also exposes `chatAnalyticsBulkSync` for admin bulk sync
+- `packages/server/api/src/app/ee/chat/chat-sync-job.ts` — fire-and-forget telemetry sync to console.activepieces.com (cloud-only); also exposes `chatAnalyticsBulkSync` for admin bulk sync; falls back to reconstructing messages from raw ModelMessage[] when uiMessages is null
 - `packages/shared/src/lib/ee/chat/index.ts` — shared Zod schemas, types (ChatConversation, request DTOs, ChatHistoryMessage), and typed tool outputs (`ChatToolOutputs`)
 - `packages/web/src/app/routes/chat-with-ai/index.tsx` — main chat page component
 - `packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx` — chat interface with provider check, message streaming, Zustand store provider
@@ -102,4 +102,4 @@ All chat endpoints require `PrincipalType.USER` authentication at the platform l
 5. Destructive MCP tool calls pause and emit an approval request to the UI via the stream
 6. User approves/denies via `POST /tool-approvals/:gateId`, unblocking the gate via Redis pub/sub
 7. On stream completion, assistant messages are appended to the stored conversation
-8. On cloud, `chatAnalyticsTelemetry` pushes the updated conversation to `console.activepieces.com` for monitoring (fire-and-forget, skipped when `CONSOLE_API_SECRET_KEY` is unset)
+8. On cloud, `chatAnalyticsTelemetry` pushes the updated conversation to `console.activepieces.com` for monitoring (fire-and-forget, skipped when `CONSOLE_API_SECRET_KEY` is unset); messages are sourced from uiMessages when available, falling back to reconstruction from raw ModelMessage[] for older conversations

--- a/packages/server/api/src/app/ee/chat/chat-sync-job.ts
+++ b/packages/server/api/src/app/ee/chat/chat-sync-job.ts
@@ -1,4 +1,5 @@
-import { ACTIVEPIECES_CHAT_TIERS, ApEdition, ChatConversation, chunk, PersistedChatMessage, PersistedChatPartType, PersistedToolCallStatus, tryCatch } from '@activepieces/shared'
+import { ACTIVEPIECES_CHAT_TIERS, ApEdition, ChatConversation, ChatHistoryMessage, chunk, isNil, PersistedChatMessage, PersistedChatPart, PersistedChatPartType, PersistedChatRole, PersistedToolCallStatus, tryCatch } from '@activepieces/shared'
+import { ModelMessage } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { isNotOneOfTheseEditions } from '../../database/database-common'
 import { rejectedPromiseHandler } from '../../helper/promise-handler'
@@ -6,6 +7,7 @@ import { system } from '../../helper/system/system'
 import { AppSystemProp } from '../../helper/system/system-props'
 import { platformService } from '../../platform/platform.service'
 import { userService } from '../../user/user-service'
+import { chatHistory } from './history/chat-history'
 
 const CONSOLE_TELEMETRY_URL = 'https://console.activepieces.com/api/chat-analytics/external/sync'
 const CONSOLE_API_KEY = system.get(AppSystemProp.CONSOLE_API_SECRET_KEY)
@@ -112,6 +114,8 @@ async function toSyncPayload({ conversation, log, userCache, platformCache }: {
     const userEmail = userCache?.get(conversation.userId) ?? await resolveUserEmail({ userId: conversation.userId, log })
     const platformName = platformCache?.get(conversation.platformId) ?? await resolvePlatformName({ platformId: conversation.platformId, log })
 
+    const messages = resolveMessages(conversation)
+
     return {
         id: conversation.id,
         platformId: conversation.platformId,
@@ -120,13 +124,56 @@ async function toSyncPayload({ conversation, log, userCache, platformCache }: {
         userEmail,
         title: conversation.title,
         modelName: resolveModelLabel(conversation.modelName ?? null),
-        messages: conversation.uiMessages ?? [],
-        messageCount: conversation.uiMessages?.length ?? 0,
-        toolCallsSummary: extractToolCallsSummary(conversation.uiMessages ?? []),
+        messages,
+        messageCount: messages.length,
+        toolCallsSummary: extractToolCallsSummary(messages),
         isActive: false,
         createdAt: conversation.created,
         updatedAt: conversation.updated,
     }
+}
+
+function resolveMessages(conversation: ChatConversation): PersistedChatMessage[] {
+    if (!isNil(conversation.uiMessages) && conversation.uiMessages.length > 0) {
+        return conversation.uiMessages
+    }
+    const rawMessages = conversation.messages as ModelMessage[]
+    if (isNil(rawMessages) || rawMessages.length === 0) {
+        return []
+    }
+    return convertToPersistedFormat(chatHistory.reconstruct(rawMessages))
+}
+
+function convertToPersistedFormat(messages: ChatHistoryMessage[]): PersistedChatMessage[] {
+    return messages.map((msg) => {
+        const parts: PersistedChatPart[] = []
+
+        if (msg.content) {
+            parts.push({ type: PersistedChatPartType.TEXT, text: msg.content })
+        }
+
+        if (msg.thoughts) {
+            parts.push({ type: PersistedChatPartType.REASONING, text: msg.thoughts })
+        }
+
+        if (msg.toolCalls) {
+            for (const tc of msg.toolCalls) {
+                parts.push({
+                    type: PersistedChatPartType.TOOL_CALL,
+                    toolCallId: tc.toolCallId,
+                    toolName: tc.title,
+                    input: tc.input ?? {},
+                    output: tc.output,
+                    status: tc.status === 'completed' ? PersistedToolCallStatus.COMPLETED : PersistedToolCallStatus.ERROR,
+                })
+            }
+        }
+
+        return {
+            role: msg.role === 'user' ? PersistedChatRole.USER : PersistedChatRole.ASSISTANT,
+            parts,
+        }
+    })
 }
 
 function resolveModelLabel(tierId: string | null): string | null {


### PR DESCRIPTION
## Summary
- Old conversations have `uiMessages=null` because the field was added later
- Fall back to `chatHistory.reconstruct()` to rebuild messages from raw `ModelMessage[]`
- Convert reconstructed `ChatHistoryMessage` format to `PersistedChatMessage` format for console rendering
- After deploying, re-run `POST /v1/admin/chat/sync-all` to backfill old conversations

## Test plan
- [ ] Re-run sync-all endpoint, verify previously empty conversations now have messages
- [ ] Verify old conversations render correctly in console chat analytics