### PR TITLE
fix(mcp): support OAuth handshake for subpath-hosted instances

### DIFF
--- a/.agents/features/mcp.md
+++ b/.agents/features/mcp.md
@@ -86,6 +86,10 @@ Bearer token (`Authorization: Bearer {token}`) or query param (`?token={token}`)
 
 OAuth 2.0 PKCE flow is supported for AI clients that require OAuth. The MCP OAuth module (`mcp-oauth.module.ts`) registers metadata, authorization, token, and revocation endpoints.
 
+**Discovery & base-path awareness** — The OAuth issuer, `authorize`/`token`/`register`/`revoke` endpoints, the `resource`, and the `/mcp-authorize` redirect are built via `domainHelper.getPublicUrlFromRequest({ req, path })`. It keeps the request-derived host (so cloud custom domains still work) but appends the path prefix from `AP_FRONTEND_URL`, so subpath-hosted instances (`host/<prefix>/mcp` behind a reverse proxy) advertise URLs under the prefix. On root deployments the prefix is empty and behavior is unchanged.
+
+**RFC 9728 §5.1** — MCP `401` responses include a `WWW-Authenticate: Bearer resource_metadata="…"` header pointing at the prefixed protected-resource metadata URL (`/.well-known/oauth-protected-resource/mcp` for project, `/mcp/platform` for platform), so clients can locate discovery without guessing host-root well-known paths. Clients that ignore the header and probe host-root well-known paths still require the operator to forward `host/.well-known/oauth-*` to AP (that namespace is host-root-anchored by RFC 8414/9728).
+
 ## Server Building
 
 `mcpServerService.buildServer()` — built per-request:

--- a/docs/mcp/overview.mdx
+++ b/docs/mcp/overview.mdx
@@ -61,6 +61,16 @@ Tools are organized into categories. **Discovery tools** are always available. O
 
 See the [Tools Reference](/mcp/tools) for the complete catalog with input schemas.
 
+## Self-Hosting Behind a Reverse Proxy
+
+The MCP server and its OAuth endpoints are reachable both at the host root (`https://your-instance.com/mcp`) and under a path prefix (`https://your-instance.com/<prefix>/mcp`) when your reverse proxy routes `https://host/<prefix>/*` to Activepieces.
+
+For a subpath deployment to work, set `AP_FRONTEND_URL` to the full public URL **including the prefix** (e.g. `https://your-instance.com/activepieces`). Activepieces then advertises its OAuth issuer, authorization/token endpoints, protected-resource metadata, and the `WWW-Authenticate` discovery header under that prefix, so the entire handshake stays inside your proxy rule.
+
+<Note>
+Clients that ignore the `WWW-Authenticate` header and probe the RFC well-known paths at the host root (`https://host/.well-known/oauth-*`) require an additional proxy rule forwarding those host-root paths to Activepieces — that namespace is anchored to the host root by RFC 8414/9728 and cannot be relocated under the prefix. Header-honoring clients (such as Claude) do not need this.
+</Note>
+
 ## Security
 
 - **OAuth authentication** — secure, token-based authentication handled automatically by your MCP client

--- a/packages/server/api/src/app/helper/domain-helper.ts
+++ b/packages/server/api/src/app/helper/domain-helper.ts
@@ -1,3 +1,5 @@
+import { tryCatchSync } from '@activepieces/shared'
+import { FastifyRequest } from 'fastify'
 import { networkUtils } from './network-utils'
 import { system } from './system/system'
 import { AppSystemProp } from './system/system-props'
