### PR TITLE
feat(pieces): add Slite piece

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6564,6 +6564,16 @@
         "tslib": "^2.3.0",
       },
     },
+    "packages/pieces/community/slite": {
+      "name": "@activepieces/piece-slite",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/smaily": {
       "name": "@activepieces/piece-smaily",
       "version": "0.1.4",
@@ -9952,6 +9962,8 @@
     "@activepieces/piece-slack": ["@activepieces/piece-slack@workspace:packages/pieces/community/slack"],
 
     "@activepieces/piece-slidespeak": ["@activepieces/piece-slidespeak@workspace:packages/pieces/community/slidespeak"],
+
+    "@activepieces/piece-slite": ["@activepieces/piece-slite@workspace:packages/pieces/community/slite"],
 
     "@activepieces/piece-smaily": ["@activepieces/piece-smaily@workspace:packages/pieces/community/smaily"],
 

--- a/packages/pieces/community/slite/.eslintrc.json
+++ b/packages/pieces/community/slite/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/slite/package.json
+++ b/packages/pieces/community/slite/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-slite",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/slite/src/index.ts
+++ b/packages/pieces/community/slite/src/index.ts
@@ -1,0 +1,42 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { sliteAuth } from './lib/auth';
+import { sliteApi } from './lib/common/client';
+import { sliteAskQuestionAction } from './lib/actions/ask-question';
+import { sliteCreateDocAction } from './lib/actions/create-doc';
+import { sliteFetchSubDocsAction } from './lib/actions/fetch-sub-docs';
+import { sliteReplaceDocAction } from './lib/actions/replace-doc';
+import { sliteIndexAskxObjectAction } from './lib/actions/index-askx-object';
+import { sliteFetchDocAction } from './lib/actions/fetch-doc';
+import { sliteSearchDocsAction } from './lib/actions/search-docs';
+import { sliteUpdateDocAction } from './lib/actions/update-doc';
+
+export const slite = createPiece({
+  displayName: 'Slite',
+  description:
+    'Slite is a modern knowledge base. Create, search, update, and ask questions about your team docs.',
+  auth: sliteAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/slite.png',
+  categories: [PieceCategory.PRODUCTIVITY],
+  authors: ['onyedikachi-david'],
+  actions: [
+    sliteAskQuestionAction,
+    sliteCreateDocAction,
+    sliteFetchSubDocsAction,
+    sliteReplaceDocAction,
+    sliteIndexAskxObjectAction,
+    sliteFetchDocAction,
+    sliteSearchDocsAction,
+    sliteUpdateDocAction,
+    createCustomApiCallAction({
+      baseUrl: () => sliteApi.baseUrl,
+      auth: sliteAuth,
+      authMapping: async (auth) => ({
+        'x-slite-api-key': auth.secret_text,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/slite/src/lib/actions/ask-question.ts
+++ b/packages/pieces/community/slite/src/lib/actions/ask-question.ts
@@ -1,0 +1,39 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { sliteAuth } from '../auth';
+import { sliteApi } from '../common/client';
+import { sliteProps } from '../common/props';
+import { SliteAskResponse } from '../common/types';
+
+export const sliteAskQuestionAction = createAction({
+  auth: sliteAuth,
+  name: 'ask_question',
+  displayName: 'Ask Question',
+  description:
+    'Asks a question in natural language and returns an answer drawn from your Slite docs, with sources.',
+  props: {
+    question: Property.LongText({
+      displayName: 'Question',
+      description: 'The question to ask your Slite knowledge base.',
+      required: true,
+    }),
+    parent_note_id: sliteProps.noteId({
+      required: false,
+      displayName: 'Parent Doc',
+      description: 'Limit the answer to docs nested under this parent.',
+    }),
+  },
+  async run(context) {
+    const { question, parent_note_id } = context.propsValue;
+    const response = await sliteApi.call<SliteAskResponse>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      resourceUri: '/ask',
+      query: {
+        question,
+        parentNoteId: parent_note_id,
+      },
+    });
+    return response;
+  },
+});

--- a/packages/pieces/community/slite/src/lib/actions/create-doc.ts
+++ b/packages/pieces/community/slite/src/lib/actions/create-doc.ts
@@ -1,0 +1,75 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { sliteAuth } from '../auth';
+import { sliteApi } from '../common/client';
+import { sliteProps } from '../common/props';
+import { SliteNote } from '../common/types';
+
+export const sliteCreateDocAction = createAction({
+  auth: sliteAuth,
+  name: 'create_doc',
+  displayName: 'Create Doc',
+  description: 'Creates a doc inside a parent doc or your private channel.',
+  props: {
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The title of the new doc.',
+      required: true,
+    }),
+    parent_note_id: sliteProps.noteId({
+      required: false,
+      displayName: 'Parent Doc',
+      description:
+        'Where to create the new doc. Leave blank to create it in your private channel.',
+    }),
+    content: Property.LongText({
+      displayName: 'Content',
+      description: 'The body of the doc.',
+      required: false,
+    }),
+    content_format: Property.StaticDropdown({
+      displayName: 'Content Format',
+      description: 'How the content above is written.',
+      required: false,
+      defaultValue: 'markdown',
+      options: {
+        options: [
+          { label: 'Markdown', value: 'markdown' },
+          { label: 'HTML', value: 'html' },
+        ],
+      },
+    }),
+    template_id: Property.ShortText({
+      displayName: 'Template ID',
+      description: 'Apply a template to the new doc by its ID.',
+      required: false,
+    }),
+    attributes: Property.Array({
+      displayName: 'Attributes',
+      description:
+        "Attributes for the parent collection, ordered by column. Ignored if they don't match the column type.",
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { title, parent_note_id, content, content_format, template_id, attributes } =
+      context.propsValue;
+    const note = await sliteApi.call<SliteNote>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.POST,
+      resourceUri: '/notes',
+      body: {
+        title,
+        parentNoteId: parent_note_id,
+        templateId: template_id,
+        attributes,
+        ...(content
+          ? content_format === 'html'
+            ? { html: content }
+            : { markdown: content }
+          : {}),
+      },
+    });
+    return note;
+  },
+});

--- a/packages/pieces/community/slite/src/lib/actions/fetch-doc.ts
+++ b/packages/pieces/community/slite/src/lib/actions/fetch-doc.ts
@@ -1,0 +1,39 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { sliteAuth } from '../auth';
+import { sliteApi } from '../common/client';
+import { sliteProps } from '../common/props';
+import { SliteNote } from '../common/types';
+
+export const sliteFetchDocAction = createAction({
+  auth: sliteAuth,
+  name: 'fetch_doc',
+  displayName: 'Fetch Doc',
+  description: 'Returns a readable doc by its ID.',
+  props: {
+    note_id: sliteProps.noteId({ required: true }),
+    format: Property.StaticDropdown({
+      displayName: 'Content Format',
+      description: 'The format to return the doc content in.',
+      required: false,
+      defaultValue: 'md',
+      options: {
+        options: [
+          { label: 'Markdown', value: 'md' },
+          { label: 'HTML', value: 'html' },
+          { label: 'SliteML', value: 'sliteml' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { note_id, format } = context.propsValue;
+    const note = await sliteApi.call<SliteNote>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      resourceUri: `/notes/${note_id}`,
+      query: { format },
+    });
+    return note;
+  },
+});

--- a/packages/pieces/community/slite/src/lib/actions/fetch-sub-docs.ts
+++ b/packages/pieces/community/slite/src/lib/actions/fetch-sub-docs.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { sliteAuth } from '../auth';
+import { sliteApi } from '../common/client';
+import { sliteProps } from '../common/props';
+
+export const sliteFetchSubDocsAction = createAction({
+  auth: sliteAuth,
+  name: 'fetch_sub_docs',
+  displayName: 'Fetch Sub Docs',
+  description: 'Returns the list of sub docs nested under a parent doc.',
+  props: {
+    note_id: sliteProps.noteId({
+      required: true,
+      displayName: 'Parent Doc',
+      description: 'The doc whose sub docs you want to list.',
+    }),
+  },
+  async run(context) {
+    const { note_id } = context.propsValue;
+    if (!note_id) {
+      return { notes: [], total: 0 };
+    }
+    const notes = await sliteApi.getAllChildren({
+      apiKey: context.auth.secret_text,
+      noteId: note_id,
+    });
+    return {
+      notes,
+      total: notes.length,
+    };
+  },
+});

--- a/packages/pieces/community/slite/src/lib/actions/index-askx-object.ts
+++ b/packages/pieces/community/slite/src/lib/actions/index-askx-object.ts
@@ -1,0 +1,76 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { sliteAuth } from '../auth';
+import { sliteApi } from '../common/client';
+import { SliteIndexResponse } from '../common/types';
+
+export const sliteIndexAskxObjectAction = createAction({
+  auth: sliteAuth,
+  name: 'index_askx_object',
+  displayName: 'Index AskX Object',
+  description:
+    'Sends an object to be indexed by AskX for your custom source. Note: Slite has deprecated this endpoint.',
+  props: {
+    root_id: Property.ShortText({
+      displayName: 'Root ID',
+      description: 'The root ID of your custom data source (created in Slite).',
+      required: true,
+    }),
+    object_id: Property.ShortText({
+      displayName: 'Object ID',
+      description: 'A unique identifier for this object within the source.',
+      required: true,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The title of the object.',
+      required: true,
+    }),
+    content: Property.LongText({
+      displayName: 'Content',
+      description: 'The content of the object.',
+      required: true,
+    }),
+    type: Property.StaticDropdown({
+      displayName: 'Content Format',
+      description: 'How the content above is written.',
+      required: true,
+      defaultValue: 'markdown',
+      options: {
+        options: [
+          { label: 'Markdown', value: 'markdown' },
+          { label: 'HTML', value: 'html' },
+        ],
+      },
+    }),
+    updated_at: Property.DateTime({
+      displayName: 'Updated At',
+      description: 'When the object was last modified.',
+      required: true,
+    }),
+    url: Property.ShortText({
+      displayName: 'URL',
+      description: 'The redirect URL for the object.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { root_id, object_id, title, content, type, updated_at, url } =
+      context.propsValue;
+    const response = await sliteApi.call<SliteIndexResponse>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.POST,
+      resourceUri: '/ask/index',
+      body: {
+        rootId: root_id,
+        id: object_id,
+        title,
+        content,
+        type,
+        updatedAt: updated_at,
+        url,
+      },
+    });
+    return response;
+  },
+});

--- a/packages/pieces/community/slite/src/lib/actions/replace-doc.ts
+++ b/packages/pieces/community/slite/src/lib/actions/replace-doc.ts
@@ -1,0 +1,63 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { sliteAuth } from '../auth';
+import { sliteApi } from '../common/client';
+import { sliteProps } from '../common/props';
+import { SliteNote } from '../common/types';
+
+export const sliteReplaceDocAction = createAction({
+  auth: sliteAuth,
+  name: 'replace_doc',
+  displayName: 'Replace Doc',
+  description:
+    'Replaces the entire content and/or title of a doc. Fields you leave blank are kept unchanged.',
+  props: {
+    note_id: sliteProps.noteId({ required: true }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'A new title for the doc.',
+      required: false,
+    }),
+    content: Property.LongText({
+      displayName: 'Content',
+      description: 'New content that replaces the entire doc body.',
+      required: false,
+    }),
+    content_format: Property.StaticDropdown({
+      displayName: 'Content Format',
+      description: 'How the content above is written.',
+      required: false,
+      defaultValue: 'markdown',
+      options: {
+        options: [
+          { label: 'Markdown', value: 'markdown' },
+          { label: 'HTML', value: 'html' },
+        ],
+      },
+    }),
+    attributes: Property.Array({
+      displayName: 'Attributes',
+      description: 'Attributes for the parent collection, ordered by column.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { note_id, title, content, content_format, attributes } =
+      context.propsValue;
+    const note = await sliteApi.call<SliteNote>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.PUT,
+      resourceUri: `/notes/${note_id}`,
+      body: {
+        title,
+        attributes,
+        ...(content
+          ? content_format === 'html'
+            ? { html: content }
+            : { markdown: content }
+          : {}),
+      },
+    });
+    return note;
+  },
+});

--- a/packages/pieces/community/slite/src/lib/actions/search-docs.ts
+++ b/packages/pieces/community/slite/src/lib/actions/search-docs.ts
@@ -1,0 +1,60 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { sliteAuth } from '../auth';
+import { sliteApi } from '../common/client';
+import { sliteProps } from '../common/props';
+import { SliteSearchResponse } from '../common/types';
+
+export const sliteSearchDocsAction = createAction({
+  auth: sliteAuth,
+  name: 'search_docs',
+  displayName: 'Search Docs',
+  description: 'Performs a keyword search across the docs you have access to.',
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Term',
+      description: 'The keywords to search for.',
+      required: true,
+    }),
+    parent_note_id: sliteProps.noteId({
+      required: false,
+      displayName: 'Parent Doc',
+      description: 'Limit results to docs nested under this parent.',
+    }),
+    include_archived: Property.Checkbox({
+      displayName: 'Include Archived',
+      description: 'Also search archived docs.',
+      required: false,
+      defaultValue: false,
+    }),
+    hits_per_page: Property.Number({
+      displayName: 'Results Per Page',
+      description: 'How many results to return per page (1–100).',
+      required: false,
+      defaultValue: 25,
+    }),
+    page: Property.Number({
+      displayName: 'Page',
+      description: 'Which page of results to return (starts at 0).',
+      required: false,
+      defaultValue: 0,
+    }),
+  },
+  async run(context) {
+    const { query, parent_note_id, include_archived, hits_per_page, page } =
+      context.propsValue;
+    const response = await sliteApi.call<SliteSearchResponse>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      resourceUri: '/search-notes',
+      query: {
+        query,
+        parentNoteId: parent_note_id,
+        includeArchived: include_archived,
+        hitsPerPage: hits_per_page,
+        page,
+      },
+    });
+    return response;
+  },
+});

--- a/packages/pieces/community/slite/src/lib/actions/update-doc.ts
+++ b/packages/pieces/community/slite/src/lib/actions/update-doc.ts
@@ -63,7 +63,7 @@ export const sliteUpdateDocAction = createAction({
         url,
         iconURL: icon_url,
         status: status_label
-          ? { label: status_label, colorHex: status_color }
+          ? { label: status_label, ...(status_color ? { colorHex: status_color } : {}) }
           : undefined,
       },
     });

