### PR TITLE
fix(web): require chat message text before sending

### DIFF
--- a/packages/web/src/features/chat/chat-input/chat-input-utils.test.ts
+++ b/packages/web/src/features/chat/chat-input/chat-input-utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { chatInputUtils } from './chat-input-utils';
+
+describe('chatInputUtils.canSubmitMessage', () => {
+  it('requires non-empty message text', () => {
+    expect(
+      chatInputUtils.canSubmitMessage({
+        disabled: false,
+        textContent: '',
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects whitespace-only message text', () => {
+    expect(
+      chatInputUtils.canSubmitMessage({
+        disabled: false,
+        textContent: '   ',
+      }),
+    ).toBe(false);
+  });
+
+  it('allows non-empty message text', () => {
+    expect(
+      chatInputUtils.canSubmitMessage({
+        disabled: false,
+        textContent: 'hello',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not allow sending while disabled', () => {
+    expect(
+      chatInputUtils.canSubmitMessage({
+        disabled: true,
+        textContent: 'hello',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/web/src/features/chat/chat-input/chat-input-utils.ts
+++ b/packages/web/src/features/chat/chat-input/chat-input-utils.ts
@@ -1,0 +1,13 @@
+function canSubmitMessage({
+  disabled,
+  textContent,
+}: {
+  disabled: boolean;
+  textContent: string;
+}): boolean {
+  return !disabled && textContent.trim().length > 0;
+}
+
+export const chatInputUtils = {
+  canSubmitMessage,
+};

--- a/packages/web/src/features/chat/chat-input/index.tsx
+++ b/packages/web/src/features/chat/chat-input/index.tsx
@@ -8,6 +8,7 @@ import { ResizableTextareaProps, Textarea } from '@/components/ui/textarea';
 import { useElementSize } from '@/hooks/use-element-size';
 import { cn } from '@/lib/utils';
 
+import { chatInputUtils } from './chat-input-utils';
 import { FileInputPreview } from './file-input-preview';
 
 export interface ChatMessage {
@@ -54,9 +55,14 @@ const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
       setFiles((prevFiles) => prevFiles.filter((_, i) => i !== index));
     };
 
+    const canSubmit = chatInputUtils.canSubmitMessage({
+      disabled,
+      textContent: input,
+    });
+
     const handleSubmit = (e: React.FormEvent) => {
       e.preventDefault();
-      if ((!input && files.length === 0) || disabled) return;
+      if (!canSubmit) return;
 
       onSendMessage({
         textContent: input,
@@ -71,7 +77,7 @@ const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
-        if (!disabled && (input || files.length > 0)) {
+        if (canSubmit) {
           handleSubmit(e as unknown as React.FormEvent);
         }
       }
@@ -153,7 +159,7 @@ const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
                 className="hidden"
               />
               <Button
-                disabled={(!input && files.length === 0) || disabled}
+                disabled={!canSubmit}
                 type="submit"
                 size="icon"
                 variant="default"


### PR DESCRIPTION
## What does this PR do?

Prevents the Human Input Chat UI from submitting a file-only message when the chat trigger requires `message` to be present. The input now only enables send/Enter submit when the user has typed non-whitespace text, while still allowing files to be attached to a text message.

### Explain How the Feature Works

The chat input uses a shared `canSubmitMessage` helper so the submit button, Enter key handler, and form submit path all enforce the same text-required rule.

### Relevant User Scenarios

- A user uploads a file in Chat UI without typing a message; the send button remains disabled instead of sending a request that fails with `Message is required`.
- A user types a message and attaches files; the chat submits as before.

### Verification

- `PATH=/opt/homebrew/Cellar/node/25.8.1_1/bin:$PATH node_modules/.bin/vitest run packages/web/src/features/chat/chat-input/chat-input-utils.test.ts --config packages/web/vitest.config.ts`
- `PATH=/opt/homebrew/Cellar/node/25.8.1_1/bin:$PATH node_modules/.bin/turbo run lint --filter=web -- --fix`
- `PATH=/opt/homebrew/Cellar/node/25.8.1_1/bin:$PATH node_modules/.bin/turbo run typecheck --filter=web`

Fixes #9399