### PR TITLE
fix(polling): preserve lastPoll checkpoint on flow republish

### DIFF
--- a/packages/pieces/common/src/lib/polling/index.ts
+++ b/packages/pieces/common/src/lib/polling/index.ts
@@ -116,11 +116,14 @@ export const pollingHelper = {
       store,
       auth,
       propsValue,
-    }: { store: Store; auth: AuthValue; propsValue: PropsValue }
+      isRepublish,                                 
+    }: { store: Store; auth: AuthValue; propsValue: PropsValue; isRepublish?: boolean }
   ): Promise<void> {
     switch (polling.strategy) {
       case DedupeStrategy.TIMEBASED: {
-        await store.put('lastPoll', Date.now());
+        if (!isRepublish) {                         
+          await store.put('lastPoll', Date.now());
+        }
         break;
       }
       case DedupeStrategy.LAST_ITEM: {

--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -357,13 +357,16 @@ export const flowService = (log: FastifyBaseLogger) => ({
 
         switch (operation.type) {
             case FlowOperationType.LOCK_AND_PUBLISH: {
+                const flowBeforePublish = await this.getOneOrThrow({ id, projectId })
+                const isRepublish = flowBeforePublish.status === FlowStatus.ENABLED  
+
                 await this.updatedPublishedVersionId({
                     id,
                     userId,
                     projectId,
                     platformId,
                 })
-                await applyStatusChange({ id, projectId, newStatus: operation.request.status ?? FlowStatus.ENABLED }, log)
+                await applyStatusChange({ id, projectId, newStatus: operation.request.status ?? FlowStatus.ENABLED, isRepublish }, log)   
                 break
             }
 
@@ -682,6 +685,7 @@ async function applyStatusChange(params: {
     id: FlowId
     projectId: ProjectId
     newStatus: FlowStatus
+    isRepublish?: boolean   
 }, log: FastifyBaseLogger): Promise<void> {
     const triggerTimeout = system.getNumberOrThrow(AppSystemProp.TRIGGER_TIMEOUT_SECONDS)
     await distributedLock(log).runExclusive({
@@ -703,11 +707,13 @@ async function applyStatusChange(params: {
                 versionId: publishedFlowVersionId,
             })
 
+          
             await flowSideEffects(log).preUpdateStatus({
                 flowToUpdate,
                 publishedFlowVersion,
                 newStatus: params.newStatus,
                 templateId: flowToUpdate.templateId ?? undefined,
+                isRepublish: params.isRepublish,   
             })
 
             await flowRepo().save({

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
@@ -58,6 +58,7 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
                 pieceName: flowVersion.trigger.settings.pieceName,
                 pieceTrigger,
                 simulate,
+                isRepublish: params.isRepublish,   
             })
 
             if (templateId) {
@@ -232,4 +233,5 @@ type EnableTriggerParams = {
     projectId: string
     simulate: boolean
     templateId?: string
+    isRepublish?: boolean    
 }

--- a/packages/server/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/server/engine/src/lib/helper/trigger-helper.ts
@@ -153,7 +153,10 @@ export const triggerHelper = {
                 return {}
             }
             case TriggerHookType.ON_ENABLE: {
-                await pieceTrigger.onEnable(context)
+             await pieceTrigger.onEnable({
+                ...context,
+                isRepublish: params.isRepublish ?? false,
+            })
                 return {
                     listeners: appListeners,
                     scheduleOptions: pieceTrigger.type === TriggerStrategy.POLLING ? scheduleOptions : undefined,
@@ -238,9 +241,11 @@ export const triggerHelper = {
     },
 }
 
+
 type ExecuteTriggerParams = {
     params: ExecuteTriggerOperation<TriggerHookType>
     constants: EngineConstants
+    isRepublish?: boolean     
 }
 
 async function prepareTriggerExecution({ pieceName, pieceVersion, triggerName, input, propertySettings, projectId, apiUrl, engineToken, devPieces, stepNames }: PrepareTriggerExecutionParams) {


### PR DESCRIPTION
Fixes #13311

* Root cause was in `pollingHelper.onEnable` (`polling/index.ts`)
* `lastPoll` was being reset to `Date.now()` every time `onEnable` ran
* During `LOCK_AND_PUBLISH`, the flow internally goes through `onDisable -> onEnable`
* Because of that, republishes were treated the same as a fresh enable
* This caused events between the previous poll and the republish time to get skipped silently

### What changed

* Added an `isRepublish` flag starting from `flow.service.ts`
* Passed the flag through:

  * `trigger-source-service.ts`
  * `trigger-helper.ts`
  * `polling/index.ts`
* `lastPoll` is now only reset on a real first-time enable, not during republishes

### Result

* Events that happen between the last poll and a republish are now picked up correctly on the next polling cycle.