### PR TITLE
fix(flows): admin endpoint to repair v22 output-nesting corruption

### DIFF
--- a/packages/server/api/src/app/ee/platform/admin/admin-platform.controller.ts
+++ b/packages/server/api/src/app/ee/platform/admin/admin-platform.controller.ts
@@ -6,6 +6,7 @@ import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
 import { repoFactory } from '../../../core/db/repo-factory'
 import { securityAccess } from '../../../core/security/authorization/fastify-security'
+import { flowVersionOutputRepairService } from '../../../flows/flow-version/flow-version-output-repair.service'
 import { system } from '../../../helper/system/system'
 import { AppSystemProp } from '../../../helper/system/system-props'
 import { pieceMetadataService } from '../../../pieces/metadata/piece-metadata-service'
@@ -74,6 +75,10 @@ const adminPlatformController: FastifyPluginAsyncZod = async (
         await workerGroupService(req.log).moveJobsToTargetQueue({ platformId, workerGroupId: canary ? CANARY_WORKER_GROUP_ID : null })
         await workerGroupService(req.log).updateCanary({ platformId, canary })
         return res.status(StatusCodes.OK).send()
+    })
+
+    app.post('/flow-versions/repair-output-nesting', RepairOutputNestingRequest, async (req) => {
+        return flowVersionOutputRepairService(req.log).repairOutputNesting(req.body.flowVersionId)
     })
 
     app.post('/chat/sync-all', SyncAllConversationsRequest, async (req, res) => {
@@ -197,6 +202,17 @@ const CreatePieceRequest = {
 }
 
 const SyncAllConversationsRequest = {
+    config: {
+        security: securityAccess.public(),
+    },
+}
+
+const RepairOutputNestingRequest = {
+    schema: {
+        body: z.object({
+            flowVersionId: z.string(),
+        }),
+    },
     config: {
         security: securityAccess.public(),
     },

--- a/packages/server/api/src/app/flows/flow-version/flow-version-output-repair.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/flow-version-output-repair.service.ts
@@ -1,0 +1,65 @@
+import {
+    ActivepiecesError,
+    ErrorCode,
+    FlowActionType,
+    flowStructureUtil,
+    Step,
+} from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { flowVersionRepo } from './flow-version.service'
+import { expressionRewriter } from './migrations/expression-rewriter'
+
+export const flowVersionOutputRepairService = (log: FastifyBaseLogger) => ({
+    async repairOutputNesting(flowVersionId: string): Promise<RepairOutputNestingResponse> {
+        const flowVersion = await flowVersionRepo().findOneBy({ id: flowVersionId })
+        if (flowVersion === null) {
+            throw new ActivepiecesError({
+                code: ErrorCode.ENTITY_NOT_FOUND,
+                params: { entityType: 'flow_version', entityId: flowVersionId },
+            })
+        }
+
+        const erroneousLevels = await countErroneousLevels({
+            flowId: flowVersion.flowId,
+            created: flowVersion.created,
+        })
+        if (erroneousLevels <= 0) {
+            return { flowVersionId, erroneousLevels: 0, stepsChanged: 0 }
+        }
+
+        const stepNames = flowStructureUtil.getAllSteps(flowVersion.trigger).map((step) => step.name)
+        let stepsChanged = 0
+        const repaired = flowStructureUtil.transferFlow(flowVersion, (step: Step) => {
+            const strippedSettings = expressionRewriter.stripOutputDeep(step.settings, stepNames, erroneousLevels)
+            const newStep = { ...step, settings: strippedSettings }
+            if (newStep.type === FlowActionType.CODE) {
+                newStep.settings.sourceCode = step.settings.sourceCode
+            }
+            if (JSON.stringify(step.settings) !== JSON.stringify(newStep.settings)) {
+                stepsChanged++
+            }
+            return newStep
+        })
+
+        await flowVersionRepo().update(flowVersion.id, { trigger: repaired.trigger })
+        log.info({ flowVersionId, erroneousLevels, stepsChanged }, 'Repaired flow version output nesting')
+
+        return { flowVersionId, erroneousLevels, stepsChanged }
+    },
+})
+
+async function countErroneousLevels({ flowId, created }: { flowId: string, created: string }): Promise<number> {
+    const lineageCount = await flowVersionRepo()
+        .createQueryBuilder('flow_version')
+        .where('flow_version."flowId" = :flowId', { flowId })
+        .andWhere('flow_version."created" <= :created', { created })
+        .andWhere('jsonb_exists(flow_version."backupFiles", \'21\')')
+        .getCount()
+    return Math.max(0, lineageCount - 1)
+}
+
+export type RepairOutputNestingResponse = {
+    flowVersionId: string
+    erroneousLevels: number
+    stepsChanged: number
+}

--- a/packages/server/api/src/app/flows/flow-version/migrations/expression-rewriter.ts
+++ b/packages/server/api/src/app/flows/flow-version/migrations/expression-rewriter.ts
@@ -1,4 +1,4 @@
-import { extractMustacheTokens } from '@activepieces/shared'
+import { extractMustacheTokens, isNil } from '@activepieces/shared'
 import { AnyNode, AssignmentProperty, Identifier, MemberExpression, parse, Property } from 'acorn'
 import { ancestor } from 'acorn-walk'
 import { analyze } from 'eslint-scope'
@@ -158,8 +158,132 @@ function isVariableReferenceInProperty(node: Identifier, parent: Property | Assi
     return true
 }
 
+function collectOutputChain(node: Identifier, ancestors: AnyNode[]): MemberExpression[] {
+    const chain: MemberExpression[] = []
+    let child: AnyNode = node
+    let index = ancestors.length - 1
+    while (index - 1 >= 0) {
+        const parent = ancestors[index - 1]
+        if (parent.type !== 'MemberExpression') {
+            break
+        }
+        if (parent.object !== child || !parent.computed) {
+            break
+        }
+        const prop = parent.property
+        if (prop.type !== 'Literal' || prop.value !== 'output') {
+            break
+        }
+        chain.push(parent)
+        child = parent
+        index -= 1
+    }
+    return chain
+}
+
+function stripOutputToken(code: string, stepNames: Set<string>, levels: number): string | null {
+    if (levels <= 0) {
+        return null
+    }
+    let ast: AnyNode
+    try {
+        ast = parse(`(${code})`, { ecmaVersion: ECMA_VERSION, sourceType: 'script', ranges: true })
+    }
+    catch {
+        return null
+    }
+    let scopeManager
+    try {
+        scopeManager = analyze(ast, { ecmaVersion: ECMA_VERSION, sourceType: 'script' })
+    }
+    catch {
+        return null
+    }
+
+    const globalScope = scopeManager.scopes[0]
+    const unresolvedIdentifiers = new Set<unknown>()
+    for (const ref of globalScope.through) {
+        unresolvedIdentifiers.add(ref.identifier)
+    }
+
+    const rewrites: Rewrite[] = []
+    ancestor(ast, {
+        Identifier(node, _state, ancestors) {
+            if (!isStepRef(node.name, stepNames)) {
+                return
+            }
+            if (!unresolvedIdentifiers.has(node)) {
+                return
+            }
+            const parent = ancestors.length >= 2 ? ancestors[ancestors.length - 2] : null
+            if (!isVariableReference(node, parent)) {
+                return
+            }
+            const outputChain = collectOutputChain(node, [...ancestors])
+            const stripCount = Math.min(levels, outputChain.length - 1)
+            for (let i = 0; i < stripCount; i++) {
+                const member = outputChain[i]
+                rewrites.push({
+                    start: member.object.end - WRAP_OFFSET,
+                    end: member.end - WRAP_OFFSET,
+                    text: '',
+                })
+            }
+        },
+    })
+
+    if (rewrites.length === 0) {
+        return null
+    }
+    return applyRewrites(code, rewrites)
+}
+
+function stripOutputDeep<T>(value: T, stepNames: string[], levels: number): T {
+    const stepNameSet = new Set<string>(stepNames)
+    stepNameSet.add(TRIGGER_NAME)
+    return stripOutputDeepWithSet(value, stepNameSet, levels)
+}
+
+function stripOutputDeepWithSet<T>(value: T, stepNameSet: Set<string>, levels: number): T {
+    if (typeof value === 'string') {
+        return stripOutputString({ input: value, stepNameSet, levels }) as T
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => stripOutputDeepWithSet(item, stepNameSet, levels)) as T
+    }
+    if (!isNil(value) && typeof value === 'object') {
+        const result: Record<string, unknown> = {}
+        for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+            result[key] = stripOutputDeepWithSet(child, stepNameSet, levels)
+        }
+        return result as T
+    }
+    return value
+}
+
+function stripOutputString({ input, stepNameSet, levels }: { input: string, stepNameSet: Set<string>, levels: number }): string {
+    if (!input.includes('{{')) {
+        return input
+    }
+    const tokens = extractMustacheTokens(input)
+    if (tokens.length === 0) {
+        return input
+    }
+    const chunks: string[] = []
+    let cursor = 0
+    for (const { token, inner, index } of tokens) {
+        chunks.push(input.slice(cursor, index))
+        const rewritten = stripOutputToken(inner, stepNameSet, levels)
+        chunks.push(rewritten === null ? token : `{{${rewritten}}}`)
+        cursor = index + token.length
+    }
+    chunks.push(input.slice(cursor))
+    return chunks.join('')
+}
+
 export const expressionRewriter = {
     rewriteStepReferences,
+    stripOutputDeep,
 }
 
 const STEP_NAME_PATTERN = /^step_\d+$/

--- a/packages/server/api/test/unit/app/flows/migrations/strip-output-access.test.ts
+++ b/packages/server/api/test/unit/app/flows/migrations/strip-output-access.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { expressionRewriter } from '../../../../../src/app/flows/flow-version/migrations/expression-rewriter'
+
+const strip = (input: string, levels: number, stepNames: string[] = []): string =>
+    expressionRewriter.stripOutputDeep(input, stepNames, levels)
+
+describe('expressionRewriter.stripOutputDeep', () => {
+    it('removes one erroneous level', () => {
+        expect(strip('{{step_1[\'output\'][\'output\'].foo}}', 1))
+            .toBe('{{step_1[\'output\'].foo}}')
+    })
+    it('removes two erroneous levels', () => {
+        expect(strip('{{step_1[\'output\'][\'output\'][\'output\'].foo}}', 2))
+            .toBe('{{step_1[\'output\'].foo}}')
+    })
+    it('never strips below one output (cap leaves >=1)', () => {
+        expect(strip('{{step_1[\'output\'].foo}}', 3))
+            .toBe('{{step_1[\'output\'].foo}}')
+    })
+    it('preserves legit pre-migration bracket access (run longer than levels)', () => {
+        // user wrote step_1[\'output\'] pre-migration -> 1 synthetic + 1 real, plus 1 erroneous = 3
+        expect(strip('{{step_1[\'output\'][\'output\'][\'output\']}}', 1))
+            .toBe('{{step_1[\'output\'][\'output\']}}')
+    })
+    it('handles trigger reference', () => {
+        expect(strip('{{trigger[\'output\'][\'output\'].body}}', 1))
+            .toBe('{{trigger[\'output\'].body}}')
+    })
+    it('does not touch error access', () => {
+        expect(strip('{{step_1[\'output\'][\'error\']}}', 2))
+            .toBe('{{step_1[\'output\'][\'error\']}}')
+    })
+    it('does not touch dot-output (real field)', () => {
+        expect(strip('{{step_1[\'output\'].output}}', 2))
+            .toBe('{{step_1[\'output\'].output}}')
+    })
+    it('strips per-ref independently (mixed depths)', () => {
+        expect(strip('{{step_1[\'output\'][\'output\']}} and {{step_5[\'output\']}}', 1, ['step_1', 'step_5']))
+            .toBe('{{step_1[\'output\']}} and {{step_5[\'output\']}}')
+    })
+    it('leaves non-step identifiers alone', () => {
+        expect(strip('{{foo[\'output\'][\'output\']}}', 1))
+            .toBe('{{foo[\'output\'][\'output\']}}')
+    })
+    it('no-op when levels is zero', () => {
+        expect(strip('{{step_1[\'output\'][\'output\']}}', 0))
+            .toBe('{{step_1[\'output\'][\'output\']}}')
+    })
+    it('strips deeply nested in object values', () => {
+        const input = { a: { b: '{{step_1[\'output\'][\'output\'].x}}' }, c: ['{{step_2[\'output\'][\'output\']}}'] }
+        expect(expressionRewriter.stripOutputDeep(input, ['step_1', 'step_2'], 1))
+            .toEqual({ a: { b: '{{step_1[\'output\'].x}}' }, c: ['{{step_2[\'output\']}}'] })
+    })
+
+    describe('round-trip: repair inverts the erroneous extra migrations', () => {
+        const cases = [
+            '{{step_1.foo}}',
+            '{{step_1}}',
+            '{{step_1.foo[\'bar\'][0].baz}}',
+            '{{step_1[\'output\']}}', // user legitimately accessed an "output" field pre-migration
+            '{{trigger.body.items[2]}}',
+        ]
+        const stepNames = ['step_1']
+        for (const original of cases) {
+            it(`recovers ${original}`, () => {
+                const correct = expressionRewriter.rewriteStepReferences({ input: original, stepNames })
+                let corrupted = correct
+                const extraMigrations = 3
+                for (let i = 0; i < extraMigrations; i++) {
+                    corrupted = expressionRewriter.rewriteStepReferences({ input: corrupted, stepNames })
+                }
+                expect(corrupted).not.toBe(correct)
+                expect(expressionRewriter.stripOutputDeep(corrupted, stepNames, extraMigrations)).toBe(correct)
+            })
+        }
+    })
+
+    describe('multiple output levels x how many to cut', () => {
+        const out = (n: number): string => '[\'output\']'.repeat(n)
+        const ref = (depth: number, suffix = '.foo'): string => `{{step_1${out(depth)}${suffix}}}`
+
+        // [ startingDepth, levelsToCut (E), expectedDepth ]
+        const matrix: [number, number, number][] = [
+            [2, 1, 1], // output output      , cut 1 -> output
+            [3, 1, 2], // output^3           , cut 1 -> output^2 (partial: E underestimates)
+            [3, 2, 1], // output^3           , cut 2 -> output
+            [4, 3, 1], // output^4           , cut 3 -> output
+            [5, 4, 1], // output^5           , cut 4 -> output
+            [5, 2, 3], // output^5           , cut 2 -> output^3 (partial)
+            [3, 9, 1], // E overshoots       , cut capped -> never below 1 output
+            [1, 5, 1], // already correct     , cut nothing (cap leaves >=1)
+        ]
+        for (const [startDepth, levels, expectedDepth] of matrix) {
+            it(`depth ${startDepth}, cut ${levels} -> depth ${expectedDepth}`, () => {
+                expect(expressionRewriter.stripOutputDeep(ref(startDepth), ['step_1'], levels))
+                    .toBe(ref(expectedDepth))
+            })
+        }
+
+        it('cuts each reference by its own available depth, not a flat count', () => {
+            // step_1 has 3 outputs, step_5 (added later) has only 2; cut up to 2
+            const input = `{{step_1${out(3)}}} {{step_5${out(2)}}}`
+            expect(expressionRewriter.stripOutputDeep(input, ['step_1', 'step_5'], 2))
+                .toBe(`{{step_1${out(1)}}} {{step_5${out(1)}}}`)
+        })
+
+        it('preserves a real trailing output field while cutting synthetic ones', () => {
+            // user wrote step_1['output'] (real field) -> correct migration makes output^2;
+            // 2 extra erroneous migrations -> output^4. Cut 2 -> output^2 (1 synthetic + 1 real).
+            expect(expressionRewriter.stripOutputDeep(ref(4, ''), ['step_1'], 2))
+                .toBe(ref(2, ''))
+        })
+    })
+})


### PR DESCRIPTION
Cherry-pick of the output-nesting repair endpoint onto the current cloud deploy branch (`deploy/cloud/2026-06-04`), where the canary is actively producing the corruption. Equivalent of #13592 (against `main`).

## Problem

During the canary rollout the canary migrates a `flow_version` `21 → 22` (reshaping `step_1.foo` → `step_1['output'].foo`). An older node still on `LATEST='21'` stamps it back to `21` on publish (`createEmptyVersion` hardcodes `LATEST_FLOW_SCHEMA_VERSION`), then the canary re-migrates it. The v21→22 migration is not idempotent, so each extra pass injects another synthetic `['output']`, producing `step_1['output']['output']…` that resolves to nothing.

## Fix

`POST /v1/admin/flow-versions/repair-output-nesting` (api-key gated), body `{ flowVersionId }`:

1. Derives erroneous depth `E` from the version lineage — count of same-flow versions created `<=` this one that went `21→22` (via `jsonb_exists("backupFiles",'21')`), minus the one legitimate migration.
2. Strips up to `E` leading `['output']` per step/`trigger` reference via the existing acorn AST machinery, capped so a reference is never reduced below one `['output']`. Handles steps added mid-window, preserves legitimate pre-migration bracket access, only `['output']` (never `['error']`), skips CODE `sourceCode`.

Returns `{ flowVersionId, erroneousLevels, stepsChanged }`.

## Conflict resolution note

The cloud branch carries the pre-refactor `expression-rewriter.ts` (no `rewriteDeep`/idempotent machinery; the v21 migration still uses a local `wrapStepReferencesInOutputProperty`). Only the new `stripOutputDeep` functions + export entry were applied; `main`'s unrelated rewriter refactor was intentionally left out. The round-trip test corrupts via the branch's non-idempotent `rewriteStepReferences` accordingly.

## Notes

- Not idempotent by design (writes immediately, no marker/backup). Run exactly once per id.

## Tests

26 unit tests: strips, cap/floor, `['error']` + real-field preservation, round-trip invertibility, full depth × cut matrix. Build + lint green.
