### PR TITLE
fix(chat): robust connection management during chat sessions

### DIFF
--- a/packages/server/api/src/assets/prompts/chat-compaction-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-compaction-prompt.md
@@ -3,6 +3,7 @@ You are a conversation summarizer for an AI chat assistant in Activepieces. Summ
 You MUST preserve:
 - All user-stated facts, preferences, and decisions
 - Names of entities: flows, pieces, connections, tables, projects (with IDs where available)
+- Connections used so far (piece name → connection label → externalId → projectId)
 - Tool call outcomes: what was called and the final result (omit intermediate failed attempts — only note if a tool ultimately failed)
 - The current task or question being worked on
 - Any errors or issues encountered and their resolution status

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -43,20 +43,24 @@ You speak naturally and conversationally — like a knowledgeable friend, not a 
 
 **CRITICAL: The thinking status and tool title are shown together in the UI. They MUST say completely different things. If they overlap even slightly, the user sees the same sentence twice — this is a broken experience.**
 
-**Thinking status** (`ap_update_thinking_status`) = A warm, high-level sentence about your GOAL for the user. Never mention the tool name, the app name, or the action. Think of it as "what am I trying to accomplish for this person?"
+**Thinking status** (`ap_update_thinking_status`) = A warm, personal sentence about your GOAL for the user. Write it as if you're talking directly to them — conversational, not robotic. **Never use "-ing" progressive form** (e.g. "Getting…", "Finding…", "Checking…"). Never mention the tool name, the app name, or the action. **Vary your sentence starters** — rotate between these patterns and don't repeat the same pattern twice in a row:
 
-| ❌ NEVER (describes the tool) | ✅ ALWAYS (describes the goal) |
+- First-person intent: "I'll …", "I need to …"
+- Direct statements: "Quick check on …", "Almost done — …", "One more thing …"
+- Collaborative: "Time to …", "Next up — …", "This should be fun …"
+
+| ❌ NEVER (progressive / describes the tool) | ✅ ALWAYS (personal, varied) |
 |---|---|
-| "Loading your Slack channels" | "Getting your workspace ready" |
-| "Researching Gmail and Slack integrations" | "Finding the best way to connect your apps" |
-| "Checking your Gmail connection" | "Making sure everything is connected" |
-| "Building the automation flow" | "Putting it all together for you" |
-| "Searching for email actions" | "Exploring what's possible here" |
-| "Validating step configuration" | "Double-checking everything works" |
-| "Testing the flow" | "Almost done — running a quick test" |
-| "Resolving property options" | "Figuring out the right settings" |
+| "Loading your Slack channels" | "I'll get your workspace ready" |
+| "Researching Gmail and Slack integrations" | "Time to find the best way to connect your apps" |
+| "Checking your Gmail connection" | "Quick check on your connections" |
+| "Building the automation flow" | "I'll put it all together for you" |
+| "Searching for email actions" | "Next up — seeing what's possible here" |
+| "Validating step configuration" | "One more thing before we're done" |
+| "Testing the flow" | "Almost done — one quick test" |
+| "Resolving property options" | "I need to figure out the right settings" |
 
-Self-check before writing a thinking status: "Does this sentence mention any app name (Gmail, Slack, etc.) or action word (searching, loading, building) that will also appear in the tool's `activeTitle`?" If yes, rewrite it.
+Self-check before writing a thinking status: (1) "Does this start with an -ing word?" If yes, rewrite. (2) "Did I use the same starter pattern as the previous status?" If yes, pick a different one. (3) "Does this mention any app name or action word that will also appear in the tool's `activeTitle`?" If yes, rewrite.
 
 **STRICT 1:1 RULE: Every single tool call MUST be preceded by its own unique `ap_update_thinking_status`.** Never batch. If you call 3 tools, you call `ap_update_thinking_status` 3 separate times, each with a different sentence. The pattern is always: status → tool → status → tool → status → tool. NEVER: status → tool → tool → tool.
 
@@ -69,11 +73,11 @@ ap_update_step(...)              → "Fixed Slack step"
 ap_validate_step_config(...)     → "Slack step valid"
 
 ✅ Correct (1:1 — every pill has its own description):
-ap_update_thinking_status("Making sure the Slack step is set up right")
+ap_update_thinking_status("I'll make sure this step is set up right")
 ap_validate_step_config(...)     → doneTitle: "Validated Slack setup"
-ap_update_thinking_status("Fixing a small issue I found")
+ap_update_thinking_status("Found a small issue — quick fix")
 ap_update_step(...)              → doneTitle: "Updated Slack step"
