### PR TITLE
fix(embed): avoid hard reload on resource takeover

### DIFF
--- a/.agents/features/flows.md
+++ b/.agents/features/flows.md
@@ -1,7 +1,7 @@
 # Flows Module
 
 ## Summary
-Flows are the core automation primitive in Activepieces. Each flow is a versioned directed graph of trigger and action steps stored as a JSONB tree. The module handles the full lifecycle: draft editing via a single-endpoint operation dispatch, publishing (locking a version and registering the trigger source), enabling/disabling, folder organization, sample data capture for testing, human-input forms/chat interfaces, PNG export of the canvas, and the visual builder frontend powered by XYFlow. All 26 flow modification types are dispatched through one endpoint (`POST /v1/flows/:id`) with a discriminated-union body.
+Flows are the core automation primitive in Activepieces. Each flow is a versioned directed graph of trigger and action steps stored as a JSONB tree. The module handles the full lifecycle: draft editing via a single-endpoint operation dispatch, publishing (locking a version and registering the trigger source), enabling/disabling, folder organization, sample data capture for testing, human-input forms/chat interfaces, PNG export of the canvas, and the visual builder frontend powered by XYFlow. All 26 flow modification types are dispatched through one endpoint (`POST /v1/flows/:id`) with a discriminated-union body. In embedded mode, taking over a locked flow fetches the latest flow version and updates the visual builder in-place rather than triggering a full page reload.
 
 ## Key Files
 - `packages/server/api/src/app/flows/flow/flow.service.ts` — core service (operations, publish, enable/disable)

--- a/.agents/features/tables.md
+++ b/.agents/features/tables.md
@@ -1,7 +1,7 @@
 # Tables Module
 
 ## Summary
-A built-in relational database feature that lets users store structured data directly within Activepieces, without needing an external database. Tables support typed fields, cell-level storage, per-row webhooks that fire flow automations, and a rich spreadsheet-like editor in the UI. They are tightly integrated with the flow engine through the Tables piece, which provides trigger and action steps for reacting to and manipulating table data.
+A built-in relational database feature that lets users store structured data directly within Activepieces, without needing an external database. Tables support typed fields, cell-level storage, per-row webhooks that fire flow automations, and a rich spreadsheet-like editor in the UI. They are tightly integrated with the flow engine through the Tables piece, which provides trigger and action steps for reacting to and manipulating table data. In embedded mode, taking over a locked table refreshes all table data (fields, records, metadata) in-place instead of triggering a full page reload; this is implemented through `replaceFromServer` on the client state store.
 
 ## Key Files
 - `packages/server/api/src/app/tables/table/table.service.ts` — table CRUD, export, webhook management

