### PR TITLE
feat(UXsniff): add piece with feedback and survey response triggers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4365,7 +4365,7 @@
     },
     "packages/pieces/community/maileroo": {
       "name": "@activepieces/piece-maileroo",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7263,6 +7263,16 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/uxsniff": {
+      "name": "@activepieces/piece-uxsniff",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/vadoo-ai": {
       "name": "@activepieces/piece-vadoo-ai",
       "version": "0.1.3",
@@ -8346,7 +8356,7 @@
     },
     "packages/pieces/framework": {
       "name": "@activepieces/pieces-framework",
-      "version": "0.28.2",
+      "version": "0.29.0",
       "dependencies": {
         "@activepieces/shared": "workspace:*",
         "ai": "^6.0.0",
@@ -8599,7 +8609,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.78.1",
+      "version": "0.79.0",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",
@@ -10078,6 +10088,8 @@
     "@activepieces/piece-uscreen": ["@activepieces/piece-uscreen@workspace:packages/pieces/community/uscreen"],
 
     "@activepieces/piece-useinbox": ["@activepieces/piece-useinbox@workspace:packages/pieces/community/useinbox"],
+
+    "@activepieces/piece-uxsniff": ["@activepieces/piece-uxsniff@workspace:packages/pieces/community/uxsniff"],
 
     "@activepieces/piece-vadoo-ai": ["@activepieces/piece-vadoo-ai@workspace:packages/pieces/community/vadoo-ai"],
 

--- a/packages/pieces/community/uxsniff/.eslintrc.json
+++ b/packages/pieces/community/uxsniff/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/uxsniff/package.json
+++ b/packages/pieces/community/uxsniff/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-uxsniff",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/uxsniff/src/index.ts
+++ b/packages/pieces/community/uxsniff/src/index.ts
@@ -1,0 +1,55 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import {
+  createCustomApiCallAction,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/shared';
+import { newFeedbackTrigger } from './lib/triggers/new-feedback';
+import { newSurveyResponseTrigger } from './lib/triggers/new-survey-response';
+
+export const uxsniffAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: `To get your UXsniff API key:
+1. Log in to your UXsniff account.
+2. Open the [Account page](https://app.uxsniff.com/login?next=account).
+3. Copy your API Key and paste it below.`,
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://api.uxsniff.com/v1/list-survey',
+        headers: { Authorization: auth },
+        queryParams: { limit: '1' },
+      });
+      return { valid: true };
+    } catch (e) {
+      return {
+        valid: false,
+        error: 'Invalid API Key. Find it on your UXsniff Account page.',
+      };
+    }
+  },
+});
+
+export const uxsniff = createPiece({
+  displayName: 'UXsniff',
+  description:
+    'AI-powered UX analytics: session recordings, heatmaps, feedback widgets, and surveys for your website.',
+  auth: uxsniffAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/uxsniff.png',
+  categories: [PieceCategory.BUSINESS_INTELLIGENCE, PieceCategory.MARKETING],
+  authors: ['sanket'],
+  actions: [
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.uxsniff.com/v1',
+      auth: uxsniffAuth,
+      authMapping: async (auth) => ({
+        Authorization: (auth as { secret_text: string }).secret_text,
+      }),
+    }),
+  ],
+  triggers: [newFeedbackTrigger, newSurveyResponseTrigger],
+});

