### PR TITLE
feat(chat): improve streaming reliability, thinking UI, and connection handling

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -1,7 +1,7 @@
 # Chat Module
 
 ## Summary
-A platform-level AI chat assistant that lets users interact with an LLM to manage their Activepieces projects through natural language. The chat connects to the platform's configured AI provider, streams responses via the Vercel AI SDK, and exposes Activepieces resources (flows, tables, connections, runs) as callable tools through the project's MCP server. Conversations are persisted per-user with support for message compaction, file attachments, multi-project context switching, plan approval for multi-step operations, and a tool approval gate for destructive operations.
+A platform-level AI chat assistant that lets users interact with an LLM to manage their Activepieces projects through natural language. The chat connects to the platform's configured AI provider, streams responses via a custom WebSocket chunk reducer, and exposes Activepieces resources (flows, tables, connections, runs) as callable tools through the project's MCP server. Conversations are persisted per-user with support for message compaction, file attachments, multi-project context switching, plan approval for multi-step operations, and a tool approval gate for destructive operations.
 
 ## Key Files
 - `packages/server/api/src/app/ee/chat/chat.module.ts` — module registration with `chatEnabled` plan gate
@@ -28,7 +28,9 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - `packages/web/src/features/chat/lib/chat-api.ts` — API client for `/v1/chat/*` endpoints
 - `packages/web/src/features/chat/lib/chat-store.ts` — Zustand store for interaction state (approvals, plan progress, display cards, thinking panel)
 - `packages/web/src/features/chat/lib/chat-store-context.tsx` — React context provider and `useChatStoreContext` selector hook
-- `packages/web/src/features/chat/lib/use-chat.ts` — `useAgentChat()` hook bridging AI SDK transport to Zustand store
+- `packages/web/src/features/chat/lib/use-chat.ts` — `useAgentChat()` hook managing message state (persisted, optimistic, streaming) and polling fallback
+- `packages/web/src/features/chat/lib/chunk-reducer.ts` — pure streaming state machine that accumulates `UIMessageChunk` events into a `ChatUIMessage`
+- `packages/web/src/features/chat/lib/use-streaming-reducer.ts` — WebSocket-driven streaming lifecycle hook; buffers chunks and throttles React re-renders
 - `packages/web/src/features/chat/lib/chat-types.ts` — frontend type definitions, tool output parsing, display/hidden tool name sets
 - `packages/web/src/features/chat/lib/use-voice-input.ts` — `useVoiceInput()` hook for speech-to-text via the Web Speech API (`SpeechRecognition`)
 - `packages/web/src/features/chat/lib/use-tts.ts` — `useTts()` hook for text-to-speech via the `SpeechSynthesis` API

