### PR TITLE
feat(chat): make display tools block execution with agentic rendering

### DIFF
--- a/packages/server/api/src/app/ee/chat/chat-approval-gate.ts
+++ b/packages/server/api/src/app/ee/chat/chat-approval-gate.ts
@@ -1,7 +1,7 @@
 import { distributedStore } from '../../database/redis-connections'
 import { pubsub } from '../../helper/pubsub'
 
-const GATE_TTL_SECONDS = 5 * 60
+const GATE_TTL_SECONDS = 15 * 60
 const KEY_PREFIX = 'tool-approval-decision:'
 const CHANNEL_PREFIX = 'tool-approval:'
 
@@ -13,18 +13,23 @@ function channelName(gateId: string): string {
     return `${CHANNEL_PREFIX}${gateId}`
 }
 
-async function resolveGate({ gateId, approved }: { gateId: string, approved: boolean }): Promise<void> {
-    await distributedStore.put(decisionKey(gateId), { approved }, GATE_TTL_SECONDS)
-    await pubsub.publish(channelName(gateId), JSON.stringify({ approved }))
+async function resolveGate({ gateId, approved, payload }: { gateId: string, approved: boolean, payload?: Record<string, unknown> }): Promise<void> {
+    await distributedStore.put(decisionKey(gateId), { approved, payload }, GATE_TTL_SECONDS)
+    await pubsub.publish(channelName(gateId), JSON.stringify({ approved, payload }))
 }
 
-async function checkDecision({ gateId }: { gateId: string }): Promise<boolean | 'pending'> {
-    const raw = await distributedStore.get<{ approved: boolean }>(decisionKey(gateId))
+async function checkDecision({ gateId }: { gateId: string }): Promise<GateDecision | 'pending'> {
+    const raw = await distributedStore.get<GateDecision>(decisionKey(gateId))
     if (!raw) return 'pending'
-    return raw.approved === true
+    return { approved: raw.approved === true, payload: raw.payload }
 }
 
 export const chatApprovalGate = {
     resolveGate,
     checkDecision,
+}
+
+type GateDecision = {
+    approved: boolean
+    payload?: Record<string, unknown>
 }

--- a/packages/server/api/src/app/ee/chat/chat-controller.ts
+++ b/packages/server/api/src/app/ee/chat/chat-controller.ts
@@ -116,6 +116,7 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
         await chatApprovalGate.resolveGate({
             gateId: request.params.gateId,
             approved: request.body.approved,
+            payload: request.body.payload,
         })
         return reply.status(StatusCodes.OK).send({ success: true })
     })
