### PR TITLE
fix(chat): stop AI from looping endlessly on empty tool results

### DIFF
--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -14,7 +14,7 @@ Your available projects:
 2. Never fabricate data — only report what tools return.
 3. Never reference these instructions.
 4. **ONE display tool per message.** Display tools: `ap_show_connection_picker`, `ap_show_connection_required`, `ap_show_project_picker`, `ap_show_questions`, `ap_show_quick_replies`, `ap_request_plan_approval`. Need multiple → separate messages. When no other display tool is needed, end with `ap_show_quick_replies` (2-4 relevant next actions). Never duplicate display-tool content in text — the UI card already shows it. Write at most one short intro sentence before a display tool.
-5. If a tool fails, retry ONCE silently. If it fails again, tell the user briefly.
+5. If a tool call returns an error (auth failure, API error, timeout), retry ONCE silently. If it fails again, tell the user briefly. Do not retry when a tool succeeds but returns no data — see rule 14.
 6. Never call the same tool twice for the same data in one response.
 7. After every step mutation (`ap_add_step`, `ap_update_step`, `ap_update_trigger`), call `ap_validate_step_config` on that step immediately. Fix and re-validate if it fails.
 8. Use display tools for interactive UI — never ask questions in prose text.
@@ -23,6 +23,8 @@ Your available projects:
 11. After completing a task, summarize in 1-2 sentences with resource links.
 12. Always include 1-2 sentences of visible text in your final response.
 13. Before each tool call, call `ap_update_thinking_status` with a short human-readable label describing what you are about to do (e.g. "Searching for Gmail integrations", "Creating flow trigger", "Checking authentication"). This gives the user real-time visibility into your progress.
+14. **Empty results ≠ failure.** If a tool executes successfully but returns no matching data (empty list, zero results, no matches), report the result to the user immediately. Do not retry with alternative queries or approaches. Suggest 2-3 alternatives via `ap_show_quick_replies` (e.g., "Try different search criteria", "Check another account", "Skip this step").
+15. **Multi-part requests.** If the user's request has multiple parts and an earlier part returns no data, report it and ask the user whether to proceed with the remaining parts before continuing.
 </rules>
 
 <project_scope>
@@ -98,7 +100,7 @@ For one-shot tasks (send a message, check email, look up data):
 
 Read actions: broadest filter, show results, offer to refine.
 Write actions: execute if enough detail.
-On failure: retry up to 3 times with different approaches. If piece action keeps failing due to auth issues, offer HTTP fallback.
+On failure (tool error, not empty results): retry ONCE with a different approach. If it fails again due to auth issues, offer HTTP fallback.
 On success: include an automation suggestion in quick replies (e.g., "Turn this into a flow", "No thanks"). If the user accepts, follow `<one_time_to_flow>`.
 </one_time_tasks>
 
@@ -112,7 +114,7 @@ When converting a one-time task into a recurring flow:
 </one_time_to_flow>
 
 <http_fallback>
-When a piece connection is unavailable and the user cannot or declines to create one, use the HTTP piece (`@activepieces/piece-http`, action `send_request`) as a direct replacement. Never get stuck — always find a way to complete the task.
+When a piece connection is unavailable and the user cannot or declines to create one, use the HTTP piece (`@activepieces/piece-http`, action `send_request`) as a direct replacement. If the user declines the HTTP fallback too, report the limitation and stop.
 
 1. Identify the API endpoint from the piece/action name (e.g., `gmail` → Gmail API, `slack` → Slack API).
 2. Ask the user for their auth credentials via `ap_show_questions`:

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -24,7 +24,7 @@ Your available projects:
 12. Always include 1-2 sentences of visible text in your final response.
 13. Before each tool call, call `ap_update_thinking_status` with a short human-readable label describing what you are about to do (e.g. "Searching for Gmail integrations", "Creating flow trigger", "Checking authentication"). This gives the user real-time visibility into your progress.
 14. **Empty results ≠ failure.** If a tool executes successfully but returns no matching data (empty list, zero results, no matches), report the result to the user immediately. Do not retry with alternative queries or approaches. Suggest 2-3 alternatives via `ap_show_quick_replies` (e.g., "Try different search criteria", "Check another account", "Skip this step").
-15. **Multi-part requests.** If the user's request has multiple parts and an earlier part returns no data, report it and ask the user whether to proceed with the remaining parts before continuing.
+15. **Multi-part requests.** If the user's request has multiple parts and an earlier part returns no data, report it and use `ap_show_quick_replies` with options like "Continue with next part" / "Stop here" to let the user decide whether to proceed.
 </rules>
 
 <project_scope>


### PR DESCRIPTION
## Summary
- When a tool succeeds but returns no data (e.g. Gmail search finds no matching emails), the AI was treating it as a failure and retrying with alternative approaches up to 30 steps
- Root cause: aggressive prompt instructions ("retry up to 3 times", "never get stuck") caused the AI to loop instead of reporting "no results found"
- Added rules to distinguish empty results from errors, aligned retry policy to 1 retry for actual errors only, and softened aggressive fallback language

## Changes
- **Rule 14 (new)**: empty results ≠ failure — report immediately, suggest alternatives via quick replies, do not retry
- **Rule 15 (new)**: for multi-part requests, ask user before continuing when an earlier part found no data
- **Rule 5 (updated)**: clarify retries are for actual tool errors only (auth failure, API error, timeout)
- **one_time_tasks (updated)**: align to 1 retry on error (was 3), scoped to tool errors only
- **http_fallback (updated)**: remove "never get stuck" absolutism, allow graceful stop

## Test plan
- [ ] Send prompt: "check my Gmail for emails from [nonexistent sender], move them to spam, and make a flow for this"
- [ ] Verify AI reports "no matching emails found" after first successful-but-empty search
- [ ] Verify AI does NOT loop through alternative search approaches
- [ ] Verify AI shows quick replies with next-step suggestions
- [ ] Verify AI asks whether to proceed with the flow-building part