### PR TITLE
fix(chat): eliminate Redis project selection for chat, use Postgres

### DIFF
--- a/packages/server/api/src/app/ee/chat/chat-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/chat/chat-rpc-handlers.ts
@@ -19,7 +19,6 @@ import { ModelMessage } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { system } from '../../helper/system/system'
 import { AppSystemProp } from '../../helper/system/system-props'
-import { mcpProjectSelection } from '../../mcp/mcp-project-selection'
 import { chatApprovalGate } from './chat-approval-gate'
 import { chatCompaction } from './chat-compaction'
 import { buildUserContentWithFiles } from './chat-file-utils'
@@ -66,14 +65,6 @@ export const chatRpcHandlers = (log: FastifyBaseLogger) => ({
         const previousMessages = conversation.messages as ModelMessage[]
         const newUserMessage: ModelMessage = { role: 'user' as const, content: userContent }
         const allMessages = [...previousMessages, newUserMessage]
-
-        const selectionScope = { conversationId }
-        if (selectedProjectId) {
-            await mcpProjectSelection.set({ scope: selectionScope, projectId: selectedProjectId })
-        }
-        else {
-            await mcpProjectSelection.clear(selectionScope)
-        }
 
         const previousUiMessages = (conversation.uiMessages ?? []) as PersistedChatMessage[]
         const uiMessagesWithUser: PersistedChatMessage[] = [
@@ -165,13 +156,6 @@ export const chatRpcHandlers = (log: FastifyBaseLogger) => ({
 
     async updateProjectContext(input: UpdateProjectContextRequest): Promise<void> {
         await chatHelpers.conversationRepo().update(input.conversationId, { projectId: input.projectId })
-        const scope = { conversationId: input.conversationId }
-        if (input.projectId) {
-            await mcpProjectSelection.set({ scope, projectId: input.projectId })
-        }
-        else {
-            await mcpProjectSelection.clear(scope)
-        }
     },
 
     async executeChatTool(input: ExecuteChatToolRequest): Promise<ExecuteChatToolResponse> {

--- a/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
@@ -79,8 +79,7 @@ function registerMcpEndpoint(app: Parameters<FastifyPluginAsyncZod>[0], scope: M
         const serverMcp = conversationProjectId
             ? await mcpServerService(req.log).getPopulatedByProjectId(conversationProjectId) ?? mcp
             : mcp
-        const selectionScope = !conversationProjectId && conversationId ? { conversationId } : null
-        const { server } = await mcpServerService(req.log).buildServer({ mcp: serverMcp, userId, selectionScope })
+        const { server } = await mcpServerService(req.log).buildServer({ mcp: serverMcp, userId })
 
         const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: undefined,
@@ -152,9 +151,13 @@ async function resolveConversationProjectId({ conversationId, log }: {
     conversationId: string
     log: FastifyBaseLogger
 }): Promise<string | null> {
-    const { data: conversation } = await tryCatch(async () =>
+    const { data: conversation, error } = await tryCatch(async () =>
         chatConversationRepo().findOne({ where: { id: conversationId }, select: ['projectId'] }),
     )
+    if (error) {
+        log.warn({ err: error, conversationId }, 'DB error resolving conversation project')
+        return null
+    }
     if (!conversation) {
         log.debug({ conversationId }, 'Conversation not found for project resolution')
         return null

--- a/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
@@ -2,7 +2,9 @@ import { isNil, McpServerType, PopulatedMcpServer, TelemetryEventName, tryCatch 
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { FastifyBaseLogger } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { repoFactory } from '../../core/db/repo-factory'
 import { securityAccess } from '../../core/security/authorization/fastify-security'
+import { ChatConversationEntity } from '../../ee/chat/chat-conversation-entity'
 import { CONVERSATION_ID_HEADER } from '../../ee/chat/mcp/chat-mcp'
 import { rejectedPromiseHandler } from '../../helper/promise-handler'
 import { telemetry } from '../../helper/telemetry.utils'
@@ -71,8 +73,14 @@ function registerMcpEndpoint(app: Parameters<FastifyPluginAsyncZod>[0], scope: M
         }
 
         const conversationId = req.headers[CONVERSATION_ID_HEADER] as string | undefined
-        const selectionScope = conversationId ? { conversationId } : null
-        const { server } = await mcpServerService(req.log).buildServer({ mcp, userId, selectionScope })
+        const conversationProjectId = conversationId
+            ? await resolveConversationProjectId({ conversationId, log: req.log })
+            : null
+        const serverMcp = conversationProjectId
+            ? await mcpServerService(req.log).getPopulatedByProjectId(conversationProjectId) ?? mcp
+            : mcp
+        const selectionScope = !conversationProjectId && conversationId ? { conversationId } : null
+        const { server } = await mcpServerService(req.log).buildServer({ mcp: serverMcp, userId, selectionScope })
 
         const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: undefined,
@@ -137,6 +145,22 @@ async function resolveMcpAndUser({ identity, log }: { identity: ResolvedIdentity
 type ResolvedIdentity =
     | { type: McpServerType.PROJECT, projectId: string, userId: string }
     | { type: McpServerType.PLATFORM, platformId: string, userId: string }
+
+const chatConversationRepo = repoFactory(ChatConversationEntity)
+
+async function resolveConversationProjectId({ conversationId, log }: {
+    conversationId: string
+    log: FastifyBaseLogger
+}): Promise<string | null> {
+    const { data: conversation } = await tryCatch(async () =>
+        chatConversationRepo().findOne({ where: { id: conversationId }, select: ['projectId'] }),
+    )
+    if (!conversation) {
+        log.debug({ conversationId }, 'Conversation not found for project resolution')
+        return null
+    }
+    return conversation.projectId ?? null
+}
 
 const McpEndpointConfig = {
     config: { security: securityAccess.public() },

--- a/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
@@ -73,8 +73,8 @@ function registerMcpEndpoint(app: Parameters<FastifyPluginAsyncZod>[0], scope: M
         }
 
         const conversationId = req.headers[CONVERSATION_ID_HEADER] as string | undefined
-        const conversationProjectId = conversationId
-            ? await resolveConversationProjectId({ conversationId, log: req.log })
+        const conversationProjectId = conversationId && userId
+            ? await resolveConversationProjectId({ conversationId, userId, log: req.log })
             : null
         const serverMcp = conversationProjectId
             ? await mcpServerService(req.log).getPopulatedByProjectId(conversationProjectId) ?? mcp
@@ -147,12 +147,13 @@ type ResolvedIdentity =
 
 const chatConversationRepo = repoFactory(ChatConversationEntity)
 
-async function resolveConversationProjectId({ conversationId, log }: {
+async function resolveConversationProjectId({ conversationId, userId, log }: {
     conversationId: string
+    userId: string
     log: FastifyBaseLogger
 }): Promise<string | null> {
     const { data: conversation, error } = await tryCatch(async () =>
-        chatConversationRepo().findOne({ where: { id: conversationId }, select: ['projectId'] }),
+        chatConversationRepo().findOne({ where: { id: conversationId, userId }, select: ['projectId'] }),
     )
     if (error) {
         log.warn({ err: error, conversationId }, 'DB error resolving conversation project')


### PR DESCRIPTION
## Summary

Project ID was stored in 3 places: Postgres (`conversation.projectId`), Redis (`mcpProjectSelection`), and the system prompt. A crash between the DB write and Redis write would cause the MCP server to target the wrong project.

Now the MCP controller reads `projectId` from the conversation DB row directly (via the `x-ap-conversation-id` header already sent on every request). Redis project selection is only used for non-chat MCP clients.

## Changes

- **MCP controller:** when conversation header is present, fetch `conversation.projectId` from DB and use project-scoped MCP server directly
- **Chat RPC handlers:** remove all `mcpProjectSelection.set/clear` calls — Postgres is the single source of truth
- Non-chat MCP clients still use Redis selection (unchanged)

## Performance
- Before: 30-90 Redis round-trips per conversation turn (1 per tool call)
- After: 1 DB query per HTTP request (conversation.projectId lookup)

## Test plan
- [ ] Send message, select project → verify MCP tools execute in correct project
- [ ] Switch project mid-conversation → verify tools switch correctly
- [ ] Non-chat MCP client → verify Redis selection still works