### PR TITLE
fix(text-helper): add Find All action and fix Find action gaps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8194,7 +8194,7 @@
     },
     "packages/pieces/core/text-helper": {
       "name": "@activepieces/piece-text-helper",
-      "version": "0.4.15",
+      "version": "0.5.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/core/text-helper/package.json
+++ b/packages/pieces/core/text-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-text-helper",
-  "version": "0.4.15",
+  "version": "0.5.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/text-helper/src/index.ts
+++ b/packages/pieces/core/text-helper/src/index.ts
@@ -2,6 +2,7 @@ import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import { concat } from './lib/actions/concat';
 import { find } from './lib/actions/find';
+import { findAll } from './lib/actions/find-all';
 import { htmlToMarkdown } from './lib/actions/html-to-markdown';
 import { markdownToHTML } from './lib/actions/markdown-to-html';
 import { replace } from './lib/actions/replace';
@@ -28,6 +29,7 @@ export const textHelper = createPiece({
     'Anmol-Gup',
     'geekyme',
     'bertrandong',
+    'onyedikachi-david',
   ],
   categories: [PieceCategory.CORE],
   actions: [
@@ -35,6 +37,7 @@ export const textHelper = createPiece({
     replace,
     split,
     find,
+    findAll,
     markdownToHTML,
     htmlToMarkdown,
     stripHtmlContent,

--- a/packages/pieces/core/text-helper/src/lib/actions/find-all.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/find-all.ts
@@ -31,7 +31,14 @@ export const findAll = createAction({
   },
   run: async (ctx): Promise<string[]> => {
     const flags = ctx.propsValue.ignoreCase ? 'gi' : 'g';
-    const regex = new RegExp(ctx.propsValue.expression, flags);
+    let regex: RegExp;
+    try {
+      regex = new RegExp(ctx.propsValue.expression, flags);
+    } catch {
+      throw new Error(
+        `Invalid regular expression: ${ctx.propsValue.expression}`
+      );
+    }
     return [...ctx.propsValue.text.matchAll(regex)].map((m) => m[0]);
   },
 });

--- a/packages/pieces/core/text-helper/src/lib/actions/find-all.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/find-all.ts
@@ -1,9 +1,9 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
-export const find = createAction({
-  description: 'Find substring (Regex or Text).',
-  displayName: 'Find',
-  name: 'find',
+export const findAll = createAction({
+  description: 'Find all substrings matching a regex or text pattern.',
+  displayName: 'Find All',
+  name: 'find_all',
   errorHandlingOptions: {
     continueOnFailure: {
       hide: true,
@@ -19,8 +19,7 @@ export const find = createAction({
     }),
     expression: Property.ShortText({
       displayName: 'Expression',
-      description:
-        'Regex or text to search for. Returns the first match and its capture groups.',
+      description: 'Regex or text to search for. Returns every occurrence.',
       required: true,
     }),
     ignoreCase: Property.Checkbox({
@@ -30,9 +29,9 @@ export const find = createAction({
       defaultValue: false,
     }),
   },
-  run: async (ctx): Promise<RegExpMatchArray | null> => {
-    const flags = ctx.propsValue.ignoreCase ? 'i' : '';
-    const expression = new RegExp(ctx.propsValue.expression, flags);
-    return ctx.propsValue.text.match(expression);
+  run: async (ctx): Promise<string[]> => {
+    const flags = ctx.propsValue.ignoreCase ? 'gi' : 'g';
+    const regex = new RegExp(ctx.propsValue.expression, flags);
+    return [...ctx.propsValue.text.matchAll(regex)].map((m) => m[0]);
   },
 });

--- a/packages/pieces/core/text-helper/src/lib/actions/find.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/find.ts
@@ -32,7 +32,14 @@ export const find = createAction({
   },
   run: async (ctx): Promise<RegExpMatchArray | null> => {
     const flags = ctx.propsValue.ignoreCase ? 'i' : '';
-    const expression = new RegExp(ctx.propsValue.expression, flags);
+    let expression: RegExp;
+    try {
+      expression = new RegExp(ctx.propsValue.expression, flags);
+    } catch {
+      throw new Error(
+        `Invalid regular expression: ${ctx.propsValue.expression}`
+      );
+    }
     return ctx.propsValue.text.match(expression);
   },
 });

--- a/packages/pieces/core/text-helper/src/lib/actions/markdown-to-html.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/markdown-to-html.ts
@@ -79,7 +79,6 @@ export const markdownToHTML = createAction({
       simpleLineBreaks: context.propsValue.simpleLineBreaks,
       openLinksInNewWindow: context.propsValue.openLinksInNewWindow,
     });
-    console.log('noHeaderId', context.propsValue.noHeaderId);
     converter.setFlavor(context.propsValue.flavor as Flavor);
     return converter.makeHtml(context.propsValue.markdown);
   },

--- a/packages/pieces/core/text-helper/test/find-all.test.ts
+++ b/packages/pieces/core/text-helper/test/find-all.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="vitest/globals" />
+
+import { findAll } from '../src/lib/actions/find-all';
+import { createMockActionContext } from '@activepieces/pieces-framework';
+
+describe('findAll action', () => {
+  test('returns all plain text occurrences', async () => {
+    const ctx = createMockActionContext({
+      propsValue: {
+        text: 'cat and dog and cat',
+        expression: 'cat',
+        ignoreCase: false,
+      },
+    });
+    expect(await findAll.run(ctx)).toEqual(['cat', 'cat']);
+  });
+
+  test('returns empty array when no match', async () => {
+    const ctx = createMockActionContext({
+      propsValue: { text: 'hello world', expression: 'xyz', ignoreCase: false },
+    });
+    expect(await findAll.run(ctx)).toEqual([]);
+  });
+
+  test('returns all regex matches', async () => {
+    const ctx = createMockActionContext({
+      propsValue: {
+        text: 'abc 123 def 456 ghi 789',
+        expression: '\\d+',
+        ignoreCase: false,
+      },
+    });
+    expect(await findAll.run(ctx)).toEqual(['123', '456', '789']);
+  });
+
+  test('returns full match for patterns with capture groups', async () => {
+    // m[0] is the full match; capture groups are intentionally not surfaced
+    const ctx = createMockActionContext({
+      propsValue: {
+        text: 'born 1990, graduated 2012, hired 2020',
+        expression: '(\\d{4})',
+        ignoreCase: false,
+      },
+    });
+    expect(await findAll.run(ctx)).toEqual(['1990', '2012', '2020']);
+  });
+
+  test('is case-sensitive by default', async () => {
+    const ctx = createMockActionContext({
+      propsValue: { text: 'Cat cat CAT', expression: 'cat', ignoreCase: false },
+    });
+    expect(await findAll.run(ctx)).toEqual(['cat']);
+  });
+
+  test('ignores case when ignoreCase is true', async () => {
+    const ctx = createMockActionContext({
+      propsValue: { text: 'Cat cat CAT', expression: 'cat', ignoreCase: true },
+    });
+    expect(await findAll.run(ctx)).toEqual(['Cat', 'cat', 'CAT']);
+  });
+
+  test('regression: returns all occurrences, not just the first match and its capture group', async () => {
+    // Before the fix, find() with no g flag returned [" V0099=T700", "V0099=T700"] (first full match +
+    // capture group) instead of all 4 occurrences.
+    const ctx = createMockActionContext({
+      propsValue: {
+        text: 'codes: V0099=T700 V1234=T500 E5678=T321 G9999=T000',
+        expression: '[VEG]\\d{4}=T\\d{3}',
+        ignoreCase: false,
+      },
+    });
+    const result = await findAll.run(ctx);
+    expect(result).toHaveLength(4);
+    expect(result).toEqual([
+      'V0099=T700',
+      'V1234=T500',
+      'E5678=T321',
+      'G9999=T000',
+    ]);
+  });
+
+  test('handles a single match correctly', async () => {
+    const ctx = createMockActionContext({
+      propsValue: {
+        text: 'only one match here',
+        expression: 'one',
+        ignoreCase: false,
+      },
+    });
+    expect(await findAll.run(ctx)).toEqual(['one']);
+  });
+});

--- a/packages/pieces/core/text-helper/test/find-all.test.ts
+++ b/packages/pieces/core/text-helper/test/find-all.test.ts
@@ -89,4 +89,11 @@ describe('findAll action', () => {
     });
     expect(await findAll.run(ctx)).toEqual(['one']);
   });
+
+  test('throws a descriptive error for an invalid regex', async () => {
+    const ctx = createMockActionContext({
+      propsValue: { text: 'hello', expression: '[unclosed', ignoreCase: false },
+    });
+    await expect(findAll.run(ctx)).rejects.toThrow('Invalid regular expression: [unclosed');
+  });
 });

--- a/packages/pieces/core/text-helper/test/find.test.ts
+++ b/packages/pieces/core/text-helper/test/find.test.ts
@@ -77,4 +77,11 @@ describe('find action', () => {
     expect(result).not.toBeNull();
     expect(result![0]).toBe('Cat');
   });
+
+  test('throws a descriptive error for an invalid regex', async () => {
+    const ctx = createMockActionContext({
+      propsValue: { text: 'hello', expression: '[unclosed', ignoreCase: false },
+    });
+    await expect(find.run(ctx)).rejects.toThrow('Invalid regular expression: [unclosed');
+  });
 });

--- a/packages/pieces/core/text-helper/test/find.test.ts
+++ b/packages/pieces/core/text-helper/test/find.test.ts
@@ -9,6 +9,7 @@ describe('find action', () => {
       propsValue: {
         text: 'hello world',
         expression: 'world',
+        ignoreCase: false,
       },
     });
     const result = await find.run(ctx);
@@ -18,10 +19,7 @@ describe('find action', () => {
 
   test('finds regex match', async () => {
     const ctx = createMockActionContext({
-      propsValue: {
-        text: 'abc123def',
-        expression: '\\d+',
-      },
+      propsValue: { text: 'abc123def', expression: '\\d+', ignoreCase: false },
     });
     const result = await find.run(ctx);
     expect(result).not.toBeNull();
@@ -30,10 +28,7 @@ describe('find action', () => {
 
   test('returns null when no match', async () => {
     const ctx = createMockActionContext({
-      propsValue: {
-        text: 'hello world',
-        expression: 'xyz',
-      },
+      propsValue: { text: 'hello world', expression: 'xyz', ignoreCase: false },
     });
     const result = await find.run(ctx);
     expect(result).toBeNull();
@@ -44,6 +39,7 @@ describe('find action', () => {
       propsValue: {
         text: '2024-01-15',
         expression: '(\\d{4})-(\\d{2})-(\\d{2})',
+        ignoreCase: false,
       },
     });
     const result = await find.run(ctx);
@@ -52,5 +48,33 @@ describe('find action', () => {
     expect(result![1]).toBe('2024');
     expect(result![2]).toBe('01');
     expect(result![3]).toBe('15');
+  });
+
+  test('returns only the first match when multiple exist', async () => {
+    const ctx = createMockActionContext({
+      propsValue: { text: 'cat and cat', expression: 'cat', ignoreCase: false },
+    });
+    const result = await find.run(ctx);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]).toBe('cat');
+  });
+
+  test('is case-sensitive by default', async () => {
+    const ctx = createMockActionContext({
+      propsValue: { text: 'Cat cat', expression: 'cat', ignoreCase: false },
+    });
+    const result = await find.run(ctx);
+    expect(result).not.toBeNull();
+    expect(result![0]).toBe('cat');
+  });
+
+  test('ignores case when ignoreCase is true', async () => {
+    const ctx = createMockActionContext({
+      propsValue: { text: 'Cat cat', expression: 'cat', ignoreCase: true },
+    });
+    const result = await find.run(ctx);
+    expect(result).not.toBeNull();
+    expect(result![0]).toBe('Cat');
   });
 });


### PR DESCRIPTION
- Add Find All action using matchAll + g flag, returning all occurrences as string[]
- Add ignoreCase checkbox to both Find and Find All for consistent API
- Fix Find action's text prop displayName casing (text → Text)
- Clarify Find description to make clear it returns only the first match
- Remove stray console.log from markdown-to-html
- Add 8 tests for Find All including regression test for the multi-match bug
- Expand Find tests to cover ignoreCase and single-match-only behaviour
- Bump version 0.4.15 → 0.5.0

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
