### PR TITLE
docs(piece-builder): correct auth access patterns for context

### DIFF
--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -165,7 +165,7 @@ npx turbo run build --filter=@activepieces/piece-<name>
 
 `bun install` is required for new pieces so the workspace symlinks are created before TypeScript can resolve imports. Skip it on subsequent rebuilds.
 
-Fix TypeScript errors and rebuild. Common causes: missing import in `src/index.ts`, missing `tsconfig.base.json` entry, wrong type cast on `context.auth` (use `context.auth as unknown as string` for SecretText), missing `sampleData` on a trigger.
+Fix TypeScript errors and rebuild. Common causes: missing import in `src/index.ts`, missing `tsconfig.base.json` entry, accessing `context.auth` as a string for SecretText (use `context.auth.secret_text` instead — see Quick Auth Reference), missing `sampleData` on a trigger.
 
 #### Test locally
 
@@ -208,13 +208,17 @@ packages/pieces/community/<piece-name>/
 
 ## Quick Auth Reference
 
-| API Auth Method        | Activepieces Type        | Access Pattern                       |
-| ---------------------- | ------------------------ | ------------------------------------ |
-| API key / Bearer token | `PieceAuth.SecretText()` | `context.auth` (string)              |
-| OAuth2                 | `PieceAuth.OAuth2()`     | `context.auth.access_token`          |
-| Username + password    | `PieceAuth.BasicAuth()`  | `context.auth.username`, `.password` |
-| Multiple fields        | `PieceAuth.CustomAuth()` | `context.auth.<field_name>`          |
-| No auth needed         | `PieceAuth.None()`       | No `context.auth` available          |
+In actions and triggers, `context.auth` is the resolved connection object — not a flat string. Access fields per type below:
+
+| API Auth Method        | Activepieces Type        | Access Pattern                                                                |
+| ---------------------- | ------------------------ | ----------------------------------------------------------------------------- |
+| API key / Bearer token | `PieceAuth.SecretText()` | `context.auth.secret_text`                                                    |
+| OAuth2                 | `PieceAuth.OAuth2()`     | `context.auth.access_token`; extra props via `context.auth.props?.['<key>']`  |
+| Username + password    | `PieceAuth.BasicAuth()`  | `context.auth.username`, `context.auth.password`                              |
+| Multiple fields        | `PieceAuth.CustomAuth()` | `context.auth.props.<field_name>`                                             |
+| No auth needed         | `PieceAuth.None()`       | No `context.auth` available                                                   |
+
+Inside the auth's own `validate` callback the shape is different (it receives the raw entered values — e.g. `auth` is the plain string for SecretText, the flat `{ base_url, api_key }` for CustomAuth). The patterns above apply to action/trigger `run()` only.
 
 Full code examples: read `auth-patterns.md`
 