--- a/bun.lock
+++ b/bun.lock
@@ -8466,7 +8466,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.77.1",
+      "version": "0.78.0",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",
@@ -8497,7 +8497,6 @@
       "dependencies": {
         "@activepieces/pieces-framework": "workspace:*",
         "@activepieces/shared": "workspace:*",
-        "@ai-sdk/react": "3.0.156",
         "@codemirror/commands": "6.10.3",
         "@codemirror/lang-javascript": "6.2.2",
         "@codemirror/lang-json": "6.0.1",
@@ -10112,8 +10111,6 @@
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.9", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-/ngMKqKdL9dSlY/eQ3NFDzzFyw0Hix+cbFFlyuKEKcOgpHdBt/spKUvX/i0wGrDLFPYJeVvv3N0j92LxWRL7yQ=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.24", "", { "dependencies": { "@ai-sdk/provider": "3.0.9", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oXIw1oLmuBILuvHgSj6w5LOV8oSnFRouPSv0MGkG9sRMeukZ9JnMF17kldaRQaRq8lSJIxo6aS3NzWlVmSb+4Q=="],
-
-    "@ai-sdk/react": ["@ai-sdk/react@3.0.156", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.23", "ai": "6.0.154", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-/6rmGxOJlCNS6wJBUNsO49aeSK740fS2wVcA3Xn8IOBRFFz3hWm6auQTMoA0nHKu4hnH6ivA6hog6Ul+1Bv4Rg=="],
 
     "@ai-sdk/replicate": ["@ai-sdk/replicate@2.0.8", "", { "dependencies": { "@ai-sdk/provider": "3.0.4", "@ai-sdk/provider-utils": "4.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Y+nlRIK80XXvkScHT/wqWmYk7GNL+6+CK6YkTWj4jF2BX/1sVNXBGmxQ7BSeRrqOpgUuJOCPV6lbLbsUPcSMgg=="],
 
@@ -15251,8 +15248,6 @@
 
     "svix": ["svix@1.92.2", "", { "dependencies": { "standardwebhooks": "1.0.0" } }, "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ=="],
 
-    "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
-
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "symlink-or-copy": ["symlink-or-copy@1.3.1", "", {}, "sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA=="],
@@ -15296,8 +15291,6 @@
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
     "throttle-debounce": ["throttle-debounce@3.0.1", "", {}, "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="],
-
-    "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
@@ -15844,10 +15837,6 @@
     "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.8", "", { "dependencies": { "@ai-sdk/provider": "3.0.4", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ns9gN7MmpI8vTRandzgz+KK/zNMLzhrriiKECMt4euLtQFSBgNfydtagPOX4j4pS1/3KvHF6RivhT3gNQgBZsg=="],
 
     "@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
-
-    "@ai-sdk/react/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
-
-    "@ai-sdk/react/ai": ["ai@6.0.154", "", { "dependencies": { "@ai-sdk/gateway": "3.0.94", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HfKJKCTJsDZxqrIUDSVnBQ7DpQlx5WI4ExqtLd7Bl70epLmvkpc/HYMzU1hP9W+g9VEAcvZo4fbMqc3v5D+9gQ=="],
 
     "@ai-sdk/replicate/@ai-sdk/provider": ["@ai-sdk/provider@3.0.4", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ=="],
 
@@ -18457,14 +18446,6 @@
 
     "@ai-sdk/openai-compatible/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
-    "@ai-sdk/react/@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
-
-    "@ai-sdk/react/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
-
-    "@ai-sdk/react/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.94", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uDDwLZhCkvC89crVS3S90D5L7AcVN8WriGuYVNYgVAaVcvy3Mthy3R9ICfzG75BObhz6pm2FWnhxDfNRK+t69Q=="],
-
-    "@ai-sdk/react/ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
-
     "@ai-sdk/replicate/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "@anthropic-ai/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
@@ -20030,8 +20011,6 @@
     "@ai-sdk/google-vertex/google-auth-library/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "@ai-sdk/google-vertex/google-auth-library/jws/jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
-
-    "@ai-sdk/react/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
     "@atlaskit/adf-utils/@atlaskit/adf-schema/linkify-it/uc.micro": ["uc.micro@1.0.6", "", {}, "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="],
 

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -51,7 +51,7 @@ Gather ALL information before presenting the plan. Once approved, execute withou
 
 **2 — GATHER INFO** (each sub-step may require user input):
 - **Project**: one → select silently; multiple → `ap_show_project_picker`.
-- **Connections**: `ap_list_connections` ONCE. One active → use it. Multiple → `ap_show_connection_picker`. None/error → `ap_show_connection_required`. Never re-show a picker the user already answered.
+- **Connections**: `ap_list_connections` ONCE. Active connections found → `ap_show_connection_picker` (even if only one — always let the user confirm). None/error → `ap_show_connection_required`. If user cannot connect → use HTTP piece with inline auth for that step (see `<http_fallback>`). Never re-show a picker the user already answered.
 - **Config**: unresolved fields → `ap_get_piece_props` + `ap_resolve_property_options` → `ap_show_questions`.
 
 **3 — PLAN**: `ap_request_plan_approval` with summary and steps. Steps MUST match what you will actually do:
@@ -88,14 +88,17 @@ For one-shot tasks (send a message, check email, look up data):
 2. `ap_discover_action_auth` with pieceName.
    - `noAuthRequired: true` → skip to step 5.
    - `needsConnection: true` → `ap_show_connection_required`. Wait.
-   - `pickConnection: true` → `ap_show_connection_picker`. Wait.
+     - If user cannot or declines to connect → offer HTTP fallback (see `<http_fallback>`).
+   - `pickConnection: true` → check connection statuses.
+     - All connections in ERROR → suggest reconnecting first. If user can't → offer HTTP fallback.
+     - At least one healthy → `ap_show_connection_picker`. Wait. Always show the picker, even for a single connection.
 3. After user picks, `ap_get_piece_props` with auth externalId.
 4. Fill fields (use IDs for dropdowns). For read actions, use broad defaults.
 5. `ap_run_one_time_action` with pieceName, actionName, input, projectId, connectionExternalId.
 
 Read actions: broadest filter, show results, offer to refine.
 Write actions: execute if enough detail.
-On failure: retry up to 3 times with different approaches.
+On failure: retry up to 3 times with different approaches. If piece action keeps failing due to auth issues, offer HTTP fallback.
 On success: include an automation suggestion in quick replies (e.g., "Turn this into a flow", "No thanks"). If the user accepts, follow `<one_time_to_flow>`.
 </one_time_tasks>
 
@@ -107,6 +110,24 @@ When converting a one-time task into a recurring flow:
 3. **Reuse context**: same piece, action, connection, and inputs from the one-time task.
 4. **Plan and build**: follow `<automation_build>` steps 3-4. Use `ap_build_flow` for simple flows.
 </one_time_to_flow>
+
+<http_fallback>
+When a piece connection is unavailable and the user cannot or declines to create one, use the HTTP piece (`@activepieces/piece-http`, action `send_request`) as a direct replacement. Never get stuck — always find a way to complete the task.
+
+1. Identify the API endpoint from the piece/action name (e.g., `gmail` → Gmail API, `slack` → Slack API).
+2. Ask the user for their auth credentials via `ap_show_questions`:
+   - OAuth2 pieces → ask for a Bearer Token (user can get one from the service's developer console).
+   - API Key pieces → ask for the API key.
+   - Basic Auth pieces → ask for username and password.
+3. Build the HTTP request with `ap_run_one_time_action`:
+   - **pieceName**: `@activepieces/piece-http`
+   - **actionName**: `send_request`
+   - **input**: `{ method, url, headers, body, authentication }` matching the original action's API call.
+   - No connectionExternalId needed.
+4. For automation builds, use the HTTP piece step with the same inline auth pattern.
+
+Always explain to the user: "Since we don't have a [Piece] connection set up, I'll call the [Service] API directly using HTTP."
+</http_fallback>
 
 <links>
 - Flows: {{FRONTEND_URL}}/projects/{projectId}/flows/{flowId}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/shared/src/lib/management/ai-providers/index.ts
@@ -380,8 +380,8 @@ function getMaxContextTokens({ provider }: { provider: AIProviderName | undefine
 
 export const ACTIVEPIECES_CHAT_TIERS = [
     { id: 'fast', label: 'Fast', modelId: 'anthropic/claude-opus-4.7', thinkingBudget: 5_000 },
-    { id: 'smart', label: 'Smart', modelId: 'anthropic/claude-opus-4.7', thinkingBudget: 10_000 },
-    { id: 'premium', label: 'Premium', modelId: 'anthropic/claude-opus-4.7', thinkingBudget: 20_000 },
+    { id: 'smart', label: 'Expert', modelId: 'anthropic/claude-opus-4.7', thinkingBudget: 10_000 },
+    { id: 'premium', label: 'Heavy', modelId: 'anthropic/claude-opus-4.7', thinkingBudget: 20_000 },
 ] as const
 
 export const DEFAULT_CHAT_TIER_ID = 'smart' as const

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@activepieces/pieces-framework": "workspace:*",
     "@activepieces/shared": "workspace:*",
-    "@ai-sdk/react": "3.0.156",
     "@codemirror/commands": "6.10.3",
     "@codemirror/lang-javascript": "6.2.2",
     "@codemirror/lang-json": "6.0.1",

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -236,5 +236,5 @@ type AIChatBoxProps = {
   incognito: boolean;
   conversationId?: string | null;
   onConversationCreated?: (conversationId: string) => void;
-  onTitleUpdate?: (title: string, conversationId?: string) => void;
+  onTitleUpdate?: (title: string) => void;
 };

--- a/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
@@ -63,86 +63,84 @@ export function ThinkingBlock({
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, ease: 'easeOut' }}
     >
-      {isStreaming ? (
-        <div>
-          <TextShimmer className="text-sm" duration={3}>
-            {t('Thinking...')}
-          </TextShimmer>
-
-          {lastStep && (
-            <div className="mt-3 ml-1">
-              <AnimatePresence mode="wait">
-                <motion.div
-                  key={`step-${lastStepIdx}`}
-                  initial={{ opacity: 0, y: 4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.3 }}
-                >
-                  <StepRenderer
-                    step={lastStep}
-                    showConnector={false}
-                    isStreaming={true}
-                    showIcon={false}
-                  />
-                </motion.div>
-              </AnimatePresence>
-            </div>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <button
+          type="button"
+          disabled={!isExpandable}
+          onClick={() => setIsOpen(!isOpen)}
+          className={cn(
+            'flex items-center gap-1.5 text-sm text-muted-foreground text-left w-full',
+            isExpandable &&
+              'hover:text-foreground transition-colors cursor-pointer',
           )}
-        </div>
-      ) : (
-        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-          <button
-            type="button"
-            disabled={!isExpandable}
-            onClick={() => setIsOpen(!isOpen)}
-            className={cn(
-              'flex items-center gap-1.5 text-sm text-muted-foreground text-left w-full',
-              isExpandable &&
-                'hover:text-foreground transition-colors cursor-pointer',
-            )}
-          >
+        >
+          {isStreaming ? (
+            <TextShimmer className="text-sm" duration={3}>
+              {t('Thinking...')}
+            </TextShimmer>
+          ) : (
             <span>{doneLabel}</span>
-            {isExpandable && (
-              <ChevronDown
-                className={cn(
-                  'size-4 shrink-0 text-muted-foreground/50 transition-transform',
-                  isOpen && 'rotate-180',
-                )}
-              />
-            )}
-          </button>
-
-          <CollapsibleContent className="data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down overflow-hidden">
-            <div className="mt-3 ml-1">
-              {thinkingSteps.map((step, idx) => (
-                <StepRenderer
-                  key={
-                    step.kind === 'tool'
-                      ? step.part.toolCallId
-                      : `${step.kind}-${idx}`
-                  }
-                  step={step}
-                  showConnector={true}
-                  isStreaming={false}
-                  showIcon={true}
-                />
-              ))}
-
-              {hasSteps && (
-                <div className="flex gap-3 items-center">
-                  <div className="flex items-center justify-center size-5 rounded-full bg-muted">
-                    <Check className="size-3 text-muted-foreground" />
-                  </div>
-                  <span className="text-xs text-muted-foreground">
-                    {t('Done')}
-                  </span>
-                </div>
+          )}
+          {isExpandable && (
+            <ChevronDown
+              className={cn(
+                'size-4 shrink-0 text-muted-foreground/50 transition-transform',
+                isOpen && 'rotate-180',
               )}
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+            />
+          )}
+        </button>
+
+        {!isOpen && isStreaming && lastStep && (
+          <div className="mt-3 ml-1">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={`step-${lastStepIdx}`}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.3 }}
+              >
+                <StepRenderer
+                  step={lastStep}
+                  showConnector={false}
+                  isStreaming={true}
+                  showIcon={false}
+                />
+              </motion.div>
+            </AnimatePresence>
+          </div>
+        )}
+
+        <CollapsibleContent className="data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down overflow-hidden">
+          <div className="mt-3 ml-1">
+            {thinkingSteps.map((step, idx) => (
+              <StepRenderer
+                key={
+                  step.kind === 'tool'
+                    ? step.part.toolCallId
+                    : `${step.kind}-${idx}`
+                }
+                step={step}
+                showConnector={true}
+                isStreaming={isStreaming}
+                showIcon={true}
+              />
+            ))}
+
+            {!isStreaming && hasSteps && (
+              <div className="flex gap-3 items-center">
+                <div className="flex items-center justify-center size-5 rounded-full bg-muted">
+                  <Check className="size-3 text-muted-foreground" />
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {t('Done')}
+                </span>
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
     </motion.div>
   );
 }
@@ -179,6 +177,16 @@ function StepRenderer({
         </StepLayout>
       );
     case 'thinking-status':
+      if (step.toolPart) {
+        return (
+          <ToolStep
+            part={step.toolPart}
+            showConnector={showConnector}
+            showIcon={showIcon}
+            label={step.text}
+          />
+        );
+      }
       return (
         <StepLayout
           showIcon={showIcon}
@@ -191,11 +199,6 @@ function StepRenderer({
             </TextShimmer>
           ) : (
             <p className="text-xs text-muted-foreground">{step.text}</p>
-          )}
-          {step.toolPart && (
-            <div className="mt-2">
-              <ToolCard part={step.toolPart} />
-            </div>
           )}
         </StepLayout>
       );
@@ -240,10 +243,12 @@ function ToolStep({
   part,
   showConnector,
   showIcon,
+  label,
 }: {
   part: AnyToolPart;
   showConnector: boolean;
   showIcon: boolean;
+  label?: string;
 }) {
   const status = chatPartUtils.deriveToolStatus(part);
   const icon =
@@ -251,12 +256,12 @@ function ToolStep({
 
   return (
     <StepLayout showIcon={showIcon} showConnector={showConnector} icon={icon}>
-      <ToolCard part={part} />
+      <ToolCard part={part} label={label} />
     </StepLayout>
   );
 }
 
-function ToolCard({ part }: { part: AnyToolPart }) {
+function ToolCard({ part, label }: { part: AnyToolPart; label?: string }) {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const input = isObject(part.input) ? part.input : undefined;
   const output = chatPartUtils.extractToolOutputText(part);
@@ -275,6 +280,8 @@ function ToolCard({ part }: { part: AnyToolPart }) {
     names: pieceNames,
   });
   const summary = buildToolSummary({ part });
+  const displayLabel = label ?? summary.label;
+  const primaryPiece = pieceSummaries.find((p) => p.logoUrl);
 
   return (
     <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
@@ -285,23 +292,20 @@ function ToolCard({ part }: { part: AnyToolPart }) {
         )}
         onClick={() => hasDetails && setDetailsOpen(!detailsOpen)}
       >
-        <summary.icon className="size-3 text-muted-foreground shrink-0" />
-        <span className="text-xs text-muted-foreground whitespace-nowrap">
-          {summary.label}
-        </span>
-        {pieceSummaries.map(
-          (piece) =>
-            piece.logoUrl && (
-              <PieceIcon
-                key={piece.name}
-                displayName={piece.displayName}
-                logoUrl={piece.logoUrl}
-                size="xxs"
-                border={false}
-                showTooltip={true}
-              />
-            ),
+        {primaryPiece ? (
+          <PieceIcon
+            displayName={primaryPiece.displayName}
+            logoUrl={primaryPiece.logoUrl!}
+            size="xxs"
+            border={false}
+            showTooltip={false}
+          />
+        ) : (
+          <summary.icon className="size-3 text-muted-foreground shrink-0" />
         )}
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {displayLabel}
+        </span>
         {hasDetails && (
           <ChevronDown
             className={cn(

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -58,80 +58,114 @@ export const AssistantMessage = memo(function AssistantMessage({
   onSend: (text: string, files?: File[]) => void;
   lastAssistantMessage?: ChatUIMessage;
 }) {
-  const { renderedParts, thinkingSteps, hasContent, reasoningText } =
-    useMemo(() => {
-      const rendered: RenderedPart[] = [];
-      const steps: ThinkingStep[] = [];
-      let hasText = false;
-      let reasoning = '';
-      let lastThinkingStatus: string | null = null;
+  const { blocks, hasContent } = useMemo(() => {
+    const result: MessageBlock[] = [];
+    let currentThinking: {
+      steps: ThinkingStep[];
+      reasoningText: string;
+    } | null = null;
+    let hasText = false;
+    let lastThinkingStatus: string | null = null;
 
-      for (let i = 0; i < message.parts.length; i++) {
-        const p = message.parts[i];
+    function flushThinking() {
+      if (
+        currentThinking &&
+        (currentThinking.steps.length > 0 ||
+          currentThinking.reasoningText.length > 0)
+      ) {
+        result.push({ kind: 'thinking', ...currentThinking });
+      }
+      currentThinking = null;
+    }
 
-        if (p.type === 'text' && p.text.length > 0) {
-          hasText = true;
-          rendered.push({ kind: 'text', text: p.text });
-        } else if (p.type === 'reasoning') {
-          reasoning += p.text;
-          const trimmed = p.text.trim();
-          if (trimmed) {
-            steps.push({ kind: 'reasoning', text: trimmed });
+    function ensureThinking() {
+      if (!currentThinking) {
+        currentThinking = { steps: [], reasoningText: '' };
+      }
+      return currentThinking;
+    }
+
+    for (let i = 0; i < message.parts.length; i++) {
+      const p = message.parts[i];
+
+      if (p.type === 'text' && p.text.length > 0) {
+        flushThinking();
+        hasText = true;
+        result.push({ kind: 'text', text: p.text });
+      } else if (p.type === 'reasoning') {
+        const thinking = ensureThinking();
+        thinking.reasoningText += p.text;
+        const trimmed = p.text.trim();
+        if (trimmed) {
+          thinking.steps.push({ kind: 'reasoning', text: trimmed });
+        }
+      } else if (chatPartUtils.isAnyToolPart(p)) {
+        const toolName = chatPartUtils.getToolPartName(p);
+        if (chatPartUtils.isThinkingStatusTool(toolName)) {
+          const input = p.input as { status?: string } | undefined;
+          const statusText = (input?.status ?? '').trim();
+          if (statusText) {
+            const thinking = ensureThinking();
+            thinking.steps.push({
+              kind: 'thinking-status',
+              text: statusText,
+            });
+            lastThinkingStatus = statusText;
           }
-        } else if (chatPartUtils.isAnyToolPart(p)) {
-          const toolName = chatPartUtils.getToolPartName(p);
-          if (chatPartUtils.isThinkingStatusTool(toolName)) {
-            const input = p.input as { status?: string } | undefined;
-            const statusText = (input?.status ?? '').trim();
-            if (statusText) {
-              steps.push({ kind: 'thinking-status', text: statusText });
-              lastThinkingStatus = statusText;
-            }
-            continue;
-          }
-          if (chatPartUtils.HIDDEN_TOOL_NAMES.has(toolName)) {
-            continue;
-          }
-          if (chatPartUtils.isDisplayTool(toolName)) {
-            rendered.push({ kind: 'display-tool', part: p });
-          } else if (toolName === 'ap_request_plan_approval') {
-            rendered.push({ kind: 'plan-marker', part: p });
+          continue;
+        }
+        if (chatPartUtils.HIDDEN_TOOL_NAMES.has(toolName)) {
+          continue;
+        }
+        if (chatPartUtils.isDisplayTool(toolName)) {
+          flushThinking();
+          result.push({ kind: 'display-tool', part: p });
+        } else if (toolName === 'ap_request_plan_approval') {
+          flushThinking();
+          result.push({ kind: 'plan-marker', part: p });
+        } else {
+          const thinking = ensureThinking();
+          const lastStep = thinking.steps[thinking.steps.length - 1];
+          if (
+            lastThinkingStatus &&
+            lastStep?.kind === 'thinking-status' &&
+            lastStep.text === lastThinkingStatus
+          ) {
+            thinking.steps[thinking.steps.length - 1] = {
+              ...lastStep,
+              toolPart: p,
+            };
           } else {
-            const lastStep = steps[steps.length - 1];
-            if (
-              lastThinkingStatus &&
-              lastStep?.kind === 'thinking-status' &&
-              lastStep.text === lastThinkingStatus
-            ) {
-              steps[steps.length - 1] = { ...lastStep, toolPart: p };
-            } else {
-              steps.push({ kind: 'tool', part: p });
-            }
-            lastThinkingStatus = null;
+            thinking.steps.push({ kind: 'tool', part: p });
           }
+          lastThinkingStatus = null;
         }
       }
+    }
 
-      if (isStreaming) {
-        const lastDisplayIdx = rendered.findLastIndex(
-          (r) => r.kind === 'display-tool',
-        );
-        if (lastDisplayIdx > -1) {
-          for (let j = rendered.length - 1; j >= 0; j--) {
-            if (rendered[j].kind === 'display-tool' && j !== lastDisplayIdx) {
-              rendered.splice(j, 1);
-            }
-          }
+    flushThinking();
+
+    const lastDisplayIdx = result.findLastIndex(
+      (b) => b.kind === 'display-tool',
+    );
+    if (lastDisplayIdx > -1) {
+      for (let j = result.length - 1; j >= 0; j--) {
+        if (result[j].kind === 'display-tool' && j !== lastDisplayIdx) {
+          result.splice(j, 1);
         }
       }
+    }
 
-      return {
-        renderedParts: rendered,
-        thinkingSteps: steps,
-        hasContent: hasText,
-        reasoningText: reasoning,
-      };
-    }, [message.parts, isStreaming]);
+    if (
+      isStreaming &&
+      !result.some((b) => b.kind === 'thinking') &&
+      result.length === 0
+    ) {
+      result.push({ kind: 'thinking', steps: [], reasoningText: '' });
+    }
+
+    return { blocks: result, hasContent: hasText };
+  }, [message.parts, isStreaming]);
 
   const fullText = useMemo(
     () => (isStreaming ? '' : getTextFromParts(message.parts)),
@@ -140,13 +174,11 @@ export const AssistantMessage = memo(function AssistantMessage({
 
   const { isSpeaking, isSupported: isTtsSupported, speak, stop } = useTts();
 
-  const hasPlanMarker = renderedParts.some((p) => p.kind === 'plan-marker');
-  const hasRenderedContent = renderedParts.some(
-    (p) => p.kind !== 'plan-marker',
+  const hasPlanMarker = blocks.some((b) => b.kind === 'plan-marker');
+  const hasRenderedContent = blocks.some(
+    (b) => b.kind !== 'plan-marker' && b.kind !== 'thinking',
   );
-  const hasThinkingContent =
-    thinkingSteps.length > 0 || reasoningText.length > 0;
-  const showThinking = isStreaming || hasThinkingContent;
+  const hasThinkingContent = blocks.some((b) => b.kind === 'thinking');
 
   if (
     !hasContent &&
@@ -158,40 +190,50 @@ export const AssistantMessage = memo(function AssistantMessage({
     return null;
   }
 
+  const isFromHistory = message.id.startsWith('hist-');
+  const lastThinkingIdx = blocks.findLastIndex((b) => b.kind === 'thinking');
+
   return (
     <motion.div
       className="py-3 group/msg"
-      initial={{ opacity: 0, y: 10 }}
+      initial={isFromHistory ? false : { opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
     >
       <Message>
         <div className="min-w-0 space-y-2 flex-1">
-          {showThinking && (
-            <ThinkingBlock
-              thinkingSteps={thinkingSteps}
-              reasoningText={reasoningText}
-              isStreaming={isStreaming}
-              thinkingDurationMs={
-                (message as ChatUIMessage & { thinkingDurationMs?: number })
-                  .thinkingDurationMs
-              }
-            />
-          )}
-
-          {renderedParts.map((part, i) => {
-            switch (part.kind) {
+          {blocks.map((block, i) => {
+            switch (block.kind) {
+              case 'thinking':
+                return (
+                  <ThinkingBlock
+                    key={`thinking-${i}`}
+                    thinkingSteps={block.steps}
+                    reasoningText={block.reasoningText}
+                    isStreaming={isStreaming && i === lastThinkingIdx}
+                    thinkingDurationMs={
+                      i === lastThinkingIdx
+                        ? (
+                            message as ChatUIMessage & {
+                              thinkingDurationMs?: number;
+                            }
+                          ).thinkingDurationMs
+                        : undefined
+                    }
+                  />
+                );
               case 'text':
                 return (
-                  <div key={i} className={PROSE_CLASSES}>
-                    <Markdown>{part.text}</Markdown>
+                  <div key={`text-${i}`} className={PROSE_CLASSES}>
+                    <Markdown>{block.text}</Markdown>
                   </div>
                 );
               case 'display-tool':
+                if (isStreaming) return null;
                 return (
                   <DisplayToolCard
-                    key={part.part.toolCallId}
-                    part={part.part}
+                    key={block.part.toolCallId}
+                    part={block.part}
                     onSend={onSend}
                     isInteractive={isLastMessage}
                   />
@@ -200,7 +242,7 @@ export const AssistantMessage = memo(function AssistantMessage({
                 return (
                   <InlinePlanCard
                     key={`plan-${i}`}
-                    planPart={part.part}
+                    planPart={block.part}
                     lastAssistantMessage={lastAssistantMessage}
                     isStreaming={isStreaming}
                   />
@@ -368,7 +410,12 @@ function DisplayToolCard({
   }
 }
 
-type RenderedPart =
+type MessageBlock =
+  | {
+      kind: 'thinking';
+      steps: ThinkingStep[];
+      reasoningText: string;
+    }
   | { kind: 'text'; text: string }
   | { kind: 'display-tool'; part: AnyToolPart }
   | { kind: 'plan-marker'; part: AnyToolPart };

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
@@ -73,7 +73,7 @@ export function ChatBottomBar({
     );
   }
 
-  if (hasActiveForm) {
+  if (hasActiveForm && !isStreaming) {
     return (
       <MultiQuestionForm
         key={lastMessageId}

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-input.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-input.tsx
@@ -138,6 +138,7 @@ export function ChatInput({
           </div>
         ) : (
           <PromptInputTextarea
+            autoFocus
             placeholder={placeholder ?? t('Tell me what you need...')}
             className="min-h-[44px] text-sm"
           />

--- a/packages/web/src/app/routes/chat-with-ai/components/user-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/user-message.tsx
@@ -38,10 +38,12 @@ export const UserMessage = memo(function UserMessage({
     )
     .map((p) => p.filename);
 
+  const isFromHistory = message.id.startsWith('hist-');
+
   return (
     <motion.div
       className="flex justify-end py-3 group/msg"
-      initial={{ opacity: 0, x: 16 }}
+      initial={isFromHistory ? false : { opacity: 0, x: 16 }}
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.25 }}
     >

--- a/packages/web/src/app/routes/chat-with-ai/index.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/index.tsx
@@ -67,19 +67,13 @@ export function ChatWithAIPage() {
   );
 
   const handleTitleUpdate = useCallback(
-    (title: string, conversationId?: string) => {
+    (title: string) => {
       setConversationTitle(title);
       void queryClient.invalidateQueries({
         queryKey: ['chat-conversations'],
       });
-      if (conversationId && !selectedConversationId) {
-        setPendingConversationId(null);
-        navigate(`/chat/${conversationId}`, {
-          replace: true,
-        });
-      }
     },
-    [queryClient, selectedConversationId, navigate],
+    [queryClient],
   );
 
   const handleRename = useCallback(async () => {

--- a/packages/web/src/features/chat/lib/chunk-reducer.ts
+++ b/packages/web/src/features/chat/lib/chunk-reducer.ts
@@ -1,0 +1,383 @@
+import { DynamicToolUIPart, UIMessageChunk } from 'ai';
+
+import { ChatUIMessage } from './chat-types';
+
+function createStreamingState({
+  messageId,
+}: { messageId?: string } = {}): StreamingState {
+  return {
+    message: {
+      id: messageId ?? `stream-${Date.now()}`,
+      role: 'assistant',
+      parts: [],
+    },
+    activeTextParts: {},
+    activeReasoningParts: {},
+    partialToolCalls: {},
+    seenToolCallIds: new Set(),
+  };
+}
+
+function findToolPartIndex({
+  state,
+  toolCallId,
+}: {
+  state: StreamingState;
+  toolCallId: string;
+}): number {
+  return state.message.parts.findIndex(
+    (p) =>
+      p.type === 'dynamic-tool' &&
+      'toolCallId' in p &&
+      p.toolCallId === toolCallId,
+  );
+}
+
+function updateToolPartFields({
+  state,
+  idx,
+  fields,
+}: {
+  state: StreamingState;
+  idx: number;
+  fields: Partial<
+    Pick<MutableToolPart, 'state' | 'input' | 'output' | 'errorText'>
+  >;
+}): void {
+  const part = state.message.parts[idx] as MutableToolPart;
+  if (fields.state !== undefined) part.state = fields.state;
+  if ('input' in fields) part.input = fields.input;
+  if ('output' in fields) part.output = fields.output;
+  if ('errorText' in fields) part.errorText = fields.errorText;
+}
+
+function applyChunk({
+  state,
+  chunk,
+}: {
+  state: StreamingState;
+  chunk: UIMessageChunk;
+}): void {
+  switch (chunk.type) {
+    case 'start': {
+      if (chunk.messageId) {
+        state.message.id = chunk.messageId;
+      }
+      break;
+    }
+
+    case 'text-start': {
+      const partIndex = state.message.parts.length;
+      state.message.parts.push({ type: 'text', text: '' });
+      state.activeTextParts[chunk.id] = partIndex;
+      break;
+    }
+
+    case 'text-delta': {
+      const idx = state.activeTextParts[chunk.id];
+      if (idx === undefined) break;
+      const part = state.message.parts[idx];
+      if (part?.type === 'text') {
+        part.text += chunk.delta;
+      }
+      break;
+    }
+
+    case 'text-end': {
+      delete state.activeTextParts[chunk.id];
+      break;
+    }
+
+    case 'reasoning-start': {
+      const partIndex = state.message.parts.length;
+      state.message.parts.push({ type: 'reasoning', text: '' });
+      state.activeReasoningParts[chunk.id] = partIndex;
+      break;
+    }
+
+    case 'reasoning-delta': {
+      const idx = state.activeReasoningParts[chunk.id];
+      if (idx === undefined) break;
+      const part = state.message.parts[idx];
+      if (part?.type === 'reasoning') {
+        part.text += chunk.delta;
+      }
+      break;
+    }
+
+    case 'reasoning-end': {
+      delete state.activeReasoningParts[chunk.id];
+      break;
+    }
+
+    case 'tool-input-start': {
+      if (state.seenToolCallIds.has(chunk.toolCallId)) break;
+      state.seenToolCallIds.add(chunk.toolCallId);
+
+      state.message.parts.push({
+        type: 'dynamic-tool',
+        toolCallId: chunk.toolCallId,
+        toolName: chunk.toolName,
+        title: chunk.title ?? chunk.toolName,
+        state: 'input-streaming',
+        input: undefined,
+      });
+      state.partialToolCalls[chunk.toolCallId] = {
+        toolName: chunk.toolName,
+        inputText: '',
+      };
+      break;
+    }
+
+    case 'tool-input-delta': {
+      const partial = state.partialToolCalls[chunk.toolCallId];
+      if (!partial) break;
+      partial.inputText += chunk.inputTextDelta;
+      break;
+    }
+
+    case 'tool-input-available': {
+      const idx = findToolPartIndex({ state, toolCallId: chunk.toolCallId });
+      if (idx === -1) {
+        if (state.seenToolCallIds.has(chunk.toolCallId)) break;
+        state.seenToolCallIds.add(chunk.toolCallId);
+        state.message.parts.push({
+          type: 'dynamic-tool',
+          toolCallId: chunk.toolCallId,
+          toolName: chunk.toolName,
+          title: chunk.title ?? chunk.toolName,
+          state: 'input-available',
+          input: chunk.input,
+        });
+      } else {
+        updateToolPartFields({
+          state,
+          idx,
+          fields: { state: 'input-available', input: chunk.input },
+        });
+      }
+      delete state.partialToolCalls[chunk.toolCallId];
+      break;
+    }
+
+    case 'tool-input-error': {
+      const idx = findToolPartIndex({ state, toolCallId: chunk.toolCallId });
+      if (idx === -1) {
+        state.message.parts.push({
+          type: 'dynamic-tool',
+          toolCallId: chunk.toolCallId,
+          toolName: chunk.toolName,
+          title: chunk.title ?? chunk.toolName,
+          state: 'output-error',
+          input: chunk.input,
+          errorText: chunk.errorText,
+        });
+        state.seenToolCallIds.add(chunk.toolCallId);
+      } else {
+        updateToolPartFields({
+          state,
+          idx,
+          fields: {
+            state: 'output-error',
+            input: chunk.input,
+            errorText: chunk.errorText,
+          },
+        });
+      }
+      delete state.partialToolCalls[chunk.toolCallId];
+      break;
+    }
+
+    case 'tool-output-available': {
+      const idx = findToolPartIndex({ state, toolCallId: chunk.toolCallId });
+      if (idx === -1) break;
+      updateToolPartFields({
+        state,
+        idx,
+        fields: { state: 'output-available', output: chunk.output },
+      });
+      break;
+    }
+
+    case 'tool-output-error': {
+      const idx = findToolPartIndex({ state, toolCallId: chunk.toolCallId });
+      if (idx === -1) break;
+      updateToolPartFields({
+        state,
+        idx,
+        fields: { state: 'output-error', errorText: chunk.errorText },
+      });
+      break;
+    }
+
+    case 'tool-output-denied': {
+      const idx = findToolPartIndex({ state, toolCallId: chunk.toolCallId });
+      if (idx === -1) break;
+      updateToolPartFields({ state, idx, fields: { state: 'output-denied' } });
+      break;
+    }
+
+    case 'start-step': {
+      state.message.parts.push({ type: 'step-start' });
+      break;
+    }
+
+    case 'finish-step': {
+      state.activeTextParts = {};
+      state.activeReasoningParts = {};
+      break;
+    }
+
+    case 'source-url': {
+      state.message.parts.push({
+        type: 'source-url',
+        sourceId: chunk.sourceId,
+        url: chunk.url,
+        title: chunk.title,
+      });
+      break;
+    }
+
+    case 'source-document': {
+      state.message.parts.push({
+        type: 'source-document',
+        sourceId: chunk.sourceId,
+        mediaType: chunk.mediaType,
+        title: chunk.title,
+        filename: chunk.filename,
+      });
+      break;
+    }
+
+    case 'file': {
+      state.message.parts.push({
+        type: 'file',
+        mediaType: chunk.mediaType,
+        url: chunk.url,
+      });
+      break;
+    }
+
+    case 'finish':
+    case 'error':
+    case 'abort':
+    case 'message-metadata':
+    case 'tool-approval-request':
+      break;
+
+    default: {
+      handleDataChunk({ state, chunk: chunk as DataChunk });
+      break;
+    }
+  }
+}
+
+function handleDataChunk({
+  state,
+  chunk,
+}: {
+  state: StreamingState;
+  chunk: DataChunk;
+}): void {
+  if (!chunk.type?.startsWith('data-')) return;
+  if (chunk.transient) return;
+
+  if (chunk.id) {
+    const existing = state.message.parts.findIndex(
+      (p) => 'id' in p && p.id === chunk.id && p.type === chunk.type,
+    );
+    if (existing >= 0) {
+      (state.message.parts[existing] as Record<string, unknown>).data =
+        chunk.data;
+      return;
+    }
+  }
+
+  state.message.parts.push(chunk as ChatUIMessage['parts'][number]);
+}
+
+function applyChunks({
+  state,
+  chunks,
+}: {
+  state: StreamingState;
+  chunks: UIMessageChunk[];
+}): void {
+  for (const chunk of chunks) {
+    applyChunk({ state, chunk });
+  }
+}
+
+function extractDataParts({
+  chunks,
+}: {
+  chunks: UIMessageChunk[];
+}): DataPart[] {
+  const result: DataPart[] = [];
+  for (const chunk of chunks) {
+    if (
+      typeof chunk.type === 'string' &&
+      chunk.type.startsWith('data-') &&
+      'data' in chunk
+    ) {
+      result.push({
+        type: chunk.type,
+        data: (chunk as DataChunk).data,
+      });
+    }
+  }
+  return result;
+}
+
+function snapshotMessage({ state }: { state: StreamingState }): ChatUIMessage {
+  return {
+    ...state.message,
+    parts: state.message.parts.map((part) => ({ ...part })),
+  };
+}
+
+export const chunkReducer = {
+  createStreamingState,
+  applyChunk,
+  applyChunks,
+  extractDataParts,
+  snapshotMessage,
+};
+
+/**
+ * Writable view of DynamicToolUIPart fields. The AI SDK types use a discriminated
+ * union keyed on `state`, which prevents mutating the discriminant in-place.
+ * This type is used only inside updateToolPartFields where we deliberately
+ * mutate the runtime object to avoid re-creating it on every chunk.
+ */
+type MutableToolPart = Pick<
+  DynamicToolUIPart,
+  'type' | 'toolCallId' | 'toolName' | 'title'
+> & {
+  state: string;
+  input: unknown;
+  output?: unknown;
+  errorText?: string;
+};
+
+type StreamingState = {
+  message: ChatUIMessage;
+  activeTextParts: Record<string, number>;
+  activeReasoningParts: Record<string, number>;
+  partialToolCalls: Record<string, { toolName: string; inputText: string }>;
+  seenToolCallIds: Set<string>;
+};
+
+type DataChunk = {
+  type: string;
+  id?: string;
+  data: unknown;
+  transient?: boolean;
+};
+
+type DataPart = {
+  type: string;
+  data: unknown;
+};
+
+export type { StreamingState, DataPart };

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -451,11 +451,13 @@ export function useAgentChat({
   useQuery({
     queryKey: ['chat-agent-poll', conversationId],
     queryFn: async () => {
-      if (!conversationId) return null;
+      if (!conversationId || conversationIdRef.current !== conversationId)
+        return null;
       const [messagesResult, convResult] = await Promise.all([
         chatApi.getMessages(conversationId),
         chatApi.getConversation(conversationId),
       ]);
+      if (conversationIdRef.current !== conversationId) return null;
       const mapped = chatUtils.mapHistoryToUIMessages(messagesResult.data);
       const current = persistedMessagesRef.current;
       const hasChanged =

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -1,5 +1,4 @@
 import {
-  ChatAgentEventType,
   ChatAllowedMimeType,
   ChatConversationStatus,
   CHAT_ALLOWED_MIME_TYPES,
@@ -7,22 +6,18 @@ import {
   isObject,
   PlanStepUpdate,
   tryCatch,
-  WebsocketClientEvent,
 } from '@activepieces/shared';
-import { useChat } from '@ai-sdk/react';
 import { useQuery } from '@tanstack/react-query';
-import { ChatTransport, UIMessage, UIMessageChunk } from 'ai';
 import { useCallback, useMemo, useRef, useState } from 'react';
-
-import { useSocket } from '@/components/providers/socket-provider';
 
 import { chatApi } from './chat-api';
 import { useChatStoreApi } from './chat-store-context';
 import { ChatUIMessage } from './chat-types';
 import { chatUtils } from './chat-utils';
+import { DataPart } from './chunk-reducer';
+import { useStreamingReducer } from './use-streaming-reducer';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
-const STREAM_TIMEOUT_MS = 10 * 60 * 1000;
 const AGENT_POLL_INTERVAL_MS = 5_000;
 
 const ALLOWED_MIME_SET: ReadonlySet<string> = new Set(CHAT_ALLOWED_MIME_TYPES);
@@ -86,121 +81,12 @@ function injectFilePartsIntoLastUserMessage({
   return result;
 }
 
-function removeMessageById({
-  id,
-  setMessages,
-}: {
-  id: string;
-  setMessages: (fn: (prev: ChatUIMessage[]) => ChatUIMessage[]) => void;
-}) {
-  setMessages((prev) => prev.filter((m) => m.id !== id));
-}
-
 const DISPLAY_CARD_DATA_TYPES = new Set([
   'data-connection-required',
   'data-connection-picker',
   'data-project-picker',
   'data-questions',
 ]);
-
-type SocketEvent = {
-  conversationId: string;
-  type: string;
-  data: unknown;
-};
-
-function createSocketChatTransport({
-  socket,
-  getConversationId,
-  getFiles,
-}: {
-  socket: ReturnType<typeof useSocket>;
-  getConversationId: () => string | null;
-  getFiles: () =>
-    | Array<{ name: string; mimeType: ChatAllowedMimeType; data: string }>
-    | undefined;
-}): ChatTransport<UIMessage> {
-  return {
-    async sendMessages({ messages, abortSignal }) {
-      const conversationId = getConversationId();
-      if (!conversationId) {
-        throw new Error('No conversation ID');
-      }
-
-      const lastUser = messages.findLast((m) => m.role === 'user');
-      const content =
-        lastUser?.parts
-          .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-          .map((p) => p.text)
-          .join('') ?? '';
-
-      const files = getFiles();
-
-      let cleanupFn: () => void = () => {};
-      const stream = new ReadableStream<UIMessageChunk>({
-        start(controller) {
-          const closeStream = () => {
-            cleanupFn();
-            try {
-              controller.close();
-            } catch {
-              // stream may already be closed
-            }
-          };
-
-          const timeout = setTimeout(closeStream, STREAM_TIMEOUT_MS);
-
-          const handler = (event: SocketEvent) => {
-            if (event.conversationId !== conversationId) return;
-            if (event.type === ChatAgentEventType.CHUNK) {
-              const chunks = Array.isArray(event.data)
-                ? event.data
-                : [event.data];
-              for (const chunk of chunks) {
-                controller.enqueue(chunk as UIMessageChunk);
-              }
-            } else if (event.type === ChatAgentEventType.ERROR) {
-              const errorData = event.data as { message?: string };
-              controller.enqueue({
-                type: 'error',
-                errorText: errorData?.message ?? 'An error occurred',
-              } as UIMessageChunk);
-            } else if (event.type === ChatAgentEventType.FINISHED) {
-              closeStream();
-            }
-          };
-
-          cleanupFn = () => {
-            clearTimeout(timeout);
-            socket.off(WebsocketClientEvent.CHAT_MESSAGE_CHUNK, handler);
-          };
-
-          socket.on(WebsocketClientEvent.CHAT_MESSAGE_CHUNK, handler);
-        },
-        cancel() {
-          cleanupFn();
-        },
-      });
-
-      abortSignal?.addEventListener('abort', () => cleanupFn(), {
-        once: true,
-      });
-
-      try {
-        await chatApi.sendMessage({ conversationId, content, files });
-      } catch (err) {
-        cleanupFn();
-        throw err;
-      }
-
-      return stream;
-    },
-
-    async reconnectToStream() {
-      return null;
-    },
-  };
-}
 
 type SendStatus =
   | { type: 'idle' }
@@ -212,7 +98,7 @@ export function useAgentChat({
   onTitleUpdate,
   onConversationCreated,
 }: {
-  onTitleUpdate?: (title: string, conversationId?: string) => void;
+  onTitleUpdate?: (title: string) => void;
   onConversationCreated?: (conversationId: string) => void;
 } = {}) {
   const store = useChatStoreApi();
@@ -228,22 +114,36 @@ export function useAgentChat({
   const [sendStatus, setSendStatus] = useState<SendStatus>({ type: 'idle' });
   const sendStatusRef = useRef<SendStatus>({ type: 'idle' });
 
+  const [persistedMessages, setPersistedMessages] = useState<ChatUIMessage[]>(
+    [],
+  );
+  const persistedMessagesRef = useRef(persistedMessages);
+  persistedMessagesRef.current = persistedMessages;
+  const [optimisticUserMessage, setOptimisticUserMessage] =
+    useState<ChatUIMessage | null>(null);
+
   const pendingFilesRef = useRef<
     { name: string; mimeType: ChatAllowedMimeType; data: string }[] | undefined
   >(undefined);
   const lastSentFileNamesRef = useRef<string[]>([]);
   const conversationIdRef = useRef<string | null>(null);
   const modelNameRef = useRef<string | null>(DEFAULT_CHAT_TIER_ID);
-  const optimisticIdRef = useRef<string | null>(null);
   const onTitleUpdateRef = useRef(onTitleUpdate);
   onTitleUpdateRef.current = onTitleUpdate;
   const onConversationCreatedRef = useRef(onConversationCreated);
   onConversationCreatedRef.current = onConversationCreated;
 
   const handleDataPart = useCallback(
-    (dataPart: { type: string; data: unknown }) => {
+    (dataPart: DataPart) => {
       if (!isObject(dataPart.data)) return;
-      const d = dataPart.data;
+      const d = dataPart.data as Record<string, unknown>;
+
+      if (
+        dataPart.type === 'data-session-title' &&
+        typeof d['title'] === 'string'
+      ) {
+        onTitleUpdateRef.current?.(d['title']);
+      }
 
       switch (dataPart.type) {
         case 'data-approval-request':
@@ -318,104 +218,73 @@ export function useAgentChat({
     setSendStatus(next);
   }, []);
 
-  const socket = useSocket();
-
-  const transport = useMemo(() => {
-    return createSocketChatTransport({
-      socket,
-      getConversationId: () => conversationIdRef.current,
-      getFiles: () => pendingFilesRef.current,
-    });
-  }, [socket]);
+  const reconcile = useCallback(
+    async (convId: string) => {
+      if (conversationIdRef.current !== convId) return;
+      const { data: result } = await tryCatch(() =>
+        chatApi.getMessages(convId),
+      );
+      if (result && conversationIdRef.current === convId) {
+        const mapped = chatUtils.mapHistoryToUIMessages(result.data);
+        setPersistedMessages(mapped);
+        const restoredReplies =
+          chatUtils.extractQuickRepliesFromHistory(mapped);
+        if (restoredReplies.length > 0) {
+          store.setState({ quickReplies: restoredReplies });
+        }
+      }
+      setOptimisticUserMessage(null);
+    },
+    [store],
+  );
 
   const {
-    messages: uiMessages,
-    status,
-    sendMessage: chatSendMessage,
-    stop,
-    setMessages: sdkSetMessages,
-    error: useChatError,
-  } = useChat({
-    transport,
-    experimental_throttle: 100,
-    onData: (dataPart) => {
-      const data = dataPart.data;
-      if (
-        dataPart.type === 'data-session-title' &&
-        isObject(data) &&
-        typeof data['title'] === 'string'
-      ) {
-        onTitleUpdateRef.current?.(
-          data['title'],
-          conversationIdRef.current ?? undefined,
-        );
-      }
-      handleDataPart(dataPart);
+    streamingMessage,
+    streamPhase,
+    streamError,
+    startStream,
+    stopStream,
+    clearStreamingState,
+  } = useStreamingReducer({
+    onDataPart: handleDataPart,
+    onStreamFinished: (convId) => {
+      void reconcile(convId).then(() => clearStreamingState());
     },
-    onError: () => {
-      if (optimisticIdRef.current) {
-        removeMessageById({
-          id: optimisticIdRef.current,
-          setMessages: sdkSetMessages as (
-            fn: (prev: ChatUIMessage[]) => ChatUIMessage[],
-          ) => void,
-        });
-        optimisticIdRef.current = null;
-      }
-      const convId = conversationIdRef.current;
-      if (convId) {
-        setTimeout(async () => {
-          if (conversationIdRef.current !== convId) return;
-          const { data: result } = await tryCatch(() =>
-            chatApi.getMessages(convId),
-          );
-          if (result && conversationIdRef.current === convId) {
-            (sdkSetMessages as (msgs: ChatUIMessage[]) => void)(
-              chatUtils.mapHistoryToUIMessages(result.data),
-            );
-          }
-        }, 3000);
-      }
+    onStreamError: ({ conversationId: convId }) => {
+      void reconcile(convId).then(() => clearStreamingState());
     },
   });
 
-  const setUiMessages = sdkSetMessages as (
-    msgs: ChatUIMessage[] | ((prev: ChatUIMessage[]) => ChatUIMessage[]),
-  ) => void;
-
-  const sdkIsActive = status === 'streaming' || status === 'submitted';
+  const isStreamActive = streamPhase !== 'idle';
   const isStreaming =
-    sdkIsActive ||
+    isStreamActive ||
     sendStatusRef.current.type === 'submitting' ||
     isPollingForAgentReply;
 
   const messages: ChatUIMessage[] = useMemo(() => {
+    const base = [...persistedMessages];
+    if (optimisticUserMessage) base.push(optimisticUserMessage);
+    if (streamingMessage) base.push(streamingMessage);
     return injectFilePartsIntoLastUserMessage({
-      messages: uiMessages as ChatUIMessage[],
+      messages: base,
       fileNames: lastSentFileNamesRef.current,
     });
-  }, [uiMessages]);
+  }, [persistedMessages, optimisticUserMessage, streamingMessage]);
 
   const error =
     sendStatus.type === 'error'
       ? sendStatus.message
-      : useChatError
-      ? useChatError.message
+      : streamError
+      ? streamError
       : null;
 
   const wasCancelled = sendStatus.type === 'cancelled';
 
   const cancelStream = useCallback(() => {
-    void stop();
+    stopStream();
     updateSendStatus({ type: 'cancelled' });
-    if (optimisticIdRef.current) {
-      removeMessageById({
-        id: optimisticIdRef.current,
-        setMessages: setUiMessages,
-      });
-      optimisticIdRef.current = null;
-    }
-  }, [stop, setUiMessages, updateSendStatus]);
+    setOptimisticUserMessage(null);
+  }, [stopStream, updateSendStatus]);
 
   const createConversation = useCallback(
     async ({
@@ -440,10 +309,8 @@ export function useAgentChat({
       const fileNames = files?.map((f) => f.name) ?? [];
       lastSentFileNamesRef.current = fileNames;
 
-      const optimisticId = `optimistic-${Date.now()}`;
-      optimisticIdRef.current = optimisticId;
       const optimisticUser: ChatUIMessage = {
-        id: optimisticId,
+        id: `optimistic-${Date.now()}`,
         role: 'user',
         parts: [
           { type: 'text', text: content },
@@ -451,14 +318,13 @@ export function useAgentChat({
         ],
       };
 
-      setUiMessages((prev) => [...prev, optimisticUser]);
+      setOptimisticUserMessage(optimisticUser);
       store.getState().resetInteractions();
 
       if (files && files.length > 0) {
         const oversized = files.find((f) => f.size > MAX_FILE_SIZE);
         if (oversized) {
-          removeMessageById({ id: optimisticId, setMessages: setUiMessages });
-          optimisticIdRef.current = null;
+          setOptimisticUserMessage(null);
           updateSendStatus({
             type: 'error',
             message: `File "${oversized.name}" exceeds 10 MB limit`,
@@ -469,8 +335,7 @@ export function useAgentChat({
           async () => Promise.all(files.map(fileToBase64)),
         );
         if (fileError) {
-          removeMessageById({ id: optimisticId, setMessages: setUiMessages });
-          optimisticIdRef.current = null;
+          setOptimisticUserMessage(null);
           updateSendStatus({
             type: 'error',
             message: fileError.message ?? 'Failed to read attached files',
@@ -491,8 +356,7 @@ export function useAgentChat({
           onConversationCreatedRef.current?.(conv.id);
         });
         if (convError) {
-          removeMessageById({ id: optimisticId, setMessages: setUiMessages });
-          optimisticIdRef.current = null;
+          setOptimisticUserMessage(null);
           updateSendStatus({
             type: 'error',
             message: convError.message ?? 'Failed to start conversation',
@@ -500,28 +364,46 @@ export function useAgentChat({
           return;
         }
         if (sendStatusRef.current.type === 'cancelled') {
-          removeMessageById({ id: optimisticId, setMessages: setUiMessages });
-          optimisticIdRef.current = null;
+          setOptimisticUserMessage(null);
           return;
         }
       }
 
+      const convId = conversationIdRef.current;
+      if (!convId) {
+        setOptimisticUserMessage(null);
+        updateSendStatus({
+          type: 'error',
+          message: 'No conversation ID',
+        });
+        return;
+      }
+
+      startStream(convId);
       updateSendStatus({ type: 'idle' });
-      await chatSendMessage({ text: content, messageId: optimisticId });
-      optimisticIdRef.current = null;
+
+      const { error: sendError } = await tryCatch(async () =>
+        chatApi.sendMessage({
+          conversationId: convId,
+          content,
+          files: pendingFilesRef.current,
+        }),
+      );
+      if (sendError) {
+        stopStream();
+        setOptimisticUserMessage(null);
+        updateSendStatus({
+          type: 'error',
+          message: sendError.message ?? 'Failed to send message',
+        });
+      }
     },
-    [
-      createConversation,
-      chatSendMessage,
-      setUiMessages,
-      updateSendStatus,
-      store,
-    ],
+    [createConversation, startStream, stopStream, updateSendStatus, store],
   );
 
   const setConversationId = useCallback(
     async (id: string) => {
-      void stop();
+      stopStream();
       setIsPollingForAgentReply(false);
       updateSendStatus({ type: 'idle' });
       conversationIdRef.current = id;
@@ -530,7 +412,7 @@ export function useAgentChat({
 
       pendingFilesRef.current = undefined;
       lastSentFileNamesRef.current = [];
-      optimisticIdRef.current = null;
+      setOptimisticUserMessage(null);
 
       setIsLoadingHistory(true);
       const [historyResult, convResult] = await Promise.all([
@@ -544,12 +426,12 @@ export function useAgentChat({
           message: 'Failed to load conversation history',
         });
       } else {
-        const uiMessages = chatUtils.mapHistoryToUIMessages(
+        const mapped = chatUtils.mapHistoryToUIMessages(
           historyResult.data.data,
         );
-        setUiMessages(uiMessages);
+        setPersistedMessages(mapped);
         const restoredReplies =
-          chatUtils.extractQuickRepliesFromHistory(uiMessages);
+          chatUtils.extractQuickRepliesFromHistory(mapped);
         if (restoredReplies.length > 0) {
           store.setState({ quickReplies: restoredReplies });
         }
@@ -563,7 +445,7 @@ export function useAgentChat({
       }
       setIsLoadingHistory(false);
     },
-    [stop, setUiMessages, updateSendStatus, store],
+    [stopStream, updateSendStatus, store],
   );
 
   useQuery({
@@ -575,14 +457,12 @@ export function useAgentChat({
         chatApi.getConversation(conversationId),
       ]);
       const mapped = chatUtils.mapHistoryToUIMessages(messagesResult.data);
-      const currentMessages = uiMessages as ChatUIMessage[];
+      const current = persistedMessagesRef.current;
       const hasChanged =
-        mapped.length !== currentMessages.length ||
-        mapped.some(
-          (m, i) => m.parts.length !== currentMessages[i]?.parts.length,
-        );
+        mapped.length !== current.length ||
+        mapped.some((m, i) => m.parts.length !== current[i]?.parts.length);
       if (hasChanged) {
-        setUiMessages(mapped);
+        setPersistedMessages(mapped);
         const restoredReplies =
           chatUtils.extractQuickRepliesFromHistory(mapped);
         if (restoredReplies.length > 0) {
@@ -594,7 +474,7 @@ export function useAgentChat({
       }
       return mapped;
     },
-    enabled: isPollingForAgentReply && !sdkIsActive,
+    enabled: isPollingForAgentReply && !isStreamActive,
     refetchInterval: AGENT_POLL_INTERVAL_MS,
   });
 

--- a/packages/web/src/features/chat/lib/use-streaming-reducer.ts
+++ b/packages/web/src/features/chat/lib/use-streaming-reducer.ts
@@ -1,0 +1,195 @@
+import { ChatAgentEventType, WebsocketClientEvent } from '@activepieces/shared';
+import { UIMessageChunk } from 'ai';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useSocket } from '@/components/providers/socket-provider';
+
+import { ChatUIMessage } from './chat-types';
+import { chunkReducer, DataPart, StreamingState } from './chunk-reducer';
+
+const THROTTLE_MS = 100;
+const STREAM_TIMEOUT_MS = 10 * 60 * 1000;
+
+export function useStreamingReducer({
+  onDataPart,
+  onStreamFinished,
+  onStreamError,
+}: {
+  onDataPart: (part: DataPart) => void;
+  onStreamFinished: (conversationId: string) => void;
+  onStreamError: (params: {
+    conversationId: string;
+    errorMessage: string;
+  }) => void;
+}) {
+  const socket = useSocket();
+
+  const [streamingMessage, setStreamingMessage] =
+    useState<ChatUIMessage | null>(null);
+  const [streamPhase, setStreamPhase] = useState<StreamPhase>('idle');
+  const [streamError, setStreamError] = useState<string | null>(null);
+
+  const streamPhaseRef = useRef<StreamPhase>('idle');
+  const reducerStateRef = useRef<StreamingState | null>(null);
+  const chunkBufferRef = useRef<UIMessageChunk[]>([]);
+  const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const streamTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const onDataPartRef = useRef(onDataPart);
+  onDataPartRef.current = onDataPart;
+  const onStreamFinishedRef = useRef(onStreamFinished);
+  onStreamFinishedRef.current = onStreamFinished;
+  const onStreamErrorRef = useRef(onStreamError);
+  onStreamErrorRef.current = onStreamError;
+
+  const updatePhase = useCallback((phase: StreamPhase) => {
+    if (streamPhaseRef.current === phase) return;
+    streamPhaseRef.current = phase;
+    setStreamPhase(phase);
+  }, []);
+
+  const flush = useCallback(() => {
+    throttleTimerRef.current = null;
+    const chunks = chunkBufferRef.current;
+    if (chunks.length === 0) return;
+    chunkBufferRef.current = [];
+
+    const dataParts = chunkReducer.extractDataParts({ chunks });
+    for (const dp of dataParts) {
+      onDataPartRef.current(dp);
+    }
+
+    const state = reducerStateRef.current;
+    if (!state) return;
+
+    chunkReducer.applyChunks({ state, chunks });
+    setStreamingMessage(chunkReducer.snapshotMessage({ state }));
+  }, []);
+
+  const scheduleFlush = useCallback(() => {
+    if (throttleTimerRef.current !== null) return;
+    throttleTimerRef.current = setTimeout(flush, THROTTLE_MS);
+  }, [flush]);
+
+  const teardown = useCallback(() => {
+    if (cleanupRef.current) {
+      cleanupRef.current();
+      cleanupRef.current = null;
+    }
+    if (throttleTimerRef.current !== null) {
+      clearTimeout(throttleTimerRef.current);
+      throttleTimerRef.current = null;
+    }
+    if (streamTimeoutRef.current !== null) {
+      clearTimeout(streamTimeoutRef.current);
+      streamTimeoutRef.current = null;
+    }
+    chunkBufferRef.current = [];
+    reducerStateRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      teardown();
+    };
+  }, [teardown]);
+
+  const startStream = useCallback(
+    (conversationId: string) => {
+      teardown();
+
+      reducerStateRef.current = chunkReducer.createStreamingState();
+      setStreamingMessage({
+        id: reducerStateRef.current.message.id,
+        role: 'assistant',
+        parts: [],
+      });
+      updatePhase('awaiting-stream');
+      setStreamError(null);
+
+      const handleFinish = () => {
+        flush();
+        teardown();
+        updatePhase('reconciling');
+        onStreamFinishedRef.current(conversationId);
+      };
+
+      const handleError = (errorMessage: string) => {
+        flush();
+        teardown();
+        setStreamError(errorMessage);
+        updatePhase('reconciling');
+        onStreamErrorRef.current({ conversationId, errorMessage });
+      };
+
+      const handler = (event: SocketEvent) => {
+        if (event.conversationId !== conversationId) return;
+
+        if (event.type === ChatAgentEventType.CHUNK) {
+          updatePhase('streaming');
+          const chunks = Array.isArray(event.data) ? event.data : [event.data];
+          for (const chunk of chunks) {
+            chunkBufferRef.current.push(chunk as UIMessageChunk);
+          }
+          scheduleFlush();
+
+          if (streamTimeoutRef.current !== null) {
+            clearTimeout(streamTimeoutRef.current);
+          }
+          streamTimeoutRef.current = setTimeout(() => {
+            handleError('Stream timed out');
+          }, STREAM_TIMEOUT_MS);
+        } else if (event.type === ChatAgentEventType.ERROR) {
+          const errorData = event.data as { message?: string };
+          handleError(errorData?.message ?? 'An error occurred');
+        } else if (event.type === ChatAgentEventType.FINISHED) {
+          handleFinish();
+        }
+      };
+
+      socket.on(WebsocketClientEvent.CHAT_MESSAGE_CHUNK, handler);
+
+      streamTimeoutRef.current = setTimeout(() => {
+        handleError('Stream timed out');
+      }, STREAM_TIMEOUT_MS);
+
+      cleanupRef.current = () => {
+        socket.off(WebsocketClientEvent.CHAT_MESSAGE_CHUNK, handler);
+      };
+    },
+    [socket, teardown, flush, scheduleFlush, updatePhase],
+  );
+
+  const stopStream = useCallback(() => {
+    teardown();
+    setStreamingMessage(null);
+    setStreamError(null);
+    updatePhase('idle');
+  }, [teardown, updatePhase]);
+
+  const clearStreamingState = useCallback(() => {
+    setStreamingMessage(null);
+    setStreamError(null);
+    updatePhase('idle');
+  }, [updatePhase]);
+
+  return {
+    streamingMessage,
+    streamPhase,
+    streamError,
+    startStream,
+    stopStream,
+    clearStreamingState,
+  };
+}
+
+type SocketEvent = {
+  conversationId: string;
+  type: string;
+  data: unknown;
+};
+
+type StreamPhase = 'idle' | 'awaiting-stream' | 'streaming' | 'reconciling';
+
+export type { StreamPhase };

--- a/packages/web/test/features/chat/lib/chunk-reducer.test.ts
+++ b/packages/web/test/features/chat/lib/chunk-reducer.test.ts
@@ -1,0 +1,411 @@
+import { UIMessageChunk } from 'ai';
+import { describe, expect, it } from 'vitest';
+
+import { chunkReducer, StreamingState } from '@/features/chat/lib/chunk-reducer';
+
+function makeChunk(override: UIMessageChunk): UIMessageChunk {
+  return override;
+}
+
+function createAndApply(chunks: UIMessageChunk[]): StreamingState {
+  const state = chunkReducer.createStreamingState({ messageId: 'test-msg' });
+  chunkReducer.applyChunks({ state, chunks });
+  return state;
+}
+
+describe('chunkReducer', () => {
+  describe('createStreamingState', () => {
+    it('creates an empty assistant message', () => {
+      const state = chunkReducer.createStreamingState({ messageId: 'msg-1' });
+      expect(state.message.id).toBe('msg-1');
+      expect(state.message.role).toBe('assistant');
+      expect(state.message.parts).toEqual([]);
+    });
+
+    it('generates a default id when none provided', () => {
+      const state = chunkReducer.createStreamingState();
+      expect(state.message.id).toMatch(/^stream-/);
+    });
+  });
+
+  describe('text accumulation', () => {
+    it('accumulates text from start + deltas + end', () => {
+      const state = createAndApply([
+        makeChunk({ type: 'text-start', id: 't1' }),
+        makeChunk({ type: 'text-delta', id: 't1', delta: 'Hello' }),
+        makeChunk({ type: 'text-delta', id: 't1', delta: ' world' }),
+        makeChunk({ type: 'text-end', id: 't1' }),
+      ]);
+      expect(state.message.parts).toHaveLength(1);
+      expect(state.message.parts[0]).toEqual({
+        type: 'text',
+        text: 'Hello world',
+      });
+    });
+
+    it('handles multiple text parts', () => {
+      const state = createAndApply([
+        makeChunk({ type: 'text-start', id: 't1' }),
+        makeChunk({ type: 'text-delta', id: 't1', delta: 'First' }),
+        makeChunk({ type: 'text-end', id: 't1' }),
+        makeChunk({ type: 'text-start', id: 't2' }),
+        makeChunk({ type: 'text-delta', id: 't2', delta: 'Second' }),
+        makeChunk({ type: 'text-end', id: 't2' }),
+      ]);
+      expect(state.message.parts).toHaveLength(2);
+      expect(state.message.parts[0]).toEqual({ type: 'text', text: 'First' });
+      expect(state.message.parts[1]).toEqual({ type: 'text', text: 'Second' });
+    });
+  });
+
+  describe('reasoning accumulation', () => {
+    it('accumulates reasoning from start + deltas + end', () => {
+      const state = createAndApply([
+        makeChunk({ type: 'reasoning-start', id: 'r1' }),
+        makeChunk({ type: 'reasoning-delta', id: 'r1', delta: 'Thinking' }),
+        makeChunk({ type: 'reasoning-delta', id: 'r1', delta: '...' }),
+        makeChunk({ type: 'reasoning-end', id: 'r1' }),
+      ]);
+      expect(state.message.parts).toHaveLength(1);
+      expect(state.message.parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Thinking...',
+      });
+    });
+  });
+
+  describe('tool call lifecycle', () => {
+    it('handles full tool lifecycle: start → delta → available → output', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'tool-input-start',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+        }),
+        makeChunk({
+          type: 'tool-input-delta',
+          toolCallId: 'tc1',
+          inputTextDelta: '{"key":',
+        }),
+        makeChunk({
+          type: 'tool-input-delta',
+          toolCallId: 'tc1',
+          inputTextDelta: '"value"}',
+        }),
+        makeChunk({
+          type: 'tool-input-available',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+          input: { key: 'value' },
+        }),
+        makeChunk({
+          type: 'tool-output-available',
+          toolCallId: 'tc1',
+          output: { result: 'ok' },
+        }),
+      ]);
+      expect(state.message.parts).toHaveLength(1);
+      const part = state.message.parts[0] as Record<string, unknown>;
+      expect(part.type).toBe('dynamic-tool');
+      expect(part.toolCallId).toBe('tc1');
+      expect(part.state).toBe('output-available');
+      expect(part.input).toEqual({ key: 'value' });
+      expect(part.output).toEqual({ result: 'ok' });
+    });
+
+    it('handles tool-input-available without prior start', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'tool-input-available',
+          toolCallId: 'tc1',
+          toolName: 'ap_search',
+          input: { query: 'test' },
+        }),
+      ]);
+      expect(state.message.parts).toHaveLength(1);
+      const part = state.message.parts[0] as Record<string, unknown>;
+      expect(part.state).toBe('input-available');
+      expect(part.input).toEqual({ query: 'test' });
+    });
+
+    it('handles tool-output-error', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'tool-input-start',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+        }),
+        makeChunk({
+          type: 'tool-input-available',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+          input: {},
+        }),
+        makeChunk({
+          type: 'tool-output-error',
+          toolCallId: 'tc1',
+          errorText: 'Something went wrong',
+        }),
+      ]);
+      const part = state.message.parts[0] as Record<string, unknown>;
+      expect(part.state).toBe('output-error');
+      expect(part.errorText).toBe('Something went wrong');
+    });
+
+    it('handles tool-output-denied', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'tool-input-start',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+        }),
+        makeChunk({
+          type: 'tool-input-available',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+          input: {},
+        }),
+        makeChunk({ type: 'tool-output-denied', toolCallId: 'tc1' }),
+      ]);
+      const part = state.message.parts[0] as Record<string, unknown>;
+      expect(part.state).toBe('output-denied');
+    });
+
+    it('handles tool-input-error', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'tool-input-error',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+          input: {},
+          errorText: 'Invalid input',
+        }),
+      ]);
+      const part = state.message.parts[0] as Record<string, unknown>;
+      expect(part.state).toBe('output-error');
+      expect(part.errorText).toBe('Invalid input');
+    });
+  });
+
+  describe('dedup', () => {
+    it('ignores duplicate tool-input-start for same toolCallId', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'tool-input-start',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+        }),
+        makeChunk({
+          type: 'tool-input-start',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+        }),
+      ]);
+      expect(state.message.parts).toHaveLength(1);
+    });
+
+    it('ignores duplicate tool-input-available for already-seen toolCallId', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'tool-input-start',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+        }),
+        makeChunk({
+          type: 'tool-input-available',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+          input: { v: 1 },
+        }),
+        makeChunk({
+          type: 'tool-input-available',
+          toolCallId: 'tc1',
+          toolName: 'ap_run_action',
+          input: { v: 2 },
+        }),
+      ]);
+      expect(state.message.parts).toHaveLength(1);
+      const part = state.message.parts[0] as Record<string, unknown>;
+      expect(part.input).toEqual({ v: 2 });
+    });
+  });
+
+  describe('resilience', () => {
+    it('silently skips text-delta for unknown id', () => {
+      const state = createAndApply([
+        makeChunk({ type: 'text-delta', id: 'unknown', delta: 'orphan' }),
+      ]);
+      expect(state.message.parts).toHaveLength(0);
+    });
+
+    it('silently skips reasoning-delta for unknown id', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'reasoning-delta',
+          id: 'unknown',
+          delta: 'orphan',
+        }),
+      ]);
+      expect(state.message.parts).toHaveLength(0);
+    });
+
+    it('silently skips tool-input-delta for unknown toolCallId', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'tool-input-delta',
+          toolCallId: 'unknown',
+          inputTextDelta: '{}',
+        }),
+      ]);
+      expect(state.message.parts).toHaveLength(0);
+    });
+
+    it('silently skips tool-output-available for unknown toolCallId', () => {
+      const state = createAndApply([
+        makeChunk({
+          type: 'tool-output-available',
+          toolCallId: 'unknown',
+          output: {},
+        }),
+      ]);
+      expect(state.message.parts).toHaveLength(0);
+    });
+  });
+
+  describe('step boundaries', () => {
+    it('finish-step resets active text parts', () => {
+      const state = chunkReducer.createStreamingState({ messageId: 'test' });
+
+      chunkReducer.applyChunks({
+        state,
+        chunks: [
+          makeChunk({ type: 'text-start', id: 't1' }),
+          makeChunk({ type: 'text-delta', id: 't1', delta: 'Step 1' }),
+          makeChunk({ type: 'finish-step' }),
+        ],
+      });
+
+      expect(Object.keys(state.activeTextParts)).toHaveLength(0);
+
+      chunkReducer.applyChunks({
+        state,
+        chunks: [
+          makeChunk({ type: 'text-delta', id: 't1', delta: ' more' }),
+        ],
+      });
+
+      const textPart = state.message.parts[0] as { type: string; text: string };
+      expect(textPart.text).toBe('Step 1');
+    });
+  });
+
+  describe('data parts', () => {
+    it('adds non-transient data parts to message', () => {
+      const state = createAndApply([
+        {
+          type: 'data-connection-picker',
+          data: { connections: [] },
+        } as unknown as UIMessageChunk,
+      ]);
+      expect(state.message.parts).toHaveLength(1);
+    });
+
+    it('skips transient data parts from message', () => {
+      const state = createAndApply([
+        {
+          type: 'data-session-title',
+          data: { title: 'Test' },
+          transient: true,
+        } as unknown as UIMessageChunk,
+      ]);
+      expect(state.message.parts).toHaveLength(0);
+    });
+  });
+
+  describe('extractDataParts', () => {
+    it('extracts data-* chunks from a batch', () => {
+      const chunks: UIMessageChunk[] = [
+        makeChunk({ type: 'text-start', id: 't1' }),
+        {
+          type: 'data-session-title',
+          data: { title: 'Hello' },
+          transient: true,
+        } as unknown as UIMessageChunk,
+        makeChunk({ type: 'text-delta', id: 't1', delta: 'hi' }),
+        {
+          type: 'data-quick-replies',
+          data: { replies: ['a', 'b'] },
+        } as unknown as UIMessageChunk,
+      ];
+      const parts = chunkReducer.extractDataParts({ chunks });
+      expect(parts).toHaveLength(2);
+      expect(parts[0].type).toBe('data-session-title');
+      expect(parts[1].type).toBe('data-quick-replies');
+    });
+  });
+
+  describe('snapshotMessage', () => {
+    it('returns a deep clone of parts so mutations do not leak', () => {
+      const state = createAndApply([
+        makeChunk({ type: 'text-start', id: 't1' }),
+        makeChunk({ type: 'text-delta', id: 't1', delta: 'Hello' }),
+      ]);
+      const snapshot = chunkReducer.snapshotMessage({ state });
+      expect(snapshot.parts).toEqual(state.message.parts);
+      expect(snapshot.parts).not.toBe(state.message.parts);
+      expect(snapshot.parts[0]).not.toBe(state.message.parts[0]);
+
+      chunkReducer.applyChunk({
+        state,
+        chunk: makeChunk({ type: 'text-delta', id: 't1', delta: ' world' }),
+      });
+      const snapshotText = (snapshot.parts[0] as { text: string }).text;
+      expect(snapshotText).toBe('Hello');
+    });
+  });
+
+  describe('start chunk', () => {
+    it('sets message id from start chunk', () => {
+      const state = createAndApply([
+        makeChunk({ type: 'start', messageId: 'server-id-123' }),
+      ]);
+      expect(state.message.id).toBe('server-id-123');
+    });
+  });
+
+  describe('batch consistency', () => {
+    it('produces same result whether applied one-by-one or as batch', () => {
+      const chunks: UIMessageChunk[] = [
+        makeChunk({ type: 'text-start', id: 't1' }),
+        makeChunk({ type: 'text-delta', id: 't1', delta: 'Hello' }),
+        makeChunk({
+          type: 'tool-input-start',
+          toolCallId: 'tc1',
+          toolName: 'test',
+        }),
+        makeChunk({
+          type: 'tool-input-available',
+          toolCallId: 'tc1',
+          toolName: 'test',
+          input: { a: 1 },
+        }),
+        makeChunk({ type: 'text-delta', id: 't1', delta: ' world' }),
+        makeChunk({ type: 'text-end', id: 't1' }),
+      ];
+
+      const batchState = chunkReducer.createStreamingState({
+        messageId: 'test',
+      });
+      chunkReducer.applyChunks({ state: batchState, chunks });
+
+      const oneByOneState = chunkReducer.createStreamingState({
+        messageId: 'test',
+      });
+      for (const chunk of chunks) {
+        chunkReducer.applyChunk({ state: oneByOneState, chunk });
+      }
+
+      expect(batchState.message.parts).toEqual(oneByOneState.message.parts);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replace `@ai-sdk/react` `useChat` hook with a custom chunk reducer + streaming lifecycle hook for full control over message state
- Own message state: `persistedMessages` (server truth) + `optimisticUserMessage` + `streamingMessage` — eliminates duplicate cards, orphaned thinking blocks, and jarring error recovery
- Interleaved thinking + content blocks matching the model's actual think → respond → think flow
- Display tools (connection picker, project picker) hidden during streaming, interactive only after stream finishes
- HTTP fallback in system prompt when piece connection is unavailable
- Piece icons as primary tool card icons with AI-provided labels
- Tier label rename: Smart → Expert, Premium → Heavy
- Always show connection picker even for a single connection

## Test plan

- [ ] Send a message in chat — verify streaming renders correctly (thinking block + text + tool calls)
- [ ] Verify connection picker card appears once (not duplicated) and only after streaming finishes
- [ ] Trigger a provider error — verify clean error display, no orphaned content, error clears on retry
- [ ] Switch conversations after an error — verify error banner does not carry over
- [ ] Navigate to an existing conversation — verify messages appear instantly (no fade-in animation)
- [ ] Refresh page during active stream — verify polling picks up the response
- [ ] Cancel mid-stream — verify clean cancellation
- [ ] Expand thinking accordion during streaming — verify all steps visible
- [ ] Verify tier selector shows Fast / Expert / Heavy labels
- [ ] Ask agent to do something without a connection — verify HTTP fallback is offered
- [ ] Run `cd packages/web && npm test` — 23 chunk reducer unit tests pass