### PR TITLE
feat: polish AI piece selector cards

### DIFF
--- a/packages/web/src/app/builder/pieces-selector/ai-tab-content/ai-action.tsx
+++ b/packages/web/src/app/builder/pieces-selector/ai-tab-content/ai-action.tsx
@@ -6,6 +6,7 @@ import {
   PieceSelectorItem,
   StepMetadataWithSuggestions,
 } from '@/features/pieces';
+import { cn } from '@/lib/utils';
 
 type AIActionItemProps = {
   item: PieceSelectorItem;
@@ -32,28 +33,55 @@ const getPieceSelectorItemInfo = (item: PieceSelectorItem) => {
 
 const AIActionItem = ({
   item,
+  hidePieceIconAndDescription,
   stepMetadataWithSuggestions,
   onClick,
 }: AIActionItemProps) => {
   const pieceSelectorItemInfo = getPieceSelectorItemInfo(item);
+  const description = pieceSelectorItemInfo.description?.endsWith('.')
+    ? pieceSelectorItemInfo.description.slice(0, -1)
+    : pieceSelectorItemInfo.description;
 
   return (
     <CardListItem
-      className="p-4 w-full h-full rounded-md flex flex-col justify-between h-[125px]"
+      className="group relative min-h-[132px] overflow-hidden rounded-xl border border-border/60 bg-background p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-accent/40 hover:shadow-md"
       onClick={onClick}
     >
-      <div className="flex flex-col gap-3">
-        <div className="flex items-center justify-center">
-          <PieceIcon
-            logoUrl={stepMetadataWithSuggestions.logoUrl}
-            displayName={stepMetadataWithSuggestions.displayName}
-            showTooltip={false}
-            size={'lg'}
-          />
+      <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary/70 via-primary/30 to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
+      <div className="flex w-full flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div
+            className={cn(
+              'flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/15 to-primary/5 ring-1 ring-primary/10 transition-transform group-hover:scale-105',
+              {
+                'opacity-0': hidePieceIconAndDescription,
+              }
+            )}
+          >
+            <PieceIcon
+              logoUrl={stepMetadataWithSuggestions.logoUrl}
+              displayName={stepMetadataWithSuggestions.displayName}
+              showTooltip={false}
+              size={'lg'}
+            />
+          </div>
+          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+            AI
+          </span>
         </div>
-        <div className="flex flex-col gap-1 text-center">
-          <div className="text-sm font-medium leading-tight">
+        <div className="flex flex-col gap-1">
+          <div className="line-clamp-2 text-sm font-semibold leading-tight text-foreground">
             {pieceSelectorItemInfo.displayName}
+          </div>
+          <div
+            className={cn(
+              'line-clamp-2 text-xs leading-snug text-muted-foreground',
+              {
+                hidden: hidePieceIconAndDescription,
+              }
+            )}
+          >
+            {description}
           </div>
         </div>
       </div>

--- a/packages/web/src/app/builder/pieces-selector/ai-tab-content/ai-actions-list.tsx
+++ b/packages/web/src/app/builder/pieces-selector/ai-tab-content/ai-actions-list.tsx
@@ -49,17 +49,17 @@ export const AIPieceActionsList: React.FC<AIPieceActionsListProps> = ({
     state.handleAddingOrUpdatingStep,
   ]);
   const { data: isAgentsConfigured } = flagsHooks.useFlag<boolean>(
-    ApFlagId.AGENTS_CONFIGURED,
+    ApFlagId.AGENTS_CONFIGURED
   );
   const navigate = useNavigate();
 
   const aiActions = convertStepMetadataToPieceSelectorItems(
-    stepMetadataWithSuggestions,
+    stepMetadataWithSuggestions
   );
 
   return (
     <ScrollArea className="h-full" viewPortClassName="h-full">
-      <div className="grid grid-cols-3 p-2 gap-3 min-w-[350px]">
+      <div className="grid min-w-[350px] grid-cols-2 gap-3 p-3 sm:grid-cols-3">
         {aiActions.map((item, index) => {
           const actionIcon =
             item.type === FlowActionType.PIECE
@@ -78,7 +78,7 @@ export const AIPieceActionsList: React.FC<AIPieceActionsListProps> = ({
                 if (!isAgentsConfigured) {
                   toast('Connect to OpenAI', {
                     description: t(
-                      "To create an agent, you'll first need to connect to OpenAI in platform settings.",
+                      "To create an agent, you'll first need to connect to OpenAI in platform settings."
                     ),
                     action: {
                       label: 'Set Up',


### PR DESCRIPTION
## Summary
- Revamps the AI selector action cards with a more polished visual treatment
- Adds richer card styling: rounded border, hover elevation, gradient accent, icon container, and AI badge
- Shows action descriptions on AI selector cards and adjusts the grid spacing/responsiveness

## Test Plan
- `bun x prettier --check packages/web/src/app/builder/pieces-selector/ai-tab-content/ai-action.tsx packages/web/src/app/builder/pieces-selector/ai-tab-content/ai-actions-list.tsx`
- `git diff --check`

/claim #10618