--- a/packages/pieces/community/slite/src/lib/actions/update-doc.ts
+++ b/packages/pieces/community/slite/src/lib/actions/update-doc.ts
@@ -1,0 +1,72 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { sliteAuth } from '../auth';
+import { sliteApi } from '../common/client';
+import { sliteProps } from '../common/props';
+import { SliteTileUpdateResponse } from '../common/types';
+
+export const sliteUpdateDocAction = createAction({
+  auth: sliteAuth,
+  name: 'update_doc',
+  displayName: 'Update Doc',
+  description:
+    'Updates a specific part (tile) of a doc. Fields you leave blank are kept unchanged.',
+  props: {
+    note_id: sliteProps.noteId({ required: true }),
+    tile_id: Property.ShortText({
+      displayName: 'Tile ID',
+      description:
+        'The block to update. In Slite, hover an empty line, open its menu, and choose "Copy block id".',
+      required: true,
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'New header text for the tile.',
+      required: false,
+    }),
+    content: Property.LongText({
+      displayName: 'Content',
+      description: 'New Markdown content for the tile.',
+      required: false,
+    }),
+    url: Property.ShortText({
+      displayName: 'URL',
+      description: 'An external link for the tile.',
+      required: false,
+    }),
+    icon_url: Property.ShortText({
+      displayName: 'Icon URL',
+      description: 'An icon to display on the tile.',
+      required: false,
+    }),
+    status_label: Property.ShortText({
+      displayName: 'Status Label',
+      description: 'Text for the tile status badge.',
+      required: false,
+    }),
+    status_color: Property.ShortText({
+      displayName: 'Status Color',
+      description: 'Status badge color as a hex code, e.g. #2F80ED.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { note_id, tile_id, title, content, url, icon_url, status_label, status_color } =
+      context.propsValue;
+    const tile = await sliteApi.call<SliteTileUpdateResponse>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.PUT,
+      resourceUri: `/notes/${note_id}/tiles/${tile_id}`,
+      body: {
+        title,
+        content,
+        url,
+        iconURL: icon_url,
+        status: status_label
+          ? { label: status_label, colorHex: status_color }
+          : undefined,
+      },
+    });
+    return tile;
+  },
+});

