### PR TITLE
feat(embed-sdk): add embedding.hideActiveUsers flag to suppress active users widget

### DIFF
--- a/docs/embedding/embed-builder.mdx
+++ b/docs/embedding/embed-builder.mdx
@@ -77,6 +77,7 @@ Please check the [navigation](./navigation) section, as it's very important to u
 | embedding.dashboard.hidePageHeader | ❌ | boolean | Hides the page header in the dashboard by default it is false. (added in [0.8.0](./sdk-changelog#09%2F21%2F2025-0-8-0)) |
 | embedding.hideFolders | ❌ | boolean | Hides all things related to folders in both the flows table and builder by default it is false. |
 | embedding.hideTables | ❌ | boolean | Hides the Tables UI in the dashboard (tree, filters, create/import buttons) and blocks direct access to the table editor route. The Tables piece used inside flows is unaffected. By default it is false. (added in [0.9.0](./sdk-changelog#04%2F21%2F2026-0-9-0)) |
+| embedding.hideActiveUsers | ❌ | boolean | Hides the active users (presence) avatars in the builder's header and the table editor's header. When hidden, the embedded user also stops appearing in other collaborators' active-users list. By default it is false. (added in [0.12.0](./sdk-changelog#07%2F09%2F2026-0-12-0)) |
 | embedding.styling.fontUrl | ❌ | string | The url of the font to be used in the embedding, by default it is `https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap`. |
 | embedding.styling.fontFamily | ❌ | string | The font family to be used in the embedding, by default it is `Roboto`. |
 | embedding.styling.mode | ❌ | `light` \| `dark` | Controls light/dark mode (added in [0.5.0](./sdk-changelog#03%2F07%2F2025-0-5-0))|

--- a/docs/embedding/sdk-changelog.mdx
+++ b/docs/embedding/sdk-changelog.mdx
@@ -18,6 +18,10 @@ Change log format: MM/DD/YYYY (version)
 
 
 
+### 07/09/2026 (0.12.0)
+- SDK URL: https://cdn.activepieces.com/sdk/embed/0.12.0.js
+- Added `embedding.hideActiveUsers` parameter to the [configure](./embed-builder#configure-parameters) method **(value: true | false)**. When `true`, hides the active users (presence) avatars in the builder's header and the table editor's header. The embedded user will also not appear in other collaborators' active-users list. This version requires an Activepieces release that includes [#13630](https://github.com/activepieces/activepieces/pull/13630).
+
 ### 06/18/2026 (0.10.0)
 - SDK URL: https://cdn.activepieces.com/sdk/embed/0.10.0.js
 - Added `authorizeMcp({ authRequestId })` — opens an in-embed MCP OAuth consent dialog so embedded (managed-auth) users can approve connecting an AI client to their project **without a standalone Activepieces login**. Resolves with `{ redirectUrl }` on approval or `{ denied: true }`. See [Embeddable MCP](./embeddable-mcp).

--- a/packages/ee/embed-sdk/package.json
+++ b/packages/ee/embed-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ee-embed-sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "commonjs",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/ee/embed-sdk/src/index.ts
+++ b/packages/ee/embed-sdk/src/index.ts
@@ -124,7 +124,7 @@ export interface ActivepiecesVendorInit {
     hideTables?: boolean;
     sdkVersion?: string;
     jwtToken: string;
-    initialRoute?: string 
+    initialRoute?: string
     fontUrl?: string;
     fontFamily?: string;
     hideExportAndImportFlow?: boolean;
@@ -135,6 +135,7 @@ export interface ActivepiecesVendorInit {
     mode?: 'light' | 'dark';
     hideFlowsPageNavbar?: boolean;
     hidePageHeader?: boolean;
+    hideActiveUsers?: boolean;
   };
 }
 
@@ -157,6 +158,7 @@ type EmbeddingParam = {
   builder?: {
     disableNavigation?: boolean;
     hideFlowName?: boolean;
+    hideActiveUsers?: boolean;
     homeButtonIcon: 'back' | 'logo';
     homeButtonClickedHandler?: (data: {
       route: string;
@@ -306,6 +308,7 @@ class ActivepiecesEmbedded {
                 hideDuplicateFlow: this._embeddingState?.hideDuplicateFlow ?? false,
                 mode: this._embeddingState?.styling?.mode,
                 hidePageHeader: this._embeddingState?.dashboard?.hidePageHeader ?? false,
+                hideActiveUsers: this._embeddingState?.builder?.hideActiveUsers ?? false,
               },
             };
             targetWindow.postMessage(apEvent, '*');

--- a/packages/ee/embed-sdk/src/index.ts
+++ b/packages/ee/embed-sdk/src/index.ts
@@ -158,7 +158,6 @@ type EmbeddingParam = {
   builder?: {
     disableNavigation?: boolean;
     hideFlowName?: boolean;
-    hideActiveUsers?: boolean;
     homeButtonIcon: 'back' | 'logo';
     homeButtonClickedHandler?: (data: {
       route: string;
@@ -173,6 +172,7 @@ type EmbeddingParam = {
   hideDuplicateFlow?: boolean;
   hideFolders?: boolean;
   hideTables?: boolean;
+  hideActiveUsers?: boolean;
   navigation?: {
     handler?: (data: { route: string }) => void;
   }
@@ -308,7 +308,7 @@ class ActivepiecesEmbedded {
                 hideDuplicateFlow: this._embeddingState?.hideDuplicateFlow ?? false,
                 mode: this._embeddingState?.styling?.mode,
                 hidePageHeader: this._embeddingState?.dashboard?.hidePageHeader ?? false,
-                hideActiveUsers: this._embeddingState?.builder?.hideActiveUsers ?? false,
+                hideActiveUsers: this._embeddingState?.hideActiveUsers ?? false,
               },
             };
             targetWindow.postMessage(apEvent, '*');

--- a/packages/web/src/app/builder/builder-header/builder-header.tsx
+++ b/packages/web/src/app/builder/builder-header/builder-header.tsx
@@ -187,7 +187,9 @@ export const BuilderHeader = () => {
           {t('Support')}
         </Button>
       )}
-      <ActiveUsersWidget resourceId={flow.id} />
+      {!embedState.hideActiveUsers && (
+        <ActiveUsersWidget resourceId={flow.id} />
+      )}
       {hasPermissionToReadRuns && (
         <Button
           variant="ghost"

--- a/packages/web/src/app/routes/embed/index.tsx
+++ b/packages/web/src/app/routes/embed/index.tsx
@@ -159,6 +159,7 @@ const EmbedPage = React.memo(() => {
                   hideFlowsPageNavbar:
                     event.data.data.hideFlowsPageNavbar ?? false,
                   hidePageHeader: event.data.data.hidePageHeader ?? false,
+                  hideActiveUsers: event.data.data.hideActiveUsers ?? false,
                 });
               });
               memoryRouter.navigate(initialRoute);

--- a/packages/web/src/components/providers/embed-provider.tsx
+++ b/packages/web/src/components/providers/embed-provider.tsx
@@ -21,6 +21,7 @@ type EmbeddingState = {
   homeButtonIcon: 'back' | 'logo';
   hideDuplicateFlow: boolean;
   hidePageHeader: boolean;
+  hideActiveUsers: boolean;
 };
 
 const defaultState: EmbeddingState = {
@@ -38,6 +39,7 @@ const defaultState: EmbeddingState = {
   homeButtonIcon: 'logo',
   hideDuplicateFlow: false,
   hidePageHeader: false,
+  hideActiveUsers: false,
 };
 
 const EmbeddingContext = createContext<{

--- a/packages/web/src/features/tables/components/ap-table-header.tsx
+++ b/packages/web/src/features/tables/components/ap-table-header.tsx
@@ -18,6 +18,7 @@ import { ConfirmationDeleteDialog } from '@/components/custom/delete-dialog';
 import EditableText from '@/components/custom/editable-text';
 import { PageHeader } from '@/components/custom/page-header';
 import { PermissionNeededTooltip } from '@/components/custom/permission-needed-tooltip';
+import { useEmbedding } from '@/components/providers/embed-provider';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -60,6 +61,7 @@ export function ApTableHeader({
   lockedBy,
   takeOver,
 }: ApTableHeaderProps) {
+  const { embedState } = useEmbedding();
   const [
     selectedRecords,
     setSelectedRecords,
@@ -236,7 +238,9 @@ export function ApTableHeader({
           </button>
         </div>
       )}
-      <ActiveUsersWidget resourceId={table.id} />
+      {!embedState.hideActiveUsers && (
+        <ActiveUsersWidget resourceId={table.id} />
+      )}
       {selectedRecords.size > 0 && (
         <PermissionNeededTooltip hasPermission={canEdit}>
           <ConfirmationDeleteDialog


### PR DESCRIPTION
## Summary

- Adds a top-level `embedding.hideActiveUsers` flag to the embed SDK
- Gates the `<ActiveUsersWidget />` (presence avatars) in **both** the builder header and the table editor header behind that flag
- Documents the param, adds an SDK changelog entry, and bumps `ee-embed-sdk` to `0.12.0`
- Default is `false` — no behaviour change for existing embedders

## Problem

Since 0.85.0 the builder header renders an active-users presence badge (`ActiveUsersWidget`) unconditionally. Unlike every other header element (breadcrumb navigation, flow name), this widget had no `embedState` guard, so embedders had no way to suppress it even when it was visually inappropriate in their shell. The widget only self-hides when `activeUsers.length === 0`, which is unreliable — it remains visible whenever more than one user has the flow open.

The same widget also renders in the table editor header (`ap-table-header.tsx`), so a builder-scoped flag would have left the table editor uncovered.

Reported via Pylon #5020 post-0.85.0 upgrade.

## Solution

The flag is top-level (`embedding.hideActiveUsers`, like `hideFolders` / `hideTables`) rather than `builder.*`-scoped, since the widget appears in more than one surface. It follows the exact pattern every other hideable element uses:

1. **Embed SDK** (`packages/ee/embed-sdk/src/index.ts`): added `hideActiveUsers?: boolean` to `ActivepiecesVendorInit['data']` (the wire format) and to the top level of the public `EmbeddingParam` type. Wired into the `VENDOR_INIT` message posted on `CLIENT_INIT`.
2. **Embed provider** (`packages/web/src/components/providers/embed-provider.tsx`): added `hideActiveUsers: boolean` to `EmbeddingState` with a default of `false`.
3. **Embed page** (`packages/web/src/app/routes/embed/index.tsx`): mapped `event.data.data.hideActiveUsers ?? false` into `setEmbedState`.
4. **Builder header** (`packages/web/src/app/builder/builder-header/builder-header.tsx`): wrapped `<ActiveUsersWidget />` in `{!embedState.hideActiveUsers && ...}`.
5. **Table editor header** (`packages/web/src/features/tables/components/ap-table-header.tsx`): same gate on its `<ActiveUsersWidget />`.
6. **Docs**: added the param row to `docs/embedding/embed-builder.mdx` and a `0.12.0` entry to `docs/embedding/sdk-changelog.mdx`.
7. **Version**: bumped `packages/ee/embed-sdk/package.json` to `0.12.0`.

## Behaviour note

`usePresence` (mounted by the widget) is what joins the presence channel and sends the heartbeat, so hiding the widget also removes the embedded user from **other** collaborators' active-users lists. Presence drives nothing else (no locking or conflict resolution), so the only effect is cosmetic. This is called out in the docs.

## Usage

```js
activepieces.configure({
  instanceUrl: 'https://your-instance.example.com',
  jwtToken: '...',
  embedding: {
    hideActiveUsers: true, // ← new
  },
});
```

## Testing

- [x] `npx turbo run lint --filter=web --filter=ee-embed-sdk` — 0 errors (pre-existing warnings unchanged)
- [x] With `hideActiveUsers: false` (or omitted): widget renders normally in both headers — no regression
- [x] With `hideActiveUsers: true`: widget does not render in the builder header or the table editor header
- [x] Non-embedded (standalone) usage is unaffected — `embedState.hideActiveUsers` defaults to `false`

## Edition Impact

Frontend-only. No server changes, no database migration, no plan flag required. Applies to all editions (CE, EE, Cloud) — the embed SDK is edition-neutral; the flag is a UI suppression hint, not a feature gate.

## Breaking Changes

None. `hideActiveUsers` is optional and defaults to `false`. All existing embed configurations continue to render the widget unchanged.

## Related

Closes #13562
