### PR TITLE
revert: adding llm description to triggers and actions

### DIFF
--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.28.2",
+  "version": "0.28.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.28.3",
+  "version": "0.29.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.28.1",
+  "version": "0.28.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/framework/src/lib/action/action.ts
+++ b/packages/pieces/framework/src/lib/action/action.ts
@@ -30,13 +30,6 @@ type CreateActionParams<PieceAuth extends PieceAuthProperty | PieceAuthProperty[
   auth?: PieceAuth
   displayName: string
   description: string
-  /**
-   * Optional alternate description shown to LLMs (chat / MCP).
-   * Use this for tool-selection guidance, anti-patterns, disambiguation,
-   * and parameter pitfalls that would be noise in the human UI description.
-   * Falls back to {@code description} when omitted.
-   */
-  llmDescription?: string
   props: ActionProps
   run: ActionRunner<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, ActionProps>
   test?: ActionRunner<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, ActionProps>
@@ -55,7 +48,6 @@ export class IAction<PieceAuth extends PieceAuthProperty | PieceAuthProperty[] |
     public readonly test: ActionRunner<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, ActionProps>,
     public readonly requireAuth: boolean,
     public readonly errorHandlingOptions: ErrorHandlingOptionsParam,
-    public readonly llmDescription?: string,
   ) { }
 }
 
@@ -88,6 +80,5 @@ export const createAction = <
         defaultValue: false,
       }
     },
-    params.llmDescription,
   )
 }

--- a/packages/pieces/framework/src/lib/piece-metadata.ts
+++ b/packages/pieces/framework/src/lib/piece-metadata.ts
@@ -49,7 +49,6 @@ export const ActionBase = z.object({
   name: z.string(),
   displayName: z.string(),
   description: z.string(),
-  llmDescription: z.string().optional(),
   props: PiecePropertyMap,
   requireAuth: z.boolean(),
   errorHandlingOptions: ErrorHandlingOptionsParam.optional(),
@@ -59,7 +58,6 @@ export type ActionBase = {
   name: string,
   displayName: string,
   description: string,
-  llmDescription?: string,
   props: PiecePropertyMap,
   requireAuth: boolean;
   errorHandlingOptions?: ErrorHandlingOptionsParam;
@@ -69,7 +67,6 @@ export const TriggerBase = z.object({
   name: z.string(),
   displayName: z.string(),
   description: z.string(),
-  llmDescription: z.string().optional(),
   props: PiecePropertyMap,
   errorHandlingOptions: ErrorHandlingOptionsParam.optional(),
   type: z.nativeEnum(TriggerStrategy),

--- a/packages/pieces/framework/src/lib/trigger/trigger.ts
+++ b/packages/pieces/framework/src/lib/trigger/trigger.ts
@@ -44,13 +44,6 @@ type BaseTriggerParams<
   name: string
   displayName: string
   description: string
-  /**
-   * Optional alternate description shown to LLMs (chat / MCP).
-   * Use this for tool-selection guidance, anti-patterns, disambiguation,
-   * and parameter pitfalls that would be noise in the human UI description.
-   * Falls back to {@code description} when omitted.
-   */
-  llmDescription?: string
   requireAuth?: boolean
   auth?: PieceAuth
   props: TriggerProps
@@ -105,7 +98,6 @@ export class ITrigger<
     public readonly test: (ctx: TestOrRunHookContext<ExtractPieceAuthPropertyTypeForMethods<PieceAuth>, TriggerProps, TS>) => Promise<unknown[]>,
     public readonly sampleData: unknown,
     public readonly testStrategy: TriggerTestStrategy,
-    public readonly llmDescription?: string,
   ) { }
 }
 
@@ -142,7 +134,6 @@ export const createTrigger = <
         params.test ?? (() => Promise.resolve([params.sampleData])),
         params.sampleData,
         params.test ? TriggerTestStrategy.TEST_FUNCTION : TriggerTestStrategy.SIMULATION,
-        params.llmDescription,
       )
     case TriggerStrategy.POLLING:
       return new ITrigger(
@@ -163,7 +154,6 @@ export const createTrigger = <
         params.test ?? (() => Promise.resolve([params.sampleData])),
         params.sampleData,
         TriggerTestStrategy.TEST_FUNCTION,
-        params.llmDescription,
       )
     case TriggerStrategy.MANUAL:
       return new ITrigger(
@@ -184,7 +174,6 @@ export const createTrigger = <
         params.test ?? (() => Promise.resolve([params.sampleData])),
         params.sampleData,
         TriggerTestStrategy.TEST_FUNCTION,
-        params.llmDescription,
       )
     case TriggerStrategy.APP_WEBHOOK:
       return new ITrigger(
@@ -205,7 +194,6 @@ export const createTrigger = <
         params.test ?? (() => Promise.resolve([params.sampleData])),
         params.sampleData,
         (isNil(params.sampleData) && isNil(params.test)) ? TriggerTestStrategy.SIMULATION : TriggerTestStrategy.TEST_FUNCTION,
-        params.llmDescription,
       )
   }
 }


### PR DESCRIPTION
## What does this PR do?

Reverts #13315 ("feat: add llmDescription to pieces and their actions and triggers"). Removes the optional `llmDescription` field from `createAction`, `createTrigger`, `ActionBase`, and `TriggerBase`, and restores `@activepieces/pieces-framework` to `0.29.0`.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

This is a straight `git revert` of the squash-merge commit. No piece or downstream consumer (MCP, chat) had started using `llmDescription` yet, so removing it is a clean inverse of the merged change — `description` remains the single source of truth for both human and LLM consumers.

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->

- Rolling back the field while we reconsider the right shape for LLM-facing piece metadata before any piece authors adopt it.

Fixes # (issue)
