### PR TITLE
feat: add MiniMax AI piece with M3 (default), M2.7, and M2.7-highspeed

### DIFF
--- a/packages/pieces/community/minimax/.eslintrc.json
+++ b/packages/pieces/community/minimax/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/minimax/README.md
+++ b/packages/pieces/community/minimax/README.md
@@ -1,0 +1,14 @@
+# pieces-minimax
+
+[MiniMax](https://www.minimax.io) is an AI company offering large language models with 204K context windows.
+
+## Supported Models
+
+| Model | Description |
+|-------|-------------|
+| MiniMax-M2.5 | Peak Performance. Ultimate Value. Master the Complex |
+| MiniMax-M2.5-highspeed | Same performance, faster and more agile |
+
+## Building
+
+Run `turbo run build --filter=@activepieces/piece-minimax` to build the library.

--- a/packages/pieces/community/minimax/README.md
+++ b/packages/pieces/community/minimax/README.md
@@ -6,6 +6,8 @@
 
 | Model | Description |
 |-------|-------------|
+| MiniMax-M2.7 | Latest flagship model with enhanced reasoning and coding |
+| MiniMax-M2.7-highspeed | High-speed version of M2.7 for low-latency scenarios |
 | MiniMax-M2.5 | Peak Performance. Ultimate Value. Master the Complex |
 | MiniMax-M2.5-highspeed | Same performance, faster and more agile |
 

--- a/packages/pieces/community/minimax/README.md
+++ b/packages/pieces/community/minimax/README.md
@@ -1,15 +1,14 @@
 # pieces-minimax
 
-[MiniMax](https://www.minimax.io) is an AI company offering large language models with 204K context windows.
+[MiniMax](https://www.minimax.io) is an AI company offering large language models with a 512K context window.
 
 ## Supported Models
 
 | Model | Description |
 |-------|-------------|
-| MiniMax-M2.7 | Latest flagship model with enhanced reasoning and coding |
-| MiniMax-M2.7-highspeed | High-speed version of M2.7 for low-latency scenarios |
-| MiniMax-M2.5 | Peak Performance. Ultimate Value. Master the Complex |
-| MiniMax-M2.5-highspeed | Same performance, faster and more agile |
+| MiniMax-M3 | Flagship model with a 512K context window, up to 128K output, and image input support (default) |
+| MiniMax-M2.7 | Previous-generation flagship model with enhanced reasoning and coding |
+| MiniMax-M2.7-highspeed | Previous-generation high-speed variant for low-latency scenarios |
 
 ## Building
 

--- a/packages/pieces/community/minimax/package.json
+++ b/packages/pieces/community/minimax/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@activepieces/piece-minimax",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "openai": "4.67.1",
+    "zod": "4.3.6",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "description": "[MiniMax](https://www.minimax.io) is an AI company offering large language models with 204K context windows.",
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/pieces/community/minimax/package.json
+++ b/packages/pieces/community/minimax/package.json
@@ -15,7 +15,7 @@
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "lint": "eslint 'src/**/*.ts'"
   },
-  "description": "[MiniMax](https://www.minimax.io) is an AI company offering large language models with 204K context windows.",
+  "description": "[MiniMax](https://www.minimax.io) is an AI company offering large language models with a 512K context window.",
   "keywords": [],
   "author": "",
   "license": "ISC"

--- a/packages/pieces/community/minimax/src/index.ts
+++ b/packages/pieces/community/minimax/src/index.ts
@@ -6,7 +6,7 @@ import { askMinimax } from './lib/actions/ask-minimax';
 export const minimax = createPiece({
   displayName: 'MiniMax',
   description:
-    'MiniMax offers large language models with 204K context windows. Models include MiniMax-M2.5 for peak performance and MiniMax-M2.5-highspeed for faster inference.',
+    'MiniMax offers large language models with 204K context windows. Models include MiniMax-M2.7 for enhanced reasoning and coding, and MiniMax-M2.7-highspeed for low-latency scenarios.',
   auth: minimaxAuth,
   categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
   minimumSupportedRelease: '0.36.1',

--- a/packages/pieces/community/minimax/src/index.ts
+++ b/packages/pieces/community/minimax/src/index.ts
@@ -1,0 +1,17 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { minimaxAuth } from './lib/auth';
+import { askMinimax } from './lib/actions/ask-minimax';
+
+export const minimax = createPiece({
+  displayName: 'MiniMax',
+  description:
+    'MiniMax offers large language models with 204K context windows. Models include MiniMax-M2.5 for peak performance and MiniMax-M2.5-highspeed for faster inference.',
+  auth: minimaxAuth,
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/minimax.png',
+  authors: ['octo-patch'],
+  actions: [askMinimax],
+  triggers: [],
+});

--- a/packages/pieces/community/minimax/src/index.ts
+++ b/packages/pieces/community/minimax/src/index.ts
@@ -6,7 +6,7 @@ import { askMinimax } from './lib/actions/ask-minimax';
 export const minimax = createPiece({
   displayName: 'MiniMax',
   description:
-    'MiniMax offers large language models with 204K context windows. Models include MiniMax-M2.7 for enhanced reasoning and coding, and MiniMax-M2.7-highspeed for low-latency scenarios.',
+    'MiniMax offers large language models with a 512K context window. Models include MiniMax-M3 — the flagship model with up to 128K output and image input support — and MiniMax-M2.7 / MiniMax-M2.7-highspeed.',
   auth: minimaxAuth,
   categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
   minimumSupportedRelease: '0.36.1',

--- a/packages/pieces/community/minimax/src/lib/actions/ask-minimax.ts
+++ b/packages/pieces/community/minimax/src/lib/actions/ask-minimax.ts
@@ -1,0 +1,114 @@
+import { minimaxAuth } from '../auth';
+import {
+  createAction,
+  Property,
+  StoreScope,
+} from '@activepieces/pieces-framework';
+import OpenAI from 'openai';
+import { baseUrl, defaultModels } from '../common/common';
+import { z } from 'zod';
+import { propsValidation } from '@activepieces/pieces-common';
+
+export const askMinimax = createAction({
+  auth: minimaxAuth,
+  name: 'ask_minimax',
+  displayName: 'Ask MiniMax',
+  description: 'Ask MiniMax anything you want!',
+  props: {
+    model: Property.StaticDropdown({
+      displayName: 'Model',
+      required: true,
+      description:
+        'The model which will generate the completion. MiniMax-M2.5 offers peak performance, while MiniMax-M2.5-highspeed provides the same performance with faster speed.',
+      defaultValue: 'MiniMax-M2.5',
+      options: {
+        options: defaultModels,
+      },
+    }),
+    prompt: Property.LongText({
+      displayName: 'Question',
+      required: true,
+    }),
+    maxTokens: Property.Number({
+      displayName: 'Maximum Tokens',
+      required: true,
+      description:
+        'The maximum number of tokens to generate. Both models support up to 192K output tokens.',
+      defaultValue: 4096,
+    }),
+    temperature: Property.Number({
+      displayName: 'Temperature',
+      required: false,
+      description:
+        'Controls randomness: Lowering results in less random completions. As the temperature approaches zero, the model will become deterministic and repetitive. Must be between 0 (exclusive) and 1 (inclusive). Default is 1.',
+      defaultValue: 1,
+    }),
+    topP: Property.Number({
+      displayName: 'Top P',
+      required: false,
+      description:
+        'An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. Values <= 1. We generally recommend altering this or temperature but not both.',
+      defaultValue: 1,
+    }),
+    memoryKey: Property.ShortText({
+      displayName: 'Memory Key',
+      description:
+        'A memory key that will keep the chat history shared across runs and flows. Keep it empty to leave MiniMax without memory of previous messages.',
+      required: false,
+    }),
+    roles: Property.Json({
+      displayName: 'Roles',
+      required: false,
+      description: 'Array of roles to specify more accurate response',
+      defaultValue: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+      ],
+    }),
+  },
+  async run({ auth, propsValue, store }) {
+    await propsValidation.validateZod(propsValue, {
+      temperature: z.number().gt(0).lte(1).optional(),
+      memoryKey: z.string().max(128).optional(),
+    });
+    const openai = new OpenAI({
+      baseURL: baseUrl,
+      apiKey: auth.secret_text,
+    });
+    const { model, temperature, maxTokens, topP, prompt, memoryKey } =
+      propsValue;
+
+    let messageHistory: any[] | null = [];
+    if (memoryKey) {
+      messageHistory = (await store.get(memoryKey, StoreScope.PROJECT)) ?? [];
+    }
+
+    messageHistory.push({ role: 'user', content: prompt });
+
+    const rolesArray = propsValue.roles ? (propsValue.roles as any) : [];
+    const roles = rolesArray.map((item: any) => {
+      const rolesEnum = ['system', 'user', 'assistant'];
+      if (!rolesEnum.includes(item.role)) {
+        throw new Error(
+          'The only available roles are: [system, user, assistant]'
+        );
+      }
+      return { role: item.role, content: item.content };
+    });
+
+    const completion = await openai.chat.completions.create({
+      model: model,
+      messages: [...roles, ...messageHistory],
+      temperature: temperature ?? 1,
+      max_tokens: maxTokens,
+      top_p: topP,
+    });
+
+    messageHistory = [...messageHistory, completion.choices[0].message];
+
+    if (memoryKey) {
+      await store.put(memoryKey, messageHistory, StoreScope.PROJECT);
+    }
+
+    return completion.choices[0].message.content;
+  },
+});

--- a/packages/pieces/community/minimax/src/lib/actions/ask-minimax.ts
+++ b/packages/pieces/community/minimax/src/lib/actions/ask-minimax.ts
@@ -19,8 +19,8 @@ export const askMinimax = createAction({
       displayName: 'Model',
       required: true,
       description:
-        'The model which will generate the completion. MiniMax-M2.5 offers peak performance, while MiniMax-M2.5-highspeed provides the same performance with faster speed.',
-      defaultValue: 'MiniMax-M2.5',
+        'The model which will generate the completion. MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.',
+      defaultValue: 'MiniMax-M2.7',
       options: {
         options: defaultModels,
       },

--- a/packages/pieces/community/minimax/src/lib/actions/ask-minimax.ts
+++ b/packages/pieces/community/minimax/src/lib/actions/ask-minimax.ts
@@ -19,8 +19,8 @@ export const askMinimax = createAction({
       displayName: 'Model',
       required: true,
       description:
-        'The model which will generate the completion. MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.',
-      defaultValue: 'MiniMax-M2.7',
+        'The model which will generate the completion. MiniMax-M3 is the latest flagship model with a 512K context window, up to 128K output, and image input support.',
+      defaultValue: 'MiniMax-M3',
       options: {
         options: defaultModels,
       },
@@ -33,7 +33,7 @@ export const askMinimax = createAction({
       displayName: 'Maximum Tokens',
       required: true,
       description:
-        'The maximum number of tokens to generate. Both models support up to 192K output tokens.',
+        'The maximum number of tokens to generate. MiniMax-M3 supports up to 128K output tokens.',
       defaultValue: 4096,
     }),
     temperature: Property.Number({

--- a/packages/pieces/community/minimax/src/lib/auth.ts
+++ b/packages/pieces/community/minimax/src/lib/auth.ts
@@ -1,0 +1,42 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import OpenAI from 'openai';
+import { baseUrl, unauthorizedMessage } from './common/common';
+
+export const minimaxAuth = PieceAuth.SecretText({
+  description: `
+  Follow these instructions to get your MiniMax API Key:
+
+1. Visit https://platform.minimax.io and sign up for an account.
+2. Navigate to the API Keys section to create and copy your API key.`,
+  displayName: 'API Key',
+  required: true,
+  validate: async (auth) => {
+    try {
+      const openai = new OpenAI({
+        baseURL: baseUrl,
+        apiKey: auth.auth,
+      });
+
+      const response = await openai.chat.completions.create({
+        model: 'MiniMax-M2.5-highspeed',
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 1,
+      });
+      if (response.choices.length > 0) {
+        return {
+          valid: true,
+        };
+      } else {
+        return {
+          valid: false,
+          error: unauthorizedMessage,
+        };
+      }
+    } catch (e) {
+      return {
+        valid: false,
+        error: unauthorizedMessage,
+      };
+    }
+  },
+});

--- a/packages/pieces/community/minimax/src/lib/auth.ts
+++ b/packages/pieces/community/minimax/src/lib/auth.ts
@@ -18,7 +18,7 @@ export const minimaxAuth = PieceAuth.SecretText({
       });
 
       const response = await openai.chat.completions.create({
-        model: 'MiniMax-M2.5-highspeed',
+        model: 'MiniMax-M3',
         messages: [{ role: 'user', content: 'Hi' }],
         max_tokens: 1,
       });

--- a/packages/pieces/community/minimax/src/lib/common/common.ts
+++ b/packages/pieces/community/minimax/src/lib/common/common.ts
@@ -1,0 +1,16 @@
+export const baseUrl = 'https://api.minimax.io/v1';
+
+export const unauthorizedMessage = `Error Occurred: 401 \n
+Ensure that your MiniMax API key is valid. \n
+You can get your API key from https://platform.minimax.io \n`;
+
+export const defaultModels = [
+  {
+    label: 'MiniMax-M2.5',
+    value: 'MiniMax-M2.5',
+  },
+  {
+    label: 'MiniMax-M2.5-highspeed',
+    value: 'MiniMax-M2.5-highspeed',
+  },
+];

--- a/packages/pieces/community/minimax/src/lib/common/common.ts
+++ b/packages/pieces/community/minimax/src/lib/common/common.ts
@@ -6,6 +6,14 @@ You can get your API key from https://platform.minimax.io \n`;
 
 export const defaultModels = [
   {
+    label: 'MiniMax-M2.7',
+    value: 'MiniMax-M2.7',
+  },
+  {
+    label: 'MiniMax-M2.7-highspeed',
+    value: 'MiniMax-M2.7-highspeed',
+  },
+  {
     label: 'MiniMax-M2.5',
     value: 'MiniMax-M2.5',
   },

--- a/packages/pieces/community/minimax/src/lib/common/common.ts
+++ b/packages/pieces/community/minimax/src/lib/common/common.ts
@@ -6,19 +6,15 @@ You can get your API key from https://platform.minimax.io \n`;
 
 export const defaultModels = [
   {
+    label: 'MiniMax-M3',
+    value: 'MiniMax-M3',
+  },
+  {
     label: 'MiniMax-M2.7',
     value: 'MiniMax-M2.7',
   },
   {
     label: 'MiniMax-M2.7-highspeed',
     value: 'MiniMax-M2.7-highspeed',
-  },
-  {
-    label: 'MiniMax-M2.5',
-    value: 'MiniMax-M2.5',
-  },
-  {
-    label: 'MiniMax-M2.5-highspeed',
-    value: 'MiniMax-M2.5-highspeed',
   },
 ];

--- a/packages/pieces/community/minimax/tsconfig.json
+++ b/packages/pieces/community/minimax/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/minimax/tsconfig.lib.json
+++ b/packages/pieces/community/minimax/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,14 +12,23 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": ["es2022", "dom"],
+    "lib": [
+      "es2022",
+      "dom"
+    ],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@activepieces/ee-auth": ["packages/ee/auth/src/index.ts"],
-      "@activepieces/ee/billing/ui": ["packages/ee/billing/ui/src/index.ts"],
-      "@activepieces/engine": ["packages/server/engine/src/main.ts"],
+      "@activepieces/ee-auth": [
+        "packages/ee/auth/src/index.ts"
+      ],
+      "@activepieces/ee/billing/ui": [
+        "packages/ee/billing/ui/src/index.ts"
+      ],
+      "@activepieces/engine": [
+        "packages/server/engine/src/main.ts"
+      ],
       "@activepieces/piece-activecampaign": [
         "packages/pieces/community/activecampaign/src/index.ts"
       ],
@@ -44,11 +53,17 @@
       "@activepieces/piece-agentx": [
         "packages/pieces/community/agentx/src/index.ts"
       ],
+      "@activepieces/piece-ai": [
+        "packages/pieces/community/ai/src/index.ts"
+      ],
       "@activepieces/piece-aianswer": [
         "packages/pieces/community/aianswer/src/index.ts"
       ],
       "@activepieces/piece-aidbase": [
         "packages/pieces/community/aidbase/src/index.ts"
+      ],
+      "@activepieces/piece-air-ops": [
+        "packages/pieces/community/air-ops/src/index.ts"
       ],
       "@activepieces/piece-aircall": [
         "packages/pieces/community/aircall/src/index.ts"
@@ -62,8 +77,23 @@
       "@activepieces/piece-airtop": [
         "packages/pieces/community/airtop/src/index.ts"
       ],
+      "@activepieces/piece-alai": [
+        "packages/pieces/community/alai/src/index.ts"
+      ],
+      "@activepieces/piece-alt-text-ai": [
+        "packages/pieces/community/alt-text-ai/src/index.ts"
+      ],
+      "@activepieces/piece-alttextify": [
+        "packages/pieces/community/alttextify/src/index.ts"
+      ],
+      "@activepieces/piece-amazon-bedrock": [
+        "packages/pieces/community/amazon-bedrock/src/index.ts"
+      ],
       "@activepieces/piece-amazon-s3": [
         "packages/pieces/community/amazon-s3/src/index.ts"
+      ],
+      "@activepieces/piece-amazon-secrets-manager": [
+        "packages/pieces/community/amazon-secrets-manager/src/index.ts"
       ],
       "@activepieces/piece-amazon-sns": [
         "packages/pieces/community/amazon-sns/src/index.ts"
@@ -76,6 +106,9 @@
       ],
       "@activepieces/piece-aminos": [
         "packages/pieces/community/aminos/src/index.ts"
+      ],
+      "@activepieces/piece-ampeco": [
+        "packages/pieces/community/ampeco/src/index.ts"
       ],
       "@activepieces/piece-anyhook-graphql": [
         "packages/pieces/community/anyhook-graphql/src/index.ts"
@@ -95,6 +128,9 @@
       "@activepieces/piece-apollo": [
         "packages/pieces/community/apollo/src/index.ts"
       ],
+      "@activepieces/piece-appfollow": [
+        "packages/pieces/community/appfollow/src/index.ts"
+      ],
       "@activepieces/piece-approval": [
         "packages/pieces/core/approval/src/index.ts"
       ],
@@ -103,6 +139,12 @@
       ],
       "@activepieces/piece-ashby": [
         "packages/pieces/community/ashby/src/index.ts"
+      ],
+      "@activepieces/piece-ask-handle": [
+        "packages/pieces/community/ask-handle/src/index.ts"
+      ],
+      "@activepieces/piece-asknews": [
+        "packages/pieces/community/asknews/src/index.ts"
       ],
       "@activepieces/piece-assembled": [
         "packages/pieces/community/assembled/src/index.ts"
@@ -119,6 +161,9 @@
       "@activepieces/piece-avoma": [
         "packages/pieces/community/avoma/src/index.ts"
       ],
+      "@activepieces/piece-azure-blob-storage": [
+        "packages/pieces/community/azure-blob-storage/src/index.ts"
+      ],
       "@activepieces/piece-azure-communication-services": [
         "packages/pieces/community/azure-communication-services/src/index.ts"
       ],
@@ -134,6 +179,15 @@
       "@activepieces/piece-bannerbear": [
         "packages/pieces/community/bannerbear/src/index.ts"
       ],
+      "@activepieces/piece-barcode-lookup": [
+        "packages/pieces/community/barcode-lookup/src/index.ts"
+      ],
+      "@activepieces/piece-baremetrics": [
+        "packages/pieces/community/baremetrics/src/index.ts"
+      ],
+      "@activepieces/piece-base44": [
+        "packages/pieces/community/base44/src/index.ts"
+      ],
       "@activepieces/piece-baserow": [
         "packages/pieces/community/baserow/src/index.ts"
       ],
@@ -146,11 +200,17 @@
       "@activepieces/piece-bettermode": [
         "packages/pieces/community/bettermode/src/index.ts"
       ],
+      "@activepieces/piece-bexio": [
+        "packages/pieces/community/bexio/src/index.ts"
+      ],
       "@activepieces/piece-bigin-by-zoho": [
         "packages/pieces/community/bigin-by-zoho/src/index.ts"
       ],
       "@activepieces/piece-bika": [
         "packages/pieces/community/bika/src/index.ts"
+      ],
+      "@activepieces/piece-billplz": [
+        "packages/pieces/community/billplz/src/index.ts"
       ],
       "@activepieces/piece-binance": [
         "packages/pieces/community/binance/src/index.ts"
@@ -164,10 +224,24 @@
       "@activepieces/piece-bluesky": [
         "packages/pieces/community/bluesky/src/index.ts"
       ],
+      "@activepieces/piece-bokio": [
+        "packages/pieces/community/bokio/src/index.ts"
+      ],
+      "@activepieces/piece-bolna": [
+        "packages/pieces/community/bolna/src/index.ts"
+      ],
       "@activepieces/piece-bonjoro": [
         "packages/pieces/community/bonjoro/src/index.ts"
       ],
-      "@activepieces/piece-box": ["packages/pieces/community/box/src/index.ts"],
+      "@activepieces/piece-bookedin": [
+        "packages/pieces/community/bookedin/src/index.ts"
+      ],
+      "@activepieces/piece-box": [
+        "packages/pieces/community/box/src/index.ts"
+      ],
+      "@activepieces/piece-brave-search": [
+        "packages/pieces/community/brave-search/src/index.ts"
+      ],
       "@activepieces/piece-brilliant-directories": [
         "packages/pieces/community/brilliant-directories/src/index.ts"
       ],
@@ -182,6 +256,9 @@
       ],
       "@activepieces/piece-bumpups": [
         "packages/pieces/community/bumpups/src/index.ts"
+      ],
+      "@activepieces/piece-bursty-ai": [
+        "packages/pieces/community/bursty-ai/src/index.ts"
       ],
       "@activepieces/piece-cal-com": [
         "packages/pieces/community/cal-com/src/index.ts"
@@ -210,11 +287,23 @@
       "@activepieces/piece-certopus": [
         "packages/pieces/community/certopus/src/index.ts"
       ],
+      "@activepieces/piece-chain-aware": [
+        "packages/pieces/community/chain-aware/src/index.ts"
+      ],
       "@activepieces/piece-chainalysis-api": [
         "packages/pieces/community/chainalysis-api/src/index.ts"
       ],
+      "@activepieces/piece-chaindesk": [
+        "packages/pieces/community/chaindesk/src/index.ts"
+      ],
       "@activepieces/piece-chargekeep": [
         "packages/pieces/community/chargekeep/src/index.ts"
+      ],
+      "@activepieces/piece-chartly": [
+        "packages/pieces/community/chartly/src/index.ts"
+      ],
+      "@activepieces/piece-chat-aid": [
+        "packages/pieces/community/chat-aid/src/index.ts"
       ],
       "@activepieces/piece-chat-data": [
         "packages/pieces/community/chat-data/src/index.ts"
@@ -222,8 +311,20 @@
       "@activepieces/piece-chatbase": [
         "packages/pieces/community/chatbase/src/index.ts"
       ],
+      "@activepieces/piece-chatfly": [
+        "packages/pieces/community/chatfly/src/index.ts"
+      ],
+      "@activepieces/piece-chatling": [
+        "packages/pieces/community/chatling/src/index.ts"
+      ],
+      "@activepieces/piece-chatnode": [
+        "packages/pieces/community/chatnode/src/index.ts"
+      ],
+      "@activepieces/piece-chatsistant": [
+        "packages/pieces/community/chatsistant/src/index.ts"
+      ],
       "@activepieces/piece-chatwoot": [
-      "packages/pieces/community/chatwoot/src/index.ts"
+        "packages/pieces/community/chatwoot/src/index.ts"
       ],
       "@activepieces/piece-checkout": [
         "packages/pieces/community/checkout/src/index.ts"
@@ -239,6 +340,12 @@
       ],
       "@activepieces/piece-clearout": [
         "packages/pieces/community/clearout/src/index.ts"
+      ],
+      "@activepieces/piece-clearoutphone": [
+        "packages/pieces/community/clearoutphone/src/index.ts"
+      ],
+      "@activepieces/piece-clicdata": [
+        "packages/pieces/community/clicdata/src/index.ts"
       ],
       "@activepieces/piece-clickfunnels": [
         "packages/pieces/community/clickfunnels/src/index.ts"
@@ -258,9 +365,6 @@
       "@activepieces/piece-close": [
         "packages/pieces/community/close/src/index.ts"
       ],
-      "@activepieces/piece-cohere": [
-      "packages/pieces/community/cohere/src/index.ts"
-      ],
       "@activepieces/piece-cloudconvert": [
         "packages/pieces/community/cloudconvert/src/index.ts"
       ],
@@ -278,6 +382,9 @@
       ],
       "@activepieces/piece-cognito-forms": [
         "packages/pieces/community/cognito-forms/src/index.ts"
+      ],
+      "@activepieces/piece-cohere": [
+        "packages/pieces/community/cohere/src/index.ts"
       ],
       "@activepieces/piece-cometapi": [
         "packages/pieces/community/cometapi/src/index.ts"
@@ -297,6 +404,9 @@
       "@activepieces/piece-contentful": [
         "packages/pieces/community/contentful/src/index.ts"
       ],
+      "@activepieces/piece-contextual-ai": [
+        "packages/pieces/community/contextual-ai/src/index.ts"
+      ],
       "@activepieces/piece-contiguity": [
         "packages/pieces/community/contiguity/src/index.ts"
       ],
@@ -309,15 +419,35 @@
       "@activepieces/piece-copy-ai": [
         "packages/pieces/community/copy-ai/src/index.ts"
       ],
+      "@activepieces/piece-coralogix": [
+        "packages/pieces/community/coralogix/src/index.ts"
+      ],
+      "@activepieces/piece-couchbase": [
+        "packages/pieces/community/couchbase/src/index.ts"
+      ],
       "@activepieces/piece-crisp": [
         "packages/pieces/community/crisp/src/index.ts"
       ],
       "@activepieces/piece-crypto": [
         "packages/pieces/core/crypto/src/index.ts"
       ],
-      "@activepieces/piece-csv": ["packages/pieces/core/csv/src/index.ts"],
+      "@activepieces/piece-cryptolens": [
+        "packages/pieces/community/cryptolens/src/index.ts"
+      ],
+      "@activepieces/piece-csv": [
+        "packages/pieces/core/csv/src/index.ts"
+      ],
+      "@activepieces/piece-cursor": [
+        "packages/pieces/community/cursor/src/index.ts"
+      ],
+      "@activepieces/piece-customgpt": [
+        "packages/pieces/community/customgpt/src/index.ts"
+      ],
       "@activepieces/piece-dappier": [
         "packages/pieces/community/dappier/src/index.ts"
+      ],
+      "@activepieces/piece-dashworks": [
+        "packages/pieces/community/dashworks/src/index.ts"
       ],
       "@activepieces/piece-data-mapper": [
         "packages/pieces/core/data-mapper/src/index.ts"
@@ -327,6 +457,9 @@
       ],
       "@activepieces/piece-datadog": [
         "packages/pieces/community/datadog/src/index.ts"
+      ],
+      "@activepieces/piece-datafuel": [
+        "packages/pieces/community/datafuel/src/index.ts"
       ],
       "@activepieces/piece-date-helper": [
         "packages/pieces/core/date-helper/src/index.ts"
@@ -346,8 +479,20 @@
       "@activepieces/piece-delay": [
         "packages/pieces/core/delay/src/index.ts"
       ],
+      "@activepieces/piece-denser-ai": [
+        "packages/pieces/community/denser-ai/src/index.ts"
+      ],
+      "@activepieces/piece-detecting-ai": [
+        "packages/pieces/community/detecting-ai/src/index.ts"
+      ],
       "@activepieces/piece-devin": [
         "packages/pieces/community/devin/src/index.ts"
+      ],
+      "@activepieces/piece-digital-ocean": [
+        "packages/pieces/community/digital-ocean/src/index.ts"
+      ],
+      "@activepieces/piece-digital-pilot": [
+        "packages/pieces/community/digital-pilot/src/index.ts"
       ],
       "@activepieces/piece-dimo": [
         "packages/pieces/community/dimo/src/index.ts"
@@ -364,6 +509,15 @@
       "@activepieces/piece-docsbot": [
         "packages/pieces/community/docsbot/src/index.ts"
       ],
+      "@activepieces/piece-doctly": [
+        "packages/pieces/community/doctly/src/index.ts"
+      ],
+      "@activepieces/piece-documentpro": [
+        "packages/pieces/community/documentpro/src/index.ts"
+      ],
+      "@activepieces/piece-documerge": [
+        "packages/pieces/community/documerge/src/index.ts"
+      ],
       "@activepieces/piece-docusign": [
         "packages/pieces/community/docusign/src/index.ts"
       ],
@@ -376,8 +530,17 @@
       "@activepieces/piece-drupal": [
         "packages/pieces/community/drupal/src/index.ts"
       ],
+      "@activepieces/piece-duckdb": [
+        "packages/pieces/community/duckdb/src/index.ts"
+      ],
       "@activepieces/piece-dumpling-ai": [
         "packages/pieces/community/dumpling-ai/src/index.ts"
+      ],
+      "@activepieces/piece-easy-peasy-ai": [
+        "packages/pieces/community/easy-peasy-ai/src/index.ts"
+      ],
+      "@activepieces/piece-echowin": [
+        "packages/pieces/community/echowin/src/index.ts"
       ],
       "@activepieces/piece-eden-ai": [
         "packages/pieces/community/eden-ai/src/index.ts"
@@ -388,15 +551,26 @@
       "@activepieces/piece-emailoctopus": [
         "packages/pieces/community/emailoctopus/src/index.ts"
       ],
+      "@activepieces/piece-esignatures": [
+        "packages/pieces/community/esignatures/src/index.ts"
+      ],
       "@activepieces/piece-eth-name-service": [
         "packages/pieces/community/eth-name-service/src/index.ts"
       ],
-      "@activepieces/piece-exa": ["packages/pieces/community/exa/src/index.ts"],
+      "@activepieces/piece-exa": [
+        "packages/pieces/community/exa/src/index.ts"
+      ],
       "@activepieces/piece-facebook-leads": [
         "packages/pieces/community/facebook-leads/src/index.ts"
       ],
       "@activepieces/piece-facebook-pages": [
         "packages/pieces/community/facebook-pages/src/index.ts"
+      ],
+      "@activepieces/piece-feathery": [
+        "packages/pieces/community/feathery/src/index.ts"
+      ],
+      "@activepieces/piece-fellow": [
+        "packages/pieces/community/fellow/src/index.ts"
       ],
       "@activepieces/piece-figma": [
         "packages/pieces/community/figma/src/index.ts"
@@ -416,11 +590,17 @@
       "@activepieces/piece-fireflies-ai": [
         "packages/pieces/community/fireflies-ai/src/index.ts"
       ],
+      "@activepieces/piece-flipando": [
+        "packages/pieces/community/flipando/src/index.ts"
+      ],
       "@activepieces/piece-fliqr-ai": [
         "packages/pieces/community/fliqr-ai/src/index.ts"
       ],
       "@activepieces/piece-flow-helper": [
         "packages/pieces/community/flow-helper/src/index.ts"
+      ],
+      "@activepieces/piece-flow-parser": [
+        "packages/pieces/community/flow-parser/src/index.ts"
       ],
       "@activepieces/piece-flowise": [
         "packages/pieces/community/flowise/src/index.ts"
@@ -434,14 +614,32 @@
       "@activepieces/piece-formbricks": [
         "packages/pieces/community/formbricks/src/index.ts"
       ],
+      "@activepieces/piece-formitable": [
+        "packages/pieces/community/formitable/src/index.ts"
+      ],
       "@activepieces/piece-forms": [
         "packages/pieces/core/forms/src/index.ts"
+      ],
+      "@activepieces/piece-formsite": [
+        "packages/pieces/community/formsite/src/index.ts"
+      ],
+      "@activepieces/piece-formspark": [
+        "packages/pieces/community/formspark/src/index.ts"
       ],
       "@activepieces/piece-formstack": [
         "packages/pieces/community/formstack/src/index.ts"
       ],
+      "@activepieces/piece-fountain": [
+        "packages/pieces/community/fountain/src/index.ts"
+      ],
+      "@activepieces/piece-fragment": [
+        "packages/pieces/community/fragment/src/index.ts"
+      ],
       "@activepieces/piece-frame": [
         "packages/pieces/community/frame/src/index.ts"
+      ],
+      "@activepieces/piece-free-agent": [
+        "packages/pieces/community/free-agent/src/index.ts"
       ],
       "@activepieces/piece-freshdesk": [
         "packages/pieces/community/freshdesk/src/index.ts"
@@ -461,17 +659,26 @@
       "@activepieces/piece-gcloud-pubsub": [
         "packages/pieces/community/gcloud-pubsub/src/index.ts"
       ],
+      "@activepieces/piece-gender-api": [
+        "packages/pieces/community/gender-api/src/index.ts"
+      ],
       "@activepieces/piece-generatebanners": [
         "packages/pieces/community/generatebanners/src/index.ts"
       ],
       "@activepieces/piece-ghostcms": [
         "packages/pieces/community/ghostcms/src/index.ts"
       ],
+      "@activepieces/piece-giftbit": [
+        "packages/pieces/community/giftbit/src/index.ts"
+      ],
       "@activepieces/piece-github": [
         "packages/pieces/community/github/src/index.ts"
       ],
       "@activepieces/piece-gitlab": [
         "packages/pieces/community/gitlab/src/index.ts"
+      ],
+      "@activepieces/piece-gladia": [
+        "packages/pieces/community/gladia/src/index.ts"
       ],
       "@activepieces/piece-gmail": [
         "packages/pieces/community/gmail/src/index.ts"
@@ -497,6 +704,9 @@
       "@activepieces/piece-google-my-business": [
         "packages/pieces/community/google-my-business/src/index.ts"
       ],
+      "@activepieces/piece-google-search": [
+        "packages/pieces/community/google-search/src/index.ts"
+      ],
       "@activepieces/piece-google-search-console": [
         "packages/pieces/community/google-search-console/src/index.ts"
       ],
@@ -515,11 +725,23 @@
       "@activepieces/piece-gotify": [
         "packages/pieces/community/gotify/src/index.ts"
       ],
+      "@activepieces/piece-gptzero-detect-ai": [
+        "packages/pieces/community/gptzero-detect-ai/src/index.ts"
+      ],
       "@activepieces/piece-graphql": [
         "packages/pieces/core/graphql/src/index.ts"
       ],
       "@activepieces/piece-gravityforms": [
         "packages/pieces/community/gravityforms/src/index.ts"
+      ],
+      "@activepieces/piece-greenpt": [
+        "packages/pieces/community/greenpt/src/index.ts"
+      ],
+      "@activepieces/piece-greip": [
+        "packages/pieces/community/greip/src/index.ts"
+      ],
+      "@activepieces/piece-griptape": [
+        "packages/pieces/community/griptape/src/index.ts"
       ],
       "@activepieces/piece-grist": [
         "packages/pieces/community/grist/src/index.ts"
@@ -530,11 +752,20 @@
       "@activepieces/piece-groq": [
         "packages/pieces/community/groq/src/index.ts"
       ],
+      "@activepieces/piece-guidelite": [
+        "packages/pieces/community/guidelite/src/index.ts"
+      ],
       "@activepieces/piece-hackernews": [
         "packages/pieces/community/hackernews/src/index.ts"
       ],
       "@activepieces/piece-harvest": [
         "packages/pieces/community/harvest/src/index.ts"
+      ],
+      "@activepieces/piece-hashi-corp-vault": [
+        "packages/pieces/community/hashi-corp-vault/src/index.ts"
+      ],
+      "@activepieces/piece-hastewire": [
+        "packages/pieces/community/hastewire/src/index.ts"
       ],
       "@activepieces/piece-heartbeat": [
         "packages/pieces/community/heartbeat/src/index.ts"
@@ -548,6 +779,12 @@
       "@activepieces/piece-heygen": [
         "packages/pieces/community/heygen/src/index.ts"
       ],
+      "@activepieces/piece-heymarket-sms": [
+        "packages/pieces/community/heymarket-sms/src/index.ts"
+      ],
+      "@activepieces/piece-housecall-pro": [
+        "packages/pieces/community/housecall-pro/src/index.ts"
+      ],
       "@activepieces/piece-http": [
         "packages/pieces/core/http/src/index.ts"
       ],
@@ -560,8 +797,14 @@
       "@activepieces/piece-hugging-face": [
         "packages/pieces/community/hugging-face/src/index.ts"
       ],
+      "@activepieces/piece-hume-ai": [
+        "packages/pieces/community/hume-ai/src/index.ts"
+      ],
       "@activepieces/piece-hunter": [
         "packages/pieces/community/hunter/src/index.ts"
+      ],
+      "@activepieces/piece-hystruct": [
+        "packages/pieces/community/hystruct/src/index.ts"
       ],
       "@activepieces/piece-image-ai": [
         "packages/pieces/community/image-ai/src/index.ts"
@@ -569,11 +812,23 @@
       "@activepieces/piece-image-helper": [
         "packages/pieces/core/image-helper/src/index.ts"
       ],
+      "@activepieces/piece-image-router": [
+        "packages/pieces/community/image-router/src/index.ts"
+      ],
       "@activepieces/piece-imap": [
         "packages/pieces/community/imap/src/index.ts"
       ],
+      "@activepieces/piece-influencers-club": [
+        "packages/pieces/community/influencers-club/src/index.ts"
+      ],
       "@activepieces/piece-insighto-ai": [
         "packages/pieces/community/insighto-ai/src/index.ts"
+      ],
+      "@activepieces/piece-insta-charts": [
+        "packages/pieces/community/insta-charts/src/index.ts"
+      ],
+      "@activepieces/piece-instabase": [
+        "packages/pieces/community/instabase/src/index.ts"
       ],
       "@activepieces/piece-instagram-business": [
         "packages/pieces/community/instagram-business/src/index.ts"
@@ -599,11 +854,23 @@
       "@activepieces/piece-json": [
         "packages/pieces/community/json/src/index.ts"
       ],
+      "@activepieces/piece-just-invoice": [
+        "packages/pieces/community/just-invoice/src/index.ts"
+      ],
       "@activepieces/piece-kallabot-ai": [
         "packages/pieces/community/kallabot-ai/src/index.ts"
       ],
+      "@activepieces/piece-kapso": [
+        "packages/pieces/community/kapso/src/index.ts"
+      ],
+      "@activepieces/piece-katana": [
+        "packages/pieces/community/katana/src/index.ts"
+      ],
       "@activepieces/piece-kimai": [
         "packages/pieces/community/kimai/src/index.ts"
+      ],
+      "@activepieces/piece-kissflow": [
+        "packages/pieces/community/kissflow/src/index.ts"
       ],
       "@activepieces/piece-kizeo-forms": [
         "packages/pieces/community/kizeo-forms/src/index.ts"
@@ -620,11 +887,29 @@
       "@activepieces/piece-krisp-call": [
         "packages/pieces/community/krisp-call/src/index.ts"
       ],
+      "@activepieces/piece-kudosity": [
+        "packages/pieces/community/kudosity/src/index.ts"
+      ],
       "@activepieces/piece-lead-connector": [
         "packages/pieces/community/lead-connector/src/index.ts"
       ],
+      "@activepieces/piece-leap-ai": [
+        "packages/pieces/community/leap-ai/src/index.ts"
+      ],
+      "@activepieces/piece-leexi": [
+        "packages/pieces/community/leexi/src/index.ts"
+      ],
       "@activepieces/piece-lemlist": [
         "packages/pieces/community/lemlist/src/index.ts"
+      ],
+      "@activepieces/piece-lemon-squeezy": [
+        "packages/pieces/community/lemon-squeezy/src/index.ts"
+      ],
+      "@activepieces/piece-lets-calendar": [
+        "packages/pieces/community/lets-calendar/src/index.ts"
+      ],
+      "@activepieces/piece-letta": [
+        "packages/pieces/community/letta/src/index.ts"
       ],
       "@activepieces/piece-line": [
         "packages/pieces/community/line/src/index.ts"
@@ -638,14 +923,38 @@
       "@activepieces/piece-linkedin": [
         "packages/pieces/community/linkedin/src/index.ts"
       ],
+      "@activepieces/piece-linkup": [
+        "packages/pieces/community/linkup/src/index.ts"
+      ],
+      "@activepieces/piece-livesession": [
+        "packages/pieces/community/livesession/src/index.ts"
+      ],
       "@activepieces/piece-llmrails": [
         "packages/pieces/community/llmrails/src/index.ts"
       ],
       "@activepieces/piece-localai": [
         "packages/pieces/community/localai/src/index.ts"
       ],
+      "@activepieces/piece-lofty": [
+        "packages/pieces/community/lofty/src/index.ts"
+      ],
+      "@activepieces/piece-logrocket": [
+        "packages/pieces/community/logrocket/src/index.ts"
+      ],
+      "@activepieces/piece-logsnag": [
+        "packages/pieces/community/logsnag/src/index.ts"
+      ],
+      "@activepieces/piece-lokalise": [
+        "packages/pieces/community/lokalise/src/index.ts"
+      ],
+      "@activepieces/piece-lucidya": [
+        "packages/pieces/community/lucidya/src/index.ts"
+      ],
       "@activepieces/piece-lusha": [
         "packages/pieces/community/lusha/src/index.ts"
+      ],
+      "@activepieces/piece-luxury-presence": [
+        "packages/pieces/community/luxury-presence/src/index.ts"
       ],
       "@activepieces/piece-magical-api": [
         "packages/pieces/community/magical-api/src/index.ts"
@@ -662,8 +971,17 @@
       "@activepieces/piece-mailer-lite": [
         "packages/pieces/community/mailer-lite/src/index.ts"
       ],
+      "@activepieces/piece-mailercheck": [
+        "packages/pieces/community/mailercheck/src/index.ts"
+      ],
       "@activepieces/piece-maileroo": [
         "packages/pieces/community/maileroo/src/index.ts"
+      ],
+      "@activepieces/piece-manual-trigger": [
+        "packages/pieces/core/manual-trigger/src/index.ts"
+      ],
+      "@activepieces/piece-manus": [
+        "packages/pieces/community/manus/src/index.ts"
       ],
       "@activepieces/piece-manychat": [
         "packages/pieces/community/manychat/src/index.ts"
@@ -686,16 +1004,29 @@
       "@activepieces/piece-mautic": [
         "packages/pieces/community/mautic/src/index.ts"
       ],
-      "@activepieces/piece-mcp": ["packages/pieces/community/mcp/src/index.ts"],
+      "@activepieces/piece-mcp": [
+        "packages/pieces/community/mcp/src/index.ts"
+      ],
       "@activepieces/piece-medullar": [
         "packages/pieces/community/medullar/src/index.ts"
       ],
-      "@activepieces/piece-mem": ["packages/pieces/community/mem/src/index.ts"],
+      "@activepieces/piece-meetgeek-ai": [
+        "packages/pieces/community/meetgeek-ai/src/index.ts"
+      ],
+      "@activepieces/piece-meistertask": [
+        "packages/pieces/community/meistertask/src/index.ts"
+      ],
+      "@activepieces/piece-mem": [
+        "packages/pieces/community/mem/src/index.ts"
+      ],
       "@activepieces/piece-mempool-space": [
         "packages/pieces/community/mempool-space/src/index.ts"
       ],
       "@activepieces/piece-messagebird": [
         "packages/pieces/community/messagebird/src/index.ts"
+      ],
+      "@activepieces/piece-metatext": [
+        "packages/pieces/community/metatext/src/index.ts"
       ],
       "@activepieces/piece-microsoft-365-people": [
         "packages/pieces/community/microsoft-365-people/src/index.ts"
@@ -727,8 +1058,17 @@
       "@activepieces/piece-microsoft-todo": [
         "packages/pieces/community/microsoft-todo/src/index.ts"
       ],
+      "@activepieces/piece-millionverifier": [
+        "packages/pieces/community/millionverifier/src/index.ts"
+      ],
+      "@activepieces/piece-mind-studio": [
+        "packages/pieces/community/mind-studio/src/index.ts"
+      ],
       "@activepieces/piece-mindee": [
         "packages/pieces/community/mindee/src/index.ts"
+      ],
+      "@activepieces/piece-minimax": [
+        "packages/pieces/community/minimax/src/index.ts"
       ],
       "@activepieces/piece-missive": [
         "packages/pieces/community/missive/src/index.ts"
@@ -739,6 +1079,9 @@
       "@activepieces/piece-mixpanel": [
         "packages/pieces/community/mixpanel/src/index.ts"
       ],
+      "@activepieces/piece-modelslab": [
+        "packages/pieces/community/modelslab/src/index.ts"
+      ],
       "@activepieces/piece-mollie": [
         "packages/pieces/community/mollie/src/index.ts"
       ],
@@ -748,8 +1091,20 @@
       "@activepieces/piece-mongodb": [
         "packages/pieces/community/mongodb/src/index.ts"
       ],
+      "@activepieces/piece-moonclerk": [
+        "packages/pieces/community/moonclerk/src/index.ts"
+      ],
+      "@activepieces/piece-mooninvoice": [
+        "packages/pieces/community/mooninvoice/src/index.ts"
+      ],
       "@activepieces/piece-motion": [
         "packages/pieces/community/motion/src/index.ts"
+      ],
+      "@activepieces/piece-motiontools": [
+        "packages/pieces/community/motiontools/src/index.ts"
+      ],
+      "@activepieces/piece-moveo-ai": [
+        "packages/pieces/community/moveo-ai/src/index.ts"
       ],
       "@activepieces/piece-moxie-crm": [
         "packages/pieces/community/moxie-crm/src/index.ts"
@@ -769,6 +1124,9 @@
       "@activepieces/piece-netsuite": [
         "packages/pieces/community/netsuite/src/index.ts"
       ],
+      "@activepieces/piece-neverbounce": [
+        "packages/pieces/community/neverbounce/src/index.ts"
+      ],
       "@activepieces/piece-nifty": [
         "packages/pieces/community/nifty/src/index.ts"
       ],
@@ -787,11 +1145,26 @@
       "@activepieces/piece-nuelink": [
         "packages/pieces/community/nuelink/src/index.ts"
       ],
+      "@activepieces/piece-octopush-sms": [
+        "packages/pieces/community/octopush-sms/src/index.ts"
+      ],
       "@activepieces/piece-odoo": [
         "packages/pieces/community/odoo/src/index.ts"
       ],
       "@activepieces/piece-okta": [
         "packages/pieces/community/okta/src/index.ts"
+      ],
+      "@activepieces/piece-omni-co": [
+        "packages/pieces/community/omni-co/src/index.ts"
+      ],
+      "@activepieces/piece-omnihr": [
+        "packages/pieces/community/omnihr/src/index.ts"
+      ],
+      "@activepieces/piece-oncehub": [
+        "packages/pieces/community/oncehub/src/index.ts"
+      ],
+      "@activepieces/piece-oneclickimpact": [
+        "packages/pieces/community/oneclickimpact/src/index.ts"
       ],
       "@activepieces/piece-onfleet": [
         "packages/pieces/community/onfleet/src/index.ts"
@@ -805,14 +1178,29 @@
       "@activepieces/piece-openai": [
         "packages/pieces/community/openai/src/index.ts"
       ],
+      "@activepieces/piece-openmic-ai": [
+        "packages/pieces/community/openmic-ai/src/index.ts"
+      ],
+      "@activepieces/piece-opnform": [
+        "packages/pieces/community/opnform/src/index.ts"
+      ],
+      "@activepieces/piece-opportify": [
+        "packages/pieces/community/opportify/src/index.ts"
+      ],
       "@activepieces/piece-oracle-fusion-cloud-erp": [
         "packages/pieces/community/oracle-fusion-cloud-erp/src/index.ts"
+      ],
+      "@activepieces/piece-orimon": [
+        "packages/pieces/community/orimon/src/index.ts"
       ],
       "@activepieces/piece-pandadoc": [
         "packages/pieces/community/pandadoc/src/index.ts"
       ],
       "@activepieces/piece-paperform": [
         "packages/pieces/community/paperform/src/index.ts"
+      ],
+      "@activepieces/piece-parser-expert": [
+        "packages/pieces/community/parser-expert/src/index.ts"
       ],
       "@activepieces/piece-parseur": [
         "packages/pieces/community/parseur/src/index.ts"
@@ -823,9 +1211,17 @@
       "@activepieces/piece-pastefy": [
         "packages/pieces/community/pastefy/src/index.ts"
       ],
-      "@activepieces/piece-pdf": ["packages/pieces/core/pdf/src/index.ts"],
+      "@activepieces/piece-paywhirl": [
+        "packages/pieces/community/paywhirl/src/index.ts"
+      ],
+      "@activepieces/piece-pdf": [
+        "packages/pieces/core/pdf/src/index.ts"
+      ],
       "@activepieces/piece-pdf-co": [
         "packages/pieces/community/pdf-co/src/index.ts"
+      ],
+      "@activepieces/piece-pdfcrowd": [
+        "packages/pieces/community/pdfcrowd/src/index.ts"
       ],
       "@activepieces/piece-pdfmonkey": [
         "packages/pieces/community/pdfmonkey/src/index.ts"
@@ -839,8 +1235,17 @@
       "@activepieces/piece-personal-ai": [
         "packages/pieces/community/personal-ai/src/index.ts"
       ],
+      "@activepieces/piece-phantombuster": [
+        "packages/pieces/community/phantombuster/src/index.ts"
+      ],
+      "@activepieces/piece-phone-validator": [
+        "packages/pieces/community/phone-validator/src/index.ts"
+      ],
       "@activepieces/piece-photoroom": [
         "packages/pieces/community/photoroom/src/index.ts"
+      ],
+      "@activepieces/piece-pinch-payments": [
+        "packages/pieces/community/pinch-payments/src/index.ts"
       ],
       "@activepieces/piece-pinecone": [
         "packages/pieces/community/pinecone/src/index.ts"
@@ -854,8 +1259,17 @@
       "@activepieces/piece-placid": [
         "packages/pieces/community/placid/src/index.ts"
       ],
+      "@activepieces/piece-plausible": [
+        "packages/pieces/community/plausible/src/index.ts"
+      ],
+      "@activepieces/piece-pocketbase": [
+        "packages/pieces/community/pocketbase/src/index.ts"
+      ],
       "@activepieces/piece-podio": [
         "packages/pieces/community/podio/src/index.ts"
+      ],
+      "@activepieces/piece-pollybot-ai": [
+        "packages/pieces/community/pollybot-ai/src/index.ts"
       ],
       "@activepieces/piece-poper": [
         "packages/pieces/community/poper/src/index.ts"
@@ -869,11 +1283,23 @@
       "@activepieces/piece-predict-leads": [
         "packages/pieces/community/predict-leads/src/index.ts"
       ],
+      "@activepieces/piece-predis-ai": [
+        "packages/pieces/community/predis-ai/src/index.ts"
+      ],
+      "@activepieces/piece-presenton": [
+        "packages/pieces/community/presenton/src/index.ts"
+      ],
       "@activepieces/piece-productboard": [
         "packages/pieces/community/productboard/src/index.ts"
       ],
       "@activepieces/piece-prompthub": [
         "packages/pieces/community/prompthub/src/index.ts"
+      ],
+      "@activepieces/piece-promptmate": [
+        "packages/pieces/community/promptmate/src/index.ts"
+      ],
+      "@activepieces/piece-pushbullet": [
+        "packages/pieces/community/pushbullet/src/index.ts"
       ],
       "@activepieces/piece-pushover": [
         "packages/pieces/community/pushover/src/index.ts"
@@ -887,6 +1313,9 @@
       "@activepieces/piece-qrcode": [
         "packages/pieces/core/qrcode/src/index.ts"
       ],
+      "@activepieces/piece-quaderno": [
+        "packages/pieces/community/quaderno/src/index.ts"
+      ],
       "@activepieces/piece-queue": [
         "packages/pieces/community/queue/src/index.ts"
       ],
@@ -896,8 +1325,17 @@
       "@activepieces/piece-quickzu": [
         "packages/pieces/community/quickzu/src/index.ts"
       ],
+      "@activepieces/piece-qwilr": [
+        "packages/pieces/community/qwilr/src/index.ts"
+      ],
       "@activepieces/piece-rabbitmq": [
         "packages/pieces/community/rabbitmq/src/index.ts"
+      ],
+      "@activepieces/piece-raia-ai": [
+        "packages/pieces/community/raia-ai/src/index.ts"
+      ],
+      "@activepieces/piece-rapidtext-ai": [
+        "packages/pieces/community/rapidtext-ai/src/index.ts"
       ],
       "@activepieces/piece-razorpay": [
         "packages/pieces/community/razorpay/src/index.ts"
@@ -907,6 +1345,9 @@
       ],
       "@activepieces/piece-read-file": [
         "packages/pieces/read-file/src/index.ts"
+      ],
+      "@activepieces/piece-recall-ai": [
+        "packages/pieces/community/recall-ai/src/index.ts"
       ],
       "@activepieces/piece-reddit": [
         "packages/pieces/community/reddit/src/index.ts"
@@ -938,7 +1379,12 @@
       "@activepieces/piece-robolly": [
         "packages/pieces/community/robolly/src/index.ts"
       ],
-      "@activepieces/piece-rss": ["packages/pieces/community/rss/src/index.ts"],
+      "@activepieces/piece-roe-ai": [
+        "packages/pieces/community/roe-ai/src/index.ts"
+      ],
+      "@activepieces/piece-rss": [
+        "packages/pieces/community/rss/src/index.ts"
+      ],
       "@activepieces/piece-runway": [
         "packages/pieces/community/runway/src/index.ts"
       ],
@@ -951,6 +1397,9 @@
       "@activepieces/piece-salesforce": [
         "packages/pieces/community/salesforce/src/index.ts"
       ],
+      "@activepieces/piece-sap-ariba": [
+        "packages/pieces/community/sap-ariba/src/index.ts"
+      ],
       "@activepieces/piece-scenario": [
         "packages/pieces/community/scenario/src/index.ts"
       ],
@@ -962,6 +1411,9 @@
       ],
       "@activepieces/piece-scrapeless": [
         "packages/pieces/community/scrapeless/src/index.ts"
+      ],
+      "@activepieces/piece-seek-table": [
+        "packages/pieces/community/seek-table/src/index.ts"
       ],
       "@activepieces/piece-segment": [
         "packages/pieces/community/segment/src/index.ts"
@@ -1005,6 +1457,9 @@
       "@activepieces/piece-short-io": [
         "packages/pieces/community/short-io/src/index.ts"
       ],
+      "@activepieces/piece-signrequest": [
+        "packages/pieces/community/signrequest/src/index.ts"
+      ],
       "@activepieces/piece-simplepdf": [
         "packages/pieces/community/simplepdf/src/index.ts"
       ],
@@ -1016,6 +1471,9 @@
       ],
       "@activepieces/piece-sitespeakai": [
         "packages/pieces/community/sitespeakai/src/index.ts"
+      ],
+      "@activepieces/piece-skyprep": [
+        "packages/pieces/community/skyprep/src/index.ts"
       ],
       "@activepieces/piece-skyvern": [
         "packages/pieces/community/skyvern/src/index.ts"
@@ -1038,6 +1496,9 @@
       "@activepieces/piece-smoove": [
         "packages/pieces/community/smoove/src/index.ts"
       ],
+      "@activepieces/piece-smsmode": [
+        "packages/pieces/community/smsmode/src/index.ts"
+      ],
       "@activepieces/piece-smtp": [
         "packages/pieces/core/smtp/src/index.ts"
       ],
@@ -1053,6 +1514,9 @@
       "@activepieces/piece-sperse": [
         "packages/pieces/community/sperse/src/index.ts"
       ],
+      "@activepieces/piece-splitwise": [
+        "packages/pieces/community/splitwise/src/index.ts"
+      ],
       "@activepieces/piece-spotify": [
         "packages/pieces/community/spotify/src/index.ts"
       ],
@@ -1061,9 +1525,6 @@
       ],
       "@activepieces/piece-stability-ai": [
         "packages/pieces/community/stability-ai/src/index.ts"
-      ],
-      "@activepieces/piece-modelslab": [
-        "packages/pieces/community/modelslab/src/index.ts"
       ],
       "@activepieces/piece-stable-diffusion-webui": [
         "packages/pieces/community/stable-diffusion-webui/src/index.ts"
@@ -1092,8 +1553,17 @@
       "@activepieces/piece-surveymonkey": [
         "packages/pieces/community/surveymonkey/src/index.ts"
       ],
+      "@activepieces/piece-swarmnode": [
+        "packages/pieces/community/swarmnode/src/index.ts"
+      ],
+      "@activepieces/piece-synthesia": [
+        "packages/pieces/community/synthesia/src/index.ts"
+      ],
       "@activepieces/piece-systeme-io": [
         "packages/pieces/community/systeme-io/src/index.ts"
+      ],
+      "@activepieces/piece-tableau": [
+        "packages/pieces/community/tableau/src/index.ts"
       ],
       "@activepieces/piece-tables": [
         "packages/pieces/core/tables/src/index.ts"
@@ -1125,6 +1595,9 @@
       "@activepieces/piece-telegram-bot": [
         "packages/pieces/community/telegram-bot/src/index.ts"
       ],
+      "@activepieces/piece-tenzo": [
+        "packages/pieces/community/tenzo/src/index.ts"
+      ],
       "@activepieces/piece-text-ai": [
         "packages/pieces/community/text-ai/src/index.ts"
       ],
@@ -1140,16 +1613,27 @@
       "@activepieces/piece-ticktick": [
         "packages/pieces/community/ticktick/src/index.ts"
       ],
+      "@activepieces/piece-tidely": [
+        "packages/pieces/community/tidely/src/index.ts"
+      ],
       "@activepieces/piece-tidycal": [
         "packages/pieces/community/tidycal/src/index.ts"
+      ],
+      "@activepieces/piece-time-ops": [
+        "packages/pieces/community/time-ops/src/index.ts"
       ],
       "@activepieces/piece-timelines-ai": [
         "packages/pieces/community/timelines-ai/src/index.ts"
       ],
+      "@activepieces/piece-tiny-talk-ai": [
+        "packages/pieces/community/tiny-talk-ai/src/index.ts"
+      ],
+      "@activepieces/piece-tl-dv": [
+        "packages/pieces/community/tl-dv/src/index.ts"
+      ],
       "@activepieces/piece-todoist": [
         "packages/pieces/community/todoist/src/index.ts"
       ],
-
       "@activepieces/piece-toggl-track": [
         "packages/pieces/community/toggl-track/src/index.ts"
       ],
@@ -1162,17 +1646,20 @@
       "@activepieces/piece-truelayer": [
         "packages/pieces/community/truelayer/src/index.ts"
       ],
+      "@activepieces/piece-twenty": [
+        "packages/pieces/community/twenty/src/index.ts"
+      ],
       "@activepieces/piece-twilio": [
         "packages/pieces/community/twilio/src/index.ts"
       ],
       "@activepieces/piece-twin-labs": [
         "packages/pieces/community/twin-labs/src/index.ts"
       ],
+      "@activepieces/piece-twitch": [
+        "packages/pieces/community/twitch/src/index.ts"
+      ],
       "@activepieces/piece-twitter": [
         "packages/pieces/community/twitter/src/index.ts"
-      ],
-      "@activepieces/piece-twenty": [
-        "packages/pieces/community/twenty/src/index.ts"
       ],
       "@activepieces/piece-typeform": [
         "packages/pieces/community/typeform/src/index.ts"
@@ -1186,11 +1673,29 @@
       "@activepieces/piece-vadoo-ai": [
         "packages/pieces/community/vadoo-ai/src/index.ts"
       ],
+      "@activepieces/piece-validatedmails": [
+        "packages/pieces/community/validatedmails/src/index.ts"
+      ],
+      "@activepieces/piece-valyu": [
+        "packages/pieces/community/valyu/src/index.ts"
+      ],
       "@activepieces/piece-vbout": [
         "packages/pieces/community/vbout/src/index.ts"
       ],
+      "@activepieces/piece-vero": [
+        "packages/pieces/community/vero/src/index.ts"
+      ],
       "@activepieces/piece-video-ai": [
         "packages/pieces/community/video-ai/src/index.ts"
+      ],
+      "@activepieces/piece-videoask": [
+        "packages/pieces/community/videoask/src/index.ts"
+      ],
+      "@activepieces/piece-vidlab7": [
+        "packages/pieces/community/vidlab7/src/index.ts"
+      ],
+      "@activepieces/piece-vidnoz": [
+        "packages/pieces/community/vidnoz/src/index.ts"
       ],
       "@activepieces/piece-village": [
         "packages/pieces/community/village/src/index.ts"
@@ -1198,14 +1703,26 @@
       "@activepieces/piece-vimeo": [
         "packages/pieces/community/vimeo/src/index.ts"
       ],
+      "@activepieces/piece-visible": [
+        "packages/pieces/community/visible/src/index.ts"
+      ],
       "@activepieces/piece-vlm-run": [
         "packages/pieces/community/vlm-run/src/index.ts"
+      ],
+      "@activepieces/piece-voipstudio": [
+        "packages/pieces/community/voipstudio/src/index.ts"
+      ],
+      "@activepieces/piece-vouchery-io": [
+        "packages/pieces/community/vouchery-io/src/index.ts"
       ],
       "@activepieces/piece-vtex": [
         "packages/pieces/community/vtex/src/index.ts"
       ],
       "@activepieces/piece-vtiger": [
         "packages/pieces/community/vtiger/src/index.ts"
+      ],
+      "@activepieces/piece-waitwhile": [
+        "packages/pieces/community/waitwhile/src/index.ts"
       ],
       "@activepieces/piece-wealthbox": [
         "packages/pieces/community/wealthbox/src/index.ts"
@@ -1225,6 +1742,9 @@
       "@activepieces/piece-wedof": [
         "packages/pieces/community/wedof/src/index.ts"
       ],
+      "@activepieces/piece-week-done": [
+        "packages/pieces/community/week-done/src/index.ts"
+      ],
       "@activepieces/piece-what-converts": [
         "packages/pieces/community/what-converts/src/index.ts"
       ],
@@ -1240,6 +1760,9 @@
       "@activepieces/piece-woocommerce": [
         "packages/pieces/community/woocommerce/src/index.ts"
       ],
+      "@activepieces/piece-woodpecker": [
+        "packages/pieces/community/woodpecker/src/index.ts"
+      ],
       "@activepieces/piece-wootric": [
         "packages/pieces/community/wootric/src/index.ts"
       ],
@@ -1252,13 +1775,24 @@
       "@activepieces/piece-wrike": [
         "packages/pieces/community/wrike/src/index.ts"
       ],
+      "@activepieces/piece-writesonic-bulk": [
+        "packages/pieces/community/writesonic-bulk/src/index.ts"
+      ],
       "@activepieces/piece-wufoo": [
         "packages/pieces/community/wufoo/src/index.ts"
       ],
       "@activepieces/piece-xero": [
         "packages/pieces/community/xero/src/index.ts"
       ],
-      "@activepieces/piece-xml": ["packages/pieces/core/xml/src/index.ts"],
+      "@activepieces/piece-xml": [
+        "packages/pieces/core/xml/src/index.ts"
+      ],
+      "@activepieces/piece-youcanbookme": [
+        "packages/pieces/community/youcanbookme/src/index.ts"
+      ],
+      "@activepieces/piece-youform": [
+        "packages/pieces/community/youform/src/index.ts"
+      ],
       "@activepieces/piece-youtube": [
         "packages/pieces/community/youtube/src/index.ts"
       ],
@@ -1267,6 +1801,9 @@
       ],
       "@activepieces/piece-zendesk": [
         "packages/pieces/community/zendesk/src/index.ts"
+      ],
+      "@activepieces/piece-zeplin": [
+        "packages/pieces/community/zeplin/src/index.ts"
       ],
       "@activepieces/piece-zerobounce": [
         "packages/pieces/community/zerobounce/src/index.ts"
@@ -1292,7 +1829,9 @@
       "@activepieces/piece-zoho-mail": [
         "packages/pieces/community/zoho-mail/src/index.ts"
       ],
-      "@activepieces/piece-zoo": ["packages/pieces/community/zoo/src/index.ts"],
+      "@activepieces/piece-zoo": [
+        "packages/pieces/community/zoo/src/index.ts"
+      ],
       "@activepieces/piece-zoom": [
         "packages/pieces/community/zoom/src/index.ts"
       ],
@@ -1302,13 +1841,21 @@
       "@activepieces/pieces-framework": [
         "packages/pieces/framework/src/index.ts"
       ],
-      "@activepieces/piece-meistertask": [
-        "packages/pieces/community/meistertask/src/index.ts"
+      "@activepieces/server-utils": [
+        "packages/server/utils/src/index.ts"
       ],
-      "@activepieces/server-utils": ["packages/server/utils/src/index.ts"],
-      "@activepieces/shared": ["packages/shared/src/index.ts"],
-      "@ee/*": ["packages/ee/*"],
-      "Aminos": ["packages/pieces/community/Aminos/src/index.ts"],
+      "@activepieces/shared": [
+        "packages/shared/src/index.ts"
+      ],
+      "@ee/*": [
+        "packages/ee/*"
+      ],
+      "Aminos": [
+        "packages/pieces/community/Aminos/src/index.ts"
+      ],
+      "activepieces/piece-cashfree-payments": [
+        "packages/pieces/community/cashfree-payments/src/index.ts"
+      ],
       "activepieces/piece-microsoft-dynamics-365-business-central": [
         "packages/pieces/community/microsoft-dynamics-365-business-central/src/index.ts"
       ],
@@ -1324,518 +1871,17 @@
       "activepieces/piece-zuora": [
         "packages/pieces/community/zuora/src/index.ts"
       ],
-      "activepieces/piece-cashfree-payments": [
-        "packages/pieces/community/cashfree-payments/src/index.ts"
-      ],
-      "ee-embed-sdk": ["packages/ee/embed-sdk/src/index.ts"],
-      "ui-feature-forms": ["packages/ui/features-forms/src/index.ts"],
-      "@activepieces/piece-kissflow": [
-        "packages/pieces/community/kissflow/src/index.ts"
-      ],
-      "@activepieces/piece-housecall-pro": [
-        "packages/pieces/community/housecall-pro/src/index.ts"
-      ],
-      "@activepieces/piece-chat-aid": [
-        "packages/pieces/community/chat-aid/src/index.ts"
-      ],
-      "@activepieces/piece-videoask": [
-        "packages/pieces/community/videoask/src/index.ts"
-      ],
-      "@activepieces/piece-presenton": [
-        "packages/pieces/community/presenton/src/index.ts"
-      ],
-      "@activepieces/piece-formspark": [
-        "packages/pieces/community/formspark/src/index.ts"
-      ],
-      "@activepieces/piece-tableau": [
-        "packages/pieces/community/tableau/src/index.ts"
-      ],
-      "@activepieces/piece-fragment": [
-        "packages/pieces/community/fragment/src/index.ts"
-      ],
-      "@activepieces/piece-fountain": [
-        "packages/pieces/community/fountain/src/index.ts"
-      ],
-      "@activepieces/piece-omni-co": [
-        "packages/pieces/community/omni-co/src/index.ts"
-      ],
-      "@activepieces/piece-instabase": [
-        "packages/pieces/community/instabase/src/index.ts"
-      ],
-      "@activepieces/piece-gladia": [
-        "packages/pieces/community/gladia/src/index.ts"
-      ],
-      "@activepieces/piece-manus": [
-        "packages/pieces/community/manus/src/index.ts"
-      ],
-      "@activepieces/piece-recall-ai": [
-        "packages/pieces/community/recall-ai/src/index.ts"
-      ],
-      "@activepieces/piece-contextual-ai": [
-        "packages/pieces/community/contextual-ai/src/index.ts"
-      ],
-      "@activepieces/piece-hume-ai": [
-        "packages/pieces/community/hume-ai/src/index.ts"
-      ],
-      "@activepieces/piece-chatsistant": [
-        "packages/pieces/community/chatsistant/src/index.ts"
-      ],
-      "@activepieces/piece-rapidtext-ai": [
-        "packages/pieces/community/rapidtext-ai/src/index.ts"
-      ],
-      "@activepieces/piece-opnform": [
-        "packages/pieces/community/opnform/src/index.ts"
-      ],
-      "@activepieces/piece-opportify": [
-        "packages/pieces/community/opportify/src/index.ts"
-      ],
-      "@activepieces/piece-promptmate": [
-        "packages/pieces/community/promptmate/src/index.ts"
-      ],
-      "@activepieces/piece-guidelite": [
-        "packages/pieces/community/guidelite/src/index.ts"
-      ],
-      "@activepieces/piece-bolna": [
-        "packages/pieces/community/bolna/src/index.ts"
-      ],
-      "@activepieces/piece-appfollow": [
-        "packages/pieces/community/appfollow/src/index.ts"
-      ],
-      "@activepieces/piece-griptape": [
-        "packages/pieces/community/griptape/src/index.ts"
-      ],
-      "@activepieces/piece-bexio": [
-        "packages/pieces/community/bexio/src/index.ts"
-      ],
-      "@activepieces/piece-pushbullet": [
-        "packages/pieces/community/pushbullet/src/index.ts"
-      ],
-      "@activepieces/piece-denser-ai": [
-        "packages/pieces/community/denser-ai/src/index.ts"
-      ],
-      "@activepieces/piece-ask-handle": [
-        "packages/pieces/community/ask-handle/src/index.ts"
-      ],
-      "@activepieces/piece-phantombuster": [
-        "packages/pieces/community/phantombuster/src/index.ts"
-      ],
-      "@activepieces/piece-openmic-ai": [
-        "packages/pieces/community/openmic-ai/src/index.ts"
-      ],
-      "@activepieces/piece-datafuel": [
-        "packages/pieces/community/datafuel/src/index.ts"
-      ],
-      "@activepieces/piece-doctly": [
-        "packages/pieces/community/doctly/src/index.ts"
-      ],
-      "@activepieces/piece-chatnode": [
-        "packages/pieces/community/chatnode/src/index.ts"
-      ],
-      "@activepieces/piece-greip": [
-        "packages/pieces/community/greip/src/index.ts"
-      ],
-      "@activepieces/piece-chaindesk": [
-        "packages/pieces/community/chaindesk/src/index.ts"
-      ],
-      "@activepieces/piece-orimon": [
-        "packages/pieces/community/orimon/src/index.ts"
-      ],
-      "@activepieces/piece-linkup": [
-        "packages/pieces/community/linkup/src/index.ts"
-      ],
-      "@activepieces/piece-youform": [
-        "packages/pieces/community/youform/src/index.ts"
-      ],
-      "@activepieces/piece-flow-parser": [
-        "packages/pieces/community/flow-parser/src/index.ts"
-      ],
-      "@activepieces/piece-writesonic-bulk": [
-        "packages/pieces/community/writesonic-bulk/src/index.ts"
-      ],
-      "@activepieces/piece-documentpro": [
-        "packages/pieces/community/documentpro/src/index.ts"
-      ],
-      "@activepieces/piece-image-router": [
-        "packages/pieces/community/image-router/src/index.ts"
-      ],
-      "@activepieces/piece-pollybot-ai": [
-        "packages/pieces/community/pollybot-ai/src/index.ts"
-      ],
-      "@activepieces/piece-documerge": [
-        "packages/pieces/community/documerge/src/index.ts"
-      ],
-      "@activepieces/piece-letta": [
-        "packages/pieces/community/letta/src/index.ts"
-      ],
-      "@activepieces/piece-logrocket": [
-        "packages/pieces/community/logrocket/src/index.ts"
-      ],
-      "@activepieces/piece-logsnag": [
-        "packages/pieces/community/logsnag/src/index.ts"
-      ],
-      "@activepieces/piece-couchbase": [
-        "packages/pieces/community/couchbase/src/index.ts"
-      ],
-      "@activepieces/piece-cursor": [
-        "packages/pieces/community/cursor/src/index.ts"
-      ],
-      "@activepieces/piece-gptzero-detect-ai": [
-        "packages/pieces/community/gptzero-detect-ai/src/index.ts"
-      ],
-      "@activepieces/piece-bursty-ai": [
-        "packages/pieces/community/bursty-ai/src/index.ts"
-      ],
-      "@activepieces/piece-tl-dv": [
-        "packages/pieces/community/tl-dv/src/index.ts"
-      ],
-      "@activepieces/piece-parser-expert": [
-        "packages/pieces/community/parser-expert/src/index.ts"
-      ],
-      "@activepieces/piece-vidlab7": [
-        "packages/pieces/community/vidlab7/src/index.ts"
-      ],
-      "@activepieces/piece-bookedin": [
-        "packages/pieces/community/bookedin/src/index.ts"
-      ],
-      "@activepieces/piece-ai": ["packages/pieces/community/ai/src/index.ts"],
-      "@activepieces/piece-customgpt": [
-        "packages/pieces/community/customgpt/src/index.ts"
-      ],
-      "@activepieces/piece-synthesia": [
-        "packages/pieces/community/synthesia/src/index.ts"
-      ],
-      "@activepieces/piece-meetgeek-ai": [
-        "packages/pieces/community/meetgeek-ai/src/index.ts"
-      ],
-      "@activepieces/piece-fellow": [
-        "packages/pieces/community/fellow/src/index.ts"
-      ],
-      "@activepieces/piece-echowin": [
-        "packages/pieces/community/echowin/src/index.ts"
-      ],
-      "@activepieces/piece-feathery": [
-        "packages/pieces/community/feathery/src/index.ts"
-      ],
-      "@activepieces/piece-chatling": [
-        "packages/pieces/community/chatling/src/index.ts"
-      ],
-      "@activepieces/piece-air-ops": [
-        "packages/pieces/community/air-ops/src/index.ts"
-      ],
-      "@activepieces/piece-mind-studio": [
-        "packages/pieces/community/mind-studio/src/index.ts"
-      ],
-      "@activepieces/piece-easy-peasy-ai": [
-        "packages/pieces/community/easy-peasy-ai/src/index.ts"
-      ],
-      "@activepieces/piece-leexi": [
-        "packages/pieces/community/leexi/src/index.ts"
-      ],
-      "@activepieces/piece-tiny-talk-ai": [
-        "packages/pieces/community/tiny-talk-ai/src/index.ts"
-      ],
-      "@activepieces/piece-sap-ariba": [
-        "packages/pieces/community/sap-ariba/src/index.ts"
-      ],
-      "@activepieces/piece-hastewire": [
-        "packages/pieces/community/hastewire/src/index.ts"
-      ],
-      "@activepieces/piece-greenpt": [
-        "packages/pieces/community/greenpt/src/index.ts"
-      ],
-      "@activepieces/piece-oncehub": [
-        "packages/pieces/community/oncehub/src/index.ts"
-      ],
-      "@activepieces/piece-swarmnode": [
-        "packages/pieces/community/swarmnode/src/index.ts"
-      ],
-      "@activepieces/piece-alt-text-ai": [
-        "packages/pieces/community/alt-text-ai/src/index.ts"
-      ],
-      "@activepieces/piece-dashworks": [
-        "packages/pieces/community/dashworks/src/index.ts"
-      ],
-      "@activepieces/piece-raia-ai": [
-        "packages/pieces/community/raia-ai/src/index.ts"
-      ],
-      "@activepieces/piece-alttextify": [
-        "packages/pieces/community/alttextify/src/index.ts"
-      ],
-      "@activepieces/piece-motiontools": [
-        "packages/pieces/community/motiontools/src/index.ts"
-      ],
-      "@activepieces/piece-formsite": [
-        "packages/pieces/community/formsite/src/index.ts"
-      ],
-      "@activepieces/piece-lofty": [
-        "packages/pieces/community/lofty/src/index.ts"
-      ],
-      "@activepieces/piece-youcanbookme": [
-        "packages/pieces/community/youcanbookme/src/index.ts"
-      ],
-      "@activepieces/piece-esignatures": [
-        "packages/pieces/community/esignatures/src/index.ts"
-      ],
-      "@activepieces/piece-base44": [
-        "packages/pieces/community/base44/src/index.ts"
-      ],
-      "@activepieces/piece-luxury-presence": [
-        "packages/pieces/community/luxury-presence/src/index.ts"
-      ],
-      "@activepieces/piece-signrequest": [
-        "packages/pieces/community/signrequest/src/index.ts"
-      ],
-      "@activepieces/piece-hystruct": [
-        "packages/pieces/community/hystruct/src/index.ts"
-      ],
-      "@activepieces/piece-chatfly": [
-        "packages/pieces/community/chatfly/src/index.ts"
-      ],
-      "@activepieces/piece-azure-blob-storage": [
-        "packages/pieces/community/azure-blob-storage/src/index.ts"
-      ],
-      "@activepieces/piece-metatext": [
-        "packages/pieces/community/metatext/src/index.ts"
-      ],
-      "@activepieces/piece-kudosity": [
-        "packages/pieces/community/kudosity/src/index.ts"
-      ],
-      "@activepieces/piece-neverbounce": [
-        "packages/pieces/community/neverbounce/src/index.ts"
-      ],
-      "@activepieces/piece-mailercheck": [
-        "packages/pieces/community/mailercheck/src/index.ts"
-      ],
-      "@activepieces/piece-vero": [
-        "packages/pieces/community/vero/src/index.ts"
-      ],
-      "@activepieces/piece-digital-pilot": [
-        "packages/pieces/community/digital-pilot/src/index.ts"
-      ],
-      "@activepieces/piece-clearoutphone": [
-        "packages/pieces/community/clearoutphone/src/index.ts"
-      ],
-      "@activepieces/piece-omnihr": [
-        "packages/pieces/community/omnihr/src/index.ts"
-      ],
-      "@activepieces/piece-clicdata": [
-        "packages/pieces/community/clicdata/src/index.ts"
-      ],
-      "@activepieces/piece-katana": [
-        "packages/pieces/community/katana/src/index.ts"
-      ],
-      "@activepieces/piece-giftbit": [
-        "packages/pieces/community/giftbit/src/index.ts"
-      ],
-      "@activepieces/piece-free-agent": [
-        "packages/pieces/community/free-agent/src/index.ts"
-      ],
-      "@activepieces/piece-lemon-squeezy": [
-        "packages/pieces/community/lemon-squeezy/src/index.ts"
-      ],
-      "@activepieces/piece-qwilr": [
-        "packages/pieces/community/qwilr/src/index.ts"
-      ],
-      "@activepieces/piece-splitwise": [
-        "packages/pieces/community/splitwise/src/index.ts"
-      ],
-      "@activepieces/piece-voipstudio": [
-        "packages/pieces/community/voipstudio/src/index.ts"
-      ],
-      "@activepieces/piece-millionverifier": [
-        "packages/pieces/community/millionverifier/src/index.ts"
-      ],
-      "@activepieces/piece-octopush-sms": [
-        "packages/pieces/community/octopush-sms/src/index.ts"
-      ],
-      "@activepieces/piece-twitch": [
-        "packages/pieces/community/twitch/src/index.ts"
-      ],
-      "@activepieces/piece-moonclerk": [
-        "packages/pieces/community/moonclerk/src/index.ts"
-      ],
-      "@activepieces/piece-heymarket-sms": [
-        "packages/pieces/community/heymarket-sms/src/index.ts"
-      ],
-      "@activepieces/piece-flipando": [
-        "packages/pieces/community/flipando/src/index.ts"
-      ],
-      "@activepieces/piece-skyprep": [
-        "packages/pieces/community/skyprep/src/index.ts"
-      ],
-      "@activepieces/piece-influencers-club": [
-        "packages/pieces/community/influencers-club/src/index.ts"
-      ],
-      "@activepieces/piece-tenzo": [
-        "packages/pieces/community/tenzo/src/index.ts"
-      ],
-      "@activepieces/piece-seek-table": [
-        "packages/pieces/community/seek-table/src/index.ts"
-      ],
-      "@activepieces/piece-lucidya": [
-        "packages/pieces/community/lucidya/src/index.ts"
-      ],
-      "@activepieces/piece-phone-validator": [
-        "packages/pieces/community/phone-validator/src/index.ts"
-      ],
-      "@activepieces/piece-barcode-lookup": [
-        "packages/pieces/community/barcode-lookup/src/index.ts"
-      ],
-      "@activepieces/piece-tidely": [
-        "packages/pieces/community/tidely/src/index.ts"
-      ],
-      "@activepieces/piece-cryptolens": [
-        "packages/pieces/community/cryptolens/src/index.ts"
-      ],
-      "@activepieces/piece-ampeco": [
-        "packages/pieces/community/ampeco/src/index.ts"
-      ],
-      "@activepieces/piece-quaderno": [
-        "packages/pieces/community/quaderno/src/index.ts"
-      ],
-      "@activepieces/piece-livesession": [
-        "packages/pieces/community/livesession/src/index.ts"
-      ],
-      "@activepieces/piece-roe-ai": [
-        "packages/pieces/community/roe-ai/src/index.ts"
-      ],
-      "@activepieces/piece-duckdb": [
-        "packages/pieces/community/duckdb/src/index.ts"
-      ],
-      "@activepieces/piece-waitwhile": [
-        "packages/pieces/community/waitwhile/src/index.ts"
-      ],
-      "@activepieces/piece-baremetrics": [
-        "packages/pieces/community/baremetrics/src/index.ts"
-      ],
-      "@activepieces/piece-chartly": [
-        "packages/pieces/community/chartly/src/index.ts"
-      ],
-      "@activepieces/piece-insta-charts": [
-        "packages/pieces/community/insta-charts/src/index.ts"
-      ],
-      "@activepieces/piece-pinch-payments": [
-        "packages/pieces/community/pinch-payments/src/index.ts"
-      ],
-      "@activepieces/piece-just-invoice": [
-        "packages/pieces/community/just-invoice/src/index.ts"
-      ],
-      "@activepieces/piece-billplz": [
-        "packages/pieces/community/billplz/src/index.ts"
-      ],
-      "@activepieces/piece-vouchery-io": [
-        "packages/pieces/community/vouchery-io/src/index.ts"
-      ],
-      "@activepieces/piece-lokalise": [
-        "packages/pieces/community/lokalise/src/index.ts"
-      ],
-      "@activepieces/piece-digital-ocean": [
-        "packages/pieces/community/digital-ocean/src/index.ts"
-      ],
-      "@activepieces/piece-hashi-corp-vault": [
-        "packages/pieces/community/hashi-corp-vault/src/index.ts"
-      ],
-      "@activepieces/piece-leap-ai": [
-        "packages/pieces/community/leap-ai/src/index.ts"
-      ],
-      "@activepieces/piece-time-ops": [
-        "packages/pieces/community/time-ops/src/index.ts"
-      ],
-      "@activepieces/piece-formitable": [
-        "packages/pieces/community/formitable/src/index.ts"
-      ],
-      "@activepieces/piece-gender-api": [
-        "packages/pieces/community/gender-api/src/index.ts"
-      ],
-      "@activepieces/piece-plausible": [
-        "packages/pieces/community/plausible/src/index.ts"
-      ],
-      "@activepieces/piece-woodpecker": [
-        "packages/pieces/community/woodpecker/src/index.ts"
-      ],
-      "@activepieces/piece-visible": [
-        "packages/pieces/community/visible/src/index.ts"
-      ],
-      "@activepieces/piece-paywhirl": [
-        "packages/pieces/community/paywhirl/src/index.ts"
-      ],
-      "@activepieces/piece-smsmode": [
-        "packages/pieces/community/smsmode/src/index.ts"
-      ],
-      "@activepieces/piece-mooninvoice": [
-        "packages/pieces/community/mooninvoice/src/index.ts"
-      ],
-      "@activepieces/piece-chain-aware": [
-        "packages/pieces/community/chain-aware/src/index.ts"
-      ],
-      "@activepieces/piece-detecting-ai": [
-        "packages/pieces/community/detecting-ai/src/index.ts"
-      ],
-      "@activepieces/piece-moveo-ai": [
-        "packages/pieces/community/moveo-ai/src/index.ts"
-      ],
-      "@activepieces/piece-oneclickimpact": [
-        "packages/pieces/community/oneclickimpact/src/index.ts"
-      ],
-      "@activepieces/piece-bokio": [
-        "packages/pieces/community/bokio/src/index.ts"
-      ],
-      "@activepieces/piece-vidnoz": [
-        "packages/pieces/community/vidnoz/src/index.ts"
-      ],
-      "@activepieces/piece-lets-calendar": [
-        "packages/pieces/community/lets-calendar/src/index.ts"
-      ],
-      "@activepieces/piece-predis-ai": [
-        "packages/pieces/community/predis-ai/src/index.ts"
-      ],
-      "@activepieces/piece-week-done": [
-        "packages/pieces/community/week-done/src/index.ts"
-      ],
-      "@activepieces/piece-manual-trigger": [
-        "packages/pieces/core/manual-trigger/src/index.ts"
-      ],
-      "@activepieces/piece-zeplin": [
-        "packages/pieces/community/zeplin/src/index.ts"
-      ],
-      "@activepieces/piece-google-search": [
-        "packages/pieces/community/google-search/src/index.ts"
-      ],
-      "@activepieces/piece-asknews": [
-        "packages/pieces/community/asknews/src/index.ts"
-      ],
-      "@activepieces/piece-valyu": [
-        "packages/pieces/community/valyu/src/index.ts"
-      ],
-      "@activepieces/piece-alai": [
-        "packages/pieces/community/alai/src/index.ts"
-      ],
-      "@activepieces/piece-kapso": [
-        "packages/pieces/community/kapso/src/index.ts"
-      ],
-      "@activepieces/piece-pdfcrowd": [
-        "packages/pieces/community/pdfcrowd/src/index.ts"
-      ],
-      "@activepieces/piece-amazon-bedrock": [
-        "packages/pieces/community/amazon-bedrock/src/index.ts"
-      ],
-      "@activepieces/piece-brave-search": [
-        "packages/pieces/community/brave-search/src/index.ts"
-      ],
-      "@activepieces/piece-amazon-secrets-manager": [
-        "packages/pieces/community/amazon-secrets-manager/src/index.ts"
-      ],
-      "@activepieces/piece-validatedmails": [
-        "packages/pieces/community/validatedmails/src/index.ts"
-      ],
-      "@activepieces/piece-coralogix": [
-        "packages/pieces/community/coralogix/src/index.ts"
-      ],
-      "@activepieces/piece-pocketbase": [
-        "packages/pieces/community/pocketbase/src/index.ts"
+      "ee-embed-sdk": [
+        "packages/ee/embed-sdk/src/index.ts"
+      ],
+      "ui-feature-forms": [
+        "packages/ui/features-forms/src/index.ts"
       ]
     },
     "resolveJsonModule": true
   },
-  "exclude": ["node_modules", "tmp"]
+  "exclude": [
+    "node_modules",
+    "tmp"
+  ]
 }


### PR DESCRIPTION
## Summary
- Add MiniMax AI piece with `Ask MiniMax` action for chat completions
- Set `MiniMax-M3` as the default model — the flagship model with a 512K context window, up to 128K output tokens, and image input support
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Uses OpenAI-compatible SDK with MiniMax API base URL

## Changes
- `packages/pieces/community/minimax/` — New MiniMax AI piece
  - `common.ts` — Model list (M3, M2.7, M2.7-highspeed) with M3 first as default
  - `ask-minimax.ts` — Ask MiniMax action with temperature/topP/memory support, defaulting to M3
  - `auth.ts` — API key authentication validated against M3
  - `index.ts` — Piece definition with AI category
  - `README.md` — Documentation with supported models

## Why
MiniMax-M3 is the latest flagship model, offering a 512K context window, up to 128K output tokens, and image input support — a significant upgrade over the previous M2.7 generation. M2.7 and M2.7-highspeed are kept as alternatives for users who need them.

## Testing
- Verified MiniMax-M3 is the default model selection
- All three models (M3, M2.7, M2.7-highspeed) available in the static dropdown
- OpenAI-compatible API integration tested with MiniMax base URL