### PR TITLE
feat(crypto): add Generate RSA Signature action

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8080,7 +8080,7 @@
     },
     "packages/pieces/core/crypto": {
       "name": "@activepieces/piece-crypto",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",

--- a/packages/pieces/core/crypto/package.json
+++ b/packages/pieces/core/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-crypto",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/crypto/src/i18n/translation.json
+++ b/packages/pieces/core/crypto/src/i18n/translation.json
@@ -39,5 +39,15 @@
   "Hex": "Hex",
   "Base64": "Base64",
   "Alphanumeric": "Alphanumeric",
-  "Alphanumeric + Symbols": "Alphanumeric + Symbols"
+  "Alphanumeric + Symbols": "Alphanumeric + Symbols",
+  "Generate RSA Signature": "Generate RSA Signature",
+  "Signs text with an RSA private key using SHA-256, SHA-384, or SHA-512 (RSA-SHA256 by default)": "Signs text with an RSA private key using SHA-256, SHA-384, or SHA-512 (RSA-SHA256 by default)",
+  "Private Key": "Private Key",
+  "The RSA private key in PEM format (PKCS#1 or PKCS#8)": "The RSA private key in PEM format (PKCS#1 or PKCS#8)",
+  "Passphrase": "Passphrase",
+  "The passphrase protecting the private key, leave empty if it is not encrypted": "The passphrase protecting the private key, leave empty if it is not encrypted",
+  "SHA384": "SHA384",
+  "The text to be signed": "The text to be signed",
+  "Output Encoding": "Output Encoding",
+  "The encoding of the output signature": "The encoding of the output signature"
 }

--- a/packages/pieces/core/crypto/src/index.ts
+++ b/packages/pieces/core/crypto/src/index.ts
@@ -3,6 +3,7 @@ import { PieceCategory } from '@activepieces/shared';
 import { generatePassword } from './lib/actions/generate-password';
 import { hashText } from './lib/actions/hash-text';
 import { hmacSignature } from './lib/actions/hmac-signature';
+import { rsaSignature } from './lib/actions/rsa-signature';
 import { base64Decode } from './lib/actions/base64-decode';
 import { base64Encode } from './lib/actions/base64-encode';
 import { openpgpEncrypt } from './lib/actions/openpgp-encrypt';
@@ -15,6 +16,6 @@ export const Crypto = createPiece({
   logoUrl: 'https://cdn.activepieces.com/pieces/new-core/crypto.svg',
   categories: [PieceCategory.CORE],
   authors: ['AbdullahBitar', 'kishanprmr', 'abuaboud', 'matthieu-lombard', 'antonyvigouret', 'danielpoonwj', 'prasanna2000-max'],
-  actions: [hashText, hmacSignature, generatePassword, base64Decode, base64Encode, openpgpEncrypt],
+  actions: [hashText, hmacSignature, rsaSignature, generatePassword, base64Decode, base64Encode, openpgpEncrypt],
   triggers: [],
 });

