### PR TITLE
fix(web): MCP Tool test dialog crashes when trigger has no input parameters

### DIFF
--- a/packages/web/src/app/builder/test-step/custom-test-step/mcp-tool-testing-dialog.tsx
+++ b/packages/web/src/app/builder/test-step/custom-test-step/mcp-tool-testing-dialog.tsx
@@ -60,7 +60,8 @@ function McpToolTestingDialog({
 }: McpToolTestingDialogProps) {
   const form = useFormContext<FlowTrigger>();
   const formValues = form.getValues();
-  const formProps = formValues.settings.input.inputSchema as McpFormField[];
+  const formProps = (formValues.settings.input.inputSchema ??
+    []) as McpFormField[];
   const { mutate: saveMockAsSampleData, isPending: isSavingMockdata } =
     testStepHooks.useSaveMockData({
       onSuccess: () => {


### PR DESCRIPTION
## Problem

Production was throwing `TypeError: i.filter is not a function` and rendering the React Router "Unexpected Application Error!" page (reported on cloud, v0.83.0).

Hand-mapping the minified prod stack (`bp` in `index-B2Ay5Ckl.js`) pinned it to **`McpToolTestingDialog`** — the "Set Sample Data" dialog for an **MCP Tool trigger**:

```tsx
const formProps = formValues.settings.input.inputSchema as McpFormField[];
...
defaultValues: formProps.filter(...)   // crashes when inputSchema is undefined
```

## Root cause

`inputSchema` is an **optional** array property on the MCP Tool trigger (`Property.Array({ required: false })`), and the backend itself reads it as `McpProperty[] | undefined`. When a trigger has no parameters set (imported flow, template, or older saved flow), `settings.input.inputSchema` is `undefined`. The unsafe `as McpFormField[]` cast hid the `undefined` from TypeScript, so `.filter()`/`.reduce()` blew up at runtime. The dialog is mounted whenever `testType === 'mcp-tool'`, so simply opening the test panel on such a trigger crashed the whole builder.

## Fix

Default to an empty array, so a missing schema renders the existing "No input fields defined in the schema" empty state instead of crashing.

```tsx
const formProps = (formValues.settings.input.inputSchema ?? []) as McpFormField[];
```

This guards all three consumers of `formProps` (defaultValues, resolver, pieceProps).