--- a/packages/pieces/community/slite/src/lib/auth.ts
+++ b/packages/pieces/community/slite/src/lib/auth.ts
@@ -1,0 +1,34 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { sliteApi } from './common/client';
+
+const markdownDescription = `
+**Authenticate with your Slite API key.**
+
+1. Open your organization menu at the top-left of the Slite app.
+2. Go to **Settings → API**.
+3. Click **Create a new key** and follow the steps.
+4. Copy the key (it is shown only once) and paste it here.
+`;
+
+export const sliteAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: markdownDescription,
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await sliteApi.call({
+        apiKey: auth,
+        method: HttpMethod.GET,
+        resourceUri: '/me',
+      });
+      return { valid: true };
+    } catch (e) {
+      return {
+        valid: false,
+        error:
+          'Invalid API key. Generate one in Slite under Settings → API, then paste it here.',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/slite/src/lib/common/client.ts
+++ b/packages/pieces/community/slite/src/lib/common/client.ts
@@ -1,0 +1,120 @@
+import {
+  httpClient,
+  HttpMessageBody,
+  HttpMethod,
+  HttpRequest,
+  QueryParams,
+} from '@activepieces/pieces-common';
+import { SliteChildrenResponse, SliteNote } from './types';
+
+const BASE_URL = 'https://api.slite.com/v1';
+const MAX_CHILDREN_PAGES = 100;
+
+async function apiCall<T extends HttpMessageBody>({
+  apiKey,
+  method,
+  resourceUri,
+  query,
+  body,
+}: SliteApiCallParams): Promise<T> {
+  const queryParams: QueryParams = {};
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== null && value !== undefined) {
+        queryParams[key] = Array.isArray(value)
+          ? value.join(',')
+          : String(value);
+      }
+    }
+  }
+
+  const request: HttpRequest = {
+    method,
+    url: `${BASE_URL}${resourceUri}`,
+    headers: {
+      'x-slite-api-key': apiKey,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    queryParams,
+    body: compactBody(body),
+  };
+
+  const response = await httpClient.sendRequest<T>(request);
+  return response.body;
+}
+
+async function getAllChildren({
+  apiKey,
+  noteId,
+  maxPages = MAX_CHILDREN_PAGES,
+}: {
+  apiKey: string;
+  noteId: string;
+  maxPages?: number;
+}): Promise<SliteNote[]> {
+  const notes: SliteNote[] = [];
+  let cursor: string | undefined = undefined;
+  let pages = 0;
+
+  do {
+    const response: SliteChildrenResponse = await apiCall<SliteChildrenResponse>({
+      apiKey,
+      method: HttpMethod.GET,
+      resourceUri: `/notes/${noteId}/children`,
+      query: cursor ? { cursor } : undefined,
+    });
+    notes.push(...(response.notes ?? []));
+    cursor =
+      response.hasNextPage && response.nextCursor
+        ? response.nextCursor
+        : undefined;
+    pages += 1;
+  } while (cursor && pages < maxPages);
+
+  return notes;
+}
+
+// Slite authenticates with a custom header, and an omitted body field means
+// "leave unchanged". Blank optional inputs reach us as null (dropdowns) or {}/[]
+// (objects/arrays), so strip nil/empty top-level values before sending to avoid
+// clobbering existing doc content on replace/update. Shallow only — never mutate
+// nested user-supplied data.
+function compactBody(body: unknown): unknown {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return body;
+  }
+  const entries = Object.entries(body).filter(
+    ([, value]) => !isNilOrEmpty(value)
+  );
+  return Object.fromEntries(entries);
+}
+
+function isNilOrEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  return typeof value === 'object' && Object.keys(value).length === 0;
+}
+
+export const sliteApi = {
+  baseUrl: BASE_URL,
+  call: apiCall,
+  getAllChildren,
+};
+
+export type SliteQuery = Record<
+  string,
+  string | number | boolean | string[] | undefined | null
+>;
+
+export type SliteApiCallParams = {
+  apiKey: string;
+  method: HttpMethod;
+  resourceUri: string;
+  query?: SliteQuery;
+  body?: unknown;
+};