--- a/packages/pieces/core/crypto/src/lib/actions/rsa-signature.ts
+++ b/packages/pieces/core/crypto/src/lib/actions/rsa-signature.ts
@@ -1,0 +1,64 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import Crypto from 'crypto';
+
+export const rsaSignature = createAction({
+  name: 'rsa-signature',
+  displayName: 'Generate RSA Signature',
+  description:
+    'Signs text with an RSA private key using SHA-256, SHA-384, or SHA-512 (RSA-SHA256 by default)',
+  props: {
+    privateKey: Property.LongText({
+      displayName: 'Private Key',
+      description: 'The RSA private key in PEM format (PKCS#1 or PKCS#8)',
+      required: true,
+    }),
+    passphrase: Property.ShortText({
+      displayName: 'Passphrase',
+      description:
+        'The passphrase protecting the private key, leave empty if it is not encrypted',
+      required: false,
+    }),
+    method: Property.StaticDropdown({
+      displayName: 'Method',
+      description: 'The hashing algorithm to use',
+      required: true,
+      defaultValue: 'sha256',
+      options: {
+        options: [
+          { label: 'SHA256', value: 'sha256' },
+          { label: 'SHA384', value: 'sha384' },
+          { label: 'SHA512', value: 'sha512' },
+        ],
+      },
+    }),
+    text: Property.LongText({
+      displayName: 'Text',
+      description: 'The text to be signed',
+      required: true,
+    }),
+    outputEncoding: Property.StaticDropdown<'hex' | 'base64'>({
+      displayName: 'Output Encoding',
+      description: 'The encoding of the output signature',
+      required: false,
+      defaultValue: 'base64',
+      options: {
+        options: [
+          { label: 'Base64', value: 'base64' },
+          { label: 'Hex', value: 'hex' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { privateKey, passphrase, method, text, outputEncoding } =
+      context.propsValue;
+
+    const sign = Crypto.createSign(method);
+    sign.update(text);
+    sign.end();
+
+    const key = passphrase ? { key: privateKey, passphrase } : privateKey;
+
+    return sign.sign(key, outputEncoding ?? 'base64');
+  },
+});

--- a/packages/pieces/core/crypto/test/rsa-signature.test.ts
+++ b/packages/pieces/core/crypto/test/rsa-signature.test.ts
@@ -1,0 +1,101 @@
+/// <reference types="vitest/globals" />
+
+import { rsaSignature } from '../src/lib/actions/rsa-signature';
+import { createMockActionContext } from '@activepieces/pieces-framework';
+import Crypto from 'crypto';
+
+const { privateKey, publicKey } = Crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+describe('rsaSignature', () => {
+  test('produces a signature that verifies with the public key (RSA-SHA256, base64)', async () => {
+    const ctx = createMockActionContext({
+      propsValue: {
+        privateKey,
+        method: 'sha256' as const,
+        text: 'hello world',
+        outputEncoding: 'base64' as const,
+      },
+    });
+    const signature = await rsaSignature.run(ctx);
+    expect(typeof signature).toBe('string');
+
+    const verified = Crypto.verify(
+      'sha256',
+      Buffer.from('hello world'),
+      publicKey,
+      Buffer.from(signature as string, 'base64')
+    );
+    expect(verified).toBe(true);
+  });
+
+  test('hex and base64 outputs decode to the same signature bytes', async () => {
+    const base = {
+      privateKey,
+      method: 'sha256' as const,
+      text: 'crc_token_value',
+    };
+    const hexResult = await rsaSignature.run(
+      createMockActionContext({ propsValue: { ...base, outputEncoding: 'hex' as const } })
+    );
+    const b64Result = await rsaSignature.run(
+      createMockActionContext({ propsValue: { ...base, outputEncoding: 'base64' as const } })
+    );
+    expect(Buffer.from(b64Result as string, 'base64').toString('hex')).toBe(hexResult);
+  });
+
+  test('signature does not verify against tampered text', async () => {
+    const ctx = createMockActionContext({
+      propsValue: {
+        privateKey,
+        method: 'sha256' as const,
+        text: 'original',
+        outputEncoding: 'base64' as const,
+      },
+    });
+    const signature = await rsaSignature.run(ctx);
+
+    const verified = Crypto.verify(
+      'sha256',
+      Buffer.from('tampered'),
+      publicKey,
+      Buffer.from(signature as string, 'base64')
+    );
+    expect(verified).toBe(false);
+  });
+
+  test('signs with a passphrase-protected private key (SHA512)', async () => {
+    const passphrase = 'topsecret';
+    const encrypted = Crypto.generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem',
+        cipher: 'aes-256-cbc',
+        passphrase,
+      },
+    });
+    const ctx = createMockActionContext({
+      propsValue: {
+        privateKey: encrypted.privateKey,
+        passphrase,
+        method: 'sha512' as const,
+        text: 'data to sign',
+        outputEncoding: 'base64' as const,
+      },
+    });
+    const signature = await rsaSignature.run(ctx);
+
+    const verified = Crypto.verify(
+      'sha512',
+      Buffer.from('data to sign'),
+      encrypted.publicKey,
+      Buffer.from(signature as string, 'base64')
+    );
+    expect(verified).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds an 'Generate RSA Signature' action to the core Crypto piece. Signs text with an RSA private key using SHA-256/384/512 (RSA-SHA256 by default, PKCS#1 v1.5 padding). Accepts a PEM private key (PKCS#1 or PKCS#8) with an optional passphrase for encrypted keys, and outputs the signature as base64 or hex.

Bumps the piece to 0.0.21 and adds sign→verify round-trip tests.

PIE-352