### PR TITLE
feat(EditionGuard ): add piece with send protected eBook download link

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2422,6 +2422,16 @@
         "zod": "4.3.6",
       },
     },
+    "packages/pieces/community/editionguard": {
+      "name": "@activepieces/piece-editionguard",
+      "version": "0.1.0",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "^2.3.0",
+      },
+    },
     "packages/pieces/community/elastic-email": {
       "name": "@activepieces/piece-elastic-email",
       "version": "0.2.1",
@@ -3075,7 +3085,7 @@
     },
     "packages/pieces/community/google-calendar": {
       "name": "@activepieces/piece-google-calendar",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3155,7 +3165,7 @@
     },
     "packages/pieces/community/google-gemini": {
       "name": "@activepieces/piece-google-gemini",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -8608,7 +8618,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.79.0",
+      "version": "0.81.0",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",
@@ -9158,6 +9168,8 @@
     "@activepieces/piece-echowin": ["@activepieces/piece-echowin@workspace:packages/pieces/community/echowin"],
 
     "@activepieces/piece-eden-ai": ["@activepieces/piece-eden-ai@workspace:packages/pieces/community/eden-ai"],
+
+    "@activepieces/piece-editionguard": ["@activepieces/piece-editionguard@workspace:packages/pieces/community/editionguard"],
 
     "@activepieces/piece-elastic-email": ["@activepieces/piece-elastic-email@workspace:packages/pieces/community/elastic-email"],
 
@@ -15925,6 +15937,8 @@
 
     "@activepieces/piece-crisp/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@activepieces/piece-editionguard/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@activepieces/piece-frill/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@activepieces/piece-google-vertexai/@google/genai": ["@google/genai@1.43.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw=="],
@@ -20318,8 +20332,6 @@
     "@aws-sdk/s3-request-presigner/@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3/@aws-sdk/core": ["@aws-sdk/core@3.894.0", "", { "dependencies": { "@aws-sdk/types": "3.893.0", "@aws-sdk/xml-builder": "3.894.0", "@smithy/core": "^3.11.1", "@smithy/node-config-provider": "^4.2.2", "@smithy/property-provider": "^4.1.1", "@smithy/protocol-http": "^5.2.1", "@smithy/signature-v4": "^5.2.1", "@smithy/smithy-client": "^4.6.3", "@smithy/types": "^4.5.0", "@smithy/util-base64": "^4.1.0", "@smithy/util-body-length-browser": "^4.1.0", "@smithy/util-middleware": "^4.1.1", "@smithy/util-utf8": "^4.1.0", "tslib": "^2.6.2" } }, "sha512-7zbO31NV2FaocmMtWOg/fuTk3PC2Ji2AC0Fi2KqrppEDIcwLlTTuT9w/rdu/93Pz+wyUhCxWnDc0tPbwtCLs+A=="],
 
     "@aws-sdk/s3-request-presigner/@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3/@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.893.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA=="],
-
-    "@aws-sdk/s3-request-presigner/@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3/@smithy/signature-v4": ["@smithy/signature-v4@5.3.14", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA=="],
 
     "@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.0", "", { "dependencies": { "@smithy/types": "^4.12.0", "fast-xml-parser": "5.2.5", "tslib": "^2.6.2" } }, "sha512-POaGMcXnozzqBUyJM3HLUZ9GR6OKJWPGJEmhtTnxZXt8B6JcJ/6K3xRJ5H/j8oovVLz8Wg6vFxAHv8lvuASxMg=="],
 

--- a/packages/pieces/community/editionguard/.eslintrc.json
+++ b/packages/pieces/community/editionguard/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["../../../../.eslintrc.base.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    { "files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {} },
+    { "files": ["*.ts", "*.tsx"], "rules": {} },
+    { "files": ["*.js", "*.jsx"], "rules": {} }
+  ]
+}