--- a/packages/pieces/community/slite/src/lib/common/props.ts
+++ b/packages/pieces/community/slite/src/lib/common/props.ts
@@ -1,0 +1,65 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { Property } from '@activepieces/pieces-framework';
+import { sliteAuth } from '../auth';
+import { sliteApi } from './client';
+import { SliteSearchResponse } from './types';
+
+const noteId = ({
+  required = true,
+  displayName = 'Doc',
+  description = 'Start typing to search your docs by title.',
+}: {
+  required?: boolean;
+  displayName?: string;
+  description?: string;
+} = {}) =>
+  Property.Dropdown({
+    displayName,
+    description,
+    auth: sliteAuth,
+    required,
+    refreshers: [],
+    options: async ({ auth, searchValue }) => {
+      if (!auth) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Please connect your Slite account first.',
+        };
+      }
+      try {
+        const query = typeof searchValue === 'string' ? searchValue : undefined;
+        const response = await sliteApi.call<SliteSearchResponse>({
+          apiKey: auth.secret_text,
+          method: HttpMethod.GET,
+          resourceUri: '/search-notes',
+          query: { query, hitsPerPage: 100 },
+        });
+        const hits = response.hits ?? [];
+        if (hits.length === 0) {
+          return {
+            disabled: false,
+            options: [],
+            placeholder: 'No docs found.',
+          };
+        }
+        return {
+          disabled: false,
+          options: hits.map((hit) => ({
+            label: hit.title || hit.id,
+            value: hit.id,
+          })),
+        };
+      } catch (e) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Could not load docs. Check your connection.',
+        };
+      }
+    },
+  });
+
+export const sliteProps = {
+  noteId,
+};

