### PR TITLE
feat(chat): replace keyword-based plan status with ap_update_plan tool

### DIFF
--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -58,6 +58,8 @@ Gather ALL information before presenting the plan. Once approved, execute withou
 - Using granular tools: list each step individually (create flow, set trigger, add step X, validate, test, notes)
 
 **4 — EXECUTE** (no text until ALL steps done):
+- Before starting each step, call `ap_update_plan` with `status: "executing"` for that step.
+- After completing each step, call `ap_update_plan` with `status: "done"` (or `"error"` if it failed).
 - **Simple flows** (linear, no branches/loops): `ap_build_flow` → validate every step (see below) → `ap_test_flow` → `ap_manage_notes`.
 - **Complex flows** (branches, loops, many steps): `ap_create_flow` → configure trigger → validate → for each action: `ap_add_step` → validate → `ap_test_flow` → `ap_manage_notes`.
 - Share flow link. Flow is in draft — do NOT auto-publish.

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
@@ -62,11 +62,11 @@ function hasExecute(tool: object): tool is object & { execute: (args: unknown) =
     return 'execute' in tool && typeof tool.execute === 'function'
 }
 
-function withApprovalGates({ mcpToolSet, writer, log, planExecution, waitForApproval }: {
+function withApprovalGates({ mcpToolSet, writer, log, isApproved, waitForApproval }: {
     mcpToolSet: Record<string, unknown>
     writer: ChatStreamWriter
     log: FastifyBaseLogger
-    planExecution: PlanExecution
+    isApproved: () => boolean
     waitForApproval: (gateId: string) => Promise<boolean>
 }): Record<string, unknown> {
     const result: Record<string, unknown> = {}
@@ -82,10 +82,7 @@ function withApprovalGates({ mcpToolSet, writer, log, planExecution, waitForAppr
 
         result[name] = Object.assign({}, tool, {
             execute: async (args: unknown) => {
-                if (planExecution.isApproved()) {
-                    return planExecution.trackStep({ execute: () => originalExecute(args) })
-                }
-                if (!needsApproval) {
+                if (isApproved() || !needsApproval) {
                     return originalExecute(args)
                 }
                 const gateId = apId()
@@ -103,11 +100,9 @@ function withApprovalGates({ mcpToolSet, writer, log, planExecution, waitForAppr
                 const approved = await waitForApproval(gateId)
 
                 if (!approved) {
-                    log.info({ gateId, toolName: name }, 'Tool approval rejected or timed out')
                     return { content: [{ type: 'text', text: 'Action cancelled by user.' }] }
                 }
 
-                log.info({ gateId, toolName: name }, 'Tool approval granted')
                 return originalExecute(args)
             },
         })
@@ -119,11 +114,6 @@ function withApprovalGates({ mcpToolSet, writer, log, planExecution, waitForAppr
 type McpConnection = {
     mcpClient: Awaited<ReturnType<typeof createMCPClient>> | null
     mcpToolSet: Record<string, unknown>
-}
-
-export type PlanExecution = {
-    isApproved: () => boolean
-    trackStep: (params: { execute: () => Promise<unknown> }) => Promise<unknown>
 }
 
 export const chatMcpClient = {

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
@@ -100,9 +100,11 @@ function withApprovalGates({ mcpToolSet, writer, log, isApproved, waitForApprova
                 const approved = await waitForApproval(gateId)
 
                 if (!approved) {
+                    log.info({ gateId, toolName: name }, 'Tool approval rejected or timed out')
                     return { content: [{ type: 'text', text: 'Action cancelled by user.' }] }
                 }
 
+                log.info({ gateId, toolName: name }, 'Tool approval granted')
                 return originalExecute(args)
             },
         })

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -179,7 +179,7 @@ function createCrossProjectTools({ executeTool }: {
     }
 }
 
-function createPlanApprovalTool({ writer, onPlanApproved, waitForApproval }: {
+function createPlanTools({ writer, onPlanApproved, waitForApproval }: {
     writer: ChatStreamWriter
     onPlanApproved: () => void
     waitForApproval: (gateId: string) => Promise<boolean>
@@ -201,9 +201,25 @@ function createPlanApprovalTool({ writer, onPlanApproved, waitForApproval }: {
                 const approved = await waitForApproval(gateId)
                 if (approved) {
                     onPlanApproved()
-                    return { success: true, message: 'Plan approved by the user. Execute each step in order now.' }
+                    return { success: true, message: 'Plan approved by the user. Execute each step in order now. Call ap_update_plan to update step statuses as you work.' }
                 }
                 return { success: false, message: 'Plan rejected by user. Do not proceed.' }
+            },
+        }),
+
+        ap_update_plan: tool({
+            description: 'Update the status of plan steps. Call this before starting each step (status: executing) and after completing it (status: done or error).',
+            inputSchema: z.object({
+                updates: z.array(z.object({
+                    stepIndex: z.number().describe('Zero-based index of the step in the plan'),
+                    status: z.enum(['pending', 'executing', 'done', 'error']).describe('New status for this step'),
+                })).min(1),
+            }),
+            execute: async (input) => {
+                for (const update of input.updates) {
+                    writer.write({ type: 'data-plan-progress', data: update, transient: true })
+                }
+                return { success: true }
             },
         }),
     }
@@ -214,5 +230,5 @@ export const chatWorkerTools = {
     createDisplayTools,
     createLocalTools,
     createCrossProjectTools,
-    createPlanApprovalTool,
+    createPlanTools,
 }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -13,7 +13,7 @@ import {
 } from '@activepieces/shared'
 import { createUIMessageStream, ModelMessage, stepCountIs, streamText } from 'ai'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../../../types'
-import { chatMcpClient, PlanExecution } from './chat-mcp-client'
+import { chatMcpClient } from './chat-mcp-client'
 import { chatWorkerTools } from './chat-worker-tools'
 
 const MAX_STEPS = 30
@@ -49,7 +49,6 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
 
         try {
             const planApproved = { approved: false }
-            const planStepCounter = { current: 0 }
             let pendingTitle = ''
 
             const waitForApproval = async (gateId: string): Promise<boolean> => {
@@ -75,24 +74,6 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
                 await ctx.apiClient.updateProjectContext({ conversationId, projectId })
             }
 
-            const planExecution: PlanExecution = {
-                isApproved: () => planApproved.approved,
-                async trackStep({ execute }) {
-                    const stepIndex = planStepCounter.current
-                    writer.write({ type: 'data-plan-progress', data: { stepIndex, status: 'executing' }, transient: true })
-                    try {
-                        const result = await execute()
-                        writer.write({ type: 'data-plan-progress', data: { stepIndex, status: 'done' }, transient: true })
-                        planStepCounter.current++
-                        return result
-                    }
-                    catch (err) {
-                        writer.write({ type: 'data-plan-progress', data: { stepIndex, status: 'error' }, transient: true })
-                        throw err
-                    }
-                },
-            }
-
             const displayTools = chatWorkerTools.createDisplayTools({ writer })
             const localTools = chatWorkerTools.createLocalTools({
                 writer,
@@ -102,7 +83,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
                 onSetProjectContext,
                 projects: config.projects,
             })
-            const planApprovalTool = chatWorkerTools.createPlanApprovalTool({
+            const planTools = chatWorkerTools.createPlanTools({
                 writer,
                 onPlanApproved: () => {
                     planApproved.approved = true
@@ -121,9 +102,9 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
                 },
             })
             const gatedMcpTools = chatMcpClient.withApprovalGates({
-                mcpToolSet, writer, log, planExecution, waitForApproval,
+                mcpToolSet, writer, log, isApproved: () => planApproved.approved, waitForApproval,
             })
-            const allTools = { ...localTools, ...displayTools, ...crossProjectTools, ...planApprovalTool, ...(gatedMcpTools as Record<string, typeof localTools[keyof typeof localTools]>) }
+            const allTools = { ...localTools, ...displayTools, ...crossProjectTools, ...planTools, ...(gatedMcpTools as Record<string, typeof localTools[keyof typeof localTools]>) }
 
             const sanitizedMessages = chatAiUtils.stripThinkingBlocks(config.messages as ModelMessage[])
             const systemPrompt = chatAiUtils.buildSystemPromptWithCaching({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.77.0",
+  "version": "0.77.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -174,7 +174,6 @@ export const AssistantMessage = memo(function AssistantMessage({
                   <InlinePlanCard
                     key={`plan-${i}`}
                     planPart={part.part}
-                    message={message}
                     lastAssistantMessage={lastAssistantMessage}
                     isStreaming={isStreaming}
                   />
@@ -237,12 +236,10 @@ export const AssistantMessage = memo(function AssistantMessage({
 
 function InlinePlanCard({
   planPart,
-  message,
   lastAssistantMessage,
   isStreaming,
 }: {
   planPart: AnyToolPart;
-  message: ChatUIMessage;
   lastAssistantMessage?: ChatUIMessage;
   isStreaming: boolean;
 }) {
@@ -250,7 +247,7 @@ function InlinePlanCard({
     chatStoreSelectors.planProgress({ state: s, lastAssistantMessage }),
   );
   const storePlanUpdates = useChatStoreContext((s) =>
-    chatStoreSelectors.effectivePlanUpdates({ state: s, lastAssistantMessage }),
+    chatStoreSelectors.effectivePlanUpdates({ state: s }),
   );
 
   const localPlan = (() => {
@@ -286,18 +283,8 @@ function InlinePlanCard({
         (_stepText, i): PlanStepUpdate => ({ stepIndex: i, status: 'done' }),
       );
     }
-    if (storePlanUpdates.length > 0) return storePlanUpdates;
-    const toolParts = message.parts.filter((p): p is AnyToolPart =>
-      chatPartUtils.isAnyToolPart(p),
-    );
-    if (toolParts.length === 0) return [];
-    return progress.steps.map(
-      (stepText, i): PlanStepUpdate => ({
-        stepIndex: i,
-        status: chatStoreSelectors.deriveStepStatus({ stepText, toolParts }),
-      }),
-    );
-  }, [storePlanUpdates, progress, message.parts, planCompleted]);
+    return storePlanUpdates;
+  }, [storePlanUpdates, progress, planCompleted]);
 
   if (!progress) return null;
 

--- a/packages/web/src/features/chat/lib/chat-store.ts
+++ b/packages/web/src/features/chat/lib/chat-store.ts
@@ -248,12 +248,13 @@ function selectShouldShowPlan({
   if (progress === null) return false;
 
   const hasLiveUpdates = selectEffectivePlanUpdates({ state }).length > 0;
-  const planToolWasCompleted = lastAssistantMessage?.parts.some(
-    (p) =>
-      chatPartUtils.isAnyToolPart(p) &&
-      chatPartUtils.getToolPartName(p) === 'ap_request_plan_approval' &&
-      p.state === 'output-available',
-  ) ?? false;
+  const planToolWasCompleted =
+    lastAssistantMessage?.parts.some(
+      (p) =>
+        chatPartUtils.isAnyToolPart(p) &&
+        chatPartUtils.getToolPartName(p) === 'ap_request_plan_approval' &&
+        p.state === 'output-available',
+    ) ?? false;
   const planWasExecuted = hasLiveUpdates || planToolWasCompleted;
 
   if (!isLastAssistant) {

--- a/packages/web/src/features/chat/lib/chat-store.ts
+++ b/packages/web/src/features/chat/lib/chat-store.ts
@@ -35,89 +35,6 @@ function extractQuestionsFromToolParts(
   return input?.questions ?? [];
 }
 
-type StepCategory = {
-  keywords: string[];
-  tools: string[];
-};
-
-const STEP_CATEGORIES: StepCategory[] = [
-  {
-    keywords: ['create flow', 'create a flow', 'new flow', 'build flow'],
-    tools: ['ap_create_flow', 'ap_build_flow'],
-  },
-  {
-    keywords: ['trigger', 'set trigger', 'configure trigger'],
-    tools: ['ap_update_trigger', 'ap_build_flow'],
-  },
-  {
-    keywords: [
-      'action',
-      'step',
-      'add step',
-      'add action',
-      'configure action',
-      'configure step',
-    ],
-    tools: ['ap_add_step', 'ap_build_flow'],
-  },
-  {
-    keywords: ['validate', 'test', 'fix'],
-    tools: [
-      'ap_validate_flow',
-      'ap_validate_step_config',
-      'ap_test_flow',
-      'ap_test_step',
-      'ap_update_step',
-      'ap_update_trigger',
-    ],
-  },
-  {
-    keywords: ['note', 'notes', 'add note', 'summary note'],
-    tools: ['ap_manage_notes'],
-  },
-  {
-    keywords: ['publish', 'enable', 'activate', 'draft'],
-    tools: ['ap_lock_and_publish', 'ap_change_flow_status'],
-  },
-];
-
-function deriveStepStatus({
-  stepText,
-  toolParts,
-}: {
-  stepText: string;
-  toolParts: AnyToolPart[];
-}): 'pending' | 'executing' | 'done' {
-  const lower = stepText.toLowerCase();
-  const category = STEP_CATEGORIES.find((c) =>
-    c.keywords.some((kw) => {
-      const idx = lower.indexOf(kw);
-      if (idx === -1) return false;
-      const before = idx === 0 || /\W/.test(lower[idx - 1]);
-      const after =
-        idx + kw.length >= lower.length || /\W/.test(lower[idx + kw.length]);
-      return before && after;
-    }),
-  );
-
-  if (!category) return 'pending';
-
-  const matchingTools = toolParts.filter((p) => {
-    const name = chatPartUtils.getToolPartName(p);
-    return category.tools.some((t) => name === t);
-  });
-
-  if (matchingTools.length === 0) return 'pending';
-  if (matchingTools.some((t) => t.state === 'output-available')) return 'done';
-  if (
-    matchingTools.some(
-      (t) => t.state === 'input-available' || t.state === 'input-streaming',
-    )
-  )
-    return 'executing';
-  return 'pending';
-}
-
 function extractPlanFromToolParts(
   message: ChatUIMessage | undefined,
 ): PlanProgressData | null {
@@ -310,24 +227,10 @@ function selectPlanProgress({
 
 function selectEffectivePlanUpdates({
   state,
-  lastAssistantMessage,
 }: {
   state: ChatStoreState;
-  lastAssistantMessage: ChatUIMessage | undefined;
 }): PlanStepUpdate[] {
-  const progress = selectPlanProgress({ state, lastAssistantMessage });
-  if (!progress || !lastAssistantMessage) return [];
-
-  const toolParts = lastAssistantMessage.parts.filter((p): p is AnyToolPart =>
-    chatPartUtils.isAnyToolPart(p),
-  );
-
-  if (toolParts.length === 0) return state.planProgressUpdates;
-
-  return progress.steps.map((stepText, i) => ({
-    stepIndex: i,
-    status: deriveStepStatus({ stepText, toolParts }),
-  }));
+  return state.planProgressUpdates;
 }
 
 function selectShouldShowPlan({
@@ -345,7 +248,7 @@ function selectShouldShowPlan({
   if (progress === null) return false;
 
   const planWasExecuted =
-    selectEffectivePlanUpdates({ state, lastAssistantMessage }).length > 0;
+    selectEffectivePlanUpdates({ state }).length > 0;
 
   if (!isLastAssistant) {
     return !isStreaming && planWasExecuted;
@@ -367,7 +270,6 @@ export const chatStoreSelectors = {
   planProgress: selectPlanProgress,
   effectivePlanUpdates: selectEffectivePlanUpdates,
   shouldShowPlan: selectShouldShowPlan,
-  deriveStepStatus,
 };
 
 export type SetChatStore = StoreApi<ChatStoreState>['setState'];

--- a/packages/web/src/features/chat/lib/chat-store.ts
+++ b/packages/web/src/features/chat/lib/chat-store.ts
@@ -247,8 +247,14 @@ function selectShouldShowPlan({
   const progress = selectPlanProgress({ state, lastAssistantMessage });
   if (progress === null) return false;
 
-  const planWasExecuted =
-    selectEffectivePlanUpdates({ state }).length > 0;
+  const hasLiveUpdates = selectEffectivePlanUpdates({ state }).length > 0;
+  const planToolWasCompleted = lastAssistantMessage?.parts.some(
+    (p) =>
+      chatPartUtils.isAnyToolPart(p) &&
+      chatPartUtils.getToolPartName(p) === 'ap_request_plan_approval' &&
+      p.state === 'output-available',
+  ) ?? false;
+  const planWasExecuted = hasLiveUpdates || planToolWasCompleted;
 
   if (!isLastAssistant) {
     return !isStreaming && planWasExecuted;


### PR DESCRIPTION
## Summary

- Replaces fragile keyword-based plan step derivation with an explicit `ap_update_plan` tool that the AI calls to update step statuses
- Deletes `STEP_CATEGORIES`, `deriveStepStatus`, and `planExecution.trackStep` (~120 lines removed)
- The AI now drives plan progress directly — no NLP guessing needed

## Changes

**Worker:**
- Add `ap_update_plan` tool — AI calls it with `{stepIndex, status}` to mark steps as executing/done/error
- Remove `planExecution` object, `planStepCounter`, `trackStep` wrapping from MCP tools
- Remove `PlanExecution` type from `chat-mcp-client.ts`
- Simplify `withApprovalGates` — takes `isApproved` callback instead of full `PlanExecution`

**Frontend:**
- Delete `STEP_CATEGORIES` table (6 categories of keywords/tools)
- Delete `deriveStepStatus` function (keyword matching logic)
- Simplify `selectEffectivePlanUpdates` to just return `state.planProgressUpdates`
- Remove `message` prop from `InlinePlanCard` (no longer scans tool parts)
- Remove keyword-based fallback from `updates` useMemo

**Prompt:**
- Add instruction to call `ap_update_plan` before/after each step during execution

## Test plan
- [ ] Send "create a flow that forwards gmail to slack" → approve plan → verify steps update to executing/done as agent works
- [ ] Verify plan card renders correctly with `ap_build_flow` (single tool does all build steps)
- [ ] Verify plan card works with granular tools (ap_create_flow + ap_add_step)