### PR TITLE
fix(engine): resolve large webhook & resume payloads inside the engine subprocess (rc6 backport)

### DIFF
--- a/.agents/features/webhooks.md
+++ b/.agents/features/webhooks.md
@@ -47,9 +47,11 @@ All routes accept GET, POST, PUT, DELETE, PATCH methods.
 ## Sync vs Async Execution
 
 **Async path**:
-1. Offload payload to S3 if > `AP_WEBHOOK_PAYLOAD_INLINE_THRESHOLD_KB` (default 512KB)
+1. Offload payload to S3/DB if > `AP_WEBHOOK_PAYLOAD_INLINE_THRESHOLD_KB` (default 512KB). The job carries a `JobPayload` discriminated union — `inline` (value embedded) or `ref` (`fileId` of a `WEBHOOK_PAYLOAD` file).
 2. Queue BullMQ job (`WorkerJobType.EXECUTE_WEBHOOK`)
 3. Return 200 with `x-webhook-id` header immediately
+
+The worker forwards the `JobPayload` straight into the `EXECUTE_TRIGGER_HOOK` engine operation; the **engine** resolves it at execution time (inline value, or a `ref` downloaded via the engine file-download endpoint `GET /v1/engine/files/:fileId`). Workers no longer fetch payloads themselves.
 
 **Sync path**:
 1. Create FlowRun with `ProgressUpdateType.WEBHOOK_RESPONSE`

--- a/packages/server/api/src/app/workers/engine-controller.ts
+++ b/packages/server/api/src/app/workers/engine-controller.ts
@@ -2,8 +2,10 @@
 import { FlowVersion, GetFlowVersionForWorkerRequest, ListFlowsRequest } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
+import { z } from 'zod'
 import { entitiesMustBeOwnedByCurrentProject } from '../authentication/authorization'
 import { securityAccess } from '../core/security/authorization/fastify-security'
+import { fileService } from '../file/file.service'
 import { flowService } from '../flows/flow/flow.service'
 import { flowVersionService } from '../flows/flow-version/flow-version.service'
 
@@ -35,6 +37,17 @@ export const flowEngineWorker: FastifyPluginAsyncZod = async (app) => {
         return flowVersion
     })
 
+    app.get('/files/:fileId', GetEnginePayloadFileRequest, async (request, reply) => {
+        const { data } = await fileService(request.log).getDataOrThrow({
+            fileId: request.params.fileId,
+            projectId: request.principal.projectId,
+        })
+        return reply
+            .type('application/octet-stream')
+            .status(StatusCodes.OK)
+            .send(data)
+    })
+
 
 }
 
@@ -57,5 +70,16 @@ const GetLockedVersionRequest = {
         response: {
             [StatusCodes.OK]: FlowVersion,
         },
+    },
+}
+
+const GetEnginePayloadFileRequest = {
+    config: {
+        security: securityAccess.engine(),
+    },
+    schema: {
+        params: z.object({
+            fileId: z.string(),
+        }),
     },
 }

--- a/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
+++ b/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
@@ -177,14 +177,6 @@ export function createHandlers(log: FastifyBaseLogger, workerGroupId?: string): 
             await jobBroker(log).extendLock(input)
         },
 
