### PR TITLE
feat(gorgias): add Gorgias helpdesk piece with ticket, message & cust…

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -570,7 +570,7 @@
     },
     "packages/pieces/community/airtable": {
       "name": "@activepieces/piece-airtable",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3155,7 +3155,7 @@
     },
     "packages/pieces/community/google-gemini": {
       "name": "@activepieces/piece-google-gemini",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3271,6 +3271,16 @@
         "@activepieces/shared": "workspace:*",
         "tslib": "^2.3.0",
         "zod": "4.3.6",
+      },
+    },
+    "packages/pieces/community/gorgias": {
+      "name": "@activepieces/piece-gorgias",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
       },
     },
     "packages/pieces/community/gotify": {
@@ -4356,7 +4366,7 @@
     },
     "packages/pieces/community/mailgun": {
       "name": "@activepieces/piece-mailgun",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -6312,7 +6322,7 @@
     },
     "packages/pieces/community/senja": {
       "name": "@activepieces/piece-senja",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7175,7 +7185,7 @@
     },
     "packages/pieces/community/typefully": {
       "name": "@activepieces/piece-typefully",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7338,7 +7348,7 @@
     },
     "packages/pieces/community/village": {
       "name": "@activepieces/piece-village",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -8126,7 +8136,7 @@
     },
     "packages/pieces/core/pdf": {
       "name": "@activepieces/piece-pdf",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -9264,6 +9274,8 @@
     "@activepieces/piece-google-vertexai": ["@activepieces/piece-google-vertexai@workspace:packages/pieces/community/google-vertexai"],
 
     "@activepieces/piece-googlechat": ["@activepieces/piece-googlechat@workspace:packages/pieces/community/googlechat"],
+
+    "@activepieces/piece-gorgias": ["@activepieces/piece-gorgias@workspace:packages/pieces/community/gorgias"],
 
     "@activepieces/piece-gotify": ["@activepieces/piece-gotify@workspace:packages/pieces/community/gotify"],
 

--- a/packages/pieces/community/gorgias/.eslintrc.json
+++ b/packages/pieces/community/gorgias/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/gorgias/package.json
+++ b/packages/pieces/community/gorgias/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-gorgias",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/gorgias/src/index.ts
+++ b/packages/pieces/community/gorgias/src/index.ts
@@ -1,0 +1,100 @@
+import { createPiece, PieceAuth, Property } from '@activepieces/pieces-framework';
+import {
+  createCustomApiCallAction,
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/shared';
+import { gorgiasApi } from './lib/common/client';
+import { createTicket } from './lib/actions/create-ticket';
+import { getTicket } from './lib/actions/get-ticket';
+import { updateTicket } from './lib/actions/update-ticket';
+import { listTickets } from './lib/actions/list-tickets';
+import { addMessage } from './lib/actions/add-message';
+import { createCustomer } from './lib/actions/create-customer';
+import { updateCustomer } from './lib/actions/update-customer';
+import { findCustomer } from './lib/actions/find-customer';
+import { newTicket } from './lib/triggers/new-ticket';
+import { updatedTicket } from './lib/triggers/updated-ticket';
+import { ticketStatusUpdated } from './lib/triggers/ticket-status-updated';
+import { newMessage } from './lib/triggers/new-message';
+
+export const gorgiasAuth = PieceAuth.CustomAuth({
+  description: `Connect your Gorgias account using your account email and an API key.
+
+**How to get your API key:**
+1. Log in to your Gorgias account.
+2. Go to **Settings → REST API** (or visit \`https://YOUR-DOMAIN.gorgias.com/settings/rest-api\`).
+3. Copy your **API key**.
+
+Your domain is the subdomain in your Gorgias URL — for \`https://acme.gorgias.com\` the domain is \`acme\`.`,
+  required: true,
+  props: {
+    domain: Property.ShortText({
+      displayName: 'Domain',
+      description: 'Your Gorgias subdomain. For "https://acme.gorgias.com" enter "acme".',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Account Email',
+      description: 'The email address of your Gorgias account.',
+      required: true,
+    }),
+    api_key: PieceAuth.SecretText({
+      displayName: 'API Key',
+      description: 'Found under Settings → REST API in your Gorgias account.',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${gorgiasApi.buildBaseUrl(auth.domain)}/tickets`,
+        authentication: {
+          type: AuthenticationType.BASIC,
+          username: auth.email,
+          password: auth.api_key,
+        },
+        queryParams: { limit: '1' },
+      });
+      return { valid: true };
+    } catch (e) {
+      return {
+        valid: false,
+        error: 'Invalid credentials. Check your domain, email, and API key.',
+      };
+    }
+  },
+});
+
+export const gorgias = createPiece({
+  displayName: 'Gorgias',
+  description:
+    'Helpdesk for ecommerce. Manage tickets, messages, and customers in your Gorgias support inbox.',
+  auth: gorgiasAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/gorgias.png',
+  categories: [PieceCategory.CUSTOMER_SUPPORT],
+  authors: ['sanket-a11y'],
+  actions: [
+    createTicket,
+    getTicket,
+    updateTicket,
+    listTickets,
+    addMessage,
+    createCustomer,
+    updateCustomer,
+    findCustomer,
+    createCustomApiCallAction({
+      baseUrl: (auth) => (auth ? gorgiasApi.buildBaseUrl(auth.props.domain) : ''),
+      auth: gorgiasAuth,
+      authMapping: async (auth) => {
+        const token = Buffer.from(`${auth.props.email}:${auth.props.api_key}`).toString('base64');
+        return { Authorization: `Basic ${token}` };
+      },
+    }),
+  ],
+  triggers: [newTicket, updatedTicket, ticketStatusUpdated, newMessage],
+});

--- a/packages/pieces/community/gorgias/src/lib/actions/add-message.ts
+++ b/packages/pieces/community/gorgias/src/lib/actions/add-message.ts
@@ -1,0 +1,69 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from '../common/client';
+import { gorgiasProps } from '../common/props';
+
+export const addMessage = createAction({
+  auth: gorgiasAuth,
+  name: 'add_message',
+  displayName: 'Add Message to Ticket',
+  description: 'Reply to a ticket or add an internal note that only agents can see.',
+  props: {
+    ticket_id: gorgiasProps.ticketId(true),
+    message_type: Property.StaticDropdown({
+      displayName: 'Message Type',
+      description:
+        'A public reply is sent to the customer. An internal note stays private to your team.',
+      required: true,
+      defaultValue: 'reply',
+      options: {
+        options: [
+          { label: 'Public reply to customer', value: 'reply' },
+          { label: 'Internal note (agents only)', value: 'note' },
+        ],
+      },
+    }),
+    body_text: Property.LongText({
+      displayName: 'Message',
+      description: 'The content of the message.',
+      required: true,
+    }),
+    channel: Property.StaticDropdown({
+      displayName: 'Channel',
+      description: 'The channel to send a public reply through. Ignored for internal notes.',
+      required: false,
+      defaultValue: 'email',
+      options: {
+        options: [
+          { label: 'Email', value: 'email' },
+          { label: 'Chat', value: 'chat' },
+          { label: 'SMS', value: 'sms' },
+          { label: 'Facebook', value: 'facebook' },
+          { label: 'Instagram', value: 'instagram' },
+          { label: 'Twitter', value: 'twitter' },
+          { label: 'WhatsApp', value: 'whatsapp' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { ticket_id, message_type, body_text, channel } = context.propsValue;
+    const isNote = message_type === 'note';
+
+    const response = await gorgiasApi.call({
+      auth: context.auth.props,
+      method: HttpMethod.POST,
+      path: `/tickets/${ticket_id}/messages`,
+      body: {
+        channel: isNote ? 'internal-note' : channel ?? 'email',
+        via: isNote ? 'internal-note' : channel ?? 'email',
+        from_agent: true,
+        body_text,
+        public: !isNote,
+      },
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/actions/create-customer.ts
+++ b/packages/pieces/community/gorgias/src/lib/actions/create-customer.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from '../common/client';
+import { gorgiasCustomer, GorgiasCustomer } from '../common/customer';
+
+export const createCustomer = createAction({
+  auth: gorgiasAuth,
+  name: 'create_customer',
+  displayName: 'Create Customer',
+  description: 'Create a new customer in your Gorgias account.',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'The primary email address of the customer.',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Name',
+      description: 'The full name of the customer.',
+      required: false,
+    }),
+    external_id: Property.ShortText({
+      displayName: 'External ID',
+      description: 'An ID from an external system (e.g. your store or CRM) to link this customer to.',
+      required: false,
+    }),
+    language: Property.ShortText({
+      displayName: 'Language',
+      description: 'The preferred language as an ISO 639-1 code (e.g. "en", "fr").',
+      required: false,
+    }),
+    timezone: Property.ShortText({
+      displayName: 'Timezone',
+      description: 'An IANA timezone name (e.g. "America/New_York"). Defaults to UTC.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { email, name, external_id, language, timezone } = context.propsValue;
+
+    const response = await gorgiasApi.call<GorgiasCustomer>({
+      auth: context.auth.props,
+      method: HttpMethod.POST,
+      path: '/customers',
+      body: {
+        name,
+        external_id,
+        language,
+        timezone,
+        channels: [{ type: 'email', address: email, preferred: true }],
+      },
+    });
+
+    return gorgiasCustomer.flattenCustomer(response.body);
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/actions/create-ticket.ts
+++ b/packages/pieces/community/gorgias/src/lib/actions/create-ticket.ts
@@ -1,0 +1,131 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from '../common/client';
+import { gorgiasProps } from '../common/props';
+import { gorgiasTicket, GorgiasTicket } from '../common/ticket';
+
+export const createTicket = createAction({
+  auth: gorgiasAuth,
+  name: 'create_ticket',
+  displayName: 'Create Ticket',
+  description: 'Create a new support ticket with an initial message.',
+  props: {
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'The subject line of the ticket (max 998 characters).',
+      required: true,
+    }),
+    customer_email: Property.ShortText({
+      displayName: 'Customer Email',
+      description:
+        'Email address of the customer this ticket is for. If no customer with this email exists, one is created.',
+      required: true,
+    }),
+    customer_name: Property.ShortText({
+      displayName: 'Customer Name',
+      description: 'Full name of the customer. Used only when creating a new customer.',
+      required: false,
+    }),
+    body_text: Property.LongText({
+      displayName: 'Message',
+      description: 'The body of the first message in the ticket.',
+      required: true,
+    }),
+    channel: Property.StaticDropdown({
+      displayName: 'Channel',
+      description: 'The channel the conversation came through.',
+      required: true,
+      defaultValue: 'email',
+      options: {
+        options: [
+          { label: 'Email', value: 'email' },
+          { label: 'Phone', value: 'phone' },
+          { label: 'Chat', value: 'chat' },
+          { label: 'SMS', value: 'sms' },
+          { label: 'Facebook', value: 'facebook' },
+          { label: 'Instagram', value: 'instagram' },
+          { label: 'Twitter', value: 'twitter' },
+          { label: 'WhatsApp', value: 'whatsapp' },
+          { label: 'API', value: 'api' },
+        ],
+      },
+    }),
+    from_agent: Property.Checkbox({
+      displayName: 'Message From Agent',
+      description: 'Enable if the first message was written by your company rather than the customer.',
+      required: false,
+      defaultValue: false,
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      required: false,
+      defaultValue: 'open',
+      options: {
+        options: [
+          { label: 'Open', value: 'open' },
+          { label: 'Closed', value: 'closed' },
+        ],
+      },
+    }),
+    priority: Property.StaticDropdown({
+      displayName: 'Priority',
+      required: false,
+      defaultValue: 'normal',
+      options: {
+        options: [
+          { label: 'Low', value: 'low' },
+          { label: 'Normal', value: 'normal' },
+          { label: 'High', value: 'high' },
+          { label: 'Critical', value: 'critical' },
+        ],
+      },
+    }),
+    assignee_user: gorgiasProps.assigneeUserId(false),
+    tags: gorgiasProps.tagNames,
+  },
+  async run(context) {
+    const {
+      subject,
+      customer_email,
+      customer_name,
+      body_text,
+      channel,
+      from_agent,
+      status,
+      priority,
+      assignee_user,
+      tags,
+    } = context.propsValue;
+
+    const response = await gorgiasApi.call<GorgiasTicket>({
+      auth: context.auth.props,
+      method: HttpMethod.POST,
+      path: '/tickets',
+      body: {
+        subject,
+        channel,
+        from_agent: from_agent ?? false,
+        status,
+        priority,
+        customer: { email: customer_email, name: customer_name },
+        ...(assignee_user ? { assignee_user: { id: assignee_user } } : {}),
+        ...(tags && tags.length > 0 ? { tags: tags.map((name) => ({ name })) } : {}),
+        messages: [
+          {
+            channel,
+            from_agent: from_agent ?? false,
+            via: channel,
+            source: {
+              from: { address: from_agent ? undefined : customer_email },
+            },
+            body_text,
+            public: !from_agent,
+          },
+        ],
+      },
+    });
+
+    return gorgiasTicket.flattenTicket(response.body);
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/actions/find-customer.ts
+++ b/packages/pieces/community/gorgias/src/lib/actions/find-customer.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from '../common/client';
+import { gorgiasCustomer, GorgiasCustomer } from '../common/customer';
+
+export const findCustomer = createAction({
+  auth: gorgiasAuth,
+  name: 'find_customer',
+  displayName: 'Find Customer by Email',
+  description: 'Search for a customer by their email address.',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'The email address of the customer to find.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await gorgiasApi.call<{ data: GorgiasCustomer[] }>({
+      auth: context.auth.props,
+      method: HttpMethod.GET,
+      path: '/customers',
+      queryParams: {
+        email: context.propsValue.email,
+        limit: '30',
+      },
+    });
+
+    const customers = response.body.data ?? [];
+    return {
+      found: customers.length > 0,
+      customers: customers.map((customer) => gorgiasCustomer.flattenCustomer(customer)),
+    };
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/actions/get-ticket.ts
+++ b/packages/pieces/community/gorgias/src/lib/actions/get-ticket.ts
@@ -1,0 +1,24 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from '../common/client';
+import { gorgiasProps } from '../common/props';
+import { gorgiasTicket, GorgiasTicket } from '../common/ticket';
+
+export const getTicket = createAction({
+  auth: gorgiasAuth,
+  name: 'get_ticket',
+  displayName: 'Get Ticket',
+  description: 'Retrieve the details of a single ticket.',
+  props: {
+    ticket_id: gorgiasProps.ticketId(true),
+  },
+  async run(context) {
+    const response = await gorgiasApi.call<GorgiasTicket>({
+      auth: context.auth.props,
+      method: HttpMethod.GET,
+      path: `/tickets/${context.propsValue.ticket_id}`,
+    });
+    return gorgiasTicket.flattenTicket(response.body);
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/actions/list-tickets.ts
+++ b/packages/pieces/community/gorgias/src/lib/actions/list-tickets.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from '../common/client';
+import { gorgiasTicket, GorgiasTicket } from '../common/ticket';
+
+export const listTickets = createAction({
+  auth: gorgiasAuth,
+  name: 'list_tickets',
+  displayName: 'List Tickets',
+  description: 'Retrieve a list of tickets, most recently created first.',
+  props: {
+    order_by: Property.StaticDropdown({
+      displayName: 'Sort Order',
+      required: false,
+      defaultValue: 'created_datetime:desc',
+      options: {
+        options: [
+          { label: 'Newest created first', value: 'created_datetime:desc' },
+          { label: 'Oldest created first', value: 'created_datetime:asc' },
+          { label: 'Most recently updated first', value: 'updated_datetime:desc' },
+          { label: 'Least recently updated first', value: 'updated_datetime:asc' },
+        ],
+      },
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of tickets to return (1-100).',
+      required: false,
+      defaultValue: 30,
+    }),
+  },
+  async run(context) {
+    const limit = Math.min(Math.max(context.propsValue.limit ?? 30, 1), 100);
+    const response = await gorgiasApi.call<{ data: GorgiasTicket[] }>({
+      auth: context.auth.props,
+      method: HttpMethod.GET,
+      path: '/tickets',
+      queryParams: {
+        limit: String(limit),
+        order_by: context.propsValue.order_by ?? 'created_datetime:desc',
+      },
+    });
+    return response.body.data.map((ticket) => gorgiasTicket.flattenTicket(ticket));
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/actions/update-customer.ts
+++ b/packages/pieces/community/gorgias/src/lib/actions/update-customer.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { spreadIfNotUndefined } from '@activepieces/shared';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from '../common/client';
+import { gorgiasCustomer, GorgiasCustomer } from '../common/customer';
+
+export const updateCustomer = createAction({
+  auth: gorgiasAuth,
+  name: 'update_customer',
+  displayName: 'Update Customer',
+  description: 'Update the details of an existing customer.',
+  props: {
+    customer_id: Property.Number({
+      displayName: 'Customer ID',
+      description:
+        'The numeric ID of the customer to update. Use the "Find Customer" action to look it up by email.',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Name',
+      description: 'Leave empty to keep the current name.',
+      required: false,
+    }),
+    external_id: Property.ShortText({
+      displayName: 'External ID',
+      description: 'Leave empty to keep the current external ID.',
+      required: false,
+    }),
+    language: Property.ShortText({
+      displayName: 'Language',
+      description: 'ISO 639-1 code (e.g. "en"). Leave empty to keep the current value.',
+      required: false,
+    }),
+    timezone: Property.ShortText({
+      displayName: 'Timezone',
+      description: 'IANA timezone name. Leave empty to keep the current value.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { customer_id, name, external_id, language, timezone } = context.propsValue;
+
+    const response = await gorgiasApi.call<GorgiasCustomer>({
+      auth: context.auth.props,
+      method: HttpMethod.PUT,
+      path: `/customers/${customer_id}`,
+      body: {
+        ...spreadIfNotUndefined('name', name),
+        ...spreadIfNotUndefined('external_id', external_id),
+        ...spreadIfNotUndefined('language', language),
+        ...spreadIfNotUndefined('timezone', timezone),
+      },
+    });
+
+    return gorgiasCustomer.flattenCustomer(response.body);
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/actions/update-ticket.ts
+++ b/packages/pieces/community/gorgias/src/lib/actions/update-ticket.ts
@@ -1,0 +1,64 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { isNil, spreadIfNotUndefined } from '@activepieces/shared';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from '../common/client';
+import { gorgiasProps } from '../common/props';
+import { gorgiasTicket, GorgiasTicket } from '../common/ticket';
+
+export const updateTicket = createAction({
+  auth: gorgiasAuth,
+  name: 'update_ticket',
+  displayName: 'Update Ticket',
+  description: 'Update the status, priority, subject, or assignee of a ticket.',
+  props: {
+    ticket_id: gorgiasProps.ticketId(true),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      description: 'Leave empty to keep the current status.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Open', value: 'open' },
+          { label: 'Closed', value: 'closed' },
+        ],
+      },
+    }),
+    priority: Property.StaticDropdown({
+      displayName: 'Priority',
+      description: 'Leave empty to keep the current priority.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Low', value: 'low' },
+          { label: 'Normal', value: 'normal' },
+          { label: 'High', value: 'high' },
+          { label: 'Critical', value: 'critical' },
+        ],
+      },
+    }),
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      description: 'Leave empty to keep the current subject.',
+      required: false,
+    }),
+    assignee_user: gorgiasProps.assigneeUserId(false),
+  },
+  async run(context) {
+    const { ticket_id, status, priority, subject, assignee_user } = context.propsValue;
+
+    const response = await gorgiasApi.call<GorgiasTicket>({
+      auth: context.auth.props,
+      method: HttpMethod.PUT,
+      path: `/tickets/${ticket_id}`,
+      body: {
+        ...spreadIfNotUndefined('status', status),
+        ...spreadIfNotUndefined('priority', priority),
+        ...spreadIfNotUndefined('subject', subject),
+        ...(isNil(assignee_user) ? {} : { assignee_user: { id: assignee_user } }),
+      },
+    });
+
+    return gorgiasTicket.flattenTicket(response.body);
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/common/client.ts
+++ b/packages/pieces/community/gorgias/src/lib/common/client.ts
@@ -1,0 +1,51 @@
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+  HttpMessageBody,
+  HttpResponse,
+  QueryParams,
+} from '@activepieces/pieces-common';
+
+function buildBaseUrl(domain: string): string {
+  const normalized = domain
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\.gorgias\.com.*$/i, '')
+    .replace(/\/+$/, '');
+  return `https://${normalized}.gorgias.com/api`;
+}
+
+async function call<T extends HttpMessageBody>({
+  auth,
+  method,
+  path,
+  body,
+  queryParams,
+}: {
+  auth: GorgiasAuth;
+  method: HttpMethod;
+  path: string;
+  body?: unknown;
+  queryParams?: QueryParams;
+}): Promise<HttpResponse<T>> {
+  return httpClient.sendRequest<T>({
+    method,
+    url: `${buildBaseUrl(auth.domain)}${path}`,
+    authentication: {
+      type: AuthenticationType.BASIC,
+      username: auth.email,
+      password: auth.api_key,
+    },
+    queryParams,
+    body,
+  });
+}
+
+export const gorgiasApi = { call, buildBaseUrl };
+
+export type GorgiasAuth = {
+  domain: string;
+  email: string;
+  api_key: string;
+};

--- a/packages/pieces/community/gorgias/src/lib/common/customer.ts
+++ b/packages/pieces/community/gorgias/src/lib/common/customer.ts
@@ -1,0 +1,29 @@
+function flattenCustomer(customer: GorgiasCustomer) {
+  return {
+    id: customer.id,
+    name: customer.name ?? null,
+    firstname: customer.firstname ?? null,
+    lastname: customer.lastname ?? null,
+    email: customer.email ?? null,
+    external_id: customer.external_id ?? null,
+    language: customer.language ?? null,
+    timezone: customer.timezone ?? null,
+    created_datetime: customer.created_datetime ?? null,
+    updated_datetime: customer.updated_datetime ?? null,
+  };
+}
+
+export const gorgiasCustomer = { flattenCustomer };
+
+export type GorgiasCustomer = {
+  id: number;
+  name: string | null;
+  firstname: string | null;
+  lastname: string | null;
+  email: string | null;
+  external_id: string | null;
+  language: string | null;
+  timezone: string | null;
+  created_datetime: string;
+  updated_datetime: string;
+};

--- a/packages/pieces/community/gorgias/src/lib/common/props.ts
+++ b/packages/pieces/community/gorgias/src/lib/common/props.ts
@@ -1,0 +1,98 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { Property } from '@activepieces/pieces-framework';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from './client';
+
+const NOT_CONNECTED = {
+  disabled: true,
+  options: [],
+  placeholder: 'Please connect your Gorgias account first',
+};
+
+const ticketId = (required: boolean) =>
+  Property.Dropdown({
+    displayName: 'Ticket',
+    description: 'Pick the ticket from your 100 most recently updated tickets.',
+    auth: gorgiasAuth,
+    required,
+    refreshers: [],
+    options: async ({ auth }) => {
+      if (!auth) {
+        return NOT_CONNECTED;
+      }
+      const response = await gorgiasApi.call<{
+        data: { id: number; subject: string | null; status: string }[];
+      }>({
+        auth: auth.props,
+        method: HttpMethod.GET,
+        path: '/tickets',
+        queryParams: { limit: '100', order_by: 'updated_datetime:desc' },
+      });
+      return {
+        disabled: false,
+        options: response.body.data.map((ticket) => ({
+          label: `#${ticket.id} - ${ticket.subject ?? '(no subject)'} (${ticket.status})`,
+          value: ticket.id,
+        })),
+      };
+    },
+  });
+
+const assigneeUserId = (required: boolean) =>
+  Property.Dropdown({
+    displayName: 'Assignee',
+    description: 'The agent to assign the ticket to.',
+    auth: gorgiasAuth,
+    required,
+    refreshers: [],
+    options: async ({ auth }) => {
+      if (!auth) {
+        return NOT_CONNECTED;
+      }
+      const response = await gorgiasApi.call<{
+        data: { id: number; name: string | null; email: string }[];
+      }>({
+        auth: auth.props,
+        method: HttpMethod.GET,
+        path: '/users',
+        queryParams: { limit: '100' },
+      });
+      return {
+        disabled: false,
+        options: response.body.data.map((user) => ({
+          label: user.name ? `${user.name} (${user.email})` : user.email,
+          value: user.id,
+        })),
+      };
+    },
+  });
+
+const tagNames = Property.MultiSelectDropdown({
+  displayName: 'Tags',
+  description: 'Select existing tags to apply.',
+  auth: gorgiasAuth,
+  required: false,
+  refreshers: [],
+  options: async ({ auth }) => {
+    if (!auth) {
+      return NOT_CONNECTED;
+    }
+    const response = await gorgiasApi.call<{
+      data: { id: number; name: string }[];
+    }>({
+      auth: auth.props,
+      method: HttpMethod.GET,
+      path: '/tags',
+      queryParams: { limit: '100' },
+    });
+    return {
+      disabled: false,
+      options: response.body.data.map((tag) => ({
+        label: tag.name,
+        value: tag.name,
+      })),
+    };
+  },
+});
+
+export const gorgiasProps = { ticketId, assigneeUserId, tagNames };

--- a/packages/pieces/community/gorgias/src/lib/common/ticket.ts
+++ b/packages/pieces/community/gorgias/src/lib/common/ticket.ts
@@ -1,0 +1,46 @@
+function flattenTicket(ticket: GorgiasTicket) {
+  return {
+    id: ticket.id,
+    subject: ticket.subject ?? null,
+    status: ticket.status ?? null,
+    priority: ticket.priority ?? null,
+    channel: ticket.channel ?? null,
+    via: ticket.via ?? null,
+    language: ticket.language ?? null,
+    is_spam: ticket.spam ?? null,
+    messages_count: ticket.messages_count ?? null,
+    customer_id: ticket.customer?.id ?? null,
+    customer_email: ticket.customer?.email ?? null,
+    customer_name: ticket.customer?.name ?? null,
+    assignee_user_id: ticket.assignee_user?.id ?? null,
+    assignee_user_email: ticket.assignee_user?.email ?? null,
+    assignee_user_name: ticket.assignee_user?.name ?? null,
+    assignee_team_id: ticket.assignee_team?.id ?? null,
+    assignee_team_name: ticket.assignee_team?.name ?? null,
+    tags: Array.isArray(ticket.tags) ? ticket.tags.map((tag) => tag.name).join(', ') : null,
+    created_datetime: ticket.created_datetime ?? null,
+    updated_datetime: ticket.updated_datetime ?? null,
+    closed_datetime: ticket.closed_datetime ?? null,
+  };
+}
+
+export const gorgiasTicket = { flattenTicket };
+
+export type GorgiasTicket = {
+  id: number;
+  subject: string | null;
+  status: string;
+  priority: string;
+  channel: string;
+  via: string;
+  language: string | null;
+  spam: boolean;
+  messages_count: number;
+  customer?: { id: number; email: string | null; name: string | null };
+  assignee_user?: { id: number; email: string; name: string | null };
+  assignee_team?: { id: number; name: string };
+  tags?: { id: number; name: string }[];
+  created_datetime: string;
+  updated_datetime: string;
+  closed_datetime: string | null;
+};

--- a/packages/pieces/community/gorgias/src/lib/common/webhooks.ts
+++ b/packages/pieces/community/gorgias/src/lib/common/webhooks.ts
@@ -1,0 +1,76 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gorgiasApi, GorgiasAuth } from './client';
+
+const TICKET_FORM = {
+  id: '{{ticket.id}}',
+  subject: '{{ticket.subject}}',
+  status: '{{ticket.status}}',
+  priority: '{{ticket.priority}}',
+  channel: '{{ticket.channel}}',
+  via: '{{ticket.via}}',
+  language: '{{ticket.language}}',
+  customer_id: '{{ticket.customer.id}}',
+  customer_email: '{{ticket.customer.email}}',
+  customer_name: '{{ticket.customer.name}}',
+  assignee_user_id: '{{ticket.assignee_user.id}}',
+  assignee_user_email: '{{ticket.assignee_user.email}}',
+  created_datetime: '{{ticket.created_datetime}}',
+  updated_datetime: '{{ticket.updated_datetime}}',
+};
+
+const MESSAGE_FORM = {
+  ...TICKET_FORM,
+  message_id: '{{message.id}}',
+  message_body_text: '{{message.body_text}}',
+  message_from_agent: '{{message.from_agent}}',
+  message_channel: '{{message.channel}}',
+  message_public: '{{message.public}}',
+  message_created_datetime: '{{message.created_datetime}}',
+};
+
+async function register({
+  auth,
+  webhookUrl,
+  event,
+  withMessageFields,
+}: {
+  auth: GorgiasAuth;
+  webhookUrl: string;
+  event: string;
+  withMessageFields: boolean;
+}): Promise<number> {
+  const response = await gorgiasApi.call<{ id: number }>({
+    auth,
+    method: HttpMethod.POST,
+    path: '/integrations',
+    body: {
+      name: `Activepieces - ${event}`,
+      type: 'http',
+      http: {
+        url: webhookUrl,
+        method: 'POST',
+        request_content_type: 'application/json',
+        response_content_type: 'application/json',
+        triggers: { [event]: true },
+        form: withMessageFields ? MESSAGE_FORM : TICKET_FORM,
+      },
+    },
+  });
+  return response.body.id;
+}
+
+async function unregister({
+  auth,
+  integrationId,
+}: {
+  auth: GorgiasAuth;
+  integrationId: number;
+}): Promise<void> {
+  await gorgiasApi.call({
+    auth,
+    method: HttpMethod.DELETE,
+    path: `/integrations/${integrationId}`,
+  });
+}
+
+export const gorgiasWebhooks = { register, unregister };

--- a/packages/pieces/community/gorgias/src/lib/triggers/create-trigger.ts
+++ b/packages/pieces/community/gorgias/src/lib/triggers/create-trigger.ts
@@ -1,0 +1,99 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gorgiasAuth } from '../../';
+import { gorgiasApi } from '../common/client';
+import { gorgiasWebhooks } from '../common/webhooks';
+import { GorgiasTicket } from '../common/ticket';
+
+const STORE_KEY = 'gorgias_integration_id';
+
+export function createGorgiasWebhookTrigger({
+  name,
+  displayName,
+  description,
+  event,
+  withMessageFields,
+  sampleData,
+}: {
+  name: string;
+  displayName: string;
+  description: string;
+  event: string;
+  withMessageFields: boolean;
+  sampleData: Record<string, unknown>;
+}) {
+  return createTrigger({
+    auth: gorgiasAuth,
+    name,
+    displayName,
+    description,
+    type: TriggerStrategy.WEBHOOK,
+    props: {},
+    sampleData,
+    async onEnable(context) {
+      const integrationId = await gorgiasWebhooks.register({
+        auth: context.auth.props,
+        webhookUrl: context.webhookUrl,
+        event,
+        withMessageFields,
+      });
+      await context.store.put(STORE_KEY, integrationId);
+    },
+    async onDisable(context) {
+      const integrationId = await context.store.get<number>(STORE_KEY);
+      if (integrationId) {
+        await gorgiasWebhooks.unregister({
+          auth: context.auth.props,
+          integrationId,
+        });
+      }
+    },
+    async run(context) {
+      return [context.payload.body];
+    },
+    async test(context) {
+      const response = await gorgiasApi.call<{ data: GorgiasTicket[] }>({
+        auth: context.auth.props,
+        method: HttpMethod.GET,
+        path: '/tickets',
+        queryParams: { limit: '5', order_by: 'updated_datetime:desc' },
+      });
+      const tickets = response.body.data ?? [];
+      if (tickets.length === 0) {
+        return [sampleData];
+      }
+      return tickets.map((ticket) =>
+        withMessageFields
+          ? {
+              ...ticketToSample(ticket),
+              message_id: null,
+              message_body_text: null,
+              message_from_agent: null,
+              message_channel: null,
+              message_public: null,
+              message_created_datetime: null,
+            }
+          : ticketToSample(ticket)
+      );
+    },
+  });
+}
+
+function ticketToSample(ticket: GorgiasTicket): Record<string, unknown> {
+  return {
+    id: ticket.id,
+    subject: ticket.subject,
+    status: ticket.status,
+    priority: ticket.priority,
+    channel: ticket.channel,
+    via: ticket.via,
+    language: ticket.language,
+    customer_id: ticket.customer?.id ?? null,
+    customer_email: ticket.customer?.email ?? null,
+    customer_name: ticket.customer?.name ?? null,
+    assignee_user_id: ticket.assignee_user?.id ?? null,
+    assignee_user_email: ticket.assignee_user?.email ?? null,
+    created_datetime: ticket.created_datetime,
+    updated_datetime: ticket.updated_datetime,
+  };
+}

--- a/packages/pieces/community/gorgias/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/gorgias/src/lib/triggers/new-message.ts
@@ -1,0 +1,31 @@
+import { createGorgiasWebhookTrigger } from './create-trigger';
+
+export const newMessage = createGorgiasWebhookTrigger({
+  name: 'new_message',
+  displayName: 'New Message',
+  description: 'Triggers when a new message is added to a ticket (from a customer or an agent).',
+  event: 'ticket-message-created',
+  withMessageFields: true,
+  sampleData: {
+    id: 123,
+    subject: 'Can I get a refund?',
+    status: 'open',
+    priority: 'normal',
+    channel: 'email',
+    via: 'email',
+    language: 'en',
+    customer_id: 3924,
+    customer_email: 'john@example.com',
+    customer_name: 'John Smith',
+    assignee_user_id: 7,
+    assignee_user_email: 'agent@example.com',
+    created_datetime: '2019-07-05T14:42:00.384938',
+    updated_datetime: '2020-01-27T10:42:21.932637',
+    message_id: 9876,
+    message_body_text: 'Thanks for reaching out, we will process your refund shortly.',
+    message_from_agent: true,
+    message_channel: 'email',
+    message_public: true,
+    message_created_datetime: '2020-01-27T10:42:21.932637',
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/triggers/new-ticket.ts
+++ b/packages/pieces/community/gorgias/src/lib/triggers/new-ticket.ts
@@ -1,0 +1,25 @@
+import { createGorgiasWebhookTrigger } from './create-trigger';
+
+export const newTicket = createGorgiasWebhookTrigger({
+  name: 'new_ticket',
+  displayName: 'New Ticket',
+  description: 'Triggers when a new ticket is created.',
+  event: 'ticket-created',
+  withMessageFields: false,
+  sampleData: {
+    id: 123,
+    subject: 'Can I get a refund?',
+    status: 'open',
+    priority: 'normal',
+    channel: 'email',
+    via: 'email',
+    language: 'en',
+    customer_id: 3924,
+    customer_email: 'john@example.com',
+    customer_name: 'John Smith',
+    assignee_user_id: null,
+    assignee_user_email: null,
+    created_datetime: '2019-07-05T14:42:00.384938',
+    updated_datetime: '2019-07-05T14:42:00.384938',
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/triggers/ticket-status-updated.ts
+++ b/packages/pieces/community/gorgias/src/lib/triggers/ticket-status-updated.ts
@@ -1,0 +1,25 @@
+import { createGorgiasWebhookTrigger } from './create-trigger';
+
+export const ticketStatusUpdated = createGorgiasWebhookTrigger({
+  name: 'ticket_status_updated',
+  displayName: 'Ticket Status Updated',
+  description: 'Triggers when a ticket is opened or closed.',
+  event: 'ticket-status-updated',
+  withMessageFields: false,
+  sampleData: {
+    id: 123,
+    subject: 'Can I get a refund?',
+    status: 'closed',
+    priority: 'normal',
+    channel: 'email',
+    via: 'email',
+    language: 'en',
+    customer_id: 3924,
+    customer_email: 'john@example.com',
+    customer_name: 'John Smith',
+    assignee_user_id: 7,
+    assignee_user_email: 'agent@example.com',
+    created_datetime: '2019-07-05T14:42:00.384938',
+    updated_datetime: '2020-01-27T10:42:21.932637',
+  },
+});

--- a/packages/pieces/community/gorgias/src/lib/triggers/updated-ticket.ts
+++ b/packages/pieces/community/gorgias/src/lib/triggers/updated-ticket.ts
@@ -1,0 +1,25 @@
+import { createGorgiasWebhookTrigger } from './create-trigger';
+
+export const updatedTicket = createGorgiasWebhookTrigger({
+  name: 'updated_ticket',
+  displayName: 'Updated Ticket',
+  description: 'Triggers when any field of a ticket is updated.',
+  event: 'ticket-updated',
+  withMessageFields: false,
+  sampleData: {
+    id: 123,
+    subject: 'Can I get a refund?',
+    status: 'open',
+    priority: 'high',
+    channel: 'email',
+    via: 'email',
+    language: 'en',
+    customer_id: 3924,
+    customer_email: 'john@example.com',
+    customer_name: 'John Smith',
+    assignee_user_id: 7,
+    assignee_user_email: 'agent@example.com',
+    created_datetime: '2019-07-05T14:42:00.384938',
+    updated_datetime: '2020-01-27T10:42:21.932637',
+  },
+});

--- a/packages/pieces/community/gorgias/tsconfig.json
+++ b/packages/pieces/community/gorgias/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/gorgias/tsconfig.lib.json
+++ b/packages/pieces/community/gorgias/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -563,6 +563,9 @@
       "@activepieces/piece-googlechat": [
         "packages/pieces/community/googlechat/src/index.ts"
       ],
+      "@activepieces/piece-gorgias": [
+        "packages/pieces/community/gorgias/src/index.ts"
+      ],
       "@activepieces/piece-gotify": [
         "packages/pieces/community/gotify/src/index.ts"
       ],


### PR DESCRIPTION
…omer support

Adds a Gorgias integration with basic-auth (domain + email + API key) connection.

Actions: create/get/update/list tickets, add message (reply or internal note), create/update customer, find customer by email, plus a custom API call action.

Triggers (registered via Gorgias HTTP integrations webhook): new ticket, updated ticket, ticket status updated, and new message.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
