### PR TITLE
fix(mcp): enforce ['output'] syntax in step references server-side

### DIFF
--- a/packages/server/api/src/app/flows/flow-version/migrations/expression-rewriter.ts
+++ b/packages/server/api/src/app/flows/flow-version/migrations/expression-rewriter.ts
@@ -1,4 +1,4 @@
-import { extractMustacheTokens } from '@activepieces/shared'
+import { extractMustacheTokens, isNil } from '@activepieces/shared'
 import { AnyNode, AssignmentProperty, Identifier, MemberExpression, parse, Property } from 'acorn'
 import { ancestor } from 'acorn-walk'
 import { analyze } from 'eslint-scope'
@@ -16,29 +16,13 @@ import { analyze } from 'eslint-scope'
  *    https://eslint.org/docs/latest/extend/scope-manager-interface
  */
 
-function rewriteStepReferences({ input, stepNames }: { input: string, stepNames: string[] }): string {
-    if (!input.includes('{{')) {
-        return input
-    }
+function rewriteStepReferences({ input, stepNames, idempotent }: { input: string, stepNames: string[], idempotent?: boolean }): string {
     const stepNameSet = new Set<string>(stepNames)
     stepNameSet.add(TRIGGER_NAME)
-    const tokens = extractMustacheTokens(input)
-    if (tokens.length === 0) {
-        return input
-    }
-    const chunks: string[] = []
-    let cursor = 0
-    for (const { token, inner, index } of tokens) {
-        chunks.push(input.slice(cursor, index))
-        const rewritten = rewriteToken(inner, stepNameSet)
-        chunks.push(rewritten === null ? token : `{{${rewritten}}}`)
-        cursor = index + token.length
-    }
-    chunks.push(input.slice(cursor))
-    return chunks.join('')
+    return rewriteStringWithSet({ input, stepNameSet, idempotent: idempotent ?? false })
 }
 
-function rewriteToken(code: string, stepNames: Set<string>): string | null {
+function rewriteToken(code: string, stepNames: Set<string>, idempotent: boolean): string | null {
     if (code.trim().length === 0) {
         return null
     }
@@ -76,6 +60,9 @@ function rewriteToken(code: string, stepNames: Set<string>): string | null {
             }
             const parent = ancestors.length >= 2 ? ancestors[ancestors.length - 2] : null
             if (!isVariableReference(node, parent)) {
+                return
+            }
+            if (idempotent && alreadyHasOutputAccess(node, parent)) {
                 return
             }
             const start = node.start - WRAP_OFFSET
@@ -141,6 +128,17 @@ function isVariableReference(node: Identifier, parent: AnyNode | null): boolean 
     }
 }
 
+function alreadyHasOutputAccess(node: Identifier, parent: AnyNode | null): boolean {
+    if (parent === null || parent.type !== 'MemberExpression') {
+        return false
+    }
+    if (parent.object !== node || !parent.computed) {
+        return false
+    }
+    const prop = parent.property
+    return prop.type === 'Literal' && (prop.value === 'output' || prop.value === 'error')
+}
+
 function isVariableReferenceInMemberExpression(node: Identifier, parent: MemberExpression): boolean {
     if (parent.object === node) {
         return true
@@ -158,8 +156,52 @@ function isVariableReferenceInProperty(node: Identifier, parent: Property | Assi
     return true
 }
 
+function rewriteDeep<T>(value: T, stepNames: string[], idempotent = false): T {
+    const stepNameSet = new Set<string>(stepNames)
+    stepNameSet.add(TRIGGER_NAME)
+    return rewriteDeepWithSet(value, stepNameSet, idempotent)
+}
+
+function rewriteDeepWithSet<T>(value: T, stepNameSet: Set<string>, idempotent: boolean): T {
+    if (typeof value === 'string') {
+        return rewriteStringWithSet({ input: value, stepNameSet, idempotent }) as T
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => rewriteDeepWithSet(item, stepNameSet, idempotent)) as T
+    }
+    if (!isNil(value) && typeof value === 'object') {
+        const result: Record<string, unknown> = {}
+        for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+            result[key] = rewriteDeepWithSet(child, stepNameSet, idempotent)
+        }
+        return result as T
+    }
+    return value
+}
+
+function rewriteStringWithSet({ input, stepNameSet, idempotent }: { input: string, stepNameSet: Set<string>, idempotent: boolean }): string {
+    if (!input.includes('{{')) {
+        return input
+    }
+    const tokens = extractMustacheTokens(input)
+    if (tokens.length === 0) {
+        return input
+    }
+    const chunks: string[] = []
+    let cursor = 0
+    for (const { token, inner, index } of tokens) {
+        chunks.push(input.slice(cursor, index))
+        const rewritten = rewriteToken(inner, stepNameSet, idempotent)
+        chunks.push(rewritten === null ? token : `{{${rewritten}}}`)
+        cursor = index + token.length
+    }
+    chunks.push(input.slice(cursor))
+    return chunks.join('')
+}
+
 export const expressionRewriter = {
     rewriteStepReferences,
+    rewriteDeep,
 }
 
 const STEP_NAME_PATTERN = /^step_\d+$/

--- a/packages/server/api/src/app/flows/flow-version/migrations/migrate-v21-step-output-nesting.ts
+++ b/packages/server/api/src/app/flows/flow-version/migrations/migrate-v21-step-output-nesting.ts
@@ -2,28 +2,10 @@ import {
     FlowActionType,
     flowStructureUtil,
     FlowVersion,
-    isNil,
     Step,
 } from '@activepieces/shared'
 import { expressionRewriter } from './expression-rewriter'
 import { Migration } from '.'
-
-function wrapStepReferencesInOutputProperty <T>(value: T, stepNames: string[]): T {
-    if (typeof value === 'string') {
-        return expressionRewriter.rewriteStepReferences({ input: value, stepNames }) as T
-    }
-    if (Array.isArray(value)) {
-        return value.map((item) => wrapStepReferencesInOutputProperty(item, stepNames)) as T
-    }
-    if (!isNil(value) && typeof value === 'object') {
-        const result: Record<string, unknown> = {}
-        for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-            result[key] = wrapStepReferencesInOutputProperty(child, stepNames)
-        }
-        return result as T
-    }
-    return value
-}
 
 export const migrateV21StepOutputNesting: Migration = {
     targetSchemaVersion: '21',
@@ -32,7 +14,7 @@ export const migrateV21StepOutputNesting: Migration = {
         const newFlowVersion = flowStructureUtil.transferFlow(flowVersion, (step: Step) => {
             const newStep = {
                 ...step,
-                settings: wrapStepReferencesInOutputProperty(step.settings, stepNames),
+                settings: expressionRewriter.rewriteDeep(step.settings, stepNames),
             }
             if (newStep.type === FlowActionType.CODE) {
                 newStep.settings.sourceCode = step.settings.sourceCode

--- a/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-branch.ts
@@ -44,6 +44,8 @@ export const apAddBranchTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                     return { content: [{ type: 'text', text: '❌ Flow not found' }] }
                 }
 
+                const rewritten = mcpUtils.rewriteAllReferences({ conditions, trigger: flow.version.trigger })
+
                 const resolved = mcpUtils.resolveRouterStep({ stepName: routerStepName, trigger: flow.version.trigger })
                 if (resolved.error) {
                     return resolved.error
@@ -61,7 +63,7 @@ export const apAddBranchTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                         branchIndex,
                         branchName,
                         // .min(1) and .superRefine on the input schema align the runtime shape with BranchCondition's discriminated union.
-                        conditions: (conditions ?? [[]]) as BranchCondition[][],
+                        conditions: (rewritten.conditions ?? [[]]) as BranchCondition[][],
                     },
                 }
 

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -77,8 +77,10 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
                 return authError
             }
 
+            const rewritten = mcpUtils.rewriteAllReferences({ input, loopItems, trigger: flow.version.trigger })
+
             const resolvedInput = {
-                ...(input ?? {}),
+                ...(rewritten.input ?? {}),
                 ...(auth !== undefined && { auth: `{{connections['${auth}']}}` }),
             }
 
@@ -140,7 +142,7 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
                         displayName,
                         valid: false,
                         settings: {
-                            items: loopItems ?? '',
+                            items: rewritten.loopItems ?? '',
                         },
                     }
                     break

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -142,7 +142,9 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
                         resolvedPieceName = versionResult.normalizedPieceName
                     }
 
