### PR TITLE
fix(engine): self-exit on socket loss to break the OOM-orphan ratchet

### DIFF
--- a/packages/server/engine/src/lib/worker-socket.ts
+++ b/packages/server/engine/src/lib/worker-socket.ts
@@ -20,6 +20,14 @@ const INITIAL_CONNECT_TIMEOUT_MS = 60_000
 let socket: Socket | undefined
 let workerClient: WorkerContract | undefined
 let notifyClient: WorkerNotifyContract | undefined
+let initialConnectWatchdog: NodeJS.Timeout | undefined
+
+function clearInitialConnectWatchdog(): void {
+    if (initialConnectWatchdog) {
+        clearTimeout(initialConnectWatchdog)
+        initialConnectWatchdog = undefined
+    }
+}
 
 export const workerSocket = {
     init: (sandboxId: string): void => {
@@ -30,7 +38,8 @@ export const workerSocket = {
         // the engine ever connects, the engine sits forever retrying the handshake on a
         // dead port — orphaned, idle, holding ~80 MB. The worker is the only thing that
         // can kill us, so if it's not there to talk to, we self-terminate.
-        const initialConnectWatchdog = setTimeout(() => {
+        initialConnectWatchdog = setTimeout(() => {
+            initialConnectWatchdog = undefined
             // eslint-disable-next-line no-console
             console.error('[engine] Failed to connect to worker within 60s, exiting')
             process.exit(5)
@@ -40,7 +49,7 @@ export const workerSocket = {
         notifyClient = createNotifyClient<WorkerNotifyContract>(socket)
 
         socket.on('connect', () => {
-            clearTimeout(initialConnectWatchdog)
+            clearInitialConnectWatchdog()
         })
 
         // Same rationale as the watchdog: once the control channel is gone, this engine
@@ -113,6 +122,7 @@ export const workerSocket = {
     },
 
     disconnect: (): void => {
+        clearInitialConnectWatchdog()
         socket?.disconnect()
         socket = undefined
         workerClient = undefined

--- a/packages/server/engine/src/lib/worker-socket.ts
+++ b/packages/server/engine/src/lib/worker-socket.ts
@@ -15,6 +15,8 @@ import { io, type ManagerOptions, type Socket, type SocketOptions } from 'socket
 import { flowRunProgressReporter } from './helper/flow-run-progress-reporter'
 import { execute } from './operations'
 
+const INITIAL_CONNECT_TIMEOUT_MS = 60_000
+
 let socket: Socket | undefined
 let workerClient: WorkerContract | undefined
 let notifyClient: WorkerNotifyContract | undefined
@@ -24,8 +26,36 @@ export const workerSocket = {
         const wsUrl = `ws://127.0.0.1:${process.env.AP_SANDBOX_WS_PORT ?? '12345'}`
         socket = io(wsUrl, buildSocketOptions(sandboxId))
 
+        // Without this watchdog, if the parent worker is SIGKILLed (OOM, crash) before
+        // the engine ever connects, the engine sits forever retrying the handshake on a
+        // dead port — orphaned, idle, holding ~80 MB. The worker is the only thing that
+        // can kill us, so if it's not there to talk to, we self-terminate.
+        const initialConnectWatchdog = setTimeout(() => {
+            // eslint-disable-next-line no-console
+            console.error('[engine] Failed to connect to worker within 60s, exiting')
+            process.exit(5)
+        }, INITIAL_CONNECT_TIMEOUT_MS)
+
         workerClient = createRpcClient<WorkerContract>(socket, 60_000)
         notifyClient = createNotifyClient<WorkerNotifyContract>(socket)
+
+        socket.on('connect', () => {
+            clearTimeout(initialConnectWatchdog)
+        })
+
+        // Same rationale as the watchdog: once the control channel is gone, this engine
+        // can never reattach (worker rotates the handshake token per start()), so we'd
+        // just be a zombie sandbox-* process accumulating until the next host OOM.
+        // Exclude 'io client disconnect' so the engine's own workerSocket.disconnect()
+        // path (used by tests) doesn't fire process.exit on the test runner.
+        socket.on('disconnect', (reason) => {
+            if (reason === 'io client disconnect') {
+                return
+            }
+            // eslint-disable-next-line no-console
+            console.error(`[engine] Worker socket disconnected (${reason}), exiting`)
+            process.exit(6)
+        })
 
         const originalLog = console.log
         console.log = function (...args): void {
@@ -98,7 +128,11 @@ function buildSocketOptions(sandboxId: string): Partial<ManagerOptions & SocketO
             connectionToken: process.env.AP_SANDBOX_WS_TOKEN,
         },
         autoConnect: false,
-        reconnection: true,
+        // Engines are one-shot per sandbox. The worker rotates the handshake token on
+        // every start(), so any reconnect attempt after a disconnect is permanently
+        // unauthorized — looping just turns the engine into a zombie. Self-exit on
+        // disconnect (above) handles teardown.
+        reconnection: false,
     }
     // In STRICT mode ssrf-guard rebinds http.globalAgent to HttpProxyAgent; a
     // plain http.Agent here keeps the loopback worker RPC handshake off the proxy.


### PR DESCRIPTION
## Summary
Cloud hotfix for the 2026-05-26 incident — same change as #13409 (targeting main), cherry-picked onto the live deploy branch.

Worker hosts have been ratcheting toward OOM because engine sandbox processes orphaned by kernel-OOM-killed worker generations never self-terminate. ~690 orphans × ~78 MB ≈ 48 GB of permanently-held RAM per host. The kamal worker deploy stalls under that load.

## What this changes
`packages/server/engine/src/lib/worker-socket.ts`:
- `reconnection: false` — engines are one-shot per sandbox; with the rotated handshake token any reconnect is guaranteed-unauthorized.
- 60-second initial-connect watchdog — exits if the worker never accepts the handshake.
- `socket.on('disconnect')` → `process.exit(6)` for any non-self-initiated disconnect (excludes `'io client disconnect'` so tests don't kill themselves).

## Why this is the right layer
OOM SIGKILL leaves no cleanup window for the worker; engines must own their own teardown. Infra fixes (swap, container mem-limit, drop `--max-old-space-size=64512`, `boot: { limit: 25% }`) are tracked separately.

## Test plan
- [ ] Same as #13409
- [ ] Cloud canary first, then full promote