### PR TITLE
fix(worker): install pieces referenced in AI Agent tools

### DIFF
--- a/packages/server/worker/src/lib/execute/utils/flow-helpers.ts
+++ b/packages/server/worker/src/lib/execute/utils/flow-helpers.ts
@@ -1,4 +1,4 @@
-import { FlowActionType, flowStructureUtil, FlowTriggerType, FlowVersion, PiecePackage, tryCatch, WorkerToApiContract } from '@activepieces/shared'
+import { AgentPieceProps, AgentToolType, FlowActionType, flowStructureUtil, FlowTriggerType, FlowVersion, PiecePackage, tryCatch, WorkerToApiContract } from '@activepieces/shared'
 import { Logger } from 'pino'
 import { CodeArtifact } from '../../cache/code/code-builder'
 import { pieceCache, PieceNotFoundError } from '../../cache/pieces/piece-cache'
@@ -38,11 +38,20 @@ export async function extractPiecePackages(flowVersion: FlowVersion, platformId:
     const pieceSteps = flowStructureUtil.getAllSteps(flowVersion.trigger)
         .filter((step) => step.type === FlowActionType.PIECE || step.type === FlowTriggerType.PIECE)
 
+    const refs = new Map<string, { pieceName: string, pieceVersion: string }>()
+    for (const step of pieceSteps) {
+        const { pieceName, pieceVersion } = step.settings
+        refs.set(`${pieceName}@${pieceVersion}`, { pieceName, pieceVersion })
+        for (const tool of extractAgentPieceToolRefs(step)) {
+            refs.set(`${tool.pieceName}@${tool.pieceVersion}`, tool)
+        }
+    }
+
     return Promise.all(
-        pieceSteps.map((step) =>
+        Array.from(refs.values()).map((ref) =>
             pieceCache(log, apiClient).getPiece({
-                pieceName: step.settings.pieceName,
-                pieceVersion: step.settings.pieceVersion,
+                pieceName: ref.pieceName,
+                pieceVersion: ref.pieceVersion,
                 platformId,
             }),
         ),
@@ -58,4 +67,30 @@ export function extractCodeArtifacts(flowVersion: FlowVersion): CodeArtifact[] {
             flowVersionId: flowVersion.id,
             flowVersionState: flowVersion.state,
         }))
+}
+
+function extractAgentPieceToolRefs(step: ReturnType<typeof flowStructureUtil.getAllSteps>[number]): { pieceName: string, pieceVersion: string }[] {
+    if (step.type !== FlowActionType.PIECE) {
+        return []
+    }
+    const tools = step.settings.input?.[AgentPieceProps.AGENT_TOOLS]
+    if (!Array.isArray(tools)) {
+        return []
+    }
+    const refs: { pieceName: string, pieceVersion: string }[] = []
+    for (const tool of tools) {
+        if (
+            tool != null
+            && typeof tool === 'object'
+            && (tool as { type?: unknown }).type === AgentToolType.PIECE
+        ) {
+            const metadata = (tool as { pieceMetadata?: { pieceName?: unknown, pieceVersion?: unknown } }).pieceMetadata
+            const pieceName = metadata?.pieceName
+            const pieceVersion = metadata?.pieceVersion
+            if (typeof pieceName === 'string' && typeof pieceVersion === 'string') {
+                refs.push({ pieceName, pieceVersion })
+            }
+        }
+    }
+    return refs
 }

--- a/packages/server/worker/test/lib/execute/utils/flow-helpers.test.ts
+++ b/packages/server/worker/test/lib/execute/utils/flow-helpers.test.ts
@@ -141,6 +141,85 @@ describe('extractPiecePackages', () => {
         expect(packages[0].pieceName).toBe('@activepieces/piece-gmail')
         expect(packages[1].pieceName).toBe('@activepieces/piece-slack')
     })