-        async getPayloadFile(input) {
-            const { data } = await fileService(log).getDataOrThrow({
-                fileId: input.fileId,
-                projectId: input.projectId,
-            })
-            return data
-        },
-
         async getPieceArchive(input) {
             const { data } = await fileService(log).getDataOrThrow({
                 fileId: input.archiveId,

--- a/packages/server/engine/src/lib/handler/context/engine-constants.ts
+++ b/packages/server/engine/src/lib/handler/context/engine-constants.ts
@@ -1,5 +1,5 @@
 import { ContextVersion } from '@activepieces/pieces-framework'
-import { DEFAULT_MCP_DATA, EngineGenericError, ExecuteFlowOperation, ExecutePropsOptions, ExecuteToolOperation, ExecuteTriggerOperation, ExecutionType, flowStructureUtil, FlowVersionState, PlatformId, Project, ProjectId, ResumePayload, RunEnvironment, StreamStepProgress, TriggerHookType } from '@activepieces/shared'
+import { BeginExecuteFlowOperation, DEFAULT_MCP_DATA, EngineGenericError, ExecutePropsOptions, ExecuteToolOperation, ExecuteTriggerOperation, ExecutionState, ExecutionType, flowStructureUtil, FlowVersionState, PlatformId, Project, ProjectId, ResumeExecuteFlowOperation, ResumePayload, RunEnvironment, StreamStepProgress, TriggerHookType } from '@activepieces/shared'
 import { createPropsResolver, PropsResolver } from '../../variables/props-resolver'
 
 type RetryConstants = {
@@ -118,7 +118,7 @@ export class EngineConstants {
         this.stepNames = params.stepNames
     }
   
-    public static fromExecuteFlowInput(input: ExecuteFlowOperation): EngineConstants {
+    public static fromExecuteFlowInput(input: ResolvedExecuteFlowOperation): EngineConstants {
         return new EngineConstants({
             flowId: input.flowVersion.flowId,
             flowVersionId: input.flowVersion.id,
@@ -136,7 +136,7 @@ export class EngineConstants {
             resumePayload: input.executionType === ExecutionType.RESUME ? input.resumePayload : undefined,
             runEnvironment: input.runEnvironment,
             stepNameToTest: input.stepNameToTest ?? undefined,
-            logsUploadUrl: input.logsUploadUrl, 
+            logsUploadUrl: input.logsUploadUrl,
             logsFileId: input.logsFileId,
             timeoutInSeconds: input.timeoutInSeconds,
             platformId: input.platformId,
@@ -251,3 +251,14 @@ export class EngineConstants {
 const addTrailingSlashIfMissing = (url: string): string => {
     return url.endsWith('/') ? url : url + '/'
 }
+
+export type ResolvedBeginExecuteFlowOperation = Omit<BeginExecuteFlowOperation, 'triggerPayload'> & {
+    triggerPayload: unknown
+}
+
+export type ResolvedResumeExecuteFlowOperation = Omit<ResumeExecuteFlowOperation, 'resumePayload'> & {
+    resumePayload: ResumePayload
+    executionState: ExecutionState
+}
+
+export type ResolvedExecuteFlowOperation = ResolvedBeginExecuteFlowOperation | ResolvedResumeExecuteFlowOperation

--- a/packages/server/engine/src/lib/handler/context/engine-constants.ts
+++ b/packages/server/engine/src/lib/handler/context/engine-constants.ts
@@ -192,7 +192,7 @@ export class EngineConstants {
         })
     }
 
-    public static fromExecuteTriggerInput(input: ExecuteTriggerOperation<TriggerHookType>): EngineConstants {
+    public static fromExecuteTriggerInput(input: ResolvedExecuteTriggerOperation<TriggerHookType>): EngineConstants {
         return new EngineConstants({
             flowId: input.flowVersion.flowId,
             flowVersionId: input.flowVersion.id,
@@ -254,6 +254,10 @@ const addTrailingSlashIfMissing = (url: string): string => {
 
 export type ResolvedBeginExecuteFlowOperation = Omit<BeginExecuteFlowOperation, 'triggerPayload'> & {
     triggerPayload: unknown
+}
+
+export type ResolvedExecuteTriggerOperation<HT extends TriggerHookType> = Omit<ExecuteTriggerOperation<HT>, 'triggerPayload'> & {
+    triggerPayload?: unknown
 }
 
 export type ResolvedResumeExecuteFlowOperation = Omit<ResumeExecuteFlowOperation, 'resumePayload'> & {

--- a/packages/server/engine/src/lib/handler/flow-executor.ts
+++ b/packages/server/engine/src/lib/handler/flow-executor.ts
@@ -1,11 +1,11 @@
 import { performance } from 'node:perf_hooks'
-import { EngineGenericError, ExecuteFlowOperation, ExecutionType, FlowAction, FlowActionType, FlowRunStatus, FlowTrigger, GenericStepOutput, isNil, StepOutputStatus } from '@activepieces/shared'
+import { EngineGenericError, ExecutionType, FlowAction, FlowActionType, FlowRunStatus, FlowTrigger, GenericStepOutput, isNil, StepOutputStatus } from '@activepieces/shared'
 import dayjs from 'dayjs'
 import { loggingUtils } from '../helper/logging-utils'
 import { triggerHelper } from '../helper/trigger-helper'
 import { BaseExecutor } from './base-executor'
 import { codeExecutor } from './code-executor'
-import { EngineConstants } from './context/engine-constants'
+import { EngineConstants, ResolvedExecuteFlowOperation } from './context/engine-constants'
 import { FlowExecutorContext } from './context/flow-execution-context'
 import { loopExecutor } from './loop-executor'
 import { pieceExecutor } from './piece-executor'
@@ -35,7 +35,7 @@ export const flowExecutor = {
     async executeFromTrigger({ executionState, constants, input }: {
         executionState: FlowExecutorContext
         constants: EngineConstants
-        input: ExecuteFlowOperation
+        input: ResolvedExecuteFlowOperation
     }): Promise<FlowExecutorContext> {
         const trigger = input.flowVersion.trigger
         if (input.executionType === ExecutionType.BEGIN) {

--- a/packages/server/engine/src/lib/helper/payload-file-client.ts
+++ b/packages/server/engine/src/lib/helper/payload-file-client.ts
@@ -1,0 +1,23 @@
+import { EngineGenericError } from '@activepieces/shared'
+
+export const payloadFileClient = {
+    get: async ({ apiUrl, engineToken, fileId }: GetPayloadFileRequest): Promise<Buffer> => {
+        const response = await fetch(`${apiUrl}v1/engine/files/${fileId}`, {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${engineToken}`,
+            },
+        })
+        if (!response.ok) {
+            throw new EngineGenericError('PayloadFileFetchError', `Failed to fetch payload file ${fileId}: ${response.status} ${response.statusText}`)
+        }
+        const arrayBuffer = await response.arrayBuffer()
+        return Buffer.from(arrayBuffer)
+    },
+}
+
+type GetPayloadFileRequest = {
+    apiUrl: string
+    engineToken: string
+    fileId: string
+}

--- a/packages/server/engine/src/lib/helper/payload-file-client.ts
+++ b/packages/server/engine/src/lib/helper/payload-file-client.ts
@@ -2,7 +2,8 @@ import { EngineGenericError } from '@activepieces/shared'
 
 export const payloadFileClient = {
     get: async ({ apiUrl, engineToken, fileId }: GetPayloadFileRequest): Promise<Buffer> => {
-        const response = await fetch(`${apiUrl}v1/engine/files/${fileId}`, {
+        const baseUrl = apiUrl.endsWith('/') ? apiUrl : `${apiUrl}/`
+        const response = await fetch(`${baseUrl}v1/engine/files/${fileId}`, {
             method: 'GET',
             headers: {
                 Authorization: `Bearer ${engineToken}`,

--- a/packages/server/engine/src/lib/helper/trigger-helper.ts
+++ b/packages/server/engine/src/lib/helper/trigger-helper.ts
@@ -1,7 +1,7 @@
 import { PiecePropertyMap, StaticPropsValue, TriggerStrategy } from '@activepieces/pieces-framework'
-import { assertEqual, AUTHENTICATION_PROPERTY_NAME, EngineGenericError, EventPayload, ExecuteTriggerOperation, ExecuteTriggerResponse, FlowTrigger, InvalidCronExpressionError, isNil, PieceTrigger, PropertySettings, ScheduleOptions, TriggerHookType, TriggerSourceScheduleType } from '@activepieces/shared'
+import { assertEqual, AUTHENTICATION_PROPERTY_NAME, EngineGenericError, EventPayload, ExecuteTriggerResponse, FlowTrigger, InvalidCronExpressionError, isNil, PieceTrigger, PropertySettings, ScheduleOptions, TriggerHookType, TriggerSourceScheduleType } from '@activepieces/shared'
 import { isValidCron } from 'cron-validator'
-import { EngineConstants } from '../handler/context/engine-constants'
+import { EngineConstants, ResolvedExecuteTriggerOperation } from '../handler/context/engine-constants'
 import { FlowExecutorContext } from '../handler/context/flow-execution-context'
 import { createFileUploader } from '../piece-context/file-uploader'
 import { createFlowsContext } from '../piece-context/flows'
@@ -243,7 +243,7 @@ export const triggerHelper = {
 }
 
 type ExecuteTriggerParams = {
-    params: ExecuteTriggerOperation<TriggerHookType>
+    params: ResolvedExecuteTriggerOperation<TriggerHookType>
     constants: EngineConstants
 }
 

--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -158,7 +158,7 @@ async function fetchExecutionStateFromLogs(logsFileId: string | undefined, opera
     }
     const buffer = await payloadFileClient.get({ apiUrl: operation.internalApiUrl, engineToken: operation.engineToken, fileId: logsFileId })
     const parsed = JSON.parse(buffer.toString('utf-8'))
-    if (isNil(parsed?.executionState)) {
+    if (isNil(parsed?.executionState?.steps)) {
         throw new EngineGenericError('ExecutionStateMissing', 'executionState is missing in logs file')
     }
     return parsed.executionState as ExecutionState

--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -1,34 +1,37 @@
 import {
-    BeginExecuteFlowOperation,
     EngineGenericError,
     EngineResponse,
     EngineResponseStatus,
     ExecuteFlowOperation,
     ExecuteTriggerResponse,
+    ExecutionState,
     ExecutionType,
     FlowActionType,
     FlowRunStatus,
     flowStructureUtil,
     GenericStepOutput,
     isNil,
+    JobPayload,
     LoopStepOutput,
+    ResumePayload,
     StepOutput,
     StepOutputStatus,
     TriggerHookType,
     TriggerPayload,
 } from '@activepieces/shared'
-import { EngineConstants } from '../handler/context/engine-constants'
+import { EngineConstants, ResolvedBeginExecuteFlowOperation, ResolvedExecuteFlowOperation } from '../handler/context/engine-constants'
 import { FlowExecutorContext } from '../handler/context/flow-execution-context'
 import { testExecutionContext } from '../handler/context/test-execution-context'
 import { flowExecutor } from '../handler/flow-executor'
 import { runProgressService } from '../handler/run-progress'
+import { payloadFileClient } from '../helper/payload-file-client'
 import { triggerHelper } from '../helper/trigger-helper'
 
 export const flowOperation = {
     execute: async (operation: ExecuteFlowOperation): Promise<EngineResponse<undefined>> => {
-        const input = operation as ExecuteFlowOperation
+        const input = await resolveExecuteFlowOperation(operation)
         const constants = EngineConstants.fromExecuteFlowInput(input)
-        const output: FlowExecutorContext = (await executieSingleStepOrFlowOperation(input)).finishExecution()
+        const output: FlowExecutorContext = (await executieSingleStepOrFlowOperation(input, constants)).finishExecution()
         await runProgressService.backup({
             engineConstants: constants,
             flowExecutorContext: output,
@@ -43,8 +46,7 @@ export const flowOperation = {
     },
 }
 
-const executieSingleStepOrFlowOperation = async (input: ExecuteFlowOperation): Promise<FlowExecutorContext> => {
-    const constants = EngineConstants.fromExecuteFlowInput(input)
+const executieSingleStepOrFlowOperation = async (input: ResolvedExecuteFlowOperation, constants: EngineConstants): Promise<FlowExecutorContext> => {
     const testSingleStepMode = !isNil(constants.stepNameToTest)
     if (testSingleStepMode) {
         const testContext = await testExecutionContext.stateFromFlowVersion({
@@ -59,37 +61,27 @@ const executieSingleStepOrFlowOperation = async (input: ExecuteFlowOperation): P
         const step = flowStructureUtil.getActionOrThrow(input.stepNameToTest!, input.flowVersion.trigger)
         return flowExecutor.execute({
             action: step,
-            executionState: await getFlowExecutionState(input, testContext),
-            constants: EngineConstants.fromExecuteFlowInput(input),
+            executionState: await getFlowExecutionState(input, constants, testContext),
+            constants,
         })
     }
     return flowExecutor.executeFromTrigger({
-        executionState: await getFlowExecutionState(input, FlowExecutorContext.empty()),
+        executionState: await getFlowExecutionState(input, constants, FlowExecutorContext.empty()),
         constants,
         input,
     })
 }
 
-async function getFlowExecutionState(input: ExecuteFlowOperation, flowContext: FlowExecutorContext): Promise<FlowExecutorContext> {
-    switch (input.executionType) {
-        case ExecutionType.BEGIN: {
-            if (Object.keys(input.executionState.steps).length > 0) {
-                throw new EngineGenericError('InvalidBeginStateError', 'BEGIN operation received with non-empty execution state')
-            }
-            const newPayload = await runOrReturnPayload(input)
-            flowContext = flowContext.upsertStep(input.flowVersion.trigger.name, GenericStepOutput.create({
-                type: input.flowVersion.trigger.type,
-                status: StepOutputStatus.SUCCEEDED,
-                input: {},
-            }).setOutput(newPayload))
-            break
-        }
-        case ExecutionType.RESUME: {
-            flowContext = flowContext.addTags(input.executionState.tags)
-            break
-        }
+async function getFlowExecutionState(input: ResolvedExecuteFlowOperation, constants: EngineConstants, flowContext: FlowExecutorContext): Promise<FlowExecutorContext> {
+    if (input.executionType === ExecutionType.BEGIN) {
+        const newPayload = await runOrReturnPayload(input, constants)
+        return flowContext.upsertStep(input.flowVersion.trigger.name, GenericStepOutput.create({
+            type: input.flowVersion.trigger.type,
+            status: StepOutputStatus.SUCCEEDED,
+            input: {},
+        }).setOutput(newPayload))
     }
-
+    flowContext = flowContext.addTags(input.executionState.tags)
     for (const [step, output] of Object.entries(input.executionState.steps)) {
         if ([StepOutputStatus.SUCCEEDED, StepOutputStatus.PAUSED].includes(output.status)) {
             const newOutput = await insertSuccessStepsOrPausedRecursively(output)
@@ -101,7 +93,7 @@ async function getFlowExecutionState(input: ExecuteFlowOperation, flowContext: F
     return flowContext
 }
 
-async function runOrReturnPayload(input: BeginExecuteFlowOperation): Promise<TriggerPayload> {
+async function runOrReturnPayload(input: ResolvedBeginExecuteFlowOperation, constants: EngineConstants): Promise<TriggerPayload> {
     if (!input.executeTrigger) {
         return input.triggerPayload as TriggerPayload
     }
@@ -113,7 +105,7 @@ async function runOrReturnPayload(input: BeginExecuteFlowOperation): Promise<Tri
             webhookUrl: '',
             triggerPayload: input.triggerPayload as TriggerPayload,
         },
-        constants: EngineConstants.fromExecuteFlowInput(input),
+        constants,
     }) as ExecuteTriggerResponse<TriggerHookType.RUN>
     return newPayload.output[0] as TriggerPayload
 }
@@ -140,4 +132,42 @@ async function insertSuccessStepsOrPausedRecursively(stepOutput: StepOutput): Pr
         return loopOutput.setIterations(newIterations)
     }
     return stepOutput
+}
+
+async function resolveExecuteFlowOperation(operation: ExecuteFlowOperation): Promise<ResolvedExecuteFlowOperation> {
+    if (operation.executionType === ExecutionType.BEGIN) {
+        return {
+            ...operation,
+            triggerPayload: await resolveJobPayload(operation.triggerPayload, operation),
+        }
+    }
+    const executionState = await fetchExecutionStateFromLogs(operation.logsFileId, operation)
+    if (Object.keys(executionState.steps).length === 0) {
+        throw new EngineGenericError('EmptyResumeStateError', 'RESUME operation received with empty execution state')
+    }
+    return {
+        ...operation,
+        resumePayload: await resolveJobPayload(operation.resumePayload, operation) as ResumePayload,
+        executionState,
+    }
+}
+
+async function resolveJobPayload(payload: JobPayload, operation: ExecuteFlowOperation): Promise<unknown> {
+    if (payload.type === 'inline') {
+        return payload.value
+    }
+    const buffer = await payloadFileClient.get({ apiUrl: operation.internalApiUrl, engineToken: operation.engineToken, fileId: payload.fileId })
+    return JSON.parse(buffer.toString('utf-8'))
+}
+
+async function fetchExecutionStateFromLogs(logsFileId: string | undefined, operation: ExecuteFlowOperation): Promise<ExecutionState> {
+    if (isNil(logsFileId)) {
+        throw new EngineGenericError('ResumeLogsFileMissing', 'logsFileId is missing for RESUME operation')
+    }
+    const buffer = await payloadFileClient.get({ apiUrl: operation.internalApiUrl, engineToken: operation.engineToken, fileId: logsFileId })
+    const parsed = JSON.parse(buffer.toString('utf-8'))
+    if (isNil(parsed?.executionState)) {
+        throw new EngineGenericError('ExecutionStateMissing', 'executionState is missing in logs file')
+    }
+    return parsed.executionState as ExecutionState
 }

--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -11,7 +11,6 @@ import {
     flowStructureUtil,
     GenericStepOutput,
     isNil,
-    JobPayload,
     LoopStepOutput,
     ResumePayload,
     StepOutput,
@@ -26,6 +25,7 @@ import { flowExecutor } from '../handler/flow-executor'
 import { runProgressService } from '../handler/run-progress'
 import { payloadFileClient } from '../helper/payload-file-client'
 import { triggerHelper } from '../helper/trigger-helper'
+import { resolveJobPayload } from './utils/resolve-job-payload'
 
 export const flowOperation = {
     execute: async (operation: ExecuteFlowOperation): Promise<EngineResponse<undefined>> => {
@@ -103,7 +103,7 @@ async function runOrReturnPayload(input: ResolvedBeginExecuteFlowOperation, cons
             hookType: TriggerHookType.RUN,
             test: false,
             webhookUrl: '',
-            triggerPayload: input.triggerPayload as TriggerPayload,
+            triggerPayload: input.triggerPayload,
         },
         constants,
     }) as ExecuteTriggerResponse<TriggerHookType.RUN>
@@ -138,7 +138,7 @@ async function resolveExecuteFlowOperation(operation: ExecuteFlowOperation): Pro
     if (operation.executionType === ExecutionType.BEGIN) {
         return {
             ...operation,
-            triggerPayload: await resolveJobPayload(operation.triggerPayload, operation),
+            triggerPayload: await resolveJobPayload({ payload: operation.triggerPayload, apiUrl: operation.internalApiUrl, engineToken: operation.engineToken }),
         }
     }
     const executionState = await fetchExecutionStateFromLogs(operation.logsFileId, operation)
@@ -147,17 +147,9 @@ async function resolveExecuteFlowOperation(operation: ExecuteFlowOperation): Pro
     }
     return {
         ...operation,
-        resumePayload: await resolveJobPayload(operation.resumePayload, operation) as ResumePayload,
+        resumePayload: await resolveJobPayload({ payload: operation.resumePayload, apiUrl: operation.internalApiUrl, engineToken: operation.engineToken }) as ResumePayload,
         executionState,
     }
-}
-
-async function resolveJobPayload(payload: JobPayload, operation: ExecuteFlowOperation): Promise<unknown> {
-    if (payload.type === 'inline') {
-        return payload.value
-    }
-    const buffer = await payloadFileClient.get({ apiUrl: operation.internalApiUrl, engineToken: operation.engineToken, fileId: payload.fileId })
-    return JSON.parse(buffer.toString('utf-8'))
 }
 
 async function fetchExecutionStateFromLogs(logsFileId: string | undefined, operation: ExecuteFlowOperation): Promise<ExecutionState> {

--- a/packages/server/engine/src/lib/operations/trigger-hook.operation.ts
+++ b/packages/server/engine/src/lib/operations/trigger-hook.operation.ts
@@ -6,14 +6,22 @@ import {
     ExecuteTriggerResponse,
     TriggerHookType,
 } from '@activepieces/shared'
-import { EngineConstants } from '../handler/context/engine-constants'
+import { EngineConstants, ResolvedExecuteTriggerOperation } from '../handler/context/engine-constants'
 import { triggerHelper } from '../helper/trigger-helper'
 import { utils } from '../utils'
+import { resolveJobPayload } from './utils/resolve-job-payload'
 
 
 export const triggerHookOperation = {
     execute: async (operation: ExecuteTriggerOperation<TriggerHookType>): Promise<EngineResponse<ExecuteTriggerResponse<TriggerHookType>>> => {
-        const input = operation as ExecuteTriggerOperation<TriggerHookType>
+        const input: ResolvedExecuteTriggerOperation<TriggerHookType> = {
+            ...operation,
+            triggerPayload: await resolveJobPayload({
+                payload: operation.triggerPayload,
+                apiUrl: operation.internalApiUrl,
+                engineToken: operation.engineToken,
+            }),
+        }
         const { data: output, error } = await utils.tryCatchAndThrowOnEngineError(() =>
             triggerHelper.executeTrigger({
                 params: input,

--- a/packages/server/engine/src/lib/operations/utils/resolve-job-payload.ts
+++ b/packages/server/engine/src/lib/operations/utils/resolve-job-payload.ts
@@ -1,0 +1,23 @@
+import { isNil, JobPayload } from '@activepieces/shared'
+import { payloadFileClient } from '../../helper/payload-file-client'
+
+export async function resolveJobPayload({ payload, apiUrl, engineToken }: ResolveJobPayloadParams): Promise<unknown> {
+    if (isNil(payload)) {
+        return undefined
+    }
+    if (payload.type === 'inline') {
+        return payload.value
+    }
+    const buffer = await payloadFileClient.get({
+        apiUrl,
+        engineToken,
+        fileId: payload.fileId,
+    })
+    return JSON.parse(buffer.toString('utf-8'))
+}
+
+type ResolveJobPayloadParams = {
+    payload: JobPayload | undefined
+    apiUrl: string
+    engineToken: string
+}

--- a/packages/server/engine/test/handler/test-helper.ts
+++ b/packages/server/engine/test/handler/test-helper.ts
@@ -1,5 +1,5 @@
 import { ActionErrorHandlingOptions, BeginExecuteFlowOperation, BranchCondition, BranchExecutionType, CodeAction, ExecutionType, FlowAction, FlowActionType, FlowVersionState, LoopOnItemsAction, PieceAction, StreamStepProgress, PropertyExecutionType, RouterExecutionType, RunEnvironment } from '@activepieces/shared'
-import { EngineConstants } from '../../src/lib/handler/context/engine-constants'
+import { EngineConstants, ResolvedBeginExecuteFlowOperation } from '../../src/lib/handler/context/engine-constants'
 
 export const generateMockEngineConstants = (params?: Partial<EngineConstants>): EngineConstants => {
     return new EngineConstants(
@@ -123,8 +123,8 @@ export function buildPieceAction({ name, input, skip, pieceName, actionName, nex
 }
 
 export function buildMockBeginExecuteFlowOperation(
-    params: Partial<BeginExecuteFlowOperation> & Pick<BeginExecuteFlowOperation, 'flowVersion'>,
-): BeginExecuteFlowOperation {
+    params: Partial<ResolvedBeginExecuteFlowOperation> & Pick<BeginExecuteFlowOperation, 'flowVersion'>,
+): ResolvedBeginExecuteFlowOperation {
     return {
         projectId: 'projectId',
         engineToken: 'engineToken',
@@ -135,7 +135,6 @@ export function buildMockBeginExecuteFlowOperation(
         flowRunId: 'flowRunId',
         executionType: ExecutionType.BEGIN,
         runEnvironment: RunEnvironment.TESTING,
-        executionState: { steps: {}, tags: [] },
         workerHandlerId: null,
         httpRequestId: null,
         streamStepProgress: StreamStepProgress.NONE,

--- a/packages/server/engine/test/operations/flow-operation-invariants.test.ts
+++ b/packages/server/engine/test/operations/flow-operation-invariants.test.ts
@@ -195,4 +195,45 @@ describe('flow operation invariants', () => {
             })
         })
     })
+
+    describe('RESUME payload hydration', () => {
+        it('resolves a ref resumePayload via the engine file client', async () => {
+            mockGetPayloadFile.mockReset()
+            mockGetPayloadFile.mockImplementation(({ fileId }: { fileId: string }) => {
+                if (fileId === 'logs-file-1') {
+                    return Promise.resolve(Buffer.from(JSON.stringify({
+                        executionState: {
+                            steps: {
+                                trigger_1: {
+                                    type: FlowTriggerType.EMPTY,
+                                    status: StepOutputStatus.SUCCEEDED,
+                                    input: {},
+                                    output: {},
+                                },
+                            },
+                            tags: [],
+                        },
+                    })))
+                }
+                return Promise.resolve(Buffer.from(JSON.stringify({ resumed: 'from-ref' })))
+            })
+
+            const operation = makeResumeOperation({
+                resumePayload: { type: 'ref', fileId: 'resume-file-1' },
+            })
+
+            try {
+                await flowOperation.execute(operation)
+            }
+            catch {
+                // downstream execution may fail; we only assert the resume payload was resolved
+            }
+
+            expect(mockGetPayloadFile).toHaveBeenCalledWith({
+                apiUrl: 'http://localhost:3000/',
+                engineToken: 'test-token',
+                fileId: 'resume-file-1',
+            })
+        })
+    })
 })

--- a/packages/server/engine/test/operations/flow-operation-invariants.test.ts
+++ b/packages/server/engine/test/operations/flow-operation-invariants.test.ts
@@ -126,6 +126,16 @@ describe('flow operation invariants', () => {
             await expect(flowOperation.execute(operation)).rejects.toThrow('executionState is missing in logs file')
         })
 
+        it('throws a descriptive error when steps is missing from executionState', async () => {
+            mockGetPayloadFile.mockReset()
+            mockGetPayloadFile.mockResolvedValue(Buffer.from(JSON.stringify({ executionState: { tags: [] } })))
+
+            const operation = makeResumeOperation()
+
+            await expect(flowOperation.execute(operation)).rejects.toThrow(EngineGenericError)
+            await expect(flowOperation.execute(operation)).rejects.toThrow('executionState is missing in logs file')
+        })
+
         it('proceeds past hydration when logs file has non-empty execution state', async () => {
             mockGetPayloadFile.mockReset()
             mockGetPayloadFile.mockResolvedValue(

--- a/packages/server/engine/test/operations/flow-operation-invariants.test.ts
+++ b/packages/server/engine/test/operations/flow-operation-invariants.test.ts
@@ -8,11 +8,18 @@ import {
     RunEnvironment,
     StepOutputStatus,
 } from '@activepieces/shared'
-import type { BeginExecuteFlowOperation, FlowVersion } from '@activepieces/shared'
+import type { BeginExecuteFlowOperation, FlowVersion, ResumeExecuteFlowOperation } from '@activepieces/shared'
 
 vi.mock('../../src/lib/handler/run-progress', () => ({
     runProgressService: {
         backup: vi.fn(),
+    },
+}))
+
+const { mockGetPayloadFile } = vi.hoisted(() => ({ mockGetPayloadFile: vi.fn() }))
+vi.mock('../../src/lib/helper/payload-file-client', () => ({
+    payloadFileClient: {
+        get: mockGetPayloadFile,
     },
 }))
 
@@ -55,51 +62,137 @@ function makeBeginOperation(overrides?: Partial<BeginExecuteFlowOperation>): Beg
         flowRunId: 'run-1',
         executionType: ExecutionType.BEGIN,
         runEnvironment: RunEnvironment.TESTING,
-        executionState: { steps: {}, tags: [] },
         workerHandlerId: null,
         httpRequestId: null,
         streamStepProgress: StreamStepProgress.NONE,
         stepNameToTest: null,
-        triggerPayload: {},
+        triggerPayload: { type: 'inline', value: {} },
         executeTrigger: false,
         ...overrides,
     }
 }
 
+function makeResumeOperation(overrides?: Partial<ResumeExecuteFlowOperation>): ResumeExecuteFlowOperation {
+    return {
+        projectId: 'proj-1',
+        engineToken: 'test-token',
+        internalApiUrl: 'http://localhost:3000/',
+        publicApiUrl: 'http://localhost:4200/api/',
+        timeoutInSeconds: 600,
+        platformId: 'plat-1',
+        flowVersion: makeFlowVersion(),
+        flowRunId: 'run-1',
+        executionType: ExecutionType.RESUME,
+        runEnvironment: RunEnvironment.TESTING,
+        workerHandlerId: null,
+        httpRequestId: null,
+        streamStepProgress: StreamStepProgress.NONE,
+        stepNameToTest: null,
+        resumePayload: { type: 'inline', value: { data: {} } },
+        logsFileId: 'logs-file-1',
+        ...overrides,
+    }
+}
+
 describe('flow operation invariants', () => {
-    describe('BEGIN execution state assertion', () => {
-        it('should throw EngineGenericError when BEGIN has non-empty execution state', async () => {
-            const operation = makeBeginOperation({
-                executionState: {
-                    steps: {
-                        trigger_1: {
-                            type: FlowTriggerType.EMPTY as any,
-                            status: StepOutputStatus.SUCCEEDED,
-                            input: {},
-                            output: {},
-                        },
-                    },
-                    tags: [],
-                },
-            })
+    describe('RESUME execution state hydration', () => {
+        it('throws EngineGenericError when RESUME has empty execution state in logs file', async () => {
+            mockGetPayloadFile.mockReset()
+            mockGetPayloadFile.mockResolvedValue(
+                Buffer.from(JSON.stringify({ executionState: { steps: {}, tags: [] } })),
+            )
+
+            const operation = makeResumeOperation()
 
             await expect(flowOperation.execute(operation)).rejects.toThrow(EngineGenericError)
-            await expect(flowOperation.execute(operation)).rejects.toThrow('BEGIN operation received with non-empty execution state')
+            await expect(flowOperation.execute(operation)).rejects.toThrow('RESUME operation received with empty execution state')
         })
 
-        it('should pass the assertion when BEGIN has empty execution state', async () => {
-            const operation = makeBeginOperation({
-                executionState: { steps: {}, tags: [] },
-            })
+        it('throws when logsFileId is missing on RESUME', async () => {
+            mockGetPayloadFile.mockReset()
+            const operation = makeResumeOperation({ logsFileId: undefined })
 
-            // The operation will fail further downstream (trigger setup),
-            // but it should NOT throw InvalidBeginStateError
+            await expect(flowOperation.execute(operation)).rejects.toThrow(EngineGenericError)
+            await expect(flowOperation.execute(operation)).rejects.toThrow('logsFileId is missing for RESUME operation')
+        })
+
+        it('throws when executionState is missing in logs file', async () => {
+            mockGetPayloadFile.mockReset()
+            mockGetPayloadFile.mockResolvedValue(Buffer.from(JSON.stringify({})))
+
+            const operation = makeResumeOperation()
+
+            await expect(flowOperation.execute(operation)).rejects.toThrow(EngineGenericError)
+            await expect(flowOperation.execute(operation)).rejects.toThrow('executionState is missing in logs file')
+        })
+
+        it('proceeds past hydration when logs file has non-empty execution state', async () => {
+            mockGetPayloadFile.mockReset()
+            mockGetPayloadFile.mockResolvedValue(
+                Buffer.from(JSON.stringify({
+                    executionState: {
+                        steps: {
+                            trigger_1: {
+                                type: FlowTriggerType.EMPTY,
+                                status: StepOutputStatus.SUCCEEDED,
+                                input: {},
+                                output: {},
+                            },
+                        },
+                        tags: [],
+                    },
+                })),
+            )
+
+            const operation = makeResumeOperation()
+
             try {
                 await flowOperation.execute(operation)
             }
             catch (e) {
-                expect((e as Error).name).not.toBe('InvalidBeginStateError')
+                expect((e as Error).message).not.toContain('empty execution state')
+                expect((e as Error).message).not.toContain('logsFileId is missing')
+                expect((e as Error).message).not.toContain('executionState is missing')
             }
+        })
+    })
+
+    describe('BEGIN payload hydration', () => {
+        it('inline payload is forwarded without calling getPayloadFile', async () => {
+            mockGetPayloadFile.mockReset()
+            const operation = makeBeginOperation({
+                triggerPayload: { type: 'inline', value: { hello: 'world' } },
+            })
+
+            try {
+                await flowOperation.execute(operation)
+            }
+            catch {
+                // downstream may fail; we only assert RPC call shape
+            }
+
+            expect(mockGetPayloadFile).not.toHaveBeenCalled()
+        })
+
+        it('ref payload is fetched via the engine HTTP client', async () => {
+            mockGetPayloadFile.mockReset()
+            mockGetPayloadFile.mockResolvedValue(Buffer.from(JSON.stringify({ hello: 'ref' })))
+            const operation = makeBeginOperation({
+                triggerPayload: { type: 'ref', fileId: 'payload-file-1' },
+            })
+
+            try {
+                await flowOperation.execute(operation)
+            }
+            catch {
+                // downstream may fail; we only assert RPC call shape
+            }
+
+            expect(mockGetPayloadFile).toHaveBeenCalledWith({
+                apiUrl: 'http://localhost:3000/',
+                engineToken: 'test-token',
+                fileId: 'payload-file-1',
+            })
         })
     })
 })

--- a/packages/server/engine/test/operations/trigger-hook-operation.test.ts
+++ b/packages/server/engine/test/operations/trigger-hook-operation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+    FlowTriggerType,
+    FlowVersionState,
+    TriggerHookType,
+} from '@activepieces/shared'
+import type { ExecuteTriggerOperation, FlowVersion } from '@activepieces/shared'
+
+const { mockGetPayloadFile } = vi.hoisted(() => ({
+    mockGetPayloadFile: vi.fn(),
+}))
+vi.mock('../../src/lib/helper/payload-file-client', () => ({
+    payloadFileClient: {
+        get: mockGetPayloadFile,
+    },
+}))
+
+const { mockExecuteTrigger } = vi.hoisted(() => ({
+    mockExecuteTrigger: vi.fn(),
+}))
+vi.mock('../../src/lib/helper/trigger-helper', () => ({
+    triggerHelper: {
+        executeTrigger: mockExecuteTrigger,
+    },
+}))
+
+import { triggerHookOperation } from '../../src/lib/operations/trigger-hook.operation'
+
+function makeFlowVersion(): FlowVersion {
+    return {
+        id: 'fv-1',
+        created: '2024-01-01T00:00:00Z',
+        updated: '2024-01-01T00:00:00Z',
+        flowId: 'flow-1',
+        displayName: 'Test Flow',
+        trigger: {
+            name: 'trigger_1',
+            valid: true,
+            displayName: 'Test Trigger',
+            type: FlowTriggerType.EMPTY,
+            settings: {},
+        },
+        updatedBy: null,
+        valid: true,
+        state: FlowVersionState.DRAFT,
+        schemaVersion: null,
+        connectionIds: [],
+        agentIds: [],
+    } as unknown as FlowVersion
+}
+
+function makeOperation(triggerPayload: ExecuteTriggerOperation<TriggerHookType.RUN>['triggerPayload']): ExecuteTriggerOperation<TriggerHookType.RUN> {
+    return {
+        hookType: TriggerHookType.RUN,
+        test: false,
+        flowVersion: makeFlowVersion(),
+        webhookUrl: 'http://localhost:4200/webhook',
+        triggerPayload,
+        projectId: 'project-1',
+        platformId: 'platform-1',
+        engineToken: 'test-token',
+        internalApiUrl: 'http://localhost:3000/',
+        publicApiUrl: 'http://localhost:4200/api/',
+        timeoutInSeconds: 30,
+    } as unknown as ExecuteTriggerOperation<TriggerHookType.RUN>
+}
+
+describe('triggerHookOperation payload resolution', () => {
+    beforeEach(() => {
+        mockGetPayloadFile.mockReset()
+        mockExecuteTrigger.mockReset()
+        mockExecuteTrigger.mockResolvedValue({ success: true, output: [] })
+    })
+
+    it('forwards an inline payload without hitting the engine file client', async () => {
+        await triggerHookOperation.execute(makeOperation({ type: 'inline', value: { hello: 'world' } }))
+
+        expect(mockGetPayloadFile).not.toHaveBeenCalled()
+        expect(mockExecuteTrigger).toHaveBeenCalledTimes(1)
+        expect(mockExecuteTrigger.mock.calls[0][0].params.triggerPayload).toEqual({ hello: 'world' })
+    })
+
+    it('downloads a ref payload via the engine file client and forwards the parsed value', async () => {
+        mockGetPayloadFile.mockResolvedValue(Buffer.from(JSON.stringify({ hello: 'ref' })))
+
+        await triggerHookOperation.execute(makeOperation({ type: 'ref', fileId: 'payload-file-1' }))
+
+        expect(mockGetPayloadFile).toHaveBeenCalledWith({
+            apiUrl: 'http://localhost:3000/',
+            engineToken: 'test-token',
+            fileId: 'payload-file-1',
+        })
+        expect(mockExecuteTrigger.mock.calls[0][0].params.triggerPayload).toEqual({ hello: 'ref' })
+    })
+
+    it('forwards an undefined payload without hitting the engine file client', async () => {
+        await triggerHookOperation.execute(makeOperation(undefined))
+
+        expect(mockGetPayloadFile).not.toHaveBeenCalled()
+        expect(mockExecuteTrigger.mock.calls[0][0].params.triggerPayload).toBeUndefined()
+    })
+})

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -7,23 +7,19 @@ import {
     EngineResponseStatus,
     ErrorCode,
     ExecuteFlowJobData,
-    ExecutionState,
     ExecutionType,
     FlowRunStatus,
     FlowVersion,
     isNil,
     ResumeExecuteFlowOperation,
-    ResumePayload,
     tryCatch,
     WorkerJobType,
-    WorkerToApiContract,
 } from '@activepieces/shared'
 import { flowCache } from '../../cache/flow/flow-cache'
 import { system, WorkerSystemProp } from '../../config/configs'
 import { workerSettings } from '../../config/worker-settings'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../types'
 import { provisionFlowPieces } from '../utils/flow-helpers'
-import { resolvePayload } from '../utils/resolve-payload'
 
 export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResult> = {
     jobType: WorkerJobType.EXECUTE_FLOW,
@@ -47,6 +43,14 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResu
             return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.INTERNAL_ERROR }
         }
 
+        if (data.executionType === ExecutionType.RESUME && isNil(data.logsFileId)) {
+            await reportFlowStatus(ctx, data, FlowRunStatus.INTERNAL_ERROR)
+            throw new ActivepiecesError({
+                code: ErrorCode.RESUME_LOGS_FILE_MISSING,
+                params: { runId: data.runId },
+            }, 'logsFileId is missing for RESUME operation')
+        }
+
         const sandbox = ctx.sandboxManager.acquire({ log: ctx.log, apiClient: ctx.apiClient })
         try {
             await sandbox.start({
@@ -55,8 +59,7 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResu
                 mounts: [],
             })
 
-            const resolvedPayload = await resolvePayload(data.payload, data.projectId, ctx.apiClient)
-            const operation = await buildFlowOperation(ctx, data, resolvedPayload, flowVersion, timeoutInSeconds)
+            const operation = buildFlowOperation(ctx, data, flowVersion, timeoutInSeconds)
             const result = await sandbox.execute(
                 EngineOperationType.EXECUTE_FLOW,
                 operation,
@@ -100,13 +103,12 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResu
     },
 }
 
-async function buildFlowOperation(
+function buildFlowOperation(
     ctx: JobContext,
     data: ExecuteFlowJobData,
-    resolvedPayload: unknown,
     flowVersion: FlowVersion,
     timeoutInSeconds: number,
-): Promise<BeginExecuteFlowOperation | ResumeExecuteFlowOperation> {
+): BeginExecuteFlowOperation | ResumeExecuteFlowOperation {
     const base = {
         flowVersion,
         flowRunId: data.runId,
@@ -126,50 +128,20 @@ async function buildFlowOperation(
     }
 
     if (data.executionType === ExecutionType.RESUME) {
-        const executionState = await fetchExecutionState({ apiClient: ctx.apiClient, data })
-        if (Object.keys(executionState.steps).length === 0) {
-            ctx.log.error({ runId: data.runId, executionType: data.executionType }, 'RESUME operation has empty execution state — this is a bug that would cause an infinite loop')
-            throw new ActivepiecesError({
-                code: ErrorCode.VALIDATION,
-                params: {
-                    message: 'RESUME operation received with empty execution state',
-                },
-            })
-        }
         return {
             ...base,
             executionType: ExecutionType.RESUME,
-            executionState,
-            resumePayload: resolvedPayload as ResumePayload,
+            resumePayload: data.payload,
         }
     }
 
     return {
         ...base,
         executionType: ExecutionType.BEGIN,
-        executionState: { steps: {}, tags: [] },
-        triggerPayload: resolvedPayload,
+        triggerPayload: data.payload,
         executeTrigger: data.executeTrigger ?? false,
         sampleData: data.sampleData,
     }
-}
-
-async function fetchExecutionState({ apiClient, data }: { apiClient: WorkerToApiContract, data: ExecuteFlowJobData }): Promise<ExecutionState> {
-    if (isNil(data.logsFileId)) {
-        throw new ActivepiecesError({
-            code: ErrorCode.RESUME_LOGS_FILE_MISSING,
-            params: { runId: data.runId },
-        }, 'logsFileId is missing for RESUME operation')
-    }
-    const buffer = await apiClient.getPayloadFile({ fileId: data.logsFileId, projectId: data.projectId })
-    const parsed = JSON.parse(buffer.toString('utf-8'))
-    if (isNil(parsed.executionState)) {
-        throw new ActivepiecesError({
-            code: ErrorCode.EXECUTION_STATE_MISSING,
-            params: { logsFileId: data.logsFileId },
-        }, 'executionState is missing in logs file')
-    }
-    return parsed.executionState
 }
 
 async function reportFlowStatus(

--- a/packages/server/worker/src/lib/execute/jobs/execute-trigger-hook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-trigger-hook.ts
@@ -2,6 +2,7 @@ import {
     EngineOperationType,
     EngineResponseStatus,
     ExecuteTriggerHookJobData,
+    isNil,
     tryCatch,
     WorkerJobType,
 } from '@activepieces/shared'
@@ -43,7 +44,7 @@ export const executeTriggerHookJob: JobHandler<ExecuteTriggerHookJobData, Synchr
                     hookType: data.hookType,
                     flowVersion,
                     webhookUrl: getWebhookUrl(ctx.publicApiUrl, data.flowId, data.test),
-                    triggerPayload: data.triggerPayload,
+                    triggerPayload: isNil(data.triggerPayload) ? undefined : { type: 'inline', value: data.triggerPayload },
                     test: data.test,
                     projectId: data.projectId,
                     platformId: data.platformId,

--- a/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
@@ -8,7 +8,6 @@ import {
     PieceTrigger,
     StreamStepProgress,
     TriggerHookType,
-    TriggerPayload,
     tryCatch,
     WebhookJobData,
     WorkerJobType,
@@ -17,7 +16,6 @@ import { flowCache } from '../../cache/flow/flow-cache'
 import { workerSettings } from '../../config/worker-settings'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../types'
 import { provisionFlowPieces } from '../utils/flow-helpers'
-import { resolvePayload } from '../utils/resolve-payload'
 import { isSandboxTimeout } from '../utils/sandbox-helpers'
 import { getAppWebhookUrl, getWebhookUrl } from '../utils/webhook-url'
 
@@ -41,7 +39,6 @@ export const executeWebhookJob: JobHandler<WebhookJobData, FireAndForgetJobResul
     async execute(ctx: JobContext, data: WebhookJobData): Promise<FireAndForgetJobResult> {
         const settings = workerSettings.getSettings()
         const timeoutInSeconds = settings.TRIGGER_TIMEOUT_SECONDS
-        const resolvedPayload = await resolvePayload(data.payload, data.projectId, ctx.apiClient)
 
         const flowVersion = await flowCache(ctx.log, ctx.apiClient).getVersion({ flowVersionId: data.flowVersionIdToRun })
         if (isNil(flowVersion)) {
@@ -71,7 +68,7 @@ export const executeWebhookJob: JobHandler<WebhookJobData, FireAndForgetJobResul
                         hookType: TriggerHookType.RUN,
                         flowVersion,
                         webhookUrl: getWebhookUrl(ctx.publicApiUrl, data.flowId, true),
-                        triggerPayload: resolvedPayload as TriggerPayload,
+                        triggerPayload: data.payload,
                         test: true,
                         projectId: data.projectId,
                         platformId: data.platformId,
@@ -108,7 +105,7 @@ export const executeWebhookJob: JobHandler<WebhookJobData, FireAndForgetJobResul
                     hookType: TriggerHookType.RUN,
                     flowVersion,
                     webhookUrl: getWebhookUrl(ctx.publicApiUrl, data.flowId),
-                    triggerPayload: resolvedPayload as TriggerPayload,
+                    triggerPayload: data.payload,
                     test: false,
                     projectId: data.projectId,
                     platformId: data.platformId,

--- a/packages/server/worker/src/lib/execute/utils/resolve-payload.ts
+++ b/packages/server/worker/src/lib/execute/utils/resolve-payload.ts
@@ -1,9 +1,0 @@
-import { JobPayload, WorkerToApiContract } from '@activepieces/shared'
-
-export async function resolvePayload(payload: JobPayload, projectId: string, apiClient: WorkerToApiContract): Promise<unknown> {
-    if (payload.type === 'inline') {
-        return payload.value
-    }
-    const data = await apiClient.getPayloadFile({ fileId: payload.fileId, projectId })
-    return JSON.parse(data.toString('utf8'))
-}

--- a/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
@@ -9,7 +9,6 @@ import {
     FlowVersionState,
     StreamStepProgress,
     RunEnvironment,
-    StepOutputStatus,
     WorkerJobType,
 } from '@activepieces/shared'
 import type { ExecuteFlowJobData, FlowVersion } from '@activepieces/shared'
@@ -30,10 +29,6 @@ vi.mock('../../../../src/lib/config/worker-settings', () => ({
 
 vi.mock('../../../../src/lib/execute/utils/flow-helpers', () => ({
     provisionFlowPieces: vi.fn().mockResolvedValue(true),
-}))
-
-vi.mock('../../../../src/lib/execute/utils/resolve-payload', () => ({
-    resolvePayload: vi.fn().mockImplementation((payload: unknown) => Promise.resolve(payload)),
 }))
 
 import { executeFlowJob } from '../../../../src/lib/execute/jobs/execute-flow'
@@ -95,7 +90,7 @@ function makeResumeJobData(overrides?: Partial<ExecuteFlowJobData>): ExecuteFlow
         flowId: 'flow-1',
         flowVersionId: 'fv-1',
         runId: 'run-1',
-        payload: {},
+        payload: { type: 'inline', value: {} },
         executionType: ExecutionType.RESUME,
         streamStepProgress: StreamStepProgress.NONE,
         logsUploadUrl: 'http://example.com/upload',
@@ -107,7 +102,7 @@ function makeResumeJobData(overrides?: Partial<ExecuteFlowJobData>): ExecuteFlow
 function makeMockContext(apiOverrides?: Record<string, vi.Mock>) {
     const mockSandbox = {
         start: vi.fn(),
-        execute: vi.fn().mockResolvedValue({ engine: { status: 'OK' } }),
+        execute: vi.fn().mockResolvedValue({ status: 'OK' }),
     }
     return {
         log: {
@@ -129,6 +124,7 @@ function makeMockContext(apiOverrides?: Record<string, vi.Mock>) {
         engineToken: 'test-token',
         internalApiUrl: 'http://localhost:3000',
         publicApiUrl: 'http://localhost:4200',
+        mockSandbox,
     } as any
 }
 
@@ -137,14 +133,56 @@ describe('executeFlowJob', () => {
         mockGetVersion.mockResolvedValue(makeFlowVersion())
     })
 
-    describe('RESUME execution state validation', () => {
-        it('should throw VALIDATION error when RESUME has empty execution state', async () => {
+    describe('payload pass-through (no worker-side fetch)', () => {
+        it('does not call getPayloadFile in the worker — payload resolution is deferred to the engine', async () => {
             const ctx = makeMockContext()
-            ctx.apiClient.getPayloadFile.mockResolvedValue(
-                Buffer.from(JSON.stringify({ executionState: { steps: {}, tags: [] } })),
-            )
+            const data = makeResumeJobData({
+                executionType: ExecutionType.BEGIN,
+                payload: { type: 'ref', fileId: 'huge-file-1' },
+            })
 
-            const data = makeResumeJobData()
+            await executeFlowJob.execute(ctx, data)
+
+            expect(ctx.apiClient.getPayloadFile).not.toHaveBeenCalled()
+        })
+
+        it('forwards the JobPayload ref unchanged to the engine for BEGIN', async () => {
+            const ctx = makeMockContext()
+            const data = makeResumeJobData({
+                executionType: ExecutionType.BEGIN,
+                payload: { type: 'ref', fileId: 'huge-file-1' },
+            })
+
+            await executeFlowJob.execute(ctx, data)
+
+            const operation = ctx.mockSandbox.execute.mock.calls[0][1]
+            expect(operation.executionType).toBe(ExecutionType.BEGIN)
+            expect(operation.triggerPayload).toEqual({ type: 'ref', fileId: 'huge-file-1' })
+            expect(operation.executionState).toBeUndefined()
+        })
+
+        it('forwards the JobPayload ref unchanged to the engine for RESUME and never reads logsFileId', async () => {
+            const ctx = makeMockContext()
+            const data = makeResumeJobData({
+                payload: { type: 'ref', fileId: 'resume-payload-1' },
+                logsFileId: 'logs-file-1',
+            })
+
+            await executeFlowJob.execute(ctx, data)
+
+            const operation = ctx.mockSandbox.execute.mock.calls[0][1]
+            expect(operation.executionType).toBe(ExecutionType.RESUME)
+            expect(operation.resumePayload).toEqual({ type: 'ref', fileId: 'resume-payload-1' })
+            expect(operation.logsFileId).toBe('logs-file-1')
+            expect(operation.executionState).toBeUndefined()
+            expect(ctx.apiClient.getPayloadFile).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('RESUME validation', () => {
+        it('still throws when logsFileId is missing for RESUME', async () => {
+            const ctx = makeMockContext()
+            const data = makeResumeJobData({ logsFileId: undefined as unknown as string })
 
             try {
                 await executeFlowJob.execute(ctx, data)
@@ -152,49 +190,17 @@ describe('executeFlowJob', () => {
             }
             catch (e) {
                 expect(e).toBeInstanceOf(ActivepiecesError)
-                expect((e as ActivepiecesError).error.code).toBe(ErrorCode.VALIDATION)
+                expect((e as ActivepiecesError).error.code).toBe(ErrorCode.RESUME_LOGS_FILE_MISSING)
             }
 
-            expect(ctx.log.error).toHaveBeenCalledWith(
-                expect.objectContaining({ runId: 'run-1' }),
-                expect.stringContaining('empty execution state'),
-            )
-
             expect(ctx.apiClient.uploadRunLog).toHaveBeenCalledWith(
-                expect.objectContaining({ status: FlowRunStatus.INTERNAL_ERROR }),
-            )
-        })
-
-        it('should proceed normally when RESUME has non-empty execution state', async () => {
-            const ctx = makeMockContext()
-            ctx.apiClient.getPayloadFile.mockResolvedValue(
-                Buffer.from(JSON.stringify({
-                    executionState: {
-                        steps: {
-                            trigger_1: {
-                                type: FlowTriggerType.EMPTY,
-                                status: StepOutputStatus.SUCCEEDED,
-                                input: {},
-                                output: {},
-                            },
-                        },
-                        tags: [],
-                    },
-                })),
-            )
-
-            const data = makeResumeJobData()
-            const result = await executeFlowJob.execute(ctx, data)
-
-            expect(result).toBeDefined()
-            expect(ctx.apiClient.uploadRunLog).not.toHaveBeenCalledWith(
                 expect.objectContaining({ status: FlowRunStatus.INTERNAL_ERROR }),
             )
         })
     })
 
     describe('missing piece handling', () => {
-        it('should mark run as FAILED and skip sandbox when flow version is not found (missing piece)', async () => {
+        it('marks run as FAILED and skips sandbox when flow version is not found', async () => {
             mockGetVersion.mockResolvedValue(null)
 
             const ctx = makeMockContext()

--- a/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
@@ -112,7 +112,6 @@ function makeMockContext(apiOverrides?: Record<string, vi.Mock>) {
             debug: vi.fn(),
         },
         apiClient: {
-            getPayloadFile: vi.fn(),
             uploadRunLog: vi.fn(),
             ...apiOverrides,
         },
@@ -134,18 +133,6 @@ describe('executeFlowJob', () => {
     })
 
     describe('payload pass-through (no worker-side fetch)', () => {
-        it('does not call getPayloadFile in the worker — payload resolution is deferred to the engine', async () => {
-            const ctx = makeMockContext()
-            const data = makeResumeJobData({
-                executionType: ExecutionType.BEGIN,
-                payload: { type: 'ref', fileId: 'huge-file-1' },
-            })
-
-            await executeFlowJob.execute(ctx, data)
-
-            expect(ctx.apiClient.getPayloadFile).not.toHaveBeenCalled()
-        })
-
         it('forwards the JobPayload ref unchanged to the engine for BEGIN', async () => {
             const ctx = makeMockContext()
             const data = makeResumeJobData({
@@ -175,7 +162,6 @@ describe('executeFlowJob', () => {
             expect(operation.resumePayload).toEqual({ type: 'ref', fileId: 'resume-payload-1' })
             expect(operation.logsFileId).toBe('logs-file-1')
             expect(operation.executionState).toBeUndefined()
-            expect(ctx.apiClient.getPayloadFile).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/server/worker/test/lib/worker-settings-override.test.ts
+++ b/packages/server/worker/test/lib/worker-settings-override.test.ts
@@ -83,7 +83,6 @@ function buildMinimalHandlers(): WorkerToApiContract {
         getPiece: vi.fn(),
         getPieceArchive: vi.fn(),
         extendLock: vi.fn(),
-        getPayloadFile: vi.fn(),
         getUsedPieces: vi.fn().mockResolvedValue([]),
         markPieceAsUsed: vi.fn(),
         disableFlow: vi.fn(),

--- a/packages/server/worker/test/lib/worker.test.ts
+++ b/packages/server/worker/test/lib/worker.test.ts
@@ -163,7 +163,6 @@ describe('worker integration', () => {
                     getPiece: vi.fn(),
                     getPieceArchive: vi.fn(),
                     extendLock: vi.fn(),
-                    getPayloadFile: vi.fn(),
                     getUsedPieces: vi.fn().mockResolvedValue([]),
                     markPieceAsUsed: vi.fn(),
                     disableFlow: vi.fn(),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/automation/engine/engine-operation.ts
+++ b/packages/shared/src/lib/automation/engine/engine-operation.ts
@@ -3,11 +3,12 @@ import { PlatformId } from '../../management/platform'
 import { ProjectId } from '../../management/project/project'
 import { ExecutionToolStatus, PredefinedInputsStructure } from '../agents'
 import { AppConnectionValue } from '../app-connection/app-connection'
-import { ExecutionState, ExecutionType, ResumePayload } from '../flow-run/execution/execution-output'
+import { ExecutionType } from '../flow-run/execution/execution-output'
 import { FlowRunId, RunEnvironment } from '../flow-run/flow-run'
 import { FlowVersion } from '../flows/flow-version'
 import { PiecePackage } from '../pieces'
 import { ScheduleOptions } from '../trigger'
+import { JobPayload } from '../workers/job-data'
 
 export enum EngineOperationType {
     EXTRACT_PIECE_METADATA = 'EXTRACT_PIECE_METADATA',
@@ -89,7 +90,6 @@ type BaseExecuteFlowOperation<T extends ExecutionType> = BaseEngineOperation & {
     flowRunId: FlowRunId
     executionType: T
     runEnvironment: RunEnvironment
-    executionState: ExecutionState
     workerHandlerId: string | null
     httpRequestId: string | null
     streamStepProgress: StreamStepProgress
@@ -105,12 +105,12 @@ export enum StreamStepProgress {
 }
 
 export type BeginExecuteFlowOperation = BaseExecuteFlowOperation<ExecutionType.BEGIN> & {
-    triggerPayload: unknown
+    triggerPayload: JobPayload
     executeTrigger: boolean
 }
 
 export type ResumeExecuteFlowOperation = BaseExecuteFlowOperation<ExecutionType.RESUME> & {
-    resumePayload: ResumePayload
+    resumePayload: JobPayload
 }
 
 export type ExecuteFlowOperation = BeginExecuteFlowOperation | ResumeExecuteFlowOperation

--- a/packages/shared/src/lib/automation/engine/engine-operation.ts
+++ b/packages/shared/src/lib/automation/engine/engine-operation.ts
@@ -121,7 +121,7 @@ export type ExecuteTriggerOperation<HT extends TriggerHookType> = BaseEngineOper
     test: boolean
     flowVersion: FlowVersion
     webhookUrl: string
-    triggerPayload?: TriggerPayload
+    triggerPayload?: JobPayload
     appWebhookUrl?: string
     webhookSecret?: string | Record<string, string>
 }

--- a/packages/shared/src/lib/automation/workers/worker-contract.ts
+++ b/packages/shared/src/lib/automation/workers/worker-contract.ts
@@ -43,7 +43,6 @@ export type WorkerToApiContract = {
     getPiece(input: GetPieceRequest): Promise<unknown>
     getPieceArchive(input: { archiveId: string }): Promise<Buffer>
     extendLock(input: { jobId: string, token: string, queueName: string }): Promise<void>
-    getPayloadFile(input: { fileId: string, projectId: string }): Promise<Buffer>
     getUsedPieces(input: Record<string, never>): Promise<PiecePackage[]>
     markPieceAsUsed(input: { pieces: PiecePackage[] }): Promise<void>
     disableFlow(input: DisableFlowRequest): Promise<void>


### PR DESCRIPTION
## What

Backports engine-side payload resolution to the `0.82.1` rc line and removes the worker→API `getPayloadFile` RPC. Targets a new **rc6** because the rc5 image is already published (the release workflow's `docker manifest inspect` guard refuses to overwrite an existing tag).

Cherry-picked (adapted) from `main`:
- `5069fce557` — `fix(engine): defer flow payload resolution to engine subprocess (#13087)`
- `aa9c351b77` — `refactor(worker): resolve webhook payloads engine-side instead of via a worker RPC (#13553)`

## Why

The worker used to fetch `ref` payloads (and the RESUME logs file) itself via the `getPayloadFile` RPC and hand the engine an already-resolved value. This moves resolution into the engine subprocess: jobs carry a `JobPayload` (`inline` value or `ref` fileId), the worker forwards it unchanged, and the **engine** hydrates a `ref` via a new download endpoint `GET /v1/engine/files/:fileId`. Covers both the **flow** (BEGIN/RESUME) and **trigger/webhook** execution paths.

## Adaptations vs. main (release branch predates several refactors)

- The big S3-dehydration feature (#13103) that sits between the two commits on `main` is **excluded** (out of scope for a release branch). It's what introduced `engine-file-api.ts`, so `engineFileApi.download(...)` is adapted to this branch's `payloadFileClient.get(...)` (Buffer-based) in `resolve-job-payload.ts` and the new engine test.
- Kept the release branch's newer socket-buffer logic (`maxSocketHttpBufferSizeBytes({ webhookPayloadSizeMb, logFileRunSizeMb })`) and existing `killedByShutdown` / `maxHttpBufferSizeBytes` sandbox code — `main`'s commit carried an older form.
- Kept `runProgressService` (release predates the `flowRunProgressReporter` rename).
- Dropped the new `workers.md` doc and trimmed an "S3 signed-link redirect" line from `webhooks.md` (both described main-only behavior).
- Single `@activepieces/shared` minor bump `0.66.0 → 0.67.0` (contract/type changes).

## Rolling-deploy note

The contract drops `getPayloadFile`. `apVersionUtil.getCurrentRelease()` reads `package.json.version`, which is `0.82.1` for **both** rc5 and rc6 images — so the worker↔app version gate treats them as the same release and will exchange jobs. Safe for a single-image self-hosted deploy; **do not** straddle rc5 and rc6 across a split app/worker fleet mid-deploy.

## Verification

- Typecheck: engine, worker, api, shared clean (only pre-existing `dns-lookup-guard.ts` `@types/node` noise, present on the untouched release branch).
- Lint: 0 errors across shared/worker/engine/api.
- Tests: engine **295/295**, shared **149/149**, worker **188/189**.
  - The one worker failure (`interleaved nulls, invalid jobs, and valid jobs`) is **pre-existing** — it fails identically on the clean release tip, uses a mocked handler, and none of the changed files are on its path.