--- a/packages/pieces/community/slite/src/lib/common/types.ts
+++ b/packages/pieces/community/slite/src/lib/common/types.ts
@@ -1,0 +1,79 @@
+export type SliteOwner = {
+  userId?: string;
+  groupId?: string;
+};
+
+export type SliteNote = {
+  id: string;
+  title: string;
+  url: string;
+  parentNoteId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastEditedAt: string;
+  archivedAt: string | null;
+  iconShape: string | null;
+  iconColor: string | null;
+  owner: SliteOwner;
+  columns?: string[];
+  attributes?: string[];
+  reviewState?: string;
+  content?: string;
+};
+
+export type SliteChildrenResponse = {
+  notes: SliteNote[];
+  total: number;
+  hasNextPage: boolean;
+  nextCursor: string | null;
+};
+
+export type SliteParentNote = {
+  id?: string;
+  title?: string;
+};
+
+export type SliteSearchHit = {
+  id: string;
+  title: string;
+  type: string;
+  highlight: string;
+  parentNotes: SliteParentNote[];
+  lastEditedAt: string;
+  updatedAt: string;
+  archivedAt: string | null;
+  iconColor: string | null;
+  iconShape: string | null;
+  reviewState?: string;
+};
+
+export type SliteSearchResponse = {
+  hits: SliteSearchHit[];
+  page: number;
+  nbPages: number;
+};
+
+export type SliteAskSource = {
+  id: string;
+  title: string;
+  url: string;
+  updatedAt: string;
+  explanation?: string;
+};
+
+export type SliteAskResponse = {
+  answer: string;
+  sources: SliteAskSource[];
+};
+
+export type SliteIndexResponse = {
+  id: string;
+  title: string;
+  url: string;
+  updatedAt: string;
+  explanation?: string;
+};
+
+export type SliteTileUpdateResponse = {
+  url: string;
+};

--- a/packages/pieces/community/slite/tsconfig.json
+++ b/packages/pieces/community/slite/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/slite/tsconfig.lib.json
+++ b/packages/pieces/community/slite/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1178,6 +1178,9 @@
       "@activepieces/piece-slidespeak": [
         "packages/pieces/community/slidespeak/src/index.ts"
       ],
+      "@activepieces/piece-slite": [
+        "packages/pieces/community/slite/src/index.ts"
+      ],
       "@activepieces/piece-smaily": [
         "packages/pieces/community/smaily/src/index.ts"
       ],


### PR DESCRIPTION
Slite knowledge-base integration with x-slite-api-key header auth, a shared API client (custom-header auth, cursor-based pagination for sub docs, request-body compaction) and a searchable Doc picker reused across actions.

Actions:
- Ask Question
- Create Doc
- Fetch Doc
- Fetch Sub Docs
- Replace Doc
- Update Doc
- Search Docs
- Index AskX Object
- Custom API Call