### PR TITLE
feat(tables): add Download Table action with include/exclude headers …

### DIFF
--- a/packages/pieces/core/tables/package.json
+++ b/packages/pieces/core/tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-tables",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/tables/src/index.ts
+++ b/packages/pieces/core/tables/src/index.ts
@@ -6,6 +6,7 @@ import { updateRecord } from "./lib/actions/update-record";
 import { getRecord } from "./lib/actions/get-record";
 import { findRecords } from "./lib/actions/find-records";
 import { clearTable } from "./lib/actions/clear-table";
+import { downloadTable } from "./lib/actions/download-table";
 import { newRecordTrigger } from "./lib/triggers/new-record";
 import { deletedRecordTrigger } from "./lib/triggers/deleted-record";
 import { updatedRecordTrigger } from "./lib/triggers/updated-record";
@@ -17,6 +18,6 @@ export const tables = createPiece({
   minimumSupportedRelease: '0.80.0',
   authors: ['amrdb'],
   auth: PieceAuth.None(),
-  actions: [createRecords, deleteRecord, updateRecord, getRecord, findRecords, clearTable],
+  actions: [createRecords, deleteRecord, updateRecord, getRecord, findRecords, clearTable, downloadTable],
   triggers: [newRecordTrigger, updatedRecordTrigger, deletedRecordTrigger],
 });

--- a/packages/pieces/core/tables/src/lib/actions/download-table.ts
+++ b/packages/pieces/core/tables/src/lib/actions/download-table.ts
@@ -1,0 +1,61 @@
+import {
+  createAction,
+  PieceAuth,
+  Property,
+} from '@activepieces/pieces-framework';
+import { tablesCommon, csvUtils } from '../common';
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import { ExportTableResponse } from '@activepieces/shared';
+
+export const downloadTable = createAction({
+  name: 'tables-download-table',
+  displayName: 'Download Table',
+  description: 'Export a table as a CSV file.',
+  auth: PieceAuth.None(),
+  props: {
+    table_id: tablesCommon.table_id,
+    include_headers: Property.Checkbox({
+      displayName: 'Include Headers',
+      description:
+        'Whether to include column headers as the first row of the CSV.',
+      required: true,
+      defaultValue: true,
+    }),
+  },
+  async run(context) {
+    const { table_id: tableExternalId, include_headers: includeHeaders } =
+      context.propsValue;
+    const tableId = await tablesCommon.convertTableExternalIdToId(
+      tableExternalId,
+      context
+    );
+
+    const response = await httpClient.sendRequest<ExportTableResponse>({
+      method: HttpMethod.GET,
+      url: `${context.server.apiUrl}v1/tables/${tableId}/export`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: context.server.token,
+      },
+      retries: 5,
+    });
+
+    const { fields, rows, name } = response.body;
+    const csvContent = csvUtils.buildCsv({
+      fields,
+      rows,
+      includeHeaders: includeHeaders ?? true,
+    });
+
+    const file = await context.files.write({
+      fileName: `${name}.csv`,
+      data: Buffer.from(csvContent, 'utf-8'),
+    });
+
+    return { file, name: `${name}.csv` };
+  },
+});

--- a/packages/pieces/core/tables/src/lib/common/index.ts
+++ b/packages/pieces/core/tables/src/lib/common/index.ts
@@ -287,6 +287,30 @@ export const tablesCommon = {
   }
 }
 
+export const csvUtils = {
+  buildCsv({ fields, rows, includeHeaders }: { fields: { name: string }[], rows: Record<string, string>[], includeHeaders: boolean }): string {
+    const columnNames = fields.map((f) => f.name);
+    const lines: string[] = [];
+
+    if (includeHeaders) {
+      lines.push(columnNames.map(this.escapeCsvCell).join(','));
+    }
+
+    for (const row of rows) {
+      lines.push(columnNames.map((name) => this.escapeCsvCell(row[name] ?? '')).join(','));
+    }
+
+    return lines.join('\n');
+  },
+
+  escapeCsvCell(value: string): string {
+    if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+      return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
+  },
+}
+
 const fetchAllTables = async (context: { server: { apiUrl: string, token: string }, project: { id: string } }): Promise<Table[]> => {
   const res = await httpClient.sendRequest({
     method: HttpMethod.GET,


### PR DESCRIPTION
…option

Adds a new "Download Table" action to the Tables core piece that exports a table as a CSV file. Supports toggling column headers on/off. Extracts CSV building logic into shared csvUtils in the common module.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
