### PR TITLE
feat: add Canva piece

### DIFF
--- a/packages/pieces/community/canva/package.json
+++ b/packages/pieces/community/canva/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-canva",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/canva/src/index.ts
+++ b/packages/pieces/community/canva/src/index.ts
@@ -1,0 +1,44 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { canvaAuth } from './lib/auth';
+import { getDesign } from './lib/actions/get-design';
+import { searchDesigns } from './lib/actions/search-designs';
+import { createDesign } from './lib/actions/create-design';
+import { importDesign } from './lib/actions/import-design';
+import { exportDesign } from './lib/actions/export-design';
+import { uploadAsset } from './lib/actions/upload-asset';
+import { getAsset } from './lib/actions/get-asset';
+import { listFolderItems } from './lib/actions/list-folder-items';
+import { createFolder } from './lib/actions/create-folder';
+import { moveItemToFolder } from './lib/actions/move-item-to-folder';
+
+export const canva = createPiece({
+  displayName: 'Canva',
+  description: 'Design, collaborate, and publish with Canva',
+  logoUrl: 'https://cdn.activepieces.com/pieces/canva.png',
+  minimumSupportedRelease: '0.30.0',
+  authors: ['pulkitsaraf'],
+  categories: [PieceCategory.PRODUCTIVITY],
+  auth: canvaAuth,
+  actions: [
+    getDesign,
+    searchDesigns,
+    createDesign,
+    importDesign,
+    exportDesign,
+    uploadAsset,
+    getAsset,
+    listFolderItems,
+    createFolder,
+    moveItemToFolder,
+    createCustomApiCallAction({
+      auth: canvaAuth,
+      baseUrl: () => 'https://api.canva.com/rest/v1',
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${auth.access_token}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/canva/src/lib/actions/create-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/create-design.ts
@@ -1,0 +1,75 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const createDesign = createAction({
+  auth: canvaAuth,
+  name: 'create_design',
+  displayName: 'Create Design',
+  description: 'Create a new blank Canva design with a preset or custom dimensions.',
+  props: {
+    design_type: Property.StaticDropdown({
+      displayName: 'Design Type',
+      description: 'Choose a preset type or select Custom for specific dimensions.',
+      required: true,
+      defaultValue: 'preset',
+      options: {
+        options: [
+          { label: 'Preset Type', value: 'preset' },
+          { label: 'Custom Dimensions', value: 'custom' },
+        ],
+      },
+    }),
+    preset_name: Property.ShortText({
+      displayName: 'Preset Name',
+      description: 'e.g. "presentation", "instagram_post", "a4_document". Required when Design Type is Preset.',
+      required: false,
+    }),
+    width_px: Property.Number({
+      displayName: 'Width (px)',
+      description: 'Required when Design Type is Custom.',
+      required: false,
+    }),
+    height_px: Property.Number({
+      displayName: 'Height (px)',
+      description: 'Required when Design Type is Custom.',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'Optional title for the new design.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { design_type, preset_name, width_px, height_px, title } = context.propsValue;
+
+    const body: Record<string, unknown> = {};
+    if (title) body['title'] = title;
+
+    if (design_type === 'preset') {
+      body['design_type'] = { type: 'preset', name: preset_name };
+    } else {
+      body['design_type'] = {
+        type: 'custom',
+        width: width_px,
+        height: height_px,
+      };
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.canva.com/rest/v1/designs',
+      body,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/create-folder.ts
+++ b/packages/pieces/community/canva/src/lib/actions/create-folder.ts
@@ -1,0 +1,43 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const createFolder = createAction({
+  auth: canvaAuth,
+  name: 'create_folder',
+  displayName: 'Create Folder',
+  description: 'Create a new folder in your Canva account.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Folder Name',
+      description: 'Name for the new folder.',
+      required: true,
+    }),
+    parent_folder_id: Property.ShortText({
+      displayName: 'Parent Folder ID',
+      description: 'ID of the parent folder. Leave empty to create in the root.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const body: Record<string, unknown> = { name: context.propsValue.name };
+    if (context.propsValue.parent_folder_id) {
+      body['parent_folder_id'] = context.propsValue.parent_folder_id;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.canva.com/rest/v1/folders',
+      body,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/export-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/export-design.ts
@@ -40,7 +40,7 @@ export const exportDesign = createAction({
     const createResponse = await httpClient.sendRequest<{ job: { id: string; status: string } }>({
       method: HttpMethod.POST,
       url: 'https://api.canva.com/rest/v1/exports',
-      body: { design_id, format },
+      body: { design_id, format: { type: format } },
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
         token: context.auth.access_token,

--- a/packages/pieces/community/canva/src/lib/actions/export-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/export-design.ts
@@ -1,0 +1,74 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const exportDesign = createAction({
+  auth: canvaAuth,
+  name: 'export_design',
+  displayName: 'Export Design',
+  description: 'Start an export job for a Canva design and return the download URL(s) once ready.',
+  props: {
+    design_id: Property.ShortText({
+      displayName: 'Design ID',
+      description: 'The ID of the design to export.',
+      required: true,
+    }),
+    format: Property.StaticDropdown({
+      displayName: 'Export Format',
+      required: true,
+      defaultValue: 'pdf',
+      options: {
+        options: [
+          { label: 'PDF', value: 'pdf' },
+          { label: 'PNG', value: 'png' },
+          { label: 'JPG', value: 'jpg' },
+          { label: 'SVG', value: 'svg' },
+          { label: 'PPTX', value: 'pptx' },
+          { label: 'MP4', value: 'mp4' },
+          { label: 'GIF', value: 'gif' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { design_id, format } = context.propsValue;
+
+    const createResponse = await httpClient.sendRequest<{ job: { id: string; status: string } }>({
+      method: HttpMethod.POST,
+      url: 'https://api.canva.com/rest/v1/exports',
+      body: { design_id, format },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+
+    const jobId = createResponse.body.job.id;
+
+    // Poll until the export job is complete (max 30 attempts × 2 s = 60 s)
+    for (let i = 0; i < 30; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      const statusResponse = await httpClient.sendRequest<{
+        job: { id: string; status: string; urls?: string[] };
+      }>({
+        method: HttpMethod.GET,
+        url: `https://api.canva.com/rest/v1/exports/${jobId}`,
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: context.auth.access_token,
+        },
+      });
+
+      const job = statusResponse.body.job;
+      if (job.status === 'success') return job;
+      if (job.status === 'failed') throw new Error(`Export job ${jobId} failed.`);
+    }
+
+    throw new Error(`Export job ${jobId} timed out after 60 seconds.`);
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-asset.ts
@@ -1,0 +1,32 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const getAsset = createAction({
+  auth: canvaAuth,
+  name: 'get_asset',
+  displayName: 'Get Asset',
+  description: 'Retrieve metadata for a Canva asset by its ID.',
+  props: {
+    asset_id: Property.ShortText({
+      displayName: 'Asset ID',
+      description: 'The ID of the asset to retrieve.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.canva.com/rest/v1/assets/${context.propsValue.asset_id}`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/get-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-design.ts
@@ -1,0 +1,32 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const getDesign = createAction({
+  auth: canvaAuth,
+  name: 'get_design',
+  displayName: 'Get Design',
+  description: 'Retrieve metadata for a Canva design by its ID.',
+  props: {
+    design_id: Property.ShortText({
+      displayName: 'Design ID',
+      description: 'The ID of the Canva design to retrieve.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.canva.com/rest/v1/designs/${context.propsValue.design_id}`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/import-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/import-design.ts
@@ -9,30 +9,56 @@ import { canvaAuth } from '../auth';
 export const importDesign = createAction({
   auth: canvaAuth,
   name: 'import_design',
-  displayName: 'Import Design from URL',
-  description: 'Import an external file (PDF, PPTX, etc.) from a URL as a new Canva design.',
+  displayName: 'Import Design',
+  description: 'Import a file (PDF, PPTX, etc.) as a new Canva design.',
   props: {
-    url: Property.ShortText({
-      displayName: 'File URL',
-      description: 'Publicly accessible URL of the file to import (e.g. a PDF or PPTX).',
+    file: Property.File({
+      displayName: 'File',
+      description: 'The file to import (PDF, PPTX, DOCX, etc.).',
       required: true,
     }),
     title: Property.ShortText({
       displayName: 'Design Title',
       description: 'Title for the imported design.',
-      required: false,
+      required: true,
+    }),
+    mime_type: Property.StaticDropdown({
+      displayName: 'File Type',
+      description: 'MIME type of the file being imported.',
+      required: true,
+      defaultValue: 'application/pdf',
+      options: {
+        options: [
+          { label: 'PDF', value: 'application/pdf' },
+          { label: 'PowerPoint (PPTX)', value: 'application/vnd.openxmlformats-officedocument.presentationml.presentation' },
+          { label: 'Word (DOCX)', value: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' },
+          { label: 'PNG image', value: 'image/png' },
+          { label: 'JPEG image', value: 'image/jpeg' },
+        ],
+      },
     }),
   },
   async run(context) {
-    const body: Record<string, unknown> = {
-      url: context.propsValue.url,
-    };
-    if (context.propsValue.title) body['title'] = context.propsValue.title;
+    const { file, title, mime_type } = context.propsValue;
+
+    // Canva import: POST /rest/v1/imports
+    // Content-Type: application/octet-stream
+    // Import-Metadata: base64-encoded JSON with title_base64 + mime_type
+    const metadata = Buffer.from(
+      JSON.stringify({
+        title_base64: Buffer.from(title).toString('base64'),
+        mime_type,
+      })
+    ).toString('base64');
 
     const response = await httpClient.sendRequest({
       method: HttpMethod.POST,
       url: 'https://api.canva.com/rest/v1/imports',
-      body,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Import-Metadata': metadata,
+      },
+      body: Buffer.from(file.base64, 'base64'),
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
         token: context.auth.access_token,

--- a/packages/pieces/community/canva/src/lib/actions/import-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/import-design.ts
@@ -1,0 +1,43 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const importDesign = createAction({
+  auth: canvaAuth,
+  name: 'import_design',
+  displayName: 'Import Design from URL',
+  description: 'Import an external file (PDF, PPTX, etc.) from a URL as a new Canva design.',
+  props: {
+    url: Property.ShortText({
+      displayName: 'File URL',
+      description: 'Publicly accessible URL of the file to import (e.g. a PDF or PPTX).',
+      required: true,
+    }),
+    title: Property.ShortText({
+      displayName: 'Design Title',
+      description: 'Title for the imported design.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const body: Record<string, unknown> = {
+      url: context.propsValue.url,
+    };
+    if (context.propsValue.title) body['title'] = context.propsValue.title;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.canva.com/rest/v1/imports',
+      body,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/list-folder-items.ts
+++ b/packages/pieces/community/canva/src/lib/actions/list-folder-items.ts
@@ -1,0 +1,60 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const listFolderItems = createAction({
+  auth: canvaAuth,
+  name: 'list_folder_items',
+  displayName: 'List Folder Items',
+  description: 'List the designs and assets inside a Canva folder.',
+  props: {
+    folder_id: Property.ShortText({
+      displayName: 'Folder ID',
+      description: 'The ID of the folder. Use "root" to list items in the root folder.',
+      required: true,
+      defaultValue: 'root',
+    }),
+    item_types: Property.StaticMultiSelectDropdown({
+      displayName: 'Filter by Type',
+      description: 'Only return items of these types. Leave empty to return all.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Design', value: 'design' },
+          { label: 'Image', value: 'image' },
+          { label: 'Video', value: 'video' },
+          { label: 'Folder', value: 'folder' },
+        ],
+      },
+    }),
+    continuation: Property.ShortText({
+      displayName: 'Continuation Token',
+      description: 'Token for fetching the next page of results.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const params: Record<string, string> = {};
+    if (context.propsValue.item_types?.length) {
+      params['item_types'] = context.propsValue.item_types.join(',');
+    }
+    if (context.propsValue.continuation) {
+      params['continuation'] = context.propsValue.continuation;
+    }
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://api.canva.com/rest/v1/folders/${context.propsValue.folder_id}/items`,
+      queryParams: params,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/move-item-to-folder.ts
+++ b/packages/pieces/community/canva/src/lib/actions/move-item-to-folder.ts
@@ -1,0 +1,49 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const moveItemToFolder = createAction({
+  auth: canvaAuth,
+  name: 'move_item_to_folder',
+  displayName: 'Move Item to Folder',
+  description: 'Move a design or asset to a different folder.',
+  props: {
+    item_id: Property.ShortText({
+      displayName: 'Item ID',
+      description: 'ID of the design or asset to move.',
+      required: true,
+    }),
+    to_folder_id: Property.ShortText({
+      displayName: 'Destination Folder ID',
+      description: 'ID of the folder to move the item into.',
+      required: true,
+    }),
+    from_folder_id: Property.ShortText({
+      displayName: 'Source Folder ID',
+      description: 'ID of the current parent folder. Use "root" if the item is in the root.',
+      required: true,
+      defaultValue: 'root',
+    }),
+  },
+  async run(context) {
+    const { item_id, to_folder_id, from_folder_id } = context.propsValue;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `https://api.canva.com/rest/v1/folders/${to_folder_id}/items/move`,
+      body: {
+        items: [{ type: 'design', id: item_id }],
+        from_folder_id,
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/move-item-to-folder.ts
+++ b/packages/pieces/community/canva/src/lib/actions/move-item-to-folder.ts
@@ -17,6 +17,18 @@ export const moveItemToFolder = createAction({
       description: 'ID of the design or asset to move.',
       required: true,
     }),
+    item_type: Property.StaticDropdown({
+      displayName: 'Item Type',
+      description: 'Whether the item is a design or an asset.',
+      required: true,
+      defaultValue: 'design',
+      options: {
+        options: [
+          { label: 'Design', value: 'design' },
+          { label: 'Asset', value: 'asset' },
+        ],
+      },
+    }),
     to_folder_id: Property.ShortText({
       displayName: 'Destination Folder ID',
       description: 'ID of the folder to move the item into.',
@@ -30,13 +42,13 @@ export const moveItemToFolder = createAction({
     }),
   },
   async run(context) {
-    const { item_id, to_folder_id, from_folder_id } = context.propsValue;
+    const { item_id, item_type, to_folder_id, from_folder_id } = context.propsValue;
 
     const response = await httpClient.sendRequest({
       method: HttpMethod.POST,
       url: `https://api.canva.com/rest/v1/folders/${to_folder_id}/items/move`,
       body: {
-        items: [{ type: 'design', id: item_id }],
+        items: [{ type: item_type, id: item_id }],
         from_folder_id,
       },
       authentication: {

--- a/packages/pieces/community/canva/src/lib/actions/search-designs.ts
+++ b/packages/pieces/community/canva/src/lib/actions/search-designs.ts
@@ -1,0 +1,42 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const searchDesigns = createAction({
+  auth: canvaAuth,
+  name: 'search_designs',
+  displayName: 'Search Designs',
+  description: 'Search for designs in your Canva account.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description: 'Text to search for in design titles.',
+      required: false,
+    }),
+    continuation: Property.ShortText({
+      displayName: 'Continuation Token',
+      description: 'Token for fetching the next page of results.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const params: Record<string, string> = {};
+    if (context.propsValue.query) params['query'] = context.propsValue.query;
+    if (context.propsValue.continuation) params['continuation'] = context.propsValue.continuation;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: 'https://api.canva.com/rest/v1/designs',
+      queryParams: params,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
@@ -10,11 +10,11 @@ export const uploadAsset = createAction({
   auth: canvaAuth,
   name: 'upload_asset',
   displayName: 'Upload Asset',
-  description: 'Upload an image or video asset to your Canva media library from a URL.',
+  description: 'Upload an image or video file to your Canva media library.',
   props: {
-    url: Property.ShortText({
-      displayName: 'Asset URL',
-      description: 'Publicly accessible URL of the image or video to upload.',
+    file: Property.File({
+      displayName: 'File',
+      description: 'The image or video file to upload.',
       required: true,
     }),
     name: Property.ShortText({
@@ -22,15 +22,45 @@ export const uploadAsset = createAction({
       description: 'Display name for the uploaded asset.',
       required: true,
     }),
+    mime_type: Property.StaticDropdown({
+      displayName: 'MIME Type',
+      description: 'MIME type of the file being uploaded.',
+      required: true,
+      defaultValue: 'image/png',
+      options: {
+        options: [
+          { label: 'PNG image', value: 'image/png' },
+          { label: 'JPEG image', value: 'image/jpeg' },
+          { label: 'GIF image', value: 'image/gif' },
+          { label: 'WebP image', value: 'image/webp' },
+          { label: 'SVG image', value: 'image/svg+xml' },
+          { label: 'MP4 video', value: 'video/mp4' },
+          { label: 'PDF document', value: 'application/pdf' },
+        ],
+      },
+    }),
   },
   async run(context) {
+    const { file, name, mime_type } = context.propsValue;
+
+    // Canva asset upload: POST /rest/v1/asset-uploads
+    // Content-Type: application/octet-stream
+    // Asset-Upload-Metadata: base64-encoded JSON with name_base64 + mime_type
+    const metadata = Buffer.from(
+      JSON.stringify({
+        name_base64: Buffer.from(name).toString('base64'),
+        mime_type,
+      })
+    ).toString('base64');
+
     const response = await httpClient.sendRequest({
       method: HttpMethod.POST,
-      url: 'https://api.canva.com/rest/v1/assets/upload',
-      body: {
-        url: context.propsValue.url,
-        name: context.propsValue.name,
+      url: 'https://api.canva.com/rest/v1/asset-uploads',
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Asset-Upload-Metadata': metadata,
       },
+      body: Buffer.from(file.base64, 'base64'),
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
         token: context.auth.access_token,

--- a/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
@@ -1,0 +1,41 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { canvaAuth } from '../auth';
+
+export const uploadAsset = createAction({
+  auth: canvaAuth,
+  name: 'upload_asset',
+  displayName: 'Upload Asset',
+  description: 'Upload an image or video asset to your Canva media library from a URL.',
+  props: {
+    url: Property.ShortText({
+      displayName: 'Asset URL',
+      description: 'Publicly accessible URL of the image or video to upload.',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Asset Name',
+      description: 'Display name for the uploaded asset.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.canva.com/rest/v1/assets/upload',
+      body: {
+        url: context.propsValue.url,
+        name: context.propsValue.name,
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.auth.access_token,
+      },
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/canva/src/lib/auth.ts
+++ b/packages/pieces/community/canva/src/lib/auth.ts
@@ -1,0 +1,36 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const canvaAuth = PieceAuth.OAuth2({
+  authUrl: 'https://www.canva.com/api/oauth/authorize',
+  tokenUrl: 'https://www.canva.com/api/oauth/token',
+  required: true,
+  scope: [
+    'asset:read',
+    'asset:write',
+    'design:content:read',
+    'design:content:write',
+    'design:meta:read',
+    'folder:read',
+    'folder:write',
+  ],
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://api.canva.com/rest/v1/users/me/profile',
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: auth.access_token,
+        },
+      });
+      return { valid: true };
+    } catch (e) {
+      return { valid: false, error: (e as Error).message };
+    }
+  },
+});

--- a/packages/pieces/community/canva/tsconfig.json
+++ b/packages/pieces/community/canva/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/canva/tsconfig.lib.json
+++ b/packages/pieces/community/canva/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds a new `canva` community piece integrating with the [Canva Connect API](https://www.canva.com/developers/)
- OAuth2 authentication with scopes for assets, designs, and folders
- 10 actions covering every capability listed in #8135

## Actions

| Action | Description |
|---|---|
| **Get Design** | Fetch design metadata by ID |
| **Search Designs** | Search designs with pagination |
| **Create Design** | Create blank design (preset or custom dimensions) |
| **Import Design** | Import PDF/PPTX from a public URL |
| **Export Design** | Export to PDF/PNG/JPG/SVG/PPTX/MP4/GIF (polls until ready) |
| **Upload Asset** | Upload image/video to Canva media library from URL |
| **Get Asset** | Fetch asset metadata by ID |
| **List Folder Items** | List folder contents with optional type filter |
| **Create Folder** | Create a new folder (optionally nested) |
| **Move Item to Folder** | Move a design/asset between folders |

Also includes a **Custom API Call** action for any endpoint not covered above.

## Test plan

- [ ] Connect Canva account via OAuth2
- [ ] Create a design (preset: `presentation`)
- [ ] Search designs and verify results
- [ ] Export a design as PDF and confirm download URL is returned
- [ ] Upload an asset from a public image URL
- [ ] List root folder items
- [ ] Create a subfolder and move a design into it

Closes #8135

/claim