### PR TITLE
feat(flows): add custom version naming and draft deduplication

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1794000000000-AddVersionNameToFlowVersion.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1794000000000-AddVersionNameToFlowVersion.ts
@@ -1,0 +1,31 @@
+import { QueryRunner } from 'typeorm'
+import { Migration } from '../../migration'
+
+export class AddVersionNameToFlowVersion1794000000000 implements Migration {
+    name = 'AddVersionNameToFlowVersion1794000000000'
+    breaking = false
+    release = '0.84.0'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Human-readable label the user assigns to each version
+        await queryRunner.query(`
+            ALTER TABLE "flow_version"
+            ADD COLUMN IF NOT EXISTS "versionName" character varying NULL
+        `)
+        // Tracks which locked version a draft was cloned from (USE_AS_DRAFT)
+        // so that publishing can reuse the original locked row.
+        await queryRunner.query(`
+            ALTER TABLE "flow_version"
+            ADD COLUMN IF NOT EXISTS "usedAsDraftFromVersionId" character varying NULL
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "flow_version" DROP COLUMN IF EXISTS "versionName"
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "flow_version" DROP COLUMN IF EXISTS "usedAsDraftFromVersionId"
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -379,6 +379,7 @@ import { RemoveMcpServerStatus1790000000000 } from './migration/postgres/1790000
 import { RenameEnabledToolsToDisabledTools1791000000000 } from './migration/postgres/1791000000000-RenameEnabledToolsToDisabledTools'
 import { AddTriggerSourceFlowVersionIdIndex1792000000000 } from './migration/postgres/1792000000000-AddTriggerSourceFlowVersionIdIndex'
 import { AddVariableTable1793000000000 } from './migration/postgres/1793000000000-AddVariableTable'
+import { AddVersionNameToFlowVersion1794000000000 } from './migration/postgres/1794000000000-AddVersionNameToFlowVersion'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -773,6 +774,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         AddUiMessagesToChatConversation1778983371000,
         AddVariableTable1793000000000,
         AddStatusToChatConversation1779500000000,
+        AddVersionNameToFlowVersion1794000000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/flows/flow-version/flow-version-entity.ts
+++ b/packages/server/api/src/app/flows/flow-version/flow-version-entity.ts
@@ -54,6 +54,14 @@ export const FlowVersionEntity = new EntitySchema<FlowVersionSchema>({
             type: 'jsonb',
             nullable: false,
         },
+        versionName: {
+            type: String,
+            nullable: true,
+        },
+        usedAsDraftFromVersionId: {
+            type: String,
+            nullable: true,
+        },
     },
     indices: [
         {

--- a/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
@@ -121,6 +121,12 @@ export const flowVersionService = (log: FastifyBaseLogger) => ({
         if (userId) {
             mutatedFlowVersion.updatedBy = userId
         }
+
+        if (userOperation.type === FlowOperationType.USE_AS_DRAFT) {
+            mutatedFlowVersion.usedAsDraftFromVersionId = userOperation.request.versionId
+        } else {
+            mutatedFlowVersion.usedAsDraftFromVersionId = null
+        }
         mutatedFlowVersion.connectionIds = flowStructureUtil.extractConnectionIds(mutatedFlowVersion)
         mutatedFlowVersion.agentIds = flowStructureUtil.extractAgentIds(mutatedFlowVersion)
         return flowVersionRepo(entityManager).save(sanitizeObjectForPostgresql(mutatedFlowVersion))

--- a/packages/server/api/src/app/flows/flow/flow-version.controller.ts
+++ b/packages/server/api/src/app/flows/flow/flow-version.controller.ts
@@ -1,4 +1,5 @@
 import { FlowVersionMetadata, ListFlowVersionRequest, PrincipalType, SeekPage } from '@activepieces/shared'
+import { flowVersionRepo } from '../flow-version/flow-version.service'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
@@ -24,6 +25,42 @@ export const flowVersionController: FastifyPluginAsyncZod = async (fastify) => {
         })
     },
     )
+    fastify.patch('/:flowId/versions/:versionId/name', PatchVersionNameParams, async (request, reply) => {
+        await flowService(request.log).getOneOrThrow({
+            id: request.params.flowId,
+            projectId: request.projectId,
+        })
+        await flowVersionRepo().update(
+            { id: request.params.versionId, flowId: request.params.flowId },
+            { versionName: request.body.versionName ?? null },
+        )
+        return reply.status(StatusCodes.NO_CONTENT).send()
+    })
+}
+
+const PatchVersionNameParams = {
+    config: {
+        security: securityAccess.project([PrincipalType.USER], undefined, {
+            type: ProjectResourceType.TABLE,
+            tableName: FlowEntity,
+            lookup: {
+                paramKey: 'flowId',
+                entityField: 'id',
+            },
+        }),
+    },
+    schema: {
+        params: z.object({
+            flowId: z.string(),
+            versionId: z.string(),
+        }),
+        body: z.object({
+            versionName: z.string().nullable().optional(),
+        }),
+        response: {
+            [StatusCodes.NO_CONTENT]: z.undefined(),
+        },
+    },
 }
 
 const ListVersionParams = {

--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -664,6 +664,19 @@ const lockFlowVersionIfNotLocked = async ({
         return flowVersion
     }
 
+    if (!isNil(flowVersion.usedAsDraftFromVersionId)) {
+        const originalVersion = await flowVersionService(log).getOne(flowVersion.usedAsDraftFromVersionId)
+        if (!isNil(originalVersion) && originalVersion.state === FlowVersionState.LOCKED) {
+            await flowVersionRepo(entityManager).delete({ id: flowVersion.id })
+            const now = dayjs().toISOString()
+            await flowVersionRepo(entityManager).update(
+                { id: originalVersion.id },
+                { created: now, updated: now },
+            )
+            return { ...originalVersion, created: now, updated: now }
+        }
+    }
+
     return flowVersionService(log).applyOperation({
         userId,
         projectId,

--- a/packages/shared/src/lib/automation/flows/flow-version.ts
+++ b/packages/shared/src/lib/automation/flows/flow-version.ts
@@ -27,6 +27,8 @@ export const FlowVersion = z.object({
     connectionIds: z.array(z.string()),
     backupFiles: Nullable(z.record(z.string(), z.string())),
     notes: z.array(Note),
+    versionName: Nullable(z.string()),
+    usedAsDraftFromVersionId: Nullable(z.string()),
 })
 
 export type FlowVersion = z.infer<typeof FlowVersion>
@@ -40,6 +42,7 @@ export const FlowVersionMetadata = z.object({
     updatedBy: Nullable(z.string()),
     schemaVersion: Nullable(z.string()),
     updatedByUser: Nullable(UserWithMetaInformation),
+    versionName: Nullable(z.string()),
 })
 
 export type FlowVersionMetadata = z.infer<typeof FlowVersionMetadata>

--- a/packages/shared/src/lib/automation/flows/operations/index.ts
+++ b/packages/shared/src/lib/automation/flows/operations/index.ts
@@ -52,6 +52,7 @@ export enum FlowOperationType {
     DELETE_NOTE = 'DELETE_NOTE',
     ADD_NOTE = 'ADD_NOTE',
     UPDATE_SAMPLE_DATA_INFO = 'UPDATE_SAMPLE_DATA_INFO',
+    SET_VERSION_NAME = 'SET_VERSION_NAME',
 }
 
 export const DeleteBranchRequest = z.object({
@@ -212,6 +213,11 @@ export const UpdateOwnerRequest = z.object({
 })
 export type UpdateOwnerRequest = z.infer<typeof UpdateOwnerRequest>
 
+export const SetVersionNameRequest = z.object({
+    versionName: Nullable(z.string()),
+})
+export type SetVersionNameRequest = z.infer<typeof SetVersionNameRequest>
+
 export const FlowOperationRequest = z.union([
     z.object({
         type: z.literal(FlowOperationType.MOVE_ACTION),
@@ -317,6 +323,10 @@ export const FlowOperationRequest = z.union([
         type: z.literal(FlowOperationType.UPDATE_SAMPLE_DATA_INFO),
         request: UpdateSampleDataInfoRequest,
     }).describe('Update Sample Data Info'),
+    z.object({
+        type: z.literal(FlowOperationType.SET_VERSION_NAME),
+        request: SetVersionNameRequest,
+    }).describe('Set Version Name'),
 ])
 
 
@@ -420,6 +430,9 @@ export const flowOperations = {
                 clonedVersion = _updateSampleDataInfo(clonedVersion, operation.request)
                 break
             }
+            case FlowOperationType.SET_VERSION_NAME:
+                clonedVersion.versionName = operation.request.versionName
+                break
             default:
                 break
         }

--- a/packages/shared/src/lib/ee/audit-events/index.ts
+++ b/packages/shared/src/lib/ee/audit-events/index.ts
@@ -615,6 +615,8 @@ function convertUpdateActionToDetails(event: FlowUpdatedEvent) {
             return `Deleted note in flow "${event.data.flowVersion.displayName}".`
         case FlowOperationType.UPDATE_SAMPLE_DATA_INFO:
             return `Updated sample data info for step "${event.data.request.request.stepName}" in flow "${event.data.flowVersion.displayName}".`
+        case FlowOperationType.SET_VERSION_NAME:
+            return `Renamed version in flow "${event.data.flowVersion.displayName}".`
     }
 }
 

--- a/packages/web/src/app/builder/flow-versions/flow-versions-card.tsx
+++ b/packages/web/src/app/builder/flow-versions/flow-versions-card.tsx
@@ -28,6 +28,10 @@ import { FlowVersionStateDot, flowHooks } from '@/features/flows';
 import { useAuthorization } from '@/hooks/authorization-hooks';
 
 import { OverwriteDraftDialog } from './overwrite-draft-dialog';
+import { Input } from '@/components/ui/input';
+import { Check, X } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRef } from 'react';
 
 const FlowVersionDetailsCard = React.memo(
   ({
@@ -43,6 +47,22 @@ const FlowVersionDetailsCard = React.memo(
       state.setReadOnly,
     ]);
     const [dropdownMenuOpen, setDropdownMenuOpen] = useState(false);
+    const [editingName, setEditingName] = useState(false);
+    const [nameInput, setNameInput] = useState(flowVersion.versionName ?? '');
+    const inputRef = useRef<HTMLInputElement>(null);
+    const queryClient = useQueryClient();
+
+    const { mutate: setVersionName } = flowHooks.useSetVersionName({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['flow-versions', flowVersion.flowId] });
+        setEditingName(false);
+      },
+    });
+
+    const commitName = () => {
+      setVersionName({ flowId: flowVersion.flowId, versionId: flowVersion.id, versionName: nameInput.trim() || null })
+    };
+
     const { mutate: viewVersion, isPending } = flowHooks.useFetchFlowVersion({
       onSuccess: (populatedFlowVersion) => {
         setVersion(populatedFlowVersion);
@@ -56,7 +76,7 @@ const FlowVersionDetailsCard = React.memo(
     const showAvatar = !useEmbedding().embedState.isEmbedded;
 
     return (
-      <CardListItem interactive={false} className="px-4">
+      <CardListItem interactive={false} className="px-4 group">
         {showAvatar && flowVersion.updatedByUser && (
           <UserAvatar
             size={45}
@@ -75,9 +95,40 @@ const FlowVersionDetailsCard = React.memo(
             includeTime={true}
             className="text-sm font-medium leading-none select-none cursor-default"
           ></FormattedDate>
-          <p className="flex gap-1 text-xs text-muted-foreground">
-            {t('Version')} #{flowVersionNumber}
-          </p>
+          {editingName ? (
+            <div className="flex items-center gap-1">
+              <Input
+                ref={inputRef}
+                autoFocus
+                className="h-6 text-xs px-1 py-0 w-36"
+                value={nameInput}
+                onChange={(e) => setNameInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitName();
+                  if (e.key === 'Escape') setEditingName(false);
+                }}
+                placeholder={t('Version #{{n}}', { n: flowVersionNumber })}
+              />
+              <Button variant="ghost" size="icon" className="size-5 p-0" onClick={commitName}>
+                <Check className="w-3 h-3 text-green-500" />
+              </Button>
+              <Button variant="ghost" size="icon" className="size-5 p-0" onClick={() => setEditingName(false)}>
+                <X className="w-3 h-3 text-destructive" />
+              </Button>
+            </div>
+          ) : (
+            <p
+              className="flex gap-1 text-xs text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
+              onClick={() => { setNameInput(flowVersion.versionName ?? ''); setEditingName(true); }}
+              title={t('Click to rename')}
+            >
+              {flowVersion.versionName
+                ? <span className="font-medium text-foreground">{flowVersion.versionName}</span>
+                : <span>{t('Version')} #{flowVersionNumber}</span>
+              }
+              <Pencil className="w-3 h-3 ml-1 opacity-0 group-hover:opacity-60" />
+            </p>
+          )}
         </div>
         <div className="grow"></div>
         <div className="flex font-medium gap-2 justify-center items-center">

--- a/packages/web/src/features/flows/hooks/flow-hooks.tsx
+++ b/packages/web/src/features/flows/hooks/flow-hooks.tsx
@@ -214,6 +214,22 @@ export const flowHooks = {
       onSuccess,
     });
   },
+  useSetVersionName: ({
+    onSuccess,
+  }: {
+    onSuccess?: () => void
+  } = {}) => {
+    return useMutation<
+      void,
+      Error,
+      { flowId: string; versionId: string; versionName: string | null }
+    >({
+      mutationFn: async ({ flowId, versionId, versionName }) => {
+        await api.patch(`/v1/flows/${flowId}/versions/${versionId}/name`, { versionName })
+      },
+      onSuccess,
+    })
+  },
   useCreateMcpFlow: () => {
     const navigate = useNavigate();
     return useMutation({


### PR DESCRIPTION
## What does this PR do?

This PR introduces two highly requested quality-of-life improvements to the Flow Version History sidebar:
1. **Custom Flow Version Naming:** Users can now click the version label in the sidebar to assign a custom, human-readable name to specific versions (e.g., "Added Slack Integration" instead of "Version #2").
2. **"Use as Draft" Deduplication:** Prevents the system from creating exact duplicate version rows when a user uses a previous version as a draft and publishes it without making any changes.

### Explain How the Feature Works

**Custom Version Naming:**
* Added an inline `<Input>` to `flow-versions-card.tsx` to handle editing.
* Created a dedicated `PATCH /v1/flows/:flowId/versions/:versionId/name` endpoint to update the `versionName` directly in the database.
* This bypasses the standard draft operations pipeline, preventing false "unpublished changes" warnings when simply renaming a version.

**Draft Deduplication:**
* Added `usedAsDraftFromVersionId` to the entity to track the origin of a cloned draft.
* Updated `lockFlowVersionIfNotLocked`: If a draft is published without modifications, the system deletes the redundant draft and reuses the original locked version.
* Updates the `created` and `updated` timestamps of the reused version so it accurately jumps to the top of the version history UI.

### Relevant User Scenarios

* **Scenario 1:** A user creates a complex flow and wants to label a specific stable version as "Production Ready v1" so they can easily identify it later.
* **Scenario 2:** A user rolls back to an older version using "Use as Draft", realizes that older version is exactly what they want to keep, and hits publish. Instead of polluting the version history with a visually identical "Version #6", the system intelligently bumps the reused version to the top.