### PR TITLE
fix(web): preserve dynamic property values on refresh

### DIFF
--- a/packages/web/src/app/builder/piece-properties/dynamic-piece-property.tsx
+++ b/packages/web/src/app/builder/piece-properties/dynamic-piece-property.tsx
@@ -66,6 +66,10 @@ const DynamicPropertiesImplementation = React.memo(
     >(undefined);
     const propertyPrefix =
       props.placedInside === 'stepSettings' ? 'settings.input' : '';
+    const dynamicPropertyPath = prependPrefixToPropertyName({
+      propertyName: props.propertyName,
+      prefix: propertyPrefix,
+    });
     const { mutate, isPending } =
       piecesHooks.usePieceOptions<PropertyType.DYNAMIC>({
         onMutate: () => {
@@ -97,18 +101,12 @@ const DynamicPropertiesImplementation = React.memo(
           );
         });
       }
-      form.setValue(
-        prependPrefixToPropertyName({
-          propertyName: props.propertyName,
-          prefix: propertyPrefix,
-        }),
-        null,
-        {
-          shouldValidate: true,
-        },
-      );
+      form.setValue(dynamicPropertyPath, null, {
+        shouldValidate: true,
+      });
     };
     useDeepCompareEffectNoCheck(() => {
+      const valueBeforeClear = form.getValues(dynamicPropertyPath);
       if (!deepEqual(previousRefresherValues.current, refresherValues)) {
         clearPropertyValue();
       }
@@ -129,25 +127,16 @@ const DynamicPropertiesImplementation = React.memo(
         },
         {
           onSuccess: (response) => {
-            const currentValue = form.getValues(
-              prependPrefixToPropertyName({
-                propertyName: props.propertyName,
-                prefix: propertyPrefix,
-              }),
-            );
             const defaultValue = formUtils.getDefaultValueForProperties({
               props: response.options,
-              existingInput: currentValue ?? {},
+              existingInput: valueBeforeClear ?? {},
               propertySettings: props.propertySettings ?? {},
             });
             setPropertyMap(response.options);
             const schemaWithoutDropdownOptions =
               removeOptionsFromDropdownPropertiesSchema(response.options);
             props.updateFormSchema?.(
-              prependPrefixToPropertyName({
-                propertyName: props.propertyName,
-                prefix: propertyPrefix,
-              }),
+              dynamicPropertyPath,
               schemaWithoutDropdownOptions,
             );
 
@@ -158,17 +147,10 @@ const DynamicPropertiesImplementation = React.memo(
                 form,
               );
             }
-            form.setValue(
-              prependPrefixToPropertyName({
-                propertyName: props.propertyName,
-                prefix: propertyPrefix,
-              }),
-              defaultValue,
-              {
-                shouldValidate: true,
-                shouldDirty: true,
-              },
-            );
+            form.setValue(dynamicPropertyPath, defaultValue, {
+              shouldValidate: true,
+              shouldDirty: true,
+            });
           },
         },
       );
@@ -181,10 +163,7 @@ const DynamicPropertiesImplementation = React.memo(
         )}
         {!isPending && propertyMap && (
           <GenericPropertiesForm
-            prefixValue={prependPrefixToPropertyName({
-              propertyName: props.propertyName,
-              prefix: propertyPrefix,
-            })}
+            prefixValue={dynamicPropertyPath}
             props={propertyMap}
             useMentionTextInput={!isNil(props.propertySettings)}
             disabled={props.disabled}


### PR DESCRIPTION
## Summary
- preserve the current dynamic property value snapshot before clearing fields on refresher changes
- reuse the resolved dynamic property path for schema updates, final value writes, and form rendering
- keep the refreshed schema merge path intact so removed child keys are still dropped by `getDefaultValueForProperties`

## Why
When a refresher changes, the component clears the dynamic property value synchronously, then reads the form value inside the async options refresh success handler. By then the value is already `null`, so existing child inputs cannot be merged into the new defaults. Capturing the value before the clear keeps user-entered values available for the existing merge logic.

Closes #13427

## Validation
- `npx prettier --check packages/web/src/app/builder/piece-properties/dynamic-piece-property.tsx`
- `git diff --check`

## Notes
- I did not run a full repo lint/test pass locally. This checkout is running under WSL because the repository currently contains Windows-invalid `:Zone.Identifier` paths, and dependencies are not installed. A transient `npx eslint` invocation pulled ESLint v10, which is incompatible with the repository's `.eslintrc` setup, so I did not count that as a valid lint result.
