### PR TITLE
Add Voxell Forge embeddings piece

### DIFF
--- a/packages/pieces/community/voxell-forge/.eslintrc.json
+++ b/packages/pieces/community/voxell-forge/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/voxell-forge/package.json
+++ b/packages/pieces/community/voxell-forge/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-voxell-forge",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/voxell-forge/src/i18n/translation.json
+++ b/packages/pieces/community/voxell-forge/src/i18n/translation.json
@@ -1,0 +1,21 @@
+{
+  "Managed embeddings API for AI search, retrieval, and semantic workflows.": "Managed embeddings API for AI search, retrieval, and semantic workflows.",
+  "\n**Get your Voxell Forge API key:**\n\n1. Sign in at https://dash.voxell.ai\n2. Open **API Keys**\n3. Create a key and paste it here.\n  ": "\n**Get your Voxell Forge API key:**\n\n1. Sign in at https://dash.voxell.ai\n2. Open **API Keys**\n3. Create a key and paste it here.\n  ",
+  "Create Embeddings": "Create Embeddings",
+  "Create vector embeddings for one or more text inputs using Voxell Forge.": "Create vector embeddings for one or more text inputs using Voxell Forge.",
+  "Texts": "Texts",
+  "One or more text inputs to embed.": "One or more text inputs to embed.",
+  "Model": "Model",
+  "Forge embedding model tier.": "Forge embedding model tier.",
+  "Dimensions": "Dimensions",
+  "Optional Matryoshka truncation dimension. Leave blank to use the model's native dimension.": "Optional Matryoshka truncation dimension. Leave blank to use the model's native dimension.",
+  "Input Type": "Input Type",
+  "Use query for search queries and document for content being indexed.": "Use query for search queries and document for content being indexed.",
+  "Turbo - 1024 dimensions": "Turbo - 1024 dimensions",
+  "Pro - 2560 dimensions": "Pro - 2560 dimensions",
+  "Ultra 4K - 4096 dimensions": "Ultra 4K - 4096 dimensions",
+  "Document": "Document",
+  "Query": "Query",
+  "Custom API Call": "Custom API Call",
+  "Make a custom API call to a specific endpoint": "Make a custom API call to a specific endpoint"
+}

