### PR TITLE
fix(git-sync): allow protocol.file.allow config write

### DIFF
--- a/packages/server/api/src/app/ee/projects/project-release/git-sync/git-helper.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/git-sync/git-helper.ts
@@ -89,6 +89,7 @@ async function initGitRepo(
         binary: 'git',
         unsafe: {
             allowUnsafeSshCommand: true,
+            allowUnsafeProtocolOverride: true,
         },
     }).env('GIT_SSH_COMMAND', `ssh -i ${keyPath} -o StrictHostKeyChecking=no`)
     await git.init()


### PR DESCRIPTION
## Summary
Follow-up to #13407. simple-git 3.36 also blocks any `protocol.*.allow` config write unless `unsafe.allowUnsafeProtocolOverride` is enabled, so git push now 500s with:

```
Configuring protocol.allow is not permitted without enabling allowUnsafeProtocolOverride
```

We set `protocol.file.allow=never` — this *tightens* the protocol allow-list (denies `file://` submodule LFI) rather than loosens it, so opting in is safe.

Validated locally against simple-git 3.36.0:

```
without unsafe opts                            → FAIL (GIT_SSH_COMMAND blocked)
with allowUnsafeSshCommand only                → FAIL (protocol.allow blocked)
with both unsafe opts                          → PASS
```

The cloud deploy branch already has this fix (pushed directly on the hotfix path); this PR brings `main` in sync.

## Test plan
- [ ] Push a flow to a git repo on `main` — should succeed
- [ ] Validate connection on configure repo — should succeed
- [ ] `npm run lint-dev` clean