### PR TITLE
fix(server): enforce table permissions on field endpoints

### DIFF
--- a/.agents/features/tables.md
+++ b/.agents/features/tables.md
@@ -86,14 +86,14 @@ A built-in relational database feature that lets users store structured data dir
 
 All table / field / record routes use `securityAccess.project([...], <permission>, <resource>)`. The required permission per resource:
 
-- **Read** (`GET /v1/tables`, `GET /v1/tables/:id`, `GET /v1/fields`, `GET /v1/records`, `GET /v1/records/:id`): `READ_TABLE`
-- **Write** (`POST /v1/tables`, `POST /v1/tables/:id`, `DELETE /v1/tables/:id`, `POST /v1/fields`, `DELETE /v1/fields/:id`, `POST /v1/records`, `POST /v1/records/:id`, `DELETE /v1/records`): `WRITE_TABLE`
+- **Read** (`GET /v1/tables`, `GET /v1/tables/:id`, `GET /v1/fields`, `GET /v1/fields/:id`, `GET /v1/records`, `GET /v1/records/:id`): `READ_TABLE`
+- **Write** (`POST /v1/tables`, `POST /v1/tables/:id`, `DELETE /v1/tables/:id`, `POST /v1/fields`, `POST /v1/fields/:id`, `DELETE /v1/fields/:id`, `POST /v1/records`, `POST /v1/records/:id`, `DELETE /v1/records`): `WRITE_TABLE`
 
 Default project roles: `ADMIN` and `EDITOR` have both; `VIEWER` has only `READ_TABLE`. Custom roles inherit whatever permissions are configured.
 
 `ENGINE` and `SERVICE` principals skip the per-role permission check entirely — `ENGINE` is gated on `principal.projectId === projectId` and `SERVICE` on platform-equality only — so flow steps that call the records API and service API keys are unaffected by the role-permission model.
 
-When adding a new mutation route on tables / fields / records, the `permission` argument to `securityAccess.project(...)` is required; passing `undefined` short-circuits the rbac check to allow any project member.
+When adding a new route (read or write) on tables / fields / records, the `permission` argument to `securityAccess.project(...)` is required; passing `undefined` short-circuits the rbac check to allow any project member.
 
 ## Side Effects
 

