### PR TITLE
feat(chat): use different models per tier and native Anthropic thinking

### DIFF
--- a/packages/server/utils/src/chat-ai-utils.ts
+++ b/packages/server/utils/src/chat-ai-utils.ts
@@ -125,10 +125,7 @@ function buildProviderOptions({ provider, tier }: { provider: AIProviderName, ti
             return { anthropic: { thinking: { type: 'enabled', budgetTokens: tier.thinkingBudget } } }
         case AIProviderName.ACTIVEPIECES:
         case AIProviderName.OPENROUTER:
-            return {
-                openrouter: { cache_control: { type: 'ephemeral' } },
-                anthropic: { thinking: { type: 'enabled', budgetTokens: tier.thinkingBudget } },
-            }
+            return { openrouter: { cache_control: { type: 'ephemeral' }, reasoning: { max_tokens: tier.thinkingBudget } } }
         default:
             return {}
     }

--- a/packages/server/utils/src/chat-ai-utils.ts
+++ b/packages/server/utils/src/chat-ai-utils.ts
@@ -118,8 +118,6 @@ function stripThinkingBlocks(messages: ModelMessage[], provider: AIProviderName)
         .filter((msg): msg is ModelMessage => msg !== null)
 }
 
-const OPENROUTER_EFFORT_BY_TIER: Record<string, string> = { fast: 'low', smart: 'medium', premium: 'high' }
-
 function buildProviderOptions({ provider, tier }: { provider: AIProviderName, tier: { id: string, thinkingBudget: number } }): SharedV3ProviderOptions {
     switch (provider) {
         case AIProviderName.ANTHROPIC:
@@ -127,7 +125,10 @@ function buildProviderOptions({ provider, tier }: { provider: AIProviderName, ti
             return { anthropic: { thinking: { type: 'enabled', budgetTokens: tier.thinkingBudget } } }
         case AIProviderName.ACTIVEPIECES:
         case AIProviderName.OPENROUTER:
-            return { openrouter: { cache_control: { type: 'ephemeral' }, reasoning: { effort: OPENROUTER_EFFORT_BY_TIER[tier.id] ?? 'medium' } } }
+            return {
+                openrouter: { cache_control: { type: 'ephemeral' } },
+                anthropic: { thinking: { type: 'enabled', budgetTokens: tier.thinkingBudget } },
+            }
         default:
             return {}
     }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.82.1",
+  "version": "0.82.2",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/shared/src/lib/management/ai-providers/index.ts
@@ -395,9 +395,9 @@ function getMaxContextTokens({ provider }: { provider: AIProviderName | undefine
 }
 
 export const ACTIVEPIECES_CHAT_TIERS = [
-    { id: 'fast', label: 'Fast', modelId: 'anthropic/claude-opus-4.7', thinkingBudget: 5_000 },
-    { id: 'smart', label: 'Expert', modelId: 'anthropic/claude-opus-4.7', thinkingBudget: 10_000 },
-    { id: 'premium', label: 'Heavy', modelId: 'anthropic/claude-opus-4.7', thinkingBudget: 20_000 },
+    { id: 'fast', label: 'Fast', modelId: 'anthropic/claude-haiku-4.5', thinkingBudget: 5_000 },
+    { id: 'smart', label: 'Expert', modelId: 'anthropic/claude-sonnet-4.6', thinkingBudget: 10_000 },
+    { id: 'premium', label: 'Heavy', modelId: 'anthropic/claude-opus-4.8', thinkingBudget: 20_000 },
 ] as const
 
 export const DEFAULT_CHAT_TIER_ID = 'smart' as const


### PR DESCRIPTION
## Summary
- Use distinct Anthropic models for each chat tier instead of Opus 4.7 for all: Haiku 4.5 (Fast), Sonnet 4.6 (Expert), Opus 4.8 (Heavy)
- Switch from OpenRouter's reasoning effort abstraction to Anthropic's native extended thinking API, which produces visible reasoning content instead of `[REDACTED]` blocks
- Remove dead `OPENROUTER_EFFORT_BY_TIER` constant

## Test plan
- [ ] Test Fast tier (Haiku 4.5): simple tasks like "send 3 messages to 3 Slack channels"
- [ ] Test Expert tier (Sonnet 4.6): medium tasks like "classify emails and route to right person"
- [ ] Test Heavy tier (Opus 4.8): complex tasks like "enrich leads with web search"
- [ ] Verify thinking blocks show visible reasoning (no `[REDACTED]`)
- [ ] Verify cost reduction on OpenRouter dashboard