### PR TITLE
feat(pieces): add Muna AI piece with create prediction action

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3238,7 +3238,7 @@
     },
     "packages/pieces/community/google-sheets": {
       "name": "@activepieces/piece-google-sheets",
-      "version": "0.14.8",
+      "version": "0.15.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -4960,6 +4960,16 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/muna-ai": {
+      "name": "@activepieces/piece-muna-ai",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/murf-api": {
       "name": "@activepieces/piece-murf-api",
       "version": "0.1.4",
@@ -6615,7 +6625,7 @@
     },
     "packages/pieces/community/slashed": {
       "name": "@activepieces/piece-slashed",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -8704,7 +8714,7 @@
     },
     "packages/shared": {
       "name": "@activepieces/shared",
-      "version": "0.83.0",
+      "version": "0.86.0",
       "dependencies": {
         "dayjs": "1.11.9",
         "deepmerge-ts": "7.1.0",
@@ -9730,6 +9740,8 @@
     "@activepieces/piece-moveo-ai": ["@activepieces/piece-moveo-ai@workspace:packages/pieces/community/moveo-ai"],
 
     "@activepieces/piece-moxie-crm": ["@activepieces/piece-moxie-crm@workspace:packages/pieces/community/moxie-crm"],
+
+    "@activepieces/piece-muna-ai": ["@activepieces/piece-muna-ai@workspace:packages/pieces/community/muna-ai"],
 
     "@activepieces/piece-murf-api": ["@activepieces/piece-murf-api@workspace:packages/pieces/community/murf-api"],
 

--- a/packages/pieces/community/muna-ai/.eslintrc.json
+++ b/packages/pieces/community/muna-ai/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/muna-ai/package.json
+++ b/packages/pieces/community/muna-ai/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-muna-ai",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/muna-ai/src/index.ts
+++ b/packages/pieces/community/muna-ai/src/index.ts
@@ -1,0 +1,26 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/shared';
+import { munaAiAuth } from './lib/auth';
+import { createPrediction } from './lib/actions/create-prediction';
+
+export const munaAi = createPiece({
+  displayName: 'Muna',
+  description: 'Run on-device AI predictions using Muna predictors.',
+  auth: munaAiAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/muna-ai.png',
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  authors: ['sanket-a11y'],
+  actions: [
+    createPrediction,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://api.muna.ai/v1',
+      auth: munaAiAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${auth.secret_text}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/muna-ai/src/lib/actions/create-prediction.ts
+++ b/packages/pieces/community/muna-ai/src/lib/actions/create-prediction.ts
@@ -1,0 +1,80 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { munaAiAuth } from '../auth';
+
+export const createPrediction = createAction({
+  name: 'create_prediction',
+  displayName: 'Create Prediction',
+  description: 'Run a predictor and get back prediction resources.',
+  auth: munaAiAuth,
+  props: {
+    tag: Property.ShortText({
+      displayName: 'Predictor Tag',
+      description: 'The tag of the predictor to run (e.g. `@org/my-model`).',
+      required: true,
+    }),
+    clientId: Property.ShortText({
+      displayName: 'Client ID',
+      description:
+        'A unique identifier for the client making the prediction. Used to track usage per device or user.',
+      required: true,
+    }),
+    configurationId: Property.ShortText({
+      displayName: 'Configuration ID',
+      description: 'Optional predictor configuration identifier.',
+      required: false,
+    }),
+    deviceId: Property.ShortText({
+      displayName: 'Device ID',
+      description:
+        'Optional device identifier. Muna uses this to choose the optimal implementation to respond with.',
+      required: false,
+    }),
+    predictionId: Property.ShortText({
+      displayName: 'Prediction ID',
+      description:
+        'For embedded predictors — providing the original prediction ID ensures the same implementation is delivered.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { tag, clientId, configurationId, deviceId, predictionId } =
+      context.propsValue;
+
+    const body: Record<string, string> = { tag, clientId };
+
+    if (configurationId) body['configurationId'] = configurationId;
+    if (deviceId) body['deviceId'] = deviceId;
+    if (predictionId) body['predictionId'] = predictionId;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: 'https://api.muna.ai/v1/predictions',
+      headers: {
+        Authorization: `Bearer ${context.auth.secret_text}`,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+    const prediction = response.body as {
+      id: string;
+      tag: string;
+      configuration?: string;
+      resources: Array<{ type: string; url: string; name?: string }>;
+      created: string;
+    };
+
+    return {
+      id: prediction.id,
+      tag: prediction.tag,
+      configuration: prediction.configuration ?? null,
+      created: prediction.created,
+      resources: prediction.resources.map((r) => ({
+        type: r.type,
+        url: r.url,
+        name: r.name ?? null,
+      })),
+    };
+  },
+});

--- a/packages/pieces/community/muna-ai/src/lib/auth.ts
+++ b/packages/pieces/community/muna-ai/src/lib/auth.ts
@@ -1,0 +1,8 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const munaAiAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description:
+    'Go to [Muna Settings → Developer](https://muna.ai/settings/developer) to generate an access key.',
+  required: true,
+});

--- a/packages/pieces/community/muna-ai/tsconfig.json
+++ b/packages/pieces/community/muna-ai/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/muna-ai/tsconfig.lib.json
+++ b/packages/pieces/community/muna-ai/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -854,6 +854,9 @@
       "@activepieces/piece-moxie-crm": [
         "packages/pieces/community/moxie-crm/src/index.ts"
       ],
+      "@activepieces/piece-muna-ai": [
+        "packages/pieces/community/muna-ai/src/index.ts"
+      ],
       "@activepieces/piece-murf-api": [
         "packages/pieces/community/murf-api/src/index.ts"
       ],


### PR DESCRIPTION
Adds a new community piece for Muna AI, an on-device AI inference platform. Includes a Create Prediction action (POST /v1/predictions) with Bearer token auth and a custom API call action.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