@@ -5,6 +7,11 @@ import { AppSystemProp } from './system/system-props'
 export const domainHelper = {
     async getPublicUrl({ path }: PublicUrlParams): Promise<string> {
         return networkUtils.combineUrl(system.getOrThrow(AppSystemProp.FRONTEND_URL), path ?? '')
+    },
+    getPublicUrlFromRequest({ req, path }: PublicUrlFromRequestParams): string {
+        const requestBase = networkUtils.getRequestBaseUrl(req)
+        const baseWithPrefix = networkUtils.combineUrl(requestBase, getConfiguredBasePath())
+        return cleanTrailingSlash(networkUtils.combineUrl(baseWithPrefix, path ?? ''))
     },
     async getPublicApiUrl({ path }: PublicUrlParams): Promise<string> {
         return domainHelper.getPublicUrl({ path: `/api/${cleanLeadingSlash(path ?? '')}` })
@@ -33,7 +40,21 @@ function cleanLeadingSlash(path: string) {
     return path.startsWith('/') ? path.slice(1) : path
 }
 
+function cleanTrailingSlash(url: string) {
+    return url.endsWith('/') ? url.slice(0, -1) : url
+}
+
+function getConfiguredBasePath(): string {
+    const { data: url } = tryCatchSync(() => new URL(system.getOrThrow(AppSystemProp.FRONTEND_URL)))
+    return url && url.pathname !== '/' ? url.pathname : ''
+}
+
 type PublicUrlParams = {
+    path?: string
+}
+
+type PublicUrlFromRequestParams = {
+    req: FastifyRequest
     path?: string
 }
 

--- a/packages/server/api/src/app/mcp/oauth/code/mcp-oauth-authorize.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/code/mcp-oauth-authorize.controller.ts
@@ -2,8 +2,8 @@ import { isNil } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { z } from 'zod'
 import { securityAccess } from '../../../core/security/authorization/fastify-security'
+import { domainHelper } from '../../../helper/domain-helper'
 import { JwtAudience, jwtUtils } from '../../../helper/jwt-utils'
-import { networkUtils } from '../../../helper/network-utils'
 import { mcpOAuthClientService } from '../client/mcp-oauth-client.service'
 
 const AUTH_REQUEST_TTL_10_MINUTES_SECONDS = 10 * 60
@@ -48,7 +48,7 @@ export const mcpOAuthAuthorizeController: FastifyPluginAsyncZod = async (app) =>
             audience: JwtAudience.MCP_OAUTH_AUTH_REQUEST,
         })
 
-        const authorizePageUrl = new URL('/mcp-authorize', networkUtils.getRequestBaseUrl(req))
+        const authorizePageUrl = new URL(domainHelper.getPublicUrlFromRequest({ req, path: '/mcp-authorize' }))
         authorizePageUrl.searchParams.set('authRequestId', authRequestToken)
 
         return reply.redirect(authorizePageUrl.toString())

--- a/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
@@ -1,11 +1,12 @@
 import { isNil, McpServerType, PopulatedMcpServer, TelemetryEventName, tryCatch } from '@activepieces/shared'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
-import { FastifyBaseLogger } from 'fastify'
+import { FastifyBaseLogger, FastifyReply, FastifyRequest } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { repoFactory } from '../../core/db/repo-factory'
 import { securityAccess } from '../../core/security/authorization/fastify-security'
 import { ChatConversationEntity } from '../../ee/chat/chat-conversation-entity'
 import { CONVERSATION_ID_HEADER } from '../../ee/chat/mcp/chat-mcp'
+import { domainHelper } from '../../helper/domain-helper'
 import { rejectedPromiseHandler } from '../../helper/promise-handler'
 import { telemetry } from '../../helper/telemetry.utils'
 import { mcpServerService } from '../mcp-service'
@@ -50,26 +51,17 @@ function registerMcpEndpoint(app: Parameters<FastifyPluginAsyncZod>[0], scope: M
         const [type, token] = authHeader?.split(' ') ?? []
 
         if (type !== 'Bearer' || isNil(token)) {
-            return reply.status(401).send({
-                error: 'unauthorized',
-                message: 'Authorization: Bearer <token> required',
-            })
+            return unauthorized({ req, reply, scope, message: 'Authorization: Bearer <token> required' })
         }
 
         const identity = await resolveIdentity({ token, scope, log: req.log })
         if (isNil(identity)) {
-            return reply.status(401).send({
-                error: 'unauthorized',
-                message: 'Invalid or expired access token',
-            })
+            return unauthorized({ req, reply, scope, message: 'Invalid or expired access token', invalidToken: true })
         }
 
         const { mcp, userId } = await resolveMcpAndUser({ identity, log: req.log })
         if (isNil(mcp)) {
-            return reply.status(401).send({
-                error: 'unauthorized',
-                message: 'Invalid project or token.',
-            })
+            return unauthorized({ req, reply, scope, message: 'Invalid project or token.', invalidToken: true })
         }
 
         const conversationId = req.headers[CONVERSATION_ID_HEADER] as string | undefined
@@ -92,6 +84,27 @@ function registerMcpEndpoint(app: Parameters<FastifyPluginAsyncZod>[0], scope: M
 
         await server.connect(transport)
         await transport.handleRequest(req.raw, reply.raw, req.body)
+    })
+}
+
+function unauthorized({ req, reply, scope, message, invalidToken }: {
+    req: FastifyRequest
+    reply: FastifyReply
+    scope: McpServerType
+    message: string
+    invalidToken?: boolean
+}): FastifyReply {
+    const resourcePath = scope === McpServerType.PLATFORM ? 'mcp/platform' : 'mcp'
+    const resourceMetadataUrl = domainHelper.getPublicUrlFromRequest({
+        req,
+        path: `/.well-known/oauth-protected-resource/${resourcePath}`,
+    })
+    const challenge = invalidToken
+        ? `Bearer error="invalid_token", resource_metadata="${resourceMetadataUrl}"`
+        : `Bearer resource_metadata="${resourceMetadataUrl}"`
+    return reply.status(401).header('WWW-Authenticate', challenge).send({
+        error: 'unauthorized',
+        message,
     })
 }
 

