### PR TITLE
fix(git-sync): opt in to allowUnsafeSshCommand after simple-git 3.36 bump

### DIFF
--- a/packages/server/api/src/app/ee/projects/project-release/git-sync/git-helper.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/git-sync/git-helper.ts
@@ -83,9 +83,13 @@ async function initGitRepo(
     baseDir: string,
     branch: string,
 ): Promise<SimpleGit> {
+    assertSafeKeyPath(keyPath)
     const git = simpleGit({
         baseDir,
         binary: 'git',
+        unsafe: {
+            allowUnsafeSshCommand: true,
+        },
     }).env('GIT_SSH_COMMAND', `ssh -i ${keyPath} -o StrictHostKeyChecking=no`)
     await git.init()
     await git.addConfig('core.symlinks', 'false')
@@ -97,6 +101,7 @@ async function initGitRepo(
 }
 
 const SAFE_SLUG_PATTERN = /^[A-Za-z0-9._-]{1,128}$/
+const SAFE_KEY_PATH_PATTERN = /^[A-Za-z0-9._/-]+$/
 
 function assertSafeSlug(slug: string): void {
     if (!SAFE_SLUG_PATTERN.test(slug) || slug === '.' || slug === '..') {
@@ -104,6 +109,17 @@ function assertSafeSlug(slug: string): void {
             code: ErrorCode.VALIDATION,
             params: {
                 message: `invalid gitRepo.slug "${slug}": only alphanumeric, dot, dash and underscore are allowed (max 128 chars)`,
+            },
+        })
+    }
+}
+
+function assertSafeKeyPath(keyPath: string): void {
+    if (!SAFE_KEY_PATH_PATTERN.test(keyPath)) {
+        throw new ActivepiecesError({
+            code: ErrorCode.VALIDATION,
+            params: {
+                message: 'invalid ssh key path: contains characters that are not safe to interpolate into GIT_SSH_COMMAND',
             },
         })
     }


### PR DESCRIPTION
## Summary
- simple-git 3.36 (introduced by dependabot bump `febb9f53a`) blocks `GIT_SSH_COMMAND` env injection unless `unsafe.allowUnsafeSshCommand` is enabled, causing all git-sync push/validate operations to fail with `500 Use of "GIT_SSH_COMMAND" is not permitted without enabling allowUnsafeSshCommand`.
- Opt in via `unsafe.allowUnsafeSshCommand: true` on the `simpleGit({...})` call site.
- Added defensive `assertSafeKeyPath` so the unquoted `${keyPath}` interpolation cannot become an RCE vector if `gitRepo.id` ever becomes user-controllable (today it's always a server-generated apId).

Cloud hotfix — same fix is going to `main` in a separate PR.

## Test plan
- [ ] Configure a git repo on a project and push — should succeed without the 500
- [ ] Validate connection on configure repo — should succeed
- [ ] `npm run lint-dev` clean