### PR TITLE
feat(brex): add brex piece to manage cards, expenses, transfers, and spend

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1267,6 +1267,16 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/brex": {
+      "name": "@activepieces/piece-brex",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/brilliant-directories": {
       "name": "@activepieces/piece-brilliant-directories",
       "version": "0.1.4",
@@ -4365,7 +4375,7 @@
     },
     "packages/pieces/community/maileroo": {
       "name": "@activepieces/piece-maileroo",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -8346,7 +8356,7 @@
     },
     "packages/pieces/framework": {
       "name": "@activepieces/pieces-framework",
-      "version": "0.28.2",
+      "version": "0.29.0",
       "dependencies": {
         "@activepieces/shared": "workspace:*",
         "ai": "^6.0.0",
@@ -8599,7 +8609,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.78.1",
+      "version": "0.79.0",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",
@@ -8920,6 +8930,8 @@
     "@activepieces/piece-box": ["@activepieces/piece-box@workspace:packages/pieces/community/box"],
 
     "@activepieces/piece-brave-search": ["@activepieces/piece-brave-search@workspace:packages/pieces/community/brave-search"],
+
+    "@activepieces/piece-brex": ["@activepieces/piece-brex@workspace:packages/pieces/community/brex"],
 
     "@activepieces/piece-brilliant-directories": ["@activepieces/piece-brilliant-directories@workspace:packages/pieces/community/brilliant-directories"],
 

--- a/packages/pieces/community/brex/.eslintrc.json
+++ b/packages/pieces/community/brex/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/brex/package.json
+++ b/packages/pieces/community/brex/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-brex",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/brex/src/index.ts
+++ b/packages/pieces/community/brex/src/index.ts
@@ -1,0 +1,112 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import {
+  createCustomApiCallAction,
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/shared';
+import { getCurrentUser } from './lib/actions/get-current-user';
+import { listUsers } from './lib/actions/list-users';
+import { getUser } from './lib/actions/get-user';
+import { inviteUser } from './lib/actions/invite-user';
+import { listCards } from './lib/actions/list-cards';
+import { getCard } from './lib/actions/get-card';
+import { lockCard } from './lib/actions/lock-card';
+import { unlockCard } from './lib/actions/unlock-card';
+import { terminateCard } from './lib/actions/terminate-card';
+import { listExpenses } from './lib/actions/list-expenses';
+import { getExpense } from './lib/actions/get-expense';
+import { updateCardExpense } from './lib/actions/update-card-expense';
+import { listCardTransactions } from './lib/actions/list-card-transactions';
+import { listCashAccounts } from './lib/actions/list-cash-accounts';
+import { getPrimaryCashAccount } from './lib/actions/get-primary-cash-account';
+import { listVendors } from './lib/actions/list-vendors';
+import { createVendor } from './lib/actions/create-vendor';
+import { listTransfers } from './lib/actions/list-transfers';
+import { createTransfer } from './lib/actions/create-transfer';
+import { listBudgets } from './lib/actions/list-budgets';
+import { newExpense } from './lib/triggers/new-expense';
+import { newCardTransaction } from './lib/triggers/new-card-transaction';
+import {
+  expensePaymentUpdated,
+  transferProcessed,
+  transferFailed,
+  userUpdated,
+} from './lib/triggers/webhooks';
+
+export const brexAuth = PieceAuth.SecretText({
+  displayName: 'API Token',
+  description: `To get your Brex API token:
+
+1. Sign in to [dashboard.brex.com](https://dashboard.brex.com) as an **account admin** or **card admin**.
+2. Go to **Settings → Developer** and click **Create Token**.
+3. Give the token a name and select the **scopes** your flow needs (e.g. *Users*, *Expenses*, *Transactions*, *Payments*).
+4. Click create, then copy the token (it starts with \`bxt_\`) and paste it below.
+
+Note: tokens expire if unused for 30 days.`,
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: 'https://platform.brexapis.com/v2/users/me',
+        headers: { Authorization: `Bearer ${auth}` },
+      });
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error:
+          'Invalid API token. Make sure it has not expired and has the required scopes.',
+      };
+    }
+  },
+});
+
+export const brex = createPiece({
+  displayName: 'Brex',
+  description:
+    'Manage spend on Brex: users, cards, expenses, transactions, cash accounts, vendors, transfers and budgets.',
+  auth: brexAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/brex.png',
+  categories: [PieceCategory.ACCOUNTING, PieceCategory.PAYMENT_PROCESSING],
+  authors: ['sanket-a11y'],
+  actions: [
+    getCurrentUser,
+    listUsers,
+    getUser,
+    inviteUser,
+    listCards,
+    getCard,
+    lockCard,
+    unlockCard,
+    terminateCard,
+    listExpenses,
+    getExpense,
+    updateCardExpense,
+    listCardTransactions,
+    listCashAccounts,
+    getPrimaryCashAccount,
+    listVendors,
+    createVendor,
+    listTransfers,
+    createTransfer,
+    listBudgets,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://platform.brexapis.com',
+      auth: brexAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${(auth as { secret_text: string }).secret_text}`,
+      }),
+    }),
+  ],
+  triggers: [
+    newExpense,
+    newCardTransaction,
+    expensePaymentUpdated,
+    transferProcessed,
+    transferFailed,
+    userUpdated,
+  ],
+});

--- a/packages/pieces/community/brex/src/lib/actions/create-transfer.ts
+++ b/packages/pieces/community/brex/src/lib/actions/create-transfer.ts
@@ -1,0 +1,72 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { apId } from '@activepieces/shared';
+import { brexAuth } from '../../';
+import { brexCommon, BrexTransfer } from '../common';
+
+export const createTransfer = createAction({
+  auth: brexAuth,
+  name: 'create_transfer',
+  displayName: 'Create Transfer',
+  description: 'Send a payment from a Brex Cash account to a vendor.',
+  props: {
+    vendorPaymentInstrumentId: brexCommon.vendorPaymentInstrumentDropdown,
+    originatingAccountId: brexCommon.cashAccountDropdown,
+    amount: Property.Number({
+      displayName: 'Amount',
+      description: 'The amount to send, in the major currency unit (e.g. 100.50 for $100.50).',
+      required: true,
+    }),
+    currency: Property.ShortText({
+      displayName: 'Currency',
+      description: 'The 3-letter ISO currency code (e.g. USD).',
+      required: false,
+      defaultValue: 'USD',
+    }),
+    description: Property.ShortText({
+      displayName: 'Description',
+      description: 'An internal description for this transfer (not shown to the vendor).',
+      required: true,
+    }),
+    external_memo: Property.ShortText({
+      displayName: 'Memo to Vendor',
+      description:
+        'A memo shown to the vendor on the payment. Max 90 characters for ACH/wire, 40 for cheques.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const {
+      vendorPaymentInstrumentId,
+      originatingAccountId,
+      amount,
+      currency,
+      description,
+      external_memo,
+    } = context.propsValue;
+
+    const response = await brexCommon.apiCall<BrexTransfer>({
+      token: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: '/v1/transfers',
+      idempotencyKey: apId(),
+      body: {
+        amount: {
+          amount: Math.round(amount * 100),
+          currency: currency ?? 'USD',
+        },
+        counterparty: {
+          type: 'VENDOR',
+          payment_instrument_id: vendorPaymentInstrumentId,
+        },
+        originating_account: {
+          type: 'BREX_CASH',
+          id: originatingAccountId,
+        },
+        description,
+        external_memo,
+      },
+    });
+    return brexCommon.flattenTransfer(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/create-vendor.ts
+++ b/packages/pieces/community/brex/src/lib/actions/create-vendor.ts
@@ -1,0 +1,104 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { apId } from '@activepieces/shared';
+import { brexAuth } from '../../';
+import { brexCommon, BrexVendor } from '../common';
+
+export const createVendor = createAction({
+  auth: brexAuth,
+  name: 'create_vendor',
+  displayName: 'Create Vendor',
+  description:
+    'Create a vendor, optionally with US bank (ACH) details so you can pay them with the "Create Transfer" action.',
+  props: {
+    company_name: Property.ShortText({
+      displayName: 'Company Name',
+      description: 'The name of the vendor. Must be unique within your account.',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: "The vendor's contact email address.",
+      required: false,
+    }),
+    phone: Property.ShortText({
+      displayName: 'Phone',
+      description: "The vendor's contact phone number.",
+      required: false,
+    }),
+    add_bank_details: Property.Checkbox({
+      displayName: 'Add US Bank (ACH) Details',
+      description:
+        'Turn on to add a US bank account so you can send ACH payments to this vendor.',
+      required: false,
+      defaultValue: false,
+    }),
+    routing_number: Property.ShortText({
+      displayName: 'Routing Number',
+      description: "The vendor's 9-digit US bank routing number. Required if adding bank details.",
+      required: false,
+    }),
+    account_number: Property.ShortText({
+      displayName: 'Account Number',
+      description: "The vendor's US bank account number. Required if adding bank details.",
+      required: false,
+    }),
+    account_type: Property.StaticDropdown({
+      displayName: 'Account Type',
+      description: 'The type of US bank account.',
+      required: false,
+      defaultValue: 'CHECKING',
+      options: {
+        options: [
+          { label: 'Checking', value: 'CHECKING' },
+          { label: 'Savings', value: 'SAVINGS' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const {
+      company_name,
+      email,
+      phone,
+      add_bank_details,
+      routing_number,
+      account_number,
+      account_type,
+    } = context.propsValue;
+
+    if (add_bank_details && (!routing_number || !account_number)) {
+      throw new Error(
+        'Routing Number and Account Number are required when adding US bank (ACH) details.'
+      );
+    }
+
+    const body: Record<string, unknown> = {
+      company_name,
+      ...(email ? { email } : {}),
+      ...(phone ? { phone } : {}),
+    };
+
+    if (add_bank_details) {
+      body['payment_accounts'] = [
+        {
+          details: {
+            type: 'ACH',
+            routing_number,
+            account_number,
+            account_type: account_type ?? 'CHECKING',
+          },
+        },
+      ];
+    }
+
+    const response = await brexCommon.apiCall<BrexVendor>({
+      token: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: '/v1/vendors',
+      idempotencyKey: apId(),
+      body,
+    });
+    return brexCommon.flattenVendor(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/get-card.ts
+++ b/packages/pieces/community/brex/src/lib/actions/get-card.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexCard } from '../common';
+
+export const getCard = createAction({
+  auth: brexAuth,
+  name: 'get_card',
+  displayName: 'Get Card',
+  description: 'Get the details of a single Brex card.',
+  props: {
+    cardId: brexCommon.cardDropdown,
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<BrexCard>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: `/v2/cards/${context.propsValue.cardId}`,
+    });
+    return brexCommon.flattenCard(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/get-current-user.ts
+++ b/packages/pieces/community/brex/src/lib/actions/get-current-user.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexUser } from '../common';
+
+export const getCurrentUser = createAction({
+  auth: brexAuth,
+  name: 'get_current_user',
+  displayName: 'Get Current User',
+  description: 'Get the user that the connected API token belongs to.',
+  props: {},
+  async run(context) {
+    const response = await brexCommon.apiCall<BrexUser>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v2/users/me',
+    });
+    return brexCommon.flattenUser(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/get-expense.ts
+++ b/packages/pieces/community/brex/src/lib/actions/get-expense.ts
@@ -1,0 +1,27 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexExpense } from '../common';
+
+export const getExpense = createAction({
+  auth: brexAuth,
+  name: 'get_expense',
+  displayName: 'Get Expense',
+  description: 'Get the details of a single expense by its ID.',
+  props: {
+    expenseId: Property.ShortText({
+      displayName: 'Expense ID',
+      description:
+        'The ID of the expense to retrieve. You can get this from the "List Expenses" action or the "New Expense" trigger.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<BrexExpense>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: `/v1/expenses/${context.propsValue.expenseId}?expand[]=merchant`,
+    });
+    return brexCommon.flattenExpense(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/get-primary-cash-account.ts
+++ b/packages/pieces/community/brex/src/lib/actions/get-primary-cash-account.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexCashAccount } from '../common';
+
+export const getPrimaryCashAccount = createAction({
+  auth: brexAuth,
+  name: 'get_primary_cash_account',
+  displayName: 'Get Primary Cash Account',
+  description: 'Get the primary Brex Cash account with its balance and status.',
+  props: {},
+  async run(context) {
+    const response = await brexCommon.apiCall<BrexCashAccount>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v2/accounts/cash/primary',
+    });
+    return brexCommon.flattenCashAccount(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/get-user.ts
+++ b/packages/pieces/community/brex/src/lib/actions/get-user.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexUser } from '../common';
+
+export const getUser = createAction({
+  auth: brexAuth,
+  name: 'get_user',
+  displayName: 'Get User',
+  description: 'Get the details of a single Brex user.',
+  props: {
+    userId: brexCommon.userDropdown,
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<BrexUser>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: `/v2/users/${context.propsValue.userId}`,
+    });
+    return brexCommon.flattenUser(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/invite-user.ts
+++ b/packages/pieces/community/brex/src/lib/actions/invite-user.ts
@@ -1,0 +1,45 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { apId } from '@activepieces/shared';
+import { brexAuth } from '../../';
+import { brexCommon, BrexUser } from '../common';
+
+export const inviteUser = createAction({
+  auth: brexAuth,
+  name: 'invite_user',
+  displayName: 'Invite User',
+  description: 'Invite a new employee to your Brex account.',
+  props: {
+    first_name: Property.ShortText({
+      displayName: 'First Name',
+      description: "The new user's first name.",
+      required: true,
+    }),
+    last_name: Property.ShortText({
+      displayName: 'Last Name',
+      description: "The new user's last name.",
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description:
+        'The work email address to send the invitation to. The user uses this email to activate their account.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { first_name, last_name, email } = context.propsValue;
+    const response = await brexCommon.apiCall<BrexUser>({
+      token: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: '/v2/users',
+      idempotencyKey: apId(),
+      body: {
+        first_name,
+        last_name,
+        email,
+      },
+    });
+    return brexCommon.flattenUser(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/list-budgets.ts
+++ b/packages/pieces/community/brex/src/lib/actions/list-budgets.ts
@@ -1,0 +1,30 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexBudget } from '../common';
+
+export const listBudgets = createAction({
+  auth: brexAuth,
+  name: 'list_budgets',
+  displayName: 'List Budgets',
+  description: 'List the budgets in your Brex account.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of budgets to return (1-100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<{ items: BrexBudget[] }>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v2/budgets',
+      queryParams: {
+        limit: String(context.propsValue.limit ?? 50),
+      },
+    });
+    return response.body.items.map(brexCommon.flattenBudget);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/list-card-transactions.ts
+++ b/packages/pieces/community/brex/src/lib/actions/list-card-transactions.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexCardTransaction } from '../common';
+
+export const listCardTransactions = createAction({
+  auth: brexAuth,
+  name: 'list_card_transactions',
+  displayName: 'List Card Transactions',
+  description: 'List settled transactions across all of your card accounts.',
+  props: {
+    posted_at_start: Property.DateTime({
+      displayName: 'Posted After',
+      description: 'Only return transactions posted on or after this date and time.',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of transactions to return (1-100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { posted_at_start, limit } = context.propsValue;
+    const response = await brexCommon.apiCall<{ items: BrexCardTransaction[] }>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v2/transactions/card/primary',
+      queryParams: {
+        limit: String(limit ?? 50),
+        ...(posted_at_start ? { posted_at_start } : {}),
+      },
+    });
+    return response.body.items.map(brexCommon.flattenCardTransaction);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/list-cards.ts
+++ b/packages/pieces/community/brex/src/lib/actions/list-cards.ts
@@ -1,0 +1,69 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexCard } from '../common';
+
+export const listCards = createAction({
+  auth: brexAuth,
+  name: 'list_cards',
+  displayName: 'List Cards',
+  description: 'List the cards in your Brex account, optionally for a single user.',
+  props: {
+    userId: Property.Dropdown({
+      displayName: 'Owner',
+      description: 'Only return cards owned by this user. Leave empty to list all cards.',
+      auth: brexAuth,
+      refreshers: [],
+      required: false,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please connect your Brex account first',
+          };
+        }
+        try {
+          const response = await brexCommon.apiCall<{ items: { id: string; first_name: string; last_name: string; email: string }[] }>({
+            token: brexCommon.getToken(auth),
+            method: HttpMethod.GET,
+            path: '/v2/users',
+            queryParams: { limit: '100' },
+          });
+          return {
+            disabled: false,
+            options: response.body.items.map((user) => ({
+              label: `${user.first_name} ${user.last_name} (${user.email})`,
+              value: user.id,
+            })),
+          };
+        } catch {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Failed to load users. Check your connection.',
+          };
+        }
+      },
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of cards to return (1-100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { userId, limit } = context.propsValue;
+    const response = await brexCommon.apiCall<{ items: BrexCard[] }>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v2/cards',
+      queryParams: {
+        limit: String(limit ?? 50),
+        ...(userId ? { user_id: userId } : {}),
+      },
+    });
+    return response.body.items.map(brexCommon.flattenCard);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/list-cash-accounts.ts
+++ b/packages/pieces/community/brex/src/lib/actions/list-cash-accounts.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexCashAccount } from '../common';
+
+export const listCashAccounts = createAction({
+  auth: brexAuth,
+  name: 'list_cash_accounts',
+  displayName: 'List Cash Accounts',
+  description: 'List all Brex Cash accounts with their balances and status.',
+  props: {},
+  async run(context) {
+    const response = await brexCommon.apiCall<{ items: BrexCashAccount[] }>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v2/accounts/cash',
+    });
+    return response.body.items.map(brexCommon.flattenCashAccount);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/list-expenses.ts
+++ b/packages/pieces/community/brex/src/lib/actions/list-expenses.ts
@@ -1,0 +1,68 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexExpense } from '../common';
+
+export const listExpenses = createAction({
+  auth: brexAuth,
+  name: 'list_expenses',
+  displayName: 'List Expenses',
+  description: 'List expenses, optionally filtered by type and status.',
+  props: {
+    expense_type: Property.StaticDropdown({
+      displayName: 'Expense Type',
+      description: 'Only return expenses of this type. Leave empty for all types.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Card', value: 'CARD' },
+          { label: 'Bill Pay', value: 'BILLPAY' },
+          { label: 'Reimbursement', value: 'REIMBURSEMENT' },
+          { label: 'Clawback', value: 'CLAWBACK' },
+        ],
+      },
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      description: 'Only return expenses with this status. Leave empty for all statuses.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Draft', value: 'DRAFT' },
+          { label: 'Submitted', value: 'SUBMITTED' },
+          { label: 'Approved', value: 'APPROVED' },
+          { label: 'Out of Policy', value: 'OUT_OF_POLICY' },
+          { label: 'Settled', value: 'SETTLED' },
+          { label: 'Void', value: 'VOID' },
+          { label: 'Canceled', value: 'CANCELED' },
+          { label: 'Split', value: 'SPLIT' },
+        ],
+      },
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of expenses to return (1-100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { expense_type, status, limit } = context.propsValue;
+    const queryParams: Record<string, string> = {
+      limit: String(limit ?? 50),
+    };
+    if (expense_type) {
+      queryParams['expense_type[]'] = expense_type;
+    }
+    if (status) {
+      queryParams['status[]'] = status;
+    }
+    const response = await brexCommon.apiCall<{ items: BrexExpense[] }>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v1/expenses?expand[]=merchant',
+      queryParams,
+    });
+    return response.body.items.map(brexCommon.flattenExpense);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/list-transfers.ts
+++ b/packages/pieces/community/brex/src/lib/actions/list-transfers.ts
@@ -1,0 +1,30 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexTransfer } from '../common';
+
+export const listTransfers = createAction({
+  auth: brexAuth,
+  name: 'list_transfers',
+  displayName: 'List Transfers',
+  description: 'List the payments / transfers made from your Brex account.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of transfers to return (1-100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<{ items: BrexTransfer[] }>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v1/transfers',
+      queryParams: {
+        limit: String(context.propsValue.limit ?? 50),
+      },
+    });
+    return response.body.items.map(brexCommon.flattenTransfer);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/list-users.ts
+++ b/packages/pieces/community/brex/src/lib/actions/list-users.ts
@@ -1,0 +1,38 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexUser } from '../common';
+
+export const listUsers = createAction({
+  auth: brexAuth,
+  name: 'list_users',
+  displayName: 'List Users',
+  description: 'List users in your Brex account, optionally filtered by email.',
+  props: {
+    email: Property.ShortText({
+      displayName: 'Filter by Email',
+      description:
+        'Return only the user with this exact email address. Leave empty to list all users.',
+      required: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of users to return (1-100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { email, limit } = context.propsValue;
+    const response = await brexCommon.apiCall<{ items: BrexUser[] }>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v2/users',
+      queryParams: {
+        limit: String(limit ?? 50),
+        ...(email ? { email } : {}),
+      },
+    });
+    return response.body.items.map(brexCommon.flattenUser);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/list-vendors.ts
+++ b/packages/pieces/community/brex/src/lib/actions/list-vendors.ts
@@ -1,0 +1,30 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexVendor } from '../common';
+
+export const listVendors = createAction({
+  auth: brexAuth,
+  name: 'list_vendors',
+  displayName: 'List Vendors',
+  description: 'List the vendors set up in your Brex account.',
+  props: {
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum number of vendors to return (1-100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<{ items: BrexVendor[] }>({
+      token: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/v1/vendors',
+      queryParams: {
+        limit: String(context.propsValue.limit ?? 50),
+      },
+    });
+    return response.body.items.map(brexCommon.flattenVendor);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/lock-card.ts
+++ b/packages/pieces/community/brex/src/lib/actions/lock-card.ts
@@ -1,0 +1,23 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexCard } from '../common';
+
+export const lockCard = createAction({
+  auth: brexAuth,
+  name: 'lock_card',
+  displayName: 'Lock Card',
+  description: 'Temporarily lock a card so it cannot be used. It can be unlocked later.',
+  props: {
+    cardId: brexCommon.cardDropdown,
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<BrexCard>({
+      token: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: `/v2/cards/${context.propsValue.cardId}/lock`,
+      body: {},
+    });
+    return brexCommon.flattenCard(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/terminate-card.ts
+++ b/packages/pieces/community/brex/src/lib/actions/terminate-card.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexCard } from '../common';
+
+export const terminateCard = createAction({
+  auth: brexAuth,
+  name: 'terminate_card',
+  displayName: 'Terminate Card',
+  description:
+    'Permanently terminate a card. This cannot be undone — the card can never be used again.',
+  props: {
+    cardId: brexCommon.cardDropdown,
+    reason: Property.StaticDropdown({
+      displayName: 'Reason',
+      description: 'Why the card is being terminated.',
+      required: true,
+      defaultValue: 'CARD_NOT_NEEDED',
+      options: {
+        options: [
+          { label: 'Card not needed', value: 'CARD_NOT_NEEDED' },
+          { label: 'Card lost', value: 'CARD_LOST' },
+          { label: 'Card damaged', value: 'CARD_DAMAGED' },
+          { label: 'Card not received', value: 'CARD_NOT_RECEIVED' },
+          { label: 'Suspected fraud', value: 'FRAUD' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<BrexCard>({
+      token: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: `/v2/cards/${context.propsValue.cardId}/terminate`,
+      body: {
+        reason: context.propsValue.reason,
+      },
+    });
+    return brexCommon.flattenCard(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/unlock-card.ts
+++ b/packages/pieces/community/brex/src/lib/actions/unlock-card.ts
@@ -1,0 +1,23 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexCard } from '../common';
+
+export const unlockCard = createAction({
+  auth: brexAuth,
+  name: 'unlock_card',
+  displayName: 'Unlock Card',
+  description: 'Unlock a previously locked card so it can be used again.',
+  props: {
+    cardId: brexCommon.cardDropdown,
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<BrexCard>({
+      token: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: `/v2/cards/${context.propsValue.cardId}/unlock`,
+      body: {},
+    });
+    return brexCommon.flattenCard(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/actions/update-card-expense.ts
+++ b/packages/pieces/community/brex/src/lib/actions/update-card-expense.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { brexAuth } from '../../';
+import { brexCommon, BrexExpense } from '../common';
+
+export const updateCardExpense = createAction({
+  auth: brexAuth,
+  name: 'update_card_expense',
+  displayName: 'Update Card Expense',
+  description: 'Update the memo on a card expense.',
+  props: {
+    expenseId: Property.ShortText({
+      displayName: 'Expense ID',
+      description:
+        'The ID of the card expense to update. You can get this from the "List Expenses" action (filter by type "Card") or the "New Expense" trigger.',
+      required: true,
+    }),
+    memo: Property.LongText({
+      displayName: 'Memo',
+      description: 'The memo / note to set on the expense.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const response = await brexCommon.apiCall<BrexExpense>({
+      token: context.auth.secret_text,
+      method: HttpMethod.PUT,
+      path: `/v1/expenses/card/${context.propsValue.expenseId}`,
+      body: {
+        memo: context.propsValue.memo,
+      },
+    });
+    return brexCommon.flattenExpense(response.body);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/common/index.ts
+++ b/packages/pieces/community/brex/src/lib/common/index.ts
@@ -1,0 +1,463 @@
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+  HttpMessageBody,
+  HttpResponse,
+} from '@activepieces/pieces-common';
+import { Property } from '@activepieces/pieces-framework';
+import { brexAuth } from '../../';
+
+async function brexApiCall<T extends HttpMessageBody>({
+  token,
+  method,
+  path,
+  body,
+  queryParams,
+  idempotencyKey,
+}: {
+  token: string;
+  method: HttpMethod;
+  path: string;
+  body?: unknown;
+  queryParams?: Record<string, string>;
+  idempotencyKey?: string;
+}): Promise<HttpResponse<T>> {
+  return httpClient.sendRequest<T>({
+    method,
+    url: `${BREX_BASE_URL}${path}`,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token,
+    },
+    queryParams,
+    body,
+    headers: idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : undefined,
+  });
+}
+
+function getToken(auth: unknown): string {
+  return (auth as { secret_text: string }).secret_text;
+}
+
+function toMajorUnits(money: BrexMoney | null | undefined): number | null {
+  if (!money || typeof money.amount !== 'number') {
+    return null;
+  }
+  return money.amount / 100;
+}
+
+function flattenUser(user: BrexUser) {
+  return {
+    id: user.id,
+    first_name: user.first_name,
+    last_name: user.last_name,
+    email: user.email,
+    status: user.status ?? null,
+    manager_id: user.manager_id ?? null,
+    department_id: user.department_id ?? null,
+    location_id: user.location_id ?? null,
+    title_id: user.title_id ?? null,
+    remote_display_id: user.remote_display_id ?? null,
+  };
+}
+
+function flattenCard(card: BrexCard) {
+  return {
+    id: card.id,
+    card_name: card.card_name ?? null,
+    last_four: card.last_four ?? null,
+    status: card.status ?? null,
+    owner_user_id: card.owner_user_id ?? null,
+    limit_type: card.limit_type ?? null,
+    card_type: card.card_type ?? null,
+  };
+}
+
+function flattenCashAccount(account: BrexCashAccount) {
+  return {
+    id: account.id,
+    name: account.name,
+    status: account.status ?? null,
+    account_number: account.account_number ?? null,
+    routing_number: account.routing_number ?? null,
+    current_balance: toMajorUnits(account.current_balance),
+    current_balance_currency: account.current_balance?.currency ?? null,
+    available_balance: toMajorUnits(account.available_balance),
+    available_balance_currency: account.available_balance?.currency ?? null,
+  };
+}
+
+function flattenVendor(vendor: BrexVendor) {
+  return {
+    id: vendor.id,
+    company_name: vendor.company_name,
+    email: vendor.email ?? null,
+    phone: vendor.phone ?? null,
+    payment_account_id: vendor.payment_accounts?.[0]?.id ?? null,
+    payment_account_count: vendor.payment_accounts?.length ?? 0,
+  };
+}
+
+function flattenExpense(expense: BrexExpense) {
+  return {
+    id: expense.id,
+    memo: expense.memo ?? null,
+    status: expense.status ?? null,
+    expense_type: expense.expense_type ?? null,
+    payment_status: expense.payment_status ?? null,
+    category: expense.category ?? null,
+    user_id: expense.user_id ?? null,
+    merchant_id: expense.merchant_id ?? null,
+    merchant_name: expense.merchant?.raw_descriptor ?? null,
+    department_id: expense.department_id ?? null,
+    location_id: expense.location_id ?? null,
+    budget_id: expense.budget_id ?? null,
+    purchased_at: expense.purchased_at ?? null,
+    updated_at: expense.updated_at ?? null,
+    original_amount: toMajorUnits(expense.original_amount),
+    original_amount_currency: expense.original_amount?.currency ?? null,
+    billing_amount: toMajorUnits(expense.billing_amount),
+    billing_amount_currency: expense.billing_amount?.currency ?? null,
+    usd_equivalent_amount: toMajorUnits(expense.usd_equivalent_amount),
+    dashboard_url: expense.dashboard_url ?? null,
+  };
+}
+
+function flattenCardTransaction(transaction: BrexCardTransaction) {
+  return {
+    id: transaction.id,
+    card_id: transaction.card_id ?? null,
+    description: transaction.description ?? null,
+    type: transaction.type ?? null,
+    amount: toMajorUnits(transaction.amount),
+    amount_currency: transaction.amount?.currency ?? null,
+    merchant_name: transaction.merchant?.raw_descriptor ?? null,
+    merchant_mcc: transaction.merchant?.mcc ?? null,
+    merchant_country: transaction.merchant?.country ?? null,
+    initiated_at_date: transaction.initiated_at_date ?? null,
+    posted_at_date: transaction.posted_at_date ?? null,
+  };
+}
+
+function flattenTransfer(transfer: BrexTransfer) {
+  return {
+    id: transfer.id,
+    description: transfer.description ?? null,
+    external_memo: transfer.external_memo ?? null,
+    display_name: transfer.display_name ?? null,
+    payment_type: transfer.payment_type ?? null,
+    status: transfer.status ?? null,
+    amount: toMajorUnits(transfer.amount),
+    amount_currency: transfer.amount?.currency ?? null,
+    counterparty_payment_instrument_id:
+      transfer.counterparty?.payment_instrument_id ?? null,
+    originating_account_id: transfer.originating_account?.id ?? null,
+    creator_user_id: transfer.creator_user_id ?? null,
+    created_at: transfer.created_at ?? null,
+    process_date: transfer.process_date ?? null,
+    estimated_delivery_date: transfer.estimated_delivery_date ?? null,
+  };
+}
+
+function flattenBudget(budget: BrexBudget) {
+  return {
+    id: budget.id,
+    name: budget.name ?? null,
+    description: budget.description ?? null,
+    status: budget.status ?? null,
+    parent_budget_id: budget.parent_budget_id ?? null,
+    period_type: budget.period_type ?? null,
+    limit: toMajorUnits(budget.limit),
+    limit_currency: budget.limit?.currency ?? null,
+  };
+}
+
+const userDropdown = Property.Dropdown({
+  displayName: 'User',
+  description: 'Select a Brex user.',
+  auth: brexAuth,
+  refreshers: [],
+  required: true,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Please connect your Brex account first',
+      };
+    }
+    try {
+      const response = await brexApiCall<{ items: BrexUser[] }>({
+        token: getToken(auth),
+        method: HttpMethod.GET,
+        path: '/v2/users',
+        queryParams: { limit: '100' },
+      });
+      return {
+        disabled: false,
+        options: response.body.items.map((user) => ({
+          label: `${user.first_name} ${user.last_name} (${user.email})`,
+          value: user.id,
+        })),
+      };
+    } catch {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load users. Check your connection.',
+      };
+    }
+  },
+});
+
+const cardDropdown = Property.Dropdown({
+  displayName: 'Card',
+  description: 'Select a Brex card.',
+  auth: brexAuth,
+  refreshers: [],
+  required: true,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Please connect your Brex account first',
+      };
+    }
+    try {
+      const response = await brexApiCall<{ items: BrexCard[] }>({
+        token: getToken(auth),
+        method: HttpMethod.GET,
+        path: '/v2/cards',
+        queryParams: { limit: '100' },
+      });
+      return {
+        disabled: false,
+        options: response.body.items.map((card) => ({
+          label: card.last_four
+            ? `${card.card_name ?? 'Card'} (••${card.last_four})`
+            : card.card_name ?? card.id,
+          value: card.id,
+        })),
+      };
+    } catch {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load cards. Check your connection.',
+      };
+    }
+  },
+});
+
+const cashAccountDropdown = Property.Dropdown({
+  displayName: 'Originating Cash Account',
+  description: 'The Brex Cash account the money is sent from.',
+  auth: brexAuth,
+  refreshers: [],
+  required: true,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Please connect your Brex account first',
+      };
+    }
+    try {
+      const response = await brexApiCall<{ items: BrexCashAccount[] }>({
+        token: getToken(auth),
+        method: HttpMethod.GET,
+        path: '/v2/accounts/cash',
+      });
+      return {
+        disabled: false,
+        options: response.body.items.map((account) => ({
+          label: `${account.name}${account.status ? ` (${account.status})` : ''}`,
+          value: account.id,
+        })),
+      };
+    } catch {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load cash accounts. Check your connection.',
+      };
+    }
+  },
+});
+
+const vendorPaymentInstrumentDropdown = Property.Dropdown({
+  displayName: 'Vendor',
+  description:
+    'The vendor to pay. Only vendors that already have payment (bank) details set up are shown. Add a vendor with the "Create Vendor" action or in the Brex dashboard.',
+  auth: brexAuth,
+  refreshers: [],
+  required: true,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Please connect your Brex account first',
+      };
+    }
+    try {
+      const response = await brexApiCall<{ items: BrexVendor[] }>({
+        token: getToken(auth),
+        method: HttpMethod.GET,
+        path: '/v1/vendors',
+        queryParams: { limit: '100' },
+      });
+      const options = response.body.items
+        .filter((vendor) => (vendor.payment_accounts?.length ?? 0) > 0)
+        .map((vendor) => ({
+          label: vendor.company_name,
+          value: vendor.payment_accounts[0].id,
+        }));
+      return {
+        disabled: false,
+        options,
+        placeholder: options.length
+          ? undefined
+          : 'No vendors with payment details found. Create one first.',
+      };
+    } catch {
+      return {
+        disabled: true,
+        options: [],
+        placeholder: 'Failed to load vendors. Check your connection.',
+      };
+    }
+  },
+});
+
+export const BREX_BASE_URL = 'https://platform.brexapis.com';
+
+export const brexCommon = {
+  apiCall: brexApiCall,
+  getToken,
+  toMajorUnits,
+  flattenUser,
+  flattenCard,
+  flattenCashAccount,
+  flattenVendor,
+  flattenExpense,
+  flattenCardTransaction,
+  flattenTransfer,
+  flattenBudget,
+  userDropdown,
+  cardDropdown,
+  cashAccountDropdown,
+  vendorPaymentInstrumentDropdown,
+};
+
+export type BrexMoney = {
+  amount: number;
+  currency: string;
+};
+
+export type BrexUser = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  status?: string;
+  manager_id?: string | null;
+  department_id?: string | null;
+  location_id?: string | null;
+  title_id?: string | null;
+  remote_display_id?: string | null;
+};
+
+export type BrexCard = {
+  id: string;
+  card_name?: string;
+  last_four?: string;
+  status?: string;
+  owner_user_id?: string;
+  limit_type?: string;
+  card_type?: string;
+};
+
+export type BrexCashAccount = {
+  id: string;
+  name: string;
+  status?: string;
+  account_number?: string | null;
+  routing_number?: string | null;
+  current_balance?: BrexMoney | null;
+  available_balance?: BrexMoney | null;
+};
+
+export type BrexVendorPaymentAccount = {
+  id: string;
+  type?: string;
+};
+
+export type BrexVendor = {
+  id: string;
+  company_name: string;
+  email?: string | null;
+  phone?: string | null;
+  payment_accounts: BrexVendorPaymentAccount[];
+};
+
+export type BrexExpense = {
+  id: string;
+  memo?: string | null;
+  status?: string;
+  expense_type?: string;
+  payment_status?: string;
+  category?: string | null;
+  user_id?: string | null;
+  merchant_id?: string | null;
+  department_id?: string | null;
+  location_id?: string | null;
+  budget_id?: string | null;
+  purchased_at?: string | null;
+  updated_at?: string | null;
+  dashboard_url?: string | null;
+  original_amount?: BrexMoney | null;
+  billing_amount?: BrexMoney | null;
+  usd_equivalent_amount?: BrexMoney | null;
+  merchant?: { raw_descriptor?: string; mcc?: string; country?: string } | null;
+};
+
+export type BrexCardTransaction = {
+  id: string;
+  card_id?: string | null;
+  description?: string;
+  type?: string;
+  initiated_at_date?: string;
+  posted_at_date?: string;
+  amount?: BrexMoney | null;
+  merchant?: { raw_descriptor?: string; mcc?: string; country?: string } | null;
+};
+
+export type BrexTransfer = {
+  id: string;
+  description?: string;
+  external_memo?: string;
+  display_name?: string;
+  payment_type?: string;
+  status?: string;
+  created_at?: string;
+  process_date?: string | null;
+  estimated_delivery_date?: string | null;
+  creator_user_id?: string | null;
+  amount?: BrexMoney | null;
+  counterparty?: { type?: string; payment_instrument_id?: string } | null;
+  originating_account?: { type?: string; id?: string } | null;
+};
+
+export type BrexBudget = {
+  id: string;
+  name?: string;
+  description?: string | null;
+  status?: string;
+  parent_budget_id?: string | null;
+  limit?: BrexMoney | null;
+  period_type?: string;
+};

--- a/packages/pieces/community/brex/src/lib/triggers/new-card-transaction.ts
+++ b/packages/pieces/community/brex/src/lib/triggers/new-card-transaction.ts
@@ -1,0 +1,68 @@
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import {
+  AppConnectionValueForAuthProperty,
+  TriggerStrategy,
+  createTrigger,
+} from '@activepieces/pieces-framework';
+import { brexAuth } from '../../';
+import { brexCommon, BrexCardTransaction } from '../common';
+
+const polling: Polling<
+  AppConnectionValueForAuthProperty<typeof brexAuth>,
+  Record<string, never>
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth }) => {
+    const response = await brexCommon.apiCall<{ items: BrexCardTransaction[] }>({
+      token: brexCommon.getToken(auth),
+      method: HttpMethod.GET,
+      path: '/v2/transactions/card/primary',
+      queryParams: { limit: '100' },
+    });
+    return response.body.items.map((transaction) => ({
+      epochMilliSeconds: new Date(
+        transaction.posted_at_date ?? transaction.initiated_at_date ?? 0
+      ).getTime(),
+      data: brexCommon.flattenCardTransaction(transaction),
+    }));
+  },
+};
+
+export const newCardTransaction = createTrigger({
+  auth: brexAuth,
+  name: 'new_card_transaction',
+  displayName: 'New Card Transaction',
+  description: 'Triggers when a new settled card transaction is posted.',
+  props: {},
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: 'transaction_id',
+    card_id: 'card_id',
+    description: 'SQ *COFFEE SHOP',
+    type: 'PURCHASE',
+    amount: 24.5,
+    amount_currency: 'USD',
+    merchant_name: 'SQ *COFFEE SHOP',
+    merchant_mcc: '5812',
+    merchant_country: 'USA',
+    initiated_at_date: '2024-01-01',
+    posted_at_date: '2024-01-02',
+  },
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/triggers/new-expense.ts
+++ b/packages/pieces/community/brex/src/lib/triggers/new-expense.ts
@@ -1,0 +1,77 @@
+import {
+  DedupeStrategy,
+  Polling,
+  pollingHelper,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import {
+  AppConnectionValueForAuthProperty,
+  TriggerStrategy,
+  createTrigger,
+} from '@activepieces/pieces-framework';
+import { brexAuth } from '../../';
+import { brexCommon, BrexExpense } from '../common';
+
+const polling: Polling<
+  AppConnectionValueForAuthProperty<typeof brexAuth>,
+  Record<string, never>
+> = {
+  strategy: DedupeStrategy.TIMEBASED,
+  items: async ({ auth }) => {
+    const response = await brexCommon.apiCall<{ items: BrexExpense[] }>({
+      token: brexCommon.getToken(auth),
+      method: HttpMethod.GET,
+      path: '/v1/expenses?expand[]=merchant',
+      queryParams: { limit: '100' },
+    });
+    return response.body.items.map((expense) => ({
+      epochMilliSeconds: new Date(
+        expense.updated_at ?? expense.purchased_at ?? 0
+      ).getTime(),
+      data: brexCommon.flattenExpense(expense),
+    }));
+  },
+};
+
+export const newExpense = createTrigger({
+  auth: brexAuth,
+  name: 'new_expense',
+  displayName: 'New Expense',
+  description: 'Triggers when a new expense is created or updated.',
+  props: {},
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: 'expense_id',
+    memo: 'Team lunch',
+    status: 'APPROVED',
+    expense_type: 'CARD',
+    payment_status: 'CLEARED',
+    category: 'RESTAURANTS',
+    user_id: 'user_id',
+    merchant_id: 'merchant_id',
+    merchant_name: 'SQ *COFFEE SHOP',
+    department_id: null,
+    location_id: null,
+    budget_id: null,
+    purchased_at: '2024-01-01T12:00:00Z',
+    updated_at: '2024-01-01T12:05:00Z',
+    original_amount: 24.5,
+    original_amount_currency: 'USD',
+    billing_amount: 24.5,
+    billing_amount_currency: 'USD',
+    usd_equivalent_amount: 24.5,
+    dashboard_url: 'https://dashboard.brex.com/expenses/expense_id',
+  },
+  async test(context) {
+    return await pollingHelper.test(polling, context);
+  },
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
+  },
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
+  },
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
+  },
+});

--- a/packages/pieces/community/brex/src/lib/triggers/webhooks.ts
+++ b/packages/pieces/community/brex/src/lib/triggers/webhooks.ts
@@ -1,0 +1,122 @@
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+} from '@activepieces/pieces-common';
+import { TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
+import { apId } from '@activepieces/shared';
+import { brexAuth } from '../../';
+import { BREX_BASE_URL } from '../common';
+
+const WEBHOOK_ID_STORE_KEY = 'brex_webhook_subscription_id';
+
+function createBrexWebhookTrigger({
+  name,
+  displayName,
+  description,
+  eventType,
+  sampleData,
+}: {
+  name: string;
+  displayName: string;
+  description: string;
+  eventType: string;
+  sampleData: Record<string, unknown>;
+}) {
+  return createTrigger({
+    auth: brexAuth,
+    name,
+    displayName,
+    description,
+    props: {},
+    type: TriggerStrategy.WEBHOOK,
+    sampleData,
+    async onEnable(context) {
+      const response = await httpClient.sendRequest<{ id: string }>({
+        method: HttpMethod.POST,
+        url: `${BREX_BASE_URL}/v1/webhooks`,
+        authentication: {
+          type: AuthenticationType.BEARER_TOKEN,
+          token: context.auth.secret_text,
+        },
+        headers: { 'Idempotency-Key': apId() },
+        body: {
+          url: context.webhookUrl,
+          event_types: [eventType],
+        },
+      });
+      await context.store.put(WEBHOOK_ID_STORE_KEY, response.body.id);
+    },
+    async onDisable(context) {
+      const webhookId = await context.store.get<string>(WEBHOOK_ID_STORE_KEY);
+      if (webhookId) {
+        await httpClient.sendRequest({
+          method: HttpMethod.DELETE,
+          url: `${BREX_BASE_URL}/v1/webhooks/${webhookId}`,
+          authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token: context.auth.secret_text,
+          },
+        });
+      }
+    },
+    async run(context) {
+      return [context.payload.body];
+    },
+    async test() {
+      return [sampleData];
+    },
+  });
+}
+
+export const expensePaymentUpdated = createBrexWebhookTrigger({
+  name: 'expense_payment_updated',
+  displayName: 'Expense Payment Updated',
+  description: 'Triggers when the payment status of an expense changes.',
+  eventType: 'EXPENSE_PAYMENT_UPDATED',
+  sampleData: {
+    event_type: 'EXPENSE_PAYMENT_UPDATED',
+    expense_id: 'expense_id',
+    company_id: 'company_id',
+    payment_status: 'CLEARED',
+    payment_type: 'CARD',
+    payment_description: 'SQ *COFFEE SHOP',
+    amount: { amount: 2450, currency: 'USD' },
+  },
+});
+
+export const transferProcessed = createBrexWebhookTrigger({
+  name: 'transfer_processed',
+  displayName: 'Transfer Processed',
+  description: 'Triggers when a payment / transfer is successfully processed.',
+  eventType: 'TRANSFER_PROCESSED',
+  sampleData: {
+    event_type: 'TRANSFER_PROCESSED',
+    transfer_id: 'transfer_id',
+    company_id: 'company_id',
+  },
+});
+
+export const transferFailed = createBrexWebhookTrigger({
+  name: 'transfer_failed',
+  displayName: 'Transfer Failed',
+  description: 'Triggers when a payment / transfer fails.',
+  eventType: 'TRANSFER_FAILED',
+  sampleData: {
+    event_type: 'TRANSFER_FAILED',
+    transfer_id: 'transfer_id',
+    company_id: 'company_id',
+  },
+});
+
+export const userUpdated = createBrexWebhookTrigger({
+  name: 'user_updated',
+  displayName: 'User Updated',
+  description: 'Triggers when a user is created or their details change.',
+  eventType: 'USER_UPDATED',
+  sampleData: {
+    event_type: 'USER_UPDATED',
+    user_id: 'user_id',
+    company_id: 'company_id',
+  },
+});

--- a/packages/pieces/community/brex/tsconfig.json
+++ b/packages/pieces/community/brex/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/brex/tsconfig.lib.json
+++ b/packages/pieces/community/brex/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -186,6 +186,7 @@
         "packages/pieces/community/bonjoro/src/index.ts"
       ],
       "@activepieces/piece-box": ["packages/pieces/community/box/src/index.ts"],
+      "@activepieces/piece-brex": ["packages/pieces/community/brex/src/index.ts"],
       "@activepieces/piece-brilliant-directories": [
         "packages/pieces/community/brilliant-directories/src/index.ts"
       ],


### PR DESCRIPTION
Implements the Brex integration with API-token auth and 20 actions across Users, Cards, Expenses, Transactions, Cash Accounts, Vendors, Transfers and Budgets, plus polling triggers (new expense, new card transaction) and webhook-subscription triggers (expense payment updated, transfer processed, transfer failed, user updated).

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