--- a/packages/server/api/src/app/mcp/oauth/metadata/mcp-oauth-metadata.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/metadata/mcp-oauth-metadata.controller.ts
@@ -1,11 +1,11 @@
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { securityAccess } from '../../../core/security/authorization/fastify-security'
-import { networkUtils } from '../../../helper/network-utils'
+import { domainHelper } from '../../../helper/domain-helper'
 
 export const mcpOAuthMetadataController: FastifyPluginAsyncZod = async (app) => {
 
     app.get('/.well-known/oauth-authorization-server', PublicMetadataRequest, async (req, reply) => {
-        const issuer = networkUtils.getRequestBaseUrl(req)
+        const issuer = domainHelper.getPublicUrlFromRequest({ req })
         return reply.status(200).header('Access-Control-Allow-Origin', '*').send({
             issuer,
             authorization_endpoint: `${issuer}/authorize`,
@@ -21,7 +21,7 @@ export const mcpOAuthMetadataController: FastifyPluginAsyncZod = async (app) => 
     })
 
     app.get('/.well-known/oauth-protected-resource/mcp', PublicMetadataRequest, async (req, reply) => {
-        const issuer = networkUtils.getRequestBaseUrl(req)
+        const issuer = domainHelper.getPublicUrlFromRequest({ req })
         return reply.status(200).header('Access-Control-Allow-Origin', '*').send({
             resource: `${issuer}/mcp`,
             authorization_servers: [issuer],
@@ -29,7 +29,7 @@ export const mcpOAuthMetadataController: FastifyPluginAsyncZod = async (app) => 
     })
 
     app.get('/.well-known/oauth-protected-resource/mcp/platform', PublicMetadataRequest, async (req, reply) => {
-        const issuer = networkUtils.getRequestBaseUrl(req)
+        const issuer = domainHelper.getPublicUrlFromRequest({ req })
         return reply.status(200).header('Access-Control-Allow-Origin', '*').send({
             resource: `${issuer}/mcp/platform`,
             authorization_servers: [issuer],

--- a/packages/server/api/test/integration/ce/mcp/mcp-oauth-discovery.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-oauth-discovery.test.ts
@@ -1,0 +1,107 @@
+import { FastifyInstance } from 'fastify'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { system } from '../../../../src/app/helper/system/system'
+import { AppSystemProp } from '../../../../src/app/helper/system/system-props'
+import { setupTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+const DEFAULT_FRONTEND_URL = 'https://example.com/activepieces'
+let frontendUrl = DEFAULT_FRONTEND_URL
+
+const subpathHeaders = {
+    'x-forwarded-host': 'example.com',
+    'x-forwarded-proto': 'https',
+}
+
+describe('MCP OAuth discovery', () => {
+    beforeAll(async () => {
+        app = await setupTestEnvironment({ fresh: true })
+        const original = system.getOrThrow.bind(system)
+        vi.spyOn(system, 'getOrThrow').mockImplementation((prop) => {
+            if (prop === AppSystemProp.FRONTEND_URL) {
+                return frontendUrl
+            }
+            return original(prop)
+        })
+    })
+
+    afterEach(() => {
+        frontendUrl = DEFAULT_FRONTEND_URL
+    })
+
+    afterAll(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('advertises authorization server metadata under the configured base path', async () => {
+        const res = await app.inject({
+            method: 'GET',
+            url: '/.well-known/oauth-authorization-server',
+            headers: subpathHeaders,
+        })
+
+        expect(res.statusCode).toBe(200)
+        const body = res.json()
+        expect(body.issuer).toBe('https://example.com/activepieces')
+        expect(body.authorization_endpoint).toBe('https://example.com/activepieces/authorize')
+        expect(body.token_endpoint).toBe('https://example.com/activepieces/token')
+        expect(body.registration_endpoint).toBe('https://example.com/activepieces/register')
+        expect(body.revocation_endpoint).toBe('https://example.com/activepieces/revoke')
+    })
+
+    it('advertises the protected resource under the configured base path', async () => {
+        const res = await app.inject({
+            method: 'GET',
+            url: '/.well-known/oauth-protected-resource/mcp',
+            headers: subpathHeaders,
+        })
+
+        expect(res.statusCode).toBe(200)
+        const body = res.json()
+        expect(body.resource).toBe('https://example.com/activepieces/mcp')
+        expect(body.authorization_servers).toEqual(['https://example.com/activepieces'])
+    })
+
+    it('returns WWW-Authenticate pointing at the prefixed resource metadata on a project 401', async () => {
+        const res = await app.inject({
+            method: 'POST',
+            url: '/mcp',
+            headers: subpathHeaders,
+            payload: {},
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.headers['www-authenticate']).toBe(
+            'Bearer resource_metadata="https://example.com/activepieces/.well-known/oauth-protected-resource/mcp"',
+        )
+    })
+
+    it('returns the platform resource metadata in WWW-Authenticate on a platform 401', async () => {
+        const res = await app.inject({
+            method: 'POST',
+            url: '/mcp/platform',
+            headers: subpathHeaders,
+            payload: {},
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.headers['www-authenticate']).toBe(
+            'Bearer resource_metadata="https://example.com/activepieces/.well-known/oauth-protected-resource/mcp/platform"',
+        )
+    })
+
+    it('keeps the request host with no prefix when FRONTEND_URL has no base path', async () => {
+        frontendUrl = 'https://custom-domain.com'
+
+        const res = await app.inject({
+            method: 'GET',
+            url: '/.well-known/oauth-authorization-server',
+            headers: { 'x-forwarded-host': 'custom-domain.com', 'x-forwarded-proto': 'https' },
+        })
+
+        expect(res.statusCode).toBe(200)
+        const body = res.json()
+        expect(body.issuer).toBe('https://custom-domain.com')
+        expect(body.authorization_endpoint).toBe('https://custom-domain.com/authorize')
+    })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP OAuth handshake for **self-hosted instances served under a URL path prefix** (a reverse proxy routing `https://host/<prefix>/*` to Activepieces, e.g. `https://ourdomain.com/activepieces/mcp`).

Before this change, the MCP transport worked under a prefix but OAuth did not, so clients like Claude could never authenticate. Two defects caused it:

1. **Advertised URLs dropped the prefix.** The OAuth issuer, `authorize`/`token`/`register`/`revoke` endpoints, the `resource`, and the `/mcp-authorize` redirect were all built from the request host only (`scheme://host`). They resolved to the **host root**, outside the proxy's `/<prefix>/*` rule, so they never reached AP.
2. **The MCP 401 had no `WWW-Authenticate` header.** Per RFC 9728 §5.1 the protected resource must return `WWW-Authenticate: Bearer resource_metadata="…"` so the client can locate discovery. Without it, the client guessed the well-known URL at the host root — outside the prefix again.

### Explain How the Feature Works

- New helper `domainHelper.getPublicUrlFromRequest({ req, path })` keeps the **request-derived host** (preserving cloud custom domains, the reason `MCP_OAUTH_ISSUER_URL` was removed in #13143) but **appends the path prefix taken from `AP_FRONTEND_URL`**. On cloud/root deployments the prefix is empty, so behavior there is unchanged.
- Discovery metadata (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource/mcp[/platform]`) and the `/mcp-authorize` redirect now use this helper, so every advertised URL carries the prefix.
- The MCP `401` responses now emit `WWW-Authenticate: Bearer resource_metadata="…"` pointing at the **prefixed** protected-resource metadata URL (`mcp` for project, `mcp/platform` for platform). The whole discovery flow stays under the proxy prefix.

Operators just set `AP_FRONTEND_URL` to the full public URL including the prefix (e.g. `https://ourdomain.com/activepieces`) — no new env var, no proxy root-rule changes.

**Caveat (documented):** clients that ignore `WWW-Authenticate` and probe RFC well-known paths at the host root still need a proxy rule forwarding `host/.well-known/oauth-*` to AP — that namespace is host-root-anchored by RFC 8414/9728. Header-honoring clients (Claude) do not need this.

### Relevant User Scenarios

- Self-hosted Activepieces behind a reverse proxy (Kong/NGINX) at a subpath such as `host/activepieces/*`, connecting Claude / Cursor / Claude.ai to the MCP server.
- Pylon #4867 (Funding Societies) — MCP OAuth handshake failing on a subpath-hosted instance.

### Tests

- New integration test `mcp-oauth-discovery.test.ts`: prefixed issuer/endpoints/resource, `WWW-Authenticate` on project and platform 401s, and the no-prefix (cloud custom-domain) regression case.

Fixes #13596