--- a/packages/server/api/src/app/tables/field/field.controller.ts
+++ b/packages/server/api/src/app/tables/field/field.controller.ts
@@ -1,4 +1,4 @@
-import { CreateFieldRequest, Field, ListFieldsRequestQuery, PrincipalType, UpdateFieldRequest } from '@activepieces/shared'
+import { CreateFieldRequest, Field, ListFieldsRequestQuery, Permission, PrincipalType, UpdateFieldRequest } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
@@ -51,7 +51,7 @@ export const fieldController: FastifyPluginAsyncZod = async (fastify) => {
 }
 const CreateRequest = {
     config: {
-        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], undefined, {
+        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], Permission.WRITE_TABLE, {
             type: ProjectResourceType.TABLE,
             tableName: TableEntity,
             entitySourceType: EntitySourceType.BODY,
@@ -71,7 +71,7 @@ const CreateRequest = {
 
 const GetFieldByIdRequest = {
     config: {
-        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], undefined, {
+        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], Permission.READ_TABLE, {
             type: ProjectResourceType.TABLE,
             tableName: FieldEntity,
         }),
@@ -85,7 +85,7 @@ const GetFieldByIdRequest = {
 
 const DeleteFieldRequest = {
     config: {
-        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], undefined, {
+        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], Permission.WRITE_TABLE, {
             type: ProjectResourceType.TABLE,
             tableName: FieldEntity,
         }),
@@ -99,7 +99,7 @@ const DeleteFieldRequest = {
 
 const GetFieldsRequest = {
     config: {
-        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], undefined, {
+        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], Permission.READ_TABLE, {
             type: ProjectResourceType.TABLE,
             tableName: TableEntity,
             entitySourceType: EntitySourceType.QUERY,
@@ -116,7 +116,7 @@ const GetFieldsRequest = {
 
 const UpdateRequest = {
     config: {
-        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], undefined, {
+        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], Permission.WRITE_TABLE, {
             type: ProjectResourceType.TABLE,
             tableName: FieldEntity,
         }),

--- a/packages/server/api/src/app/tables/record/record.controller.ts
+++ b/packages/server/api/src/app/tables/record/record.controller.ts
@@ -113,7 +113,7 @@ const CreateRequest = {
 
 const GetRecordByIdRequest = {
     config: {
-        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], undefined, {
+        security: securityAccess.project([PrincipalType.USER, PrincipalType.ENGINE, PrincipalType.SERVICE], Permission.READ_TABLE, {
             type: ProjectResourceType.TABLE,
             tableName: RecordEntity,
         }),

--- a/packages/server/api/test/integration/cloud/tables/field-rbac.test.ts
+++ b/packages/server/api/test/integration/cloud/tables/field-rbac.test.ts
@@ -1,0 +1,166 @@
+import { DefaultProjectRole, FieldType } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { db } from '../../../helpers/db'
+import { createMockField, createMockTable } from '../../../helpers/mocks'
+import { createMemberContext, createTestContext, TestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Field API — project-role permission enforcement', () => {
+    describe('VIEWER (READ_TABLE only — no WRITE_TABLE)', () => {
+        it('cannot create fields (POST /v1/fields → 403)', async () => {
+            const { viewerCtx, table } = await setupViewer()
+
+            const response = await viewerCtx.post('/v1/fields', {
+                tableId: table.id,
+                name: 'viewer-should-be-rejected',
+                type: FieldType.TEXT,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+            expect(response?.json()).toMatchObject({ code: 'PERMISSION_DENIED' })
+        })
+
+        it('cannot update fields (POST /v1/fields/:id → 403)', async () => {
+            const { viewerCtx, field } = await setupViewer()
+
+            const response = await viewerCtx.post(`/v1/fields/${field.id}`, {
+                name: 'viewer-renamed',
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+            expect(response?.json()).toMatchObject({ code: 'PERMISSION_DENIED' })
+        })
+
+        it('cannot delete fields (DELETE /v1/fields/:id → 403)', async () => {
+            const { viewerCtx, field } = await setupViewer()
+
+            const response = await viewerCtx.inject({
+                method: 'DELETE',
+                url: `/api/v1/fields/${field.id}`,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+            expect(response?.json()).toMatchObject({ code: 'PERMISSION_DENIED' })
+        })
+
+        it('can list fields (GET /v1/fields → 200)', async () => {
+            const { viewerCtx, table } = await setupViewer()
+
+            const response = await viewerCtx.get('/v1/fields', { tableId: table.id })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+        })
+
+        it('can read an individual field (GET /v1/fields/:id → 200)', async () => {
+            const { viewerCtx, field } = await setupViewer()
+
+            const response = await viewerCtx.get(`/v1/fields/${field.id}`)
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(response?.json()?.id).toBe(field.id)
+        })
+    })
+
+    describe('EDITOR (READ_TABLE + WRITE_TABLE) — fix must not block legitimate callers', () => {
+        it('can create fields', async () => {
+            const { editorCtx, table } = await setupEditor()
+
+            const response = await editorCtx.post('/v1/fields', {
+                tableId: table.id,
+                name: 'editor-allowed',
+                type: FieldType.TEXT,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.CREATED)
+            expect(response?.json()?.tableId).toBe(table.id)
+        })
+
+        it('can update fields', async () => {
+            const { editorCtx, field } = await setupEditor()
+
+            const response = await editorCtx.post(`/v1/fields/${field.id}`, {
+                name: 'editor-renamed',
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(response?.json()?.name).toBe('editor-renamed')
+        })
+
+        it('can delete fields', async () => {
+            const { editorCtx, field } = await setupEditor()
+
+            const response = await editorCtx.inject({
+                method: 'DELETE',
+                url: `/api/v1/fields/${field.id}`,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+        })
+    })
+
+    describe('Project owner (ADMIN role on own project)', () => {
+        it('can create, update, and delete fields', async () => {
+            const ownerCtx = await createTestContext(app, { plan: { projectRolesEnabled: true } })
+            const { table } = await createTableWithField(ownerCtx)
+
+            const createResp = await ownerCtx.post('/v1/fields', {
+                tableId: table.id,
+                name: 'owner-create',
+                type: FieldType.TEXT,
+            })
+            expect(createResp?.statusCode).toBe(StatusCodes.CREATED)
+
+            const fieldId = createResp?.json()?.id
+
+            const updateResp = await ownerCtx.post(`/v1/fields/${fieldId}`, {
+                name: 'owner-update',
+            })
+            expect(updateResp?.statusCode).toBe(StatusCodes.OK)
+
+            const deleteResp = await ownerCtx.inject({
+                method: 'DELETE',
+                url: `/api/v1/fields/${fieldId}`,
+            })
+            expect(deleteResp?.statusCode).toBe(StatusCodes.OK)
+        })
+    })
+})
+
+type TableAndField = { table: { id: string }, field: { id: string } }
+type ViewerSetup = { ownerCtx: TestContext, viewerCtx: TestContext } & TableAndField
+type EditorSetup = { ownerCtx: TestContext, editorCtx: TestContext } & TableAndField
+
+async function setupViewer(): Promise<ViewerSetup> {
+    const ownerCtx = await createTestContext(app, { plan: { projectRolesEnabled: true } })
+    const viewerCtx = await createMemberContext(app, ownerCtx, { projectRole: DefaultProjectRole.VIEWER })
+    const { table, field } = await createTableWithField(ownerCtx)
+    return { ownerCtx, viewerCtx, table, field }
+}
+
+async function setupEditor(): Promise<EditorSetup> {
+    const ownerCtx = await createTestContext(app, { plan: { projectRolesEnabled: true } })
+    const editorCtx = await createMemberContext(app, ownerCtx, { projectRole: DefaultProjectRole.EDITOR })
+    const { table, field } = await createTableWithField(ownerCtx)
+    return { ownerCtx, editorCtx, table, field }
+}
+
+async function createTableWithField(ctx: TestContext): Promise<TableAndField> {
+    const table = createMockTable({ projectId: ctx.project.id })
+    await db.save('table', table)
+    const field = createMockField({ tableId: table.id, projectId: ctx.project.id })
+    field.type = FieldType.TEXT
+    await db.save('field', field)
+    return { table, field }
+}


### PR DESCRIPTION
## Summary
- Enforce table role permissions on the field endpoints.
- Keep field operations consistent with the rest of the tables surface.
- Require the appropriate table role for reading and modifying fields.

## Test plan
- [x] `field-rbac.test.ts` (new) + `record-rbac.test.ts` pass — 18/18 green
- [x] VIEWER → 403 on create/rename/delete fields, 200 on list/read
- [x] EDITOR & project owner → can create/rename/delete fields (no regression)
