### PR TITLE
fix(web): resolve system theme to prefers-color-scheme, not hardcoded light

### DIFF
--- a/packages/web/src/components/providers/theme-provider.tsx
+++ b/packages/web/src/components/providers/theme-provider.tsx
@@ -46,7 +46,19 @@ export function ThemeProvider({
     () => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
   );
   const [forceLightMode, setForceLightMode] = useState(false);
+  const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
+  );
   const branding = flagsHooks.useWebsiteBranding();
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => {
+      setSystemTheme(e.matches ? 'dark' : 'light');
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
   useEffect(() => {
     if (!branding) {
       console.warn('Website brand is not defined');
@@ -57,7 +69,7 @@ export function ThemeProvider({
     const resolvedTheme = forceLightMode
       ? 'light'
       : theme === 'system'
-      ? 'light'
+      ? systemTheme
       : theme;
     root.classList.remove('light', 'dark');
     document.title = branding.websiteName;
@@ -95,7 +107,7 @@ export function ThemeProvider({
     }
 
     root.classList.add(resolvedTheme);
-  }, [theme, branding, forceLightMode]);
+  }, [theme, branding, forceLightMode, systemTheme]);
 
   const value = {
     theme,


### PR DESCRIPTION
## What this changes\nSystem theme mode now follows OS dark/light mode changes instead of always defaulting to light.\n\n## Why\nWhen theme was set to "System", ThemeProvider hardcoded the resolved theme to "light" regardless of the OS preference (prefers-color-scheme). Users on dark mode never saw dark mode when using the System setting.\n\n## How\nAdded a matchMedia listener that tracks the OS color scheme preference. The resolved theme now uses this value when theme is "system", and auto-updates when the OS switches modes via a change event listener.\n\n## Testing\nSet theme to "System", toggle macOS between dark/light mode, verify UI follows. Manual "Dark"/"Light" settings remain unchanged (they bypass the system branch entirely).\n\n## Notes\nFixes #13163