### PR TITLE
fix: strip models/ prefix from Google provider model ids (#13468)

### DIFF
--- a/packages/server/api/src/app/ai/providers/google-provider.ts
+++ b/packages/server/api/src/app/ai/providers/google-provider.ts
@@ -18,11 +18,17 @@ export const googleProvider: AIProviderStrategy<GoogleProviderAuthConfig, Google
             },
         })
         return res.body.models.map((model: GoogleModel) => ({
-            id: model.name,
+            id: stripModelsPrefix(model.name),
             name: model.displayName,
             type: model.name.includes('image') ? AIProviderModelType.IMAGE : AIProviderModelType.TEXT,
         }))
     },
+}
+
+const GOOGLE_MODEL_PREFIX = 'models/'
+
+function stripModelsPrefix(modelName: string): string {
+    return modelName.startsWith(GOOGLE_MODEL_PREFIX) ? modelName.slice(GOOGLE_MODEL_PREFIX.length) : modelName
 }
 
 type GoogleModel = {

--- a/packages/server/api/src/app/flows/flow-version/migrations/index.ts
+++ b/packages/server/api/src/app/flows/flow-version/migrations/index.ts
@@ -13,6 +13,7 @@ import { migrateV17AddLastUpdatedDate } from './migrate-v17-add-last-updated-dat
 import { migrateV18TablesFieldIds } from './migrate-v18-tables-find-records-field-ids'
 import { migrateV19StripPieceVersionWildcards } from './migrate-v19-strip-piece-version-wildcards'
 import { migrateAgentPieceV2 } from './migrate-v2-agent-piece'
+import { migrateV20GoogleModelPrefix } from './migrate-v20-google-model-prefix'
 import { migrateAgentPieceV3 } from './migrate-v3-agent-piece'
 import { migrateAgentPieceV4 } from './migrate-v4-agent-piece'
 import { migrateHttpToWebhookV5 } from './migrate-v5-http-to-webhook'
@@ -52,6 +53,7 @@ const migrations: Migration[] = [
     migrateV17AddLastUpdatedDate,
     migrateV18TablesFieldIds,
     migrateV19StripPieceVersionWildcards,
+    migrateV20GoogleModelPrefix,
 ] as const
 
 export const flowMigrations = {

--- a/packages/server/api/src/app/flows/flow-version/migrations/migrate-v20-google-model-prefix.ts
+++ b/packages/server/api/src/app/flows/flow-version/migrations/migrate-v20-google-model-prefix.ts
@@ -1,0 +1,70 @@
+import {
+    AgentPieceProps,
+    FlowActionType,
+    flowStructureUtil,
+    FlowVersion,
+    isNil,
+} from '@activepieces/shared'
+import { Migration } from '.'
+
+export const migrateV20GoogleModelPrefix: Migration = {
+    targetSchemaVersion: '20',
+    migrate: async (flowVersion: FlowVersion): Promise<FlowVersion> => {
+        const newVersion = flowStructureUtil.transferFlow(flowVersion, (step) => {
+            if (step.type !== FlowActionType.PIECE || step.settings.pieceName !== '@activepieces/piece-ai') {
+                return step
+            }
+
+            const input = step.settings.input as Record<string, unknown>
+
+            if (step.settings.actionName === 'askAi') {
+                return {
+                    ...step,
+                    settings: {
+                        ...step.settings,
+                        input: {
+                            ...input,
+                            model: stripGooglePrefix(input.model),
+                        },
+                    },
+                }
+            }
+
+            if (step.settings.actionName === 'run_agent') {
+                const aiProviderModel = input[AgentPieceProps.AI_PROVIDER_MODEL] as Record<string, unknown> | undefined
+                if (isNil(aiProviderModel)) {
+                    return step
+                }
+                return {
+                    ...step,
+                    settings: {
+                        ...step.settings,
+                        input: {
+                            ...input,
+                            [AgentPieceProps.AI_PROVIDER_MODEL]: {
+                                ...aiProviderModel,
+                                model: stripGooglePrefix(aiProviderModel.model),
+                            },
+                        },
+                    },
+                }
+            }
+
+            return step
+        })
+
+        return {
+            ...newVersion,
+            schemaVersion: '21',
+        }
+    },
+}
+
+const GOOGLE_MODEL_PREFIX = 'models/'
+
+function stripGooglePrefix(modelId: unknown): unknown {
+    if (typeof modelId !== 'string' || !modelId.startsWith(GOOGLE_MODEL_PREFIX)) {
+        return modelId
+    }
+    return modelId.slice(GOOGLE_MODEL_PREFIX.length)
+}

--- a/packages/server/api/test/unit/app/ai/providers/google-provider.test.ts
+++ b/packages/server/api/test/unit/app/ai/providers/google-provider.test.ts
@@ -1,0 +1,73 @@
+import { AIProviderModelType, AIProviderName, ALLOWED_CHAT_MODELS_BY_PROVIDER } from '@activepieces/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSendRequest } = vi.hoisted(() => ({ mockSendRequest: vi.fn() }))
+
+vi.mock('@activepieces/pieces-common', () => ({
+    httpClient: { sendRequest: mockSendRequest },
+    HttpMethod: { GET: 'GET' },
+}))
+
+import { googleProvider } from '../../../../../src/app/ai/providers/google-provider'
+
+describe('googleProvider.listModels', () => {
+    beforeEach(() => {
+        mockSendRequest.mockReset()
+    })
+
+    it('strips the models/ prefix from every emitted model id', async () => {
+        mockSendRequest.mockResolvedValue({
+            body: {
+                models: [
+                    { name: 'models/gemini-2.5-pro', displayName: 'Gemini 2.5 Pro' },
+                    { name: 'models/gemini-2.5-flash', displayName: 'Gemini 2.5 Flash' },
+                    { name: 'models/imagen-3.0-generate', displayName: 'Imagen 3' },
+                ],
+            },
+        })
+
+        const models = await googleProvider.listModels({ apiKey: 'test-key' }, {})
+
+        for (const model of models) {
+            expect(model.id.startsWith('models/')).toBe(false)
+        }
+    })
+
+    it('emits ids that intersect the Google chat allow-list so the picker populates', async () => {
+        mockSendRequest.mockResolvedValue({
+            body: {
+                models: [
+                    { name: 'models/gemini-2.5-pro', displayName: 'Gemini 2.5 Pro' },
+                    { name: 'models/gemini-2.5-flash', displayName: 'Gemini 2.5 Flash' },
+                ],
+            },
+        })
+
+        const models = await googleProvider.listModels({ apiKey: 'test-key' }, {})
+
+        const allowedIds = ALLOWED_CHAT_MODELS_BY_PROVIDER[AIProviderName.GOOGLE] ?? []
+        const intersection = models.filter((model) => allowedIds.includes(model.id))
+
+        expect(intersection.map((model) => model.id)).toEqual(
+            expect.arrayContaining(['gemini-2.5-pro', 'gemini-2.5-flash']),
+        )
+    })
+
+    it('still classifies image models by their name', async () => {
+        mockSendRequest.mockResolvedValue({
+            body: {
+                models: [
+                    { name: 'models/gemini-2.5-flash', displayName: 'Gemini 2.5 Flash' },
+                    { name: 'models/imagen-3.0-generate-image', displayName: 'Imagen 3' },
+                ],
+            },
+        })
+
+        const models = await googleProvider.listModels({ apiKey: 'test-key' }, {})
+
+        const imageModel = models.find((model) => model.id === 'imagen-3.0-generate-image')
+        const textModel = models.find((model) => model.id === 'gemini-2.5-flash')
+        expect(imageModel?.type).toBe(AIProviderModelType.IMAGE)
+        expect(textModel?.type).toBe(AIProviderModelType.TEXT)
+    })
+})

--- a/packages/server/api/test/unit/app/flows/flow-version/migrate-v20-google-model-prefix.test.ts
+++ b/packages/server/api/test/unit/app/flows/flow-version/migrate-v20-google-model-prefix.test.ts
@@ -1,0 +1,116 @@
+import {
+    AgentPieceProps,
+    FlowActionType,
+    flowStructureUtil,
+    FlowTriggerType,
+    FlowVersionState,
+} from '@activepieces/shared'
+import type { FlowVersion } from '@activepieces/shared'
+import { describe, expect, it } from 'vitest'
+import { migrateV20GoogleModelPrefix } from '../../../../../src/app/flows/flow-version/migrations/migrate-v20-google-model-prefix'
+
+function makeFlowVersion(): FlowVersion {
+    return {
+        id: 'fv-1',
+        created: '2024-01-01T00:00:00Z',
+        updated: '2024-01-01T00:00:00Z',
+        flowId: 'flow-1',
+        displayName: 'Test Flow',
+        trigger: {
+            name: 'trigger',
+            valid: true,
+            displayName: 'Trigger',
+            type: FlowTriggerType.EMPTY,
+            settings: {},
+            nextAction: {
+                name: 'ask_ai',
+                valid: true,
+                displayName: 'Ask AI',
+                type: FlowActionType.PIECE,
+                settings: {
+                    pieceName: '@activepieces/piece-ai',
+                    pieceVersion: '0.1.0',
+                    actionName: 'askAi',
+                    input: {
+                        provider: 'GOOGLE',
+                        model: 'models/gemini-2.5-flash',
+                    },
+                    propertySettings: {},
+                },
+                nextAction: {
+                    name: 'run_agent',
+                    valid: true,
+                    displayName: 'Run Agent',
+                    type: FlowActionType.PIECE,
+                    settings: {
+                        pieceName: '@activepieces/piece-ai',
+                        pieceVersion: '0.1.0',
+                        actionName: 'run_agent',
+                        input: {
+                            [AgentPieceProps.AI_PROVIDER_MODEL]: {
+                                provider: 'GOOGLE',
+                                model: 'models/gemini-2.5-pro',
+                            },
+                        },
+                        propertySettings: {},
+                    },
+                    nextAction: {
+                        name: 'run_agent_managed',
+                        valid: true,
+                        displayName: 'Run Agent Managed',
+                        type: FlowActionType.PIECE,
+                        settings: {
+                            pieceName: '@activepieces/piece-ai',
+                            pieceVersion: '0.1.0',
+                            actionName: 'run_agent',
+                            input: {
+                                [AgentPieceProps.AI_PROVIDER_MODEL]: {
+                                    provider: 'ACTIVEPIECES',
+                                    model: 'google/gemini-2.5-flash',
+                                },
+                            },
+                            propertySettings: {},
+                        },
+                    },
+                },
+            },
+        },
+        updatedBy: null,
+        valid: true,
+        schemaVersion: '20',
+        agentIds: [],
+        state: FlowVersionState.DRAFT,
+        connectionIds: [],
+        backupFiles: null,
+        notes: [],
+    }
+}
+
+function findStep(flowVersion: FlowVersion, name: string): Record<string, unknown> {
+    const step = flowStructureUtil.getAllSteps(flowVersion.trigger).find((s) => s.name === name)
+    return step?.settings.input as Record<string, unknown>
+}
+
+describe('migrateV20GoogleModelPrefix', () => {
+    it('strips the models/ prefix from an askAi Google model id', async () => {
+        const result = await migrateV20GoogleModelPrefix.migrate(makeFlowVersion())
+        expect(findStep(result, 'ask_ai').model).toBe('gemini-2.5-flash')
+    })
+
+    it('strips the models/ prefix from a run_agent aiProviderModel.model', async () => {
+        const result = await migrateV20GoogleModelPrefix.migrate(makeFlowVersion())
+        const aiProviderModel = findStep(result, 'run_agent')[AgentPieceProps.AI_PROVIDER_MODEL] as Record<string, unknown>
+        expect(aiProviderModel.model).toBe('gemini-2.5-pro')
+    })
+
+    it('leaves a non-prefixed managed model id untouched', async () => {
+        const result = await migrateV20GoogleModelPrefix.migrate(makeFlowVersion())
+        const aiProviderModel = findStep(result, 'run_agent_managed')[AgentPieceProps.AI_PROVIDER_MODEL] as Record<string, unknown>
+        expect(aiProviderModel.model).toBe('google/gemini-2.5-flash')
+    })
+
+    it('bumps the schema version to 21', async () => {
+        const result = await migrateV20GoogleModelPrefix.migrate(makeFlowVersion())
+        expect(result.schemaVersion).toBe('21')
+    })
+})

--- a/packages/shared/src/lib/automation/flows/flow-version.ts
+++ b/packages/shared/src/lib/automation/flows/flow-version.ts
@@ -7,7 +7,7 @@ import { FlowTrigger } from './triggers/trigger'
 
 export type FlowVersionId = ApId
 
-export const LATEST_FLOW_SCHEMA_VERSION = '20'
+export const LATEST_FLOW_SCHEMA_VERSION = '21'
 
 export enum FlowVersionState {
     LOCKED = 'LOCKED',


### PR DESCRIPTION
Cherry-pick of #13468 (already merged to main as 3bf6f53) onto the current cloud deploy branch for a production hotfix. Fixes the Run Agent model picker showing an empty model list for self-configured Google (Gemini) providers (#13467). Net change is identical to the main merge: Google provider prefix strip + flow-version migrate-v20 + schema bump to 21. No DB migration required.
