### PR TITLE
docs(piece-builder): document audience and aiMetadata fields

### DIFF
--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -139,6 +139,7 @@ Copy config files from an existing simple piece (e.g. `packages/pieces/core/qrco
 | HTTP client, shared helpers, pagination         | `common-patterns.md`  |
 | Every prop and dropdown **(mandatory for all)** | `ux-guidelines.md`    |
 | Every return value **(mandatory for all)**      | `output-quality.md`   |
+| Tagging an action/trigger for AI agents         | `ai-metadata.md`      |
 
 `ux-guidelines.md` and `output-quality.md` apply to **every** action and trigger -- read them before starting, not only when unsure.
 
@@ -291,6 +292,15 @@ Every action output must be directly mappable to Google Sheets, Excel, and Activ
 5. **Use human-readable key names** -- `company_name` not `cName`. These become column headers.
 
 Full patterns and examples: read `output-quality.md`
+
+## AI-Ready Metadata (Optional)
+
+Pieces are also called by AI agents through the MCP server. Two optional fields let an action or trigger declare how it appears to agents — both are additive and change nothing for human users:
+
+-   **`audience`** (actions only): `'human' | 'ai' | 'both'` — fence an action to one surface. Omit for "both" (the default).
+-   **`aiMetadata`** (actions and triggers): `{ description?, idempotent? }` — an agent-facing tool description and a safe-retry hint.
+
+Skip both unless you are deliberately tuning a piece for agents. Full guidance and examples: read `ai-metadata.md`
 
 ## Critical Reminders
 

--- a/.agents/skills/piece-builder/action-patterns.md
+++ b/.agents/skills/piece-builder/action-patterns.md
@@ -48,3 +48,7 @@ The `token` field above assumes a `PieceAuth.SecretText()` auth. For other auth 
 **Real example:** `packages/pieces/community/github/src/lib/actions/create-issue.ts`
 
 For all available property types (`Property.ShortText`, `Property.Dropdown`, `Property.Array`, etc.) read `props-patterns.md`.
+
+## AI-Ready Metadata (optional)
+
+Actions accept two optional fields that tune how they appear to AI agents: `audience` (`'human' | 'ai' | 'both'`) and `aiMetadata` (`{ description?, idempotent? }`). They are additive and change nothing for human users. Skip them unless you are deliberately tuning the action for agents — see `ai-metadata.md`.

--- a/.agents/skills/piece-builder/ai-metadata.md
+++ b/.agents/skills/piece-builder/ai-metadata.md
@@ -1,0 +1,86 @@
+# AI-Ready Metadata
+
+Pieces power both human flow-builders and AI agents (via the MCP server and the agent tooling). Two **optional** fields let an action or trigger declare how it should appear to agents. Both are additive: omit them and the piece behaves exactly as before. Adding them never changes anything for human users.
+
+| Field | Where | Shape |
+|---|---|---|
+| `audience` | actions only | `'human' \| 'ai' \| 'both'` |
+| `aiMetadata` | actions **and** triggers | `{ description?: string; idempotent?: boolean }` |
+
+Both are plain values on the `createAction` / `createTrigger` object — no import is needed. Triggers accept `aiMetadata` but **not** `audience`: a trigger is an event, not an agent-callable operation.
+
+---
+
+## `audience` — who the action is for
+
+```typescript
+export const createRecordAction = createAction({
+  name: 'create_record',
+  displayName: 'Create Record',
+  description: 'Creates a new record in My App',   // human-facing
+  audience: 'both',                                // 'human' | 'ai' | 'both'
+  props: { /* ... */ },
+  async run(context) { /* ... */ },
+});
+```
+
+| Value | Meaning |
+|---|---|
+| `'human'` | For human flow-builders only; kept off the agent surface. Use for actions that need human judgement or only make sense inside the visual builder. |
+| `'ai'` | For AI agents only; kept out of the human catalog to reduce clutter. Use for agent-oriented atomics. |
+| `'both'` | Useful to humans and agents alike. |
+| *(omitted)* | Treated as `'both'` — available everywhere. This is the default; most actions need nothing here. |
+
+Only set `audience` to deliberately fence an action to one surface. Leave it off otherwise.
+
+---
+
+## `aiMetadata` — describe the action for an LLM
+
+```typescript
+export const createRecordAction = createAction({
+  name: 'create_record',
+  displayName: 'Create Record',
+  description: 'Creates a new record in My App',
+  aiMetadata: {
+    description:
+      'Create a new record in My App. Use when the user wants to add an entry. Returns the created record id and fields.',
+    idempotent: false,
+  },
+  props: { /* ... */ },
+  async run(context) { /* ... */ },
+});
+```
+
+**`description`** — written **for an agent**, not for the builder UI. The human `description` answers "what does this do" for someone reading a dropdown; `aiMetadata.description` answers "when should I call this tool, and what do I get back" for an agent choosing between hundreds of tools. Be explicit about intent, inputs, and the return shape. When the human `description` already reads well for an agent, omit this and the agent falls back to it.
+
+**`idempotent`** — `true` when calling the action repeatedly with the same input is safe and yields the same result without extra side effects (a GET/lookup, or an upsert keyed on a stable id). `false` (or omitted) for actions that create or mutate on every call (`Send Message`, `Create Record`). Agents use this to reason about safe retries; it maps to the MCP `idempotentHint`.
+
+---
+
+## Triggers
+
+Triggers take `aiMetadata` only — no `audience`:
+
+```typescript
+export const newRecordTrigger = createTrigger({
+  name: 'new_record',
+  displayName: 'New Record',
+  description: 'Triggers when a new record is created',
+  aiMetadata: {
+    description: 'Fires when a new record is created in My App.',
+  },
+  // ... type, props, sampleData, run, onEnable, onDisable
+});
+```
+
+`idempotent` is accepted for shape consistency but rarely meaningful on a trigger — leave it off.
+
+---
+
+## When to add this
+
+- **Always fine to skip.** These fields are optional; an untagged piece keeps working exactly as before.
+- Add `aiMetadata.description` to your most-used actions when the human description is terse or builder-specific — it is the single highest-value thing for agent usability.
+- Set `idempotent: true` on read-only / lookup / upsert actions so agents can retry them safely.
+- Reach for `audience` only when an action should be restricted to humans or to agents.

--- a/.agents/skills/piece-builder/trigger-patterns.md
+++ b/.agents/skills/piece-builder/trigger-patterns.md
@@ -282,3 +282,9 @@ export const myTrigger = createTrigger({
 | `TriggerStrategy.POLLING` | API has no webhooks | Use `pollingHelper` with TIMEBASED or LAST_ITEM |
 | `TriggerStrategy.WEBHOOK` | API supports webhook registration | Register in `onEnable`, delete in `onDisable` |
 | `TriggerStrategy.APP_WEBHOOK` | OAuth2 apps with platform-level webhooks (Slack) | Use `context.app.createListeners()` |
+
+---
+
+## AI-Ready Metadata (optional)
+
+Triggers accept an optional `aiMetadata` field (`{ description?, idempotent? }`) to describe the event for AI agents. They do **not** take `audience` — that field is actions-only, since a trigger is an event rather than an agent-callable operation. The field is additive and changes nothing for human users. See `ai-metadata.md`.


### PR DESCRIPTION
## What

Documents the optional AI-ready metadata fields added to the pieces framework in 0.29.1 inside the `piece-builder` agent skill:

- `audience` (`'human' | 'ai' | 'both'`) — actions only
- `aiMetadata` (`{ description?, idempotent? }`) — actions and triggers

## Changes

- New `ai-metadata.md` reference: field shapes, value semantics, action and trigger examples, and when to use each.
- `SKILL.md`: a row in the Step 4 implementation table and a short "AI-Ready Metadata" section.
- `action-patterns.md` / `trigger-patterns.md`: brief pointers to the reference (triggers note that `audience` is actions-only).

## Notes

- Docs only — no code or behavior change. The fields are additive and optional; untagged pieces are unaffected.
- Mirrors the merged framework contract: `aiReady` (not yet in the framework) and `outputSchema` (removed from `aiMetadata`) are intentionally not documented.