--- a/packages/pieces/community/uxsniff/src/index.ts
+++ b/packages/pieces/community/uxsniff/src/index.ts
@@ -41,13 +41,13 @@ export const uxsniff = createPiece({
   minimumSupportedRelease: '0.36.1',
   logoUrl: 'https://cdn.activepieces.com/pieces/uxsniff.png',
   categories: [PieceCategory.BUSINESS_INTELLIGENCE, PieceCategory.MARKETING],
-  authors: ['sanket'],
+  authors: ['sanket-a11y'],
   actions: [
     createCustomApiCallAction({
       baseUrl: () => 'https://api.uxsniff.com/v1',
       auth: uxsniffAuth,
       authMapping: async (auth) => ({
-        Authorization: (auth as { secret_text: string }).secret_text,
+        Authorization: auth.secret_text,
       }),
     }),
   ],

--- a/packages/pieces/community/uxsniff/src/lib/common/index.ts
+++ b/packages/pieces/community/uxsniff/src/lib/common/index.ts
@@ -1,0 +1,163 @@
+import {
+  httpClient,
+  HttpMethod,
+  HttpMessageBody,
+  HttpResponse,
+  QueryParams,
+} from '@activepieces/pieces-common';
+import { Property } from '@activepieces/pieces-framework';
+import { uxsniffAuth } from '../../';
+
+const BASE_URL = 'https://api.uxsniff.com/v1';
+
+async function uxsniffApiCall<T extends HttpMessageBody>({
+  apiKey,
+  method,
+  path,
+  queryParams,
+  body,
+}: {
+  apiKey: string;
+  method: HttpMethod;
+  path: string;
+  queryParams?: Record<string, string | number | undefined>;
+  body?: unknown;
+}): Promise<HttpResponse<T>> {
+  const cleanedQuery: QueryParams = {};
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      if (value !== undefined && value !== null && value !== '') {
+        cleanedQuery[key] = String(value);
+      }
+    }
+  }
+
+  return await httpClient.sendRequest<T>({
+    method,
+    url: `${BASE_URL}${path}`,
+    headers: {
+      Authorization: apiKey,
+    },
+    queryParams: cleanedQuery,
+    body,
+  });
+}
+
+function toEpochMillis(value: unknown): number {
+  if (typeof value === 'number') {
+    return value < 1e12 ? value * 1000 : value;
+  }
+  if (typeof value === 'string') {
+    const asNumber = Number(value);
+    if (!Number.isNaN(asNumber) && value.trim() !== '') {
+      return asNumber < 1e12 ? asNumber * 1000 : asNumber;
+    }
+    const parsed = new Date(value).getTime();
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function startDateFromEpoch(epochMillis: number): string {
+  return new Date(epochMillis - ONE_DAY_MS).toISOString().slice(0, 10);
+}
+
+const surveyDropdown = Property.Dropdown({
+  displayName: 'Survey',
+  description: 'Select the survey to read responses from.',
+  auth: uxsniffAuth,
+  refreshers: [],
+  required: true,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Please connect your UXsniff account first',
+      };
+    }
+    try {
+      const response = await uxsniffApiCall<UxsniffSurvey[]>({
+        apiKey: auth.secret_text,
+        method: HttpMethod.GET,
+        path: '/list-survey',
+        queryParams: { limit: 200 },
+      });
+      const surveys = Array.isArray(response.body) ? response.body : [];
+      if (surveys.length === 0) {
+        return {
+          disabled: false,
+          options: [],
+          placeholder: 'No surveys found. Create one in your UXsniff dashboard first.',
+        };
+      }
+      return {
+        disabled: false,
+        options: surveys.map((survey) => ({
+          label: `${survey.survey_name}${survey.active ? '' : ' (inactive)'}`,
+          value: String(survey.survey_id),
+        })),
+      };
+    } catch (error) {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load surveys. Check your connection.',
+      };
+    }
+  },
+});
+
+export const uxsniffCommon = {
+  apiCall: uxsniffApiCall,
+  toEpochMillis,
+  startDateFromEpoch,
+  surveyDropdown,
+};
+
+export type UxsniffSurvey = {
+  survey_id: string | number;
+  survey_name: string;
+  active: boolean;
+};
+
+export type UxsniffVisitor = {
+  visitor_id?: string;
+  session_id?: string;
+  email?: string;
+  device?: string;
+  country?: string;
+  browser?: string;
+  browserSize?: string;
+  os?: string;
+};
+
+export type UxsniffFeedback = {
+  feedback_id: string | number;
+  question?: string;
+  comment?: string;
+  rating?: number | string;
+  created?: string | number;
+  url?: string;
+  screenshot?: string;
+  visitor?: UxsniffVisitor;
+};
+
+export type UxsniffSurveyResponse = {
+  id: string | number;
+  client_id?: string;
+  sessio_id?: string;
+  session_id?: string;
+  answers?: unknown;
+  url?: string;
+  country?: string;
+  countryName?: string;
+  created?: string | number;
+  os?: string;
+  browser?: string;
+  referrer?: string;
+};

--- a/packages/pieces/community/uxsniff/src/lib/triggers/new-feedback.ts
+++ b/packages/pieces/community/uxsniff/src/lib/triggers/new-feedback.ts
@@ -1,0 +1,83 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  AppConnectionValueForAuthProperty,
+} from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper, HttpMethod } from '@activepieces/pieces-common';
+import { uxsniffAuth } from '../../';
+import { uxsniffCommon, UxsniffFeedback } from '../common';
+
+const polling: Polling<AppConnectionValueForAuthProperty<typeof uxsniffAuth>, Record<string, never>> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, lastFetchEpochMS }) => {
+    const response = await uxsniffCommon.apiCall<UxsniffFeedback[]>({
+      apiKey: auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/feedback',
+      queryParams: {
+        startdate: lastFetchEpochMS ? uxsniffCommon.startDateFromEpoch(lastFetchEpochMS) : undefined,
+        limit: 50,
+      },
+    });
+
+    const items = Array.isArray(response.body) ? response.body : [];
+    return items.map((item) => ({
+      epochMilliSeconds: uxsniffCommon.toEpochMillis(item.created),
+      data: {
+        feedback_id: item.feedback_id ?? null,
+        question: item.question ?? null,
+        comment: item.comment ?? null,
+        rating: item.rating ?? null,
+        created: item.created ?? null,
+        url: item.url ?? null,
+        screenshot: item.screenshot ?? null,
+        visitor_id: item.visitor?.visitor_id ?? null,
+        session_id: item.visitor?.session_id ?? null,
+        visitor_email: item.visitor?.email ?? null,
+        device: item.visitor?.device ?? null,
+        country: item.visitor?.country ?? null,
+        browser: item.visitor?.browser ?? null,
+        browser_size: item.visitor?.browserSize ?? null,
+        os: item.visitor?.os ?? null,
+      },
+    }));
+  },
+};
+
+export const newFeedbackTrigger = createTrigger({
+  auth: uxsniffAuth,
+  name: 'new_feedback',
+  displayName: 'New Feedback',
+  description: 'Triggers when a visitor submits new feedback on your website.',
+  props: {},
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    feedback_id: 1,
+    question: 'How would you rate your experience?',
+    comment: 'Good comment',
+    rating: 5,
+    created: '2022-10-21 12:56:33',
+    url: 'https://uxsniff.com/',
+    screenshot: '',
+    visitor_id: '1666355009686.mhprr8t',
+    session_id: '1666355009686.6nzbnflq',
+    visitor_email: 'john@doe.com',
+    device: 'Desktop',
+    country: 'Singapore',
+    browser: 'Safari',
+    browser_size: '2560x1335',
+    os: 'MacOS',
+  },
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+});