--- a/packages/pieces/community/editionguard/package.json
+++ b/packages/pieces/community/editionguard/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-editionguard",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/editionguard/src/index.ts
+++ b/packages/pieces/community/editionguard/src/index.ts
@@ -1,0 +1,27 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/shared';
+import { editionguardAuth } from './lib/common/auth';
+import { sendEbookDownloadLinks } from './lib/actions/send-ebook-download-links';
+
+export const editionguard = createPiece({
+  displayName: 'EditionGuard',
+  description:
+    'Secure eBook DRM and fulfillment — protect and deliver EPUB, MOBI, and PDF files with Adobe DRM, Readium LCP, or Social DRM.',
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/editionguard.png',
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  auth: editionguardAuth,
+  authors: ['sanket-a11y'],
+  actions: [
+    sendEbookDownloadLinks,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://app.editionguard.com/api/v2',
+      auth: editionguardAuth,
+      authMapping: async (auth) => ({
+        Authorization: `token ${auth.secret_text}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/editionguard/src/lib/actions/send-ebook-download-links.ts
+++ b/packages/pieces/community/editionguard/src/lib/actions/send-ebook-download-links.ts
@@ -85,14 +85,6 @@ export const sendEbookDownloadLinks = createAction({
       watermarkPhone: watermark_phone ?? undefined,
     });
 
-    return {
-      transaction_id: transaction.id ?? null,
-      download_link: transaction.download_link ?? null,
-      resource_id: transaction.resource_id ?? null,
-      customer_email: transaction.customer_email ?? null,
-      order_number: transaction.order_number ?? null,
-      status: transaction.status ?? null,
-      created_at: transaction.created_at ?? null,
-    };
+    return transaction
   },
 });

--- a/packages/pieces/community/editionguard/src/lib/actions/send-ebook-download-links.ts
+++ b/packages/pieces/community/editionguard/src/lib/actions/send-ebook-download-links.ts
@@ -1,0 +1,98 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { editionguardAuth } from '../common/auth';
+import { editionguardApi } from '../common/api';
+
+export const sendEbookDownloadLinks = createAction({
+  auth: editionguardAuth,
+  name: 'send_ebook_download_links',
+  displayName: 'Send eBook Download Links',
+  description:
+    'Creates a transaction for an eBook and sends the download link(s) to your customer. Returns the download link you can deliver by email or any other channel.',
+  props: {
+    resource_id: Property.Dropdown({
+      displayName: 'eBook',
+      description: 'Select the eBook to send to your customer.',
+      auth: editionguardAuth,
+      refreshers: [],
+      required: true,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return { disabled: true, options: [], placeholder: 'Please connect your account first.' };
+        }
+        try {
+          const books = await editionguardApi.listBooks({ token: auth.secret_text });
+          return {
+            disabled: false,
+            options: books.map((book) => ({
+              label: `${book.title} (${book.drm_type ?? 'Unknown DRM'})`,
+              value: book.resource_id,
+            })),
+          };
+        } catch {
+          return { disabled: true, options: [], placeholder: 'Failed to load eBooks. Check your connection.' };
+        }
+      },
+    }),
+    customer_email: Property.ShortText({
+      displayName: 'Customer Email',
+      description: "The customer's email address where the download instructions will be sent.",
+      required: true,
+    }),
+    order_number: Property.ShortText({
+      displayName: 'Order Number',
+      description:
+        'Your order or transaction reference number (e.g. from your eCommerce platform). Used for tracking and reporting.',
+      required: true,
+    }),
+    quantity: Property.Number({
+      displayName: 'Quantity',
+      description:
+        'Number of download links to generate. Use 1 for a single copy. Increase for multi-seat or multi-device licenses.',
+      required: false,
+      defaultValue: 1,
+    }),
+    watermark_name: Property.ShortText({
+      displayName: "Customer's Full Name (Social DRM)",
+      description:
+        "Only applies when the eBook uses **Social DRM (EditionMark)**. The customer's name will be embedded as a visible watermark in the eBook. Leave empty for Adobe DRM or Readium LCP books.",
+      required: false,
+    }),
+    watermark_email: Property.ShortText({
+      displayName: "Customer's Email for Watermark (Social DRM)",
+      description:
+        "Only applies when the eBook uses **Social DRM (EditionMark)**. This email will be embedded as a watermark. Leave empty for Adobe DRM or Readium LCP books.",
+      required: false,
+    }),
+    watermark_phone: Property.ShortText({
+      displayName: "Customer's Phone for Watermark (Social DRM)",
+      description:
+        "Only applies when the eBook uses **Social DRM (EditionMark)**. This phone number will be embedded as a watermark. Leave empty for Adobe DRM or Readium LCP books.",
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { resource_id, customer_email, order_number, quantity, watermark_name, watermark_email, watermark_phone } =
+      context.propsValue;
+
+    const transaction = await editionguardApi.createTransaction({
+      token: context.auth.secret_text,
+      resourceId: resource_id,
+      customerEmail: customer_email,
+      orderNumber: order_number,
+      quantity: quantity ?? 1,
+      watermarkName: watermark_name ?? undefined,
+      watermarkEmail: watermark_email ?? undefined,
+      watermarkPhone: watermark_phone ?? undefined,
+    });
+
+    return {
+      transaction_id: transaction.id ?? null,
+      download_link: transaction.download_link ?? null,
+      resource_id: transaction.resource_id ?? null,
+      customer_email: transaction.customer_email ?? null,
+      order_number: transaction.order_number ?? null,
+      status: transaction.status ?? null,
+      created_at: transaction.created_at ?? null,
+    };
+  },
+});

--- a/packages/pieces/community/editionguard/src/lib/common/api.ts
+++ b/packages/pieces/community/editionguard/src/lib/common/api.ts
@@ -1,0 +1,76 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://app.editionguard.com/api/v2';
+
+type Book = {
+  resource_id: string;
+  title: string;
+  drm_type: string;
+};
+
+type BookListResponse = {
+  results: Book[];
+};
+
+type Transaction = {
+  id: string;
+  resource_id: string;
+  download_link: string | null;
+  customer_email: string | null;
+  order_number: string | null;
+  created_at: string;
+  status: string;
+};
+
+async function listBooks({ token }: { token: string }): Promise<Book[]> {
+  const response = await httpClient.sendRequest<BookListResponse>({
+    method: HttpMethod.GET,
+    url: `${BASE_URL}/book`,
+    headers: { Authorization: `token ${token}` },
+    queryParams: { page_size: '100000' },
+  });
+  return response.body.results;
+}
+
+async function createTransaction({
+  token,
+  resourceId,
+  customerEmail,
+  orderNumber,
+  quantity,
+  watermarkName,
+  watermarkEmail,
+  watermarkPhone,
+}: {
+  token: string;
+  resourceId: string;
+  customerEmail: string;
+  orderNumber: string;
+  quantity: number;
+  watermarkName?: string;
+  watermarkEmail?: string;
+  watermarkPhone?: string;
+}): Promise<Transaction> {
+  const body: Record<string, unknown> = {
+    resource_id: resourceId,
+    customer_email: customerEmail,
+    order_number: orderNumber,
+    quantity,
+  };
+  if (watermarkName) body['watermark_name'] = watermarkName;
+  if (watermarkEmail) body['watermark_email'] = watermarkEmail;
+  if (watermarkPhone) body['watermark_phone'] = watermarkPhone;
+
+  const response = await httpClient.sendRequest<Transaction>({
+    method: HttpMethod.POST,
+    url: `${BASE_URL}/transaction`,
+    headers: {
+      Authorization: `token ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body,
+  });
+  return response.body;
+}
+
+export const editionguardApi = { listBooks, createTransaction };

--- a/packages/pieces/community/editionguard/src/lib/common/auth.ts
+++ b/packages/pieces/community/editionguard/src/lib/common/auth.ts
@@ -1,0 +1,28 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://app.editionguard.com/api/v2';
+
+export const editionguardAuth = PieceAuth.SecretText({
+  displayName: 'API Token',
+  description: `Your EditionGuard API token.
+
+**How to get your API token:**
+1. Log in to your [EditionGuard dashboard](https://app.editionguard.com)
+2. Go to **Settings** (top-bar menu)
+3. Find the **API** section and copy your **Rest API Token**`,
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${BASE_URL}/book`,
+        headers: { Authorization: `token ${auth}` },
+        queryParams: { page_size: '1' },
+      });
+      return { valid: true };
+    } catch {
+      return { valid: false, error: 'Invalid API token. Please check your credentials.' };
+    }
+  },
+});

--- a/packages/pieces/community/editionguard/tsconfig.json
+++ b/packages/pieces/community/editionguard/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/editionguard/tsconfig.lib.json
+++ b/packages/pieces/community/editionguard/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -417,6 +417,9 @@
       "@activepieces/piece-eden-ai": [
         "packages/pieces/community/eden-ai/src/index.ts"
       ],
+      "@activepieces/piece-editionguard": [
+        "packages/pieces/community/editionguard/src/index.ts"
+      ],
       "@activepieces/piece-elastic-email": [
         "packages/pieces/community/elastic-email/src/index.ts"
       ],


### PR DESCRIPTION
Adds the EditionGuard eBook DRM & fulfillment piece with:
- SecretText auth using the REST API token
- Send eBook Download Links action (POST /api/v2/transaction)
- Dynamic eBook dropdown populated from GET /api/v2/book
- Custom API Call action for power users

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
