### PR TITLE
feat(helm): add cache PVC storage class option

### DIFF
--- a/deploy/activepieces-helm/Chart.yaml
+++ b/deploy/activepieces-helm/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/activepieces-helm/templates/pvc.yaml
+++ b/deploy/activepieces-helm/templates/pvc.yaml
@@ -8,7 +8,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  {{- with .Values.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-{{- end }} 
+{{- end }}

--- a/deploy/activepieces-helm/values.yaml
+++ b/deploy/activepieces-helm/values.yaml
@@ -114,6 +114,9 @@ autoscaling:
 persistence:
   enabled: true
   size: 2Gi
+  # Empty preserves the cluster default StorageClass for standalone PVCs.
+  # StatefulSet volume claim templates keep the existing local-path default when empty.
+  storageClassName: ""
   mountPath: "/usr/src/app/cache"
 
 volumes: []


### PR DESCRIPTION
Fixes #10786.

## Summary

- Add `persistence.storageClassName` to the Activepieces Helm chart values.
- Render `storageClassName` on the standalone cache PVC only when a non-empty value is provided.
- Preserve default standalone PVC behavior by omitting `storageClassName` when the value is empty.
- Keep the existing StatefulSet `local-path` default behavior unchanged.

## Verification

- `git diff --check -- deploy/activepieces-helm/Chart.yaml deploy/activepieces-helm/templates/pvc.yaml deploy/activepieces-helm/values.yaml`
- Containerized Helm validation with `alpine/helm:3.15.4`:
  - `helm lint`
  - standalone PVC default omits `storageClassName`
  - standalone PVC custom value renders `storageClassName: "fast-ssd"`
  - standalone PVC explicit empty omits `storageClassName`
  - StatefulSet default preserves `storageClassName: "local-path"`
  - StatefulSet custom value renders `storageClassName: "fast-ssd"`

Note: `npm run lint-dev` was not run because `npm` is not installed in this runner environment.
