### PR TITLE
feat(chat): replace dual-channel parsing with pure tool calling

### DIFF
--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
@@ -86,7 +86,10 @@ function withApprovalGates({ mcpToolSet, eventEmitter, log, isApproved, waitForA
                 if (isApproved() || !needsApproval) {
                     return originalExecute(args, options)
                 }
-                const toolCallId = options?.toolCallId ?? ''
+                const toolCallId = options?.toolCallId
+                if (!toolCallId) {
+                    return originalExecute(args, options)
+                }
                 const displayName = typeof args === 'object' && args !== null && 'displayName' in args && typeof args.displayName === 'string'
                     ? args.displayName
                     : humanizeToolName(name)

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
@@ -1,6 +1,7 @@
-import { apId, ChatStreamWriter, tryCatch } from '@activepieces/shared'
+import { tryCatch } from '@activepieces/shared'
 import { createMCPClient } from '@ai-sdk/mcp'
 import { FastifyBaseLogger } from 'fastify'
+import { ChatEventEmitter } from './chat-worker-tools'
 
 const CONVERSATION_ID_HEADER = 'x-ap-conversation-id'
 
@@ -58,13 +59,13 @@ function humanizeToolName(name: string): string {
         .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-function hasExecute(tool: object): tool is object & { execute: (args: unknown) => Promise<unknown> } {
+function hasExecute(tool: object): tool is object & { execute: (args: unknown, options?: { toolCallId: string }) => Promise<unknown> } {
     return 'execute' in tool && typeof tool.execute === 'function'
 }
 
-function withApprovalGates({ mcpToolSet, writer, log, isApproved, waitForApproval }: {
+function withApprovalGates({ mcpToolSet, eventEmitter, log, isApproved, waitForApproval }: {
     mcpToolSet: Record<string, unknown>
-    writer: ChatStreamWriter
+    eventEmitter: ChatEventEmitter
     log: FastifyBaseLogger
     isApproved: () => boolean
     waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<{ approved: boolean }>
@@ -81,31 +82,31 @@ function withApprovalGates({ mcpToolSet, writer, log, isApproved, waitForApprova
         const needsApproval = requiresApproval(name)
 
         result[name] = Object.assign({}, tool, {
-            execute: async (args: unknown) => {
+            execute: async (args: unknown, options?: { toolCallId: string }) => {
                 if (isApproved() || !needsApproval) {
-                    return originalExecute(args)
+                    return originalExecute(args, options)
                 }
-                const gateId = apId()
+                const toolCallId = options?.toolCallId ?? ''
                 const displayName = typeof args === 'object' && args !== null && 'displayName' in args && typeof args.displayName === 'string'
                     ? args.displayName
                     : humanizeToolName(name)
 
-                writer.write({
-                    type: 'data-approval-request',
-                    data: { gateId, toolName: name, displayName },
-                    transient: true,
+                eventEmitter.emitToolApprovalRequest({
+                    toolCallId,
+                    toolName: name,
+                    displayName,
                 })
 
-                log.info({ gateId, toolName: name }, 'Tool approval gate opened')
-                const decision = await waitForApproval({ gateId })
+                log.info({ toolCallId, toolName: name }, 'Tool approval gate opened')
+                const decision = await waitForApproval({ gateId: toolCallId })
 
                 if (!decision.approved) {
-                    log.info({ gateId, toolName: name }, 'Tool approval rejected or timed out')
+                    log.info({ toolCallId, toolName: name }, 'Tool approval rejected or timed out')
                     return { content: [{ type: 'text', text: 'Action cancelled by user.' }] }
                 }
 
-                log.info({ gateId, toolName: name }, 'Tool approval granted')
-                return originalExecute(args)
+                log.info({ toolCallId, toolName: name }, 'Tool approval granted')
+                return originalExecute(args, options)
             },
         })
     }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -1,47 +1,50 @@
 import {
-    apId,
     BatchItemResult,
     ChatAgentEventType,
-    ChatStreamWriter,
     isObject,
     SendChatEventRequest,
+    ToolApprovalRequestEvent,
+    ToolProgressEvent,
     tryCatch,
 } from '@activepieces/shared'
-import { tool, ToolSet } from 'ai'
+import { tool, ToolExecutionOptions, ToolSet } from 'ai'
 import { z } from 'zod'
 
 const MAX_BATCH_SIZE = 100
 
-function createRpcWriterForConversation({ sendEvent, userId, conversationId }: {
+function createEventEmitter({ sendEvent, userId, conversationId }: {
     sendEvent: (input: SendChatEventRequest) => Promise<void>
     userId: string
     conversationId: string
-}): ChatStreamWriter {
+}): ChatEventEmitter {
     return {
-        write(part: Record<string, unknown>): void {
+        emitToolProgress(data: ToolProgressEvent): void {
             sendEvent({
                 userId,
                 conversationId,
-                event: { type: ChatAgentEventType.CHUNK, data: part },
+                event: { type: ChatAgentEventType.TOOL_PROGRESS, data },
+            }).catch(() => {})
+        },
+        emitToolApprovalRequest(data: ToolApprovalRequestEvent): void {
+            sendEvent({
+                userId,
+                conversationId,
+                event: { type: ChatAgentEventType.TOOL_APPROVAL_REQUEST, data },
             }).catch(() => {})
         },
     }
 }
 
-function createDisplayTools({ writer, waitForApproval, displayToolTimeoutMs }: {
-    writer: ChatStreamWriter
+function createDisplayTools({ waitForApproval, displayToolTimeoutMs }: {
     waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<{ approved: boolean, payload?: Record<string, unknown> }>
     displayToolTimeoutMs: number
 }): ToolSet {
-    function blockingExecute({ dataType, dismissMessage, successKey }: {
-        dataType: string
+    function blockingExecute({ dismissMessage, successKey }: {
         dismissMessage: string
         successKey: string
     }) {
-        return async (input: Record<string, unknown>) => {
-            const gateId = apId()
-            writer.write({ type: dataType, data: { ...input, gateId }, transient: true })
-            const decision = await waitForApproval({ gateId, timeoutMs: displayToolTimeoutMs })
+        return async (_input: Record<string, unknown>, options: ToolExecutionOptions) => {
+            const decision = await waitForApproval({ gateId: options.toolCallId, timeoutMs: displayToolTimeoutMs })
             if (!decision.approved) {
                 return { dismissed: true, message: dismissMessage }
             }
@@ -57,7 +60,7 @@ function createDisplayTools({ writer, waitForApproval, displayToolTimeoutMs }: {
                 displayName: z.string().describe('Human-readable name (e.g. "Gmail", "Slack")'),
                 status: z.enum(['missing', 'error']).optional().describe('Set to "error" when connection exists but needs reconnecting'),
             }),
-            execute: blockingExecute({ dataType: 'data-connection-required', dismissMessage: 'User dismissed the connection request.', successKey: 'connected' }),
+            execute: blockingExecute({ dismissMessage: 'User dismissed the connection request.', successKey: 'connected' }),
         }),
 
         ap_show_connection_picker: tool({
@@ -73,7 +76,7 @@ function createDisplayTools({ writer, waitForApproval, displayToolTimeoutMs }: {
                     status: z.string().describe('Connection status (ACTIVE, ERROR, etc.)'),
                 })).min(1),
             }),
-            execute: blockingExecute({ dataType: 'data-connection-picker', dismissMessage: 'User dismissed the connection picker.', successKey: 'selected' }),
+            execute: blockingExecute({ dismissMessage: 'User dismissed the connection picker.', successKey: 'selected' }),
         }),
 
         ap_show_project_picker: tool({
@@ -84,7 +87,7 @@ function createDisplayTools({ writer, waitForApproval, displayToolTimeoutMs }: {
                     id: z.string().describe('Project ID'),
                 })).min(1),
             }),
-            execute: blockingExecute({ dataType: 'data-project-picker', dismissMessage: 'User dismissed the project picker.', successKey: 'selected' }),
+            execute: blockingExecute({ dismissMessage: 'User dismissed the project picker.', successKey: 'selected' }),
         }),
 
         ap_show_questions: tool({
@@ -98,7 +101,7 @@ function createDisplayTools({ writer, waitForApproval, displayToolTimeoutMs }: {
                     placeholder: z.string().optional().describe('Placeholder for text-type questions'),
                 })).min(1),
             }),
-            execute: blockingExecute({ dataType: 'data-questions', dismissMessage: 'User dismissed the questions form.', successKey: 'answered' }),
+            execute: blockingExecute({ dismissMessage: 'User dismissed the questions form.', successKey: 'answered' }),
         }),
 
         ap_show_quick_replies: tool({
@@ -106,8 +109,7 @@ function createDisplayTools({ writer, waitForApproval, displayToolTimeoutMs }: {
             inputSchema: z.object({
                 replies: z.array(z.string().max(80)).min(1).max(5).describe('Short suggestion texts'),
             }),
-            execute: async (input) => {
-                writer.write({ type: 'data-quick-replies', data: { replies: input.replies }, transient: true })
+            execute: async () => {
                 return { displayed: true }
             },
         }),
@@ -147,9 +149,9 @@ function createLocalTools({ onSetProjectContext, projects }: {
     }
 }
 
-function createCrossProjectTools({ executeTool, writer }: {
+function createCrossProjectTools({ executeTool, eventEmitter }: {
     executeTool: (toolName: string, toolInput: Record<string, unknown>) => Promise<unknown>
-    writer: ChatStreamWriter
+    eventEmitter: ChatEventEmitter
 }): ToolSet {
     return {
         ap_discover_action_auth: tool({
@@ -173,11 +175,12 @@ function createCrossProjectTools({ executeTool, writer }: {
                 connectionExternalId: z.string().optional().describe('externalId of the connection to use'),
                 projectId: z.string().optional().describe('Project ID where the connection lives'),
             }),
-            execute: async (toolInput) => {
+            execute: async (toolInput, options) => {
                 if (toolInput.items && toolInput.items.length > 0) {
                     return executeBatchAction({
                         executeTool,
-                        writer,
+                        eventEmitter,
+                        toolCallId: options.toolCallId,
                         pieceName: toolInput.pieceName,
                         actionName: toolInput.actionName,
                         items: toolInput.items,
@@ -203,9 +206,10 @@ function createCrossProjectTools({ executeTool, writer }: {
     }
 }
 
-async function executeBatchAction({ executeTool, writer, pieceName, actionName, items, description, connectionExternalId, projectId }: {
+async function executeBatchAction({ executeTool, eventEmitter, toolCallId, pieceName, actionName, items, description, connectionExternalId, projectId }: {
     executeTool: (toolName: string, toolInput: Record<string, unknown>) => Promise<unknown>
-    writer: ChatStreamWriter
+    eventEmitter: ChatEventEmitter
+    toolCallId: string
     pieceName: string
     actionName: string
     items: Record<string, unknown>[]
@@ -213,7 +217,6 @@ async function executeBatchAction({ executeTool, writer, pieceName, actionName, 
     connectionExternalId?: string
     projectId?: string
 }): Promise<unknown> {
-    const batchId = apId()
     const total = items.length
     const label = description ?? `Processing ${total} ${total === 1 ? 'item' : 'items'}`
     const results: BatchItemResult[] = []
@@ -221,9 +224,8 @@ async function executeBatchAction({ executeTool, writer, pieceName, actionName, 
     let failed = 0
 
     function pushProgress({ done }: { done: boolean }): void {
-        writer.write({
-            type: 'data-batch-progress',
-            id: batchId,
+        eventEmitter.emitToolProgress({
+            toolCallId,
             data: {
                 label,
                 total,
@@ -327,8 +329,7 @@ function extractResultText(result: unknown): string {
     return JSON.stringify(result)
 }
 
-function createPlanTools({ writer, onPlanApproved, waitForApproval }: {
-    writer: ChatStreamWriter
+function createPlanTools({ onPlanApproved, waitForApproval }: {
     onPlanApproved: () => void
     waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<{ approved: boolean }>
 }): ToolSet {
@@ -339,14 +340,8 @@ function createPlanTools({ writer, onPlanApproved, waitForApproval }: {
                 planSummary: z.string().describe('A brief 1-3 sentence summary of what you will do'),
                 steps: z.array(z.string()).describe('List of concrete actions'),
             }),
-            execute: async (input) => {
-                const gateId = apId()
-                writer.write({
-                    type: 'data-plan-approval-request',
-                    data: { gateId, planSummary: input.planSummary, steps: input.steps },
-                    transient: true,
-                })
-                const decision = await waitForApproval({ gateId })
+            execute: async (_input, options) => {
+                const decision = await waitForApproval({ gateId: options.toolCallId })
                 if (decision.approved) {
                     onPlanApproved()
                     return { success: true, message: 'Plan approved by the user. Execute each step in order now. Call ap_update_plan to update step statuses as you work.' }
@@ -363,10 +358,7 @@ function createPlanTools({ writer, onPlanApproved, waitForApproval }: {
                     status: z.enum(['pending', 'executing', 'done', 'error']).describe('New status for this step'),
                 })).min(1),
             }),
-            execute: async (input) => {
-                for (const update of input.updates) {
-                    writer.write({ type: 'data-plan-progress', data: update, transient: true })
-                }
+            execute: async () => {
                 return { success: true }
             },
         }),
@@ -387,8 +379,13 @@ function createThinkingTools(): ToolSet {
     }
 }
 
+export type ChatEventEmitter = {
+    emitToolProgress(data: ToolProgressEvent): void
+    emitToolApprovalRequest(data: ToolApprovalRequestEvent): void
+}
+
 export const chatWorkerTools = {
-    createRpcWriterForConversation,
+    createEventEmitter,
     createDisplayTools,
     createLocalTools,
     createCrossProjectTools,

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -273,6 +273,7 @@ async function generateTitleIfFirstTurn({ model, userMessage, previousUiMessages
     log: JobContext['log']
     conversationId: string
 }): Promise<string | undefined> {
+    // getChatConfig includes the just-saved user message, so length 1 = first turn
     const isFirstTurn = previousUiMessages.length === 1
     if (!isFirstTurn) return undefined
 

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -40,7 +40,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             provider, auth: config.auth, config: config.providerConfig, modelId: config.modelId,
         })
 
-        const writer = chatWorkerTools.createRpcWriterForConversation({
+        const eventEmitter = chatWorkerTools.createEventEmitter({
             sendEvent: (input) => ctx.apiClient.sendChatEvent(input),
             userId,
             conversationId,
@@ -54,7 +54,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             const planApproved = { approved: false }
 
             const allTools = buildToolSet({
-                ctx, writer, log, planApproved, mcpToolSet,
+                ctx, eventEmitter, log, planApproved, mcpToolSet,
                 projects: config.projects, conversationId, platformId, userId,
             })
 
@@ -119,7 +119,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             if (autoTitle) {
                 await ctx.apiClient.sendChatEvent({
                     userId, conversationId,
-                    event: { type: ChatAgentEventType.CHUNK, data: { type: 'data-session-title', data: { title: autoTitle }, transient: true } },
+                    event: { type: ChatAgentEventType.TITLE_UPDATE, data: { title: autoTitle } },
                 })
             }
 
@@ -157,9 +157,9 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
     },
 }
 
-function buildToolSet({ ctx, writer, log, planApproved, mcpToolSet, projects, conversationId, platformId, userId }: {
+function buildToolSet({ ctx, eventEmitter, log, planApproved, mcpToolSet, projects, conversationId, platformId, userId }: {
     ctx: JobContext
-    writer: ReturnType<typeof chatWorkerTools.createRpcWriterForConversation>
+    eventEmitter: ReturnType<typeof chatWorkerTools.createEventEmitter>
     log: JobContext['log']
     planApproved: { approved: boolean }
     mcpToolSet: Record<string, unknown>
@@ -194,18 +194,17 @@ function buildToolSet({ ctx, writer, log, planApproved, mcpToolSet, projects, co
         },
         projects,
     })
-    const displayTools = chatWorkerTools.createDisplayTools({ writer, waitForApproval, displayToolTimeoutMs: DISPLAY_TOOL_TIMEOUT_MS })
+    const displayTools = chatWorkerTools.createDisplayTools({ waitForApproval, displayToolTimeoutMs: DISPLAY_TOOL_TIMEOUT_MS })
     const planTools = chatWorkerTools.createPlanTools({
-        writer,
         onPlanApproved: () => {
-            planApproved.approved = true 
+            planApproved.approved = true
         },
         waitForApproval,
     })
-    const crossProjectTools = chatWorkerTools.createCrossProjectTools({ executeTool: executeCrossProjectTool, writer })
+    const crossProjectTools = chatWorkerTools.createCrossProjectTools({ executeTool: executeCrossProjectTool, eventEmitter })
     const thinkingTools = chatWorkerTools.createThinkingTools()
     const gatedMcpTools = chatMcpClient.withApprovalGates({
-        mcpToolSet, writer, log, isApproved: () => planApproved.approved, waitForApproval,
+        mcpToolSet, eventEmitter, log, isApproved: () => planApproved.approved, waitForApproval,
     })
 
     return { ...localTools, ...displayTools, ...crossProjectTools, ...planTools, ...thinkingTools, ...(gatedMcpTools as Record<string, typeof localTools[keyof typeof localTools]>) }

--- a/packages/server/worker/test/lib/execute/jobs/ee/chat/chat-worker-tools.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/chat/chat-worker-tools.test.ts
@@ -1,12 +1,17 @@
-import { ChatStreamWriter } from '@activepieces/shared'
+import { ToolApprovalRequestEvent, ToolProgressEvent } from '@activepieces/shared'
 import { describe, expect, it, vi } from 'vitest'
-import { chatWorkerTools } from '../../../../../../src/lib/execute/jobs/ee/chat/chat-worker-tools'
+import { ChatEventEmitter, chatWorkerTools } from '../../../../../../src/lib/execute/jobs/ee/chat/chat-worker-tools'
 
-function makeMockWriter(): { writer: ChatStreamWriter, writes: Record<string, unknown>[] } {
-    const writes: Record<string, unknown>[] = []
+function makeMockEventEmitter(): { eventEmitter: ChatEventEmitter, progressEvents: ToolProgressEvent[], approvalEvents: ToolApprovalRequestEvent[] } {
+    const progressEvents: ToolProgressEvent[] = []
+    const approvalEvents: ToolApprovalRequestEvent[] = []
     return {
-        writer: { write: (part: Record<string, unknown>) => { writes.push(part) } },
-        writes,
+        eventEmitter: {
+            emitToolProgress: (data: ToolProgressEvent) => { progressEvents.push(data) },
+            emitToolApprovalRequest: (data: ToolApprovalRequestEvent) => { approvalEvents.push(data) },
+        },
+        progressEvents,
+        approvalEvents,
     }
 }
 
@@ -84,11 +89,11 @@ describe('chatWorkerTools', () => {
     })
 
     describe('ap_execute_action batch mode', () => {
-        it('calls executeTool for each item and streams progress', async () => {
-            const { writer, writes } = makeMockWriter()
+        it('calls executeTool for each item and emits progress events', async () => {
+            const { eventEmitter, progressEvents } = makeMockEventEmitter()
             const executeTool = vi.fn().mockResolvedValue(mcpSuccess('sent'))
 
-            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, eventEmitter })
             const result = await tools.ap_execute_action.execute({
                 pieceName: 'slack',
                 actionName: 'send_message',
@@ -107,21 +112,21 @@ describe('chatWorkerTools', () => {
                 input: { channel: 'C01', text: 'Hi Alice' },
             }))
 
-            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
             expect(progressEvents.length).toBe(4)
+            expect(progressEvents[0].toolCallId).toBe('tc1')
 
-            const initial = progressEvents[0]['data'] as Record<string, unknown>
-            expect(initial['completed']).toBe(0)
-            expect(initial['total']).toBe(3)
-            expect(initial['done']).toBe(false)
-            expect(initial['label']).toBe('Sending messages')
+            const initial = progressEvents[0].data
+            expect(initial.completed).toBe(0)
+            expect(initial.total).toBe(3)
+            expect(initial.done).toBe(false)
+            expect(initial.label).toBe('Sending messages')
 
-            const final = progressEvents[3]['data'] as Record<string, unknown>
-            expect(final['completed']).toBe(3)
-            expect(final['succeeded']).toBe(3)
-            expect(final['failed']).toBe(0)
-            expect(final['done']).toBe(true)
-            expect((final['results'] as unknown[]).length).toBe(3)
+            const final = progressEvents[3].data
+            expect(final.completed).toBe(3)
+            expect(final.succeeded).toBe(3)
+            expect(final.failed).toBe(0)
+            expect(final.done).toBe(true)
+            expect(final.results.length).toBe(3)
 
             const resultObj = result as { content: Array<{ text: string }>, batchProgress: Record<string, unknown> }
             expect(resultObj.content[0].text).toContain('3/3 succeeded')
@@ -134,13 +139,13 @@ describe('chatWorkerTools', () => {
         })
 
         it('continues on error and reports failures', async () => {
-            const { writer, writes } = makeMockWriter()
+            const { eventEmitter, progressEvents } = makeMockEventEmitter()
             const executeTool = vi.fn()
                 .mockResolvedValueOnce(mcpSuccess('sent'))
                 .mockResolvedValueOnce(mcpFailure('Invalid channel'))
                 .mockResolvedValueOnce(mcpSuccess('sent'))
 
-            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, eventEmitter })
             const result = await tools.ap_execute_action.execute({
                 pieceName: 'slack',
                 actionName: 'send_message',
@@ -153,14 +158,12 @@ describe('chatWorkerTools', () => {
 
             expect(executeTool).toHaveBeenCalledTimes(3)
 
-            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
-            const final = progressEvents[progressEvents.length - 1]['data'] as Record<string, unknown>
-            expect(final['succeeded']).toBe(2)
-            expect(final['failed']).toBe(1)
-            expect(final['done']).toBe(true)
+            const final = progressEvents[progressEvents.length - 1].data
+            expect(final.succeeded).toBe(2)
+            expect(final.failed).toBe(1)
+            expect(final.done).toBe(true)
 
-            const results = final['results'] as Array<{ index: number, success: boolean, error?: string }>
-            const failedItem = results.find((r) => !r.success)
+            const failedItem = final.results.find((r) => !r.success)
             expect(failedItem).toBeDefined()
             expect(failedItem!.index).toBe(1)
             expect(failedItem!.error).toContain('Invalid channel')
@@ -172,63 +175,59 @@ describe('chatWorkerTools', () => {
         })
 
         it('uses default label when description is not provided', async () => {
-            const { writer, writes } = makeMockWriter()
+            const { eventEmitter, progressEvents } = makeMockEventEmitter()
             const executeTool = vi.fn().mockResolvedValue(mcpSuccess('done'))
 
-            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, eventEmitter })
             await tools.ap_execute_action.execute({
                 pieceName: 'http',
                 actionName: 'send_request',
                 items: [{ url: 'http://example.com' }],
             }, { toolCallId: 'tc3', messages: [], abortSignal: undefined as unknown as AbortSignal })
 
-            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
-            const initial = progressEvents[0]['data'] as Record<string, unknown>
-            expect(initial['label']).toBe('Processing 1 item')
+            const initial = progressEvents[0].data
+            expect(initial.label).toBe('Processing 1 item')
         })
 
-        it('uses upsert id for all progress events', async () => {
-            const { writer, writes } = makeMockWriter()
+        it('all progress events share the same toolCallId', async () => {
+            const { eventEmitter, progressEvents } = makeMockEventEmitter()
             const executeTool = vi.fn().mockResolvedValue(mcpSuccess('done'))
 
-            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, eventEmitter })
             await tools.ap_execute_action.execute({
                 pieceName: 'slack',
                 actionName: 'send_message',
                 items: [{ channel: 'C01', text: 'Hi' }, { channel: 'C02', text: 'Hi' }],
             }, { toolCallId: 'tc4', messages: [], abortSignal: undefined as unknown as AbortSignal })
 
-            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
-            const ids = progressEvents.map((w) => w['id'])
-            expect(ids.every((id) => id === ids[0])).toBe(true)
+            const ids = progressEvents.map((e) => e.toolCallId)
+            expect(ids.every((id) => id === 'tc4')).toBe(true)
         })
 
         it('sends empty results array for intermediate events', async () => {
-            const { writer, writes } = makeMockWriter()
+            const { eventEmitter, progressEvents } = makeMockEventEmitter()
             const executeTool = vi.fn().mockResolvedValue(mcpSuccess('done'))
 
-            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, eventEmitter })
             await tools.ap_execute_action.execute({
                 pieceName: 'slack',
                 actionName: 'send_message',
                 items: [{ channel: 'C01', text: 'Hi' }, { channel: 'C02', text: 'Hi' }],
             }, { toolCallId: 'tc5', messages: [], abortSignal: undefined as unknown as AbortSignal })
 
-            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
             const intermediate = progressEvents.slice(0, -1)
             for (const event of intermediate) {
-                const data = event['data'] as Record<string, unknown>
-                expect(data['results']).toEqual([])
+                expect(event.data.results).toEqual([])
             }
-            const final = progressEvents[progressEvents.length - 1]['data'] as Record<string, unknown>
-            expect((final['results'] as unknown[]).length).toBe(2)
+            const final = progressEvents[progressEvents.length - 1].data
+            expect(final.results.length).toBe(2)
         })
 
         it('falls back to single-item mode when items is absent', async () => {
-            const { writer } = makeMockWriter()
+            const { eventEmitter } = makeMockEventEmitter()
             const executeTool = vi.fn().mockResolvedValue(mcpSuccess('done'))
 
-            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, eventEmitter })
             await tools.ap_execute_action.execute({
                 pieceName: 'gmail',
                 actionName: 'send_email',
@@ -244,31 +243,30 @@ describe('chatWorkerTools', () => {
         })
 
         it('handles structured error results from executeCrossProjectTool', async () => {
-            const { writer, writes } = makeMockWriter()
+            const { eventEmitter, progressEvents } = makeMockEventEmitter()
             const executeTool = vi.fn()
                 .mockResolvedValueOnce({ success: false, error: 'No projects available' })
 
-            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, eventEmitter })
             const result = await tools.ap_execute_action.execute({
                 pieceName: 'slack',
                 actionName: 'send_message',
                 items: [{ channel: 'C01', text: 'Hi' }],
             }, { toolCallId: 'tc7', messages: [], abortSignal: undefined as unknown as AbortSignal })
 
-            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
-            const final = progressEvents[progressEvents.length - 1]['data'] as Record<string, unknown>
-            expect(final['failed']).toBe(1)
-            expect(final['succeeded']).toBe(0)
+            const final = progressEvents[progressEvents.length - 1].data
+            expect(final.failed).toBe(1)
+            expect(final.succeeded).toBe(0)
 
             const resultObj = result as { content: Array<{ text: string }> }
             expect(resultObj.content[0].text).toContain('0/1 succeeded')
         })
 
         it('stops early after 3 consecutive failures', async () => {
-            const { writer, writes } = makeMockWriter()
+            const { eventEmitter, progressEvents } = makeMockEventEmitter()
             const executeTool = vi.fn().mockResolvedValue(mcpFailure('Bad auth'))
 
-            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, eventEmitter })
             const result = await tools.ap_execute_action.execute({
                 pieceName: 'slack',
                 actionName: 'send_message',
@@ -278,12 +276,11 @@ describe('chatWorkerTools', () => {
 
             expect(executeTool).toHaveBeenCalledTimes(3)
 
-            const progressEvents = writes.filter((w) => w['type'] === 'data-batch-progress')
-            const final = progressEvents[progressEvents.length - 1]['data'] as Record<string, unknown>
-            expect(final['failed']).toBe(3)
-            expect(final['completed']).toBe(3)
-            expect(final['total']).toBe(10)
-            expect(final['done']).toBe(true)
+            const final = progressEvents[progressEvents.length - 1].data
+            expect(final.failed).toBe(3)
+            expect(final.completed).toBe(3)
+            expect(final.total).toBe(10)
+            expect(final.done).toBe(true)
 
             const resultObj = result as { content: Array<{ text: string }> }
             expect(resultObj.content[0].text).toContain('Stopped early')
@@ -291,7 +288,7 @@ describe('chatWorkerTools', () => {
         })
 
         it('resets consecutive failure count on success', async () => {
-            const { writer } = makeMockWriter()
+            const { eventEmitter } = makeMockEventEmitter()
             const executeTool = vi.fn()
                 .mockResolvedValueOnce(mcpFailure('err'))
                 .mockResolvedValueOnce(mcpFailure('err'))
@@ -300,7 +297,7 @@ describe('chatWorkerTools', () => {
                 .mockResolvedValueOnce(mcpFailure('err'))
                 .mockResolvedValueOnce(mcpSuccess('ok'))
 
-            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, writer })
+            const tools = chatWorkerTools.createCrossProjectTools({ executeTool, eventEmitter })
             await tools.ap_execute_action.execute({
                 pieceName: 'slack',
                 actionName: 'send_message',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.80.1",
+  "version": "0.81.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/automation/workers/worker-contract.ts
+++ b/packages/shared/src/lib/automation/workers/worker-contract.ts
@@ -65,12 +65,37 @@ export enum ChatAgentEventType {
     CHUNK = 'CHUNK',
     FINISHED = 'FINISHED',
     ERROR = 'ERROR',
+    TITLE_UPDATE = 'TITLE_UPDATE',
+    TOOL_PROGRESS = 'TOOL_PROGRESS',
+    TOOL_APPROVAL_REQUEST = 'TOOL_APPROVAL_REQUEST',
+}
+
+export type ToolProgressEvent = {
+    toolCallId: string
+    data: {
+        label: string
+        total: number
+        completed: number
+        succeeded: number
+        failed: number
+        done: boolean
+        results: { index: number, success: boolean, output?: unknown, error?: string }[]
+    }
+}
+
+export type ToolApprovalRequestEvent = {
+    toolCallId: string
+    toolName: string
+    displayName: string
 }
 
 export type ChatAgentEvent =
     | { type: ChatAgentEventType.CHUNK, data: unknown }
     | { type: ChatAgentEventType.FINISHED, data: { conversationId: string } }
     | { type: ChatAgentEventType.ERROR, data: { message: string, code?: string } }
+    | { type: ChatAgentEventType.TITLE_UPDATE, data: { title: string } }
+    | { type: ChatAgentEventType.TOOL_PROGRESS, data: ToolProgressEvent }
+    | { type: ChatAgentEventType.TOOL_APPROVAL_REQUEST, data: ToolApprovalRequestEvent }
 
 export type GetChatConfigRequest = {
     conversationId: string

--- a/packages/shared/src/lib/ee/chat/index.ts
+++ b/packages/shared/src/lib/ee/chat/index.ts
@@ -149,27 +149,11 @@ export type ChatHistoryMessage = {
     thoughts?: string
 }
 
-export type ToolApprovalRequest = {
-    gateId: string
-    toolName: string
-    displayName: string
-}
-
-export type PlanApprovalRequest = {
-    gateId: string
-    planSummary: string
-    steps: string[]
-}
-
 export type PlanStepStatus = 'pending' | 'executing' | 'done' | 'error'
 
 export type PlanStepUpdate = {
     stepIndex: number
     status: PlanStepStatus
-}
-
-export type ChatStreamWriter = {
-    write(part: Record<string, unknown>): void
 }
 
 export type ChatToolOutputs = {

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/prompt-kit/chat-container';
 import { ScrollButton } from '@/components/prompt-kit/scroll-button';
 import { Button } from '@/components/ui/button';
+import { chatStoreSelectors } from '@/features/chat/lib/chat-store';
 import {
   ChatStoreProvider,
   useChatStoreContext,
@@ -88,8 +89,6 @@ function ChatBoxContent({
   });
 
   const quickReplies = useChatStoreContext((s) => s.quickReplies);
-  const displayCard = useChatStoreContext((s) => s.displayCard);
-  const hasBlockingCard = displayCard !== null && !displayCard.resolved;
 
   useEffect(() => {
     if (initialConversationId) {
@@ -114,6 +113,10 @@ function ChatBoxContent({
   const lastAssistantMessage = useMemo(
     () => messages.findLast((m) => m.role === 'assistant'),
     [messages],
+  );
+
+  const hasBlockingCard = useChatStoreContext((s) =>
+    chatStoreSelectors.hasBlockingCard({ state: s, lastAssistantMessage }),
   );
 
   const showBanner = credits.creditsExhausted || credits.creditsWarning;
@@ -193,9 +196,6 @@ function ChatBoxContent({
                 isStreaming={isLastStreamingAssistant}
                 isLastMessage={isLastAssistant}
                 onRetry={handleRetry}
-                lastAssistantMessage={
-                  isLastAssistant ? lastAssistantMessage : msg
-                }
               />
             );
           })}

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -10,7 +10,6 @@ import {
   MessageAction,
   MessageActions,
 } from '@/components/prompt-kit/message';
-import { chatStoreSelectors } from '@/features/chat/lib/chat-store';
 import { useChatStoreContext } from '@/features/chat/lib/chat-store-context';
 import {
   AnyToolPart,
@@ -49,18 +48,13 @@ export const AssistantMessage = memo(function AssistantMessage({
   isStreaming,
   isLastMessage = false,
   onRetry,
-  lastAssistantMessage,
 }: {
   message: ChatUIMessage;
   isStreaming: boolean;
   isLastMessage?: boolean;
   onRetry: () => void;
-  lastAssistantMessage?: ChatUIMessage;
 }) {
-  const resolveDisplayCard = useChatStoreContext((s) => s.resolveDisplayCard);
-  const displayCard = useChatStoreContext((s) => s.displayCard);
-  const hasActiveDisplayCard =
-    isStreaming && displayCard !== null && !displayCard.resolved;
+  const approveGate = useChatStoreContext((s) => s.approveGate);
 
   const {
     blocks,
@@ -100,10 +94,6 @@ export const AssistantMessage = memo(function AssistantMessage({
         flushThinking();
         hasText = true;
         result.push({ kind: 'text', text: p.text });
-      } else if (p.type === 'data-batch-progress' && 'data' in p) {
-        flushThinking();
-        const batchPart = p as { data: BatchProgressData };
-        result.push({ kind: 'batch-progress', data: batchPart.data });
       } else if (p.type === 'reasoning') {
         const thinking = ensureThinking();
         thinking.reasoningText += p.text;
@@ -135,6 +125,27 @@ export const AssistantMessage = memo(function AssistantMessage({
         } else if (toolName === 'ap_request_plan_approval') {
           flushThinking();
           result.push({ kind: 'plan-marker', part: p });
+        } else if (toolName === 'ap_execute_action') {
+          const batchPart = chatPartUtils.extractBatchProgressFromOutput(p);
+          if (batchPart) {
+            flushThinking();
+            result.push({ kind: 'batch-progress', data: batchPart });
+          }
+          const thinking = ensureThinking();
+          const lastStep = thinking.steps[thinking.steps.length - 1];
+          if (
+            lastThinkingStatus &&
+            lastStep?.kind === 'thinking-status' &&
+            lastStep.text === lastThinkingStatus
+          ) {
+            thinking.steps[thinking.steps.length - 1] = {
+              ...lastStep,
+              toolPart: p,
+            };
+          } else {
+            thinking.steps.push({ kind: 'tool', part: p });
+          }
+          lastThinkingStatus = null;
         } else {
           const thinking = ensureThinking();
           const lastStep = thinking.steps[thinking.steps.length - 1];
@@ -183,7 +194,11 @@ export const AssistantMessage = memo(function AssistantMessage({
       }
     }
 
-    return { blocks: result, hasContent: hasText, lastDisplayIdx };
+    return {
+      blocks: result,
+      hasContent: hasText,
+      lastDisplayIdx,
+    };
   }, [message.parts, isStreaming]);
 
   const fullText = useMemo(
@@ -211,6 +226,9 @@ export const AssistantMessage = memo(function AssistantMessage({
 
   const isFromHistory = message.id.startsWith('hist-');
   const lastThinkingIdx = blocks.findLastIndex((b) => b.kind === 'thinking');
+  const hasActiveDisplayCard = blocks.some(
+    (b) => b.kind === 'display-tool' && b.part.state === 'input-available',
+  );
 
   return (
     <motion.div
@@ -261,7 +279,7 @@ export const AssistantMessage = memo(function AssistantMessage({
                     <DisplayToolCard
                       key={block.part.toolCallId}
                       part={block.part}
-                      onResolve={resolveDisplayCard}
+                      onResolve={approveGate}
                       isInteractive={false}
                     />
                   );
@@ -273,7 +291,7 @@ export const AssistantMessage = memo(function AssistantMessage({
                   <InlinePlanCard
                     key={`plan-${i}`}
                     planPart={block.part}
-                    lastAssistantMessage={lastAssistantMessage}
+                    message={message}
                     isStreaming={isStreaming}
                   />
                 );
@@ -339,21 +357,14 @@ export const AssistantMessage = memo(function AssistantMessage({
 
 function InlinePlanCard({
   planPart,
-  lastAssistantMessage,
+  message,
   isStreaming,
 }: {
   planPart: AnyToolPart;
-  lastAssistantMessage?: ChatUIMessage;
+  message: ChatUIMessage;
   isStreaming: boolean;
 }) {
-  const storePlanProgress = useChatStoreContext((s) =>
-    chatStoreSelectors.planProgress({ state: s, lastAssistantMessage }),
-  );
-  const storePlanUpdates = useChatStoreContext((s) =>
-    chatStoreSelectors.effectivePlanUpdates({ state: s }),
-  );
-
-  const localPlan = (() => {
+  const localPlan = useMemo(() => {
     const toolOutput = chatPartUtils.parseTypedToolOutput(
       planPart,
       'ap_request_plan_approval',
@@ -365,35 +376,41 @@ function InlinePlanCard({
     const steps = input?.steps ?? [];
     if (steps.length === 0) return null;
     return { title: input?.planSummary ?? '', steps };
-  })();
+  }, [planPart]);
 
-  const progress = storePlanProgress ?? localPlan;
+  const planCompleted = useMemo(
+    () =>
+      !isStreaming &&
+      (() => {
+        const output = chatPartUtils.parseTypedToolOutput(
+          planPart,
+          'ap_request_plan_approval',
+        );
+        return output.state === 'success' && output.data.success;
+      })(),
+    [isStreaming, planPart],
+  );
 
-  const planCompleted =
-    !isStreaming &&
-    (() => {
-      const output = chatPartUtils.parseTypedToolOutput(
-        planPart,
-        'ap_request_plan_approval',
-      );
-      return output.state === 'success' && output.data.success;
-    })();
+  const messageUpdates = useMemo(
+    () => chatPartUtils.extractPlanUpdatesFromMessage(message),
+    [message],
+  );
 
   const updates = useMemo(() => {
-    if (!progress) return [];
+    if (!localPlan) return [];
     if (planCompleted) {
-      return progress.steps.map(
+      return localPlan.steps.map(
         (_stepText, i): PlanStepUpdate => ({ stepIndex: i, status: 'done' }),
       );
     }
-    return storePlanUpdates;
-  }, [storePlanUpdates, progress, planCompleted]);
+    return messageUpdates;
+  }, [messageUpdates, localPlan, planCompleted]);
 
-  if (!progress) return null;
+  if (!localPlan) return null;
 
   return (
     <PlanProgressCard
-      progress={progress}
+      progress={localPlan}
       updates={updates}
       isStreaming={isStreaming}
     />
@@ -406,7 +423,7 @@ function DisplayToolCard({
   isInteractive,
 }: {
   part: AnyToolPart;
-  onResolve: (payload: Record<string, unknown>) => void;
+  onResolve: (gateId: string, payload?: Record<string, unknown>) => void;
   isInteractive: boolean;
 }) {
   if (!chatPartUtils.isReady(part)) return null;
@@ -417,13 +434,14 @@ function DisplayToolCard({
     parsedOutput.state === 'success'
       ? (parsedOutput.data as Record<string, unknown>)
       : undefined;
+  const toolCallId = chatPartUtils.getToolCallId(part);
 
   switch (toolName) {
     case 'ap_show_connection_required':
       return (
         <ConnectionsRequiredCard
           connections={[data as unknown as ConnectionRequiredData]}
-          onResolve={onResolve}
+          onResolve={(payload) => onResolve(toolCallId, payload)}
         />
       );
     case 'ap_show_connection_picker': {
@@ -434,7 +452,7 @@ function DisplayToolCard({
       return (
         <ConnectionPickerCard
           picker={data as unknown as ConnectionPickerData}
-          onResolve={onResolve}
+          onResolve={(payload) => onResolve(toolCallId, payload)}
           isInteractive={isInteractive}
           selectedConnectionLabel={selectedLabel}
         />
@@ -449,7 +467,7 @@ function DisplayToolCard({
         <ProjectPickerCard
           picker={data as unknown as ProjectPickerData}
           isInteractive={isInteractive}
-          onResolve={onResolve}
+          onResolve={(payload) => onResolve(toolCallId, payload)}
           selectedProjectId={selectedProjectId}
         />
       );

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
@@ -3,7 +3,11 @@ import { t } from 'i18next';
 import { chatStoreSelectors } from '@/features/chat/lib/chat-store';
 import { useChatStoreContext } from '@/features/chat/lib/chat-store-context';
 import { MultiQuestion } from '@/features/chat/lib/chat-store-types';
-import { ChatUIMessage } from '@/features/chat/lib/chat-types';
+import {
+  AnyToolPart,
+  ChatUIMessage,
+  chatPartUtils,
+} from '@/features/chat/lib/chat-types';
 
 import {
   ConnectionPickerData,
@@ -31,74 +35,82 @@ export function ChatBottomBar({
   lastAssistantMessage,
   lastMessageId,
 }: ChatBottomBarProps) {
-  const hasPlanApproval = useChatStoreContext(
-    chatStoreSelectors.hasPlanApproval,
+  const pendingPlanPart = useChatStoreContext((s) =>
+    chatStoreSelectors.pendingPlanApproval({
+      state: s,
+      lastAssistantMessage,
+    }),
   );
-  const pendingPlanApproval = useChatStoreContext((s) => s.pendingPlanApproval);
-  const approvePlan = useChatStoreContext((s) => s.approvePlan);
-  const rejectPlan = useChatStoreContext((s) => s.rejectPlan);
-  const dismissPlan = useChatStoreContext((s) => s.dismissPlan);
-
-  const hasActiveApproval = useChatStoreContext(
-    chatStoreSelectors.hasActiveApproval,
+  const pendingMcpApproval = useChatStoreContext((s) =>
+    chatStoreSelectors.pendingMcpApproval({
+      state: s,
+      lastAssistantMessage,
+    }),
   );
-  const approvalDisplayName = useChatStoreContext(
-    chatStoreSelectors.approvalDisplayName,
+  const activeDisplayTool = useChatStoreContext((s) =>
+    chatStoreSelectors.activeDisplayTool({
+      state: s,
+      lastAssistantMessage,
+    }),
   );
-  const pendingApprovalRequest = useChatStoreContext(
-    (s) => s.pendingApprovalRequest,
-  );
-  const approveToolCall = useChatStoreContext((s) => s.approveToolCall);
-  const rejectToolCall = useChatStoreContext((s) => s.rejectToolCall);
-  const dismissApproval = useChatStoreContext((s) => s.dismissApproval);
-
   const activeQuestions = useChatStoreContext((s) =>
     chatStoreSelectors.activeQuestions({ state: s, lastAssistantMessage }),
   );
   const hasActiveForm = useChatStoreContext((s) =>
     chatStoreSelectors.hasActiveForm({ state: s, lastAssistantMessage }),
   );
-  const dismissForm = useChatStoreContext((s) => s.dismissForm);
-  const displayCard = useChatStoreContext((s) => s.displayCard);
-  const resolveDisplayCard = useChatStoreContext((s) => s.resolveDisplayCard);
-  const dismissDisplayCard = useChatStoreContext((s) => s.dismissDisplayCard);
 
-  if (hasPlanApproval && pendingPlanApproval) {
+  const approveGate = useChatStoreContext((s) => s.approveGate);
+  const rejectGate = useChatStoreContext((s) => s.rejectGate);
+  const dismissGate = useChatStoreContext((s) => s.dismissGate);
+  const dismissForm = useChatStoreContext((s) => s.dismissForm);
+
+  // Plan approval from tool state
+  if (pendingPlanPart) {
+    const input = pendingPlanPart.input as
+      | { planSummary?: string; steps?: string[] }
+      | undefined;
+    const toolCallId = chatPartUtils.getToolCallId(pendingPlanPart);
     return (
       <PlanApprovalForm
-        key={pendingPlanApproval.gateId}
-        planSummary={pendingPlanApproval.planSummary}
-        steps={pendingPlanApproval.steps}
-        onApprove={approvePlan}
-        onReject={rejectPlan}
-        onDismiss={dismissPlan}
+        key={toolCallId}
+        planSummary={input?.planSummary ?? ''}
+        steps={input?.steps ?? []}
+        onApprove={() => approveGate(toolCallId)}
+        onReject={() => rejectGate(toolCallId)}
+        onDismiss={() => dismissGate(toolCallId)}
       />
     );
   }
 
-  if (hasActiveApproval) {
+  // MCP tool approval from toolCallMeta
+  if (pendingMcpApproval) {
     return (
       <ToolApprovalForm
-        key={pendingApprovalRequest?.gateId}
-        displayName={approvalDisplayName ?? ''}
-        onApprove={approveToolCall}
-        onReject={rejectToolCall}
-        onDismiss={dismissApproval}
+        key={pendingMcpApproval.toolCallId}
+        displayName={pendingMcpApproval.displayName}
+        onApprove={() => approveGate(pendingMcpApproval.toolCallId)}
+        onReject={() => rejectGate(pendingMcpApproval.toolCallId)}
+        onDismiss={() => dismissGate(pendingMcpApproval.toolCallId)}
       />
     );
   }
 
-  if (displayCard && !displayCard.resolved) {
+  // Display tool card (connection picker, questions, etc.) from tool state
+  if (activeDisplayTool) {
+    const toolCallId = chatPartUtils.getToolCallId(activeDisplayTool);
     return (
       <BlockingDisplayCard
-        displayCard={displayCard}
+        toolPart={activeDisplayTool}
+        toolCallId={toolCallId}
         activeQuestions={activeQuestions}
-        resolveDisplayCard={resolveDisplayCard}
-        dismissDisplayCard={dismissDisplayCard}
+        approveGate={approveGate}
+        rejectGate={rejectGate}
       />
     );
   }
 
+  // Questions from history (tool already completed but not dismissed)
   if (hasActiveForm && !isStreaming) {
     return (
       <MultiQuestionForm
@@ -133,45 +145,50 @@ export function ChatBottomBar({
 }
 
 function BlockingDisplayCard({
-  displayCard,
+  toolPart,
+  toolCallId,
   activeQuestions,
-  resolveDisplayCard,
-  dismissDisplayCard,
+  approveGate,
+  rejectGate,
 }: {
-  displayCard: { type: string; data: Record<string, unknown>; gateId: string };
+  toolPart: AnyToolPart;
+  toolCallId: string;
   activeQuestions: MultiQuestion[];
-  resolveDisplayCard: (payload: Record<string, unknown>) => void;
-  dismissDisplayCard: () => void;
+  approveGate: (gateId: string, payload?: Record<string, unknown>) => void;
+  rejectGate: (gateId: string) => void;
 }) {
-  switch (displayCard.type) {
-    case 'data-questions':
+  const toolName = chatPartUtils.getToolPartName(toolPart);
+  const data = toolPart.input as Record<string, unknown>;
+
+  switch (toolName) {
+    case 'ap_show_questions':
       return (
         <MultiQuestionForm
-          key={displayCard.gateId}
+          key={toolCallId}
           questions={activeQuestions}
-          onSubmit={(text) => resolveDisplayCard({ answers: text })}
-          onDismiss={() => dismissDisplayCard()}
+          onSubmit={(text) => approveGate(toolCallId, { answers: text })}
+          onDismiss={() => rejectGate(toolCallId)}
         />
       );
-    case 'data-connection-required':
+    case 'ap_show_connection_required':
       return (
         <ConnectionsRequiredCard
-          connections={[displayCard.data as unknown as ConnectionRequiredData]}
-          onResolve={resolveDisplayCard}
+          connections={[data as unknown as ConnectionRequiredData]}
+          onResolve={(payload) => approveGate(toolCallId, payload)}
         />
       );
-    case 'data-connection-picker':
+    case 'ap_show_connection_picker':
       return (
         <ConnectionPickerCard
-          picker={displayCard.data as unknown as ConnectionPickerData}
-          onResolve={resolveDisplayCard}
+          picker={data as unknown as ConnectionPickerData}
+          onResolve={(payload) => approveGate(toolCallId, payload)}
         />
       );
-    case 'data-project-picker':
+    case 'ap_show_project_picker':
       return (
         <ProjectPickerCard
-          picker={displayCard.data as unknown as ProjectPickerData}
-          onResolve={resolveDisplayCard}
+          picker={data as unknown as ProjectPickerData}
+          onResolve={(payload) => approveGate(toolCallId, payload)}
         />
       );
     default:

--- a/packages/web/src/features/chat/lib/chat-store.ts
+++ b/packages/web/src/features/chat/lib/chat-store.ts
@@ -1,12 +1,12 @@
 import {
-  PlanApprovalRequest,
-  PlanStepUpdate,
-  ToolApprovalRequest,
+  BatchProgressData,
+  omit,
+  ToolApprovalRequestEvent,
 } from '@activepieces/shared';
 import { StoreApi, create } from 'zustand';
 
 import { chatApi } from './chat-api';
-import { MultiQuestion, PlanProgressData } from './chat-store-types';
+import { MultiQuestion } from './chat-store-types';
 import { AnyToolPart, ChatUIMessage, chatPartUtils } from './chat-types';
 
 function sendApprovalDecision({
@@ -21,176 +21,136 @@ function sendApprovalDecision({
   void chatApi.approveToolCall({ gateId, approved, payload });
 }
 
-function extractQuestionsFromToolParts(
-  message: ChatUIMessage | undefined,
-): MultiQuestion[] {
-  if (!message || message.role !== 'assistant') return [];
-  const questionPart = message.parts.find(
-    (p) =>
-      chatPartUtils.isAnyToolPart(p) &&
-      chatPartUtils.getToolPartName(p) === 'ap_show_questions' &&
-      p.state !== 'output-available',
-  );
-  if (!questionPart || !chatPartUtils.isAnyToolPart(questionPart)) return [];
-  const input = questionPart.input as
-    | { questions?: MultiQuestion[] }
-    | undefined;
+function extractQuestionsFromInput(part: AnyToolPart | null): MultiQuestion[] {
+  if (!part) return [];
+  const input = part.input as { questions?: MultiQuestion[] } | undefined;
   return input?.questions ?? [];
 }
 
-function extractPlanFromToolParts(
-  message: ChatUIMessage | undefined,
-): PlanProgressData | null {
-  if (!message || message.role !== 'assistant') return null;
-  const planPart = message.parts.find(
-    (p): p is AnyToolPart =>
-      chatPartUtils.isAnyToolPart(p) &&
-      chatPartUtils.getToolPartName(p) === 'ap_request_plan_approval',
-  );
-  if (!planPart) return null;
-  const toolOutput = chatPartUtils.parseTypedToolOutput(
-    planPart,
-    'ap_request_plan_approval',
-  );
-  if (toolOutput.state === 'error') return null;
-  if (toolOutput.state === 'success' && !toolOutput.data.success) return null;
-  const input = planPart.input as
-    | { planSummary?: string; steps?: string[] }
-    | undefined;
-  const steps = input?.steps ?? [];
-  if (steps.length === 0) return null;
-  return { title: input?.planSummary ?? '', steps };
+function isNotDismissed(
+  part: AnyToolPart | null,
+  state: ChatStoreState,
+): part is AnyToolPart {
+  if (!part) return false;
+  return !state.dismissedGateIds[chatPartUtils.getToolCallId(part)];
 }
 
+export type ToolCallMeta = {
+  batchProgress?: BatchProgressData;
+  approvalRequest?: ToolApprovalRequestEvent;
+};
+
 export type ChatStoreState = {
-  pendingApprovalRequest: ToolApprovalRequest | null;
-  pendingPlanApproval: PlanApprovalRequest | null;
-  planProgressUpdates: PlanStepUpdate[];
-  planRejected: boolean;
-  displayCard: {
-    type: string;
-    data: Record<string, unknown>;
-    gateId: string;
-    resolved: boolean;
-  } | null;
   quickReplies: string[];
-
-  dismissedApprovalGateId: string | null;
-  dismissedPlanGateId: string | null;
-
+  toolCallMeta: Record<string, ToolCallMeta>;
+  dismissedGateIds: Record<string, true>;
   lastDismissedFormId: string | null;
 
-  approveToolCall: () => void;
-  rejectToolCall: () => void;
-  dismissApproval: () => void;
-
-  approvePlan: () => void;
-  rejectPlan: () => void;
-  dismissPlan: () => void;
-
+  approveGate: (gateId: string, payload?: Record<string, unknown>) => void;
+  rejectGate: (gateId: string) => void;
+  dismissGate: (gateId: string) => void;
   dismissForm: (messageId: string) => void;
-
-  resolveDisplayCard: (payload: Record<string, unknown>) => void;
-  dismissDisplayCard: () => void;
-
   resetInteractions: () => void;
 };
 
 export type ChatStore = ReturnType<typeof createChatStore>;
 
+function dismissAndCleanup(
+  prev: ChatStoreState,
+  gateId: string,
+): Partial<ChatStoreState> {
+  return {
+    dismissedGateIds: { ...prev.dismissedGateIds, [gateId]: true },
+    toolCallMeta: omit(prev.toolCallMeta, [gateId]),
+  };
+}
+
 export const createChatStore = () =>
-  create<ChatStoreState>((set, get) => ({
-    pendingApprovalRequest: null,
-    pendingPlanApproval: null,
-    planProgressUpdates: [],
-    planRejected: false,
-    displayCard: null,
+  create<ChatStoreState>((set) => ({
     quickReplies: [],
-
-    dismissedApprovalGateId: null,
-    dismissedPlanGateId: null,
-
+    toolCallMeta: {},
+    dismissedGateIds: {},
     lastDismissedFormId: null,
 
-    approveToolCall: () => {
-      const req = get().pendingApprovalRequest;
-      if (!req) return;
-      set({ dismissedApprovalGateId: req.gateId });
-      sendApprovalDecision({ gateId: req.gateId, approved: true });
+    approveGate: (gateId: string, payload?: Record<string, unknown>) => {
+      set((prev) => dismissAndCleanup(prev, gateId));
+      sendApprovalDecision({ gateId, approved: true, payload });
     },
-    rejectToolCall: () => {
-      const req = get().pendingApprovalRequest;
-      if (!req) return;
-      set({ dismissedApprovalGateId: req.gateId });
-      sendApprovalDecision({ gateId: req.gateId, approved: false });
+    rejectGate: (gateId: string) => {
+      set((prev) => dismissAndCleanup(prev, gateId));
+      sendApprovalDecision({ gateId, approved: false });
     },
-    dismissApproval: () => {
-      const req = get().pendingApprovalRequest;
-      if (req) set({ dismissedApprovalGateId: req.gateId });
+    dismissGate: (gateId: string) => {
+      set((prev) => dismissAndCleanup(prev, gateId));
     },
-
-    approvePlan: () => {
-      const plan = get().pendingPlanApproval;
-      if (!plan) return;
-      set({ dismissedPlanGateId: plan.gateId });
-      sendApprovalDecision({ gateId: plan.gateId, approved: true });
-    },
-    rejectPlan: () => {
-      const plan = get().pendingPlanApproval;
-      if (!plan) return;
-      set({ dismissedPlanGateId: plan.gateId, planRejected: true });
-      sendApprovalDecision({ gateId: plan.gateId, approved: false });
-    },
-    dismissPlan: () => {
-      const plan = get().pendingPlanApproval;
-      if (plan) set({ dismissedPlanGateId: plan.gateId });
-    },
-
     dismissForm: (messageId: string) => {
       set({ lastDismissedFormId: messageId });
     },
-
-    resolveDisplayCard: (payload: Record<string, unknown>) => {
-      const card = get().displayCard;
-      if (!card || card.resolved) return;
-      set({ displayCard: { ...card, resolved: true } });
-      sendApprovalDecision({ gateId: card.gateId, approved: true, payload });
-    },
-    dismissDisplayCard: () => {
-      const card = get().displayCard;
-      if (!card) return;
-      set({ displayCard: null });
-      sendApprovalDecision({ gateId: card.gateId, approved: false });
-    },
-
     resetInteractions: () => {
       set({
-        pendingApprovalRequest: null,
-        pendingPlanApproval: null,
-        planProgressUpdates: [],
         quickReplies: [],
-        displayCard: null,
-        planRejected: false,
+        toolCallMeta: {},
+        dismissedGateIds: {},
       });
     },
   }));
 
-function selectHasActiveApproval(s: ChatStoreState): boolean {
-  return (
-    s.pendingApprovalRequest !== null &&
-    s.pendingApprovalRequest.gateId !== s.dismissedApprovalGateId
-  );
+function selectActiveDisplayTool({
+  state,
+  lastAssistantMessage,
+}: {
+  state: ChatStoreState;
+  lastAssistantMessage: ChatUIMessage | undefined;
+}): AnyToolPart | null {
+  const part = chatPartUtils.findLastToolPart({
+    message: lastAssistantMessage,
+    predicate: (name, p) =>
+      chatPartUtils.isDisplayTool(name) &&
+      name !== 'ap_show_quick_replies' &&
+      p.state === 'input-available',
+  });
+  return isNotDismissed(part, state) ? part : null;
 }
 
-function selectApprovalDisplayName(s: ChatStoreState): string | null {
-  return s.pendingApprovalRequest?.displayName ?? null;
+function selectPendingPlanApproval({
+  state,
+  lastAssistantMessage,
+}: {
+  state: ChatStoreState;
+  lastAssistantMessage: ChatUIMessage | undefined;
+}): AnyToolPart | null {
+  const part = chatPartUtils.findLastToolPart({
+    message: lastAssistantMessage,
+    predicate: (name, p) =>
+      name === 'ap_request_plan_approval' && p.state === 'input-available',
+  });
+  return isNotDismissed(part, state) ? part : null;
 }
 
-function selectHasPlanApproval(s: ChatStoreState): boolean {
-  return (
-    s.pendingPlanApproval !== null &&
-    s.pendingPlanApproval.gateId !== s.dismissedPlanGateId
-  );
+function selectPendingMcpApproval({
+  state,
+  lastAssistantMessage,
+}: {
+  state: ChatStoreState;
+  lastAssistantMessage: ChatUIMessage | undefined;
+}): { toolCallId: string; toolName: string; displayName: string } | null {
+  const part = chatPartUtils.findLastToolPart({
+    message: lastAssistantMessage,
+    predicate: (_name, p) => {
+      if (p.state !== 'input-available') return false;
+      const id = chatPartUtils.getToolCallId(p);
+      return !!id && !!state.toolCallMeta[id]?.approvalRequest;
+    },
+  });
+  if (!isNotDismissed(part, state)) return null;
+  const toolCallId = chatPartUtils.getToolCallId(part);
+  const meta = state.toolCallMeta[toolCallId]?.approvalRequest;
+  if (!meta) return null;
+  return {
+    toolCallId,
+    toolName: meta.toolName,
+    displayName: meta.displayName,
+  };
 }
 
 function selectActiveQuestions({
@@ -200,14 +160,19 @@ function selectActiveQuestions({
   state: ChatStoreState;
   lastAssistantMessage: ChatUIMessage | undefined;
 }): MultiQuestion[] {
+  const activeTool = selectActiveDisplayTool({ state, lastAssistantMessage });
   if (
-    state.displayCard?.type === 'data-questions' &&
-    !state.displayCard.resolved
+    activeTool &&
+    chatPartUtils.getToolPartName(activeTool) === 'ap_show_questions'
   ) {
-    const input = state.displayCard.data as { questions?: MultiQuestion[] };
-    return input.questions ?? [];
+    return extractQuestionsFromInput(activeTool);
   }
-  return extractQuestionsFromToolParts(lastAssistantMessage);
+  const historyPart = chatPartUtils.findLastToolPart({
+    message: lastAssistantMessage,
+    predicate: (name, p) =>
+      name === 'ap_show_questions' && p.state !== 'output-available',
+  });
+  return extractQuestionsFromInput(historyPart);
 }
 
 function selectHasActiveForm({
@@ -218,83 +183,60 @@ function selectHasActiveForm({
   lastAssistantMessage: ChatUIMessage | undefined;
 }): boolean {
   const questions = selectActiveQuestions({ state, lastAssistantMessage });
+  if (questions.length === 0) return false;
+  const activeTool = selectActiveDisplayTool({ state, lastAssistantMessage });
+  if (
+    activeTool &&
+    chatPartUtils.getToolPartName(activeTool) === 'ap_show_questions'
+  ) {
+    return true;
+  }
   return (
-    questions.length > 0 &&
-    ((state.displayCard?.type === 'data-questions' &&
-      !state.displayCard.resolved) ||
-      (!!lastAssistantMessage &&
-        lastAssistantMessage.id !== state.lastDismissedFormId))
+    !!lastAssistantMessage &&
+    lastAssistantMessage.id !== state.lastDismissedFormId
   );
 }
 
-function selectPlanProgress({
+function selectHasBlockingCard({
   state,
   lastAssistantMessage,
 }: {
   state: ChatStoreState;
-  lastAssistantMessage: ChatUIMessage | undefined;
-}): PlanProgressData | null {
-  if (state.pendingPlanApproval && state.pendingPlanApproval.steps.length > 0) {
-    return {
-      title: state.pendingPlanApproval.planSummary,
-      steps: state.pendingPlanApproval.steps,
-    };
-  }
-  return extractPlanFromToolParts(lastAssistantMessage);
-}
-
-function selectEffectivePlanUpdates({
-  state,
-}: {
-  state: ChatStoreState;
-}): PlanStepUpdate[] {
-  return state.planProgressUpdates;
-}
-
-function selectShouldShowPlan({
-  state,
-  isStreaming,
-  isLastAssistant,
-  lastAssistantMessage,
-}: {
-  state: ChatStoreState;
-  isStreaming: boolean;
-  isLastAssistant: boolean;
   lastAssistantMessage: ChatUIMessage | undefined;
 }): boolean {
-  const progress = selectPlanProgress({ state, lastAssistantMessage });
-  if (progress === null) return false;
+  const part = chatPartUtils.findLastToolPart({
+    message: lastAssistantMessage,
+    predicate: (name, p) => {
+      if (p.state !== 'input-available') return false;
+      const id = chatPartUtils.getToolCallId(p);
+      if (state.dismissedGateIds[id]) return false;
+      if (chatPartUtils.isDisplayTool(name) && name !== 'ap_show_quick_replies')
+        return true;
+      if (name === 'ap_request_plan_approval') return true;
+      return !!state.toolCallMeta[id]?.approvalRequest;
+    },
+  });
+  return part !== null;
+}
 
-  const hasLiveUpdates = selectEffectivePlanUpdates({ state }).length > 0;
-  const planToolWasCompleted =
-    lastAssistantMessage?.parts.some(
-      (p) =>
-        chatPartUtils.isAnyToolPart(p) &&
-        chatPartUtils.getToolPartName(p) === 'ap_request_plan_approval' &&
-        p.state === 'output-available',
-    ) ?? false;
-  const planWasExecuted = hasLiveUpdates || planToolWasCompleted;
-
-  if (!isLastAssistant) {
-    return !isStreaming && planWasExecuted;
-  }
-
-  return (
-    !selectHasPlanApproval(state) &&
-    !state.planRejected &&
-    (!isStreaming || planWasExecuted)
-  );
+function selectBatchProgress({
+  state,
+  toolCallId,
+}: {
+  state: ChatStoreState;
+  toolCallId: string;
+}): BatchProgressData | undefined {
+  return state.toolCallMeta[toolCallId]?.batchProgress;
 }
 
 export const chatStoreSelectors = {
-  hasActiveApproval: selectHasActiveApproval,
-  approvalDisplayName: selectApprovalDisplayName,
-  hasPlanApproval: selectHasPlanApproval,
+  activeDisplayTool: selectActiveDisplayTool,
+  pendingPlanApproval: selectPendingPlanApproval,
+  pendingMcpApproval: selectPendingMcpApproval,
   activeQuestions: selectActiveQuestions,
   hasActiveForm: selectHasActiveForm,
-  planProgress: selectPlanProgress,
-  effectivePlanUpdates: selectEffectivePlanUpdates,
-  shouldShowPlan: selectShouldShowPlan,
+  hasBlockingCard: selectHasBlockingCard,
+  batchProgress: selectBatchProgress,
 };
 
 export type SetChatStore = StoreApi<ChatStoreState>['setState'];

--- a/packages/web/src/features/chat/lib/chat-types.ts
+++ b/packages/web/src/features/chat/lib/chat-types.ts
@@ -3,6 +3,8 @@ import {
   ChatToolName,
   ChatToolOutputs,
   isObject,
+  parseToJsonIfPossible,
+  PlanStepUpdate,
 } from '@activepieces/shared';
 import {
   DynamicToolUIPart,
@@ -12,12 +14,7 @@ import {
   UIMessage,
 } from 'ai';
 
-export type ChatDataParts = {
-  'session-title': { title: string };
-  'batch-progress': BatchProgressData;
-};
-
-export type ChatUIMessage = UIMessage<unknown, ChatDataParts>;
+export type ChatUIMessage = UIMessage;
 
 export type AnyToolPart = ToolUIPart | DynamicToolUIPart;
 
@@ -145,9 +142,87 @@ function extractPieceNames(
   return names.map(normalizePieceName);
 }
 
+function getToolCallId(part: AnyToolPart): string {
+  return 'toolCallId' in part ? (part.toolCallId as string) : '';
+}
+
+function findLastToolPart({
+  message,
+  predicate,
+}: {
+  message: ChatUIMessage | undefined;
+  predicate: (name: string, part: AnyToolPart) => boolean;
+}): AnyToolPart | null {
+  if (!message || message.role !== 'assistant') return null;
+  for (let i = message.parts.length - 1; i >= 0; i--) {
+    const p = message.parts[i];
+    if (!isAnyToolPart(p)) continue;
+    if (predicate(getToolPartName(p), p)) return p;
+  }
+  return null;
+}
+
+function extractBatchProgressFromOutput(
+  part: AnyToolPart,
+): BatchProgressData | null {
+  if (part.state !== 'output-available' || !part.output) return null;
+  const output = parseToJsonIfPossible(part.output);
+  if (!output || typeof output !== 'object') return null;
+  const record = output as Record<string, unknown>;
+  if (!record['batchProgress']) return null;
+  return record['batchProgress'] as BatchProgressData;
+}
+
+function extractPlanUpdatesFromMessage(
+  message: ChatUIMessage,
+): PlanStepUpdate[] {
+  const updates: PlanStepUpdate[] = [];
+  for (const p of message.parts) {
+    if (!isAnyToolPart(p)) continue;
+    if (getToolPartName(p) !== 'ap_update_plan') continue;
+    if (p.state === 'input-streaming') continue;
+    const input = p.input as
+      | { updates?: Array<{ stepIndex: number; status: string }> }
+      | undefined;
+    if (!input?.updates) continue;
+    for (const u of input.updates) {
+      const existing = updates.findIndex((e) => e.stepIndex === u.stepIndex);
+      if (existing >= 0) {
+        updates[existing] = {
+          stepIndex: u.stepIndex,
+          status: u.status as PlanStepUpdate['status'],
+        };
+      } else {
+        updates.push({
+          stepIndex: u.stepIndex,
+          status: u.status as PlanStepUpdate['status'],
+        });
+      }
+    }
+  }
+  return updates;
+}
+
+function extractQuickRepliesFromParts(message: ChatUIMessage | null): string[] {
+  if (!message || message.role !== 'assistant') return [];
+  for (let i = message.parts.length - 1; i >= 0; i--) {
+    const p = message.parts[i];
+    if (
+      isAnyToolPart(p) &&
+      getToolPartName(p) === 'ap_show_quick_replies' &&
+      (p.state === 'output-available' || p.state === 'input-available')
+    ) {
+      const input = p.input as { replies?: string[] } | undefined;
+      return input?.replies ?? [];
+    }
+  }
+  return [];
+}
+
 export const chatPartUtils = {
   isAnyToolPart,
   getToolPartName,
+  getToolCallId,
   isReady,
   isDisplayTool,
   isThinkingStatusTool,
@@ -156,6 +231,10 @@ export const chatPartUtils = {
   extractPieceNames,
   parseToolOutput,
   parseTypedToolOutput,
+  findLastToolPart,
+  extractBatchProgressFromOutput,
+  extractPlanUpdatesFromMessage,
+  extractQuickRepliesFromParts,
   HIDDEN_TOOL_NAMES,
   DISPLAY_TOOL_NAMES,
 };

--- a/packages/web/src/features/chat/lib/chat-utils.ts
+++ b/packages/web/src/features/chat/lib/chat-utils.ts
@@ -168,11 +168,7 @@ function persistedPartToUIPart(
         errorText: part.errorText ?? 'Tool call failed',
       };
     case PersistedChatPartType.BATCH_PROGRESS:
-      return {
-        type: 'data-batch-progress',
-        id: `batch-${idx}`,
-        data: part.data,
-      } as ChatUIMessage['parts'][number];
+      return { type: 'text', text: '' } as ChatUIMessage['parts'][number];
     default: {
       const _exhaustive: never = part;
       throw new Error(
@@ -242,9 +238,6 @@ export const chatUtils = {
     formatToolName({ part }),
   formatToolActionName: ({ part }: { part: AnyToolPart }) =>
     formatToolName({ part, includeContext: false }),
-  extractToolContext,
-  stripPiecePrefix,
-  humanizePieceName,
   mapHistoryToUIMessages,
   extractQuickRepliesFromHistory,
 };

--- a/packages/web/src/features/chat/lib/chunk-reducer.ts
+++ b/packages/web/src/features/chat/lib/chunk-reducer.ts
@@ -265,35 +265,9 @@ function applyChunk({
     case 'tool-approval-request':
       break;
 
-    default: {
-      handleDataChunk({ state, chunk: chunk as DataChunk });
+    default:
       break;
-    }
   }
-}
-
-function handleDataChunk({
-  state,
-  chunk,
-}: {
-  state: StreamingState;
-  chunk: DataChunk;
-}): void {
-  if (!chunk.type?.startsWith('data-')) return;
-  if (chunk.transient) return;
-
-  if (chunk.id) {
-    const existing = state.message.parts.findIndex(
-      (p) => 'id' in p && p.id === chunk.id && p.type === chunk.type,
-    );
-    if (existing >= 0) {
-      (state.message.parts[existing] as Record<string, unknown>).data =
-        chunk.data;
-      return;
-    }
-  }
-
-  state.message.parts.push(chunk as ChatUIMessage['parts'][number]);
 }
 
 function applyChunks({
@@ -308,27 +282,6 @@ function applyChunks({
   }
 }
 
-function extractDataParts({
-  chunks,
-}: {
-  chunks: UIMessageChunk[];
-}): DataPart[] {
-  const result: DataPart[] = [];
-  for (const chunk of chunks) {
-    if (
-      typeof chunk.type === 'string' &&
-      chunk.type.startsWith('data-') &&
-      'data' in chunk
-    ) {
-      result.push({
-        type: chunk.type,
-        data: (chunk as DataChunk).data,
-      });
-    }
-  }
-  return result;
-}
-
 function snapshotMessage({ state }: { state: StreamingState }): ChatUIMessage {
   return {
     ...state.message,
@@ -340,16 +293,9 @@ export const chunkReducer = {
   createStreamingState,
   applyChunk,
   applyChunks,
-  extractDataParts,
   snapshotMessage,
 };
 
-/**
- * Writable view of DynamicToolUIPart fields. The AI SDK types use a discriminated
- * union keyed on `state`, which prevents mutating the discriminant in-place.
- * This type is used only inside updateToolPartFields where we deliberately
- * mutate the runtime object to avoid re-creating it on every chunk.
- */
 type MutableToolPart = Pick<
   DynamicToolUIPart,
   'type' | 'toolCallId' | 'toolName' | 'title'
@@ -368,16 +314,4 @@ type StreamingState = {
   seenToolCallIds: Set<string>;
 };
 
-type DataChunk = {
-  type: string;
-  id?: string;
-  data: unknown;
-  transient?: boolean;
-};
-
-type DataPart = {
-  type: string;
-  data: unknown;
-};
-
-export type { StreamingState, DataPart };
+export type { StreamingState };

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -5,20 +5,19 @@ import {
   DEFAULT_CHAT_TIER_ID,
   ErrorCode,
   isNil,
-  isObject,
-  PlanStepUpdate,
+  ToolApprovalRequestEvent,
+  ToolProgressEvent,
   tryCatch,
 } from '@activepieces/shared';
 import { useQuery } from '@tanstack/react-query';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { api } from '@/lib/api';
 
 import { chatApi } from './chat-api';
 import { useChatStoreApi } from './chat-store-context';
-import { ChatUIMessage } from './chat-types';
+import { ChatUIMessage, chatPartUtils } from './chat-types';
 import { chatUtils } from './chat-utils';
-import { DataPart } from './chunk-reducer';
 import { useStreamingReducer } from './use-streaming-reducer';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
@@ -85,13 +84,6 @@ function injectFilePartsIntoLastUserMessage({
   return result;
 }
 
-const DISPLAY_CARD_DATA_TYPES = new Set([
-  'data-connection-required',
-  'data-connection-picker',
-  'data-project-picker',
-  'data-questions',
-]);
-
 type SendStatus =
   | { type: 'idle' }
   | { type: 'submitting' }
@@ -141,90 +133,46 @@ export function useAgentChat({
   const onConversationCreatedRef = useRef(onConversationCreated);
   onConversationCreatedRef.current = onConversationCreated;
 
-  const handleDataPart = useCallback(
-    (dataPart: DataPart) => {
-      if (!isObject(dataPart.data)) return;
-      const d = dataPart.data as Record<string, unknown>;
+  const handleTitleUpdate = useCallback((title: string) => {
+    onTitleUpdateRef.current?.(title);
+  }, []);
 
-      if (
-        dataPart.type === 'data-session-title' &&
-        typeof d['title'] === 'string'
-      ) {
-        onTitleUpdateRef.current?.(d['title']);
-      }
+  const handleToolProgress = useCallback(
+    (event: ToolProgressEvent) => {
+      store.setState((prev) => {
+        const existing = prev.toolCallMeta[event.toolCallId]?.batchProgress;
+        if (
+          existing &&
+          existing.completed === event.data.completed &&
+          existing.done === event.data.done
+        ) {
+          return prev;
+        }
+        return {
+          toolCallMeta: {
+            ...prev.toolCallMeta,
+            [event.toolCallId]: {
+              ...prev.toolCallMeta[event.toolCallId],
+              batchProgress: event.data,
+            },
+          },
+        };
+      });
+    },
+    [store],
+  );
 
-      switch (dataPart.type) {
-        case 'data-approval-request':
-          if (typeof d.gateId === 'string' && typeof d.toolName === 'string') {
-            store.setState({
-              pendingApprovalRequest: {
-                gateId: d.gateId,
-                toolName: d.toolName,
-                displayName:
-                  typeof d.displayName === 'string'
-                    ? d.displayName
-                    : d.toolName,
-              },
-            });
-          }
-          break;
-
-        case 'data-plan-approval-request':
-          if (typeof d.gateId === 'string') {
-            store.setState({
-              pendingPlanApproval: {
-                gateId: d.gateId,
-                planSummary:
-                  typeof d.planSummary === 'string' ? d.planSummary : '',
-                steps: Array.isArray(d.steps) ? (d.steps as string[]) : [],
-              },
-            });
-          }
-          break;
-
-        case 'data-plan-progress':
-          if (typeof d.stepIndex === 'number' && typeof d.status === 'string') {
-            store.setState((prev) => {
-              const stepIndex = d.stepIndex as number;
-              const status = d.status as PlanStepUpdate['status'];
-              const existing = prev.planProgressUpdates.findIndex(
-                (u) => u.stepIndex === stepIndex,
-              );
-              if (existing >= 0) {
-                const updated = [...prev.planProgressUpdates];
-                updated[existing] = { stepIndex, status };
-                return { planProgressUpdates: updated };
-              }
-              return {
-                planProgressUpdates: [
-                  ...prev.planProgressUpdates,
-                  { stepIndex, status },
-                ],
-              };
-            });
-          }
-          break;
-
-        case 'data-quick-replies':
-          if (Array.isArray(d.replies)) {
-            store.setState({ quickReplies: d.replies as string[] });
-          }
-          break;
-
-        default:
-          if (DISPLAY_CARD_DATA_TYPES.has(dataPart.type)) {
-            const gateId = typeof d['gateId'] === 'string' ? d['gateId'] : '';
-            store.setState({
-              displayCard: {
-                type: dataPart.type,
-                data: d,
-                gateId,
-                resolved: false,
-              },
-            });
-          }
-          break;
-      }
+  const handleToolApprovalRequest = useCallback(
+    (event: ToolApprovalRequestEvent) => {
+      store.setState((prev) => ({
+        toolCallMeta: {
+          ...prev.toolCallMeta,
+          [event.toolCallId]: {
+            ...prev.toolCallMeta[event.toolCallId],
+            approvalRequest: event,
+          },
+        },
+      }));
     },
     [store],
   );
@@ -262,7 +210,9 @@ export function useAgentChat({
     stopStream,
     clearStreamingState,
   } = useStreamingReducer({
-    onDataPart: handleDataPart,
+    onTitleUpdate: handleTitleUpdate,
+    onToolProgress: handleToolProgress,
+    onToolApprovalRequest: handleToolApprovalRequest,
     onStreamFinished: (convId) => {
       void reconcile(convId).then(() => clearStreamingState());
     },
@@ -285,6 +235,17 @@ export function useAgentChat({
       });
     },
   });
+
+  const streamingQuickReplies = useMemo(
+    () => chatPartUtils.extractQuickRepliesFromParts(streamingMessage),
+    [streamingMessage],
+  );
+
+  useEffect(() => {
+    if (streamingQuickReplies.length > 0) {
+      store.setState({ quickReplies: streamingQuickReplies });
+    }
+  }, [streamingQuickReplies, store]);
 
   const isStreamActive = streamPhase !== 'idle';
   const isStreaming =

--- a/packages/web/src/features/chat/lib/use-streaming-reducer.ts
+++ b/packages/web/src/features/chat/lib/use-streaming-reducer.ts
@@ -1,23 +1,32 @@
-import { ChatAgentEventType, WebsocketClientEvent } from '@activepieces/shared';
+import {
+  ChatAgentEventType,
+  ToolApprovalRequestEvent,
+  ToolProgressEvent,
+  WebsocketClientEvent,
+} from '@activepieces/shared';
 import { UIMessageChunk } from 'ai';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useSocket } from '@/components/providers/socket-provider';
 
 import { ChatUIMessage } from './chat-types';
-import { chunkReducer, DataPart, StreamingState } from './chunk-reducer';
+import { chunkReducer, StreamingState } from './chunk-reducer';
 
 const THROTTLE_MS = 100;
 const STREAM_TIMEOUT_MS = 10 * 60 * 1000;
 const STALE_CHECK_INTERVAL_MS = 15_000;
 
 export function useStreamingReducer({
-  onDataPart,
+  onTitleUpdate,
+  onToolProgress,
+  onToolApprovalRequest,
   onStreamFinished,
   onStreamError,
   onStaleCheck,
 }: {
-  onDataPart: (part: DataPart) => void;
+  onTitleUpdate: (title: string) => void;
+  onToolProgress: (event: ToolProgressEvent) => void;
+  onToolApprovalRequest: (event: ToolApprovalRequestEvent) => void;
   onStreamFinished: (conversationId: string) => void;
   onStreamError: (params: {
     conversationId: string;
@@ -40,8 +49,12 @@ export function useStreamingReducer({
   const streamTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
 
-  const onDataPartRef = useRef(onDataPart);
-  onDataPartRef.current = onDataPart;
+  const onTitleUpdateRef = useRef(onTitleUpdate);
+  onTitleUpdateRef.current = onTitleUpdate;
+  const onToolProgressRef = useRef(onToolProgress);
+  onToolProgressRef.current = onToolProgress;
+  const onToolApprovalRequestRef = useRef(onToolApprovalRequest);
+  onToolApprovalRequestRef.current = onToolApprovalRequest;
   const onStreamFinishedRef = useRef(onStreamFinished);
   onStreamFinishedRef.current = onStreamFinished;
   const onStreamErrorRef = useRef(onStreamError);
@@ -64,11 +77,6 @@ export function useStreamingReducer({
     const chunks = chunkBufferRef.current;
     if (chunks.length === 0) return;
     chunkBufferRef.current = [];
-
-    const dataParts = chunkReducer.extractDataParts({ chunks });
-    for (const dp of dataParts) {
-      onDataPartRef.current(dp);
-    }
 
     const state = reducerStateRef.current;
     if (!state) return;
@@ -170,6 +178,19 @@ export function useStreamingReducer({
           });
         } else if (event.type === ChatAgentEventType.FINISHED) {
           handleFinish();
+        } else if (event.type === ChatAgentEventType.TITLE_UPDATE) {
+          const titleData = event.data as { title?: string };
+          if (titleData?.title) {
+            onTitleUpdateRef.current(titleData.title);
+          }
+        } else if (event.type === ChatAgentEventType.TOOL_PROGRESS) {
+          lastChunkTimeRef.current = Date.now();
+          onToolProgressRef.current(event.data as ToolProgressEvent);
+        } else if (event.type === ChatAgentEventType.TOOL_APPROVAL_REQUEST) {
+          lastChunkTimeRef.current = Date.now();
+          onToolApprovalRequestRef.current(
+            event.data as ToolApprovalRequestEvent,
+          );
         }
       };
 

--- a/packages/web/test/features/chat/lib/chunk-reducer.test.ts
+++ b/packages/web/test/features/chat/lib/chunk-reducer.test.ts
@@ -299,99 +299,15 @@ describe('chunkReducer', () => {
     });
   });
 
-  describe('data parts', () => {
-    it('adds non-transient data parts to message', () => {
+  describe('unknown chunk types are ignored', () => {
+    it('ignores data-* chunks (no longer handled by chunk-reducer)', () => {
       const state = createAndApply([
         {
           type: 'data-connection-picker',
           data: { connections: [] },
         } as unknown as UIMessageChunk,
       ]);
-      expect(state.message.parts).toHaveLength(1);
-    });
-
-    it('skips transient data parts from message', () => {
-      const state = createAndApply([
-        {
-          type: 'data-session-title',
-          data: { title: 'Test' },
-          transient: true,
-        } as unknown as UIMessageChunk,
-      ]);
       expect(state.message.parts).toHaveLength(0);
-    });
-
-    it('upserts batch-progress data parts by id', () => {
-      const state = chunkReducer.createStreamingState({ messageId: 'msg-1' });
-
-      chunkReducer.applyChunks({
-        state,
-        chunks: [
-          {
-            type: 'data-batch-progress',
-            id: 'batch-1',
-            data: { label: 'Sending', total: 3, completed: 0, succeeded: 0, failed: 0, done: false, results: [] },
-          } as unknown as UIMessageChunk,
-        ],
-      });
-      expect(state.message.parts).toHaveLength(1);
-
-      chunkReducer.applyChunks({
-        state,
-        chunks: [
-          {
-            type: 'data-batch-progress',
-            id: 'batch-1',
-            data: { label: 'Sending', total: 3, completed: 2, succeeded: 2, failed: 0, done: false, results: [] },
-          } as unknown as UIMessageChunk,
-        ],
-      });
-      expect(state.message.parts).toHaveLength(1);
-      const data = (state.message.parts[0] as unknown as { data: { completed: number } }).data;
-      expect(data.completed).toBe(2);
-    });
-
-    it('appends separate batch-progress parts with different ids', () => {
-      const state = chunkReducer.createStreamingState({ messageId: 'msg-1' });
-
-      chunkReducer.applyChunks({
-        state,
-        chunks: [
-          {
-            type: 'data-batch-progress',
-            id: 'batch-1',
-            data: { label: 'First', total: 1, completed: 1, succeeded: 1, failed: 0, done: true, results: [] },
-          } as unknown as UIMessageChunk,
-          {
-            type: 'data-batch-progress',
-            id: 'batch-2',
-            data: { label: 'Second', total: 1, completed: 0, succeeded: 0, failed: 0, done: false, results: [] },
-          } as unknown as UIMessageChunk,
-        ],
-      });
-      expect(state.message.parts).toHaveLength(2);
-    });
-  });
-
-  describe('extractDataParts', () => {
-    it('extracts data-* chunks from a batch', () => {
-      const chunks: UIMessageChunk[] = [
-        makeChunk({ type: 'text-start', id: 't1' }),
-        {
-          type: 'data-session-title',
-          data: { title: 'Hello' },
-          transient: true,
-        } as unknown as UIMessageChunk,
-        makeChunk({ type: 'text-delta', id: 't1', delta: 'hi' }),
-        {
-          type: 'data-quick-replies',
-          data: { replies: ['a', 'b'] },
-        } as unknown as UIMessageChunk,
-      ];
-      const parts = chunkReducer.extractDataParts({ chunks });
-      expect(parts).toHaveLength(2);
-      expect(parts[0].type).toBe('data-session-title');
-      expect(parts[1].type).toBe('data-quick-replies');
     });
   });
 


### PR DESCRIPTION
## Summary
- Display tools (questions, connection pickers, plan approval) now render entirely from AI SDK tool call state instead of custom `data-*` sideband chunks
- `toolCallId` is used directly as the approval `gateId`, eliminating the separate `apId()` generation and sideband communication
- Batch progress and MCP approval use typed events (`TOOL_PROGRESS`, `TOOL_APPROVAL_REQUEST`) anchored to `toolCallId`
- Session title uses a dedicated `TITLE_UPDATE` event type instead of a `data-session-title` chunk
- Removed `handleDataPart` switch, `displayCard`/`pendingApproval` Zustand state, and `extractDataParts` from chunk-reducer

## Test plan
- [ ] Send a message that triggers `ap_show_questions` — verify interactive card renders and answers flow back
- [ ] Trigger `ap_show_connection_required` — verify card renders and connection completes
- [ ] Trigger plan approval — verify plan card shows, approve/reject works, progress updates live
- [ ] Run a batch action — verify progress card updates during execution
- [ ] Trigger MCP destructive tool — verify approval UI shows on the tool card
- [ ] Load a conversation from history — verify all cards reconstruct correctly
- [ ] Verify quick replies appear after streaming completes
- [ ] Verify session title auto-generates on first message