@@ -231,7 +232,7 @@ const ToolApprovalRoute = {
         tags: ['chat'],
         security: [SERVICE_KEY_SECURITY_OPENAPI],
         params: z.object({ gateId: z.string() }),
-        body: z.object({ approved: z.boolean() }),
+        body: z.object({ approved: z.boolean(), payload: z.record(z.string(), z.unknown()).optional() }),
     },
 }
 

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
@@ -67,7 +67,7 @@ function withApprovalGates({ mcpToolSet, writer, log, isApproved, waitForApprova
     writer: ChatStreamWriter
     log: FastifyBaseLogger
     isApproved: () => boolean
-    waitForApproval: (gateId: string) => Promise<boolean>
+    waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<{ approved: boolean }>
 }): Record<string, unknown> {
     const result: Record<string, unknown> = {}
 
@@ -97,9 +97,9 @@ function withApprovalGates({ mcpToolSet, writer, log, isApproved, waitForApprova
                 })
 
                 log.info({ gateId, toolName: name }, 'Tool approval gate opened')
-                const approved = await waitForApproval(gateId)
+                const decision = await waitForApproval({ gateId })
 
-                if (!approved) {
+                if (!decision.approved) {
                     log.info({ gateId, toolName: name }, 'Tool approval rejected or timed out')
                     return { content: [{ type: 'text', text: 'Action cancelled by user.' }] }
                 }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -23,23 +23,40 @@ function createRpcWriterForConversation({ sendEvent, userId, conversationId }: {
     }
 }
 
-function createDisplayTools({ writer }: { writer: ChatStreamWriter }): ToolSet {
+function createDisplayTools({ writer, waitForApproval, displayToolTimeoutMs }: {
+    writer: ChatStreamWriter
+    waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<{ approved: boolean, payload?: Record<string, unknown> }>
+    displayToolTimeoutMs: number
+}): ToolSet {
+    function blockingExecute({ dataType, dismissMessage, successKey }: {
+        dataType: string
+        dismissMessage: string
+        successKey: string
+    }) {
+        return async (input: Record<string, unknown>) => {
+            const gateId = apId()
+            writer.write({ type: dataType, data: { ...input, gateId }, transient: true })
+            const decision = await waitForApproval({ gateId, timeoutMs: displayToolTimeoutMs })
+            if (!decision.approved) {
+                return { dismissed: true, message: dismissMessage }
+            }
+            return { [successKey]: true, ...decision.payload }
+        }
+    }
+
     return {
         ap_show_connection_required: tool({
-            description: 'Display a card prompting the user to connect a service. Use when no connection exists for a required piece.',
+            description: 'Display a card prompting the user to connect a service. Use when no connection exists for a required piece. After the user connects, briefly confirm before proceeding.',
             inputSchema: z.object({
                 piece: z.string().describe('Piece short name (e.g. "gmail", "slack")'),
                 displayName: z.string().describe('Human-readable name (e.g. "Gmail", "Slack")'),
                 status: z.enum(['missing', 'error']).optional().describe('Set to "error" when connection exists but needs reconnecting'),
             }),
-            execute: async (input) => {
-                writer.write({ type: 'data-connection-required', data: input, transient: true })
-                return { displayed: true }
-            },
+            execute: blockingExecute({ dataType: 'data-connection-required', dismissMessage: 'User dismissed the connection request.', successKey: 'connected' }),
         }),
 
         ap_show_connection_picker: tool({
-            description: 'Display a card for the user to choose between multiple connections for a piece.',
+            description: 'Display a card for the user to choose between multiple connections for a piece. After selection, briefly confirm which account the user chose before proceeding.',
             inputSchema: z.object({
                 piece: z.string().describe('Piece short name'),
                 displayName: z.string().describe('Human-readable piece name'),
@@ -51,28 +68,22 @@ function createDisplayTools({ writer }: { writer: ChatStreamWriter }): ToolSet {
                     status: z.string().describe('Connection status (ACTIVE, ERROR, etc.)'),
                 })).min(1),
             }),
-            execute: async (input) => {
-                writer.write({ type: 'data-connection-picker', data: input, transient: true })
-                return { displayed: true }
-            },
+            execute: blockingExecute({ dataType: 'data-connection-picker', dismissMessage: 'User dismissed the connection picker.', successKey: 'selected' }),
         }),
 
         ap_show_project_picker: tool({
-            description: 'Display a card for the user to select a project to work in.',
+            description: 'Display a card for the user to select a project to work in. After selection, briefly confirm which project the user chose before proceeding.',
             inputSchema: z.object({
                 suggestedProjects: z.array(z.object({
                     name: z.string().describe('Project display name'),
                     id: z.string().describe('Project ID'),
                 })).min(1),
             }),
-            execute: async (input) => {
-                writer.write({ type: 'data-project-picker', data: input, transient: true })
-                return { displayed: true }
-            },
+            execute: blockingExecute({ dataType: 'data-project-picker', dismissMessage: 'User dismissed the project picker.', successKey: 'selected' }),
         }),
 
         ap_show_questions: tool({
-            description: 'Display a multi-question form to gather structured input from the user.',
+            description: 'Display a multi-question form to gather structured input from the user. After the user answers, briefly acknowledge their responses before proceeding.',
             inputSchema: z.object({
                 questions: z.array(z.object({
                     title: z.string().optional().describe('Section title'),
@@ -82,10 +93,7 @@ function createDisplayTools({ writer }: { writer: ChatStreamWriter }): ToolSet {
                     placeholder: z.string().optional().describe('Placeholder for text-type questions'),
                 })).min(1),
             }),
-            execute: async (input) => {
-                writer.write({ type: 'data-questions', data: input, transient: true })
-                return { displayed: true }
-            },
+            execute: blockingExecute({ dataType: 'data-questions', dismissMessage: 'User dismissed the questions form.', successKey: 'answered' }),
         }),
 
         ap_show_quick_replies: tool({
@@ -178,7 +186,7 @@ function createCrossProjectTools({ executeTool }: {
 function createPlanTools({ writer, onPlanApproved, waitForApproval }: {
     writer: ChatStreamWriter
     onPlanApproved: () => void
-    waitForApproval: (gateId: string) => Promise<boolean>
+    waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<{ approved: boolean }>
 }): ToolSet {
     return {
         ap_request_plan_approval: tool({
@@ -194,8 +202,8 @@ function createPlanTools({ writer, onPlanApproved, waitForApproval }: {
                     data: { gateId, planSummary: input.planSummary, steps: input.steps },
                     transient: true,
                 })
-                const approved = await waitForApproval(gateId)
-                if (approved) {
+                const decision = await waitForApproval({ gateId })
+                if (decision.approved) {
                     onPlanApproved()
                     return { success: true, message: 'Plan approved by the user. Execute each step in order now. Call ap_update_plan to update step statuses as you work.' }
                 }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -23,6 +23,7 @@ const BATCH_SIZE = 10
 const BATCH_FLUSH_MS = 50
 const APPROVAL_POLL_INTERVAL_MS = 2_000
 const APPROVAL_TIMEOUT_MS = 5 * 60 * 1_000
+const DISPLAY_TOOL_TIMEOUT_MS = 15 * 60 * 1_000
 
 export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndForgetJobResult> = {
     jobType: WorkerJobType.EXECUTE_CHAT_AGENT,
@@ -172,16 +173,19 @@ function buildToolSet({ ctx, writer, log, planApproved, mcpToolSet, projects, co
         return response.result
     }
 
-    const waitForApproval = async (gateId: string): Promise<boolean> => {
-        const deadline = Date.now() + APPROVAL_TIMEOUT_MS
+    const waitForApproval = async ({ gateId, timeoutMs }: { gateId: string, timeoutMs?: number }): Promise<GateDecision> => {
+        const deadline = Date.now() + (timeoutMs ?? APPROVAL_TIMEOUT_MS)
         while (Date.now() < deadline) {
             const response = await ctx.apiClient.executeChatTool({
                 toolName: '__approval_check', toolInput: { gateId }, platformId, userId,
             })
-            if (response.result !== 'pending') return response.result === true
+            if (response.result !== 'pending') {
+                const decision = response.result as GateDecision
+                return { approved: decision.approved, payload: decision.payload }
+            }
             await new Promise((resolve) => setTimeout(resolve, APPROVAL_POLL_INTERVAL_MS))
         }
-        return false
+        return { approved: false }
     }
 
     const localTools = chatWorkerTools.createLocalTools({
@@ -190,7 +194,7 @@ function buildToolSet({ ctx, writer, log, planApproved, mcpToolSet, projects, co
         },
         projects,
     })
-    const displayTools = chatWorkerTools.createDisplayTools({ writer })
+    const displayTools = chatWorkerTools.createDisplayTools({ writer, waitForApproval, displayToolTimeoutMs: DISPLAY_TOOL_TIMEOUT_MS })
     const planTools = chatWorkerTools.createPlanTools({
         writer,
         onPlanApproved: () => {
@@ -291,4 +295,9 @@ const CREDIT_ERROR_PATTERNS = [/credits/i, /\b402\b/, /payment.required/i]
 
 function isCreditExhaustedError(message: string): boolean {
     return CREDIT_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+type GateDecision = {
+    approved: boolean
+    payload?: Record<string, unknown>
 }

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -17,6 +17,7 @@ import {
 import { useAgentChat } from '@/features/chat/lib/use-chat';
 import { useCreditsState } from '@/features/chat/lib/use-credits-state';
 import { aiProviderQueries } from '@/features/platform-admin';
+import { cn } from '@/lib/utils';
 
 import { AssistantMessage } from './components/assistant-message';
 import { ChatBottomBar } from './components/chat-bottom-bar';
@@ -87,6 +88,8 @@ function ChatBoxContent({
   });
 
   const quickReplies = useChatStoreContext((s) => s.quickReplies);
+  const displayCard = useChatStoreContext((s) => s.displayCard);
+  const hasBlockingCard = displayCard !== null && !displayCard.resolved;
 
   useEffect(() => {
     if (initialConversationId) {
@@ -190,7 +193,6 @@ function ChatBoxContent({
                 isStreaming={isLastStreamingAssistant}
                 isLastMessage={isLastAssistant}
                 onRetry={handleRetry}
-                onSend={handleSend}
                 lastAssistantMessage={
                   isLastAssistant ? lastAssistantMessage : msg
                 }
@@ -237,8 +239,13 @@ function ChatBoxContent({
 
       <div className="px-6 pb-4">
         <div className="max-w-3xl mx-auto relative">
-          <div className="overflow-hidden rounded-2xl border border-foreground/20 hover:border-foreground/40 focus-within:border-foreground/40 transition-colors">
-            {showBanner && (
+          <div
+            className={cn(
+              !hasBlockingCard &&
+                'overflow-hidden rounded-2xl border border-foreground/20 hover:border-foreground/40 focus-within:border-foreground/40 transition-colors',
+            )}
+          >
+            {showBanner && !hasBlockingCard && (
               <CreditsBanner
                 creditsExhausted={credits.creditsExhausted}
                 creditsWarning={credits.creditsWarning}

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -1,6 +1,6 @@
 import { PlanStepUpdate } from '@activepieces/shared';
 import { t } from 'i18next';
-import { RefreshCw, Volume2, VolumeOff } from 'lucide-react';
+import { Check, RefreshCw, Volume2, VolumeOff } from 'lucide-react';
 import { motion } from 'motion/react';
 import { memo, useMemo } from 'react';
 
@@ -48,17 +48,24 @@ export const AssistantMessage = memo(function AssistantMessage({
   isStreaming,
   isLastMessage = false,
   onRetry,
-  onSend,
   lastAssistantMessage,
 }: {
   message: ChatUIMessage;
   isStreaming: boolean;
   isLastMessage?: boolean;
   onRetry: () => void;
-  onSend: (text: string, files?: File[]) => void;
   lastAssistantMessage?: ChatUIMessage;
 }) {
-  const { blocks, hasContent } = useMemo(() => {
+  const resolveDisplayCard = useChatStoreContext((s) => s.resolveDisplayCard);
+  const displayCard = useChatStoreContext((s) => s.displayCard);
+  const hasActiveDisplayCard =
+    isStreaming && displayCard !== null && !displayCard.resolved;
+
+  const {
+    blocks,
+    hasContent,
+    lastDisplayIdx: lastDisplayToolIdx,
+  } = useMemo(() => {
     const result: MessageBlock[] = [];
     let currentThinking: {
       steps: ThinkingStep[];
@@ -145,26 +152,33 @@ export const AssistantMessage = memo(function AssistantMessage({
 
     flushThinking();
 
-    const lastDisplayIdx = result.findLastIndex(
-      (b) => b.kind === 'display-tool',
-    );
-    if (lastDisplayIdx > -1) {
-      for (let j = result.length - 1; j >= 0; j--) {
-        if (result[j].kind === 'display-tool' && j !== lastDisplayIdx) {
-          result.splice(j, 1);
-        }
+    for (let j = result.length - 1; j > 0; j--) {
+      const block = result[j];
+      const prevBlock = result[j - 1];
+      if (
+        block.kind === 'thinking' &&
+        prevBlock.kind === 'display-tool' &&
+        block.reasoningText.length === 0 &&
+        block.steps.every((s) => s.kind === 'thinking-status')
+      ) {
+        result.splice(j, 1);
       }
     }
 
-    if (
-      isStreaming &&
-      !result.some((b) => b.kind === 'thinking') &&
-      result.length === 0
-    ) {
-      result.push({ kind: 'thinking', steps: [], reasoningText: '' });
+    const lastDisplayIdx = result.findLastIndex(
+      (b) => b.kind === 'display-tool',
+    );
+
+    if (isStreaming) {
+      const hasThinkingAfter = result.some(
+        (b, idx) => b.kind === 'thinking' && idx > lastDisplayIdx,
+      );
+      if (result.length === 0 || (lastDisplayIdx >= 0 && !hasThinkingAfter)) {
+        result.push({ kind: 'thinking', steps: [], reasoningText: '' });
+      }
     }
 
-    return { blocks: result, hasContent: hasText };
+    return { blocks: result, hasContent: hasText, lastDisplayIdx };
   }, [message.parts, isStreaming]);
 
   const fullText = useMemo(
@@ -210,7 +224,12 @@ export const AssistantMessage = memo(function AssistantMessage({
                     key={`thinking-${i}`}
                     thinkingSteps={block.steps}
                     reasoningText={block.reasoningText}
-                    isStreaming={isStreaming && i === lastThinkingIdx}
+                    isStreaming={
+                      isStreaming &&
+                      i === lastThinkingIdx &&
+                      !hasActiveDisplayCard &&
+                      i > lastDisplayToolIdx
+                    }
                     thinkingDurationMs={
                       i === lastThinkingIdx
                         ? (
@@ -228,16 +247,22 @@ export const AssistantMessage = memo(function AssistantMessage({
                     <Markdown>{block.text}</Markdown>
                   </div>
                 );
-              case 'display-tool':
-                if (isStreaming) return null;
-                return (
-                  <DisplayToolCard
-                    key={block.part.toolCallId}
-                    part={block.part}
-                    onSend={onSend}
-                    isInteractive={isLastMessage}
-                  />
-                );
+              case 'display-tool': {
+                const toolCompleted =
+                  block.part.state === 'output-available' ||
+                  block.part.state === 'output-error';
+                if (toolCompleted) {
+                  return (
+                    <DisplayToolCard
+                      key={block.part.toolCallId}
+                      part={block.part}
+                      onResolve={resolveDisplayCard}
+                      isInteractive={false}
+                    />
+                  );
+                }
+                return null;
+              }
               case 'plan-marker':
                 return (
                   <InlinePlanCard
@@ -368,46 +393,112 @@ function InlinePlanCard({
 
 function DisplayToolCard({
   part,
-  onSend,
+  onResolve,
   isInteractive,
 }: {
   part: AnyToolPart;
-  onSend: (text: string, files?: File[]) => void;
+  onResolve: (payload: Record<string, unknown>) => void;
   isInteractive: boolean;
 }) {
   if (!chatPartUtils.isReady(part)) return null;
   const data = part.input as Record<string, unknown>;
   const toolName = chatPartUtils.getToolPartName(part);
+  const parsedOutput = chatPartUtils.parseToolOutput(part);
+  const toolOutput =
+    parsedOutput.state === 'success'
+      ? (parsedOutput.data as Record<string, unknown>)
+      : undefined;
 
   switch (toolName) {
     case 'ap_show_connection_required':
       return (
         <ConnectionsRequiredCard
           connections={[data as unknown as ConnectionRequiredData]}
-          onSend={onSend}
+          onResolve={onResolve}
         />
       );
-    case 'ap_show_connection_picker':
+    case 'ap_show_connection_picker': {
+      const selectedLabel =
+        typeof toolOutput?.['label'] === 'string'
+          ? (toolOutput['label'] as string)
+          : undefined;
       return (
         <ConnectionPickerCard
           picker={data as unknown as ConnectionPickerData}
-          onSelect={onSend}
+          onResolve={onResolve}
           isInteractive={isInteractive}
+          selectedConnectionLabel={selectedLabel}
         />
       );
-    case 'ap_show_project_picker':
+    }
+    case 'ap_show_project_picker': {
+      const selectedProjectId =
+        typeof toolOutput?.['projectId'] === 'string'
+          ? (toolOutput['projectId'] as string)
+          : undefined;
       return (
         <ProjectPickerCard
           picker={data as unknown as ProjectPickerData}
           isInteractive={isInteractive}
-          onSelect={(_projectId, projectName) => {
-            onSend(`Use ${projectName}.`);
-          }}
+          onResolve={onResolve}
+          selectedProjectId={selectedProjectId}
         />
       );
+    }
+    case 'ap_show_questions': {
+      const answersText =
+        typeof toolOutput?.['answers'] === 'string'
+          ? (toolOutput['answers'] as string)
+          : undefined;
+      if (!answersText) return null;
+      return <AnsweredQuestionsCard answersText={answersText} />;
+    }
     default:
       return null;
   }
+}
+
+function AnsweredQuestionsCard({ answersText }: { answersText: string }) {
+  const pairs = useMemo(() => parseAnswerPairs(answersText), [answersText]);
+  if (pairs.length === 0) return null;
+
+  return (
+    <motion.div
+      className="rounded-xl border bg-background overflow-hidden my-2"
+      initial={{ opacity: 0, scale: 0.98 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.2 }}
+    >
+      <div className="px-4 py-3 flex items-center gap-2 border-b bg-muted/30">
+        <div className="bg-green-100 dark:bg-green-500/20 rounded-full p-1">
+          <Check className="h-3 w-3 text-green-600 dark:text-green-400" />
+        </div>
+        <span className="text-sm font-medium">{t('Your answers')}</span>
+      </div>
+      <div className="px-4 py-3 space-y-3">
+        {pairs.map((pair, i) => (
+          <div key={i}>
+            <div className="text-xs text-muted-foreground">{pair.question}</div>
+            <div className="text-sm font-medium">{pair.answer}</div>
+          </div>
+        ))}
+      </div>
+    </motion.div>
+  );
+}
+
+function parseAnswerPairs(
+  text: string,
+): Array<{ question: string; answer: string }> {
+  return text
+    .split('\n')
+    .filter((line) => line.startsWith('- **'))
+    .map((line) => {
+      const match = line.match(/^- \*\*(.+?)\*\*\s*(.*)$/);
+      if (!match) return null;
+      return { question: match[1], answer: match[2] };
+    })
+    .filter((p): p is { question: string; answer: string } => p !== null);
 }
 
 type MessageBlock =

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
@@ -2,12 +2,24 @@ import { t } from 'i18next';
 
 import { chatStoreSelectors } from '@/features/chat/lib/chat-store';
 import { useChatStoreContext } from '@/features/chat/lib/chat-store-context';
+import { MultiQuestion } from '@/features/chat/lib/chat-store-types';
 import { ChatUIMessage } from '@/features/chat/lib/chat-types';
+
+import {
+  ConnectionPickerData,
+  ProjectPickerData,
+} from '../lib/message-parsers';
 
 import { ChatInput } from './chat-input';
 import { ChatModelSelector } from './chat-model-selector';
+import { ConnectionPickerCard } from './connection-picker-card';
+import {
+  ConnectionRequiredData,
+  ConnectionsRequiredCard,
+} from './connections-required-card';
 import { MultiQuestionForm } from './multi-question-form';
 import { PlanApprovalForm } from './plan-approval-form';
+import { ProjectPickerCard } from './project-picker-card';
 import { ToolApprovalForm } from './tool-approval-form';
 
 export function ChatBottomBar({
@@ -47,6 +59,9 @@ export function ChatBottomBar({
     chatStoreSelectors.hasActiveForm({ state: s, lastAssistantMessage }),
   );
   const dismissForm = useChatStoreContext((s) => s.dismissForm);
+  const displayCard = useChatStoreContext((s) => s.displayCard);
+  const resolveDisplayCard = useChatStoreContext((s) => s.resolveDisplayCard);
+  const dismissDisplayCard = useChatStoreContext((s) => s.dismissDisplayCard);
 
   if (hasPlanApproval && pendingPlanApproval) {
     return (
@@ -69,6 +84,17 @@ export function ChatBottomBar({
         onApprove={approveToolCall}
         onReject={rejectToolCall}
         onDismiss={dismissApproval}
+      />
+    );
+  }
+
+  if (displayCard && !displayCard.resolved) {
+    return (
+      <BlockingDisplayCard
+        displayCard={displayCard}
+        activeQuestions={activeQuestions}
+        resolveDisplayCard={resolveDisplayCard}
+        dismissDisplayCard={dismissDisplayCard}
       />
     );
   }
@@ -104,6 +130,53 @@ export function ChatBottomBar({
       }
     />
   );
+}
+
+function BlockingDisplayCard({
+  displayCard,
+  activeQuestions,
+  resolveDisplayCard,
+  dismissDisplayCard,
+}: {
+  displayCard: { type: string; data: Record<string, unknown>; gateId: string };
+  activeQuestions: MultiQuestion[];
+  resolveDisplayCard: (payload: Record<string, unknown>) => void;
+  dismissDisplayCard: () => void;
+}) {
+  switch (displayCard.type) {
+    case 'data-questions':
+      return (
+        <MultiQuestionForm
+          key={displayCard.gateId}
+          questions={activeQuestions}
+          onSubmit={(text) => resolveDisplayCard({ answers: text })}
+          onDismiss={() => dismissDisplayCard()}
+        />
+      );
+    case 'data-connection-required':
+      return (
+        <ConnectionsRequiredCard
+          connections={[displayCard.data as unknown as ConnectionRequiredData]}
+          onResolve={resolveDisplayCard}
+        />
+      );
+    case 'data-connection-picker':
+      return (
+        <ConnectionPickerCard
+          picker={displayCard.data as unknown as ConnectionPickerData}
+          onResolve={resolveDisplayCard}
+        />
+      );
+    case 'data-project-picker':
+      return (
+        <ProjectPickerCard
+          picker={displayCard.data as unknown as ProjectPickerData}
+          onResolve={resolveDisplayCard}
+        />
+      );
+    default:
+      return null;
+  }
 }
 
 type ChatBottomBarProps = {

--- a/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
@@ -143,9 +143,10 @@ function useLiveConnections({
 
 export function ConnectionPickerCard({
   picker,
-  onSelect,
+  onResolve,
   isInteractive = true,
   selectedProjectId,
+  selectedConnectionLabel,
 }: ConnectionPickerCardProps) {
   const queryClient = useQueryClient();
   const pieceName = normalizePieceName(picker.piece);
@@ -199,37 +200,19 @@ export function ConnectionPickerCard({
   }
 
   if (!isInteractive) {
+    const historyLabel = selectedConnectionLabel ?? filteredPicker.displayName;
     return (
-      <motion.div
-        className="rounded-xl border bg-background overflow-hidden my-2"
-        initial={{ opacity: 0, scale: 0.98 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.2 }}
-      >
-        <div className="p-4 flex items-center gap-3">
-          <div className="relative">
-            <PieceIconWithPieceName
-              pieceName={pieceName}
-              size="sm"
-              border={false}
-              showTooltip={false}
-            />
-            <div className="absolute -bottom-0.5 -right-0.5 bg-green-500 rounded-full p-0.5">
-              <Check className="h-2 w-2 text-white" />
-            </div>
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="text-sm font-semibold">
-              {t('Which {name} account should I use?', {
-                name: filteredPicker.displayName,
-              })}
-            </div>
-            <div className="text-xs text-muted-foreground">
-              {t('Connected')}
-            </div>
-          </div>
-        </div>
-      </motion.div>
+      <SelectedState
+        pieceName={pieceName}
+        connection={{
+          label: historyLabel,
+          project: '',
+          externalId: '',
+          projectId: '',
+          status: AppConnectionStatus.ACTIVE,
+        }}
+        displayName={filteredPicker.displayName}
+      />
     );
   }
 
@@ -286,9 +269,11 @@ export function ConnectionPickerCard({
                     className="shrink-0"
                     onClick={() => {
                       setSelectedConnection(conn);
-                      onSelect(
-                        `Use "${conn.label}" from ${conn.project} (${conn.externalId}).`,
-                      );
+                      onResolve({
+                        connectionExternalId: conn.externalId,
+                        projectId: conn.projectId,
+                        label: conn.label,
+                      });
                     }}
                   >
                     {t('Use')}
@@ -362,7 +347,10 @@ export function ConnectionPickerCard({
                 projectId: '',
                 status: AppConnectionStatus.ACTIVE,
               });
-              onSelect(`Connected ${createdConnection.displayName}`);
+              onResolve({
+                connectionExternalId: createdConnection.externalId,
+                label: createdConnection.displayName,
+              });
             }
           }}
           reconnectConnection={reconnectConnection}
@@ -375,7 +363,8 @@ export function ConnectionPickerCard({
 
 type ConnectionPickerCardProps = {
   picker: ConnectionPickerData;
-  onSelect: (text: string) => void;
+  onResolve: (payload: Record<string, unknown>) => void;
   isInteractive?: boolean;
   selectedProjectId?: string | null;
+  selectedConnectionLabel?: string;
 };

--- a/packages/web/src/app/routes/chat-with-ai/components/connections-required-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connections-required-card.tsx
@@ -19,11 +19,11 @@ import { normalizePieceName } from '../lib/message-parsers';
 
 export function ConnectionsRequiredCard({
   connections,
-  onSend,
+  onResolve,
   projectId: selectedProjectId,
 }: {
   connections: ConnectionRequiredData[];
-  onSend?: (text: string) => void;
+  onResolve?: (payload: Record<string, unknown>) => void;
   projectId?: string | null;
 }) {
   const queryClient = useQueryClient();
@@ -132,13 +132,15 @@ export function ConnectionsRequiredCard({
                 {t('All connected')}
               </div>
             ) : (
-              onSend && (
+              onResolve && (
                 <Button
                   size="sm"
                   className="gap-1.5"
                   onClick={() => {
                     setContinued(true);
-                    onSend(t('All connections are ready, continue building.'));
+                    onResolve({
+                      message: 'All connections are ready, continue building.',
+                    });
                   }}
                 >
                   <Check className="h-3.5 w-3.5" />

--- a/packages/web/src/app/routes/chat-with-ai/components/project-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/project-picker-card.tsx
@@ -28,7 +28,7 @@ import { ProjectPickerData } from '../lib/message-parsers';
 
 export function ProjectPickerCard({
   picker,
-  onSelect,
+  onResolve,
   isInteractive = true,
   selectedProjectId,
 }: ProjectPickerCardProps) {
@@ -48,7 +48,7 @@ export function ProjectPickerCard({
 
   function handleSelect(projectId: string, name: string) {
     setSelected(projectId);
-    onSelect(projectId, name);
+    onResolve({ projectId, projectName: name });
   }
 
   if (selected || !isInteractive) {
@@ -194,7 +194,7 @@ export function ProjectPickerCard({
 
 type ProjectPickerCardProps = {
   picker: ProjectPickerData;
-  onSelect: (projectId: string, projectName: string) => void;
+  onResolve: (payload: Record<string, unknown>) => void;
   isInteractive?: boolean;
   selectedProjectId?: string | null;
 };

--- a/packages/web/src/features/chat/lib/chat-api.ts
+++ b/packages/web/src/features/chat/lib/chat-api.ts
@@ -69,11 +69,16 @@ async function sendMessage({
 async function approveToolCall({
   gateId,
   approved,
+  payload,
 }: {
   gateId: string;
   approved: boolean;
+  payload?: Record<string, unknown>;
 }): Promise<void> {
-  return api.post<void>(`/v1/chat/tool-approvals/${gateId}`, { approved });
+  return api.post<void>(`/v1/chat/tool-approvals/${gateId}`, {
+    approved,
+    payload,
+  });
 }
 
 export const chatApi = {

--- a/packages/web/src/features/chat/lib/chat-store.ts
+++ b/packages/web/src/features/chat/lib/chat-store.ts
@@ -12,11 +12,13 @@ import { AnyToolPart, ChatUIMessage, chatPartUtils } from './chat-types';
 function sendApprovalDecision({
   gateId,
   approved,
+  payload,
 }: {
   gateId: string;
   approved: boolean;
+  payload?: Record<string, unknown>;
 }): void {
-  void chatApi.approveToolCall({ gateId, approved });
+  void chatApi.approveToolCall({ gateId, approved, payload });
 }
 
 function extractQuestionsFromToolParts(
@@ -26,7 +28,8 @@ function extractQuestionsFromToolParts(
   const questionPart = message.parts.find(
     (p) =>
       chatPartUtils.isAnyToolPart(p) &&
-      chatPartUtils.getToolPartName(p) === 'ap_show_questions',
+      chatPartUtils.getToolPartName(p) === 'ap_show_questions' &&
+      p.state !== 'output-available',
   );
   if (!questionPart || !chatPartUtils.isAnyToolPart(questionPart)) return [];
   const input = questionPart.input as
@@ -64,7 +67,12 @@ export type ChatStoreState = {
   pendingPlanApproval: PlanApprovalRequest | null;
   planProgressUpdates: PlanStepUpdate[];
   planRejected: boolean;
-  displayCard: { type: string; data: Record<string, unknown> } | null;
+  displayCard: {
+    type: string;
+    data: Record<string, unknown>;
+    gateId: string;
+    resolved: boolean;
+  } | null;
   quickReplies: string[];
 
   dismissedApprovalGateId: string | null;
@@ -81,6 +89,9 @@ export type ChatStoreState = {
   dismissPlan: () => void;
 
   dismissForm: (messageId: string) => void;
+
+  resolveDisplayCard: (payload: Record<string, unknown>) => void;
+  dismissDisplayCard: () => void;
 
   resetInteractions: () => void;
 };
@@ -139,6 +150,19 @@ export const createChatStore = () =>
       set({ lastDismissedFormId: messageId });
     },
 
+    resolveDisplayCard: (payload: Record<string, unknown>) => {
+      const card = get().displayCard;
+      if (!card || card.resolved) return;
+      set({ displayCard: { ...card, resolved: true } });
+      sendApprovalDecision({ gateId: card.gateId, approved: true, payload });
+    },
+    dismissDisplayCard: () => {
+      const card = get().displayCard;
+      if (!card) return;
+      set({ displayCard: null });
+      sendApprovalDecision({ gateId: card.gateId, approved: false });
+    },
+
     resetInteractions: () => {
       set({
         pendingApprovalRequest: null,
@@ -176,7 +200,10 @@ function selectActiveQuestions({
   state: ChatStoreState;
   lastAssistantMessage: ChatUIMessage | undefined;
 }): MultiQuestion[] {
-  if (state.displayCard?.type === 'data-questions') {
+  if (
+    state.displayCard?.type === 'data-questions' &&
+    !state.displayCard.resolved
+  ) {
     const input = state.displayCard.data as { questions?: MultiQuestion[] };
     return input.questions ?? [];
   }
@@ -193,7 +220,8 @@ function selectHasActiveForm({
   const questions = selectActiveQuestions({ state, lastAssistantMessage });
   return (
     questions.length > 0 &&
-    (state.displayCard?.type === 'data-questions' ||
+    ((state.displayCard?.type === 'data-questions' &&
+      !state.displayCard.resolved) ||
       (!!lastAssistantMessage &&
         lastAssistantMessage.id !== state.lastDismissedFormId))
   );

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -4,6 +4,7 @@ import {
   CHAT_ALLOWED_MIME_TYPES,
   DEFAULT_CHAT_TIER_ID,
   ErrorCode,
+  isNil,
   isObject,
   PlanStepUpdate,
   tryCatch,
@@ -212,7 +213,15 @@ export function useAgentChat({
 
         default:
           if (DISPLAY_CARD_DATA_TYPES.has(dataPart.type)) {
-            store.setState({ displayCard: { type: dataPart.type, data: d } });
+            const gateId = typeof d['gateId'] === 'string' ? d['gateId'] : '';
+            store.setState({
+              displayCard: {
+                type: dataPart.type,
+                data: d,
+                gateId,
+                resolved: false,
+              },
+            });
           }
           break;
       }
@@ -262,6 +271,18 @@ export function useAgentChat({
         onCreditsExhaustedRef.current?.();
       }
       void reconcile(convId).then(() => clearStreamingState());
+    },
+    onStaleCheck: (convId) => {
+      void tryCatch(async () => {
+        const conv = await chatApi.getConversation(convId);
+        if (
+          !isNil(conv) &&
+          conv.status !== ChatConversationStatus.STREAMING &&
+          conversationIdRef.current === convId
+        ) {
+          void reconcile(convId).then(() => clearStreamingState());
+        }
+      });
     },
   });
 

--- a/packages/web/src/features/chat/lib/use-streaming-reducer.ts
+++ b/packages/web/src/features/chat/lib/use-streaming-reducer.ts
@@ -113,6 +113,7 @@ export function useStreamingReducer({
     (conversationId: string) => {
       teardown();
 
+      lastChunkTimeRef.current = Date.now();
       reducerStateRef.current = chunkReducer.createStreamingState();
       setStreamingMessage({
         id: reducerStateRef.current.message.id,

--- a/packages/web/src/features/chat/lib/use-streaming-reducer.ts
+++ b/packages/web/src/features/chat/lib/use-streaming-reducer.ts
@@ -9,11 +9,13 @@ import { chunkReducer, DataPart, StreamingState } from './chunk-reducer';
 
 const THROTTLE_MS = 100;
 const STREAM_TIMEOUT_MS = 10 * 60 * 1000;
+const STALE_CHECK_INTERVAL_MS = 15_000;
 
 export function useStreamingReducer({
   onDataPart,
   onStreamFinished,
   onStreamError,
+  onStaleCheck,
 }: {
   onDataPart: (part: DataPart) => void;
   onStreamFinished: (conversationId: string) => void;
@@ -22,6 +24,7 @@ export function useStreamingReducer({
     errorMessage: string;
     errorCode?: string;
   }) => void;
+  onStaleCheck: (conversationId: string) => void;
 }) {
   const socket = useSocket();
 
@@ -43,6 +46,12 @@ export function useStreamingReducer({
   onStreamFinishedRef.current = onStreamFinished;
   const onStreamErrorRef = useRef(onStreamError);
   onStreamErrorRef.current = onStreamError;
+  const onStaleCheckRef = useRef(onStaleCheck);
+  onStaleCheckRef.current = onStaleCheck;
+  const staleCheckTimerRef = useRef<ReturnType<typeof setInterval> | null>(
+    null,
+  );
+  const lastChunkTimeRef = useRef(0);
 
   const updatePhase = useCallback((phase: StreamPhase) => {
     if (streamPhaseRef.current === phase) return;
@@ -85,6 +94,10 @@ export function useStreamingReducer({
     if (streamTimeoutRef.current !== null) {
       clearTimeout(streamTimeoutRef.current);
       streamTimeoutRef.current = null;
+    }
+    if (staleCheckTimerRef.current !== null) {
+      clearInterval(staleCheckTimerRef.current);
+      staleCheckTimerRef.current = null;
     }
     chunkBufferRef.current = [];
     reducerStateRef.current = null;
@@ -135,6 +148,7 @@ export function useStreamingReducer({
 
         if (event.type === ChatAgentEventType.CHUNK) {
           updatePhase('streaming');
+          lastChunkTimeRef.current = Date.now();
           const chunks = Array.isArray(event.data) ? event.data : [event.data];
           for (const chunk of chunks) {
             chunkBufferRef.current.push(chunk as UIMessageChunk);
@@ -163,6 +177,12 @@ export function useStreamingReducer({
       streamTimeoutRef.current = setTimeout(() => {
         handleError({ errorMessage: 'Stream timed out' });
       }, STREAM_TIMEOUT_MS);
+
+      staleCheckTimerRef.current = setInterval(() => {
+        const timeSinceLastChunk = Date.now() - lastChunkTimeRef.current;
+        if (timeSinceLastChunk < STALE_CHECK_INTERVAL_MS) return;
+        onStaleCheckRef.current(conversationId);
+      }, STALE_CHECK_INTERVAL_MS);
 
       cleanupRef.current = () => {
         socket.off(WebsocketClientEvent.CHAT_MESSAGE_CHUNK, handler);


### PR DESCRIPTION
## Summary
- Display tools (connection picker, project picker, questions, connection required) now block AI execution until the user responds, creating an agentic step-by-step flow
- Extended approval gate with generic JSON payloads so the worker receives structured user responses (selected connection, project, answers)
- Added streaming recovery poll (15s) to detect lost WebSocket FINISHED events and auto-reconcile
- Blocking cards render in the bottom bar replacing the chat input; resolved cards persist in conversation history with their selected state

## Test plan
- [ ] Trigger a project picker → verify it appears in the bottom bar, AI stops reasoning, selecting resumes the AI in the same turn
- [ ] Trigger a connection picker → same blocking behavior, selected connection shows in history after refresh
- [ ] Trigger questions form → appears in bottom bar, answers persist as a Q&A card in history after refresh
- [ ] Dismiss a blocking card → AI responds gracefully ("Let me know when you're ready")
- [ ] Quick replies still render inline in the message area (non-blocking)
- [ ] Disconnect WiFi mid-stream → verify recovery poll detects finished conversation within ~15s
- [ ] Multiple display cards in one message → each renders correctly at its position, no duplicates