### PR TITLE
fix(engine): keep bare step references working after output/error nesting

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -61,6 +61,19 @@ jobs:
           chmod +x smoke-test/verify-delay.sh
           smoke-test/verify-delay.sh
 
+      - name: Setup data-mapping flow
+        id: setup-data-mapping
+        run: |
+          chmod +x benchmark/setup.sh
+          FLOW_ID=$(FLOW_SCHEMA_VERSION=22 RESPONSE_BODY='{"name":"{{trigger.body.firstName}}"}' benchmark/setup.sh)
+          echo "flow_id=$FLOW_ID" >> "$GITHUB_OUTPUT"
+          echo "Data-mapping flow ID: $FLOW_ID"
+
+      - name: Run data-mapping smoke test
+        run: |
+          chmod +x smoke-test/verify-data-mapping.sh
+          smoke-test/verify-data-mapping.sh "${{ steps.setup-data-mapping.outputs.flow_id }}"
+
       - name: Restart stack in SANDBOX_PROCESS mode
         run: |
           docker compose -f benchmark/docker-compose.yml down -v

--- a/benchmark/setup.sh
+++ b/benchmark/setup.sh
@@ -98,14 +98,21 @@ else
   RESPONSE_BODY_JSON="$RESPONSE_BODY"
 fi
 
