### PR TITLE
feat(pieces): add Ollabear piece

### DIFF
--- a/packages/pieces/community/ollabear/.eslintrc.json
+++ b/packages/pieces/community/ollabear/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    { "files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {} },
+    { "files": ["*.ts", "*.tsx"], "rules": {} },
+    { "files": ["*.js", "*.jsx"], "rules": {} }
+  ]
+}

--- a/packages/pieces/community/ollabear/README.md
+++ b/packages/pieces/community/ollabear/README.md
@@ -1,0 +1,9 @@
+# Ollabear
+
+Automate the [Ollabear](https://ollabear.com) AI chat platform from Activepieces.
+
+**Triggers:** Conversation Created, Conversation Closed, New Message (webhook-based; deliveries are HMAC-SHA256 verified).
+
+**Actions:** Send Message, Set Conversation Status, Set Conversation Tags, Get Conversation.
+
+**Auth:** a Personal Access Token (`pat_…`) — mint one in the Ollabear dashboard under **Settings → API Tokens** using the **Automation (Activepieces)** preset (grants `conversations_read/write`, `messages_write`, `webhooks_write`). Not the public `qk_` widget key.

--- a/packages/pieces/community/ollabear/package.json
+++ b/packages/pieces/community/ollabear/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-ollabear",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/ollabear/src/index.ts
+++ b/packages/pieces/community/ollabear/src/index.ts
@@ -1,0 +1,27 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { ollabearAuth } from './lib/common';
+import { sendMessage, setStatus, setTags, getConversation } from './lib/actions';
+import {
+  conversationCreated,
+  conversationClosed,
+  messageCreated,
+} from './lib/triggers';
+
+// Ollabear — automate the Ollabear AI chat platform. Triggers react to chat
+// events and actions act on conversations, all through Ollabear's
+// /v1/integrations PAT-scoped API. Authenticate with a Personal Access Token
+// minted in the Ollabear dashboard (Settings → API Tokens → "Automation
+// (Activepieces)" preset).
+export const ollabear = createPiece({
+  displayName: 'Ollabear',
+  description:
+    'Automate your Ollabear AI chat platform — trigger flows on new/closed conversations and messages, and send replies, set status, or tag conversations.',
+  auth: ollabearAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://app.ollabear.com/favicon.svg',
+  categories: [PieceCategory.CUSTOMER_SUPPORT, PieceCategory.COMMUNICATION],
+  authors: ['vikasswaminh'],
+  actions: [sendMessage, setStatus, setTags, getConversation],
+  triggers: [conversationCreated, conversationClosed, messageCreated],
+});

--- a/packages/pieces/community/ollabear/src/lib/actions.ts
+++ b/packages/pieces/community/ollabear/src/lib/actions.ts
@@ -1,0 +1,110 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { ollabearAuth, ollabearRequest, coerceAuth } from './common';
+
+const conversationIdProp = Property.ShortText({
+  displayName: 'Conversation ID',
+  description: 'The conversation UUID (e.g. from a trigger output).',
+  required: true,
+});
+
+export const sendMessage = createAction({
+  auth: ollabearAuth,
+  name: 'send_message',
+  displayName: 'Send Message',
+  description: 'Post a message into a conversation (appears as an operator reply). Requires scope: messages_write.',
+  props: {
+    conversationId: conversationIdProp,
+    content: Property.LongText({
+      displayName: 'Message',
+      description: 'Message body (max 4096 chars).',
+      required: true,
+    }),
+    isInternal: Property.Checkbox({
+      displayName: 'Internal note',
+      description: 'If on, the message is an internal note (not shown to the visitor).',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { conversationId, content, isInternal } = context.propsValue;
+    return ollabearRequest(
+      coerceAuth(context.auth),
+      HttpMethod.POST,
+      `/conversations/${conversationId}/messages`,
+      { content, is_internal: isInternal ?? false },
+    );
+  },
+});
+
+export const setStatus = createAction({
+  auth: ollabearAuth,
+  name: 'set_status',
+  displayName: 'Set Conversation Status',
+  description: 'Open or close a conversation. Requires scope: conversations_write.',
+  props: {
+    conversationId: conversationIdProp,
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      required: true,
+      options: {
+        options: [
+          { label: 'Active', value: 'active' },
+          { label: 'Closed', value: 'closed' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { conversationId, status } = context.propsValue;
+    return ollabearRequest(
+      coerceAuth(context.auth),
+      HttpMethod.PATCH,
+      `/conversations/${conversationId}/status`,
+      { status },
+    );
+  },
+});
+
+export const setTags = createAction({
+  auth: ollabearAuth,
+  name: 'set_tags',
+  displayName: 'Set Conversation Tags',
+  description: 'Replace the tags on a conversation. Requires scope: conversations_write.',
+  props: {
+    conversationId: conversationIdProp,
+    tags: Property.Array({
+      displayName: 'Tags',
+      description: 'The full tag set (replaces existing tags).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { conversationId, tags } = context.propsValue;
+    return ollabearRequest(
+      coerceAuth(context.auth),
+      HttpMethod.PATCH,
+      `/conversations/${conversationId}/tags`,
+      { tags: (tags as string[]) ?? [] },
+    );
+  },
+});
+
+export const getConversation = createAction({
+  auth: ollabearAuth,
+  name: 'get_conversation',
+  displayName: 'Get Conversation',
+  description: 'Fetch a single conversation by ID (status, subject, tags, metadata). Requires scope: conversations_read.',
+  props: {
+    conversationId: conversationIdProp,
+  },
+  async run(context) {
+    const { conversationId } = context.propsValue;
+    return ollabearRequest(
+      coerceAuth(context.auth),
+      HttpMethod.GET,
+      `/conversations/${conversationId}`,
+    );
+  },
+});

--- a/packages/pieces/community/ollabear/src/lib/common.ts
+++ b/packages/pieces/community/ollabear/src/lib/common.ts
@@ -1,0 +1,161 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod, HttpHeaders } from '@activepieces/pieces-common';
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+//
+// Ollabear's server-to-server surface (/v1/integrations) is authed by a
+// scoped Personal Access Token (Bearer pat_…), NOT the public qk_ widget
+// key — the widget key is origin-locked and meant for the browser.
+//
+// Mint a PAT in the dashboard: Settings → API tokens → New token, with the
+// scopes the flow needs (conversations_read/write, messages_write,
+// webhooks_write — triggers need webhooks_write to self-register).
+
+export const ollabearAuth = PieceAuth.CustomAuth({
+  description:
+    'Connect using a Personal Access Token (pat_…) minted in the Ollabear dashboard under Settings → API tokens. ' +
+    'Grant the scopes your flow needs: messages_write (send), conversations_read/write (read/tag/close), ' +
+    'webhooks_write (required for triggers to self-register).',
+  required: true,
+  props: {
+    baseUrl: Property.ShortText({
+      displayName: 'Ollabear Base URL',
+      description: 'Your Ollabear API base URL.',
+      required: true,
+      defaultValue: 'https://app.ollabear.com',
+    }),
+    token: PieceAuth.SecretText({
+      displayName: 'Personal Access Token',
+      description: 'The pat_… token. Stored encrypted; shown only once at mint time.',
+      required: true,
+    }),
+  },
+});
+
+export interface OllabearAuth {
+  baseUrl: string;
+  token: string;
+}
+
+// coerceAuth normalises whatever Activepieces hands us in `context.auth`.
+// At runtime a CustomAuth value is the unwrapped props object
+// ({ baseUrl, token }); some framework versions *type* it as the wrapped
+// connection shape ({ type, props }). Reading `props ?? self` through
+// `unknown` handles both without fighting version-specific types.
+export function coerceAuth(raw: unknown): OllabearAuth {
+  const v = (raw ?? {}) as {
+    baseUrl?: string;
+    token?: string;
+    props?: { baseUrl?: string; token?: string };
+  };
+  const p = v.props ?? v;
+  return { baseUrl: String(p.baseUrl ?? ''), token: String(p.token ?? '') };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helper
+// ---------------------------------------------------------------------------
+
+function trimSlash(u: string): string {
+  return u.replace(/\/+$/, '');
+}
+
+export async function ollabearRequest<T = unknown>(
+  auth: OllabearAuth,
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const headers: HttpHeaders = {
+    Authorization: `Bearer ${auth.token}`,
+    'Content-Type': 'application/json',
+  };
+  const res = await httpClient.sendRequest<T>({
+    method,
+    url: `${trimSlash(auth.baseUrl)}/v1/integrations${path}`,
+    headers,
+    body: body as Record<string, unknown> | undefined,
+  });
+  return res.body;
+}
+
+// ---------------------------------------------------------------------------
+// Webhook subscription lifecycle (shared by every trigger)
+// ---------------------------------------------------------------------------
+
+const WEBHOOK_STORE_KEY = '_ollabear_webhook_id';
+const WEBHOOK_SECRET_KEY = '_ollabear_webhook_secret';
+
+type CreatedWebhook = { id: string; secret?: string };
+
+type Store = {
+  put: (k: string, v: unknown) => Promise<unknown>;
+  get: (k: string) => Promise<unknown>;
+};
+
+export async function registerWebhook(
+  auth: OllabearAuth,
+  store: Store,
+  webhookUrl: string,
+  events: string[],
+): Promise<void> {
+  const created = await ollabearRequest<CreatedWebhook>(auth, HttpMethod.POST, '/webhooks', {
+    url: webhookUrl,
+    events,
+    description: `Activepieces trigger (${events.join(', ')})`,
+  });
+  await store.put(WEBHOOK_STORE_KEY, created.id);
+  // The HMAC signing secret is returned ONCE at creation — stash it so run()
+  // can verify the X-Webhook-Signature header on each delivery.
+  if (created.secret) {
+    await store.put(WEBHOOK_SECRET_KEY, created.secret);
+  }
+}
+
+export async function getStoredSecret(store: { get: (k: string) => Promise<unknown> }): Promise<string | undefined> {
+  const s = await store.get(WEBHOOK_SECRET_KEY);
+  return typeof s === 'string' && s.length > 0 ? s : undefined;
+}
+
+// verifyDelivery checks Ollabear's X-Webhook-Signature header against the raw
+// request body: hex(HMAC-SHA256(rawBody, secret)). Returns true = accept.
+//   - No stored secret (older subscription) → accept (can't verify, don't drop).
+//   - Secret present but rawBody unavailable → accept (some AP runtimes don't
+//     surface rawBody; re-serialising risks byte mismatch, so we don't block).
+//   - Secret + rawBody present → strict constant-time compare; mismatch = drop.
+export function verifyDelivery(
+  payload: { rawBody?: unknown; headers?: Record<string, string> },
+  secret: string | undefined,
+): boolean {
+  if (!secret) return true;
+  const raw = payload.rawBody;
+  const rawStr =
+    typeof raw === 'string' ? raw : Buffer.isBuffer(raw) ? raw.toString('utf8') : undefined;
+  if (rawStr === undefined) return true;
+
+  const headers = payload.headers ?? {};
+  const sig = headers['x-webhook-signature'] ?? headers['X-Webhook-Signature'];
+  if (!sig) return false; // secret expected, signature missing → reject
+
+  const expected = createHmac('sha256', secret).update(rawStr).digest('hex');
+  const a = Buffer.from(expected);
+  const b = Buffer.from(sig);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export async function unregisterWebhook(
+  auth: OllabearAuth,
+  store: { get: (k: string) => Promise<unknown> },
+): Promise<void> {
+  const id = (await store.get(WEBHOOK_STORE_KEY)) as string | undefined;
+  if (!id) return;
+  // Best-effort: a 404 (already gone) must not block flow teardown.
+  try {
+    await ollabearRequest(auth, HttpMethod.DELETE, `/webhooks/${id}`);
+  } catch {
+    /* swallow — the subscription is gone either way */
+  }
+}

--- a/packages/pieces/community/ollabear/src/lib/triggers.ts
+++ b/packages/pieces/community/ollabear/src/lib/triggers.ts
@@ -1,0 +1,112 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import {
+  ollabearAuth,
+  registerWebhook,
+  unregisterWebhook,
+  coerceAuth,
+  getStoredSecret,
+  verifyDelivery,
+} from './common';
+
+// Every Ollabear trigger is the same shape: on enable it POSTs a webhook
+// subscription for one event type to /v1/integrations/webhooks (pointing at
+// the unique, unguessable Activepieces flow URL), stores the returned HMAC
+// secret, and on disable it deletes the subscription. The factory keeps the
+// three of them in lockstep.
+//
+// Security: deliveries are HMAC-SHA256 signed (X-Webhook-Signature). run()
+// verifies the signature against the stored secret + raw body and DROPS any
+// delivery that fails — so a leaked/guessed webhook URL can't inject events.
+// (Falls back to accept only when the runtime can't supply rawBody; see
+// verifyDelivery.)
+
+function ollabearWebhookTrigger(opts: {
+  name: string;
+  event: string;
+  displayName: string;
+  description: string;
+  sampleData: Record<string, unknown>;
+}) {
+  return createTrigger({
+    auth: ollabearAuth,
+    name: opts.name,
+    displayName: opts.displayName,
+    description: opts.description,
+    type: TriggerStrategy.WEBHOOK,
+    props: {},
+    sampleData: opts.sampleData,
+    async onEnable(context) {
+      await registerWebhook(
+        coerceAuth(context.auth),
+        context.store,
+        context.webhookUrl,
+        [opts.event],
+      );
+    },
+    async onDisable(context) {
+      await unregisterWebhook(coerceAuth(context.auth), context.store);
+    },
+    async run(context) {
+      // Verify the HMAC signature before trusting the delivery; drop on
+      // mismatch so only genuinely Ollabear-signed events flow downstream.
+      const secret = await getStoredSecret(context.store);
+      if (!verifyDelivery(context.payload, secret)) {
+        return [];
+      }
+      // Ollabear POSTs the event envelope as the request body; surface it
+      // verbatim as the single item this trigger produces.
+      return [context.payload.body];
+    },
+  });
+}
+
+export const conversationCreated = ollabearWebhookTrigger({
+  name: 'conversation_created',
+  event: 'conversation.created',
+  displayName: 'Conversation Created',
+  description: 'Fires when a new conversation starts (e.g. a visitor opens the widget).',
+  sampleData: {
+    event: 'conversation.created',
+    conversation: {
+      id: '7e1609bf-9199-4b8a-8b89-4b859ea0f937',
+      status: 'active',
+      subject: 'Pricing question',
+      tags: [],
+      created_at: '2026-06-09T12:00:00Z',
+    },
+  },
+});
+
+export const conversationClosed = ollabearWebhookTrigger({
+  name: 'conversation_closed',
+  event: 'conversation.closed',
+  displayName: 'Conversation Closed',
+  description: 'Fires when a conversation is closed — good for CSAT, CRM sync, follow-up.',
+  sampleData: {
+    event: 'conversation.closed',
+    conversation: {
+      id: '7e1609bf-9199-4b8a-8b89-4b859ea0f937',
+      status: 'closed',
+      subject: 'Pricing question',
+      tags: ['resolved'],
+      closed_at: '2026-06-09T12:15:00Z',
+    },
+  },
+});
+
+export const messageCreated = ollabearWebhookTrigger({
+  name: 'message_created',
+  event: 'message.created',
+  displayName: 'New Message',
+  description: 'Fires on every new message (visitor or bot) in any conversation.',
+  sampleData: {
+    event: 'message.created',
+    message: {
+      id: 'b1d2c3e4-0000-4000-8000-000000000000',
+      conversation_id: '7e1609bf-9199-4b8a-8b89-4b859ea0f937',
+      role: 'visitor',
+      content: 'Do you offer annual billing?',
+      created_at: '2026-06-09T12:01:00Z',
+    },
+  },
+});

--- a/packages/pieces/community/ollabear/tsconfig.json
+++ b/packages/pieces/community/ollabear/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/packages/pieces/community/ollabear/tsconfig.lib.json
+++ b/packages/pieces/community/ollabear/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What
Adds an **Ollabear** community piece — automation for the [Ollabear](https://ollabear.com) AI chat platform.

### Triggers (webhook-based, self-register on enable / delete on disable)
- **Conversation Created** — `conversation.created`
- **Conversation Closed** — `conversation.closed`
- **New Message** — `message.created`

Deliveries are verified against the `X-Webhook-Signature` header (`hex(HMAC-SHA256(rawBody, secret))`); the secret is returned once at subscription creation. Mismatches are dropped.

### Actions
- **Send Message**, **Set Conversation Status**, **Set Conversation Tags**, **Get Conversation**

### Auth
`PieceAuth.CustomAuth` (base URL + a Personal Access Token, `pat_…`). Users mint one in the Ollabear dashboard (**Settings → API Tokens → "Automation (Activepieces)"** preset) — not the public widget key. All calls go through Ollabear's server-side `/v1/integrations` PAT-scoped API.

## Notes
- Scaffolded from the standard community-piece layout (`tsconfig`, `tsconfig.lib.json`, `.eslintrc.json` mirror an existing piece).
- All triggers/actions were exercised end-to-end against a live Ollabear backend before submission.
- Logo is a live square SVG (`app.ollabear.com/favicon.svg`); happy to switch to a CDN-hosted PNG if preferred.

I have read and signed the CLA.
