### PR TITLE
fix(server): increase MCP tool call timeout to 5 minutes

### DIFF
--- a/.agents/features/webhooks.md
+++ b/.agents/features/webhooks.md
@@ -54,7 +54,7 @@ All routes accept GET, POST, PUT, DELETE, PATCH methods.
 **Sync path**:
 1. Create FlowRun with `ProgressUpdateType.WEBHOOK_RESPONSE`
 2. Register one-time listener via `engineResponseWatcher`
-3. Wait for engine to send response (timeout: `AP_WEBHOOK_TIMEOUT_SECONDS`, default 30)
+3. Wait for engine to send response (default timeout: `AP_WEBHOOK_TIMEOUT_SECONDS`, default 30; callers may pass `timeoutMs` to override per-invocation, e.g. MCP uses 5 minutes)
 4. Return flow's response (status, body, headers) or 204 on timeout
 
 ## Request Conversion

--- a/packages/server/api/src/app/mcp/mcp-server-builder.ts
+++ b/packages/server/api/src/app/mcp/mcp-server-builder.ts
@@ -11,6 +11,7 @@ import { activepiecesTools, ALL_CONTROLLABLE_TOOL_NAMES, LOCKED_TOOL_NAMES, PLAT
 import { apSetProjectContextTool } from './tools/ap-set-project-context'
 
 const PLATFORM_LEVEL_TOOL_SET = new Set(PLATFORM_LEVEL_TOOL_NAMES)
+const MCP_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
 const MCP_SERVER_INSTRUCTIONS = `## Activepieces MCP Server
 
@@ -160,6 +161,7 @@ function registerFlowTools({ server, mcp, projectId, permissionChecker, log }: R
                 payload: args,
                 execute: true,
                 failParentOnFailure: false,
+                timeoutMs: MCP_TIMEOUT_MS,
             })
             const isOkay = Math.floor(response.status / 100) === 2
 

--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -53,6 +53,7 @@ export const webhookService = {
         onRunCreated,
         parentRunId,
         failParentOnFailure,
+        timeoutMs,
     }: HandleWebhookParams): Promise<EngineHttpResponse> {
         return tracer.startActiveSpan('webhook.service.handle', {
             attributes: {
@@ -175,6 +176,7 @@ export const webhookService = {
                     onRunCreated,
                     parentRunId,
                     failParentOnFailure,
+                    timeoutMs,
                 })
                 return {
                     status: flowHttpResponse.status,
@@ -259,7 +261,7 @@ async function handleSync(params: SyncWebhookParams): Promise<EngineHttpResponse
         },
     }, async (span) => {
         try {
-            const { payload, projectId, flow, logger, webhookRequestId, workerHandlerId, flowVersionIdToRun, runEnvironment, saveSampleData, flowVersionToRun, parentRunId, failParentOnFailure, platformId } = params
+            const { payload, projectId, flow, logger, webhookRequestId, workerHandlerId, flowVersionIdToRun, runEnvironment, saveSampleData, flowVersionToRun, parentRunId, failParentOnFailure, platformId, timeoutMs } = params
 
             if (saveSampleData) {
                 rejectedPromiseHandler(savePayload({
@@ -305,7 +307,7 @@ async function handleSync(params: SyncWebhookParams): Promise<EngineHttpResponse
             span.setAttribute('webhook.runId', createdRun.id)
             params.onRunCreated?.(createdRun)
 
-            const listenerResult = await engineResponseWatcher(logger).oneTimeListener<EngineHttpResponse>(webhookRequestId, true, WEBHOOK_TIMEOUT_MS, {
+            const listenerResult = await engineResponseWatcher(logger).oneTimeListener<EngineHttpResponse>(webhookRequestId, true, timeoutMs ?? WEBHOOK_TIMEOUT_MS, {
                 status: StatusCodes.NO_CONTENT,
                 body: {},
                 headers: {},
@@ -349,6 +351,7 @@ type HandleWebhookParams = {
     onRunCreated?: (run: FlowRun) => void
     parentRunId?: string
     failParentOnFailure: boolean
+    timeoutMs?: number
 }
 
 type AsyncWebhookParams = {
@@ -381,4 +384,5 @@ type SyncWebhookParams = {
     onRunCreated?: (run: FlowRun) => void
     parentRunId?: string
     failParentOnFailure: boolean
+    timeoutMs?: number
 }


### PR DESCRIPTION
## Summary
- MCP tool calls were using the default 30s webhook timeout (`AP_WEBHOOK_TIMEOUT_SECONDS`), causing flows that take longer to return 204 with empty body instead of actual results
- MCP clients like Claude.ai expect long-running operations, so a hardcoded 5-minute timeout is used for MCP tool calls instead
- Threads a `timeoutMs` parameter through `handleWebhook` → `handleSync` → `engineResponseWatcher.oneTimeListener` so callers can override the default webhook timeout

## Test plan
- [ ] Create an MCP flow with a Code step that sleeps >30s and "Wait for Response" enabled
- [ ] Call the MCP tool via an MCP client and verify the response contains actual data instead of 204
- [ ] Verify regular webhook flows still use the 30s default timeout