### PR TITLE
fix(worker): use bracket notation for socket.handshake.auth (TS4111)

### DIFF
--- a/packages/server/worker/src/lib/sandbox/sandbox.ts
+++ b/packages/server/worker/src/lib/sandbox/sandbox.ts
@@ -371,7 +371,7 @@ function authenticateHandshake({ getExpectedToken, log, sandboxId }: {
     sandboxId: string
 }): (socket: Socket, next: (err?: Error) => void) => void {
     return (socket, next) => {
-        const provided = socket.handshake.auth?.connectionToken
+        const provided = socket.handshake.auth?.['connectionToken']
         const expected = getExpectedToken()
         if (typeof provided !== 'string' || expected === null) {
             log.warn({ sandboxId, socketId: socket.id }, '[WebSocket] Rejecting handshake: missing connection token')


### PR DESCRIPTION
## Summary
- CD-Staging build on \`main\` is failing with \`TS4111: Property 'connectionToken' comes from an index signature, so it must be accessed with ['connectionToken']\` in \`packages/server/worker/src/lib/sandbox/sandbox.ts:374\`. The handshake-auth lookup in the recent security merge (GHSA-65m2-cp8q-6pc7) used dot access on a value that Socket.IO types as an index-signature-only object.
- Switch to bracket notation. No runtime behaviour change.

## Test plan
- [x] \`npx turbo run build --filter=worker\` succeeds locally
- [x] Sandbox unit tests (40/40) still pass
- [ ] CD-Staging build green on this branch