+# Schema version of the imported flow. Defaults to "17" so the IMPORT_FLOW
+# migration chain runs. Set to the latest version (e.g. "22") to import a flow
+# verbatim — used by the data-mapping smoke to exercise step references that
+# reach the engine without being rewritten by a migration.
+FLOW_SCHEMA_VERSION="${FLOW_SCHEMA_VERSION:-17}"
+
 IMPORT_PAYLOAD=$(jq -n \
   --arg code "$CODE_STEP_SRC" \
+  --arg schemaVersion "$FLOW_SCHEMA_VERSION" \
   --argjson body "$RESPONSE_BODY_JSON" \
   '{
     type: "IMPORT_FLOW",
     request: {
       displayName: "Benchmark Flow",
-      schemaVersion: "17",
+      schemaVersion: $schemaVersion,
       notes: [],
       trigger: {
         name: "trigger",

--- a/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
@@ -215,9 +215,22 @@ async function extractStepView(steps: Record<string, StepOutput>, engineApi: Eng
         const error = step.status === StepOutputStatus.FAILED && step.errorMessage !== undefined
             ? { message: step.errorMessage }
             : undefined
-        result[stepName] = { output, error }
+        result[stepName] = buildStepReferenceView({ output, error })
     }
     return result
+}
+
+// The step-output-nesting schema (v22) exposes a step as `{ output, error }`,
+// so references are authored as `{{ step.output.field }}`. To keep flows that
+// still use the pre-nesting form (`{{ step.field }}`) working — e.g. imported
+// templates, MCP/API-created flows, or any flow that reached v22 without the
+// rewrite migration — also surface the output's own keys at the top level.
+// The `output`/`error` accessors always win over a colliding output key.
+function buildStepReferenceView({ output, error }: { output: unknown, error: unknown }): Record<string, unknown> {
+    if (!isNil(output) && typeof output === 'object' && !Array.isArray(output)) {
+        return { ...output, output, error }
+    }
+    return { output, error }
 }
 
 async function maybeSliceOutput(value: unknown, engineApi?: EngineApiConfig): Promise<{ ref: LogSliceRef } | undefined> {

--- a/packages/server/engine/test/variables/props-resolver-backward-compat.test.ts
+++ b/packages/server/engine/test/variables/props-resolver-backward-compat.test.ts
@@ -1,0 +1,55 @@
+import { LATEST_CONTEXT_VERSION } from '@activepieces/pieces-framework'
+import { FlowActionType, FlowTriggerType, GenericStepOutput, StepOutputStatus } from '@activepieces/shared'
+import { FlowExecutorContext } from '../../src/lib/handler/context/flow-execution-context'
+import { createPropsResolver } from '../../src/lib/variables/props-resolver'
+
+const resolver = createPropsResolver({
+    projectId: 'PROJECT_ID',
+    engineToken: 'WORKER_TOKEN',
+    apiUrl: 'http://127.0.0.1:3000',
+    contextVersion: LATEST_CONTEXT_VERSION,
+    stepNames: ['trigger', 'step_1'],
+})
+
+const buildState = async (): Promise<FlowExecutorContext> => {
+    let state = await FlowExecutorContext.empty().upsertStep('trigger', GenericStepOutput.create({
+        type: FlowTriggerType.PIECE,
+        status: StepOutputStatus.SUCCEEDED,
+        input: {},
+        output: { name: 'John', body: { 'First Name': 'Jane' } },
+    }))
+    state = await state.upsertStep('step_1', GenericStepOutput.create({
+        type: FlowActionType.PIECE,
+        status: StepOutputStatus.FAILED,
+        input: {},
+        output: undefined,
+    }).setErrorMessage('boom'))
+    return state
+}
+
+describe('props resolver — backward-compatible step references after output/error nesting', () => {
+    let executionState: FlowExecutorContext
+    beforeAll(async () => {
+        executionState = await buildState()
+    })
+
+    it('resolves a bare dot reference to the step output (pre-nesting form)', async () => {
+        const { resolvedInput } = await resolver.resolve({ unresolvedInput: '{{trigger.name}}', executionState })
+        expect(resolvedInput).toEqual('John')
+    })
+
+    it('resolves a bare bracket reference with a spaced key (pre-nesting form)', async () => {
+        const { resolvedInput } = await resolver.resolve({ unresolvedInput: '{{trigger[\'body\'][\'First Name\']}}', executionState })
+        expect(resolvedInput).toEqual('Jane')
+    })
+
+    it('still resolves the nested output reference (v22 form)', async () => {
+        const { resolvedInput } = await resolver.resolve({ unresolvedInput: '{{trigger[\'output\'][\'body\'][\'First Name\']}}', executionState })
+        expect(resolvedInput).toEqual('Jane')
+    })
+
+    it('exposes the error accessor for a failed step', async () => {
+        const { resolvedInput } = await resolver.resolve({ unresolvedInput: '{{step_1.error.message}}', executionState })
+        expect(resolvedInput).toEqual('boom')
+    })
+})

--- a/smoke-test/verify-data-mapping.sh
+++ b/smoke-test/verify-data-mapping.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Data-mapping smoke: verifies that a step can reference another step's output.
+# The flow (set up with FLOW_SCHEMA_VERSION=22 and a Return Response body of
+# {"name":"{{trigger.body.firstName}}"}) maps a field from the webhook trigger
+# into the response. Regression guard for step-output reference resolution
+# (a bare {{trigger.body.x}} reference reaching the engine unmigrated).
+
+FLOW_ID="${1:?Usage: verify-data-mapping.sh <flow_id> [base_url] [num_requests]}"
+BASE_URL="${2:-localhost:8080}"
+NUM_REQUESTS="${3:-5}"
+
+PASS=0
+FAIL=0
+
+echo "=== Data Mapping Smoke Test ==="
+echo "Flow ID:      $FLOW_ID"
+echo "Base URL:     $BASE_URL"
+echo "Requests:     $NUM_REQUESTS"
+echo ""
+
+for i in $(seq 1 "$NUM_REQUESTS"); do
+  NAME="Aria-$i"
+  EXPECTED_BODY="{\"name\":\"$NAME\"}"
+  RESPONSE=$(curl -s -w '\n%{http_code}' --max-time 30 \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "{\"firstName\":\"$NAME\"}" \
+    "http://$BASE_URL/api/v1/webhooks/$FLOW_ID/sync")
+
+  BODY=$(echo "$RESPONSE" | sed '$d')
+  STATUS=$(echo "$RESPONSE" | tail -n 1)
+
+  if [ "$STATUS" = "200" ] && [ "$BODY" = "$EXPECTED_BODY" ]; then
+    echo "PASS [$i/$NUM_REQUESTS]: HTTP $STATUS, body=$BODY"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL [$i/$NUM_REQUESTS]: HTTP $STATUS, body=$BODY (expected 200, $EXPECTED_BODY)"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed out of $NUM_REQUESTS ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Problem

Data mapping between steps is broken on `main` for many existing flows — even with small payloads. A flow like webhook → **Data Mapper** with `{{trigger['body']['First Name']}}` resolves to an empty string.

### Root cause

The v22 step-output-nesting feature (#13074) changed the variable-resolution scope built in `flow-execution-context.ts` from:

```
{ trigger: <output> }          // before
{ trigger: { output, error } } // after
```

So references now have to be written as `{{ trigger.output.field }}`. The migration (`migrate-v21-step-output-nesting`) and the data-selector rewrite *new* and *sub-v22* flows to the nested form, but a flow can still reach the engine with **bare** references at schemaVersion 22 — imported templates, MCP/API-created flows, or any flow that bypassed the rewrite. Those silently resolve to `''`.

Confirmed at the resolver level:

| reference | before fix | after fix |
|---|---|---|
| `{{trigger.name}}` | `''` | `John` |
| `{{trigger['body']['First Name']}}` | `''` | `Jane` |
| `{{trigger.output.name}}` (v22 form) | `John` | `John` |
| `{{step_1.error.message}}` | `boom` | `boom` |

## Fix

In `extractStepView`, surface the step output's own keys at the top level **and** keep the `output`/`error` accessors, so both `{{ step.field }}` (pre-nesting) and `{{ step.output.field }}` (v22) resolve. The `output`/`error` accessors win over a colliding output key. Non-object outputs keep the `{ output, error }` shape.

## Tests

- **Regression unit test** `props-resolver-backward-compat.test.ts`: bare dot, bare bracket with a spaced key, the nested v22 form, and the error accessor. The existing 57 resolver tests still pass.
- **Smoke coverage**: a new data-mapping smoke imports a flow at schemaVersion 22 with a bare `{{trigger.body.firstName}}` reference and verifies the field is mapped into the sync webhook response end-to-end (`smoke-test/verify-data-mapping.sh`, wired into `.github/workflows/smoke-test.yml`; `benchmark/setup.sh` now takes `FLOW_SCHEMA_VERSION`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)