-                    const skeleton = buildSkeleton({ step, name: stepName, resolvedPieceVersion, resolvedPieceName })
+                    const rewritten = mcpUtils.rewriteAllReferences({ input: step.input, loopItems: step.loopItems, trigger: latestTrigger })
+                    const rewrittenStep = { ...step, input: rewritten.input, loopItems: rewritten.loopItems }
+                    const skeleton = buildSkeleton({ step: rewrittenStep, name: stepName, resolvedPieceVersion, resolvedPieceName })
                     const parseResult = UpdateActionRequest.safeParse(skeleton)
                     if (!parseResult.success) {
                         skippedSteps.push(step.displayName)

--- a/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-branch.ts
@@ -52,6 +52,8 @@ export const apUpdateBranchTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                     return { content: [{ type: 'text', text: '❌ Flow not found' }] }
                 }
 
+                const rewritten = mcpUtils.rewriteAllReferences({ conditions, trigger: flow.version.trigger })
+
                 const resolved = mcpUtils.resolveRouterStep({ stepName: routerStepName, trigger: flow.version.trigger })
                 if (resolved.error) {
                     return resolved.error
@@ -89,7 +91,7 @@ export const apUpdateBranchTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                         ...targetBranch,
                         ...(branchName !== undefined && { branchName }),
                         // .min(1) and .superRefine on the input schema align the runtime shape with BranchCondition's discriminated union.
-                        ...(conditions !== undefined && { conditions: conditions as BranchCondition[][] }),
+                        ...(rewritten.conditions !== undefined && { conditions: rewritten.conditions as BranchCondition[][] }),
                     }
                 }
 

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -82,13 +82,15 @@ export const apUpdateStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                 return authError
             }
 
