### PR TITLE
feat(chat): split ap_run_one_time_action into discover + execute

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1868,7 +1868,7 @@
     },
     "packages/pieces/community/connectuc": {
       "name": "@activepieces/piece-connectuc",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3474,7 +3474,7 @@
     },
     "packages/pieces/community/hootsuite": {
       "name": "@activepieces/piece-hootsuite",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -5360,7 +5360,7 @@
     },
     "packages/pieces/community/pdf4me": {
       "name": "@activepieces/piece-pdf4me",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -8397,6 +8397,15 @@
       "version": "0.1.3",
       "dependencies": {
         "@activepieces/shared": "workspace:*",
+        "@ai-sdk/amazon-bedrock": "3.0.97",
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/azure": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/openai-compatible": "2.0.16",
+        "@ai-sdk/provider": "^3.0.0",
+        "@openrouter/ai-sdk-provider": "2.1.1",
+        "ai": "^6.0.0",
         "async-mutex": "0.4.0",
         "axios": "1.15.2",
         "axios-retry": "4.4.1",
@@ -8418,6 +8427,15 @@
         "@activepieces/pieces-framework": "workspace:*",
         "@activepieces/server-utils": "workspace:*",
         "@activepieces/shared": "workspace:*",
+        "@ai-sdk/amazon-bedrock": "3.0.97",
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/azure": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/mcp": "1.0.11",
+        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/openai-compatible": "2.0.16",
+        "@ai-sdk/provider": "^3.0.0",
+        "@openrouter/ai-sdk-provider": "2.1.1",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/auto-instrumentations-node": "0.75.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.206.0",
@@ -8425,6 +8443,7 @@
         "@opentelemetry/sdk-node": "0.217.0",
         "@opentelemetry/sdk-trace-base": "2.1.0",
         "@opentelemetry/semantic-conventions": "1.37.0",
+        "ai": "^6.0.0",
         "async-mutex": "0.4.0",
         "dayjs": "1.11.9",
         "dotenv": "16.4.7",
@@ -8447,7 +8466,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.76.9",
+      "version": "0.77.1",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",

--- a/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
+++ b/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
@@ -203,6 +203,10 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
             const connectionExternalId = toolInput.connectionExternalId as string | undefined
             const projectId = toolInput.projectId as string | undefined
 
+            const resolvedProjectId = projectId ?? projects[0]?.id
+            if (!resolvedProjectId) {
+                return { success: false, error: 'No projects available. Create a project first.' }
+            }
             if (projectId && !availableProjectIds.includes(projectId)) {
                 return { success: false, error: `Project ${projectId} is not accessible.` }
             }
@@ -214,7 +218,7 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
                 }
             }
             return executeAdhocAction({
-                projectId: projectId ?? projects[0]?.id,
+                projectId: resolvedProjectId,
                 pieceName,
                 actionName,
                 input: parsedInput as Record<string, unknown> | undefined,

--- a/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
+++ b/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
@@ -194,16 +194,16 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
     const availableProjectIds = projects.map((p) => p.id)
 
     switch (toolName) {
+        case 'ap_discover_action_auth': {
+            return findConnectionsForPiece({ pieceName: toolInput.pieceName as string, projects, platformId, log })
+        }
         case 'ap_run_one_time_action': {
             const pieceName = toolInput.pieceName as string
             const actionName = toolInput.actionName as string
             const connectionExternalId = toolInput.connectionExternalId as string | undefined
             const projectId = toolInput.projectId as string | undefined
 
-            if (!connectionExternalId || !projectId) {
-                return findConnectionsForPiece({ pieceName, projects, platformId, log })
-            }
-            if (!availableProjectIds.includes(projectId)) {
+            if (projectId && !availableProjectIds.includes(projectId)) {
                 return { success: false, error: `Project ${projectId} is not accessible.` }
             }
             let parsedInput = toolInput.input
@@ -214,7 +214,7 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
                 }
             }
             return executeAdhocAction({
-                projectId,
+                projectId: projectId ?? projects[0]?.id,
                 pieceName,
                 actionName,
                 input: parsedInput as Record<string, unknown> | undefined,

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -18,7 +18,7 @@ Your available projects:
 6. Never call the same tool twice for the same data in one response.
 7. After every step mutation (`ap_add_step`, `ap_update_step`, `ap_update_trigger`), call `ap_validate_step_config` on that step immediately. Fix and re-validate if it fails.
 8. Use display tools for interactive UI — never ask questions in prose text.
-9. One-time tasks use `ap_run_one_time_action`, never `ap_run_action`.
+9. One-time tasks: use `ap_discover_action_auth` to check auth, then `ap_run_one_time_action` to execute. Never use `ap_run_action`.
 10. Projects are invisible to the user unless building an automation or they ask.
 11. After completing a task, summarize in 1-2 sentences with resource links.
 12. Always include 1-2 sentences of visible text in your final response.
@@ -84,13 +84,13 @@ Gather ALL information before presenting the plan. Once approved, execute withou
 For one-shot tasks (send a message, check email, look up data):
 
 1. `ap_list_across_projects` with resource "connections" to find accounts.
-2. `ap_run_one_time_action` with pieceName and actionName (omit connectionExternalId).
-   - `noAuthRequired: true` → call again with input to execute.
-   - `needsConnection: true` → `ap_show_connection_required`.
+2. `ap_discover_action_auth` with pieceName and actionName.
+   - `noAuthRequired: true` → skip to step 5.
+   - `needsConnection: true` → `ap_show_connection_required`. Wait.
    - `pickConnection: true` → `ap_show_connection_picker`. Wait.
 3. After user picks, `ap_get_piece_props` with auth externalId.
 4. Fill fields (use IDs for dropdowns). For read actions, use broad defaults.
-5. Execute with `ap_run_one_time_action` including projectId and connectionExternalId.
+5. `ap_run_one_time_action` with pieceName, actionName, input, projectId, connectionExternalId.
 
 Read actions: broadest filter, show results, offer to refine.
 Write actions: execute if enough detail.

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -84,7 +84,7 @@ Gather ALL information before presenting the plan. Once approved, execute withou
 For one-shot tasks (send a message, check email, look up data):
 
 1. `ap_list_across_projects` with resource "connections" to find accounts.
-2. `ap_discover_action_auth` with pieceName and actionName.
+2. `ap_discover_action_auth` with pieceName.
    - `noAuthRequired: true` → skip to step 5.
    - `needsConnection: true` → `ap_show_connection_required`. Wait.
    - `pickConnection: true` → `ap_show_connection_picker`. Wait.

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -152,8 +152,19 @@ function createCrossProjectTools({ executeTool }: {
     executeTool: (toolName: string, toolInput: Record<string, unknown>) => Promise<unknown>
 }): ToolSet {
     return {
+        ap_discover_action_auth: tool({
+            description: 'Check what authentication a piece action needs and find available connections. Call this BEFORE ap_run_one_time_action to determine if auth is needed.',
+            inputSchema: z.object({
+                pieceName: z.string().describe('Piece name, e.g. "@activepieces/piece-gmail"'),
+                actionName: z.string().describe('Action name, e.g. "gmail_search_mail"'),
+            }),
+            execute: async (input) => {
+                return executeTool('ap_discover_action_auth', input)
+            },
+        }),
+
         ap_run_one_time_action: tool({
-            description: 'Execute a single piece action once for one-time tasks like "check my inbox" or "send a Slack message". If the piece needs auth and no connectionExternalId is provided, returns connection data. If no connections exist, call ap_show_connection_required. If multiple exist, call ap_show_connection_picker.',
+            description: 'Execute a piece action once. Use ap_discover_action_auth first to check if auth is needed. If the action requires auth, provide connectionExternalId and projectId.',
             inputSchema: z.object({
                 pieceName: z.string().describe('Piece name, e.g. "@activepieces/piece-gmail"'),
                 actionName: z.string().describe('Action to run, e.g. "gmail_search_mail"'),

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -153,10 +153,9 @@ function createCrossProjectTools({ executeTool }: {
 }): ToolSet {
     return {
         ap_discover_action_auth: tool({
-            description: 'Check what authentication a piece action needs and find available connections. Call this BEFORE ap_run_one_time_action to determine if auth is needed.',
+            description: 'Check what authentication a piece needs and find available connections. Call this BEFORE ap_run_one_time_action to determine if auth is needed.',
             inputSchema: z.object({
                 pieceName: z.string().describe('Piece name, e.g. "@activepieces/piece-gmail"'),
-                actionName: z.string().describe('Action name, e.g. "gmail_search_mail"'),
             }),
             execute: async (input) => {
                 return executeTool('ap_discover_action_auth', input)


### PR DESCRIPTION
## Summary

`ap_run_one_time_action` returned 4 different shapes depending on inputs — it was both a discovery tool and an execution tool, with a multi-step protocol encoded in its semantics. Split into two clean, single-purpose tools.

## New tools

**`ap_discover_action_auth`** (discovery only)
- Input: `{ pieceName, actionName }`
- Returns: `noAuthRequired`, `needsConnection`, or `pickConnection` with available connections
- Never executes anything

**`ap_run_one_time_action`** (execution only)
- Input: `{ pieceName, actionName, input?, connectionExternalId?, projectId? }`
- Always executes the action
- Fails clearly if auth is missing

## Changes
- `chat-worker-tools.ts` — add `ap_discover_action_auth` tool, update `ap_run_one_time_action` description
- `chat-tools.ts` — add `ap_discover_action_auth` case in API handler, remove discovery branch from `ap_run_one_time_action`
- `chat-system-prompt.md` — update `<one_time_tasks>` workflow and rule 9

## Test plan
- [ ] "Check my gmail" → AI calls `ap_discover_action_auth` → gets connections → shows picker → user picks → AI calls `ap_run_one_time_action`
- [ ] Piece with no auth → `ap_discover_action_auth` returns `noAuthRequired` → AI calls `ap_run_one_time_action` directly
- [ ] Missing auth on execute → clear error instead of silent discovery response