### PR TITLE
feat(pieces): add Wistia piece with media & project management

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7590,6 +7590,16 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/wistia": {
+      "name": "@activepieces/piece-wistia",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/wonderchat": {
       "name": "@activepieces/piece-wonderchat",
       "version": "0.1.3",
@@ -10112,6 +10122,8 @@
     "@activepieces/piece-whatsapp": ["@activepieces/piece-whatsapp@workspace:packages/pieces/community/whatsapp"],
 
     "@activepieces/piece-whatsscale": ["@activepieces/piece-whatsscale@workspace:packages/pieces/community/whatsscale"],
+
+    "@activepieces/piece-wistia": ["@activepieces/piece-wistia@workspace:packages/pieces/community/wistia"],
 
     "@activepieces/piece-wonderchat": ["@activepieces/piece-wonderchat@workspace:packages/pieces/community/wonderchat"],
 

--- a/packages/pieces/community/wistia/.eslintrc.json
+++ b/packages/pieces/community/wistia/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/wistia/package.json
+++ b/packages/pieces/community/wistia/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-wistia",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/wistia/src/index.ts
+++ b/packages/pieces/community/wistia/src/index.ts
@@ -1,0 +1,74 @@
+import {
+  AuthenticationType,
+  createCustomApiCallAction,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { copyMediaAction } from './lib/actions/copy-media';
+import { createProjectAction } from './lib/actions/create-project';
+import { deleteMediaAction } from './lib/actions/delete-media';
+import { findMediaAction } from './lib/actions/find-media';
+import { getMediaAction } from './lib/actions/get-media';
+import { updateMediaAction } from './lib/actions/update-media';
+import { updateProjectAction } from './lib/actions/update-project';
+import { newMediaTrigger } from './lib/triggers/new-media';
+import { newProjectTrigger } from './lib/triggers/new-project';
+
+export const wistiaAuth = PieceAuth.SecretText({
+  displayName: 'API Access Token',
+  description: `To get your Wistia API access token:
+1. Log in to your Wistia account.
+2. Go to **Account Settings > API Access** (or visit https://my.wistia.com/account/api).
+3. Click **Create Token** and give it a name.
+4. Grant it the permissions you need (read/update/delete) and copy the token — it is only shown once.
+5. Paste the token below.`,
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://api.wistia.com/v1/projects.json',
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: auth,
+        },
+        queryParams: { per_page: '1' },
+      });
+      return { valid: true };
+    } catch (e) {
+      return {
+        valid: false,
+        error: 'Invalid API access token. Please check your token and try again.',
+      };
+    }
+  },
+});
+
+export const wistia = createPiece({
+  displayName: 'Wistia',
+  description: 'Video hosting and analytics for business. Manage your projects and media library.',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/wistia.png',
+  categories: [PieceCategory.MARKETING, PieceCategory.CONTENT_AND_FILES],
+  auth: wistiaAuth,
+  authors: ['sanket-a11y'],
+  actions: [
+    createProjectAction,
+    updateProjectAction,
+    getMediaAction,
+    findMediaAction,
+    updateMediaAction,
+    copyMediaAction,
+    deleteMediaAction,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.wistia.com/v1',
+      auth: wistiaAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${(auth as { secret_text: string }).secret_text}`,
+      }),
+    }),
+  ],
+  triggers: [newMediaTrigger, newProjectTrigger],
+});

--- a/packages/pieces/community/wistia/src/lib/actions/copy-media.ts
+++ b/packages/pieces/community/wistia/src/lib/actions/copy-media.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { wistiaAuth } from '../../';
+import { flattenMedia, wistiaApiCall, wistiaCommon, WistiaMedia } from '../common';
+
+export const copyMediaAction = createAction({
+  auth: wistiaAuth,
+  name: 'copy_media',
+  displayName: 'Copy Media',
+  description: 'Create a copy of a video or media file, optionally into a different project.',
+  props: {
+    mediaId: wistiaCommon.mediaDropdown(true),
+    projectId: wistiaCommon.projectDropdown(false),
+    owner: Property.ShortText({
+      displayName: 'New Owner Email',
+      description:
+        'The email of the user who will own the copy. Defaults to the owner of the original media if left empty.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { mediaId, projectId, owner } = context.propsValue;
+
+    const body: Record<string, string> = {};
+    if (projectId !== undefined) body['project_id'] = projectId;
+    if (owner !== undefined) body['owner'] = owner;
+
+    const response = await wistiaApiCall<WistiaMedia>({
+      token: context.auth.secret_text,
+      method: HttpMethod.POST,
+      resourceUrl: `/medias/${mediaId}/copy.json`,
+      body,
+    });
+
+    return flattenMedia(response.body);
+  },
+});

--- a/packages/pieces/community/wistia/src/lib/actions/create-project.ts
+++ b/packages/pieces/community/wistia/src/lib/actions/create-project.ts
@@ -1,0 +1,61 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { wistiaAuth } from '../../';
+import { flattenProject, wistiaApiCall, WistiaProject } from '../common';
+
+export const createProjectAction = createAction({
+  auth: wistiaAuth,
+  name: 'create_project',
+  displayName: 'Create Project',
+  description: 'Create a new project in your Wistia account.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Project Name',
+      description: 'The name of the new project.',
+      required: true,
+    }),
+    adminEmail: Property.ShortText({
+      displayName: 'Admin Email',
+      description:
+        'The email of the user who will own the project. Defaults to the owner of the API token if left empty.',
+      required: false,
+    }),
+    anonymousCanUpload: Property.Checkbox({
+      displayName: 'Allow Anonymous Uploads',
+      description: 'Allow anonymous (logged-out) users to upload media to this project.',
+      required: false,
+      defaultValue: false,
+    }),
+    anonymousCanDownload: Property.Checkbox({
+      displayName: 'Allow Anonymous Downloads',
+      description: 'Allow anonymous (logged-out) users to download media from this project.',
+      required: false,
+      defaultValue: false,
+    }),
+    public: Property.Checkbox({
+      displayName: 'Public',
+      description: 'Make the project accessible to anyone with the public link.',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { name, adminEmail, anonymousCanUpload, anonymousCanDownload, public: isPublic } =
+      context.propsValue;
+
+    const response = await wistiaApiCall<WistiaProject>({
+      token: context.auth.secret_text,
+      method: HttpMethod.POST,
+      resourceUrl: '/projects.json',
+      body: {
+        name,
+        adminEmail,
+        anonymousCanUpload: anonymousCanUpload ? 1 : 0,
+        anonymousCanDownload: anonymousCanDownload ? 1 : 0,
+        public: isPublic ? 1 : 0,
+      },
+    });
+
+    return flattenProject(response.body);
+  },
+});

--- a/packages/pieces/community/wistia/src/lib/actions/delete-media.ts
+++ b/packages/pieces/community/wistia/src/lib/actions/delete-media.ts
@@ -1,0 +1,23 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { wistiaAuth } from '../../';
+import { wistiaApiCall, wistiaCommon } from '../common';
+
+export const deleteMediaAction = createAction({
+  auth: wistiaAuth,
+  name: 'delete_media',
+  displayName: 'Delete Media',
+  description: 'Permanently delete a video or media file from your account.',
+  props: {
+    mediaId: wistiaCommon.mediaDropdown(true),
+  },
+  async run(context) {
+    await wistiaApiCall({
+      token: context.auth.secret_text,
+      method: HttpMethod.DELETE,
+      resourceUrl: `/medias/${context.propsValue.mediaId}.json`,
+    });
+
+    return { success: true, hashed_id: context.propsValue.mediaId };
+  },
+});

--- a/packages/pieces/community/wistia/src/lib/actions/find-media.ts
+++ b/packages/pieces/community/wistia/src/lib/actions/find-media.ts
@@ -1,0 +1,60 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { wistiaAuth } from '../../';
+import { flattenMedia, wistiaApiCall, wistiaCommon, WistiaMedia } from '../common';
+
+export const findMediaAction = createAction({
+  auth: wistiaAuth,
+  name: 'find_media',
+  displayName: 'Find Media',
+  description: 'Search and list media in your account, optionally filtered by project, name, or type.',
+  props: {
+    projectId: wistiaCommon.projectIdDropdown(false),
+    name: Property.ShortText({
+      displayName: 'Name',
+      description: 'Only return media whose name exactly matches this value.',
+      required: false,
+    }),
+    type: Property.StaticDropdown({
+      displayName: 'Type',
+      description: 'Only return media of this type.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Video', value: 'Video' },
+          { label: 'Audio', value: 'Audio' },
+          { label: 'Image', value: 'Image' },
+          { label: 'PDF Document', value: 'PdfDocument' },
+          { label: 'Microsoft Office Document', value: 'MicrosoftOfficeDocument' },
+          { label: 'Flash (Swf)', value: 'Swf' },
+          { label: 'Unknown', value: 'UnknownType' },
+        ],
+      },
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of media to return (up to 100).',
+      required: false,
+      defaultValue: 25,
+    }),
+  },
+  async run(context) {
+    const { projectId, name, type, limit } = context.propsValue;
+
+    const response = await wistiaApiCall<WistiaMedia[]>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      resourceUrl: '/medias.json',
+      query: {
+        project_id: projectId,
+        name,
+        type,
+        per_page: Math.min(limit ?? 25, 100),
+        sort_by: 'created',
+        sort_direction: 0,
+      },
+    });
+
+    return response.body.map(flattenMedia);
+  },
+});

--- a/packages/pieces/community/wistia/src/lib/actions/get-media.ts
+++ b/packages/pieces/community/wistia/src/lib/actions/get-media.ts
@@ -1,0 +1,23 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { wistiaAuth } from '../../';
+import { flattenMedia, wistiaApiCall, wistiaCommon, WistiaMedia } from '../common';
+
+export const getMediaAction = createAction({
+  auth: wistiaAuth,
+  name: 'get_media',
+  displayName: 'Get Media',
+  description: 'Retrieve the details of a single video or media file.',
+  props: {
+    mediaId: wistiaCommon.mediaDropdown(true),
+  },
+  async run(context) {
+    const response = await wistiaApiCall<WistiaMedia>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      resourceUrl: `/medias/${context.propsValue.mediaId}.json`,
+    });
+
+    return flattenMedia(response.body);
+  },
+});

--- a/packages/pieces/community/wistia/src/lib/actions/update-media.ts
+++ b/packages/pieces/community/wistia/src/lib/actions/update-media.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { wistiaAuth } from '../../';
+import { flattenMedia, wistiaApiCall, wistiaCommon, WistiaMedia } from '../common';
+
+export const updateMediaAction = createAction({
+  auth: wistiaAuth,
+  name: 'update_media',
+  displayName: 'Update Media',
+  description: 'Update the name or description of a video or media file.',
+  props: {
+    mediaId: wistiaCommon.mediaDropdown(true),
+    name: Property.ShortText({
+      displayName: 'Name',
+      description: 'A new name for the media. Leave empty to keep the current name.',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description:
+        'A new description shown next to the media in Wistia. Plain text or Markdown is supported.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { mediaId, name, description } = context.propsValue;
+
+    const body: Record<string, string> = {};
+    if (name !== undefined) body['name'] = name;
+    if (description !== undefined) body['description'] = description;
+
+    const response = await wistiaApiCall<WistiaMedia>({
+      token: context.auth.secret_text,
+      method: HttpMethod.PUT,
+      resourceUrl: `/medias/${mediaId}.json`,
+      body,
+    });
+
+    return flattenMedia(response.body);
+  },
+});

--- a/packages/pieces/community/wistia/src/lib/actions/update-project.ts
+++ b/packages/pieces/community/wistia/src/lib/actions/update-project.ts
@@ -1,0 +1,54 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { wistiaAuth } from '../../';
+import { flattenProject, wistiaApiCall, wistiaCommon, WistiaProject } from '../common';
+
+export const updateProjectAction = createAction({
+  auth: wistiaAuth,
+  name: 'update_project',
+  displayName: 'Update Project',
+  description: 'Update the attributes of an existing project.',
+  props: {
+    projectId: wistiaCommon.projectDropdown(true),
+    name: Property.ShortText({
+      displayName: 'Project Name',
+      description: 'A new name for the project. Leave empty to keep the current name.',
+      required: false,
+    }),
+    anonymousCanUpload: Property.Checkbox({
+      displayName: 'Allow Anonymous Uploads',
+      description: 'Allow anonymous (logged-out) users to upload media to this project.',
+      required: false,
+    }),
+    anonymousCanDownload: Property.Checkbox({
+      displayName: 'Allow Anonymous Downloads',
+      description: 'Allow anonymous (logged-out) users to download media from this project.',
+      required: false,
+    }),
+    public: Property.Checkbox({
+      displayName: 'Public',
+      description: 'Make the project accessible to anyone with the public link.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { projectId, name, anonymousCanUpload, anonymousCanDownload, public: isPublic } =
+      context.propsValue;
+
+    const body: Record<string, string | number> = {};
+    if (name !== undefined) body['name'] = name;
+    if (anonymousCanUpload !== undefined) body['anonymousCanUpload'] = anonymousCanUpload ? 1 : 0;
+    if (anonymousCanDownload !== undefined)
+      body['anonymousCanDownload'] = anonymousCanDownload ? 1 : 0;
+    if (isPublic !== undefined) body['public'] = isPublic ? 1 : 0;
+
+    const response = await wistiaApiCall<WistiaProject>({
+      token: context.auth.secret_text,
+      method: HttpMethod.PUT,
+      resourceUrl: `/projects/${projectId}.json`,
+      body,
+    });
+
+    return flattenProject(response.body);
+  },
+});

--- a/packages/pieces/community/wistia/src/lib/common/index.ts
+++ b/packages/pieces/community/wistia/src/lib/common/index.ts
@@ -1,0 +1,247 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMessageBody,
+  HttpMethod,
+  HttpResponse,
+  QueryParams,
+} from '@activepieces/pieces-common';
+import { Property } from '@activepieces/pieces-framework';
+import { wistiaAuth } from '../../';
+
+const BASE_URL = 'https://api.wistia.com/v1';
+
+export async function wistiaApiCall<T extends HttpMessageBody>({
+  token,
+  method,
+  resourceUrl,
+  query,
+  body,
+}: {
+  token: string;
+  method: HttpMethod;
+  resourceUrl: string;
+  query?: Record<string, string | number | undefined>;
+  body?: unknown;
+}): Promise<HttpResponse<T>> {
+  const queryParams: QueryParams = {};
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== null && value !== '') {
+        queryParams[key] = String(value);
+      }
+    }
+  }
+
+  return httpClient.sendRequest<T>({
+    method,
+    url: `${BASE_URL}${resourceUrl}`,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token,
+    },
+    queryParams,
+    body,
+  });
+}
+
+function getAuthToken(auth: unknown): string {
+  return (auth as { secret_text: string }).secret_text;
+}
+
+export const wistiaCommon = {
+  projectDropdown: (required: boolean) =>
+    Property.Dropdown({
+      displayName: 'Project',
+      description: 'The project to use.',
+      auth: wistiaAuth,
+      required,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please connect your Wistia account first.',
+          };
+        }
+        try {
+          const response = await wistiaApiCall<WistiaProject[]>({
+            token: getAuthToken(auth),
+            method: HttpMethod.GET,
+            resourceUrl: '/projects.json',
+            query: { per_page: 100, sort_by: 'name', sort_direction: 1 },
+          });
+          return {
+            disabled: false,
+            options: response.body.map((project) => ({
+              label: `${project.name} (${project.mediaCount} media)`,
+              value: project.hashedId,
+            })),
+          };
+        } catch (e) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Failed to load projects. Check your connection.',
+          };
+        }
+      },
+    }),
+
+  projectIdDropdown: (required: boolean) =>
+    Property.Dropdown({
+      displayName: 'Project',
+      description: 'Only return media that belong to this project.',
+      auth: wistiaAuth,
+      required,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please connect your Wistia account first.',
+          };
+        }
+        try {
+          const response = await wistiaApiCall<WistiaProject[]>({
+            token: getAuthToken(auth),
+            method: HttpMethod.GET,
+            resourceUrl: '/projects.json',
+            query: { per_page: 100, sort_by: 'name', sort_direction: 1 },
+          });
+          return {
+            disabled: false,
+            options: response.body.map((project) => ({
+              label: `${project.name} (${project.mediaCount} media)`,
+              value: project.id,
+            })),
+          };
+        } catch (e) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Failed to load projects. Check your connection.',
+          };
+        }
+      },
+    }),
+
+  mediaDropdown: (required: boolean) =>
+    Property.Dropdown({
+      displayName: 'Media',
+      description: 'The video or media file to use.',
+      auth: wistiaAuth,
+      required,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please connect your Wistia account first.',
+          };
+        }
+        try {
+          const response = await wistiaApiCall<WistiaMedia[]>({
+            token: getAuthToken(auth),
+            method: HttpMethod.GET,
+            resourceUrl: '/medias.json',
+            query: { per_page: 100, sort_by: 'name', sort_direction: 1 },
+          });
+          return {
+            disabled: false,
+            options: response.body.map((media) => ({
+              label: `${media.name} (${media.type})`,
+              value: media.hashed_id,
+            })),
+          };
+        } catch (e) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Failed to load media. Check your connection.',
+          };
+        }
+      },
+    }),
+};
+
+export function flattenMedia(media: WistiaMedia) {
+  return {
+    id: media.id,
+    hashed_id: media.hashed_id,
+    name: media.name,
+    type: media.type,
+    status: media.status ?? null,
+    progress: media.progress ?? null,
+    section: media.section ?? null,
+    description: media.description ?? null,
+    duration: media.duration ?? null,
+    created: media.created ?? null,
+    updated: media.updated ?? null,
+    thumbnail_url: media.thumbnail?.url ?? null,
+    thumbnail_width: media.thumbnail?.width ?? null,
+    thumbnail_height: media.thumbnail?.height ?? null,
+    project_id: media.project?.id ?? null,
+    project_name: media.project?.name ?? null,
+    project_hashed_id: media.project?.hashed_id ?? null,
+  };
+}
+
+export function flattenProject(project: WistiaProject) {
+  return {
+    id: project.id,
+    hashed_id: project.hashedId,
+    name: project.name,
+    description: project.description ?? null,
+    media_count: project.mediaCount ?? null,
+    public: project.public ?? null,
+    public_id: project.publicId ?? null,
+    anonymous_can_upload: project.anonymousCanUpload ?? null,
+    anonymous_can_download: project.anonymousCanDownload ?? null,
+    created: project.created ?? null,
+    updated: project.updated ?? null,
+  };
+}
+
+export type WistiaThumbnail = {
+  url: string;
+  width: number;
+  height: number;
+};
+
+export type WistiaMedia = {
+  id: number;
+  hashed_id: string;
+  name: string;
+  type: string;
+  status?: string;
+  progress?: number;
+  section?: string;
+  description?: string;
+  duration?: number;
+  created?: string;
+  updated?: string;
+  thumbnail?: WistiaThumbnail;
+  project?: {
+    id: number;
+    name: string;
+    hashed_id: string;
+  };
+};
+
+export type WistiaProject = {
+  id: number;
+  hashedId: string;
+  name: string;
+  description?: string;
+  mediaCount?: number;
+  public?: boolean;
+  publicId?: string;
+  anonymousCanUpload?: boolean;
+  anonymousCanDownload?: boolean;
+  created?: string;
+  updated?: string;
+};

--- a/packages/pieces/community/wistia/src/lib/triggers/new-media.ts
+++ b/packages/pieces/community/wistia/src/lib/triggers/new-media.ts
@@ -1,0 +1,77 @@
+import {
+  AppConnectionValueForAuthProperty,
+  createTrigger,
+  StaticPropsValue,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { DedupeStrategy, HttpMethod, Polling, pollingHelper } from '@activepieces/pieces-common';
+import { wistiaAuth } from '../../';
+import { flattenMedia, wistiaApiCall, wistiaCommon, WistiaMedia } from '../common';
+
+const props = {
+  projectId: wistiaCommon.projectIdDropdown(false),
+};
+
+const polling: Polling<
+  AppConnectionValueForAuthProperty<typeof wistiaAuth>,
+  StaticPropsValue<typeof props>
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue }) => {
+    const response = await wistiaApiCall<WistiaMedia[]>({
+      token: auth.secret_text,
+      method: HttpMethod.GET,
+      resourceUrl: '/medias.json',
+      query: {
+        project_id: propsValue.projectId,
+        per_page: 100,
+        sort_by: 'created',
+        sort_direction: 0,
+      },
+    });
+    return response.body.map((media) => ({
+      epochMilliSeconds: new Date(media.created ?? 0).getTime(),
+      data: flattenMedia(media),
+    }));
+  },
+};
+
+export const newMediaTrigger = createTrigger({
+  auth: wistiaAuth,
+  name: 'new_media',
+  displayName: 'New Media',
+  description: 'Triggers when a new video or media file is added to your account.',
+  props,
+  type: TriggerStrategy.POLLING,
+  async test(context) {
+    return pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return pollingHelper.poll(polling, context);
+  },
+  sampleData: {
+    id: 6122606,
+    hashed_id: 'abc123def4',
+    name: 'My Awesome Video',
+    type: 'Video',
+    status: 'ready',
+    progress: 1,
+    section: null,
+    description: 'A short description of the video.',
+    duration: 42.13,
+    created: '2024-01-15T10:30:00.000Z',
+    updated: '2024-01-15T10:35:00.000Z',
+    thumbnail_url: 'https://embed-ssl.wistia.com/deliveries/abc123.jpg',
+    thumbnail_width: 1280,
+    thumbnail_height: 720,
+    project_id: 215140,
+    project_name: 'Marketing Videos',
+    project_hashed_id: 'xy12ab34cd',
+  },
+});

--- a/packages/pieces/community/wistia/src/lib/triggers/new-project.ts
+++ b/packages/pieces/community/wistia/src/lib/triggers/new-project.ts
@@ -1,0 +1,62 @@
+import {
+  AppConnectionValueForAuthProperty,
+  createTrigger,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { DedupeStrategy, HttpMethod, Polling, pollingHelper } from '@activepieces/pieces-common';
+import { wistiaAuth } from '../../';
+import { flattenProject, wistiaApiCall, WistiaProject } from '../common';
+
+const polling: Polling<AppConnectionValueForAuthProperty<typeof wistiaAuth>, Record<string, never>> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth }) => {
+    const response = await wistiaApiCall<WistiaProject[]>({
+      token: auth.secret_text,
+      method: HttpMethod.GET,
+      resourceUrl: '/projects.json',
+      query: {
+        per_page: 100,
+        sort_by: 'created',
+        sort_direction: 0,
+      },
+    });
+    return response.body.map((project) => ({
+      epochMilliSeconds: new Date(project.created ?? 0).getTime(),
+      data: flattenProject(project),
+    }));
+  },
+};
+
+export const newProjectTrigger = createTrigger({
+  auth: wistiaAuth,
+  name: 'new_project',
+  displayName: 'New Project',
+  description: 'Triggers when a new project is created in your account.',
+  props: {},
+  type: TriggerStrategy.POLLING,
+  async test(context) {
+    return pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return pollingHelper.poll(polling, context);
+  },
+  sampleData: {
+    id: 215140,
+    hashed_id: 'xy12ab34cd',
+    name: 'Marketing Videos',
+    description: 'All our marketing content.',
+    media_count: 12,
+    public: false,
+    public_id: 'xy12ab34cd',
+    anonymous_can_upload: false,
+    anonymous_can_download: false,
+    created: '2024-01-10T09:00:00.000Z',
+    updated: '2024-01-15T10:35:00.000Z',
+  },
+});

--- a/packages/pieces/community/wistia/tsconfig.json
+++ b/packages/pieces/community/wistia/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/wistia/tsconfig.lib.json
+++ b/packages/pieces/community/wistia/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1403,6 +1403,9 @@
       "@activepieces/piece-whatsscale": [
         "packages/pieces/community/whatsscale/src/index.ts"
       ],
+      "@activepieces/piece-wistia": [
+        "packages/pieces/community/wistia/src/index.ts"
+      ],
       "@activepieces/piece-wonderchat": [
         "packages/pieces/community/wonderchat/src/index.ts"
       ],


### PR DESCRIPTION
Adds a Wistia integration with API-token auth and:
- Actions: Create Project, Update Project, Get Media, Find Media, Update Media, Copy Media, Delete Media, plus custom API call
- Triggers (polling): New Media, New Project

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
