### PR TITLE
feat(chat): improve AI chat reliability with instant cancel, auto-resume after stop, and connection state fixes

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -10,7 +10,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - `packages/server/api/src/app/ee/chat/chat-conversation-entity.ts` — ChatConversation TypeORM entity
 - `packages/server/api/src/app/ee/chat/chat-model-factory.ts` — creates AI SDK `LanguageModel` from provider config (OpenAI, Anthropic, Google, Azure, Bedrock, Cloudflare, Custom)
 - `packages/server/api/src/app/ee/chat/chat-compaction.ts` — long-conversation context management via summarization
-- `packages/server/api/src/app/ee/chat/chat-approval-gate.ts` — Redis pub/sub gate for tool execution approval (5-min timeout); also stores per-conversation cancel signals with a 10-min TTL
+- `packages/server/api/src/app/ee/chat/chat-approval-gate.ts` — Redis pub/sub gate for tool execution approval (5-min timeout); uses atomic SET NX for first-decision-wins semantics; also stores per-conversation cancel signals with a 10-min TTL
 - `packages/server/api/src/app/ee/chat/chat-file-utils.ts` — file attachment processing (base64, MIME validation, 10MB limit)
 - `packages/server/api/src/app/ee/chat/tools/chat-tools.ts` — local LLM tools (title, project selection, action execution, cross-project listing, plan approval)
 - `packages/server/api/src/app/ee/chat/tools/chat-display-tools.ts` — display tools for interactive UI cards (connection picker, project picker, questions, quick replies)
@@ -53,8 +53,8 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - **MCP tools** — project-scoped tools loaded from the Activepieces MCP server when a project is selected; destructive ones are wrapped with the approval gate
 - **Tool call UX metadata** — optional `title` (2-4 word chip label) and `description` (first-person conversational sentence) stored on `PersistedToolCallPart`; description is sourced from the preceding `ap_update_thinking_status` text with `input.description` as fallback, rendered above the tool card chip
 - **AI provider** — a platform-configured LLM provider with an `enabledForChat` flag; the chat resolves the first enabled provider and its default model
-- **Streaming cancel** — a Redis key (10-min TTL) signals the worker to abort via AbortController at the next `onStepFinish` boundary; partial UI parts are saved before the conversation returns to IDLE
-- **Stale recovery** — when `getConversationOrThrow` fetches a conversation stuck in STREAMING for more than 15 minutes, it automatically resets the status to IDLE before returning
+- **Streaming cancel** — a Redis key (10-min TTL) signals the worker to abort via AbortController; a 3-second periodic timer checks the Redis key so cancellation fires within 3 seconds regardless of step boundaries; partial messages (from completed steps via `onAbort` callback) are saved to preserve context for resume
+- **Stale recovery** — when `getConversationOrThrow` fetches a conversation stuck in STREAMING for more than 20 minutes, it automatically resets the status to IDLE before returning
 - **Project context** — the currently selected project for a conversation; determines which MCP tools are available and scopes resource access
 - **Chat tiers** — model configurations (fast/smart/premium) with different thinking budgets; displayed as Fast/Expert/Heavy in the UI with per-tier descriptions
 - **Credits warning banner** — a dismissible amber banner shown when Activepieces AI credits usage reaches 70%; a non-dismissible red banner is shown when credits are fully exhausted
@@ -68,11 +68,11 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 ## Key Service Methods
 - `createConversation()` — creates a new conversation for a user on a platform
 - `listConversations()` — cursor-paginated list of user's conversations, ordered by creation date descending; excludes messages, uiMessages, and summary columns for performance
-- `getConversationOrThrow()` — fetches a conversation, enforcing ownership (platformId + userId); auto-recovers stale STREAMING conversations to IDLE after a 15-minute timeout
+- `getConversationOrThrow()` — fetches a conversation, enforcing ownership (platformId + userId); auto-recovers stale STREAMING conversations to IDLE after a 20-minute timeout
 - `updateConversation()` — updates title and/or modelName
-- `deleteConversation()` — deletes a conversation after ownership check
+- `deleteConversation()` — deletes a conversation after ownership check; blocked while status is STREAMING
 - `getMessages()` — reconstructs `ChatHistoryMessage[]` from stored `ModelMessage[]`
-- `sendMessage()` — the main streaming flow: resolves provider, connects MCP, builds prompt, runs `streamText()` with `prepareStep`; persists assistant response on completion
+- `sendMessage()` — the main streaming flow: resolves provider, connects MCP, builds prompt, runs `streamText()` with `stopWhen: isLoopFinished()` (no hard step cap), `prepareStep` (hides plan approval tool after approval), `experimental_repairToolCall` (auto-fixes malformed JSON), and `experimental_onToolCallFinish` (per-tool logging); retries event delivery with exponential backoff; tools have a 5-minute per-call timeout with AbortSignal propagation; persists assistant response on completion
 
 ## Local Tools
 - `ap_set_session_title` — auto-names the conversation after the first exchange

--- a/packages/server/api/src/app/database/redis/distributed-store-factory.ts
+++ b/packages/server/api/src/app/database/redis/distributed-store-factory.ts
@@ -21,6 +21,13 @@ export const distributedStoreFactory = (getRedisClient: () => Promise<Redis>) =>
         return JSON.parse(value) as T
     },
 
