### PR TITLE
fix(server): testing queue UI

### DIFF
--- a/packages/server/api/src/app/workers/job-queue/bullboard.ts
+++ b/packages/server/api/src/app/workers/job-queue/bullboard.ts
@@ -11,6 +11,7 @@ import { systemJobsQueue } from '../../helper/system-jobs/system-job'
 import { jobQueue } from './job-queue'
 
 const QUEUE_BASE_PATH = '/ui'
+const QUEUE_UI_FULL_PATH = `/api${QUEUE_BASE_PATH}`
 
 export async function setupBullMQBoard(app: FastifyInstance): Promise<void> {
     const isQueueEnabled = (system.getBoolean(AppSystemProp.QUEUE_UI_ENABLED) ?? false)
@@ -21,7 +22,7 @@ export async function setupBullMQBoard(app: FastifyInstance): Promise<void> {
     const queueUsername = system.getOrThrow(AppSystemProp.QUEUE_UI_USERNAME)
     const queuePassword = system.getOrThrow(AppSystemProp.QUEUE_UI_PASSWORD)
     app.log.info(
-        '[setupBullMQBoard] Setting up bull board, visit /ui to see the queues',
+        `[setupBullMQBoard] Setting up bull board, visit ${QUEUE_UI_FULL_PATH} to see the queues`,
     )
 
     await app.register(basicAuth, {
@@ -54,11 +55,11 @@ export async function setupBullMQBoard(app: FastifyInstance): Promise<void> {
         serverAdapter,
     })
 
-    serverAdapter.setBasePath(`/api${QUEUE_BASE_PATH}`)
+    serverAdapter.setBasePath(QUEUE_UI_FULL_PATH)
     app.addHook('onRequest', (req, reply, next) => {
         const routerPath = req.routeOptions.url
-        assertNotNullOrUndefined(routerPath, 'routerPath is undefined'  )    
-        if (!routerPath.startsWith(QUEUE_BASE_PATH)) {
+        assertNotNullOrUndefined(routerPath, 'routerPath is undefined'  )
+        if (!routerPath.startsWith(QUEUE_UI_FULL_PATH)) {
             next()
         }
         else {

--- a/packages/server/api/test/integration/cloud/workers/bullboard.test.ts
+++ b/packages/server/api/test/integration/cloud/workers/bullboard.test.ts
@@ -1,0 +1,48 @@
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    process.env.AP_QUEUE_UI_ENABLED = 'true'
+    process.env.AP_QUEUE_UI_USERNAME = 'testuser'
+    process.env.AP_QUEUE_UI_PASSWORD = 'testpass'
+    app = await setupTestEnvironment({ fresh: true })
+})
+
+afterAll(async () => {
+    delete process.env.AP_QUEUE_UI_ENABLED
+    delete process.env.AP_QUEUE_UI_USERNAME
+    delete process.env.AP_QUEUE_UI_PASSWORD
+    await teardownTestEnvironment()
+})
+
+function basicHeader(username: string, password: string): string {
+    return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`
+}
+
+describe('BullBoard Queue UI auth', () => {
+    it('rejects unauthenticated requests to /api/ui with 401', async () => {
+        const response = await app!.inject({ method: 'GET', url: '/api/ui' })
+        expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+    })
+
+    it('rejects wrong credentials with 401', async () => {
+        const response = await app!.inject({
+            method: 'GET',
+            url: '/api/ui',
+            headers: { authorization: basicHeader('testuser', 'wrongpass') },
+        })
+        expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED)
+    })
+
+    it('allows correct credentials', async () => {
+        const response = await app!.inject({
+            method: 'GET',
+            url: '/api/ui',
+            headers: { authorization: basicHeader('testuser', 'testpass') },
+        })
+        expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+})


### PR DESCRIPTION
## Summary
- Fix the BullBoard queue UI route matching when QUEUE_UI_ENABLED=true.
- The onRequest hook compared req.routeOptions.url (the full prefixed path /api/ui/...) against '/ui', so the check never matched.
- Now matches the effective /api/ui path via a single shared constant used by both setBasePath and the hook.

## Test plan
- [x] Added integration tests: unauthenticated → 401, wrong creds → 401, correct creds → 200
- [x] Confirmed the tests fail on the old code and pass on the fix