+            const rewritten = mcpUtils.rewriteAllReferences({ input, loopItems, trigger: flow.version.trigger })
+
             const currentSettings = step.settings as Record<string, unknown>
             const updatedSettings: Record<string, unknown> = { ...currentSettings }
 
-            if (input !== undefined || auth !== undefined) {
+            if (rewritten.input !== undefined || auth !== undefined) {
                 updatedSettings.input = {
                     ...(currentSettings.input as Record<string, unknown> ?? {}),
-                    ...(input ?? {}),
+                    ...(rewritten.input ?? {}),
                     ...(auth !== undefined && { auth: `{{connections['${auth}']}}` }),
                 }
             }
@@ -100,9 +102,9 @@ export const apUpdateStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                     return { content: [{ type: 'text', text: `❌ actionName can only be set on PIECE steps, but "${stepName}" is type ${step.type}.` }] }
                 }
             }
-            if (loopItems !== undefined) {
+            if (rewritten.loopItems !== undefined) {
                 if (step.type === FlowActionType.LOOP_ON_ITEMS) {
-                    updatedSettings.items = loopItems
+                    updatedSettings.items = rewritten.loopItems
                 }
                 else {
                     return { content: [{ type: 'text', text: `❌ loopItems can only be set on LOOP_ON_ITEMS steps, but "${stepName}" is type ${step.type}.` }] }

--- a/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
@@ -71,9 +71,10 @@ export const apUpdateTriggerTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                 : null
 
             const { auth: _rawAuth, ...rawInputWithoutAuth } = rawInput ?? {}
+            const rewritten = mcpUtils.rewriteAllReferences({ input: rawInputWithoutAuth, trigger: flow.version.trigger })
             const input = {
                 ...(existingPieceSettings?.input ?? {}),
-                ...rawInputWithoutAuth,
+                ...(rewritten.input ?? {}),
                 ...(auth !== undefined && { auth: `{{connections['${auth}']}}` }),
             }
 

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -364,7 +364,7 @@ function rewriteAllReferences<C = unknown>({ input, loopItems, conditions, trigg
     const stepNames = flowStructureUtil.getAllSteps(trigger).map(s => s.name)
     return {
         input: input ? expressionRewriter.rewriteDeep(input, stepNames, true) : undefined,
-        loopItems: loopItems ? expressionRewriter.rewriteStepReferences({ input: loopItems, stepNames, idempotent: true }) : loopItems,
+        loopItems: loopItems != null ? expressionRewriter.rewriteStepReferences({ input: loopItems, stepNames, idempotent: true }) : loopItems,
         conditions: conditions ? expressionRewriter.rewriteDeep(conditions, stepNames, true) : conditions,
     }
 }

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -3,6 +3,7 @@ import { BranchOperator, FlowActionType, flowStructureUtil, isNil, isObject, Mcp
 import type { RouterAction, Step } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
+import { expressionRewriter } from '../../flows/flow-version/migrations/expression-rewriter'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
 import { projectService } from '../../project/project-service'
 
@@ -354,6 +355,20 @@ function isProjectScoped(mcp: ProjectScopedMcpServer): boolean {
     return mcp.type === McpServerType.PROJECT
 }
 
+function rewriteAllReferences<C = unknown>({ input, loopItems, conditions, trigger }: {
+    input?: Record<string, unknown>
+    loopItems?: string
+    conditions?: C
+    trigger: Step
+}): { input?: Record<string, unknown>, loopItems?: string, conditions?: C } {
+    const stepNames = flowStructureUtil.getAllSteps(trigger).map(s => s.name)
+    return {
+        input: input ? expressionRewriter.rewriteDeep(input, stepNames, true) : undefined,
+        loopItems: loopItems ? expressionRewriter.rewriteStepReferences({ input: loopItems, stepNames, idempotent: true }) : loopItems,
+        conditions: conditions ? expressionRewriter.rewriteDeep(conditions, stepNames, true) : conditions,
+    }
+}
+
 export const mcpUtils = {
     mcpToolError,
     truncate,
@@ -372,6 +387,7 @@ export const mcpUtils = {
     resolvePlatformId,
     isProjectScoped,
     withTimeout,
+    rewriteAllReferences,
     STEP_REFERENCE_HINT,
     BRANCH_CONDITIONS_INPUT_SCHEMA,
 }

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -1315,7 +1315,7 @@ describe('MCP Tools integration', () => {
         expect(output).toContain('sourceCode:')
         expect(output).toContain('inputs.name')
         expect(output).toContain('input:')
-        expect(output).toContain('{{trigger.from}}')
+        expect(output).toContain("{{trigger['output'].from}}")
     })
 
     it('51. ap_flow_structure — shows LOOP step loopItems expression', async () => {
@@ -1346,7 +1346,7 @@ describe('MCP Tools integration', () => {
         const result = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
         const output = text(result)
 
-        expect(output).toContain('loopItems: {{trigger.items}}')
+        expect(output).toContain("loopItems: {{trigger['output'].items}}")
     })
 
     it('52. ap_flow_structure — shows router branch conditions', async () => {
@@ -1384,7 +1384,7 @@ describe('MCP Tools integration', () => {
 
         expect(output).toContain('VIP')
         expect(output).toContain('conditions:')
-        expect(output).toContain('{{trigger.type}}')
+        expect(output).toContain("{{trigger['output'].type}}")
         expect(output).toContain('TEXT_EXACTLY_MATCHES')
         expect(output).toContain('vip')
     })
@@ -1566,7 +1566,7 @@ describe('MCP Tools integration', () => {
         const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
         const output = text(structure)
         expect(output).toContain('VIP Branch')
-        expect(output).toContain('{{trigger.type}}')
+        expect(output).toContain("{{trigger['output'].type}}")
         expect(output).toContain('TEXT_EXACTLY_MATCHES')
     })
 
@@ -1808,7 +1808,7 @@ describe('MCP Tools integration', () => {
         expect(output).toContain('Inner Code')
         expect(output).toContain('step_2')
         expect(output).toContain('branch 0')
-        expect(output).toContain('{{trigger.status}}')
+        expect(output).toContain("{{trigger['output'].status}}")
     })
 
     it('66. ap_update_branch — handles complex multi-group conditions', async () => {


### PR DESCRIPTION
## Summary
- The AI chat generates `{{step_1}}` or `{{step_1.field}}` instead of `{{step_1['output']}}` / `{{step_1['output'].field}}`, breaking flows. Prompt-only fixes (#13580, #13581) are unreliable — LLMs don't consistently follow syntax rules.
- Adds server-side enforcement by running the existing expression rewriter on all MCP tool inputs before saving to the flow.
- Rewrites are idempotent: correct `['output']` and `['error']` references are preserved untouched; only bare references get fixed.

## Test plan
- [x] `ap_build_flow` with bare `{{trigger.body}}` → saved as `{{trigger['output'].body}}`
- [x] `ap_add_step` with `{{step_1.message}}` and `{{trigger.body.email}}` → both rewritten
- [x] `ap_update_step` with bare `{{step_1}}` → saved as `{{step_1['output']}}`
- [x] `ap_add_step` LOOP with bare `{{step_1.items}}` loopItems → rewritten
- [x] Idempotent: `{{step_1['output'].message}}` → unchanged (no double `['output']`)
- [x] Error branch: `{{step_1['error'].message}}` → preserved
- [x] Mixed correct + bare refs in same string → only bare ones rewritten
- [x] 90 existing expression-rewriter unit tests pass
- [x] Full lint passes (0 errors)