### PR TITLE
feat(chat): run the same action on multiple items at once with live progress

### DIFF
--- a/.agents/chat-engineering-gaps.md
+++ b/.agents/chat-engineering-gaps.md
@@ -1,0 +1,52 @@
+# Chat Engineering Gaps — Priority Order
+
+## ~~Priority 1: Batch Execution for One-Time Tasks~~
+**Status:** Done
+**Impact:** Critical — blocks 8 of 10 use cases (any multi-item task)
+**Effort:** Medium
+
+**Implemented:** Extended `ap_execute_action` with `items[]` array (max 100) + `description` for progress label. Worker-side batch loop calls `executeAdhocAction` per item via RPC, pushes `data-batch-progress` stream events for a live-updating `BatchProgressCard` in the chat UI. Continue-on-error. Timeout scales with item count. Single-item path unchanged.
+
+---
+
+## Priority 2: Value-Before-Auth Flow
+**Status:** Not started
+**Impact:** High — users hit auth wall before getting any value, kills conversion
+**Effort:** Low (prompt-only change)
+
+**Problem:** The agent calls `ap_discover_action_auth` → immediately requests connection. Users are asked to authenticate before understanding what the agent will do for them. Zero value delivered before the ask.
+
+**Fix:** Add system prompt rule: "Before requesting connections, explain what you will do and show the execution plan. Only request auth after the user confirms the approach." This is a prompt-only change with outsized impact on first-time experience.
+
+---
+
+## Priority 3: Connection-Based Suggestions
+**Status:** Not started
+**Impact:** Medium — existing users get no personalized experience
+**Effort:** Medium
+
+**Problem:** Chat does not suggest actions based on existing connections. A user with Slack, GitHub, and Google Sheets connected sees the same generic empty state as a brand new user.
+
+**Fix:** On conversation start, query user's connections and show personalized suggestions via `ap_show_quick_replies` (e.g. "Send a Slack message", "Check GitHub PRs", "Add a row to your spreadsheet"). Inject connection context into the first-message prompt.
+
+---
+
+## Priority 4: Analytics Events
+**Status:** Not started
+**Impact:** Medium — flying blind on whether tasks succeed, cannot measure PMF
+**Effort:** Low-Medium
+
+**Problem:** Current telemetry only syncs tool call counts to console. No outcome-level tracking. Cannot answer: "Do users complete tasks?", "Do one-time tasks convert to flows?", "Which task types succeed?"
+
+**Fix:** Add 3 events:
+- `CHAT_TASK_COMPLETED` — fires when a one-time action or batch succeeds
+- `CHAT_FLOW_CREATED` — fires when `ap_build_flow` completes successfully from chat
+- `CHAT_CONVERSION` — fires when user converts a one-time task to a flow (Gap 2's "Automate This?" path)
+
+---
+
+## Completed
+
+### ~~Gap 2: "Automate This?" Suggestion~~
+**Status:** Done
+System prompt suggests converting successful one-time tasks to flows via `ap_show_quick_replies`.

--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -48,7 +48,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - **Message compaction** — when a conversation exceeds a token threshold, older messages are summarized by the LLM and replaced with a summary to keep context within the model's window
 - **Tool approval gate** — a Redis pub/sub mechanism that pauses destructive tool executions (delete, test, publish) until the user explicitly approves or denies in the UI; times out after 5 minutes
 - **Plan approval** — a multi-step approval mechanism where the agent presents a plan via `ap_request_plan_approval`, the user approves or rejects, and approved plans execute with progress tracking
-- **Local tools** — chat-specific tools not part of MCP: `ap_set_session_title`, `ap_select_project`, `ap_run_one_time_action`, `ap_list_across_projects`, `ap_request_plan_approval`
+- **Local tools** — chat-specific tools not part of MCP: `ap_set_session_title`, `ap_select_project`, `ap_execute_action`, `ap_list_across_projects`, `ap_request_plan_approval`
 - **Display tools** — tools that render interactive UI cards: `ap_show_connection_required`, `ap_show_connection_picker`, `ap_show_project_picker`, `ap_show_questions`, `ap_show_quick_replies`
 - **MCP tools** — project-scoped tools loaded from the Activepieces MCP server when a project is selected; destructive ones are wrapped with the approval gate
 - **AI provider** — a platform-configured LLM provider with an `enabledForChat` flag; the chat resolves the first enabled provider and its default model
@@ -74,7 +74,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 ## Local Tools
 - `ap_set_session_title` — auto-names the conversation after the first exchange
 - `ap_select_project` — switches project context (scopes MCP tools to that project)
-- `ap_run_one_time_action` — executes a single piece action ad-hoc (e.g. "check my inbox"); auto-discovers connections across projects
+- `ap_execute_action` — executes a single piece action ad-hoc (e.g. "check my inbox"); auto-discovers connections across projects
 - `ap_list_across_projects` — lists flows, tables, runs, or connections across all user-accessible projects
 - `ap_request_plan_approval` — presents a multi-step plan to the user for approval before executing destructive or write operations
 

--- a/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
+++ b/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
@@ -197,7 +197,7 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
         case 'ap_discover_action_auth': {
             return findConnectionsForPiece({ pieceName: toolInput.pieceName as string, projects, platformId, log })
         }
-        case 'ap_run_one_time_action': {
+        case 'ap_execute_action': {
             const pieceName = toolInput.pieceName as string
             const actionName = toolInput.actionName as string
             const connectionExternalId = toolInput.connectionExternalId as string | undefined

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -18,7 +18,7 @@ Your available projects:
 6. Never call the same tool twice for the same data in one response.
 7. After every step mutation (`ap_add_step`, `ap_update_step`, `ap_update_trigger`), call `ap_validate_step_config` on that step immediately. Fix and re-validate if it fails.
 8. Use display tools for interactive UI — never ask questions in prose text.
-9. One-time tasks: use `ap_discover_action_auth` to check auth, then `ap_run_one_time_action` to execute. Never use `ap_run_action`.
+9. One-time tasks: use `ap_discover_action_auth` to check auth, then `ap_execute_action` to execute. Never use `ap_run_action`.
 10. Projects are invisible to the user unless building an automation or they ask.
 11. After completing a task, summarize in 1-2 sentences with resource links.
 12. Always include 1-2 sentences of visible text in your final response.
@@ -96,7 +96,14 @@ For one-shot tasks (send a message, check email, look up data):
      - At least one healthy → `ap_show_connection_picker`. Wait. Always show the picker, even for a single connection.
 3. After user picks, `ap_get_piece_props` with auth externalId.
 4. Fill fields (use IDs for dropdowns). For read actions, use broad defaults.
-5. `ap_run_one_time_action` with pieceName, actionName, input, projectId, connectionExternalId.
+5. `ap_execute_action` with pieceName, actionName, input, projectId, connectionExternalId.
+
+**Batch execution**: When the user wants the same action on multiple items (e.g., "send a message to 10 people", "update 50 records"), use the `items` array parameter instead of calling `ap_execute_action` multiple times:
+- `items`: array of complete input objects, one per invocation (max 100). Each item has all fields for the action.
+- `description`: human-readable label for the progress card (e.g., "Sending birthday messages to your team").
+- All items share the same `pieceName`, `actionName`, `connectionExternalId`, and `projectId`.
+- The user sees a live progress card showing completed/total counts and any failures.
+- Example: `ap_execute_action({ pieceName: "slack", actionName: "send_channel_message", items: [{ channel: "C01", text: "Hi Alice" }, { channel: "C02", text: "Hi Bob" }], description: "Sending Slack messages", connectionExternalId: "abc", projectId: "proj1" })`
 
 Read actions: broadest filter, show results, offer to refine.
 Write actions: execute if enough detail.
@@ -121,7 +128,7 @@ When a piece connection is unavailable and the user cannot or declines to create
    - OAuth2 pieces → ask for a Bearer Token (user can get one from the service's developer console).
    - API Key pieces → ask for the API key.
    - Basic Auth pieces → ask for username and password.
-3. Build the HTTP request with `ap_run_one_time_action`:
+3. Build the HTTP request with `ap_execute_action`:
    - **pieceName**: `@activepieces/piece-http`
    - **actionName**: `send_request`
    - **input**: `{ method, url, headers, body, authentication }` matching the original action's API call.

--- a/packages/server/utils/src/chat-ai-utils.ts
+++ b/packages/server/utils/src/chat-ai-utils.ts
@@ -194,6 +194,12 @@ function buildStepParts({ content }: {
                     output: rawOutput,
                     status: result ? PersistedToolCallStatus.COMPLETED : PersistedToolCallStatus.ERROR,
                 })
+                if (toolName === 'ap_execute_action' && typeof rawOutput === 'object' && rawOutput !== null && 'batchProgress' in rawOutput) {
+                    parts.push({
+                        type: PersistedChatPartType.BATCH_PROGRESS,
+                        data: (rawOutput as Record<string, unknown>)['batchProgress'] as Record<string, unknown>,
+                    })
+                }
                 break
             }
         }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -214,7 +214,7 @@ async function executeBatchAction({ executeTool, writer, pieceName, actionName, 
 }): Promise<unknown> {
     const batchId = apId()
     const total = items.length
-    const label = description ?? `Processing ${total} items`
+    const label = description ?? `Processing ${total} ${total === 1 ? 'item' : 'items'}`
     const results: BatchItemResult[] = []
     let succeeded = 0
     let failed = 0
@@ -242,23 +242,30 @@ async function executeBatchAction({ executeTool, writer, pieceName, actionName, 
 
     for (let i = 0; i < items.length; i++) {
         const itemInput = items[i]
-        const result = await executeTool('ap_execute_action', {
-            pieceName,
-            actionName,
-            input: itemInput,
-            connectionExternalId,
-            projectId,
-        })
-        const success = isSuccessResult(result)
-        if (success) {
-            succeeded++
-            consecutiveFailures = 0
-            results.push({ index: i, success: true, output: result })
+        try {
+            const result = await executeTool('ap_execute_action', {
+                pieceName,
+                actionName,
+                input: itemInput,
+                connectionExternalId,
+                projectId,
+            })
+            const success = isSuccessResult(result)
+            if (success) {
+                succeeded++
+                consecutiveFailures = 0
+                results.push({ index: i, success: true, output: result })
+            }
+            else {
+                failed++
+                consecutiveFailures++
+                results.push({ index: i, success: false, error: extractResultText(result) })
+            }
         }
-        else {
+        catch (err) {
             failed++
             consecutiveFailures++
-            results.push({ index: i, success: false, error: extractResultText(result) })
+            results.push({ index: i, success: false, error: err instanceof Error ? err.message : 'Unexpected error' })
         }
 
         const stoppedEarly = consecutiveFailures >= CONSECUTIVE_FAILURE_LIMIT

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -5,6 +5,7 @@ import {
     ChatStreamWriter,
     isObject,
     SendChatEventRequest,
+    tryCatch,
 } from '@activepieces/shared'
 import { tool, ToolSet } from 'ai'
 import { z } from 'zod'
@@ -241,31 +242,27 @@ async function executeBatchAction({ executeTool, writer, pieceName, actionName, 
     pushProgress({ done: false })
 
     for (let i = 0; i < items.length; i++) {
-        const itemInput = items[i]
-        try {
-            const result = await executeTool('ap_execute_action', {
-                pieceName,
-                actionName,
-                input: itemInput,
-                connectionExternalId,
-                projectId,
-            })
-            const success = isSuccessResult(result)
-            if (success) {
-                succeeded++
-                consecutiveFailures = 0
-                results.push({ index: i, success: true, output: result })
-            }
-            else {
-                failed++
-                consecutiveFailures++
-                results.push({ index: i, success: false, error: extractResultText(result) })
-            }
-        }
-        catch (err) {
+        const { data: result, error } = await tryCatch(() => executeTool('ap_execute_action', {
+            pieceName,
+            actionName,
+            input: items[i],
+            connectionExternalId,
+            projectId,
+        }))
+        if (error) {
             failed++
             consecutiveFailures++
-            results.push({ index: i, success: false, error: err instanceof Error ? err.message : 'Unexpected error' })
+            results.push({ index: i, success: false, error: error.message })
+        }
+        else if (isSuccessResult(result)) {
+            succeeded++
+            consecutiveFailures = 0
+            results.push({ index: i, success: true, output: result })
+        }
+        else {
+            failed++
+            consecutiveFailures++
+            results.push({ index: i, success: false, error: extractResultText(result) })
         }
 
         const stoppedEarly = consecutiveFailures >= CONSECUTIVE_FAILURE_LIMIT

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -1,11 +1,15 @@
 import {
     apId,
+    BatchItemResult,
     ChatAgentEventType,
     ChatStreamWriter,
+    isObject,
     SendChatEventRequest,
 } from '@activepieces/shared'
 import { tool, ToolSet } from 'ai'
 import { z } from 'zod'
+
+const MAX_BATCH_SIZE = 100
 
 function createRpcWriterForConversation({ sendEvent, userId, conversationId }: {
     sendEvent: (input: SendChatEventRequest) => Promise<void>
@@ -142,12 +146,13 @@ function createLocalTools({ onSetProjectContext, projects }: {
     }
 }
 
-function createCrossProjectTools({ executeTool }: {
+function createCrossProjectTools({ executeTool, writer }: {
     executeTool: (toolName: string, toolInput: Record<string, unknown>) => Promise<unknown>
+    writer: ChatStreamWriter
 }): ToolSet {
     return {
         ap_discover_action_auth: tool({
-            description: 'Check what authentication a piece needs and find available connections. Call this BEFORE ap_run_one_time_action to determine if auth is needed.',
+            description: 'Check what authentication a piece needs and find available connections. Call this BEFORE ap_execute_action to determine if auth is needed.',
             inputSchema: z.object({
                 pieceName: z.string().describe('Piece name, e.g. "@activepieces/piece-gmail"'),
             }),
@@ -156,17 +161,31 @@ function createCrossProjectTools({ executeTool }: {
             },
         }),
 
-        ap_run_one_time_action: tool({
-            description: 'Execute a piece action once. Use ap_discover_action_auth first to check if auth is needed. If the action requires auth, provide connectionExternalId and projectId.',
+        ap_execute_action: tool({
+            description: 'Execute a piece action once or in batch. Use ap_discover_action_auth first to check if auth is needed. If the action requires auth, provide connectionExternalId and projectId. For batch execution, provide an items array where each element is a complete input object for one invocation.',
             inputSchema: z.object({
                 pieceName: z.string().describe('Piece name, e.g. "@activepieces/piece-gmail"'),
                 actionName: z.string().describe('Action to run, e.g. "gmail_search_mail"'),
-                input: z.record(z.string(), z.unknown()).optional().describe('Input for the action'),
+                input: z.record(z.string(), z.unknown()).optional().describe('Input for the action (single-item mode)'),
+                items: z.array(z.record(z.string(), z.unknown())).max(MAX_BATCH_SIZE).optional().describe('Array of input objects for batch execution. Each element is a complete input for one invocation. Max 100 items.'),
+                description: z.string().optional().describe('Human-readable label for batch progress card, e.g. "Sending birthday messages"'),
                 connectionExternalId: z.string().optional().describe('externalId of the connection to use'),
                 projectId: z.string().optional().describe('Project ID where the connection lives'),
             }),
-            execute: async (input) => {
-                return executeTool('ap_run_one_time_action', input)
+            execute: async (toolInput) => {
+                if (toolInput.items && toolInput.items.length > 0) {
+                    return executeBatchAction({
+                        executeTool,
+                        writer,
+                        pieceName: toolInput.pieceName,
+                        actionName: toolInput.actionName,
+                        items: toolInput.items,
+                        description: toolInput.description,
+                        connectionExternalId: toolInput.connectionExternalId,
+                        projectId: toolInput.projectId,
+                    })
+                }
+                return executeTool('ap_execute_action', toolInput)
             },
         }),
 
@@ -181,6 +200,127 @@ function createCrossProjectTools({ executeTool }: {
             },
         }),
     }
+}
+
+async function executeBatchAction({ executeTool, writer, pieceName, actionName, items, description, connectionExternalId, projectId }: {
+    executeTool: (toolName: string, toolInput: Record<string, unknown>) => Promise<unknown>
+    writer: ChatStreamWriter
+    pieceName: string
+    actionName: string
+    items: Record<string, unknown>[]
+    description?: string
+    connectionExternalId?: string
+    projectId?: string
+}): Promise<unknown> {
+    const batchId = apId()
+    const total = items.length
+    const label = description ?? `Processing ${total} items`
+    const results: BatchItemResult[] = []
+    let succeeded = 0
+    let failed = 0
+
+    function pushProgress({ done }: { done: boolean }): void {
+        writer.write({
+            type: 'data-batch-progress',
+            id: batchId,
+            data: {
+                label,
+                total,
+                completed: results.length,
+                succeeded,
+                failed,
+                done,
+                results: done ? results : [],
+            },
+        })
+    }
+
+    const CONSECUTIVE_FAILURE_LIMIT = 3
+    let consecutiveFailures = 0
+
+    pushProgress({ done: false })
+
+    for (let i = 0; i < items.length; i++) {
+        const itemInput = items[i]
+        const result = await executeTool('ap_execute_action', {
+            pieceName,
+            actionName,
+            input: itemInput,
+            connectionExternalId,
+            projectId,
+        })
+        const success = isSuccessResult(result)
+        if (success) {
+            succeeded++
+            consecutiveFailures = 0
+            results.push({ index: i, success: true, output: result })
+        }
+        else {
+            failed++
+            consecutiveFailures++
+            results.push({ index: i, success: false, error: extractResultText(result) })
+        }
+
+        const stoppedEarly = consecutiveFailures >= CONSECUTIVE_FAILURE_LIMIT
+        const isLast = i === items.length - 1
+        pushProgress({ done: isLast || stoppedEarly })
+
+        if (stoppedEarly) break
+    }
+
+    const failureSummary = failed > 0
+        ? results
+            .filter((r) => !r.success)
+            .map((r) => `#${r.index + 1}: ${r.error ?? 'unknown error'}`)
+            .join('\n')
+        : ''
+
+    const batchProgress = {
+        label,
+        total,
+        completed: results.length,
+        succeeded,
+        failed,
+        done: true,
+        results,
+    }
+
+    const skipped = total - results.length
+
+    return {
+        content: [{
+            type: 'text',
+            text: `Batch complete: ${succeeded}/${total} succeeded, ${failed} failed.`
+                + (skipped > 0 ? ` Stopped early after ${CONSECUTIVE_FAILURE_LIMIT} consecutive failures (${skipped} items skipped).` : '')
+                + (failed > 0 ? `\n\nFailed items:\n${failureSummary}` : ''),
+        }],
+        batchProgress,
+    }
+}
+
+function isSuccessResult(result: unknown): boolean {
+    if (!isObject(result)) return false
+    if (result['success'] === false) return false
+    if (result['isError'] === true) return false
+    if (Array.isArray(result['content'])) {
+        const first = result['content'][0]
+        const text = isObject(first) && typeof first['text'] === 'string' ? first['text'] : ''
+        return !text.startsWith('❌') && !text.startsWith('⏳')
+    }
+    return false
+}
+
+function extractResultText(result: unknown): string {
+    if (typeof result === 'string') return result
+    if (!isObject(result)) return JSON.stringify(result)
+    if (typeof result['error'] === 'string') return result['error']
+    if (Array.isArray(result['content'])) {
+        return result['content']
+            .filter((c): c is Record<string, unknown> & { text: string } => isObject(c) && typeof c['text'] === 'string')
+            .map((c) => c.text)
+            .join('\n')
+    }
+    return JSON.stringify(result)
 }
 
 function createPlanTools({ writer, onPlanApproved, waitForApproval }: {
@@ -250,4 +390,6 @@ export const chatWorkerTools = {
     createCrossProjectTools,
     createPlanTools,
     createThinkingTools,
+    isSuccessResult,
+    extractResultText,
 }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -202,7 +202,7 @@ function buildToolSet({ ctx, writer, log, planApproved, mcpToolSet, projects, co
         },
         waitForApproval,
     })
-    const crossProjectTools = chatWorkerTools.createCrossProjectTools({ executeTool: executeCrossProjectTool })
+    const crossProjectTools = chatWorkerTools.createCrossProjectTools({ executeTool: executeCrossProjectTool, writer })
     const thinkingTools = chatWorkerTools.createThinkingTools()
     const gatedMcpTools = chatMcpClient.withApprovalGates({
         mcpToolSet, writer, log, isApproved: () => planApproved.approved, waitForApproval,

--- a/packages/server/worker/test/lib/execute/jobs/ee/chat/chat-worker-tools.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/chat/chat-worker-tools.test.ts
@@ -184,7 +184,7 @@ describe('chatWorkerTools', () => {
 
             const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
             const initial = progressEvents[0]['data'] as Record<string, unknown>
-            expect(initial['label']).toBe('Processing 1 items')
+            expect(initial['label']).toBe('Processing 1 item')
         })
 
         it('uses upsert id for all progress events', async () => {

--- a/packages/server/worker/test/lib/execute/jobs/ee/chat/chat-worker-tools.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/chat/chat-worker-tools.test.ts
@@ -1,0 +1,313 @@
+import { ChatStreamWriter } from '@activepieces/shared'
+import { describe, expect, it, vi } from 'vitest'
+import { chatWorkerTools } from '../../../../../../src/lib/execute/jobs/ee/chat/chat-worker-tools'
+
+function makeMockWriter(): { writer: ChatStreamWriter, writes: Record<string, unknown>[] } {
+    const writes: Record<string, unknown>[] = []
+    return {
+        writer: { write: (part: Record<string, unknown>) => { writes.push(part) } },
+        writes,
+    }
+}
+
+function mcpSuccess(text: string) {
+    return { content: [{ type: 'text', text: `✅ ${text}` }] }
+}
+
+function mcpFailure(text: string) {
+    return { content: [{ type: 'text', text: `❌ ${text}` }] }
+}
+
+describe('chatWorkerTools', () => {
+    describe('isSuccessResult', () => {
+        it('returns true for MCP success result', () => {
+            expect(chatWorkerTools.isSuccessResult(mcpSuccess('Done'))).toBe(true)
+        })
+
+        it('returns false for MCP failure result', () => {
+            expect(chatWorkerTools.isSuccessResult(mcpFailure('Something broke'))).toBe(false)
+        })
+
+        it('returns false for timeout result', () => {
+            const result = { content: [{ type: 'text', text: '⏳ Action still running after 120s.' }] }
+            expect(chatWorkerTools.isSuccessResult(result)).toBe(false)
+        })
+
+        it('returns false for structured error result', () => {
+            expect(chatWorkerTools.isSuccessResult({ success: false, error: 'No projects' })).toBe(false)
+        })
+
+        it('returns false for isError flag', () => {
+            expect(chatWorkerTools.isSuccessResult({ content: [{ type: 'text', text: 'error' }], isError: true })).toBe(false)
+        })
+
+        it('returns false for null', () => {
+            expect(chatWorkerTools.isSuccessResult(null)).toBe(false)
+        })
+
+        it('returns false for string', () => {
+            expect(chatWorkerTools.isSuccessResult('some string')).toBe(false)
+        })
+
+        it('returns false for object without content array', () => {
+            expect(chatWorkerTools.isSuccessResult({ data: 'something' })).toBe(false)
+        })
+    })
+
+    describe('extractResultText', () => {
+        it('extracts text from MCP content array', () => {
+            const result = { content: [{ type: 'text', text: 'Hello' }, { type: 'text', text: 'World' }] }
+            expect(chatWorkerTools.extractResultText(result)).toBe('Hello\nWorld')
+        })
+
+        it('returns error field directly', () => {
+            expect(chatWorkerTools.extractResultText({ success: false, error: 'No projects available' })).toBe('No projects available')
+        })
+
+        it('returns raw string as-is', () => {
+            expect(chatWorkerTools.extractResultText('raw text')).toBe('raw text')
+        })
+
+        it('JSON-stringifies non-object non-string values', () => {
+            expect(chatWorkerTools.extractResultText(42)).toBe('42')
+            expect(chatWorkerTools.extractResultText(null)).toBe('null')
+        })
+
+        it('JSON-stringifies objects without content or error', () => {
+            expect(chatWorkerTools.extractResultText({ data: 'value' })).toBe('{"data":"value"}')
+        })
+
+        it('skips non-text content items', () => {
+            const result = { content: [{ type: 'image', url: 'http://...' }, { type: 'text', text: 'Hello' }] }
+            expect(chatWorkerTools.extractResultText(result)).toBe('Hello')
+        })
+    })
+
+    describe('ap_execute_action batch mode', () => {
+        it('calls executeTool for each item and streams progress', async () => {
+            const { writer, writes } = makeMockWriter()
+            const executeTool = vi.fn().mockResolvedValue(mcpSuccess('sent'))
+
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const result = await tools.ap_execute_action.execute({
+                pieceName: 'slack',
+                actionName: 'send_message',
+                items: [
+                    { channel: 'C01', text: 'Hi Alice' },
+                    { channel: 'C02', text: 'Hi Bob' },
+                    { channel: 'C03', text: 'Hi Carol' },
+                ],
+                description: 'Sending messages',
+            }, { toolCallId: 'tc1', messages: [], abortSignal: undefined as unknown as AbortSignal })
+
+            expect(executeTool).toHaveBeenCalledTimes(3)
+            expect(executeTool).toHaveBeenCalledWith('ap_execute_action', expect.objectContaining({
+                pieceName: 'slack',
+                actionName: 'send_message',
+                input: { channel: 'C01', text: 'Hi Alice' },
+            }))
+
+            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
+            expect(progressEvents.length).toBe(4)
+
+            const initial = progressEvents[0]['data'] as Record<string, unknown>
+            expect(initial['completed']).toBe(0)
+            expect(initial['total']).toBe(3)
+            expect(initial['done']).toBe(false)
+            expect(initial['label']).toBe('Sending messages')
+
+            const final = progressEvents[3]['data'] as Record<string, unknown>
+            expect(final['completed']).toBe(3)
+            expect(final['succeeded']).toBe(3)
+            expect(final['failed']).toBe(0)
+            expect(final['done']).toBe(true)
+            expect((final['results'] as unknown[]).length).toBe(3)
+
+            const resultObj = result as { content: Array<{ text: string }>, batchProgress: Record<string, unknown> }
+            expect(resultObj.content[0].text).toContain('3/3 succeeded')
+            expect(resultObj.content[0].text).toContain('0 failed')
+
+            expect(resultObj.batchProgress).toBeDefined()
+            expect(resultObj.batchProgress['succeeded']).toBe(3)
+            expect(resultObj.batchProgress['failed']).toBe(0)
+            expect(resultObj.batchProgress['done']).toBe(true)
+        })
+
+        it('continues on error and reports failures', async () => {
+            const { writer, writes } = makeMockWriter()
+            const executeTool = vi.fn()
+                .mockResolvedValueOnce(mcpSuccess('sent'))
+                .mockResolvedValueOnce(mcpFailure('Invalid channel'))
+                .mockResolvedValueOnce(mcpSuccess('sent'))
+
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const result = await tools.ap_execute_action.execute({
+                pieceName: 'slack',
+                actionName: 'send_message',
+                items: [
+                    { channel: 'C01', text: 'Hi' },
+                    { channel: 'INVALID', text: 'Hi' },
+                    { channel: 'C03', text: 'Hi' },
+                ],
+            }, { toolCallId: 'tc2', messages: [], abortSignal: undefined as unknown as AbortSignal })
+
+            expect(executeTool).toHaveBeenCalledTimes(3)
+
+            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
+            const final = progressEvents[progressEvents.length - 1]['data'] as Record<string, unknown>
+            expect(final['succeeded']).toBe(2)
+            expect(final['failed']).toBe(1)
+            expect(final['done']).toBe(true)
+
+            const results = final['results'] as Array<{ index: number, success: boolean, error?: string }>
+            const failedItem = results.find((r) => !r.success)
+            expect(failedItem).toBeDefined()
+            expect(failedItem!.index).toBe(1)
+            expect(failedItem!.error).toContain('Invalid channel')
+
+            const resultObj = result as { content: Array<{ text: string }> }
+            expect(resultObj.content[0].text).toContain('2/3 succeeded')
+            expect(resultObj.content[0].text).toContain('1 failed')
+            expect(resultObj.content[0].text).toContain('#2')
+        })
+
+        it('uses default label when description is not provided', async () => {
+            const { writer, writes } = makeMockWriter()
+            const executeTool = vi.fn().mockResolvedValue(mcpSuccess('done'))
+
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            await tools.ap_execute_action.execute({
+                pieceName: 'http',
+                actionName: 'send_request',
+                items: [{ url: 'http://example.com' }],
+            }, { toolCallId: 'tc3', messages: [], abortSignal: undefined as unknown as AbortSignal })
+
+            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
+            const initial = progressEvents[0]['data'] as Record<string, unknown>
+            expect(initial['label']).toBe('Processing 1 items')
+        })
+
+        it('uses upsert id for all progress events', async () => {
+            const { writer, writes } = makeMockWriter()
+            const executeTool = vi.fn().mockResolvedValue(mcpSuccess('done'))
+
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            await tools.ap_execute_action.execute({
+                pieceName: 'slack',
+                actionName: 'send_message',
+                items: [{ channel: 'C01', text: 'Hi' }, { channel: 'C02', text: 'Hi' }],
+            }, { toolCallId: 'tc4', messages: [], abortSignal: undefined as unknown as AbortSignal })
+
+            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
+            const ids = progressEvents.map((w) => w['id'])
+            expect(ids.every((id) => id === ids[0])).toBe(true)
+        })
+
+        it('sends empty results array for intermediate events', async () => {
+            const { writer, writes } = makeMockWriter()
+            const executeTool = vi.fn().mockResolvedValue(mcpSuccess('done'))
+
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            await tools.ap_execute_action.execute({
+                pieceName: 'slack',
+                actionName: 'send_message',
+                items: [{ channel: 'C01', text: 'Hi' }, { channel: 'C02', text: 'Hi' }],
+            }, { toolCallId: 'tc5', messages: [], abortSignal: undefined as unknown as AbortSignal })
+
+            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
+            const intermediate = progressEvents.slice(0, -1)
+            for (const event of intermediate) {
+                const data = event['data'] as Record<string, unknown>
+                expect(data['results']).toEqual([])
+            }
+            const final = progressEvents[progressEvents.length - 1]['data'] as Record<string, unknown>
+            expect((final['results'] as unknown[]).length).toBe(2)
+        })
+
+        it('falls back to single-item mode when items is absent', async () => {
+            const { writer } = makeMockWriter()
+            const executeTool = vi.fn().mockResolvedValue(mcpSuccess('done'))
+
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            await tools.ap_execute_action.execute({
+                pieceName: 'gmail',
+                actionName: 'send_email',
+                input: { to: 'test@example.com' },
+            }, { toolCallId: 'tc6', messages: [], abortSignal: undefined as unknown as AbortSignal })
+
+            expect(executeTool).toHaveBeenCalledTimes(1)
+            expect(executeTool).toHaveBeenCalledWith('ap_execute_action', expect.objectContaining({
+                pieceName: 'gmail',
+                actionName: 'send_email',
+                input: { to: 'test@example.com' },
+            }))
+        })
+
+        it('handles structured error results from executeCrossProjectTool', async () => {
+            const { writer, writes } = makeMockWriter()
+            const executeTool = vi.fn()
+                .mockResolvedValueOnce({ success: false, error: 'No projects available' })
+
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const result = await tools.ap_execute_action.execute({
+                pieceName: 'slack',
+                actionName: 'send_message',
+                items: [{ channel: 'C01', text: 'Hi' }],
+            }, { toolCallId: 'tc7', messages: [], abortSignal: undefined as unknown as AbortSignal })
+
+            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
+            const final = progressEvents[progressEvents.length - 1]['data'] as Record<string, unknown>
+            expect(final['failed']).toBe(1)
+            expect(final['succeeded']).toBe(0)
+
+            const resultObj = result as { content: Array<{ text: string }> }
+            expect(resultObj.content[0].text).toContain('0/1 succeeded')
+        })
+
+        it('stops early after 3 consecutive failures', async () => {
+            const { writer, writes } = makeMockWriter()
+            const executeTool = vi.fn().mockResolvedValue(mcpFailure('Bad auth'))
+
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const result = await tools.ap_execute_action.execute({
+                pieceName: 'slack',
+                actionName: 'send_message',
+                items: Array.from({ length: 10 }, (_, i) => ({ channel: `C${i}`, text: 'Hi' })),
+                description: 'Sending messages',
+            }, { toolCallId: 'tc8', messages: [], abortSignal: undefined as unknown as AbortSignal })
+
+            expect(executeTool).toHaveBeenCalledTimes(3)
+
+            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
+            const final = progressEvents[progressEvents.length - 1]['data'] as Record<string, unknown>
+            expect(final['failed']).toBe(3)
+            expect(final['completed']).toBe(3)
+            expect(final['total']).toBe(10)
+            expect(final['done']).toBe(true)
+
+            const resultObj = result as { content: Array<{ text: string }> }
+            expect(resultObj.content[0].text).toContain('Stopped early')
+            expect(resultObj.content[0].text).toContain('7 items skipped')
+        })
+
+        it('resets consecutive failure count on success', async () => {
+            const { writer } = makeMockWriter()
+            const executeTool = vi.fn()
+                .mockResolvedValueOnce(mcpFailure('err'))
+                .mockResolvedValueOnce(mcpFailure('err'))
+                .mockResolvedValueOnce(mcpSuccess('ok'))
+                .mockResolvedValueOnce(mcpFailure('err'))
+                .mockResolvedValueOnce(mcpFailure('err'))
+                .mockResolvedValueOnce(mcpSuccess('ok'))
+
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            await tools.ap_execute_action.execute({
+                pieceName: 'slack',
+                actionName: 'send_message',
+                items: Array.from({ length: 6 }, (_, i) => ({ channel: `C${i}` })),
+            }, { toolCallId: 'tc9', messages: [], abortSignal: undefined as unknown as AbortSignal })
+
+            expect(executeTool).toHaveBeenCalledTimes(6)
+        })
+    })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/ee/chat/index.ts
+++ b/packages/shared/src/lib/ee/chat/index.ts
@@ -28,6 +28,7 @@ export enum PersistedChatPartType {
     REASONING = 'reasoning',
     TOOL_CALL = 'tool-call',
     THINKING_STATUS = 'thinking-status',
+    BATCH_PROGRESS = 'batch-progress',
 }
 
 export enum PersistedToolCallStatus {
@@ -65,11 +66,17 @@ const PersistedThinkingStatusPartSchema = z.object({
     text: z.string(),
 })
 
+const PersistedBatchProgressPartSchema = z.object({
+    type: z.literal(PersistedChatPartType.BATCH_PROGRESS),
+    data: z.record(z.string(), z.unknown()),
+})
+
 const PersistedChatPartSchema = z.discriminatedUnion('type', [
     PersistedTextPartSchema,
     PersistedReasoningPartSchema,
     PersistedToolCallPartSchema,
     PersistedThinkingStatusPartSchema,
+    PersistedBatchProgressPartSchema,
 ])
 
 export const PersistedChatMessageSchema = z.object({

--- a/packages/shared/src/lib/ee/chat/index.ts
+++ b/packages/shared/src/lib/ee/chat/index.ts
@@ -170,7 +170,7 @@ export type ChatToolOutputs = {
     ap_select_project: { success: boolean, message?: string, error?: string }
     ap_request_plan_approval: { success: boolean, message: string }
     ap_list_across_projects: { content: { type: string, text: string }[] }
-    ap_run_one_time_action:
+    ap_execute_action:
     | { noAuthRequired: true, piece: string }
     | { needsConnection: true, piece: string, displayName: string }
     | { pickConnection: true, piece: string, displayName: string, connections: ConnectionOption[] }
@@ -205,6 +205,23 @@ function unwrapToolOutput(output: unknown): unknown {
 
 export const chatPersistenceUtils = {
     unwrapToolOutput,
+}
+
+export type BatchItemResult = {
+    index: number
+    success: boolean
+    output?: unknown
+    error?: string
+}
+
+export type BatchProgressData = {
+    label: string
+    total: number
+    completed: number
+    succeeded: number
+    failed: number
+    done: boolean
+    results: BatchItemResult[]
 }
 
 export type ChatAllowedMimeType = typeof CHAT_ALLOWED_MIME_TYPES[number]

--- a/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
@@ -357,7 +357,7 @@ function buildToolSummary({ part }: { part: AnyToolPart }): {
 } {
   const toolName = chatPartUtils.getToolPartName(part);
   const icon =
-    toolName === 'ap_run_one_time_action'
+    toolName === 'ap_execute_action'
       ? Zap
       : toolName.startsWith('mcp__')
       ? Wrench

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -1,4 +1,8 @@
-import { PlanStepUpdate } from '@activepieces/shared';
+import {
+  BatchProgressData,
+  isObject,
+  PlanStepUpdate,
+} from '@activepieces/shared';
 import { t } from 'i18next';
 import { Check, RefreshCw, Volume2, VolumeOff } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -28,6 +32,7 @@ import {
 } from '../lib/message-parsers';
 
 import { ThinkingBlock } from './activity-accordion';
+import { BatchProgressCard } from './batch-progress-card';
 import { ConnectionPickerCard } from './connection-picker-card';
 import {
   ConnectionRequiredData,
@@ -92,6 +97,10 @@ export const AssistantMessage = memo(function AssistantMessage({
       return currentThinking;
     }
 
+    const hasBatchProgressDataPart = message.parts.some(
+      (p) => p.type === 'data-batch-progress',
+    );
+
     for (let i = 0; i < message.parts.length; i++) {
       const p = message.parts[i];
 
@@ -99,6 +108,10 @@ export const AssistantMessage = memo(function AssistantMessage({
         flushThinking();
         hasText = true;
         result.push({ kind: 'text', text: p.text });
+      } else if (p.type === 'data-batch-progress' && 'data' in p) {
+        flushThinking();
+        const batchPart = p as { data: BatchProgressData };
+        result.push({ kind: 'batch-progress', data: batchPart.data });
       } else if (p.type === 'reasoning') {
         const thinking = ensureThinking();
         thinking.reasoningText += p.text;
@@ -124,12 +137,22 @@ export const AssistantMessage = memo(function AssistantMessage({
         if (chatPartUtils.HIDDEN_TOOL_NAMES.has(toolName)) {
           continue;
         }
+        const batchData =
+          toolName === 'ap_execute_action' &&
+          !hasBatchProgressDataPart &&
+          p.state === 'output-available'
+            ? extractBatchProgress(p)
+            : null;
+
         if (chatPartUtils.isDisplayTool(toolName)) {
           flushThinking();
           result.push({ kind: 'display-tool', part: p });
         } else if (toolName === 'ap_request_plan_approval') {
           flushThinking();
           result.push({ kind: 'plan-marker', part: p });
+        } else if (batchData) {
+          flushThinking();
+          result.push({ kind: 'batch-progress', data: batchData });
         } else {
           const thinking = ensureThinking();
           const lastStep = thinking.steps[thinking.steps.length - 1];
@@ -271,6 +294,10 @@ export const AssistantMessage = memo(function AssistantMessage({
                     lastAssistantMessage={lastAssistantMessage}
                     isStreaming={isStreaming}
                   />
+                );
+              case 'batch-progress':
+                return (
+                  <BatchProgressCard key={`batch-${i}`} progress={block.data} />
                 );
               default:
                 return null;
@@ -501,6 +528,13 @@ function parseAnswerPairs(
     .filter((p): p is { question: string; answer: string } => p !== null);
 }
 
+function extractBatchProgress(part: AnyToolPart): BatchProgressData | null {
+  const output = chatPartUtils.parseToolOutput(part);
+  if (output.state !== 'success') return null;
+  if (!isObject(output.data) || !('batchProgress' in output.data)) return null;
+  return output.data.batchProgress as BatchProgressData;
+}
+
 type MessageBlock =
   | {
       kind: 'thinking';
@@ -509,4 +543,5 @@ type MessageBlock =
     }
   | { kind: 'text'; text: string }
   | { kind: 'display-tool'; part: AnyToolPart }
-  | { kind: 'plan-marker'; part: AnyToolPart };
+  | { kind: 'plan-marker'; part: AnyToolPart }
+  | { kind: 'batch-progress'; data: BatchProgressData };

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -1,8 +1,4 @@
-import {
-  BatchProgressData,
-  isObject,
-  PlanStepUpdate,
-} from '@activepieces/shared';
+import { BatchProgressData, PlanStepUpdate } from '@activepieces/shared';
 import { t } from 'i18next';
 import { Check, RefreshCw, Volume2, VolumeOff } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -97,10 +93,6 @@ export const AssistantMessage = memo(function AssistantMessage({
       return currentThinking;
     }
 
-    const hasBatchProgressDataPart = message.parts.some(
-      (p) => p.type === 'data-batch-progress',
-    );
-
     for (let i = 0; i < message.parts.length; i++) {
       const p = message.parts[i];
 
@@ -137,22 +129,12 @@ export const AssistantMessage = memo(function AssistantMessage({
         if (chatPartUtils.HIDDEN_TOOL_NAMES.has(toolName)) {
           continue;
         }
-        const batchData =
-          toolName === 'ap_execute_action' &&
-          !hasBatchProgressDataPart &&
-          p.state === 'output-available'
-            ? extractBatchProgress(p)
-            : null;
-
         if (chatPartUtils.isDisplayTool(toolName)) {
           flushThinking();
           result.push({ kind: 'display-tool', part: p });
         } else if (toolName === 'ap_request_plan_approval') {
           flushThinking();
           result.push({ kind: 'plan-marker', part: p });
-        } else if (batchData) {
-          flushThinking();
-          result.push({ kind: 'batch-progress', data: batchData });
         } else {
           const thinking = ensureThinking();
           const lastStep = thinking.steps[thinking.steps.length - 1];
@@ -526,13 +508,6 @@ function parseAnswerPairs(
       return { question: match[1], answer: match[2] };
     })
     .filter((p): p is { question: string; answer: string } => p !== null);
-}
-
-function extractBatchProgress(part: AnyToolPart): BatchProgressData | null {
-  const output = chatPartUtils.parseToolOutput(part);
-  if (output.state !== 'success') return null;
-  if (!isObject(output.data) || !('batchProgress' in output.data)) return null;
-  return output.data.batchProgress as BatchProgressData;
 }
 
 type MessageBlock =

--- a/packages/web/src/app/routes/chat-with-ai/components/batch-progress-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/batch-progress-card.tsx
@@ -1,0 +1,182 @@
+import { BatchProgressData } from '@activepieces/shared';
+import { t } from 'i18next';
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  Zap,
+} from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useState } from 'react';
+
+import { Progress } from '@/components/ui/progress';
+import { cn } from '@/lib/utils';
+
+export function BatchProgressCard({
+  progress,
+}: {
+  progress: BatchProgressData;
+}) {
+  const percentage =
+    progress.total > 0
+      ? Math.round((progress.completed / progress.total) * 100)
+      : 0;
+
+  const hasFailures = progress.failed > 0;
+
+  return (
+    <motion.div
+      className="rounded-xl border bg-background overflow-hidden my-2"
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+    >
+      <div className="px-3.5 pt-3 pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="font-medium text-xs flex items-center gap-1.5 text-foreground">
+            <Zap className="h-3.5 w-3.5 text-muted-foreground" />
+            {progress.label}
+          </h3>
+          <BatchStatusBadge progress={progress} />
+        </div>
+      </div>
+
+      <div className="px-3.5 pb-3 space-y-2.5">
+        <div className="space-y-2">
+          <Progress
+            value={percentage}
+            className="h-2"
+            indicatorClassName={cn(
+              'transition-all duration-500 ease-out',
+              progress.done
+                ? hasFailures
+                  ? 'bg-amber-500'
+                  : 'bg-green-500'
+                : undefined,
+            )}
+          />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <div className="flex items-center gap-3">
+              {progress.succeeded > 0 && (
+                <span className="flex items-center gap-1 text-green-600 dark:text-green-400">
+                  <Check className="h-3 w-3" />
+                  {progress.succeeded} {t('succeeded')}
+                </span>
+              )}
+              {progress.failed > 0 && (
+                <span className="flex items-center gap-1 text-destructive">
+                  <AlertCircle className="h-3 w-3" />
+                  {progress.failed} {t('failed')}
+                </span>
+              )}
+            </div>
+            <span className="tabular-nums">
+              {progress.completed}/{progress.total}
+            </span>
+          </div>
+        </div>
+
+        {progress.done && hasFailures && (
+          <FailureDetails
+            results={progress.results.filter((r) => !r.success)}
+          />
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+function BatchStatusBadge({ progress }: { progress: BatchProgressData }) {
+  if (!progress.done) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        {progress.completed}/{progress.total}
+      </span>
+    );
+  }
+  if (progress.failed === 0) {
+    return (
+      <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400 text-xs font-medium">
+        <Check className="h-3 w-3" />
+        {t('Done')}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400 text-xs font-medium">
+      <AlertCircle className="h-3 w-3" />
+      {progress.failed} {t('failed')}
+    </span>
+  );
+}
+
+function FailureDetails({
+  results,
+}: {
+  results: BatchProgressData['results'];
+}) {
+  const [expanded, setExpanded] = useState(results.length <= 3);
+
+  if (results.length === 0) return null;
+
+  const visible = expanded ? results : results.slice(0, 2);
+  const remaining = results.length - 2;
+
+  return (
+    <div className="rounded-lg bg-destructive/5 px-3 py-2 space-y-1.5">
+      <span className="text-xs font-medium text-destructive">
+        {t('Failed items')}
+      </span>
+      <div className="space-y-1">
+        {visible.map((r) => (
+          <div
+            key={r.index}
+            className="flex items-start gap-1.5 text-xs text-destructive/80"
+          >
+            <span className="shrink-0 tabular-nums text-destructive/50">
+              #{r.index + 1}
+            </span>
+            <span className="break-words min-w-0">
+              {cleanErrorText(r.error ?? t('Unknown error'))}
+            </span>
+          </div>
+        ))}
+      </div>
+      <AnimatePresence>
+        {!expanded && remaining > 0 && (
+          <motion.button
+            type="button"
+            className="flex items-center gap-1 text-xs text-destructive/60 hover:text-destructive transition-colors"
+            onClick={() => setExpanded(true)}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <ChevronDown className="h-3 w-3" />
+            {remaining} {t('more')}
+          </motion.button>
+        )}
+        {expanded && results.length > 3 && (
+          <motion.button
+            type="button"
+            className="flex items-center gap-1 text-xs text-destructive/60 hover:text-destructive transition-colors"
+            onClick={() => setExpanded(false)}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <ChevronUp className="h-3 w-3" />
+            {t('Show less')}
+          </motion.button>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function cleanErrorText(text: string): string {
+  return text.replace(/^[❌⏳✅]\s*/, '');
+}

--- a/packages/web/src/features/chat/lib/chat-types.ts
+++ b/packages/web/src/features/chat/lib/chat-types.ts
@@ -1,4 +1,9 @@
-import { ChatToolName, ChatToolOutputs, isObject } from '@activepieces/shared';
+import {
+  BatchProgressData,
+  ChatToolName,
+  ChatToolOutputs,
+  isObject,
+} from '@activepieces/shared';
 import {
   DynamicToolUIPart,
   getToolName,
@@ -9,6 +14,7 @@ import {
 
 export type ChatDataParts = {
   'session-title': { title: string };
+  'batch-progress': BatchProgressData;
 };
 
 export type ChatUIMessage = UIMessage<unknown, ChatDataParts>;

--- a/packages/web/src/features/chat/lib/chat-utils.ts
+++ b/packages/web/src/features/chat/lib/chat-utils.ts
@@ -167,6 +167,12 @@ function persistedPartToUIPart(
         input: part.input,
         errorText: part.errorText ?? 'Tool call failed',
       };
+    case PersistedChatPartType.BATCH_PROGRESS:
+      return {
+        type: 'data-batch-progress',
+        id: `batch-${idx}`,
+        data: part.data,
+      } as ChatUIMessage['parts'][number];
     default: {
       const _exhaustive: never = part;
       throw new Error(

--- a/packages/web/test/features/chat/lib/chunk-reducer.test.ts
+++ b/packages/web/test/features/chat/lib/chunk-reducer.test.ts
@@ -320,6 +320,57 @@ describe('chunkReducer', () => {
       ]);
       expect(state.message.parts).toHaveLength(0);
     });
+
+    it('upserts batch-progress data parts by id', () => {
+      const state = chunkReducer.createStreamingState({ messageId: 'msg-1' });
+
+      chunkReducer.applyChunks({
+        state,
+        chunks: [
+          {
+            type: 'data-batch-progress',
+            id: 'batch-1',
+            data: { label: 'Sending', total: 3, completed: 0, succeeded: 0, failed: 0, done: false, results: [] },
+          } as unknown as UIMessageChunk,
+        ],
+      });
+      expect(state.message.parts).toHaveLength(1);
+
+      chunkReducer.applyChunks({
+        state,
+        chunks: [
+          {
+            type: 'data-batch-progress',
+            id: 'batch-1',
+            data: { label: 'Sending', total: 3, completed: 2, succeeded: 2, failed: 0, done: false, results: [] },
+          } as unknown as UIMessageChunk,
+        ],
+      });
+      expect(state.message.parts).toHaveLength(1);
+      const data = (state.message.parts[0] as unknown as { data: { completed: number } }).data;
+      expect(data.completed).toBe(2);
+    });
+
+    it('appends separate batch-progress parts with different ids', () => {
+      const state = chunkReducer.createStreamingState({ messageId: 'msg-1' });
+
+      chunkReducer.applyChunks({
+        state,
+        chunks: [
+          {
+            type: 'data-batch-progress',
+            id: 'batch-1',
+            data: { label: 'First', total: 1, completed: 1, succeeded: 1, failed: 0, done: true, results: [] },
+          } as unknown as UIMessageChunk,
+          {
+            type: 'data-batch-progress',
+            id: 'batch-2',
+            data: { label: 'Second', total: 1, completed: 0, succeeded: 0, failed: 0, done: false, results: [] },
+          } as unknown as UIMessageChunk,
+        ],
+      });
+      expect(state.message.parts).toHaveLength(2);
+    });
   });
 
   describe('extractDataParts', () => {


### PR DESCRIPTION
## Summary

- Rename `ap_run_one_time_action` to `ap_execute_action` and extend it with an `items[]` array parameter (max 100) for batch execution
- Worker loops through items sequentially, streaming live `data-batch-progress` events to a new `BatchProgressCard` component with progress bar, success/failure counters, and collapsible failure details
- Smart error handling: continue-on-error with early stop after 3 consecutive failures (detects systemic issues like bad auth)
- Batch progress persisted in tool output so the card renders correctly on conversation history reload

## Test plan

- [ ] Single-item execution unchanged — call without `items` param, verify same behavior as before
- [ ] Batch success — "Send a Slack message to 3 channels" → progress card animates 0/3 → 3/3 → Done
- [ ] Batch with failures — include an invalid input → card shows succeeded/failed counts with expandable failure details
- [ ] Early stop — 3+ consecutive failures → stops, reports "Stopped early" with skipped count
- [ ] History persistence — reload conversation → batch progress card still renders from tool output
- [ ] No double render — only one BatchProgressCard visible during streaming and after completion
- [ ] Run `npx vitest run` for worker and web tests (23 + 25 tests pass)