--- a/packages/web/src/app/builder/flow-canvas/widgets/use-flow-lock.ts
+++ b/packages/web/src/app/builder/flow-canvas/widgets/use-flow-lock.ts
@@ -1,19 +1,31 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
+import { flowsApi } from '@/features/flows';
 import { useResourceLock } from '@/hooks/use-resource-lock';
 
 import { useBuilderStateContext } from '../../builder-hooks';
 
 function useFlowLock() {
-  const [readonly, flowId, setReadOnly] = useBuilderStateContext((state) => [
-    state.readonly,
-    state.flow.id,
-    state.setReadOnly,
-  ]);
+  const [readonly, flowId, setReadOnly, setFlow, setVersion] =
+    useBuilderStateContext((state) => [
+      state.readonly,
+      state.flow.id,
+      state.setReadOnly,
+      state.setFlow,
+      state.setVersion,
+    ]);
   const readonlySetByLock = useRef(false);
+
+  const refreshFlowAfterTakeOver = useCallback(async () => {
+    const flow = await flowsApi.get(flowId);
+    setFlow(flow);
+    setVersion(flow.version);
+    setReadOnly(false);
+  }, [flowId, setFlow, setReadOnly, setVersion]);
 
   const { lockedBy, takeOver } = useResourceLock({
     resourceId: flowId,
+    onTakeOver: refreshFlowAfterTakeOver,
   });
 
   useEffect(() => {

--- a/packages/web/src/app/routes/tables/id/index.tsx
+++ b/packages/web/src/app/routes/tables/id/index.tsx
@@ -15,6 +15,7 @@ import {
   Row,
   ROW_HEIGHT_MAP,
   RowHeight,
+  TABLE_RECORDS_PAGE_LIMIT,
 } from '@/features/tables';
 import { fieldsApi } from '@/features/tables/api/fields-api';
 import { recordsApi } from '@/features/tables/api/records-api';
@@ -60,7 +61,7 @@ const ApTableEditorPage = () => {
       fieldsApi.list({ tableId: table.id }),
       recordsApi.list({
         tableId: table.id,
-        limit: 99999999,
+        limit: TABLE_RECORDS_PAGE_LIMIT,
         cursor: undefined,
       }),
     ]);

--- a/packages/web/src/app/routes/tables/id/index.tsx
+++ b/packages/web/src/app/routes/tables/id/index.tsx
@@ -1,6 +1,6 @@
 import { ApFlagId, Permission } from '@activepieces/shared';
 import { nanoid } from 'nanoid';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 import DataGrid, { DataGridHandle } from 'react-data-grid';
 import 'react-data-grid/lib/styles.css';
 import { useNavigate } from 'react-router-dom';
@@ -16,6 +16,9 @@ import {
   ROW_HEIGHT_MAP,
   RowHeight,
 } from '@/features/tables';
+import { fieldsApi } from '@/features/tables/api/fields-api';
+import { recordsApi } from '@/features/tables/api/records-api';
+import { tablesApi } from '@/features/tables/api/tables-api';
 import { useAuthorization } from '@/hooks/authorization-hooks';
 import { flagsHooks } from '@/hooks/flags-hooks';
 import { useResourceLock } from '@/hooks/use-resource-lock';
@@ -37,6 +40,7 @@ const ApTableEditorPage = () => {
     records,
     table,
     setLockedByOtherUser,
+    replaceFromServer,
   ] = useTableState((state) => [
     state.selectedRecords,
     state.setSelectedRecords,
@@ -47,10 +51,31 @@ const ApTableEditorPage = () => {
     state.records,
     state.table,
     state.setLockedByOtherUser,
+    state.replaceFromServer,
   ]);
+
+  const refreshTableAfterTakeOver = useCallback(async () => {
+    const [nextTable, nextFields, nextRecords] = await Promise.all([
+      tablesApi.getById(table.id),
+      fieldsApi.list({ tableId: table.id }),
+      recordsApi.list({
+        tableId: table.id,
+        limit: 99999999,
+        cursor: undefined,
+      }),
+    ]);
+
+    replaceFromServer({
+      table: nextTable,
+      fields: nextFields,
+      records: nextRecords.data,
+    });
+    setLockedByOtherUser(false);
+  }, [replaceFromServer, setLockedByOtherUser, table.id]);
 
   const { lockedBy, takeOver } = useResourceLock({
     resourceId: table.id,
+    onTakeOver: refreshTableAfterTakeOver,
   });
 
   useEffect(() => {

--- a/packages/web/src/features/tables/components/ap-table-state-provider.tsx
+++ b/packages/web/src/features/tables/components/ap-table-state-provider.tsx
@@ -19,6 +19,8 @@ import { fieldsApi } from '../api/fields-api';
 import { recordsApi } from '../api/records-api';
 import { tablesApi } from '../api/tables-api';
 
+const TABLE_RECORDS_PAGE_LIMIT = Number.MAX_SAFE_INTEGER;
+
 const TableContext = createContext<ApTableStore | null>(null);
 
 export const TableStateProviderWithTable = ({
@@ -88,7 +90,7 @@ export function ApTableStateProvider({
     queryFn: () =>
       recordsApi.list({
         tableId: tableId!,
-        limit: 99999999,
+        limit: TABLE_RECORDS_PAGE_LIMIT,
         cursor: undefined,
       }),
     refetchOnWindowFocus: true,
@@ -152,6 +154,8 @@ export function useTableState<T>(selector: (state: TableState) => T) {
   }
   return useStore(tableStore, selector);
 }
+
+export { TABLE_RECORDS_PAGE_LIMIT };
 
 export function useOptionalTableStore() {
   const tableStore = useContext(TableContext);

--- a/packages/web/src/features/tables/index.ts
+++ b/packages/web/src/features/tables/index.ts
@@ -5,6 +5,7 @@ export { ApTableHeader } from './components/ap-table-header';
 export {
   useTableState,
   ApTableStateProvider,
+  TABLE_RECORDS_PAGE_LIMIT,
 } from './components/ap-table-state-provider';
 export { ImportTableDialog } from './components/import-table-dialog';
 export { mapRecordsToRows, useTableColumns } from './components/table-columns';

--- a/packages/web/src/features/tables/stores/store/ap-tables-client-state.tsx
+++ b/packages/web/src/features/tables/stores/store/ap-tables-client-state.tsx
@@ -82,6 +82,11 @@ export type TableState = {
   setLockedByOtherUser: (locked: boolean) => void;
   serverFields: Field[];
   serverRecords: PopulatedRecord[];
+  replaceFromServer: (params: {
+    table: Table;
+    fields: Field[];
+    records: PopulatedRecord[];
+  }) => void;
 };
 
 export const createApTableStore = (
@@ -90,7 +95,7 @@ export const createApTableStore = (
   records: PopulatedRecord[],
 ) => {
   return create<TableState>((set) => {
-    const serverState = createServerState(
+    let serverState = createServerState(
       table,
       fields,
       records,
@@ -255,6 +260,39 @@ export const createApTableStore = (
       lockedByOtherUser: false,
       setLockedByOtherUser: (locked: boolean) =>
         set({ lockedByOtherUser: locked }),
+
+      replaceFromServer: ({ table, fields, records }) => {
+        serverState = createServerState(
+          table,
+          fields,
+          records,
+          (isSaving: boolean) => set({ isSaving }),
+        );
+        return set(() => ({
+          table,
+          fields: fields.map((field) => {
+            if (field.type === FieldType.STATIC_DROPDOWN) {
+              return {
+                uuid: field.id,
+                name: field.name,
+                type: field.type,
+                data: field.data,
+              };
+            }
+            return {
+              uuid: field.id,
+              name: field.name,
+              type: field.type,
+            };
+          }),
+          records: mapRecorddToClientRecordsData(records, fields),
+          serverFields: serverState.fields,
+          serverRecords: serverState.records,
+          selectedRecords: new Set(),
+          selectedCell: records.length > 0 ? { rowIdx: 0, columnIdx: 1 } : null,
+          selectedAgentRunId: null,
+        }));
+      },
       serverFields: serverState.fields,
       serverRecords: serverState.records,
     };

--- a/packages/web/src/hooks/use-resource-lock.ts
+++ b/packages/web/src/hooks/use-resource-lock.ts
@@ -5,7 +5,9 @@ import {
   WebsocketClientEvent,
   WebsocketServerEvent,
 } from '@activepieces/shared';
+import { t } from 'i18next';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import { useEmbedding } from '@/components/providers/embed-provider';
 import { useSocket } from '@/components/providers/socket-provider';
@@ -26,6 +28,31 @@ async function completeTakeOver({
   }
 
   reload();
+}
+
+async function completeTakeOverWithFeedback({
+  isEmbedded,
+  onTakeOver,
+  reload,
+  onSuccess,
+  onError,
+}: {
+  isEmbedded: boolean;
+  onTakeOver?: () => Promise<void> | void;
+  reload: () => void;
+  onSuccess: () => void;
+  onError: () => void;
+}) {
+  try {
+    await completeTakeOver({
+      isEmbedded,
+      onTakeOver,
+      reload,
+    });
+    onSuccess();
+  } catch {
+    onError();
+  }
 }
 
 function useResourceLock({ resourceId, onTakeOver }: UseResourceLockParams) {
@@ -109,11 +136,20 @@ function useResourceLock({ resourceId, onTakeOver }: UseResourceLockParams) {
       async (response: LockResourceResponse) => {
         if (response.acquired) {
           isOwner.current = true;
-          setLockedBy(null);
-          await completeTakeOver({
+          await completeTakeOverWithFeedback({
             isEmbedded,
             onTakeOver,
             reload: () => window.location.reload(),
+            onSuccess: () => {
+              setLockedBy(null);
+            },
+            onError: () => {
+              toast.error(t('Failed to load data'), {
+                description: t(
+                  'Something went wrong while loading your data. Your data is safe — please try again by refreshing the page.',
+                ),
+              });
+            },
           });
         }
       },
@@ -123,7 +159,7 @@ function useResourceLock({ resourceId, onTakeOver }: UseResourceLockParams) {
   return { lockedBy, takeOver };
 }
 
-export { completeTakeOver, useResourceLock };
+export { completeTakeOver, completeTakeOverWithFeedback, useResourceLock };
 
 type UseResourceLockParams = {
   resourceId: string;

--- a/packages/web/src/hooks/use-resource-lock.ts
+++ b/packages/web/src/hooks/use-resource-lock.ts
@@ -7,12 +7,33 @@ import {
 } from '@activepieces/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { useEmbedding } from '@/components/providers/embed-provider';
 import { useSocket } from '@/components/providers/socket-provider';
 import { authenticationSession } from '@/lib/authentication-session';
 
-function useResourceLock({ resourceId }: UseResourceLockParams) {
+async function completeTakeOver({
+  isEmbedded,
+  onTakeOver,
+  reload,
+}: {
+  isEmbedded: boolean;
+  onTakeOver?: () => Promise<void> | void;
+  reload: () => void;
+}) {
+  if (isEmbedded && onTakeOver) {
+    await onTakeOver();
+    return;
+  }
+
+  reload();
+}
+
+function useResourceLock({ resourceId, onTakeOver }: UseResourceLockParams) {
   const socket = useSocket();
   const currentUserId = authenticationSession.getCurrentUserId();
+  const {
+    embedState: { isEmbedded },
+  } = useEmbedding();
   const isOwner = useRef(false);
   const [lockedBy, setLockedBy] = useState<{
     userId: string;
@@ -85,20 +106,26 @@ function useResourceLock({ resourceId }: UseResourceLockParams) {
     socket.emit(
       WebsocketServerEvent.LOCK_RESOURCE,
       { resourceId, force: true },
-      (response: LockResourceResponse) => {
+      async (response: LockResourceResponse) => {
         if (response.acquired) {
-          isOwner.current = false;
-          window.location.reload();
+          isOwner.current = true;
+          setLockedBy(null);
+          await completeTakeOver({
+            isEmbedded,
+            onTakeOver,
+            reload: () => window.location.reload(),
+          });
         }
       },
     );
-  }, [resourceId, socket]);
+  }, [resourceId, socket, isEmbedded, onTakeOver]);
 
   return { lockedBy, takeOver };
 }
 
-export { useResourceLock };
+export { completeTakeOver, useResourceLock };
 
 type UseResourceLockParams = {
   resourceId: string;
+  onTakeOver?: () => Promise<void> | void;
 };

--- a/packages/web/test/features/tables/ap-tables-client-state.test.ts
+++ b/packages/web/test/features/tables/ap-tables-client-state.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { FieldType, TableAutomationStatus } from '@activepieces/shared';
+import { describe, expect, it } from 'vitest';
+
+import { createApTableStore } from '@/features/tables';
+
+const makeTable = (id: string, name: string) => ({
+  id,
+  projectId: 'project-1',
+  name,
+  created: '2026-01-01T00:00:00.000Z',
+  updated: '2026-01-01T00:00:00.000Z',
+  status: TableAutomationStatus.DISABLED,
+  externalId: null,
+  folderId: null,
+});
+
+const makeField = (id: string, name: string) => ({
+  id,
+  tableId: 'table-1',
+  name,
+  type: FieldType.TEXT,
+  created: '2026-01-01T00:00:00.000Z',
+  updated: '2026-01-01T00:00:00.000Z',
+  externalId: null,
+});
+
+const makeRecord = (id: string, fieldId: string, value: string) => ({
+  id,
+  projectId: 'project-1',
+  tableId: 'table-1',
+  created: '2026-01-01T00:00:00.000Z',
+  updated: '2026-01-01T00:00:00.000Z',
+  cells: {
+    [fieldId]: { value },
+  },
+});
+
+describe('createApTableStore.replaceFromServer', () => {
+  it('replaces the internal server snapshot used by later record updates', () => {
+    const oldField = makeField('field-old', 'Old');
+    const oldRecord = makeRecord('record-old', 'field-old', 'before');
+    const store = createApTableStore(
+      makeTable('table-1', 'Old Table') as any,
+      [oldField] as any,
+      [oldRecord] as any,
+    );
+
+    const newField = makeField('field-new', 'New');
+    const newRecord = makeRecord('record-new', 'field-new', 'after');
+
+    store.getState().replaceFromServer({
+      table: makeTable('table-1', 'New Table') as any,
+      fields: [newField] as any,
+      records: [newRecord] as any,
+    });
+
+    store.getState().setRecords([newRecord] as any);
+
+    expect(store.getState().table.name).toBe('New Table');
+    expect(store.getState().serverFields[0].id).toBe('field-new');
+    expect(store.getState().records[0].values[0].fieldIndex).toBe(0);
+  });
+});

--- a/packages/web/test/hooks/use-resource-lock.test.ts
+++ b/packages/web/test/hooks/use-resource-lock.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
 
-import { completeTakeOver } from '@/hooks/use-resource-lock';
+import { completeTakeOver, completeTakeOverWithFeedback } from '@/hooks/use-resource-lock';
+
 
 describe('completeTakeOver', () => {
   it('uses the embed callback instead of hard reloading when embedded', async () => {
@@ -28,5 +29,52 @@ describe('completeTakeOver', () => {
     });
 
     expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates embed callback errors', async () => {
+    const reload = vi.fn();
+    const onTakeOver = vi.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(
+      completeTakeOver({
+        isEmbedded: true,
+        onTakeOver,
+        reload,
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('calls onSuccess only after takeover refresh succeeds', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    await completeTakeOverWithFeedback({
+      isEmbedded: true,
+      onTakeOver: vi.fn().mockResolvedValue(undefined),
+      reload: vi.fn(),
+      onSuccess,
+      onError,
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('calls onError without clearing success when takeover refresh fails', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    await completeTakeOverWithFeedback({
+      isEmbedded: true,
+      onTakeOver: vi.fn().mockRejectedValue(new Error('boom')),
+      reload: vi.fn(),
+      onSuccess,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/test/hooks/use-resource-lock.test.ts
+++ b/packages/web/test/hooks/use-resource-lock.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+
+import { completeTakeOver } from '@/hooks/use-resource-lock';
+
+describe('completeTakeOver', () => {
+  it('uses the embed callback instead of hard reloading when embedded', async () => {
+    const onTakeOver = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn();
+
+    await completeTakeOver({
+      isEmbedded: true,
+      onTakeOver,
+      reload,
+    });
+
+    expect(onTakeOver).toHaveBeenCalledTimes(1);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('falls back to reload outside embed mode', async () => {
+    const reload = vi.fn();
+
+    await completeTakeOver({
+      isEmbedded: false,
+      onTakeOver: undefined,
+      reload,
+    });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #13554 by avoiding a hard iframe reload when embedded users click **Take Over** on a locked flow or table.

## Changes

- Route embedded resource takeover through local refresh callbacks instead of `window.location.reload()`
- Refresh the builder flow state in place after takeover
- Refresh table state in place after takeover, including replacing the internal server snapshot used by later edits
- Keep the existing hard reload behavior outside embed mode
- Add focused regression tests for the embed takeover path and table store snapshot replacement

## Testing

- `bun x vitest run packages/web/test/hooks/use-resource-lock.test.ts packages/web/test/features/tables/ap-tables-client-state.test.ts --config packages/web/vitest.config.ts`
- `bun x turbo run lint --filter=web -- --fix`
