### PR TITLE
fix(chat): preserve thinking blocks for providers that support them

### DIFF
--- a/packages/server/utils/src/chat-ai-utils.ts
+++ b/packages/server/utils/src/chat-ai-utils.ts
@@ -85,7 +85,16 @@ function createChatModel({ provider, auth, config, modelId }: {
     }
 }
 
-function stripThinkingBlocks(messages: ModelMessage[]): ModelMessage[] {
+const THINKING_PROVIDERS = new Set([
+    AIProviderName.ANTHROPIC,
+    AIProviderName.BEDROCK,
+    AIProviderName.OPENROUTER,
+    AIProviderName.ACTIVEPIECES,
+])
+
+function stripThinkingBlocks(messages: ModelMessage[], provider: AIProviderName): ModelMessage[] {
+    if (THINKING_PROVIDERS.has(provider)) return messages
+
     const hasThinking = messages.some(
         (msg) => msg.role === 'assistant' && Array.isArray(msg.content)
             && (msg.content as Array<Record<string, unknown>>).some(

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -106,7 +106,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             })
             const allTools = { ...localTools, ...displayTools, ...crossProjectTools, ...planTools, ...(gatedMcpTools as Record<string, typeof localTools[keyof typeof localTools]>) }
 
-            const sanitizedMessages = chatAiUtils.stripThinkingBlocks(config.messages as ModelMessage[])
+            const sanitizedMessages = chatAiUtils.stripThinkingBlocks(config.messages as ModelMessage[], config.provider as AIProviderName)
             const systemPrompt = chatAiUtils.buildSystemPromptWithCaching({
                 systemPrompt: config.systemPrompt,
                 provider: config.provider as AIProviderName,


### PR DESCRIPTION
## Summary

- `stripThinkingBlocks` was unconditionally removing all reasoning/thinking parts before every `streamText` call
- This broke Anthropic extended thinking continuity (Claude couldn't see its own prior reasoning across turns)
- Also invalidated prompt caching (content changes every turn → cache miss)

## Fix

Make `stripThinkingBlocks` provider-aware. Only strip for providers that don't support thinking:

- **Preserved**: Anthropic, Bedrock, OpenRouter, Activepieces
- **Stripped**: OpenAI, Google, Azure, Cloudflare Gateway, Custom

2 files changed, +11/-2 lines.

## Test plan
- [ ] Send multi-turn conversation with Anthropic → verify reasoning blocks preserved in DB `messages` column across turns
- [ ] Send message with OpenAI provider → verify reasoning blocks still stripped
- [ ] Verify prompt caching works (check Anthropic usage for cache hits on subsequent turns)