### PR TITLE
fix(engine): self-exit on socket loss to break the OOM-orphan ratchet

### DIFF
--- a/packages/server/engine/src/lib/worker-socket.ts
+++ b/packages/server/engine/src/lib/worker-socket.ts
@@ -20,6 +20,14 @@ const INITIAL_CONNECT_TIMEOUT_MS = 60_000
 let socket: Socket | undefined
 let workerClient: WorkerContract | undefined
 let notifyClient: WorkerNotifyContract | undefined
+let initialConnectWatchdog: NodeJS.Timeout | undefined
+
+function clearInitialConnectWatchdog(): void {
+    if (initialConnectWatchdog) {
+        clearTimeout(initialConnectWatchdog)
+        initialConnectWatchdog = undefined
+    }
+}
 
 export const workerSocket = {
     init: (sandboxId: string): void => {
@@ -30,7 +38,8 @@ export const workerSocket = {
         // the engine ever connects, the engine sits forever retrying the handshake on a
         // dead port — orphaned, idle, holding ~80 MB. The worker is the only thing that
         // can kill us, so if it's not there to talk to, we self-terminate.
-        const initialConnectWatchdog = setTimeout(() => {
+        initialConnectWatchdog = setTimeout(() => {
+            initialConnectWatchdog = undefined
             // eslint-disable-next-line no-console
             console.error('[engine] Failed to connect to worker within 60s, exiting')
             process.exit(5)
@@ -40,7 +49,7 @@ export const workerSocket = {
         notifyClient = createNotifyClient<WorkerNotifyContract>(socket)
 
         socket.on('connect', () => {
-            clearTimeout(initialConnectWatchdog)
+            clearInitialConnectWatchdog()
         })
 
         // Same rationale as the watchdog: once the control channel is gone, this engine
@@ -113,6 +122,7 @@ export const workerSocket = {
     },
 
     disconnect: (): void => {
+        clearInitialConnectWatchdog()
         socket?.disconnect()
         socket = undefined
         workerClient = undefined

--- a/packages/server/engine/src/lib/worker-socket.ts
+++ b/packages/server/engine/src/lib/worker-socket.ts
@@ -15,6 +15,8 @@ import { io, type ManagerOptions, type Socket, type SocketOptions } from 'socket
 import { flowRunProgressReporter } from './helper/flow-run-progress-reporter'
 import { execute } from './operations'
 
+const INITIAL_CONNECT_TIMEOUT_MS = 60_000
+
 let socket: Socket | undefined
 let workerClient: WorkerContract | undefined
 let notifyClient: WorkerNotifyContract | undefined
@@ -24,8 +26,36 @@ export const workerSocket = {
         const wsUrl = `ws://127.0.0.1:${process.env.AP_SANDBOX_WS_PORT ?? '12345'}`
         socket = io(wsUrl, buildSocketOptions(sandboxId))
 
+        // Without this watchdog, if the parent worker is SIGKILLed (OOM, crash) before
+        // the engine ever connects, the engine sits forever retrying the handshake on a
+        // dead port — orphaned, idle, holding ~80 MB. The worker is the only thing that
+        // can kill us, so if it's not there to talk to, we self-terminate.
+        const initialConnectWatchdog = setTimeout(() => {
+            // eslint-disable-next-line no-console
+            console.error('[engine] Failed to connect to worker within 60s, exiting')
+            process.exit(5)
+        }, INITIAL_CONNECT_TIMEOUT_MS)
+
         workerClient = createRpcClient<WorkerContract>(socket, 60_000)
         notifyClient = createNotifyClient<WorkerNotifyContract>(socket)
+
+        socket.on('connect', () => {
+            clearTimeout(initialConnectWatchdog)
+        })
+
+        // Same rationale as the watchdog: once the control channel is gone, this engine
+        // can never reattach (worker rotates the handshake token per start()), so we'd
+        // just be a zombie sandbox-* process accumulating until the next host OOM.
+        // Exclude 'io client disconnect' so the engine's own workerSocket.disconnect()
+        // path (used by tests) doesn't fire process.exit on the test runner.
+        socket.on('disconnect', (reason) => {
+            if (reason === 'io client disconnect') {
+                return
+            }
+            // eslint-disable-next-line no-console
+            console.error(`[engine] Worker socket disconnected (${reason}), exiting`)
+            process.exit(6)
+        })
 
         const originalLog = console.log
         console.log = function (...args): void {
@@ -98,7 +128,11 @@ function buildSocketOptions(sandboxId: string): Partial<ManagerOptions & SocketO
             connectionToken: process.env.AP_SANDBOX_WS_TOKEN,
         },
         autoConnect: false,
-        reconnection: true,
+        // Engines are one-shot per sandbox. The worker rotates the handshake token on
+        // every start(), so any reconnect attempt after a disconnect is permanently
+        // unauthorized — looping just turns the engine into a zombie. Self-exit on
+        // disconnect (above) handles teardown.
+        reconnection: false,
     }
     // In STRICT mode ssrf-guard rebinds http.globalAgent to HttpProxyAgent; a
     // plain http.Agent here keeps the loopback worker RPC handshake off the proxy.


### PR DESCRIPTION
## Summary
Production incident on 2026-05-26: cloud worker hosts ran out of memory because OOM-killed worker processes leave their engine sandbox processes orphaned. Engines don't self-exit when their control socket is lost — `reconnection: true` keeps them spinning forever, and the May-21 handshake token rotation (#13225 / `7ec47c30ab`) means they can never reattach to the new worker either. Confirmed in dmesg (`CONSTRAINT_NONE` global OOM) + `ps` (PPID → docker-entrypoint).

~690 orphan sandboxes per host × ~78 MB each ≈ 48 GB never reclaimed → next global OOM → ratchet. The kamal worker deploy stalls under that load.

## What this changes
`packages/server/engine/src/lib/worker-socket.ts`:
- `reconnection: false` — engines are one-shot per sandbox; with the rotated handshake token any reconnect is guaranteed-unauthorized, looping serves no purpose.
- 60-second initial-connect watchdog — exits if the worker never accepts the handshake.
- `socket.on('disconnect')` → `process.exit(6)` for any non-self-initiated disconnect. Excludes `'io client disconnect'` so the engine's own `workerSocket.disconnect()` path (used by tests) doesn't kill the test runner.

## Why this is the right layer
The worker can't be the sole reaper because OOM SIGKILL leaves no cleanup window. Engines must take responsibility for their own teardown once their control channel is gone. Belt-and-braces infra fixes (swap, container mem-limit, drop the inflated `--max-old-space-size`, `boot: { limit: 25% }` in `worker.yml`) are tracked separately — this PR breaks the orphan-accumulation primitive that makes the ratchet possible.

## Test plan
- [ ] `npm run test-unit` clean (existing `worker-socket.test.ts` covers the `'io client disconnect'` path via `afterEach`)
- [ ] Local docker-compose benchmark (`benchmark/run-local.sh SANDBOX_CODE_AND_PROCESS 200`) — verify no leftover `sandbox-*` processes in worker containers after run
- [ ] Soak: run many flows, kill the worker with `SIGKILL`, confirm engine processes die on their own within 60s instead of being adopted by entrypoint