--- a/packages/pieces/community/voxell-forge/src/index.ts
+++ b/packages/pieces/community/voxell-forge/src/index.ts
@@ -1,0 +1,26 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createEmbeddings } from './lib/actions/create-embeddings';
+import { voxellForgeAuth } from './lib/auth';
+
+export const voxellForge = createPiece({
+  displayName: 'Voxell Forge',
+  description: 'Managed embeddings API for AI search, retrieval, and semantic workflows.',
+  auth: voxellForgeAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/voxell-forge.png',
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  authors: ['JCorners68'],
+  actions: [
+    createEmbeddings,
+    createCustomApiCallAction({
+      auth: voxellForgeAuth,
+      baseUrl: () => 'https://api.voxell.ai/v1',
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${auth.secret_text}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/voxell-forge/src/lib/actions/create-embeddings.ts
+++ b/packages/pieces/community/voxell-forge/src/lib/actions/create-embeddings.ts
@@ -1,0 +1,95 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { voxellForgeAuth } from '../auth';
+
+type ForgeEmbeddingResponse = {
+  embeddings: number[][];
+  dim: number;
+  model: string;
+  tokens: number;
+  usage?: {
+    total_tokens?: number;
+  };
+  latency_ms?: number;
+};
+
+export const createEmbeddings = createAction({
+  auth: voxellForgeAuth,
+  name: 'create_embeddings',
+  displayName: 'Create Embeddings',
+  description: 'Create vector embeddings for one or more text inputs using Voxell Forge.',
+  props: {
+    texts: Property.Array({
+      displayName: 'Texts',
+      description: 'One or more text inputs to embed.',
+      required: true,
+    }),
+    model: Property.StaticDropdown({
+      displayName: 'Model',
+      description: 'Forge embedding model tier.',
+      required: true,
+      defaultValue: 'turbo',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Turbo - 1024 dimensions', value: 'turbo' },
+          { label: 'Pro - 2560 dimensions', value: 'pro' },
+          { label: 'Ultra 4K - 4096 dimensions', value: 'ultra-4k' },
+        ],
+      },
+    }),
+    dim: Property.Number({
+      displayName: 'Dimensions',
+      description:
+        "Optional Matryoshka truncation dimension. Leave blank to use the model's native dimension.",
+      required: false,
+    }),
+    inputType: Property.StaticDropdown({
+      displayName: 'Input Type',
+      description: 'Use query for search queries and document for content being indexed.',
+      required: false,
+      defaultValue: 'document',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Document', value: 'document' },
+          { label: 'Query', value: 'query' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const texts = (context.propsValue.texts as unknown[])
+      .map((text) => String(text ?? ''))
+      .filter((text) => text.trim().length > 0);
+
+    if (texts.length === 0) {
+      throw new Error('Provide at least one non-empty text input.');
+    }
+
+    const body: Record<string, unknown> = {
+      texts,
+      model: context.propsValue.model,
+    };
+
+    if (context.propsValue.dim !== undefined && context.propsValue.dim !== null) {
+      body['dim'] = context.propsValue.dim;
+    }
+
+    if (context.propsValue.inputType) {
+      body['input_type'] = context.propsValue.inputType;
+    }
+
+    const response = await httpClient.sendRequest<ForgeEmbeddingResponse>({
+      method: HttpMethod.POST,
+      url: 'https://api.voxell.ai/v1/embed',
+      headers: {
+        Authorization: `Bearer ${context.auth.secret_text}`,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+    return response.body;
+  },
+});

--- a/packages/pieces/community/voxell-forge/src/lib/auth.ts
+++ b/packages/pieces/community/voxell-forge/src/lib/auth.ts
@@ -1,0 +1,36 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+const authDescription = `
+**Get your Voxell Forge API key:**
+
+1. Sign in at https://dash.voxell.ai
+2. Open **API Keys**
+3. Create a key and paste it here.
+  `;
+
+export const voxellForgeAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: authDescription,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: 'https://api.voxell.ai/v1/embed',
+        headers: {
+          Authorization: `Bearer ${auth}`,
+          'Content-Type': 'application/json',
+        },
+        body: {
+          texts: ['hello world'],
+          model: 'turbo',
+          dim: 128,
+        },
+      });
+      return { valid: true };
+    } catch {
+      return { valid: false, error: 'Invalid Voxell Forge API key' };
+    }
+  },
+});

--- a/packages/pieces/community/voxell-forge/tsconfig.json
+++ b/packages/pieces/community/voxell-forge/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/voxell-forge/tsconfig.lib.json
+++ b/packages/pieces/community/voxell-forge/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2004,6 +2004,9 @@
       "@activepieces/piece-valyu": [
         "packages/pieces/community/valyu/src/index.ts"
       ],
+      "@activepieces/piece-voxell-forge": [
+        "packages/pieces/community/voxell-forge/src/index.ts"
+      ],
       "@activepieces/piece-alai": [
         "packages/pieces/community/alai/src/index.ts"
       ],


### PR DESCRIPTION
## Summary\n- Add a Voxell Forge community piece for creating embeddings from text inputs\n- Include API key validation against the live Forge embed API\n- Add a custom API call action using https://api.voxell.ai/v1 for advanced workflows\n\n## Notes\n- The piece uses Forge-native /v1/embed for lower-latency embeddings and supports model tier, input type, and optional Matryoshka dimension truncation.\n- OpenAI-compatible workflows can still use Forge directly by setting base URL to https://api.voxell.ai/v1.\n\n## Validation\n- bun run build-piece -- --name voxell-forge\n- bun run --cwd packages/pieces/community/voxell-forge lint