### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/packages/pieces/community/litellm/.eslintrc.json
+++ b/packages/pieces/community/litellm/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/litellm/package.json
+++ b/packages/pieces/community/litellm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-litellm",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/litellm/src/index.ts
+++ b/packages/pieces/community/litellm/src/index.ts
@@ -1,0 +1,38 @@
+import {
+  HttpMethod,
+  createCustomApiCallAction,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { askLitellm } from './lib/actions/ask-litellm';
+
+export const litellmAuth = PieceAuth.SecretText({
+  description: 'Enter your LiteLLM proxy API key (leave empty if proxy has no auth)',
+  displayName: 'API Key',
+  required: false,
+});
+
+export const litellm = createPiece({
+  displayName: 'LiteLLM',
+  description: 'Unified proxy for 100+ LLM providers with load balancing and spend tracking.',
+  minimumSupportedRelease: '0.9.0',
+  logoUrl: 'https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/proxy/swagger/favicon.png',
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  auth: litellmAuth,
+  actions: [
+    askLitellm,
+    createCustomApiCallAction({
+      auth: litellmAuth,
+      baseUrl: () => process.env['LITELLM_BASE_URL'] ?? 'http://localhost:4000',
+      authMapping: async (auth) => {
+        if (auth.secret_text) {
+          return { Authorization: `Bearer ${auth.secret_text}` };
+        }
+        return {};
+      },
+    }),
+  ],
+  authors: ['RheagalFire'],
+  triggers: [],
+});

--- a/packages/pieces/community/litellm/src/lib/actions/ask-litellm.ts
+++ b/packages/pieces/community/litellm/src/lib/actions/ask-litellm.ts
@@ -1,0 +1,143 @@
+import { createAction, Property, StoreScope } from '@activepieces/pieces-framework';
+import { litellmAuth } from '../..';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import type { DropdownState } from '@activepieces/pieces-framework';
+
+export const askLitellm = createAction({
+  auth: litellmAuth,
+  name: 'ask-ai',
+  displayName: 'Ask AI',
+  description: 'Send a prompt to any model available on your LiteLLM proxy.',
+  props: {
+    baseUrl: Property.ShortText({
+      displayName: 'Base URL',
+      description: 'LiteLLM proxy base URL (e.g. http://localhost:4000)',
+      required: true,
+      defaultValue: 'http://localhost:4000',
+    }),
+    model: Property.Dropdown<string, true, typeof litellmAuth>({
+      auth: litellmAuth,
+      displayName: 'Model',
+      required: true,
+      description: 'The model to use for completion.',
+      refreshers: ['baseUrl'] as const,
+      options: async ({ auth, baseUrl }): Promise<DropdownState<string>> => {
+        if (!baseUrl) {
+          return {
+            disabled: true,
+            placeholder: 'Please enter your LiteLLM proxy base URL first.',
+            options: [],
+          };
+        }
+        try {
+          const headers: Record<string, string> = {};
+          if (auth) {
+            headers['Authorization'] = `Bearer ${(auth as unknown as { secret_text: string }).secret_text}`;
+          }
+          const response = await httpClient.sendRequest({
+            url: `${(baseUrl as string).replace(/\/+$/, '')}/v1/models`,
+            method: HttpMethod.GET,
+            headers,
+          });
+          const models = response.body.data as Array<{ id: string }>;
+          return {
+            disabled: false,
+            options: models.map((model: { id: string }) => ({
+              label: model.id,
+              value: model.id,
+            })),
+          };
+        } catch (error) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: "Couldn't load models. Check your proxy URL and API key.",
+          };
+        }
+      },
+    }),
+    prompt: Property.LongText({
+      displayName: 'Question',
+      required: true,
+    }),
+    temperature: Property.Number({
+      displayName: 'Temperature',
+      required: false,
+      description: 'Controls randomness (0-2). Lower values are more deterministic.',
+      defaultValue: 0.7,
+    }),
+    maxTokens: Property.Number({
+      displayName: 'Maximum Tokens',
+      required: false,
+      description: 'Maximum number of tokens to generate.',
+      defaultValue: 2048,
+    }),
+    memoryKey: Property.ShortText({
+      displayName: 'Memory Key',
+      description: 'A key to maintain chat history across runs. Leave empty for stateless calls.',
+      required: false,
+    }),
+    systemMessage: Property.LongText({
+      displayName: 'System Message',
+      description: 'Optional system prompt to set the behavior of the model.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue, store }) {
+    const { baseUrl, model, temperature, maxTokens, prompt, memoryKey, systemMessage } = propsValue;
+
+    let messageHistory: Array<{ role: string; content: string }> = [];
+
+    if (memoryKey) {
+      messageHistory = (await store.get(memoryKey, StoreScope.PROJECT)) ?? [];
+    }
+
+    const messages: Array<{ role: string; content: string }> = [];
+
+    if (systemMessage) {
+      messages.push({ role: 'system', content: systemMessage });
+    }
+
+    messages.push(...messageHistory);
+    messages.push({ role: 'user', content: prompt });
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (auth) {
+      headers['Authorization'] = `Bearer ${(auth as unknown as { secret_text: string }).secret_text}`;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${(baseUrl as string).replace(/\/+$/, '')}/chat/completions`,
+      headers,
+      body: {
+        model,
+        messages,
+        ...(temperature !== undefined && temperature !== null ? { temperature } : {}),
+        ...(maxTokens !== undefined && maxTokens !== null ? { max_tokens: maxTokens } : {}),
+      },
+    });
+
+    const body = response.body;
+    if (body.error) {
+      throw new Error(body.error.message ?? JSON.stringify(body.error));
+    }
+    if (!body.choices || body.choices.length === 0) {
+      throw new Error('LiteLLM returned no choices in the response.');
+    }
+    const content = body.choices[0].message.content;
+
+    if (memoryKey) {
+      const updatedHistory = [
+        ...messageHistory,
+        { role: 'user', content: prompt },
+        { role: 'assistant', content },
+      ];
+      await store.put(memoryKey, updatedHistory, StoreScope.PROJECT);
+    }
+
+    return { content };
+  },
+});

--- a/packages/pieces/community/litellm/tsconfig.json
+++ b/packages/pieces/community/litellm/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/litellm/tsconfig.lib.json
+++ b/packages/pieces/community/litellm/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -729,6 +729,9 @@
       "@activepieces/piece-linkedin": [
         "packages/pieces/community/linkedin/src/index.ts"
       ],
+      "@activepieces/piece-litellm": [
+        "packages/pieces/community/litellm/src/index.ts"
+      ],
       "@activepieces/piece-llmrails": [
         "packages/pieces/community/llmrails/src/index.ts"
       ],


### PR DESCRIPTION
## What does this PR do?

Adds [LiteLLM](https://github.com/BerriAI/litellm) as a standalone community piece, giving users access to 100+ LLM providers through a single LiteLLM proxy gateway. \

**Changes:**
- `packages/pieces/community/litellm/` - New standalone piece with:
  - `SecretText` auth for proxy API key
  - **Ask AI** action with dynamic model dropdown (fetches from proxy's `/v1/models`)
  - Chat completions with memory support, temperature, max tokens, system message
  - Response validation for error envelopes and empty choices
  - **Custom API Call** action for raw proxy access
- `tsconfig.base.json` - Registered piece path

### How the piece works

1. User installs the LiteLLM piece in their flow
2. Connects with their proxy API key (optional if proxy has no auth)
3. Enters the proxy base URL (e.g. `http://localhost:4000`)
4. Model dropdown auto-populates from the proxy's `/v1/models` endpoint
5. Sends a prompt, gets a response

### Tested locally

- Piece builds and lints clean
- Model dropdown fetches from `/v1/models` (verified in proxy logs: 3x 200 OK)
- Chat completions work end-to-end (verified: 200 OK with correct response)
- Tested with LiteLLM proxy backed by Azure AI Foundry (claude-sonnet-4-6 + claude-opus-4-6)

#### Video Demonstration:   

https://github.com/user-attachments/assets/0d2e58e9-745b-470d-8173-4818846015a9



### Relevant user scenarios

- Users running self-hosted LLM deployments who want a unified gateway
- Users needing provider failover and load-balancing across multiple backends
- Users wanting to access providers not yet natively supported (Cohere, Mistral, Together AI, Groq, etc.)
- Enterprise teams using LiteLLM proxy for centralized API key management and cost tracking