--- a/.agents/skills/piece-builder/action-patterns.md
+++ b/.agents/skills/piece-builder/action-patterns.md
@@ -31,7 +31,7 @@ export const createRecordAction = createAction({
       url: 'https://api.example.com/v1/records',
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: context.auth as string,
+        token: context.auth.secret_text,
       },
       body: {
         name: context.propsValue.name,
@@ -42,6 +42,8 @@ export const createRecordAction = createAction({
   },
 });
 ```
+
+The `token` field above assumes a `PieceAuth.SecretText()` auth. For other auth types, swap to `context.auth.access_token` (OAuth2), `context.auth.username`/`.password` (BasicAuth), or `context.auth.props.<field>` (CustomAuth). See `auth-patterns.md` for the full table.
 
 **Real example:** `packages/pieces/community/github/src/lib/actions/create-issue.ts`
 

--- a/.agents/skills/piece-builder/auth-patterns.md
+++ b/.agents/skills/piece-builder/auth-patterns.md
@@ -2,7 +2,7 @@
 
 ## API Key (SecretText)
 
-Most common for simple APIs. The `auth` value is a plain string.
+Most common for simple APIs. Inside `validate`, `auth` is a plain string. Inside actions/triggers, the resolved value is the full connection object, so read the secret via `context.auth.secret_text`.
 
 ```typescript
 import { PieceAuth } from '@activepieces/pieces-framework';
@@ -27,7 +27,7 @@ export const myAppAuth = PieceAuth.SecretText({
 });
 ```
 
-**Access in actions/triggers:** `context.auth` is a string directly.
+**Access in actions/triggers:** `context.auth.secret_text` (string).
 
 **Real example:** `packages/pieces/community/stripe/src/index.ts`
 
@@ -55,7 +55,18 @@ export const myAppAuth = PieceAuth.OAuth2({
 });
 ```
 
-**Access in actions/triggers:** `context.auth.access_token`
+**Access in actions/triggers:**
+- `context.auth.access_token` — the OAuth2 access token
+- `context.auth.props?.['<key>']` — when the auth defines extra `props` (e.g. data center, region, subdomain)
+- `context.auth.data` — the raw token response from the provider (refresh token, scope, etc.)
+
+```typescript
+async run(context) {
+  const token = context.auth.access_token;
+  const region = context.auth.props?.['region'] as string;
+  // ...
+}
+```
 
 For custom API call actions with OAuth2:
 ```typescript
@@ -68,7 +79,7 @@ createCustomApiCallAction({
 })
 ```
 
-**Real example:** `packages/pieces/community/github/src/index.ts`
+**Real example:** `packages/pieces/community/github/src/index.ts`, `packages/pieces/community/zoho-campaigns/` (OAuth2 with extra `props`)
 
 ---
 
@@ -109,7 +120,7 @@ export const myAppAuth = PieceAuth.BasicAuth({
 });
 ```
 
-**Access:** `context.auth.username`, `context.auth.password`
+**Access in actions/triggers:** `context.auth.username`, `context.auth.password`
 
 ---
 
@@ -149,11 +160,21 @@ export const myAppAuth = PieceAuth.CustomAuth({
 });
 ```
 
-**Access:** `context.auth.base_url`, `context.auth.api_key`
+**Access in actions/triggers:** the fields live under `props`, not on `auth` directly.
+
+```typescript
+async run(context) {
+  const baseUrl = context.auth.props.base_url;
+  const apiKey = context.auth.props.api_key;
+  // ...
+}
+```
+
+Inside `validate`, the callback receives the flat shape — `auth.base_url`, `auth.api_key`. Inside actions/triggers, use `context.auth.props.<field>`.
 
 **Allowed prop types in CustomAuth:** ShortText, LongText, SecretText, Number, Checkbox, StaticDropdown, StaticMultiSelectDropdown, MarkDown.
 
-**Real example:** `packages/pieces/community/wordpress/src/index.ts`
+**Real example:** `packages/pieces/community/wordpress/src/index.ts`, `packages/pieces/community/mattermost/src/index.ts`
 
 ---
 

--- a/.agents/skills/piece-builder/common-patterns.md
+++ b/.agents/skills/piece-builder/common-patterns.md
@@ -126,7 +126,7 @@ export const myAppCommon = {
         return { disabled: true, options: [], placeholder: 'Connect your account first' };
       }
       const response = await myAppApiCall<{ data: { id: string; name: string }[] }>({
-        token: auth as string,
+        token: (auth as { secret_text: string }).secret_text,
         method: HttpMethod.GET,
         path: '/projects',
       });
@@ -158,7 +158,7 @@ export const listTasksAction = createAction({
   },
   async run(context) {
     const response = await myAppApiCall<{ data: any[] }>({
-      token: context.auth as string,
+      token: context.auth.secret_text,
       method: HttpMethod.GET,
       path: `/projects/${context.propsValue.project}/tasks`,
     });

--- a/.agents/skills/piece-builder/output-quality.md
+++ b/.agents/skills/piece-builder/output-quality.md
@@ -100,7 +100,7 @@ async run(context) {
   const response = await httpClient.sendRequest<ApiContact>({
     method: HttpMethod.GET,
     url: `https://api.example.com/v1/contacts/${context.propsValue.contactId}`,
-    authentication: { type: AuthenticationType.BEARER_TOKEN, token: context.auth as string },
+    authentication: { type: AuthenticationType.BEARER_TOKEN, token: context.auth.secret_text },
   });
 
   const contact = response.body;
@@ -128,7 +128,7 @@ async run(context) {
   const response = await httpClient.sendRequest<{ data: ApiContact[] }>({
     method: HttpMethod.GET,
     url: 'https://api.example.com/v1/contacts',
-    authentication: { type: AuthenticationType.BEARER_TOKEN, token: context.auth as string },
+    authentication: { type: AuthenticationType.BEARER_TOKEN, token: context.auth.secret_text },
     queryParams: { limit: String(context.propsValue.limit ?? 100) },
   });
 

--- a/.agents/skills/piece-builder/props-patterns.md
+++ b/.agents/skills/piece-builder/props-patterns.md
@@ -133,7 +133,7 @@ Property.Dropdown({
     const response = await httpClient.sendRequest<{ data: { id: string; name: string }[] }>({
       method: HttpMethod.GET,
       url: 'https://api.example.com/v1/projects',
-      authentication: { type: AuthenticationType.BEARER_TOKEN, token: auth as string },
+      authentication: { type: AuthenticationType.BEARER_TOKEN, token: (auth as { secret_text: string }).secret_text },
     });
     return {
       disabled: false,
@@ -161,7 +161,7 @@ Property.Dropdown({
     const response = await httpClient.sendRequest<{ data: { id: string; name: string }[] }>({
       method: HttpMethod.GET,
       url: `https://api.example.com/v1/projects/${project}/tasks`,
-      authentication: { type: AuthenticationType.BEARER_TOKEN, token: auth as string },
+      authentication: { type: AuthenticationType.BEARER_TOKEN, token: (auth as { secret_text: string }).secret_text },
     });
     return {
       disabled: false,

--- a/.agents/skills/piece-builder/trigger-patterns.md
+++ b/.agents/skills/piece-builder/trigger-patterns.md
@@ -29,7 +29,7 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof myAppAuth>, Reco
       url: 'https://api.example.com/v1/records',
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: auth as string,
+        token: auth.secret_text,
       },
       queryParams: {
         sort: 'created_at',
@@ -164,7 +164,7 @@ export const newRecordWebhookTrigger = createTrigger({
       url: 'https://api.example.com/v1/webhooks',
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: context.auth as string,
+        token: context.auth.secret_text,
       },
       body: {
         url: context.webhookUrl,         // Activepieces provides this
@@ -183,7 +183,7 @@ export const newRecordWebhookTrigger = createTrigger({
         url: `https://api.example.com/v1/webhooks/${webhookId}`,
         authentication: {
           type: AuthenticationType.BEARER_TOKEN,
-          token: context.auth as string,
+          token: context.auth.secret_text,
         },
       });
     }
@@ -201,7 +201,7 @@ export const newRecordWebhookTrigger = createTrigger({
       url: 'https://api.example.com/v1/records',
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
-        token: context.auth as string,
+        token: context.auth.secret_text,
       },
       queryParams: { limit: '5' },
     });


### PR DESCRIPTION
Update the piece-builder skill so action/trigger examples access context.auth the way pieces actually receive it under Context: secret_text, props.<field>, and props?.['<key>'] on OAuth2 — not the flat shapes.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