+    async putIfAbsent(key: string, value: unknown, ttlInSeconds: number): Promise<boolean> {
+        const serializedValue = JSON.stringify(value)
+        const redisClient = await getRedisClient()
+        const result = await redisClient.set(key, serializedValue, 'EX', ttlInSeconds, 'NX')
+        return result === 'OK'
+    },
+
     async delete(keys: string | string[]): Promise<void> {
         const keysArray = Array.isArray(keys) ? keys : [keys]
         if (keysArray.length === 0) return

--- a/packages/server/api/src/app/ee/chat/chat-approval-gate.ts
+++ b/packages/server/api/src/app/ee/chat/chat-approval-gate.ts
@@ -16,10 +16,10 @@ function channelName(gateId: string): string {
 }
 
 async function resolveGate({ gateId, approved, payload }: { gateId: string, approved: boolean, payload?: Record<string, unknown> }): Promise<void> {
-    const existing = await distributedStore.get(decisionKey(gateId))
-    if (existing) return
-    await distributedStore.put(decisionKey(gateId), { approved, payload }, GATE_TTL_SECONDS)
-    await pubsub.publish(channelName(gateId), JSON.stringify({ approved, payload }))
+    const wasSet = await distributedStore.putIfAbsent(decisionKey(gateId), { approved, payload }, GATE_TTL_SECONDS)
+    if (wasSet) {
+        await pubsub.publish(channelName(gateId), JSON.stringify({ approved, payload }))
+    }
 }
 
 async function checkDecision({ gateId }: { gateId: string }): Promise<GateDecision | 'pending'> {

--- a/packages/server/api/src/app/ee/chat/chat-approval-gate.ts
+++ b/packages/server/api/src/app/ee/chat/chat-approval-gate.ts
@@ -16,6 +16,8 @@ function channelName(gateId: string): string {
 }
 
 async function resolveGate({ gateId, approved, payload }: { gateId: string, approved: boolean, payload?: Record<string, unknown> }): Promise<void> {
+    const existing = await distributedStore.get(decisionKey(gateId))
+    if (existing) return
     await distributedStore.put(decisionKey(gateId), { approved, payload }, GATE_TTL_SECONDS)
     await pubsub.publish(channelName(gateId), JSON.stringify({ approved, payload }))
 }

--- a/packages/server/api/src/app/ee/chat/chat-controller.ts
+++ b/packages/server/api/src/app/ee/chat/chat-controller.ts
@@ -2,6 +2,7 @@ import {
     ActivepiecesError,
     AIProviderName,
     apId,
+    ChatConversationStatus,
     CreateChatConversationRequest,
     ErrorCode,
     LATEST_JOB_DATA_SCHEMA_VERSION,
@@ -20,6 +21,7 @@ import { securityAccess } from '../../core/security/authorization/fastify-securi
 import { jobQueue, JobType } from '../../workers/job-queue/job-queue'
 import { platformAiCreditsService } from '../platform/platform-plan/platform-ai-credits.service'
 import { chatApprovalGate } from './chat-approval-gate'
+import { chatHelpers } from './chat-helpers'
 import { chatService } from './chat-service'
 
 const CHAT_PRINCIPALS = [PrincipalType.USER] as const
@@ -127,6 +129,9 @@ export const chatController: FastifyPluginAsyncZod = async (app) => {
         const userId = request.principal.id
         await chatService(request.log).getConversationOrThrow({ id: conversationId, platformId, userId })
         await chatApprovalGate.requestCancel({ conversationId })
+        await chatHelpers.conversationRepo().update(conversationId, {
+            status: ChatConversationStatus.IDLE,
+        })
         return reply.status(StatusCodes.OK).send({ success: true })
     })
 

--- a/packages/server/api/src/app/ee/chat/chat-helpers.ts
+++ b/packages/server/api/src/app/ee/chat/chat-helpers.ts
@@ -17,7 +17,7 @@ import { projectService } from '../../project/project-service'
 import { userService } from '../../user/user-service'
 import { ChatConversationEntity } from './chat-conversation-entity'
 
-const STREAMING_STALENESS_TIMEOUT_MS = 15 * 60 * 1_000
+const STREAMING_STALENESS_TIMEOUT_MS = 20 * 60 * 1_000
 
 const conversationRepo = repoFactory(ChatConversationEntity)
 

--- a/packages/server/api/src/app/ee/chat/chat-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/chat/chat-rpc-handlers.ts
@@ -40,7 +40,13 @@ export const chatRpcHandlers = (log: FastifyBaseLogger) => ({
             chatMcp.getCredentials({ platformId, userId, log }),
         ])
 
-        if (conversation.status === ChatConversationStatus.STREAMING) {
+        const lockResult = await chatHelpers.conversationRepo()
+            .createQueryBuilder()
+            .update()
+            .set({ status: ChatConversationStatus.STREAMING })
+            .where('id = :id AND status != :streaming', { id: conversationId, streaming: ChatConversationStatus.STREAMING })
+            .execute()
+        if (lockResult.affected === 0) {
             throw new ActivepiecesError({
                 code: ErrorCode.VALIDATION,
                 params: { message: 'An agent is already running for this conversation' },
@@ -74,7 +80,6 @@ export const chatRpcHandlers = (log: FastifyBaseLogger) => ({
         await chatHelpers.conversationRepo().update(conversationId, {
             messages: allMessages,
             uiMessages: JSON.parse(JSON.stringify(uiMessagesWithUser)),
-            status: ChatConversationStatus.STREAMING,
         })
         await chatApprovalGate.clearCancel({ conversationId })
 
@@ -139,7 +144,10 @@ export const chatRpcHandlers = (log: FastifyBaseLogger) => ({
             if (input.modelName) updates.modelName = input.modelName
         }
 
-        await chatHelpers.conversationRepo().update(input.conversationId, updates)
+        const saveResult = await chatHelpers.conversationRepo().update(input.conversationId, updates)
+        if (saveResult.affected === 0) {
+            log.warn({ conversationId: input.conversationId }, 'saveChatMessages: conversation not found, may have been deleted')
+        }
 
         if (input.messages.length > 0) {
             const conversation = await chatHelpers.conversationRepo().findOneBy({ id: input.conversationId })

--- a/packages/server/api/src/app/ee/chat/chat-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/chat/chat-rpc-handlers.ts
@@ -81,7 +81,9 @@ export const chatRpcHandlers = (log: FastifyBaseLogger) => ({
             messages: allMessages,
             uiMessages: JSON.parse(JSON.stringify(uiMessagesWithUser)),
         })
-        await chatApprovalGate.clearCancel({ conversationId })
+        setTimeout(() => {
+            chatApprovalGate.clearCancel({ conversationId }).catch(() => {})
+        }, 5_000)
 
         const estimatedTokens = chatCompaction.estimateTokenCount({ messages: allMessages, systemPromptLength: systemPromptText.length })
         let compactionState = { summary: conversation.summary ?? null, summarizedUpToIndex: conversation.summarizedUpToIndex ?? null }

--- a/packages/server/api/src/app/ee/chat/chat-service.ts
+++ b/packages/server/api/src/app/ee/chat/chat-service.ts
@@ -1,8 +1,11 @@
 import {
+    ActivepiecesError,
     apId,
     ChatConversation,
+    ChatConversationStatus,
     ChatHistoryMessage,
     CreateChatConversationRequest,
+    ErrorCode,
     PersistedChatMessage,
     SeekPage,
     spreadIfDefined,
@@ -85,6 +88,12 @@ export const chatService = (log: FastifyBaseLogger) => ({
 
     async deleteConversation({ id, platformId, userId }: ConversationIdentifier): Promise<void> {
         const conversation = await this.getConversationOrThrow({ id, platformId, userId })
+        if (conversation.status === ChatConversationStatus.STREAMING) {
+            throw new ActivepiecesError({
+                code: ErrorCode.VALIDATION,
+                params: { message: 'Cannot delete a conversation while an agent is running. Please cancel it first.' },
+            })
+        }
         await chatHelpers.conversationRepo().delete(conversation.id)
         log.info({ conversationId: id, platformId, userId }, '[chatService] Conversation deleted')
     },

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
@@ -1,7 +1,8 @@
 import { tryCatch } from '@activepieces/shared'
 import { createMCPClient } from '@ai-sdk/mcp'
+import { ToolExecutionOptions } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
-import { ChatEventEmitter } from './chat-worker-tools'
+import { ChatEventEmitter, chatWorkerTools } from './chat-worker-tools'
 
 const CONVERSATION_ID_HEADER = 'x-ap-conversation-id'
 
@@ -59,7 +60,7 @@ function humanizeToolName(name: string): string {
         .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-function hasExecute(tool: object): tool is object & { execute: (args: unknown, options?: { toolCallId: string }) => Promise<unknown> } {
+function hasExecute(tool: object): tool is object & { execute: (args: unknown, options?: ToolExecutionOptions) => Promise<unknown> } {
     return 'execute' in tool && typeof tool.execute === 'function'
 }
 
@@ -80,15 +81,21 @@ function withApprovalGates({ mcpToolSet, eventEmitter, log, isApproved, waitForA
 
         const originalExecute = tool.execute.bind(tool)
         const needsApproval = requiresApproval(name)
+        const executeWithTimeout = (args: unknown, options?: ToolExecutionOptions) =>
+            chatWorkerTools.withToolTimeout({
+                fn: (timeoutSignal) => originalExecute(args, options ? { ...options, abortSignal: timeoutSignal } : undefined),
+                timeoutMs: chatWorkerTools.TOOL_EXECUTION_TIMEOUT_MS,
+                toolName: name,
+            })
 
         result[name] = Object.assign({}, tool, {
-            execute: async (args: unknown, options?: { toolCallId: string }) => {
+            execute: async (args: unknown, options?: ToolExecutionOptions) => {
                 if (isApproved() || !needsApproval) {
-                    return originalExecute(args, options)
+                    return executeWithTimeout(args, options)
                 }
                 const toolCallId = options?.toolCallId
                 if (!toolCallId) {
-                    return originalExecute(args, options)
+                    return executeWithTimeout(args, options)
                 }
                 const argsObj = typeof args === 'object' && args !== null ? args as Record<string, unknown> : {}
                 const displayName = (typeof argsObj['title'] === 'string' && argsObj['title'])
@@ -110,7 +117,7 @@ function withApprovalGates({ mcpToolSet, eventEmitter, log, isApproved, waitForA
                 }
 
                 log.info({ toolCallId, toolName: name }, 'Tool approval granted')
-                return originalExecute(args, options)
+                return executeWithTimeout(args, options)
             },
         })
     }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -11,26 +11,62 @@ import { tool, ToolExecutionOptions, ToolSet } from 'ai'
 import { z } from 'zod'
 
 const MAX_BATCH_SIZE = 100
+const TOOL_EXECUTION_TIMEOUT_MS = 5 * 60 * 1_000
 
-function createEventEmitter({ sendEvent, userId, conversationId }: {
+async function withToolTimeout<T>({ fn, timeoutMs, toolName }: {
+    fn: (signal: AbortSignal) => Promise<T>
+    timeoutMs: number
+    toolName: string
+}): Promise<T> {
+    const abortController = new AbortController()
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+            abortController.abort()
+            reject(new Error(`Tool "${toolName}" timed out after ${timeoutMs / 1_000} seconds. The operation took too long to complete. You may retry with different parameters or skip this step.`))
+        }, timeoutMs)
+    })
+    try {
+        return await Promise.race([fn(abortController.signal), timeoutPromise])
+    }
+    finally {
+        if (timeoutId !== undefined) {
+            clearTimeout(timeoutId)
+        }
+    }
+}
+
+function createEventEmitter({ sendEvent, userId, conversationId, log }: {
     sendEvent: (input: SendChatEventRequest) => Promise<void>
     userId: string
     conversationId: string
+    log?: { warn: (obj: Record<string, unknown>, msg: string) => void }
 }): ChatEventEmitter {
+    const sendWithRetry = async ({ event, maxAttempts }: { event: SendChatEventRequest['event'], maxAttempts: number }) => {
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            const { error } = await tryCatch(() => sendEvent({ userId, conversationId, event }))
+            if (!error) return
+            if (attempt === maxAttempts) {
+                log?.warn({ err: error, attempt, eventType: event.type }, 'Event delivery failed after retries')
+                return
+            }
+            const delayMs = attempt === 1 ? 200 : 1_000
+            await new Promise((resolve) => setTimeout(resolve, delayMs))
+        }
+    }
+
     return {
         emitToolProgress(data: ToolProgressEvent): void {
-            sendEvent({
-                userId,
-                conversationId,
+            void sendWithRetry({
                 event: { type: ChatAgentEventType.TOOL_PROGRESS, data },
-            }).catch(() => {})
+                maxAttempts: 2,
+            })
         },
         emitToolApprovalRequest(data: ToolApprovalRequestEvent): void {
-            sendEvent({
-                userId,
-                conversationId,
+            void sendWithRetry({
                 event: { type: ChatAgentEventType.TOOL_APPROVAL_REQUEST, data },
-            }).catch(() => {})
+                maxAttempts: 3,
+            })
         },
     }
 }
@@ -153,6 +189,13 @@ function createCrossProjectTools({ executeTool, eventEmitter }: {
     executeTool: (toolName: string, toolInput: Record<string, unknown>) => Promise<unknown>
     eventEmitter: ChatEventEmitter
 }): ToolSet {
+    const executeWithTimeout = (toolName: string, toolInput: Record<string, unknown>) =>
+        withToolTimeout({
+            fn: () => executeTool(toolName, toolInput),
+            timeoutMs: TOOL_EXECUTION_TIMEOUT_MS,
+            toolName,
+        })
+
     return {
         ap_discover_action_auth: tool({
             description: 'Check what authentication a piece needs and find available connections. Call this BEFORE ap_execute_action to determine if auth is needed.',
@@ -161,7 +204,7 @@ function createCrossProjectTools({ executeTool, eventEmitter }: {
                 pieceName: z.string().describe('Piece name, e.g. "@activepieces/piece-gmail"'),
             }),
             execute: async (input) => {
-                return executeTool('ap_discover_action_auth', input)
+                return executeWithTimeout('ap_discover_action_auth', input)
             },
         }),
 
@@ -180,7 +223,7 @@ function createCrossProjectTools({ executeTool, eventEmitter }: {
             execute: async (toolInput, options) => {
                 if (toolInput.items && toolInput.items.length > 0) {
                     return executeBatchAction({
-                        executeTool,
+                        executeWithTimeout,
                         eventEmitter,
                         toolCallId: options.toolCallId,
                         pieceName: toolInput.pieceName,
@@ -191,7 +234,7 @@ function createCrossProjectTools({ executeTool, eventEmitter }: {
                         projectId: toolInput.projectId,
                     })
                 }
-                return executeTool('ap_execute_action', toolInput)
+                return executeWithTimeout('ap_execute_action', toolInput)
             },
         }),
 
@@ -203,14 +246,14 @@ function createCrossProjectTools({ executeTool, eventEmitter }: {
                 status: z.string().optional().describe('Filter by status'),
             }),
             execute: async (input) => {
-                return executeTool('ap_list_across_projects', input)
+                return executeWithTimeout('ap_list_across_projects', input)
             },
         }),
     }
 }
 
-async function executeBatchAction({ executeTool, eventEmitter, toolCallId, pieceName, actionName, items, description, connectionExternalId, projectId }: {
-    executeTool: (toolName: string, toolInput: Record<string, unknown>) => Promise<unknown>
+async function executeBatchAction({ executeWithTimeout, eventEmitter, toolCallId, pieceName, actionName, items, description, connectionExternalId, projectId }: {
+    executeWithTimeout: (toolName: string, toolInput: Record<string, unknown>) => Promise<unknown>
     eventEmitter: ChatEventEmitter
     toolCallId: string
     pieceName: string
@@ -247,7 +290,7 @@ async function executeBatchAction({ executeTool, eventEmitter, toolCallId, piece
     pushProgress({ done: false })
 
     for (let i = 0; i < items.length; i++) {
-        const { data: result, error } = await tryCatch(() => executeTool('ap_execute_action', {
+        const { data: result, error } = await tryCatch(() => executeWithTimeout('ap_execute_action', {
             pieceName,
             actionName,
             input: items[i],
@@ -397,4 +440,6 @@ export const chatWorkerTools = {
     createThinkingTools,
     isSuccessResult,
     extractResultText,
+    withToolTimeout,
+    TOOL_EXECUTION_TIMEOUT_MS,
 }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -1,6 +1,7 @@
 import { chatAiUtils, ContentPartLike } from '@activepieces/server-utils'
 import {
     AIProviderName,
+    ChatAgentEvent,
     ChatAgentEventType,
     EngineResponseStatus,
     ErrorCode,
@@ -13,17 +14,18 @@ import {
     tryCatch,
     WorkerJobType,
 } from '@activepieces/shared'
-import { createUIMessageStream, generateText, ModelMessage, stepCountIs, streamText } from 'ai'
+import { createUIMessageStream, generateText, isLoopFinished, ModelMessage, streamText } from 'ai'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../../../types'
 import { chatMcpClient } from './chat-mcp-client'
 import { chatWorkerTools } from './chat-worker-tools'
 
-const MAX_STEPS = 30
 const BATCH_SIZE = 10
 const BATCH_FLUSH_MS = 50
 const APPROVAL_POLL_INTERVAL_MS = 500
 const APPROVAL_TIMEOUT_MS = 5 * 60 * 1_000
 const DISPLAY_TOOL_TIMEOUT_MS = 15 * 60 * 1_000
+const RETRY_MAX_ATTEMPTS = 3
+const RETRY_BASE_DELAY_MS = 1_000
 
 export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndForgetJobResult> = {
     jobType: WorkerJobType.EXECUTE_CHAT_AGENT,
@@ -44,24 +46,36 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             sendEvent: (input) => ctx.apiClient.sendChatEvent(input),
             userId,
             conversationId,
+            log,
         })
 
         const { mcpClient, mcpToolSet } = await chatMcpClient.connect({
             mcpCredentials: config.mcpCredentials, conversationId, log,
         })
 
+        const sendEventWithRetry = ({ event }: { event: ChatAgentEvent }) =>
+            retryWithBackoff({
+                fn: () => ctx.apiClient.sendChatEvent({ userId, conversationId, event }),
+                log,
+            })
+
+        const abortController = new AbortController()
+
+        const checkCancelled = async () => {
+            const { data: response } = await tryCatch(() => ctx.apiClient.executeChatTool({
+                toolName: '__cancel_check', toolInput: { conversationId }, platformId, userId,
+            }))
+            if (response?.result === true) {
+                abortController.abort()
+            }
+        }
+
+        const cancelCheckInterval = setInterval(() => {
+            checkCancelled().catch(() => {})
+        }, 3_000)
+
         try {
             const planApproved = { approved: false }
-            const abortController = new AbortController()
-
-            const checkCancelled = async () => {
-                const response = await ctx.apiClient.executeChatTool({
-                    toolName: '__cancel_check', toolInput: { conversationId }, platformId, userId,
-                })
-                if (response.result === true) {
-                    abortController.abort()
-                }
-            }
 
             const allTools = buildToolSet({
                 ctx, eventEmitter, log, planApproved, mcpToolSet,
@@ -70,28 +84,57 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
 
             const uiParts: PersistedChatPart[] = []
             const thinkingStartTime = Date.now()
+            let abortedStepMessages: ModelMessage[] = []
+
+            const postApprovalTools = Object.keys(allTools).filter((name) => name !== 'ap_request_plan_approval')
 
             const result = streamText({
                 model,
+                maxRetries: 3,
                 abortSignal: abortController.signal,
                 system: chatAiUtils.buildSystemPromptWithCaching({ systemPrompt: config.systemPrompt, provider }),
                 messages: chatAiUtils.stripThinkingBlocks(config.messages as ModelMessage[], provider),
                 tools: allTools,
                 providerOptions: chatAiUtils.buildProviderOptions({ provider, tier: config.tier }),
-                stopWhen: stepCountIs(MAX_STEPS),
+                stopWhen: isLoopFinished(),
+                prepareStep: ({ stepNumber }) => {
+                    if (stepNumber === 0 || !planApproved.approved) return undefined
+                    return { activeTools: postApprovalTools }
+                },
+                experimental_repairToolCall: async ({ toolCall, error }) => {
+                    log.warn({ toolName: toolCall.toolName, err: error, conversationId }, 'Repairing malformed tool call')
+                    const { data: repaired } = await tryCatch(async () => {
+                        const { text } = await generateText({
+                            model,
+                            prompt: `Fix this malformed JSON tool call for "${toolCall.toolName}". The error was: ${error.message}\n\nOriginal input:\n${toolCall.input}\n\nReturn ONLY the corrected JSON input, nothing else.`,
+                        })
+                        return { ...toolCall, input: text }
+                    })
+                    return repaired ?? null
+                },
+                experimental_onToolCallFinish: (result) => {
+                    if (result.success) {
+                        log.info({ toolName: result.toolCall.toolName, durationMs: result.durationMs, conversationId }, 'Tool call completed')
+                    }
+                    else {
+                        log.warn({ toolName: result.toolCall.toolName, durationMs: result.durationMs, err: result.error, conversationId }, 'Tool call failed')
+                    }
+                },
+                onAbort: ({ steps }) => {
+                    abortedStepMessages = steps.flatMap((step) => step.response.messages) as ModelMessage[]
+                },
                 onStepFinish: ({ content }) => {
                     uiParts.push(...chatAiUtils.buildStepParts({ content: content as ContentPartLike[] }))
-                    ctx.apiClient.updateChatProgress({
-                        conversationId,
-                        uiMessages: [
-                            ...(config.previousUiMessages as PersistedChatMessage[]),
-                            { role: PersistedChatRole.ASSISTANT, parts: [...uiParts], thinkingDurationMs: Date.now() - thinkingStartTime },
-                        ],
-                    }).catch((err: unknown) => {
-                        log.warn({ err, conversationId }, 'Failed to save chat progress')
-                    })
-                    checkCancelled().catch((err: unknown) => {
-                        log.warn({ err, conversationId }, 'Failed to check cancellation')
+                    void retryWithBackoff({
+                        fn: () => ctx.apiClient.updateChatProgress({
+                            conversationId,
+                            uiMessages: [
+                                ...(config.previousUiMessages as PersistedChatMessage[]),
+                                { role: PersistedChatRole.ASSISTANT, parts: [...uiParts], thinkingDurationMs: Date.now() - thinkingStartTime },
+                            ],
+                        }),
+                        maxAttempts: 2,
+                        log,
                     })
                 },
                 onError: ({ error }) => {
@@ -102,11 +145,11 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             await streamChunksToClient({ result, ctx, userId, conversationId, log })
 
             if (abortController.signal.aborted) {
-                log.info({ conversationId }, 'Chat agent cancelled by user')
+                log.info({ conversationId, completedSteps: abortedStepMessages.length }, 'Chat agent cancelled by user')
                 const thinkingDurationMs = Date.now() - thinkingStartTime
                 const cancelSavePayload = {
                     conversationId,
-                    messages: [...(config.allMessages as ModelMessage[])],
+                    messages: [...(config.allMessages as ModelMessage[]), ...abortedStepMessages],
                     uiMessages: [
                         ...(config.previousUiMessages as PersistedChatMessage[]),
                         ...(uiParts.length > 0 ? [{ role: PersistedChatRole.ASSISTANT, parts: uiParts, thinkingDurationMs }] : []),
@@ -121,10 +164,9 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
                         log.error({ err: retryError, conversationId }, 'Cancel save retry also failed')
                     }
                 }
-                await ctx.apiClient.sendChatEvent({
-                    userId, conversationId,
+                await sendEventWithRetry({
                     event: { type: ChatAgentEventType.FINISHED, data: { conversationId } },
-                }).catch(() => {})
+                })
                 return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
             }
 
@@ -168,14 +210,12 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             }
 
             if (autoTitle) {
-                await ctx.apiClient.sendChatEvent({
-                    userId, conversationId,
+                await sendEventWithRetry({
                     event: { type: ChatAgentEventType.TITLE_UPDATE, data: { title: autoTitle } },
                 })
             }
 
-            await ctx.apiClient.sendChatEvent({
-                userId, conversationId,
+            await sendEventWithRetry({
                 event: { type: ChatAgentEventType.FINISHED, data: { conversationId } },
             })
         }
@@ -186,17 +226,16 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             await ctx.apiClient.saveChatMessages({
                 conversationId, messages: [], uiMessages: [],
             }).catch(() => {})
-            await ctx.apiClient.sendChatEvent({
-                userId, conversationId,
+            await sendEventWithRetry({
                 event: { type: ChatAgentEventType.ERROR, data: { message: errorMessage, ...spreadIfDefined('code', errorCode) } },
-            }).catch(() => {})
-            await ctx.apiClient.sendChatEvent({
-                userId, conversationId,
+            })
+            await sendEventWithRetry({
                 event: { type: ChatAgentEventType.FINISHED, data: { conversationId } },
-            }).catch(() => {})
+            })
             throw err
         }
         finally {
+            clearInterval(cancelCheckInterval)
             if (mcpClient) {
                 await mcpClient.close().catch((closeErr: unknown) => {
                     log.warn({ err: closeErr }, 'Failed to close MCP client')
@@ -227,10 +266,13 @@ function buildToolSet({ ctx, eventEmitter, log, planApproved, mcpToolSet, projec
     const waitForApproval = async ({ gateId, timeoutMs }: { gateId: string, timeoutMs?: number }): Promise<GateDecision> => {
         const deadline = Date.now() + (timeoutMs ?? APPROVAL_TIMEOUT_MS)
         while (Date.now() < deadline) {
-            const response = await ctx.apiClient.executeChatTool({
+            const { data: response, error } = await tryCatch(() => ctx.apiClient.executeChatTool({
                 toolName: '__approval_check', toolInput: { gateId }, platformId, userId,
-            })
-            if (response.result !== 'pending') {
+            }))
+            if (error) {
+                log.warn({ err: error, gateId }, 'Approval poll RPC failed, retrying next interval')
+            }
+            else if (response.result !== 'pending') {
                 const decision = response.result as GateDecision
                 return { approved: decision.approved, payload: decision.payload }
             }
@@ -275,9 +317,13 @@ async function streamChunksToClient({ result, ctx, userId, conversationId, log }
         if (chunkBuffer.length === 0) return
         const batch = chunkBuffer
         chunkBuffer = []
-        await ctx.apiClient.sendChatEvent({
-            userId, conversationId,
-            event: { type: ChatAgentEventType.CHUNK, data: batch },
+        await retryWithBackoff({
+            fn: () => ctx.apiClient.sendChatEvent({
+                userId, conversationId,
+                event: { type: ChatAgentEventType.CHUNK, data: batch },
+            }),
+            maxAttempts: 2,
+            log,
         })
     }
 
@@ -346,6 +392,24 @@ const CREDIT_ERROR_PATTERNS = [/credits/i, /\b402\b/, /payment.required/i]
 
 function isCreditExhaustedError(message: string): boolean {
     return CREDIT_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+async function retryWithBackoff({ fn, maxAttempts = RETRY_MAX_ATTEMPTS, log }: {
+    fn: () => Promise<void>
+    maxAttempts?: number
+    log?: { warn: (obj: Record<string, unknown>, msg: string) => void }
+}): Promise<void> {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const { error } = await tryCatch(fn)
+        if (!error) return
+        if (attempt === maxAttempts) {
+            log?.warn({ err: error, attempt }, 'All retry attempts exhausted')
+            return
+        }
+        const jitter = Math.random() * 0.5 + 0.75
+        const delayMs = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1) * jitter
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
 }
 
 type GateDecision = {

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -106,6 +106,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
                     const { data: repaired } = await tryCatch(async () => {
                         const { text } = await generateText({
                             model,
+                            abortSignal: abortController.signal,
                             prompt: `Fix this malformed JSON tool call for "${toolCall.toolName}". The error was: ${error.message}\n\nOriginal input:\n${toolCall.input}\n\nReturn ONLY the corrected JSON input, nothing else.`,
                         })
                         return { ...toolCall, input: text }

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -224,7 +224,7 @@ async function executeJob(apiClient: WorkerToApiContract, job: ConsumeJobRequest
             log.debug({ handlerType: handler.jobType }, 'Executing job with handler')
             const { data: result, error } = await tryCatch(() => handler.execute(ctx, jobData))
             if (error) {
-                log.error({ error }, 'Job execution failed')
+                log.error({ err: error }, 'Job execution failed')
                 span.recordException(error)
                 throw error
             }

--- a/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
@@ -93,13 +93,13 @@ export function ThinkingBlock({
           disabled={!isExpandable}
           onClick={() => setIsOpen(!isOpen)}
           className={cn(
-            'flex items-center gap-1.5 text-xs text-muted-foreground text-left w-full',
+            'flex items-center gap-1.5 text-sm text-muted-foreground text-left w-full',
             isExpandable &&
               'hover:text-foreground transition-colors cursor-pointer',
           )}
         >
           {isStreaming ? (
-            <TextShimmer className="text-xs" duration={3}>
+            <TextShimmer className="text-sm" duration={1.5}>
               {t('Thinking...')}
             </TextShimmer>
           ) : (

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -229,36 +229,37 @@ export const AssistantMessage = memo(function AssistantMessage({
       transition={{ duration: 0.3 }}
     >
       <Message>
-        <div className="min-w-0 space-y-2 flex-1">
+        <div className="min-w-0 flex-1">
           {blocks.map((block, i) => {
             switch (block.kind) {
               case 'thinking':
                 return (
-                  <ThinkingBlock
-                    key={`thinking-${i}`}
-                    thinkingSteps={block.steps}
-                    reasoningText={block.reasoningText}
-                    isStreaming={
-                      isStreaming &&
-                      i === lastThinkingIdx &&
-                      !hasActiveDisplayCard &&
-                      i > lastDisplayToolIdx
-                    }
-                    thinkingDurationMs={
-                      i === lastThinkingIdx
-                        ? (
-                            message as ChatUIMessage & {
-                              thinkingDurationMs?: number;
-                            }
-                          ).thinkingDurationMs
-                        : undefined
-                    }
-                  />
+                  <div key={`thinking-${i}`} className="py-2">
+                    <ThinkingBlock
+                      thinkingSteps={block.steps}
+                      reasoningText={block.reasoningText}
+                      isStreaming={
+                        isStreaming &&
+                        i === lastThinkingIdx &&
+                        !hasActiveDisplayCard &&
+                        i > lastDisplayToolIdx
+                      }
+                      thinkingDurationMs={
+                        i === lastThinkingIdx
+                          ? (
+                              message as ChatUIMessage & {
+                                thinkingDurationMs?: number;
+                              }
+                            ).thinkingDurationMs
+                          : undefined
+                      }
+                    />
+                  </div>
                 );
               case 'text': {
                 const isActiveText = isStreaming && i === lastTextIdx;
                 return (
-                  <div key={`text-${i}`} className={PROSE_CLASSES}>
+                  <div key={`text-${i}`} className={cn('py-1', PROSE_CLASSES)}>
                     {isActiveText ? (
                       <StreamingText text={block.text} isStreaming={true} />
                     ) : (
@@ -276,28 +277,32 @@ export const AssistantMessage = memo(function AssistantMessage({
                   block.part.state === 'output-error';
                 if (toolCompleted) {
                   return (
-                    <DisplayToolCard
-                      key={block.part.toolCallId}
-                      part={block.part}
-                      onResolve={approveGate}
-                      isInteractive={false}
-                    />
+                    <div key={block.part.toolCallId} className="py-2">
+                      <DisplayToolCard
+                        part={block.part}
+                        onResolve={approveGate}
+                        isInteractive={false}
+                      />
+                    </div>
                   );
                 }
                 return null;
               }
               case 'plan-marker':
                 return (
-                  <InlinePlanCard
-                    key={`plan-${i}`}
-                    planPart={block.part}
-                    message={message}
-                    isStreaming={isStreaming}
-                  />
+                  <div key={`plan-${i}`} className="py-2">
+                    <InlinePlanCard
+                      planPart={block.part}
+                      message={message}
+                      isStreaming={isStreaming}
+                    />
+                  </div>
                 );
               case 'batch-progress':
                 return (
-                  <BatchProgressCard key={`batch-${i}`} progress={block.data} />
+                  <div key={`batch-${i}`} className="py-2">
+                    <BatchProgressCard progress={block.data} />
+                  </div>
                 );
               default:
                 return null;
@@ -398,6 +403,7 @@ function InlinePlanCard({
 
   const updates = useMemo(() => {
     if (!localPlan) return [];
+    if (messageUpdates.length > 0) return messageUpdates;
     if (planCompleted) {
       return localPlan.steps.map(
         (_stepText, i): PlanStepUpdate => ({ stepIndex: i, status: 'done' }),

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
@@ -1,5 +1,6 @@
 import { t } from 'i18next';
 import { motion } from 'motion/react';
+import { useEffect, useRef } from 'react';
 
 import { chatStoreSelectors } from '@/features/chat/lib/chat-store';
 import { useChatStoreContext } from '@/features/chat/lib/chat-store-context';
@@ -65,6 +66,15 @@ export function ChatBottomBar({
   const rejectGate = useChatStoreContext((s) => s.rejectGate);
   const dismissGate = useChatStoreContext((s) => s.dismissGate);
   const dismissForm = useChatStoreContext((s) => s.dismissForm);
+
+  const wasStreamingRef = useRef(isStreaming);
+  useEffect(() => {
+    if (wasStreamingRef.current && !isStreaming && activeDisplayTool) {
+      const toolCallId = chatPartUtils.getToolCallId(activeDisplayTool);
+      dismissGate(toolCallId);
+    }
+    wasStreamingRef.current = isStreaming;
+  }, [isStreaming, activeDisplayTool, dismissGate]);
 
   // Plan approval from tool state
   if (pendingPlanPart) {

--- a/packages/web/src/app/routes/chat-with-ai/components/connections-required-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connections-required-card.tsx
@@ -67,16 +67,10 @@ export function ConnectionsRequiredCard({
       if (cancelled) return;
       const map: Record<string, AppConnectionWithoutSensitiveData> = {};
       const alreadyActive = new Set<string>();
-      const aiErrorPieces = new Set(
-        connections.filter((c) => c.status === 'error').map((c) => c.piece),
-      );
       for (const { piece, connection } of results) {
         if (connection) {
           map[piece] = connection;
-          if (
-            connection.status === AppConnectionStatus.ACTIVE &&
-            !aiErrorPieces.has(piece)
-          ) {
+          if (connection.status === AppConnectionStatus.ACTIVE) {
             alreadyActive.add(piece);
           }
         }

--- a/packages/web/src/app/routes/chat-with-ai/components/plan-progress-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/plan-progress-card.tsx
@@ -1,6 +1,6 @@
 import { PlanStepStatus, PlanStepUpdate } from '@activepieces/shared';
 import { t } from 'i18next';
-import { Check, ListChecks, Loader2, X } from 'lucide-react';
+import { Check, ListChecks, Loader2, Pause, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useMemo } from 'react';
 
@@ -31,9 +31,11 @@ function computeStepStatuses({
 function StepIndicator({
   status,
   index,
+  isStreaming,
 }: {
   status: PlanStepStatus;
   index: number;
+  isStreaming: boolean;
 }) {
   switch (status) {
     case 'done':
@@ -43,6 +45,13 @@ function StepIndicator({
         </span>
       );
     case 'executing':
+      if (!isStreaming) {
+        return (
+          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-muted">
+            <Pause className="h-3 w-3 text-muted-foreground" />
+          </span>
+        );
+      }
       return (
         <span className="flex h-5 w-5 items-center justify-center">
           <Loader2 className="h-4 w-4 text-primary animate-spin" />
@@ -125,9 +134,14 @@ export function PlanProgressCard({
               <X className="h-3 w-3" />
               {t('Error')}
             </span>
-          ) : status === 'executing' ? (
+          ) : status === 'executing' && isStreaming ? (
             <span className="text-xs text-muted-foreground">
               {done}/{total}
+            </span>
+          ) : status === 'executing' && !isStreaming ? (
+            <span className="inline-flex items-center gap-1 text-muted-foreground text-xs font-medium">
+              <Pause className="h-3 w-3" />
+              {t('Paused')}
             </span>
           ) : null}
         </div>
@@ -150,7 +164,11 @@ export function PlanProgressCard({
                   }}
                   transition={{ duration: 0.2 }}
                 >
-                  <StepIndicator status={stepStatus} index={index} />
+                  <StepIndicator
+                    status={stepStatus}
+                    index={index}
+                    isStreaming={isStreaming}
+                  />
                   <div className="flex items-center gap-2 min-w-0">
                     <span
                       className={cn(
@@ -158,7 +176,11 @@ export function PlanProgressCard({
                         stepStatus === 'done' &&
                           'line-through text-muted-foreground',
                         stepStatus === 'executing' &&
+                          isStreaming &&
                           'font-medium text-foreground',
+                        stepStatus === 'executing' &&
+                          !isStreaming &&
+                          'text-muted-foreground',
                         stepStatus === 'error' && 'text-destructive',
                         stepStatus === 'pending' && 'text-muted-foreground',
                       )}
@@ -166,8 +188,15 @@ export function PlanProgressCard({
                       {step}
                     </span>
                     {stepStatus === 'executing' && (
-                      <span className="text-[11px] text-primary font-medium shrink-0">
-                        {t('Running')}
+                      <span
+                        className={cn(
+                          'text-[11px] font-medium shrink-0',
+                          isStreaming
+                            ? 'text-primary'
+                            : 'text-muted-foreground',
+                        )}
+                      >
+                        {isStreaming ? t('Running') : t('Paused')}
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## Summary

- Remove MAX_STEPS=30 limit so the AI loops until naturally done, preventing premature stop mid-plan
- Add retry with exponential backoff to all event delivery (chunks, FINISHED, ERROR, TITLE_UPDATE, tool approvals)
- Add 5-minute per-tool timeout with AbortSignal propagation to cross-project and MCP tools
- Add periodic cancel check (3s interval) so Stop button works during long tool executions
- Cancel endpoint now resets conversation status to IDLE immediately, unblocking new messages
- Save partial response messages on cancel via AI SDK `onAbort` callback to preserve context on resume
- Add `experimental_repairToolCall` to auto-fix malformed tool call JSON
- Add `experimental_onToolCallFinish` for per-tool logging with duration
- Add `prepareStep` to hide plan approval tool after plan is approved
- Fix approval gate race condition (first decision wins)
- Fix concurrent getChatConfig race (atomic status transition)
- Fix connection card showing stale "Not connected" after reconnection
- Fix orphaned display tools blocking input forever after stream crash
- Fix plan card showing all steps "Done" after crash (use actual step update data)
- Fix plan card showing "Running" after cancel (show "Paused" state)
- Block deletion of streaming conversations
- Extend stale recovery timeout to 20 min (buffer over 15-min display tool timeout)
- Polish: thinking text size, faster shimmer animation, vertical spacing between message blocks

## Test plan

- [ ] Start a complex chat that builds a flow with 10+ steps — should no longer stop at 30 tool rounds
- [ ] Press Stop mid-plan execution — should cancel within 3 seconds, show Paused state, preserve context
- [ ] Say "continue" after cancel — AI should resume from where it stopped without re-asking for connections
- [ ] Trigger a connection reconnect flow — card should show connected state after reconnection
- [ ] Refresh the page during streaming — UI should recover gracefully
- [ ] Verify tool call logging appears in worker logs with duration