-ap_update_thinking_status("Confirming the fix worked")
+ap_update_thinking_status("One more check to confirm")
 ap_validate_step_config(...)     → doneTitle: "Slack setup confirmed"
 ```
 
@@ -130,7 +134,7 @@ Gather ALL information before presenting the plan. Once approved, execute withou
 
 **2 — GATHER INFO** (each sub-step may require user input):
 - **Project**: one → select silently; multiple → `ap_show_project_picker`.
-- **Connections**: `ap_list_connections` ONCE. Active connections found → `ap_show_connection_picker` (even if only one — always let the user confirm). None/error → `ap_show_connection_required`. If user cannot connect → use HTTP piece with inline auth for that step (see `<http_fallback>`). Never re-show a picker the user already answered.
+- **Connections**: `ap_list_connections` ONCE. Active connections found → `ap_show_connection_picker` (even if only one — always let the user confirm). None/error → `ap_show_connection_required`. If user cannot connect → use HTTP piece with inline auth for that step (see `<http_fallback>`). Never re-show a picker the user already answered **for the same step**. If the user explicitly asks to switch accounts, use a different connection, or names a specific account — re-run auth discovery and show `ap_show_connection_picker` with the fresh list.
 - **Config**: unresolved fields → `ap_get_piece_props` + `ap_resolve_property_options` → `ap_show_questions`.
 
 **3 — PLAN**: `ap_request_plan_approval` with summary and steps. Steps MUST match what you will actually do:
@@ -194,6 +198,7 @@ Read actions: broadest filter, show results, offer to refine.
 Write actions: execute if enough detail.
 On failure (tool error, not empty results): retry ONCE with a different approach. If it fails again due to auth issues, offer HTTP fallback.
 On success: include an automation suggestion in quick replies (e.g., "Turn this into a flow", "No thanks"). If the user accepts, follow `<one_time_to_flow>`.
+If the user asks to repeat the same action with a different account or switch connections, treat it as a new one-time task — re-run the full auth discovery flow from step 1.
 </one_time_tasks>
 
 <one_time_to_flow>
@@ -240,7 +245,7 @@ Always explain to the user: "Since we don't have a [Piece] connection set up, I'
 - Say "automation" or "workflow," never "flow."
 - One emoji max per message, only for celebrations.
 - When something breaks, get efficient — no pleasantries, just fix it.
-- CRITICAL: Thinking status = your GOAL (never mention app names or actions). Tool titles = the ACTION. If they overlap, you broke the UI.
+- CRITICAL: Thinking status = your GOAL, personal and conversational (never "-ing", never mention app names or actions). Tool titles = the ACTION (keep "-ing" for `activeTitle`). If they overlap, you broke the UI.
 - Every tool call gets its own `ap_update_thinking_status` — NEVER batch multiple tools under one status.
 - `doneTitle` is ALWAYS past tense. Never present tense or adjective form.
 - Always include `activeTitle` and `doneTitle` on tool calls.

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -483,7 +483,8 @@ function DisplayToolCard({
   const toolCallId = chatPartUtils.getToolCallId(part);
 
   switch (toolName) {
-    case 'ap_show_connection_required':
+    case 'ap_show_connection_required': {
+      if (!isInteractive && toolOutput?.['dismissed'] === true) return null;
       return (
         <ConnectionsRequiredCard
           connections={[data as unknown as ConnectionRequiredData]}
@@ -491,6 +492,7 @@ function DisplayToolCard({
           isInteractive={isInteractive}
         />
       );
+    }
     case 'ap_show_connection_picker': {
       const selectedLabel =
         typeof toolOutput?.['label'] === 'string'

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -488,6 +488,7 @@ function DisplayToolCard({
         <ConnectionsRequiredCard
           connections={[data as unknown as ConnectionRequiredData]}
           onResolve={(payload) => onResolve(toolCallId, payload)}
+          isInteractive={isInteractive}
         />
       );
     case 'ap_show_connection_picker': {

--- a/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/chat-bottom-bar.tsx
@@ -1,6 +1,5 @@
 import { t } from 'i18next';
 import { motion } from 'motion/react';
-import { useEffect, useRef } from 'react';
 
 import { chatStoreSelectors } from '@/features/chat/lib/chat-store';
 import { useChatStoreContext } from '@/features/chat/lib/chat-store-context';
@@ -68,15 +67,6 @@ export function ChatBottomBar({
   const rejectGate = useChatStoreContext((s) => s.rejectGate);
   const dismissGate = useChatStoreContext((s) => s.dismissGate);
   const dismissForm = useChatStoreContext((s) => s.dismissForm);
-
-  const wasStreamingRef = useRef(isStreaming);
-  useEffect(() => {
-    if (wasStreamingRef.current && !isStreaming && activeDisplayTool) {
-      const toolCallId = chatPartUtils.getToolCallId(activeDisplayTool);
-      dismissGate(toolCallId);
-    }
-    wasStreamingRef.current = isStreaming;
-  }, [isStreaming, activeDisplayTool, dismissGate]);
 
   // Plan approval from tool state
   if (pendingPlanPart) {

--- a/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
@@ -340,15 +340,18 @@ export function ConnectionPickerCard({
               void queryClient.invalidateQueries({
                 queryKey: ['app-connections'],
               });
+              const resolvedProjectId =
+                selectedProjectId ?? authenticationSession.getProjectId() ?? '';
               setSelectedConnection({
                 label: createdConnection.displayName,
                 project: '',
                 externalId: createdConnection.externalId,
-                projectId: '',
+                projectId: resolvedProjectId,
                 status: AppConnectionStatus.ACTIVE,
               });
               onResolve({
                 connectionExternalId: createdConnection.externalId,
+                projectId: resolvedProjectId,
                 label: createdConnection.displayName,
               });
             }

--- a/packages/web/src/app/routes/chat-with-ai/components/connections-required-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connections-required-card.tsx
@@ -4,7 +4,7 @@ import {
 } from '@activepieces/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
-import { Check } from 'lucide-react';
+import { Check, RefreshCw } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -21,10 +21,12 @@ export function ConnectionsRequiredCard({
   connections,
   onResolve,
   projectId: selectedProjectId,
+  isInteractive = true,
 }: {
   connections: ConnectionRequiredData[];
   onResolve?: (payload: Record<string, unknown>) => void;
   projectId?: string | null;
+  isInteractive?: boolean;
 }) {
   const queryClient = useQueryClient();
   const [connectedSet, setConnectedSet] = useState<Set<string>>(new Set());
@@ -33,6 +35,7 @@ export function ConnectionsRequiredCard({
   >({});
   const [activeConnection, setActiveConnection] =
     useState<ConnectionRequiredData | null>(null);
+  const [isNewConnection, setIsNewConnection] = useState(false);
   const [continued, setContinued] = useState(false);
 
   const activePieceName = activeConnection
@@ -49,6 +52,7 @@ export function ConnectionsRequiredCard({
   );
 
   useEffect(() => {
+    if (!isInteractive) return;
     const projectId = selectedProjectId ?? authenticationSession.getProjectId();
     if (!projectId) return;
     let cancelled = false;
@@ -79,19 +83,57 @@ export function ConnectionsRequiredCard({
       if (alreadyActive.size > 0) {
         setConnectedSet(alreadyActive);
       }
-      if (alreadyActive.size === connections.length) {
-        setContinued(true);
-      }
     });
 
     return () => {
       cancelled = true;
     };
-  }, [connectionsKey, selectedProjectId]);
+  }, [connectionsKey, selectedProjectId, isInteractive]);
 
   const allConnected = connections.every((c) => connectedSet.has(c.piece));
 
-  function handleConnect(connection: ConnectionRequiredData) {
+  if (!isInteractive) {
+    return (
+      <div className="rounded-xl border bg-background overflow-hidden my-2">
+        {connections.map((conn) => {
+          const pieceName = normalizePieceName(conn.piece);
+          return (
+            <div
+              key={conn.piece}
+              className="flex items-center gap-3 px-4 py-3 border-t first:border-t-0"
+            >
+              <div className="relative">
+                <PieceIconWithPieceName
+                  pieceName={pieceName}
+                  size="sm"
+                  border={false}
+                  showTooltip={false}
+                />
+                <div className="absolute -bottom-0.5 -right-0.5 bg-green-500 rounded-full p-0.5">
+                  <Check className="h-2 w-2 text-white" />
+                </div>
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium">{conn.displayName}</div>
+                <div className="text-xs text-muted-foreground">
+                  {t('Connected')}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  function openConnectionDialog({
+    connection,
+    isNew,
+  }: {
+    connection: ConnectionRequiredData;
+    isNew: boolean;
+  }) {
+    setIsNewConnection(isNew);
     setActiveConnection(connection);
   }
 
@@ -114,7 +156,13 @@ export function ConnectionsRequiredCard({
             connection={conn}
             isConnected={connectedSet.has(conn.piece)}
             existingConn={existingConns[conn.piece] ?? null}
-            onConnect={() => handleConnect(conn)}
+            onConnect={() =>
+              openConnectionDialog({ connection: conn, isNew: false })
+            }
+            onSwitch={() =>
+              openConnectionDialog({ connection: conn, isNew: true })
+            }
+            continued={continued}
           />
         ))}
 
@@ -132,12 +180,17 @@ export function ConnectionsRequiredCard({
                   className="gap-1.5"
                   onClick={() => {
                     setContinued(true);
+                    const resolvedProjectId =
+                      selectedProjectId ??
+                      authenticationSession.getProjectId() ??
+                      '';
                     const confirmedConnections = connections.map((conn) => {
                       const existing = existingConns[conn.piece];
                       return {
                         piece: conn.piece,
                         displayName: conn.displayName,
                         connectionExternalId: existing?.externalId ?? null,
+                        projectId: resolvedProjectId,
                       };
                     });
                     onResolve({
@@ -180,7 +233,11 @@ export function ConnectionsRequiredCard({
               setActiveConnection(null);
             }
           }}
-          reconnectConnection={existingConns[activeConnection.piece] ?? null}
+          reconnectConnection={
+            isNewConnection
+              ? null
+              : existingConns[activeConnection.piece] ?? null
+          }
           isGlobalConnection={false}
         />
       )}
@@ -193,11 +250,15 @@ function ConnectionRow({
   isConnected,
   existingConn,
   onConnect,
+  onSwitch,
+  continued,
 }: {
   connection: ConnectionRequiredData;
   isConnected: boolean;
   existingConn: AppConnectionWithoutSensitiveData | null;
   onConnect: () => void;
+  onSwitch: () => void;
+  continued: boolean;
 }) {
   const pieceName = normalizePieceName(connection.piece);
   const { isLoading } = piecesHooks.usePiece({ name: pieceName });
@@ -213,7 +274,11 @@ function ConnectionRow({
         showTooltip={false}
       />
       <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium">{connection.displayName}</div>
+        <div className="text-sm font-medium">
+          {isConnected && existingConn
+            ? existingConn.displayName
+            : connection.displayName}
+        </div>
         <div className="text-xs text-muted-foreground">
           {isConnected
             ? t('Ready to use')
@@ -225,14 +290,26 @@ function ConnectionRow({
         </div>
       </div>
       {isConnected ? (
-        <motion.span
-          initial={{ scale: 0 }}
-          animate={{ scale: 1 }}
-          transition={{ type: 'spring', stiffness: 400, damping: 15 }}
-          className="shrink-0 flex items-center justify-center"
-        >
-          <Check className="h-5 w-5 text-green-600 dark:text-green-400" />
-        </motion.span>
+        continued ? (
+          <motion.span
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 15 }}
+            className="shrink-0 flex items-center justify-center"
+          >
+            <Check className="h-5 w-5 text-green-600 dark:text-green-400" />
+          </motion.span>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            className="shrink-0 gap-1.5"
+            onClick={onSwitch}
+          >
+            <RefreshCw className="h-3 w-3" />
+            {t('Switch')}
+          </Button>
+        )
       ) : (
         <Button
           size="sm"


### PR DESCRIPTION
## Summary
- Fix system prompt preventing connection switching mid-conversation by scoping "never re-show" rule to the same step
- Remove auto-dismiss that killed active connection pickers when streaming ended
- Remove auto-continue that bypassed user confirmation on existing connections; add Switch button and non-interactive history state to ConnectionsRequiredCard
- Include `projectId` in connection picker and required card resolve payloads (was missing for new connections)
- Preserve connection context (piece → label → externalId → projectId) during chat compaction for one-time tasks
- Vary thinking status sentence starters for more natural, non-repetitive conversation

## Test plan
- [ ] Start a chat, do a one-time action (e.g. read emails), then ask to "use a different email account" — LLM should show the connection picker again
- [ ] Trigger a connection picker, wait for streaming to end — picker should remain interactive in the bottom bar
- [ ] When `ap_show_connection_required` is called and a connection already exists — card should show "Switch" button and require clicking "Continue"
- [ ] Historical connection cards in chat scroll should render as non-interactive (green check, no buttons, no API calls)
- [ ] Create a new connection from the picker in a multi-project setup — verify correct `projectId` is passed to the backend