+
+    it('includes pieces referenced by AI Agent agentTools', async () => {
+        const agentStep = {
+            name: 'step_agent',
+            valid: true,
+            displayName: 'Run Agent',
+            type: FlowActionType.PIECE as const,
+            settings: {
+                pieceName: '@activepieces/piece-ai',
+                pieceVersion: '0.4.1',
+                actionName: 'runAgent',
+                input: {
+                    agentTools: [
+                        {
+                            type: 'PIECE',
+                            toolName: 'gmail_send',
+                            pieceMetadata: {
+                                pieceName: '@activepieces/piece-gmail',
+                                pieceVersion: '0.12.3',
+                                actionName: 'send_email',
+                            },
+                        },
+                        {
+                            type: 'FLOW',
+                            toolName: 'other_flow',
+                            externalFlowId: 'flow-xyz',
+                        },
+                    ],
+                },
+                propertySettings: {},
+            },
+        }
+        const fv = makeFlowVersion({
+            ...pieceTrigger,
+            nextAction: agentStep,
+        })
+        const packages = await extractPiecePackages(fv, mockPlatformId, mockLog, mockApiClient)
+        const names = packages.map((p) => `${p.pieceName}@${p.pieceVersion}`)
+        expect(names).toContain('@activepieces/piece-ai@0.4.1')
+        expect(names).toContain('@activepieces/piece-gmail@0.12.3')
+    })
+
+    it('deduplicates pieces shared between steps and agentTools', async () => {
+        const agentStep = {
+            name: 'step_agent',
+            valid: true,
+            displayName: 'Run Agent',
+            type: FlowActionType.PIECE as const,
+            settings: {
+                pieceName: '@activepieces/piece-ai',
+                pieceVersion: '0.4.1',
+                actionName: 'runAgent',
+                input: {
+                    agentTools: [
+                        {
+                            type: 'PIECE',
+                            toolName: 'slack_send',
+                            pieceMetadata: {
+                                pieceName: '@activepieces/piece-slack',
+                                pieceVersion: '0.2.0',
+                                actionName: 'send_message',
+                            },
+                        },
+                    ],
+                },
+                propertySettings: {},
+            },
+        }
+        const fv = makeFlowVersion({
+            ...pieceTrigger,
+            nextAction: {
+                ...pieceAction,
+                nextAction: agentStep,
+            },
+        })
+        const packages = await extractPiecePackages(fv, mockPlatformId, mockLog, mockApiClient)
+        const slackCount = packages.filter((p) => p.pieceName === '@activepieces/piece-slack').length
+        expect(slackCount).toBe(1)
+    })
 })
 
 describe('extractCodeArtifacts', () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a runtime `PieceNotFoundError` that occurred when an AI Agent step referenced a piece (e.g. Gmail, Slack, Google Calendar) as a tool that had never been installed on the worker. The worker built its `piecesToInstall` list by scanning only explicit flow steps and ignored pieces referenced inside an agent step's `agentTools` input, so the engine then failed when it tried to load those tool pieces from disk.

`extractPiecePackages` now also walks every piece step's `agentTools` array. Any entry of type `PIECE` contributes its `pieceMetadata.pieceName` / `pieceVersion` to the install list, deduplicated against pieces that already appear as normal steps. Non-piece tools (FLOW, MCP, KNOWLEDGE_BASE) are ignored, and steps without `agentTools` are unaffected.

### Explain How the Feature Works

1. The worker picks up a flow run and calls `provisionFlowPieces`, which calls `extractPiecePackages(flowVersion, ...)`.
2. For each piece step (trigger or action), the helper now also reads `step.settings.input.agentTools` when present.
3. Each `AgentTool` entry of type `PIECE` is turned into a `{ pieceName, pieceVersion }` reference using `pieceMetadata`, deduped by `pieceName@pieceVersion`.
4. All references are resolved through `pieceCache.getPiece(...)` exactly like normal step pieces, then handed to `provisioner.provision(...)`.
5. Result: the worker installs Gmail/Slack/etc. before the engine starts, and `pieceLoader.getPieceAndActionOrThrow()` succeeds for every agent tool.

### Relevant User Scenarios

- User creates a flow with an AI Agent step and adds Gmail "Send Email" as a tool. Previously this failed on first run with `PieceNotFoundError: Piece not found for package: @activepieces/piece-gmail-0.12.3`. Now the worker installs the Gmail piece alongside `piece-ai` before executing the agent.
- Same scenario for any other tool piece (Slack, Google Calendar, custom community pieces) that has not yet been used elsewhere in the project.
- Reproduced and reported on both `latest` and `0.83.0`, CE edition, `UNSANDBOXED` execution mode (see linked issue).

Tests added in `flow-helpers.test.ts` cover:
- `agentTools` PIECE entries are included in the install list.
- Pieces shared between a normal step and an `agentTools` entry are deduplicated.

Fixes #13431
