### PR TITLE
fix(chat): empty state stability and conversation deletion

### DIFF
--- a/packages/server/api/src/app/ee/chat/chat-service.ts
+++ b/packages/server/api/src/app/ee/chat/chat-service.ts
@@ -1,11 +1,9 @@
 import {
-    ActivepiecesError,
     apId,
     ChatConversation,
     ChatConversationStatus,
     ChatHistoryMessage,
     CreateChatConversationRequest,
-    ErrorCode,
     PersistedChatMessage,
     SeekPage,
     spreadIfDefined,
@@ -16,6 +14,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { buildPaginator } from '../../helper/pagination/build-paginator'
 import { paginationHelper } from '../../helper/pagination/pagination-utils'
 import { Order } from '../../helper/pagination/paginator'
+import { chatApprovalGate } from './chat-approval-gate'
 import { ChatConversationEntity } from './chat-conversation-entity'
 import { chatHelpers } from './chat-helpers'
 import { chatHistory } from './history/chat-history'
@@ -89,9 +88,9 @@ export const chatService = (log: FastifyBaseLogger) => ({
     async deleteConversation({ id, platformId, userId }: ConversationIdentifier): Promise<void> {
         const conversation = await this.getConversationOrThrow({ id, platformId, userId })
         if (conversation.status === ChatConversationStatus.STREAMING) {
-            throw new ActivepiecesError({
-                code: ErrorCode.VALIDATION,
-                params: { message: 'Cannot delete a conversation while an agent is running. Please cancel it first.' },
+            await chatApprovalGate.requestCancel({ conversationId: id })
+            await chatHelpers.conversationRepo().update(id, {
+                status: ChatConversationStatus.IDLE,
             })
         }
         await chatHelpers.conversationRepo().delete(conversation.id)

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -5,18 +5,6 @@ import { AlertTriangle, RefreshCw, Square } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { AssistantMessage } from './components/assistant-message';
-import { ChatBottomBar } from './components/chat-bottom-bar';
-import {
-  EmptyState,
-  MessageSkeletons,
-  SetupRequiredState,
-} from './components/chat-empty-state';
-import { CreditsBanner } from './components/credits-banner';
-import { QuickReplies } from './components/quick-replies';
-import { UserMessage } from './components/user-message';
-import { getTextFromParts } from './lib/message-parsers';
-
 import {
   ChatContainerContent,
   ChatContainerRoot,
@@ -33,6 +21,18 @@ import { useAgentChat } from '@/features/chat/lib/use-chat';
 import { useCreditsState } from '@/features/chat/lib/use-credits-state';
 import { aiProviderQueries } from '@/features/platform-admin';
 import { cn } from '@/lib/utils';
+
+import { AssistantMessage } from './components/assistant-message';
+import { ChatBottomBar } from './components/chat-bottom-bar';
+import {
+  EmptyState,
+  MessageSkeletons,
+  SetupRequiredState,
+} from './components/chat-empty-state';
+import { CreditsBanner } from './components/credits-banner';
+import { QuickReplies } from './components/quick-replies';
+import { UserMessage } from './components/user-message';
+import { getTextFromParts } from './lib/message-parsers';
 
 export function AIChatBox({
   incognito,

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -145,7 +145,13 @@ function ChatBoxContent({
 
   const [hasInput, setHasInput] = useState(false);
 
-  const isEmpty = messages.length === 0 && !isLoadingHistory && !isStreaming;
+  const isAwaitingLoad =
+    !!initialConversationId && messages.length === 0 && !error;
+  const isEmpty =
+    messages.length === 0 &&
+    !isLoadingHistory &&
+    !isStreaming &&
+    !isAwaitingLoad;
 
   const cachedConversations = queryClient.getQueryData<
     SeekPage<ChatConversation>

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -5,6 +5,18 @@ import { AlertTriangle, RefreshCw, Square } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { AssistantMessage } from './components/assistant-message';
+import { ChatBottomBar } from './components/chat-bottom-bar';
+import {
+  EmptyState,
+  MessageSkeletons,
+  SetupRequiredState,
+} from './components/chat-empty-state';
+import { CreditsBanner } from './components/credits-banner';
+import { QuickReplies } from './components/quick-replies';
+import { UserMessage } from './components/user-message';
+import { getTextFromParts } from './lib/message-parsers';
+
 import {
   ChatContainerContent,
   ChatContainerRoot,
@@ -21,18 +33,6 @@ import { useAgentChat } from '@/features/chat/lib/use-chat';
 import { useCreditsState } from '@/features/chat/lib/use-credits-state';
 import { aiProviderQueries } from '@/features/platform-admin';
 import { cn } from '@/lib/utils';
-
-import { AssistantMessage } from './components/assistant-message';
-import { ChatBottomBar } from './components/chat-bottom-bar';
-import {
-  EmptyState,
-  MessageSkeletons,
-  SetupRequiredState,
-} from './components/chat-empty-state';
-import { CreditsBanner } from './components/credits-banner';
-import { QuickReplies } from './components/quick-replies';
-import { UserMessage } from './components/user-message';
-import { getTextFromParts } from './lib/message-parsers';
 
 export function AIChatBox({
   incognito,
@@ -118,9 +118,12 @@ function ChatBoxContent({
     return () => window.removeEventListener('keydown', handler);
   }, [isStreaming, cancelStream]);
 
+  const [hasSentMessage, setHasSentMessage] = useState(false);
+
   const handleSend = useCallback(
     async (text: string, files?: File[]) => {
       if (!text.trim() && (!files || files.length === 0)) return;
+      setHasSentMessage(true);
       await sendMessage(text.trim(), files);
     },
     [sendMessage],
@@ -151,7 +154,8 @@ function ChatBoxContent({
     messages.length === 0 &&
     !isLoadingHistory &&
     !isStreaming &&
-    !isAwaitingLoad;
+    !isAwaitingLoad &&
+    !hasSentMessage;
 
   const cachedConversations = queryClient.getQueryData<
     SeekPage<ChatConversation>
@@ -160,21 +164,16 @@ function ChatBoxContent({
 
   return (
     <div className="flex flex-col h-full flex-1 min-w-0">
-      <AnimatePresence>
+      <AnimatePresence mode="wait">
         {isEmpty ? (
-          <motion.div
-            key="empty-state"
-            className="flex-1 overflow-y-auto min-h-0"
-            exit={{ opacity: 0, y: -12 }}
-            transition={{ duration: 0.25 }}
-          >
+          <div key="empty-state" className="flex-1 overflow-y-auto min-h-0">
             <EmptyState
               onSuggestionClick={(text) => void handleSend(text)}
               incognito={incognito}
               showFlowCards={!hasConversations}
               hasInput={hasInput}
             />
-          </motion.div>
+          </div>
         ) : (
           <motion.div
             key="chat-container"

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-empty-state.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-empty-state.tsx
@@ -237,20 +237,20 @@ const FLOW_CARDS: FlowCardData[] = [
   {
     title: 'Cleanup Spam Emails',
     description:
-      'Find all promotional emails from last week and move them to spam',
+      'Find promotional emails from the last week and move them to spam automatically',
     image: '/chat-suggestions/card-cleanup-spam.svg',
     bgImage: '/chat-suggestions/card-background-1.svg',
   },
   {
     title: 'Lead Enrichment',
-    description: 'Enrich all leads in this sheet with person and company info',
+    description: 'Enrich my leads with person and company info automatically',
     image: '/chat-suggestions/card-lead-enrichment.svg',
     bgImage: '/chat-suggestions/card-background-2.svg',
   },
   {
     title: 'Triage Support Tickets',
     description:
-      'Classify incoming emails to a shared inbox and forward each to the right person',
+      'Classify incoming support emails and forward each to the right person automatically',
     image: '/chat-suggestions/card-triage-support.svg',
     bgImage: '/chat-suggestions/card-background-3.svg',
     wide: true,
@@ -262,58 +262,58 @@ const TEXT_SUGGESTIONS: TextSuggestionData[] = [
     icon: '/chat-suggestions/icon-route-emails.svg',
     title: 'Route Incoming Emails',
     description:
-      'Classify every incoming email by topic and automatically route it to the right person or team.',
+      'Classify every incoming email by topic and route it to the right person automatically.',
   },
   {
     icon: '/chat-suggestions/icon-sync-contacts.svg',
-    title: 'Sync Sheet Contacts',
+    title: 'Sync Contacts to CRM',
     description:
-      'Take every row in this spreadsheet and add it as a new contact inside your CRM automatically.',
+      'Sync new contacts from a spreadsheet into my CRM automatically.',
   },
   {
     icon: '/chat-suggestions/icon-plan-crm.svg',
-    title: 'Plan CRM Tasks',
+    title: 'Plan Daily Tasks',
     description:
-      "Check your CRM deals, find today's top priorities, and build a clear task list for your day.",
+      "Check my deals, find today's top priorities, and build a clear task list for the day.",
   },
   {
     icon: '/chat-suggestions/icon-summarize-emails.svg',
     darkIcon: '/chat-suggestions/icon-summarize-emails-dark.svg',
     title: 'Summarize Daily Emails',
     description:
-      "Scan today's inbox, find the emails you haven't replied to yet, and flag them all for you.",
+      "Scan my inbox, find the emails I haven't replied to yet, and flag them for me.",
   },
   {
     icon: '/chat-suggestions/icon-slack-bot.svg',
     title: 'Build a Slack Bot',
     description:
-      "Answer your team's questions on Slack instantly using your company's internal knowledge base.",
+      "Answer my team's questions on Slack using our internal knowledge base.",
   },
   {
     icon: '/chat-suggestions/icon-screen-candidates.svg',
     darkIcon: '/chat-suggestions/icon-screen-candidates-dark.svg',
     title: 'Screen Job Candidates',
     description:
-      'Read every candidate in this sheet, score them on the filled info, and write the score back in.',
+      'Score candidates from a spreadsheet based on their info and write the scores back.',
   },
   {
     icon: '/chat-suggestions/icon-lead-enrichment.svg',
     title: 'Lead Enrichment',
     description:
-      'Take every lead in this sheet and enrich it with full person and company info automatically.',
+      'Enrich my leads with full person and company info automatically.',
   },
   {
     icon: '/chat-suggestions/icon-cleanup-spam.svg',
     darkIcon: '/chat-suggestions/icon-cleanup-spam-dark.svg',
     title: 'Cleanup Spam Emails',
     description:
-      'Find all promotional emails from the last week and move every one of them straight to spam.',
+      'Find promotional emails from the last week and move them to spam automatically.',
   },
   {
     icon: '/chat-suggestions/icon-triage-support.svg',
     title: 'Triage Support Tickets',
     description:
-      "Read your open tickets, classify each by type and urgency, then tag them so the team knows what's first.",
+      'Read open support tickets, classify by type and urgency, and tag them for the team.',
   },
 ];
 

--- a/packages/web/src/app/routes/chat-with-ai/index.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/index.tsx
@@ -34,6 +34,7 @@ export function ChatWithAIPage() {
   const [conversationTitle, setConversationTitle] = useState<string | null>(
     null,
   );
+  const [titleResolved, setTitleResolved] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState('');
   const renameCancelledRef = useRef(false);
@@ -44,6 +45,7 @@ export function ChatWithAIPage() {
     setResetKey((k) => k + 1);
     setPendingConversationId(null);
     setConversationTitle(null);
+    setTitleResolved(false);
     navigate('/chat', { replace: true });
   }, [navigate]);
 
@@ -51,6 +53,7 @@ export function ChatWithAIPage() {
     (conversationId: string) => {
       setPendingConversationId(null);
       setConversationTitle(null);
+      setTitleResolved(false);
       navigate(`/chat/${conversationId}`, {
         replace: true,
       });
@@ -136,9 +139,13 @@ export function ChatWithAIPage() {
     chatApi
       .getConversation(selectedConversationId)
       .then((conv) => {
-        if (!cancelled && conv.title) setConversationTitle(conv.title);
+        if (cancelled) return;
+        if (conv.title) setConversationTitle(conv.title);
+        setTitleResolved(true);
       })
-      .catch(() => undefined);
+      .catch(() => {
+        if (!cancelled) setTitleResolved(true);
+      });
     return () => {
       cancelled = true;
     };
@@ -170,7 +177,8 @@ export function ChatWithAIPage() {
       cached?.data?.find((c) => c.id === selectedConversationId)?.title ?? null
     );
   }, [conversationTitle, selectedConversationId, queryClient]);
-  const isTitleLoading = !!selectedConversationId && !cachedTitle;
+  const isTitleLoading =
+    !!selectedConversationId && !cachedTitle && !titleResolved;
   const displayTitle = cachedTitle ?? t('New Chat');
 
   return (

--- a/packages/web/src/app/routes/chat-with-ai/index.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/index.tsx
@@ -109,18 +109,20 @@ export function ChatWithAIPage() {
     }
   }, [selectedConversationId, pendingConversationId, renameValue, queryClient]);
 
-  const handleDelete = useCallback(async () => {
+  const handleDelete = useCallback(() => {
     const convId = selectedConversationId ?? pendingConversationId;
     if (!convId) return;
-    try {
-      await chatApi.deleteConversation(convId);
-      void queryClient.invalidateQueries({
-        queryKey: ['chat-conversations'],
-      });
-      handleNewChat();
-    } catch {
-      toast.error(t('Failed to delete conversation'));
-    }
+    handleNewChat();
+    chatApi.deleteConversation(convId).then(
+      () => {
+        void queryClient.invalidateQueries({
+          queryKey: ['chat-conversations'],
+        });
+      },
+      () => {
+        toast.error(t('Failed to delete conversation'));
+      },
+    );
   }, [
     selectedConversationId,
     pendingConversationId,

--- a/packages/web/src/app/routes/chat-with-ai/index.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/index.tsx
@@ -6,10 +6,6 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
-import { AIChatBox } from './ai-chat-box';
-import { TypewriterText } from './components/typewriter-text';
-import { ConversationList } from './conversation-list';
-
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -20,6 +16,10 @@ import {
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { chatApi } from '@/features/chat/lib/chat-api';
+
+import { AIChatBox } from './ai-chat-box';
+import { TypewriterText } from './components/typewriter-text';
+import { ConversationList } from './conversation-list';
 
 export function ChatWithAIPage() {
   const queryClient = useQueryClient();

--- a/packages/web/src/app/routes/chat-with-ai/index.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/index.tsx
@@ -1,9 +1,14 @@
+import { ChatConversation, SeekPage } from '@activepieces/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { Ellipsis, Pencil, Trash2 } from 'lucide-react';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
+
+import { AIChatBox } from './ai-chat-box';
+import { TypewriterText } from './components/typewriter-text';
+import { ConversationList } from './conversation-list';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -13,11 +18,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
 import { chatApi } from '@/features/chat/lib/chat-api';
-
-import { AIChatBox } from './ai-chat-box';
-import { TypewriterText } from './components/typewriter-text';
-import { ConversationList } from './conversation-list';
 
 export function ChatWithAIPage() {
   const queryClient = useQueryClient();
@@ -156,7 +158,18 @@ export function ChatWithAIPage() {
   }, [handleNewChat]);
 
   const activeConversationId = selectedConversationId ?? pendingConversationId;
-  const displayTitle = conversationTitle ?? t('New Chat');
+  const cachedTitle = useMemo(() => {
+    if (conversationTitle) return conversationTitle;
+    if (!selectedConversationId) return null;
+    const cached = queryClient.getQueryData<SeekPage<ChatConversation>>([
+      'chat-conversations',
+    ]);
+    return (
+      cached?.data?.find((c) => c.id === selectedConversationId)?.title ?? null
+    );
+  }, [conversationTitle, selectedConversationId, queryClient]);
+  const isTitleLoading = !!selectedConversationId && !cachedTitle;
+  const displayTitle = cachedTitle ?? t('New Chat');
 
   return (
     <div className="flex h-full overflow-hidden">
@@ -186,10 +199,14 @@ export function ChatWithAIPage() {
             />
           ) : (
             <>
-              <TypewriterText
-                text={displayTitle}
-                className="text-sm font-semibold truncate max-w-[400px]"
-              />
+              {isTitleLoading ? (
+                <Skeleton className="h-4 w-32" />
+              ) : (
+                <TypewriterText
+                  text={displayTitle}
+                  className="text-sm font-semibold truncate max-w-[400px]"
+                />
+              )}
               {activeConversationId && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary

- Prevent empty state from flashing when switching conversations (`isAwaitingLoad` guard)
- Show skeleton in header instead of "New Chat" flash (reads title from cached conversation list)
- Add `hasSentMessage` guard so empty state never returns after clicking a suggestion
- Remove exit animation on empty state for instant hide on suggestion click
- Make suggestion prompts generic (remove "this sheet", "your CRM" assumptions)
- Allow deleting conversations while streaming — frontend navigates away instantly, backend auto-cancels the stream before deleting

## Test plan

- [ ] Switch between conversations — no "New Chat" flash in header, no empty state flash
- [ ] Click a suggestion — empty state hides instantly, chat starts streaming
- [ ] Delete a conversation while it's streaming — should succeed without error
- [ ] Rapid-delete multiple conversations — UI stays stable
- [ ] Suggestion card descriptions don't mention specific apps the user may not have