--- a/packages/pieces/community/uxsniff/src/lib/triggers/new-survey-response.ts
+++ b/packages/pieces/community/uxsniff/src/lib/triggers/new-survey-response.ts
@@ -1,0 +1,93 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  AppConnectionValueForAuthProperty,
+  StaticPropsValue,
+} from '@activepieces/pieces-framework';
+import { DedupeStrategy, Polling, pollingHelper, HttpMethod } from '@activepieces/pieces-common';
+import { uxsniffAuth } from '../../';
+import { uxsniffCommon, UxsniffSurveyResponse } from '../common';
+
+const props = {
+  survey_id: uxsniffCommon.surveyDropdown,
+};
+
+type SurveyApiResponse = {
+  responses?: UxsniffSurveyResponse[];
+};
+
+const polling: Polling<
+  AppConnectionValueForAuthProperty<typeof uxsniffAuth>,
+  StaticPropsValue<typeof props>
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth, propsValue, lastFetchEpochMS }) => {
+    const response = await uxsniffCommon.apiCall<SurveyApiResponse>({
+      apiKey: auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/survey',
+      queryParams: {
+        id: propsValue.survey_id,
+        startdate: lastFetchEpochMS ? uxsniffCommon.startDateFromEpoch(lastFetchEpochMS) : undefined,
+        limit: 100,
+      },
+    });
+
+    const items = response.body.responses ?? [];
+    return items.map((item) => ({
+      epochMilliSeconds: uxsniffCommon.toEpochMillis(item.created),
+      data: {
+        response_id: item.id ?? null,
+        client_id: item.client_id ?? null,
+        session_id: item.session_id ?? item.sessio_id ?? null,
+        answers:
+          item.answers === undefined || item.answers === null
+            ? null
+            : typeof item.answers === 'object'
+            ? JSON.stringify(item.answers)
+            : String(item.answers),
+        url: item.url ?? null,
+        country: item.country ?? null,
+        country_name: item.countryName ?? null,
+        created: item.created ?? null,
+        os: item.os ?? null,
+        browser: item.browser ?? null,
+        referrer: item.referrer ?? null,
+      },
+    }));
+  },
+};
+
+export const newSurveyResponseTrigger = createTrigger({
+  auth: uxsniffAuth,
+  name: 'new_survey_response',
+  displayName: 'New Survey Response',
+  description: 'Triggers when a visitor submits a new response to the selected survey.',
+  props,
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    response_id: '98765',
+    client_id: 'visitor_abc',
+    session_id: 'session_xyz',
+    answers: '{"1":"Very satisfied","2":"Found everything I needed"}',
+    url: 'https://example.com/pricing',
+    country: 'US',
+    country_name: 'United States',
+    created: '2024-05-01T10:30:00Z',
+    os: 'Windows',
+    browser: 'Chrome',
+    referrer: 'https://google.com',
+  },
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+});

--- a/packages/pieces/community/uxsniff/tsconfig.json
+++ b/packages/pieces/community/uxsniff/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/uxsniff/tsconfig.lib.json
+++ b/packages/pieces/community/uxsniff/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1349,6 +1349,9 @@
       "@activepieces/piece-utility-ai": [
         "packages/pieces/community/utility-ai/src/index.ts"
       ],
+      "@activepieces/piece-uxsniff": [
+        "packages/pieces/community/uxsniff/src/index.ts"
+      ],
       "@activepieces/piece-vadoo-ai": [
         "packages/pieces/community/vadoo-ai/src/index.ts"
       ],


### PR DESCRIPTION

Adds the UXsniff integration with API key auth, two polling triggers (New Feedback, New Survey Response) that filter by the polling cursor, a survey dropdown, and a custom API call action.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
