### PR TITLE
fix(chat): address 10+ stability, quality, and UX bugs from end-to-end testing

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -46,19 +46,19 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - **ChatConversation** — a persisted conversation between a user and the AI assistant, scoped to a platform and user; optionally scoped to a project for tool access
 - **Message compaction** — when a conversation exceeds a token threshold, older messages are summarized by the LLM and replaced with a summary to keep context within the model's window
 - **Tool approval gate** — a Redis pub/sub mechanism that pauses destructive tool executions (delete, test, publish) until the user explicitly approves or denies in the UI; times out after 5 minutes
-- **Plan approval** — a multi-step approval mechanism where the agent presents a plan via `ap_request_plan_approval`, the user approves or rejects, and approved plans execute with progress tracking
+- **Plan approval** — a multi-step approval mechanism where the agent presents a plan via `ap_request_plan_approval` (includes a required `mode` field: `one_time` or `recurring`), the user approves or rejects, and approved plans execute with progress tracking
 - **Local tools** — chat-specific tools not part of MCP: `ap_set_session_title`, `ap_select_project`, `ap_execute_action`, `ap_list_across_projects`, `ap_request_plan_approval`
 - **Display tools** — tools that render interactive UI cards: `ap_show_connection_required`, `ap_show_connection_picker`, `ap_show_project_picker`, `ap_show_questions`, `ap_show_quick_replies`
 - **MCP tools** — project-scoped tools loaded from the Activepieces MCP server when a project is selected; destructive ones are wrapped with the approval gate
 - **Tool call UX metadata** — optional `title` (2-4 word chip label) and `description` (first-person conversational sentence) stored on `PersistedToolCallPart`; description is sourced from the preceding `ap_update_thinking_status` text with `input.description` as fallback, rendered above the tool card chip
-- **Server-managed connections** — connection externalIds are never exposed to the LLM; `ap_discover_action_auth` stores available connections in Redis, `ap_show_connection_picker` stores the user's selection, and `ap_execute_action` auto-fills the connection from the store
+- **Server-managed connections** — connection externalIds are never exposed to the LLM; `ap_discover_action_auth` stores available connections in Redis (with `grantedScopes` and `requiredScopes` for scope-aware selection), `ap_show_connection_picker` stores the user's selection, and `ap_execute_action` auto-fills the connection from the store
 - **Action preview gate** — write/destructive actions show a preview card (parameters, connection) before execution; classification uses a hybrid AI-driven (`needsConfirmation` flag) + server hard-floor (name pattern matching) approach; persisted as pending gate in Redis for refresh resilience
 - **Action receipt** — server-rendered card showing action result (status, output, connection badge, timestamp); emitted as `ACTION_RECEIPT` event and persisted as `PersistedChatPartType.ACTION_RECEIPT` in conversation history
 - **Pending gate persistence** — when a display tool or action preview blocks on approval, gate metadata is stored in Redis so the frontend can re-show the card after page refresh; cleared automatically when the gate resolves
-- **Stream reconnection** — when loading a STREAMING conversation (e.g. after refresh), the frontend calls `startStream` to reconnect to the WebSocket channel instead of just polling, receiving live chunks from the still-running worker
+- **Stream reconnection** — when loading a STREAMING conversation (e.g. after refresh), the frontend calls `getPendingGate` to re-populate any blocking display-tool card, then calls `startStream`; a socket `connect` handler re-registers the chunk listener and resets the stale-check timer on reconnect
 - **AI provider** — a platform-configured LLM provider with an `enabledForChat` flag; the chat resolves the first enabled provider and its default model
 - **Streaming cancel** — a Redis key (10-min TTL) signals the worker to abort via AbortController; a 3-second periodic timer checks the Redis key so cancellation fires within 3 seconds regardless of step boundaries; partial messages (from completed steps via `onAbort` callback) are saved to preserve context for resume
-- **Stale recovery** — when `getConversationOrThrow` fetches a conversation stuck in STREAMING for more than 20 minutes, it automatically resets the status to IDLE before returning
+- **Stale recovery** — when `getConversationOrThrow` fetches a conversation stuck in STREAMING for more than 2 minutes, it automatically resets the status to IDLE before returning
 - **Project context** — the currently selected project for a conversation; determines which MCP tools are available and scopes resource access
 - **Chat tiers** — model configurations (fast/smart/premium) with different thinking budgets; displayed as Fast/Expert/Heavy in the UI with per-tier descriptions
 - **Credits warning banner** — a dismissible amber banner shown when Activepieces AI credits usage reaches 70%; a non-dismissible red banner is shown when credits are fully exhausted
@@ -72,7 +72,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 ## Key Service Methods
 - `createConversation()` — creates a new conversation for a user on a platform
 - `listConversations()` — cursor-paginated list of user's conversations, ordered by creation date descending; excludes messages, uiMessages, and summary columns for performance
-- `getConversationOrThrow()` — fetches a conversation, enforcing ownership (platformId + userId); auto-recovers stale STREAMING conversations to IDLE after a 20-minute timeout
+- `getConversationOrThrow()` — fetches a conversation, enforcing ownership (platformId + userId); auto-recovers stale STREAMING conversations to IDLE after a 2-minute timeout
 - `updateConversation()` — updates title and/or modelName
 - `deleteConversation()` — deletes a conversation after ownership check; blocked while status is STREAMING
 - `getMessages()` — reconstructs `ChatHistoryMessage[]` from stored `ModelMessage[]`

--- a/packages/server/api/src/app/ee/chat/chat-approval-gate.ts
+++ b/packages/server/api/src/app/ee/chat/chat-approval-gate.ts
@@ -165,6 +165,7 @@ type StoredConnection = {
     projectId: string
     project: string
     status: string
+    grantedScopes: string[]
 }
 
 type SelectedConnection = Pick<StoredConnection, 'externalId' | 'label' | 'projectId'>

--- a/packages/server/api/src/app/ee/chat/chat-helpers.ts
+++ b/packages/server/api/src/app/ee/chat/chat-helpers.ts
@@ -17,7 +17,7 @@ import { projectService } from '../../project/project-service'
 import { userService } from '../../user/user-service'
 import { ChatConversationEntity } from './chat-conversation-entity'
 
-const STREAMING_STALENESS_TIMEOUT_MS = 20 * 60 * 1_000
+const STREAMING_STALENESS_TIMEOUT_MS = 2 * 60 * 1_000
 
 const conversationRepo = repoFactory(ChatConversationEntity)
 

--- a/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
+++ b/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
@@ -1,4 +1,4 @@
-import { FlowRunStatus, FlowStatus, isNil, parseToJsonIfPossible, Project, RunEnvironment } from '@activepieces/shared'
+import { AppConnectionStatus, AppConnectionType, FlowRunStatus, FlowStatus, isNil, isObject, parseToJsonIfPossible, Project, RunEnvironment } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { appConnectionService } from '../../../app-connection/app-connection-service/app-connection-service'
 import { flowService } from '../../../flows/flow/flow.service'
@@ -13,6 +13,12 @@ import { chatHelpers } from '../chat-helpers'
 import { chatPrompt } from '../prompt/chat-prompt'
 
 const CROSS_PROJECT_CONNECTION_LIMIT = 100
+const OAUTH_TYPES: ReadonlySet<AppConnectionType> = new Set([
+    AppConnectionType.OAUTH2,
+    AppConnectionType.CLOUD_OAUTH2,
+    AppConnectionType.PLATFORM_OAUTH2,
+])
+const CLOCK_SKEW_BUFFER_S = 5 * 60
 const CROSS_PROJECT_FLOW_LIMIT = 200
 const FLOW_STATUS_VALUES: ReadonlySet<string> = new Set(Object.values(FlowStatus))
 const FLOW_RUN_STATUS_VALUES: ReadonlySet<string> = new Set(Object.values(FlowRunStatus))
@@ -42,6 +48,7 @@ async function findConnectionsForPiece({ pieceName, projects, platformId, log }:
     const normalizedPiece = mcpUtils.normalizePieceName(pieceName) ?? pieceName
 
     const projectId = projects[0]?.id
+    let requiredScopes: string[] = []
     if (projectId) {
         const project = projects[0]
         const piece = await pieceMetadataService(log).get({
@@ -51,6 +58,12 @@ async function findConnectionsForPiece({ pieceName, projects, platformId, log }:
         })
         if (piece && isNil(piece.auth)) {
             return { noAuthRequired: true, piece: normalizedPiece }
+        }
+        if (piece?.auth && !Array.isArray(piece.auth)) {
+            const authScope = (piece.auth as Record<string, unknown>)['scope']
+            if (Array.isArray(authScope)) {
+                requiredScopes = authScope.filter((s): s is string => typeof s === 'string')
+            }
         }
     }
 
@@ -67,13 +80,17 @@ async function findConnectionsForPiece({ pieceName, projects, platformId, log }:
                 scope: undefined,
                 externalIds: undefined,
             })
-            return result.data.map((c) => ({
-                label: c.displayName,
-                externalId: c.externalId,
-                project: chatPrompt.projectDisplayName(project),
-                projectId: project.id,
-                status: c.status,
-            }))
+            return result.data.map((c) => {
+                const info = resolveConnectionInfo({ status: c.status, type: c.type, value: c.value })
+                return {
+                    label: c.displayName,
+                    externalId: c.externalId,
+                    project: chatPrompt.projectDisplayName(project),
+                    projectId: project.id,
+                    status: info.status,
+                    grantedScopes: info.grantedScopes,
+                }
+            })
         }),
     )
 
@@ -82,10 +99,10 @@ async function findConnectionsForPiece({ pieceName, projects, platformId, log }:
     const displayName = pieceDisplayLabel(shortName)
 
     if (flat.length === 0) {
-        return { needsConnection: true, piece: shortName, displayName }
+        return { needsConnection: true, piece: shortName, displayName, requiredScopes }
     }
 
-    return { pickConnection: true, piece: shortName, displayName, connections: flat }
+    return { pickConnection: true, piece: shortName, displayName, connections: flat, requiredScopes }
 }
 
 async function listFlowsAcrossProjects({ projects, status, log }: {
@@ -211,6 +228,7 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
                     piece: discoveryResult.piece,
                     displayName: discoveryResult.displayName,
                     connectionCount: discoveryResult.connections.length,
+                    requiredScopes: discoveryResult.requiredScopes,
                 }
             }
             return discoveryResult
@@ -291,9 +309,37 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
     }
 }
 
+function resolveConnectionInfo({ status, type, value }: { status: AppConnectionStatus, type: AppConnectionType, value: unknown }): { status: AppConnectionStatus, grantedScopes: string[] } {
+    if (!OAUTH_TYPES.has(type) || !isObject(value)) {
+        return { status, grantedScopes: [] }
+    }
+    const grantedScopes = typeof value['scope'] === 'string' ? value['scope'].split(/\s+/).filter(Boolean) : []
+    if (status !== AppConnectionStatus.ACTIVE) {
+        return { status, grantedScopes }
+    }
+    const claimedAtMs = typeof value['claimed_at'] === 'number' ? value['claimed_at'] : 0
+    const expiresInS = typeof value['expires_in'] === 'number' ? value['expires_in'] : 0
+    if (claimedAtMs > 0 && expiresInS > 0) {
+        const expiryMs = claimedAtMs + (expiresInS - CLOCK_SKEW_BUFFER_S) * 1000
+        if (Date.now() > expiryMs) {
+            return { status: AppConnectionStatus.ERROR, grantedScopes }
+        }
+    }
+    return { status, grantedScopes }
+}
+
+type ConnectionWithScopes = {
+    label: string
+    project: string
+    externalId: string
+    projectId: string
+    status: AppConnectionStatus
+    grantedScopes: string[]
+}
+
 type FindConnectionsResult =
     | { noAuthRequired: true, piece: string }
-    | { needsConnection: true, piece: string, displayName: string }
-    | { pickConnection: true, piece: string, displayName: string, connections: Array<{ label: string, project: string, externalId: string, projectId: string, status: string }> }
+    | { needsConnection: true, piece: string, displayName: string, requiredScopes: string[] }
+    | { pickConnection: true, piece: string, displayName: string, connections: ConnectionWithScopes[], requiredScopes: string[] }
 
 export { executeCrossProjectTool }

--- a/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
+++ b/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
@@ -317,10 +317,10 @@ function resolveConnectionInfo({ status, type, value }: { status: AppConnectionS
     if (status !== AppConnectionStatus.ACTIVE) {
         return { status, grantedScopes }
     }
-    const claimedAtMs = typeof value['claimed_at'] === 'number' ? value['claimed_at'] : 0
+    const claimedAtS = typeof value['claimed_at'] === 'number' ? value['claimed_at'] : 0
     const expiresInS = typeof value['expires_in'] === 'number' ? value['expires_in'] : 0
-    if (claimedAtMs > 0 && expiresInS > 0) {
-        const expiryMs = claimedAtMs + (expiresInS - CLOCK_SKEW_BUFFER_S) * 1000
+    if (claimedAtS > 0 && expiresInS > 0) {
+        const expiryMs = (claimedAtS + expiresInS - CLOCK_SKEW_BUFFER_S) * 1000
         if (Date.now() > expiryMs) {
             return { status: AppConnectionStatus.ERROR, grantedScopes }
         }

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -125,12 +125,12 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
                     operation: { type: FlowOperationType.UPDATE_TRIGGER, request: triggerPayload },
                 })
                 const skippedSteps: string[] = []
+                let lastTopLevelStepName: string | null = null
 
                 for (const step of steps) {
                     const latestTrigger = currentFlow!.version.trigger
                     const stepName = flowStructureUtil.findUnusedName(latestTrigger)
                     const allSteps = flowStructureUtil.getAllSteps(latestTrigger)
-                    const lastStep = allSteps[allSteps.length - 1]
 
                     let resolvedPieceVersion: string | undefined
                     let resolvedPieceName: string | undefined
@@ -158,12 +158,13 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
                     }
 
                     const location = step.stepLocationRelativeToParent ?? StepLocationRelativeToParent.AFTER
-                    let parentStepName = lastStep.name
+                    let parentStepName: string
                     if (step.parentStepName) {
                         const found = allSteps.find((s) => s.name === step.parentStepName)
-                        if (found) {
-                            parentStepName = found.name
-                        }
+                        parentStepName = found ? found.name : (lastTopLevelStepName ?? allSteps[allSteps.length - 1].name)
+                    }
+                    else {
+                        parentStepName = lastTopLevelStepName ?? allSteps[allSteps.length - 1].name
                     }
 
                     currentFlow = await flowService(log).update({
@@ -177,6 +178,10 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
                             },
                         },
                     })
+
+                    if (location === StepLocationRelativeToParent.AFTER) {
+                        lastTopLevelStepName = stepName
+                    }
                 }
 
                 const allSteps = flowStructureUtil.getAllSteps(currentFlow.version.trigger)

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -31,6 +31,12 @@ const stepSpec = z.object({
     loopItems: z.string().optional(),
     continueOnFailure: z.boolean().optional(),
     retryOnFailure: z.boolean().optional(),
+    parentStepName: z.string().optional().describe('Name of the parent step to nest this step inside (e.g. the loop step name). If omitted, step is added after the previous step.'),
+    stepLocationRelativeToParent: z.enum([
+        StepLocationRelativeToParent.AFTER,
+        StepLocationRelativeToParent.INSIDE_LOOP,
+        StepLocationRelativeToParent.INSIDE_BRANCH,
+    ]).optional().default(StepLocationRelativeToParent.AFTER).describe('Where to place the step relative to parentStepName. Use INSIDE_LOOP for steps inside a loop.'),
 })
 
 const buildFlowInput = z.object({
@@ -48,7 +54,7 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
     return {
         title: 'ap_build_flow',
         permission: Permission.WRITE_FLOW,
-        description: 'Create a complete flow in one call: trigger + steps. Steps are added sequentially (trigger → step_1 → step_2 → ...). Use granular tools (ap_add_step, ap_update_step) to modify flows or add nested structures (loop contents, router branches).',
+        description: 'Create a complete flow in one call: trigger + steps. Steps are added sequentially by default (trigger → step_1 → step_2 → ...). To nest steps inside a loop, set parentStepName to the loop step name and stepLocationRelativeToParent to INSIDE_LOOP.',
         inputSchema: {
             flowName: z.string().describe('Name for the new flow'),
             trigger: z.object({
@@ -57,7 +63,7 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
                 input: z.record(z.string(), z.unknown()).optional().describe('Trigger input config'),
                 auth: z.string().optional().describe('Connection externalId for trigger auth'),
             }).describe('Trigger configuration'),
-            steps: z.array(stepSpec).describe('Array of steps added sequentially after trigger. Each step supports: PIECE (pieceName+actionName+input), CODE (sourceCode+input), LOOP_ON_ITEMS (loopItems), ROUTER.'),
+            steps: z.array(stepSpec).describe('Array of steps. By default added sequentially after trigger. Use parentStepName + stepLocationRelativeToParent to nest steps inside loops. Each step supports: PIECE (pieceName+actionName+input), CODE (sourceCode+input), LOOP_ON_ITEMS (loopItems), ROUTER.'),
         },
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {
@@ -151,13 +157,22 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
                         continue
                     }
 
+                    const location = step.stepLocationRelativeToParent ?? StepLocationRelativeToParent.AFTER
+                    let parentStepName = lastStep.name
+                    if (step.parentStepName) {
+                        const found = allSteps.find((s) => s.name === step.parentStepName)
+                        if (found) {
+                            parentStepName = found.name
+                        }
+                    }
+
                     currentFlow = await flowService(log).update({
                         id: flowId, projectId, userId: null, platformId,
                         operation: {
                             type: FlowOperationType.ADD_ACTION,
                             request: {
-                                parentStep: lastStep.name,
-                                stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+                                parentStep: parentStepName,
+                                stepLocationRelativeToParent: location,
                                 action: parseResult.data,
                             },
                         },

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -156,7 +156,7 @@ Gather ALL information before presenting the plan. Once approved, execute withou
 - Before starting each step, call `ap_update_plan` with `status: "executing"` for that step.
 - After completing each step, call `ap_update_plan` with `status: "done"` (or `"error"` if it failed).
 - **Simple flows** (linear, no branches/loops): `ap_build_flow` → validate every step (see below) → `ap_test_flow` → `ap_manage_notes`.
-- **Flows with loops**: `ap_build_flow` supports nesting. For steps inside a loop, set `parentStepName` to the loop step's name and `stepLocationRelativeToParent` to `INSIDE_LOOP`. For steps after the loop, omit these fields (defaults to `AFTER`).
+- **Flows with loops**: `ap_build_flow` supports nesting. For steps inside a loop, set `parentStepName` to the loop step's name and `stepLocationRelativeToParent` to `INSIDE_LOOP`. Steps that omit `parentStepName` are automatically placed after the last top-level step (not inside the loop).
 - **Complex flows** (branches, routers, many steps): `ap_create_flow` → configure trigger → validate → for each action: `ap_add_step` → validate → `ap_test_flow` → `ap_manage_notes`.
 - Share flow link. Flow is in draft — do NOT auto-publish.
 

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -112,6 +112,11 @@ Keep all three under 40 chars. Lowercase after first word. For MCP tools (non-`a
 16. **After `ap_show_connection_required` returns successfully**, the user has confirmed all connections are active. Trust this result — do NOT call `ap_discover_action_auth` again to re-check. The system manages connections automatically.
 17. **Connection discipline.** Never use a connection the user didn't select. If an action fails due to permissions, do NOT switch to a different connection silently and do NOT retry with made-up parameters. Explain what went wrong and offer the user choices via `ap_show_quick_replies`.
 18. **Action confirmation.** For write/destructive actions, set `needsConfirmation: true` on `ap_execute_action`. The system will show the user a preview of the action before executing. For read actions (list, get, search), omit the flag — they run immediately.
+19. **Connection scope awareness.** When `ap_discover_action_auth` returns connections with `grantedScopes`, compare them against the action's `requiredScopes`. If a connection lacks required scopes, warn the user and suggest reconnecting with the needed scopes. Never build a step on a connection that lacks required scopes.
+20. **Minimal data fetching.** When working with email, spreadsheet, or any list-based API, always fetch IDs/metadata first, then fetch full content only for items that need processing. Never fetch full content for all items in a single call — large responses get truncated and break execution.
+21. **Fill all fields by default.** When writing data to a spreadsheet or table, always fill ALL available columns/fields by default. Do not selectively skip columns unless the user explicitly says to only fill specific fields. If data is unavailable for a field, use an empty value or "Not found" — never omit the column.
+22. **Prefer batch actions.** When updating, inserting, or deleting multiple rows, always use the batch variant of the action (e.g., `update-multiple-rows` instead of calling `update-row` per item, `insert-multiple-rows` instead of calling `insert-row` per item). Collect all data first, then write in one batch call.
+23. **Never guess property names.** Before calling `ap_execute_action`, you MUST call `ap_get_piece_props` to discover the exact property names and types for the action. Never invent property names like `q`, `query`, `search`, or `filter` — use only the property names returned by `ap_get_piece_props`. If the action fails with "Unknown properties", call `ap_get_piece_props` and retry with the correct names.
 </rules>
 
 <project_scope>
@@ -143,7 +148,7 @@ Gather ALL information before presenting the plan. Once approved, execute withou
 - **Connections**: `ap_list_connections` ONCE. Active connections found → `ap_show_connection_picker` (even if only one — always let the user confirm). None/error → `ap_show_connection_required`. If user cannot connect → use HTTP piece with inline auth for that step (see `<http_fallback>`). Never re-show a picker the user already answered **for the same step**. If the user explicitly asks to switch accounts, use a different connection, or names a specific account — re-run auth discovery and show `ap_show_connection_picker` with the fresh list.
 - **Config**: unresolved fields → `ap_get_piece_props` + `ap_resolve_property_options` → `ap_show_questions`.
 
-**3 — PLAN**: `ap_request_plan_approval` with summary and steps. Steps MUST match what you will actually do:
+**3 — PLAN**: `ap_request_plan_approval` with summary, steps, and `mode` ("one_time" or "recurring"). You MUST declare mode in every plan. If the user's intent is ambiguous between one-time and recurring, default to "one_time" and ask: "Would you like this to run once, or repeat automatically?" Steps MUST match what you will actually do:
 - Using `ap_build_flow`: "Build flow with trigger and actions", "Validate each step and fix issues", "Test flow", "Add notes"
 - Using granular tools: list each step individually (create flow, set trigger, add step X, validate, test, notes)
 
@@ -151,7 +156,8 @@ Gather ALL information before presenting the plan. Once approved, execute withou
 - Before starting each step, call `ap_update_plan` with `status: "executing"` for that step.
 - After completing each step, call `ap_update_plan` with `status: "done"` (or `"error"` if it failed).
 - **Simple flows** (linear, no branches/loops): `ap_build_flow` → validate every step (see below) → `ap_test_flow` → `ap_manage_notes`.
-- **Complex flows** (branches, loops, many steps): `ap_create_flow` → configure trigger → validate → for each action: `ap_add_step` → validate → `ap_test_flow` → `ap_manage_notes`.
+- **Flows with loops**: `ap_build_flow` supports nesting. For steps inside a loop, set `parentStepName` to the loop step's name and `stepLocationRelativeToParent` to `INSIDE_LOOP`. For steps after the loop, omit these fields (defaults to `AFTER`).
+- **Complex flows** (branches, routers, many steps): `ap_create_flow` → configure trigger → validate → for each action: `ap_add_step` → validate → `ap_test_flow` → `ap_manage_notes`.
 - Share flow link. Flow is in draft — do NOT auto-publish.
 
 **After `ap_build_flow`**: it creates the skeleton but does NOT validate configs or field mappings. You MUST: (1) `ap_validate_step_config` on trigger and each step, (2) fix any errors with `ap_update_step`/`ap_update_trigger`, (3) `ap_validate_flow` to confirm all steps are valid.
@@ -214,7 +220,7 @@ If the user asks to repeat the same action with a different account or switch co
 When converting a one-time task into a recurring flow:
 
 1. **Set project**: ensure the project from the one-time task is selected via `ap_select_project`.
-2. **Pick trigger**: new/incoming items → App trigger if available; periodic → Schedule trigger; ambiguous → Schedule as default.
+2. **Pick trigger**: new/incoming items → App trigger if available; periodic → Schedule trigger; ambiguous → default to one-time and ask the user "Would you like this to run once, or repeat automatically?"
 3. **Reuse context**: same piece, action, connection, and inputs from the one-time task.
 4. **Plan and build**: follow `<automation_build>` steps 3-4. Use `ap_build_flow` for simple flows.
 </one_time_to_flow>

--- a/packages/server/api/test/integration/cloud/chat/chat-stuck-streaming.test.ts
+++ b/packages/server/api/test/integration/cloud/chat/chat-stuck-streaming.test.ts
@@ -44,8 +44,8 @@ describe('Chat conversation stuck in STREAMING status', () => {
         const createResponse = await ctx.post(CONVERSATIONS_URL, { title: 'Will Auto-Recover' })
         const conversationId = createResponse.json().id
 
-        // Set status to STREAMING with an old updated timestamp (simulating worker crash 20 min ago)
-        const twentyMinutesAgo = new Date(Date.now() - 20 * 60 * 1_000).toISOString()
+        // Set status to STREAMING with an old updated timestamp (simulating worker crash 5 min ago, past the 2-min threshold)
+        const twentyMinutesAgo = new Date(Date.now() - 5 * 60 * 1_000).toISOString()
         await db.update('chat_conversation', conversationId, {
             status: ChatConversationStatus.STREAMING,
             updated: twentyMinutesAgo,
@@ -101,11 +101,11 @@ describe('Chat conversation stuck in STREAMING status', () => {
         const createResponse = await ctx.post(CONVERSATIONS_URL, { title: 'Still Running' })
         const conversationId = createResponse.json().id
 
-        // Set status to STREAMING updated 5 minutes ago (within 15-min timeout)
-        const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1_000).toISOString()
+        // Set status to STREAMING updated 1 minute ago (within 2-min timeout)
+        const oneMinuteAgo = new Date(Date.now() - 1 * 60 * 1_000).toISOString()
         await db.update('chat_conversation', conversationId, {
             status: ChatConversationStatus.STREAMING,
-            updated: fiveMinutesAgo,
+            updated: oneMinuteAgo,
         })
 
         // Should stay STREAMING — agent might still be running

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -4,6 +4,7 @@ import {
     BatchItemResult,
     ChatAgentEventType,
     chatToolClassification,
+    chunk,
     isObject,
     SendChatEventRequest,
     ToolApprovalRequestEvent,
@@ -15,6 +16,7 @@ import { z } from 'zod'
 
 const MAX_BATCH_SIZE = 100
 const TOOL_EXECUTION_TIMEOUT_MS = 5 * 60 * 1_000
+const MAX_RESULT_SIZE_BYTES = 100 * 1024
 
 async function withToolTimeout<T>({ fn, timeoutMs, toolName }: {
     fn: (signal: AbortSignal) => Promise<T>
@@ -37,6 +39,44 @@ async function withToolTimeout<T>({ fn, timeoutMs, toolName }: {
             clearTimeout(timeoutId)
         }
     }
+}
+
+function truncateLargeResult(result: unknown): unknown {
+    const serialized = JSON.stringify(result)
+    if (serialized.length <= MAX_RESULT_SIZE_BYTES) return result
+
+    const topLevelArray = findTopLevelArray(result)
+    if (topLevelArray) {
+        const { array, path, totalCount } = topLevelArray
+        const preview = array.slice(0, 3)
+        return {
+            content: [{
+                type: 'text',
+                text: `[LARGE RESPONSE] The result contains ${totalCount} items (at ${path}) but the full response is ${Math.round(serialized.length / 1024)}KB which is too large to process. Only the first 3 items are shown as a preview.\n\nTo handle this data, either:\n1. Use a more specific filter to reduce the number of results\n2. Fetch only IDs or metadata fields instead of full content\n3. Process items in smaller batches\n\nPreview (3 of ${totalCount} items):\n${JSON.stringify(preview, null, 2)}`,
+            }],
+        }
+    }
+
+    return {
+        content: [{
+            type: 'text',
+            text: `[LARGE RESPONSE] The response is ${Math.round(serialized.length / 1024)}KB which is too large to process. Retry with a more specific filter, request fewer items, or fetch only IDs/metadata fields instead of full content.`,
+        }],
+    }
+}
+
+function findTopLevelArray(obj: unknown): { array: unknown[], path: string, totalCount: number } | null {
+    if (Array.isArray(obj) && obj.length > 0) {
+        return { array: obj, path: 'root', totalCount: obj.length }
+    }
+    if (!isObject(obj)) return null
+    for (const key of Object.keys(obj)) {
+        const val = obj[key]
+        if (Array.isArray(val) && val.length > 0) {
+            return { array: val, path: key, totalCount: val.length }
+        }
+    }
+    return null
 }
 
 function createEventEmitter({ sendEvent, userId, conversationId, log }: {
@@ -318,7 +358,8 @@ function createCrossProjectTools({ executeTool, eventEmitter, waitForApproval, o
                         description: toolInput.description,
                     })
                 }
-                const result = await executeWithTimeout('ap_execute_action', toolInput)
+                const rawResult = await executeWithTimeout('ap_execute_action', toolInput)
+                const result = truncateLargeResult(rawResult)
                 const resultObj = isObject(result) ? result as Record<string, unknown> : {}
                 const meta = isObject(resultObj['_meta']) ? resultObj['_meta'] as Record<string, unknown> : undefined
                 eventEmitter.emitActionReceipt({
@@ -380,37 +421,42 @@ async function executeBatchAction({ executeWithTimeout, eventEmitter, toolCallId
     }
 
     const CONSECUTIVE_FAILURE_LIMIT = 3
+    const CONCURRENCY_LIMIT = 5
     let consecutiveFailures = 0
+    let stoppedEarly = false
 
     pushProgress({ done: false })
 
-    for (let i = 0; i < items.length; i++) {
-        const { data: result, error } = await tryCatch(() => executeWithTimeout('ap_execute_action', {
-            pieceName,
-            actionName,
-            input: items[i],
-        }))
-        if (error) {
-            failed++
-            consecutiveFailures++
-            results.push({ index: i, success: false, error: error.message })
-        }
-        else if (isSuccessResult(result)) {
-            succeeded++
-            consecutiveFailures = 0
-            results.push({ index: i, success: true, output: result })
-        }
-        else {
-            failed++
-            consecutiveFailures++
-            results.push({ index: i, success: false, error: extractResultText(result) })
-        }
-
-        const stoppedEarly = consecutiveFailures >= CONSECUTIVE_FAILURE_LIMIT
-        const isLast = i === items.length - 1
-        pushProgress({ done: isLast || stoppedEarly })
-
+    const chunks = chunk(items, CONCURRENCY_LIMIT)
+    let itemOffset = 0
+    for (const batch of chunks) {
         if (stoppedEarly) break
+        const batchResults = await Promise.all(
+            batch.map(async (item, offset) => {
+                const idx = itemOffset + offset
+                const { data: result, error } = await tryCatch(() => executeWithTimeout('ap_execute_action', {
+                    pieceName, actionName, input: item,
+                }))
+                if (error) return { index: idx, success: false as const, error: error.message }
+                if (isSuccessResult(result)) return { index: idx, success: true as const, output: result }
+                return { index: idx, success: false as const, error: extractResultText(result) }
+            }),
+        )
+        for (const r of batchResults) {
+            if (r.success) {
+                succeeded++
+                consecutiveFailures = 0
+                results.push({ index: r.index, success: true, output: r.output })
+            }
+            else {
+                failed++
+                consecutiveFailures++
+                results.push({ index: r.index, success: false, error: r.error })
+            }
+        }
+        itemOffset += batch.length
+        stoppedEarly = consecutiveFailures >= CONSECUTIVE_FAILURE_LIMIT
+        pushProgress({ done: stoppedEarly || itemOffset >= items.length })
     }
 
     const failureSummary = failed > 0
@@ -479,6 +525,7 @@ function createPlanTools({ onPlanApproved, waitForApproval }: {
                 title: z.string().optional().describe('Short human-friendly label for the tool card, e.g. "Review Automation Plan", "Approve Setup"'),
                 planSummary: z.string().describe('A brief 1-3 sentence summary of what you will do'),
                 steps: z.array(z.string()).describe('List of concrete actions'),
+                mode: z.enum(['one_time', 'recurring']).describe('Whether this is a one-time task or a recurring automation. If ambiguous, default to one_time and ask the user.'),
             }),
             execute: async (_input, options) => {
                 const decision = await waitForApproval({ gateId: options.toolCallId })

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -359,17 +359,18 @@ function createCrossProjectTools({ executeTool, eventEmitter, waitForApproval, o
                     })
                 }
                 const rawResult = await executeWithTimeout('ap_execute_action', toolInput)
+                const rawSuccess = isSuccessResult(rawResult)
                 const result = truncateLargeResult(rawResult)
-                const resultObj = isObject(result) ? result as Record<string, unknown> : {}
+                const resultObj = isObject(rawResult) ? rawResult as Record<string, unknown> : {}
                 const meta = isObject(resultObj['_meta']) ? resultObj['_meta'] as Record<string, unknown> : undefined
                 eventEmitter.emitActionReceipt({
                     toolCallId: options.toolCallId,
                     actionDisplayName: toolInput.title ?? toolInput.actionName,
                     pieceName: toolInput.pieceName,
                     connectionLabel: typeof meta?.['connectionLabel'] === 'string' ? meta['connectionLabel'] : undefined,
-                    status: isSuccessResult(result) ? 'success' : 'failed',
+                    status: rawSuccess ? 'success' : 'failed',
                     output: result,
-                    errorMessage: !isSuccessResult(result) ? extractResultText(result) : undefined,
+                    errorMessage: !rawSuccess ? extractResultText(rawResult) : undefined,
                     timestamp: new Date().toISOString(),
                 })
                 return result

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -24,6 +24,7 @@ const BATCH_FLUSH_MS = 50
 const APPROVAL_TIMEOUT_MS = 5 * 60 * 1_000
 const APPROVAL_BLOCK_MS = 50_000
 const DISPLAY_TOOL_TIMEOUT_MS = 15 * 60 * 1_000
+const HEARTBEAT_INTERVAL_MS = 15_000
 const RETRY_MAX_ATTEMPTS = 3
 const RETRY_BASE_DELAY_MS = 1_000
 
@@ -264,8 +265,16 @@ function buildToolSet({ ctx, eventEmitter, log, planApproved, mcpToolSet, projec
         return response.result
     }
 
+    const sendHeartbeat = () => {
+        void tryCatch(() => ctx.apiClient.sendChatEvent({
+            userId, conversationId,
+            event: { type: ChatAgentEventType.CHUNK, data: [] },
+        }))
+    }
+
     const waitForApproval = async ({ gateId, timeoutMs }: { gateId: string, timeoutMs?: number }): Promise<GateDecision> => {
         const deadline = Date.now() + (timeoutMs ?? APPROVAL_TIMEOUT_MS)
+        let lastHeartbeat = Date.now()
         while (Date.now() < deadline) {
             const remainingMs = deadline - Date.now()
             if (remainingMs <= 0) break
@@ -281,6 +290,10 @@ function buildToolSet({ ctx, eventEmitter, log, planApproved, mcpToolSet, projec
             if (response.result !== 'pending') {
                 const decision = response.result as GateDecision
                 return { approved: decision.approved, payload: decision.payload }
+            }
+            if (Date.now() - lastHeartbeat >= HEARTBEAT_INTERVAL_MS) {
+                lastHeartbeat = Date.now()
+                sendHeartbeat()
             }
         }
         return { approved: false }

--- a/packages/web/src/app/routes/chat-with-ai/components/action-receipt-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/action-receipt-card.tsx
@@ -46,13 +46,6 @@ export function ActionReceiptCard({
               <StatusBadge isSuccess={isSuccess} />
             </div>
             <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-              {receipt.connectionLabel && (
-                <span className="text-xs text-muted-foreground">
-                  {t('via {connectionLabel}', {
-                    connectionLabel: receipt.connectionLabel,
-                  })}
-                </span>
-              )}
               <span className="text-xs text-muted-foreground">
                 {formattedTimestamp}
               </span>

--- a/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
@@ -186,16 +186,6 @@ function ToolStepRow({
     () => (detailsOpen && output ? tryParseJson(output) : undefined),
     [detailsOpen, output],
   );
-  const connectionLabel = useMemo(() => {
-    if (part.state !== 'output-available' || !part.output) return undefined;
-    const raw =
-      typeof part.output === 'string' ? tryParseJson(part.output) : part.output;
-    if (!raw || typeof raw !== 'object') return undefined;
-    const meta = (raw as Record<string, unknown>)['_meta'];
-    if (!meta || typeof meta !== 'object') return undefined;
-    const label = (meta as Record<string, unknown>)['connectionLabel'];
-    return typeof label === 'string' ? label : undefined;
-  }, [part.state, part.output]);
   const pieceNames = useMemo(
     () => chatPartUtils.extractPieceNames(rawInput),
     [rawInput],

--- a/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/activity-accordion.tsx
@@ -273,11 +273,6 @@ function ToolStepRow({
                 />
               ))}
             </div>
-            {connectionLabel && (
-              <p className="text-xs text-muted-foreground mt-0.5 ml-1">
-                {t('via {connectionLabel}', { connectionLabel })}
-              </p>
-            )}
           </div>
         )}
         {hasDetails && (

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -114,6 +114,10 @@ export const AssistantMessage = memo(function AssistantMessage({
     for (let i = 0; i < message.parts.length; i++) {
       const p = message.parts[i];
 
+      if (p.type === 'step-start') {
+        flushThinking();
+        continue;
+      }
       if (p.type === 'text' && p.text.length > 0) {
         flushThinking();
         hasText = true;

--- a/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
@@ -159,8 +159,7 @@ export function ConnectionPickerCard({
   }>();
   const conversationId =
     routerConversationId ??
-    window.location.pathname.match(/\/chat\/(.+)/)?.[1] ??
-    undefined;
+    window.location.pathname.match(/\/chat\/([^/]+)/)?.[1];
   const pieceName = normalizePieceName(picker.piece);
   const shouldFetch =
     !picker.connections?.length && !!conversationId && isInteractive;

--- a/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/connection-picker-card.tsx
@@ -154,7 +154,13 @@ export function ConnectionPickerCard({
   selectedConnectionLabel,
 }: ConnectionPickerCardProps) {
   const queryClient = useQueryClient();
-  const { conversationId } = useParams<{ conversationId: string }>();
+  const { conversationId: routerConversationId } = useParams<{
+    conversationId: string;
+  }>();
+  const conversationId =
+    routerConversationId ??
+    window.location.pathname.match(/\/chat\/(.+)/)?.[1] ??
+    undefined;
   const pieceName = normalizePieceName(picker.piece);
   const shouldFetch =
     !picker.connections?.length && !!conversationId && isInteractive;

--- a/packages/web/src/app/routes/chat-with-ai/components/multi-question-form.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/multi-question-form.tsx
@@ -13,7 +13,6 @@ import { Fragment, useEffect, useId, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
@@ -34,8 +33,9 @@ export function MultiQuestionForm({
   const [focusedRow, setFocusedRow] = useState<number | 'custom' | null>(null);
   const [hoveredRow, setHoveredRow] = useState<number | 'custom' | null>(null);
   const fieldId = useId();
-  const firstOptionRef = useRef<HTMLButtonElement | null>(null);
-  const lastOptionRef = useRef<HTMLButtonElement | null>(null);
+  const firstOptionRef = useRef<HTMLDivElement | null>(null);
+  const lastOptionRef = useRef<HTMLDivElement | null>(null);
+  const optionRefs = useRef<(HTMLDivElement | null)[]>([]);
   const customAnswerInputRef = useRef<HTMLInputElement>(null);
   const textInputRef = useRef<HTMLInputElement>(null);
   const lastFocusedElRef = useRef<HTMLElement | null>(null);
@@ -55,7 +55,7 @@ export function MultiQuestionForm({
     setAnswers((prev) => ({ ...prev, [currentStep]: value }));
   }
 
-  function setFirstOptionEl(el: HTMLButtonElement | null) {
+  function setFirstOptionEl(el: HTMLDivElement | null) {
     firstOptionRef.current = el;
     if (el && lastFocusedElRef.current !== el) {
       el.focus({ preventScroll: true });
@@ -233,17 +233,8 @@ export function MultiQuestionForm({
           <div>
             {q.type === 'choice' && q.options && (
               <div>
-                <RadioGroup
-                  value={
-                    q.options.includes(answers[currentStep] ?? '')
-                      ? answers[currentStep]
-                      : ''
-                  }
-                  onValueChange={setAnswer}
-                  className="gap-0"
-                >
+                <div role="listbox" aria-label={q.question} className="gap-0">
                   {q.options.map((option, i) => {
-                    const id = `${fieldId}-opt-${i}`;
                     const selected = answers[currentStep] === option;
                     const isFirst = i === 0;
                     const isLast = i === q.options!.length - 1;
@@ -260,9 +251,19 @@ export function MultiQuestionForm({
                           </div>
                         )}
                         <div
-                          onClick={() => {
-                            handleNext(option);
+                          role="option"
+                          tabIndex={
+                            focusedRow === i || (focusedRow === null && isFirst)
+                              ? 0
+                              : -1
+                          }
+                          aria-selected={selected}
+                          ref={(el) => {
+                            optionRefs.current[i] = el;
+                            if (isFirst) setFirstOptionEl(el);
+                            if (isLast) lastOptionRef.current = el;
                           }}
+                          onClick={() => handleNext(option)}
                           onMouseEnter={() => setHoveredRow(i)}
                           onMouseLeave={() =>
                             setHoveredRow((prev) => (prev === i ? null : prev))
@@ -271,49 +272,52 @@ export function MultiQuestionForm({
                           onBlur={() =>
                             setFocusedRow((prev) => (prev === i ? null : prev))
                           }
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              e.preventDefault();
+                              handleNext(option);
+                              return;
+                            }
+                            if (
+                              e.key === 'ArrowLeft' ||
+                              e.key === 'ArrowRight'
+                            ) {
+                              e.preventDefault();
+                              return;
+                            }
+                            if (e.key === 'ArrowDown') {
+                              e.preventDefault();
+                              if (isLast) {
+                                customAnswerInputRef.current?.focus();
+                              } else {
+                                setFocusedRow(i + 1);
+                                optionRefs.current[i + 1]?.focus();
+                              }
+                              return;
+                            }
+                            if (e.key === 'ArrowUp') {
+                              e.preventDefault();
+                              if (isFirst) {
+                                customAnswerInputRef.current?.focus();
+                              } else {
+                                setFocusedRow(i - 1);
+                                optionRefs.current[i - 1]?.focus();
+                              }
+                              return;
+                            }
+                          }}
                           className={cn(
-                            'group flex items-center gap-3 rounded-xl px-2 py-2 text-sm font-normal cursor-pointer transition-colors hover:bg-muted',
+                            'group flex items-center gap-3 rounded-xl px-2 py-2 text-sm font-normal cursor-pointer transition-colors hover:bg-muted outline-none',
                             focusedRow === i && !selected && 'bg-muted',
                             selected && 'bg-muted-foreground/15',
                           )}
                         >
-                          <RadioGroupItem
-                            ref={(el) => {
-                              if (isFirst) setFirstOptionEl(el);
-                              if (isLast) lastOptionRef.current = el;
-                            }}
-                            id={id}
-                            value={option}
-                            className="peer sr-only"
-                            onKeyDownCapture={(e) => {
-                              if (e.key === 'Enter') {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                handleNext(option);
-                                return;
-                              }
-                              if (
-                                e.key === 'ArrowLeft' ||
-                                e.key === 'ArrowRight'
-                              ) {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                return;
-                              }
-                              const wrapDown = e.key === 'ArrowDown' && isLast;
-                              const wrapUp = e.key === 'ArrowUp' && isFirst;
-                              if (wrapDown || wrapUp) {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                setAnswer('');
-                                customAnswerInputRef.current?.focus();
-                              }
-                            }}
-                          />
                           <span
                             aria-hidden
                             className={cn(
-                              'flex size-8 shrink-0 items-center justify-center rounded-md bg-muted-foreground/10 text-xs font-medium text-muted-foreground transition-colors peer-focus:bg-foreground peer-focus:text-background',
+                              'flex size-8 shrink-0 items-center justify-center rounded-md bg-muted-foreground/10 text-xs font-medium text-muted-foreground transition-colors',
+                              focusedRow === i &&
+                                'bg-foreground text-background',
                               selected && 'bg-foreground text-background',
                             )}
                           >
@@ -324,7 +328,7 @@ export function MultiQuestionForm({
                       </Fragment>
                     );
                   })}
-                </RadioGroup>
+                </div>
 
                 <div className="px-3">
                   <Separator
@@ -374,15 +378,11 @@ export function MultiQuestionForm({
                     onKeyDown={(e) => {
                       if (e.key === 'ArrowUp') {
                         e.preventDefault();
-                        const last = q.options![q.options!.length - 1];
-                        setAnswer(last);
                         lastOptionRef.current?.focus();
                         return;
                       }
                       if (e.key === 'ArrowDown') {
                         e.preventDefault();
-                        const first = q.options![0];
-                        setAnswer(first);
                         firstOptionRef.current?.focus();
                         return;
                       }

--- a/packages/web/src/app/routes/chat-with-ai/components/multi-question-form.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/multi-question-form.tsx
@@ -233,7 +233,7 @@ export function MultiQuestionForm({
           <div>
             {q.type === 'choice' && q.options && (
               <div>
-                <div role="listbox" aria-label={q.question} className="gap-0">
+                <div role="menu" aria-label={q.question} className="gap-0">
                   {q.options.map((option, i) => {
                     const selected = answers[currentStep] === option;
                     const isFirst = i === 0;
@@ -251,13 +251,13 @@ export function MultiQuestionForm({
                           </div>
                         )}
                         <div
-                          role="option"
+                          role="menuitemradio"
                           tabIndex={
                             focusedRow === i || (focusedRow === null && isFirst)
                               ? 0
                               : -1
                           }
-                          aria-selected={selected}
+                          aria-checked={selected}
                           ref={(el) => {
                             optionRefs.current[i] = el;
                             if (isFirst) setFirstOptionEl(el);

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -46,6 +46,51 @@ function restoreReceiptsIntoStore({
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 const AGENT_POLL_INTERVAL_MS = 5_000;
 
+function buildToolCallMetaFromGate(gate: {
+  gateId: string;
+  toolName: string;
+  displayName: string;
+  toolInput: Record<string, unknown>;
+}): Record<string, ToolCallMeta> {
+  const gateInput = gate.toolInput ?? {};
+  const isActionPreview = gate.toolName === 'ap_execute_action';
+  const meta: ToolCallMeta = isActionPreview
+    ? {
+        actionPreview: {
+          toolCallId: gate.gateId,
+          pieceName:
+            typeof gateInput.pieceName === 'string' ? gateInput.pieceName : '',
+          actionName:
+            typeof gateInput.actionName === 'string'
+              ? gateInput.actionName
+              : '',
+          actionDisplayName: gate.displayName,
+          input:
+            typeof gateInput.input === 'object' && gateInput.input !== null
+              ? (gateInput.input as Record<string, unknown>)
+              : {},
+          isBatch:
+            typeof gateInput.batchCount === 'number' &&
+            gateInput.batchCount > 0,
+          batchCount:
+            typeof gateInput.batchCount === 'number'
+              ? gateInput.batchCount
+              : undefined,
+          batchSamples: Array.isArray(gateInput.items)
+            ? (gateInput.items as Record<string, unknown>[]).slice(0, 3)
+            : undefined,
+        },
+      }
+    : {
+        approvalRequest: {
+          toolCallId: gate.gateId,
+          toolName: gate.toolName,
+          displayName: gate.displayName,
+        },
+      };
+  return { [gate.gateId]: meta };
+}
+
 const ALLOWED_MIME_SET: ReadonlySet<string> = new Set(CHAT_ALLOWED_MIME_TYPES);
 
 function isAllowedMimeType(value: string): value is ChatAllowedMimeType {
@@ -53,7 +98,7 @@ function isAllowedMimeType(value: string): value is ChatAllowedMimeType {
 }
 
 function fileToBase64(
-  file: File,
+  file: File
 ): Promise<{ name: string; mimeType: ChatAllowedMimeType; data: string }> {
   return new Promise((resolve, reject) => {
     const mimeType = file.type || 'application/octet-stream';
@@ -125,10 +170,10 @@ export function useAgentChat({
   const store = useChatStoreApi();
 
   const [conversationId, setConversationIdState] = useState<string | null>(
-    null,
+    null
   );
   const [modelName, setModelNameState] = useState<string | null>(
-    DEFAULT_CHAT_TIER_ID,
+    DEFAULT_CHAT_TIER_ID
   );
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [isPollingForAgentReply, setIsPollingForAgentReply] = useState(false);
@@ -138,7 +183,7 @@ export function useAgentChat({
   onCreditsExhaustedRef.current = onCreditsExhausted;
 
   const [persistedMessages, setPersistedMessages] = useState<ChatUIMessage[]>(
-    [],
+    []
   );
   const persistedMessagesRef = useRef(persistedMessages);
   persistedMessagesRef.current = persistedMessages;
@@ -182,13 +227,13 @@ export function useAgentChat({
         };
       });
     },
-    [store],
+    [store]
   );
 
   const updateToolCallMeta = useCallback(
     <K extends keyof ToolCallMeta>(
       key: K,
-      event: ToolCallMeta[K] & { toolCallId: string },
+      event: ToolCallMeta[K] & { toolCallId: string }
     ) => {
       store.setState((prev) => ({
         toolCallMeta: {
@@ -200,28 +245,28 @@ export function useAgentChat({
         },
       }));
     },
-    [store],
+    [store]
   );
 
   const handleToolApprovalRequest = useCallback(
     (event: ToolApprovalRequestEvent) => {
       updateToolCallMeta('approvalRequest', event);
     },
-    [updateToolCallMeta],
+    [updateToolCallMeta]
   );
 
   const handleActionPreview = useCallback(
     (event: ActionPreviewEvent) => {
       updateToolCallMeta('actionPreview', event);
     },
-    [updateToolCallMeta],
+    [updateToolCallMeta]
   );
 
   const handleActionReceipt = useCallback(
     (event: ActionReceiptEvent) => {
       updateToolCallMeta('actionReceipt', event);
     },
-    [updateToolCallMeta],
+    [updateToolCallMeta]
   );
 
   const updateSendStatus = useCallback((next: SendStatus) => {
@@ -233,7 +278,7 @@ export function useAgentChat({
     async (convId: string) => {
       if (conversationIdRef.current !== convId) return;
       const { data: result } = await tryCatch(() =>
-        chatApi.getMessages(convId),
+        chatApi.getMessages(convId)
       );
       if (conversationIdRef.current !== convId) return;
       if (result) {
@@ -251,7 +296,7 @@ export function useAgentChat({
       }
       setOptimisticUserMessage(null);
     },
-    [store],
+    [store]
   );
 
   const {
@@ -304,7 +349,7 @@ export function useAgentChat({
 
   const streamingQuickReplies = useMemo(
     () => chatPartUtils.extractQuickRepliesFromParts(streamingMessage),
-    [streamingMessage],
+    [streamingMessage]
   );
 
   useEffect(() => {
@@ -362,7 +407,7 @@ export function useAgentChat({
       setConversationIdState(conv.id);
       return conv;
     },
-    [],
+    []
   );
 
   const sendMessage = useCallback(
@@ -395,7 +440,7 @@ export function useAgentChat({
           return;
         }
         const { data: encodedFiles, error: fileError } = await tryCatch(
-          async () => Promise.all(files.map(fileToBase64)),
+          async () => Promise.all(files.map(fileToBase64))
         );
         if (fileError) {
           setOptimisticUserMessage(null);
@@ -450,7 +495,7 @@ export function useAgentChat({
           conversationId: convId,
           content,
           files: pendingFilesRef.current,
-        }),
+        })
       );
       if (sendError) {
         stopStream();
@@ -466,7 +511,7 @@ export function useAgentChat({
         }
       }
     },
-    [createConversation, startStream, stopStream, updateSendStatus, store],
+    [createConversation, startStream, stopStream, updateSendStatus, store]
   );
 
   const setConversationId = useCallback(
@@ -511,11 +556,21 @@ export function useAgentChat({
       modelNameRef.current = convResult.data.modelName ?? null;
       setModelNameState(convResult.data.modelName ?? null);
       if (convResult.data.status === ChatConversationStatus.STREAMING) {
+        const { data: gate } = await tryCatch(() => chatApi.getPendingGate(id));
+        if (conversationIdRef.current !== id) return;
         startStream(id);
+        if (gate) {
+          store.setState((prev) => ({
+            toolCallMeta: {
+              ...prev.toolCallMeta,
+              ...buildToolCallMetaFromGate(gate),
+            },
+          }));
+        }
       }
       setIsLoadingHistory(false);
     },
-    [stopStream, startStream, updateSendStatus, store],
+    [stopStream, startStream, updateSendStatus, store]
   );
 
   useQuery({
@@ -550,56 +605,13 @@ export function useAgentChat({
         });
         if (!hasBlockingCard) {
           const { data: gate } = await tryCatch(() =>
-            chatApi.getPendingGate(conversationId),
+            chatApi.getPendingGate(conversationId)
           );
           if (gate && conversationIdRef.current === conversationId) {
-            const gateInput = gate.toolInput ?? {};
-            const isActionPreview = gate.toolName === 'ap_execute_action';
             store.setState((prev) => ({
               toolCallMeta: {
                 ...prev.toolCallMeta,
-                [gate.gateId]: {
-                  ...prev.toolCallMeta[gate.gateId],
-                  ...(isActionPreview
-                    ? {
-                        actionPreview: {
-                          toolCallId: gate.gateId,
-                          pieceName:
-                            typeof gateInput.pieceName === 'string'
-                              ? gateInput.pieceName
-                              : '',
-                          actionName:
-                            typeof gateInput.actionName === 'string'
-                              ? gateInput.actionName
-                              : '',
-                          actionDisplayName: gate.displayName,
-                          input:
-                            typeof gateInput.input === 'object' &&
-                            gateInput.input !== null
-                              ? (gateInput.input as Record<string, unknown>)
-                              : {},
-                          isBatch:
-                            typeof gateInput.batchCount === 'number' &&
-                            gateInput.batchCount > 0,
-                          batchCount:
-                            typeof gateInput.batchCount === 'number'
-                              ? gateInput.batchCount
-                              : undefined,
-                          batchSamples: Array.isArray(gateInput.items)
-                            ? (
-                                gateInput.items as Record<string, unknown>[]
-                              ).slice(0, 3)
-                            : undefined,
-                        },
-                      }
-                    : {
-                        approvalRequest: {
-                          toolCallId: gate.gateId,
-                          toolName: gate.toolName,
-                          displayName: gate.displayName,
-                        },
-                      }),
-                },
+                ...buildToolCallMetaFromGate(gate),
               },
             }));
           }

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -98,7 +98,7 @@ function isAllowedMimeType(value: string): value is ChatAllowedMimeType {
 }
 
 function fileToBase64(
-  file: File
+  file: File,
 ): Promise<{ name: string; mimeType: ChatAllowedMimeType; data: string }> {
   return new Promise((resolve, reject) => {
     const mimeType = file.type || 'application/octet-stream';
@@ -170,10 +170,10 @@ export function useAgentChat({
   const store = useChatStoreApi();
 
   const [conversationId, setConversationIdState] = useState<string | null>(
-    null
+    null,
   );
   const [modelName, setModelNameState] = useState<string | null>(
-    DEFAULT_CHAT_TIER_ID
+    DEFAULT_CHAT_TIER_ID,
   );
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [isPollingForAgentReply, setIsPollingForAgentReply] = useState(false);
@@ -183,7 +183,7 @@ export function useAgentChat({
   onCreditsExhaustedRef.current = onCreditsExhausted;
 
   const [persistedMessages, setPersistedMessages] = useState<ChatUIMessage[]>(
-    []
+    [],
   );
   const persistedMessagesRef = useRef(persistedMessages);
   persistedMessagesRef.current = persistedMessages;
@@ -227,13 +227,13 @@ export function useAgentChat({
         };
       });
     },
-    [store]
+    [store],
   );
 
   const updateToolCallMeta = useCallback(
     <K extends keyof ToolCallMeta>(
       key: K,
-      event: ToolCallMeta[K] & { toolCallId: string }
+      event: ToolCallMeta[K] & { toolCallId: string },
     ) => {
       store.setState((prev) => ({
         toolCallMeta: {
@@ -245,28 +245,28 @@ export function useAgentChat({
         },
       }));
     },
-    [store]
+    [store],
   );
 
   const handleToolApprovalRequest = useCallback(
     (event: ToolApprovalRequestEvent) => {
       updateToolCallMeta('approvalRequest', event);
     },
-    [updateToolCallMeta]
+    [updateToolCallMeta],
   );
 
   const handleActionPreview = useCallback(
     (event: ActionPreviewEvent) => {
       updateToolCallMeta('actionPreview', event);
     },
-    [updateToolCallMeta]
+    [updateToolCallMeta],
   );
 
   const handleActionReceipt = useCallback(
     (event: ActionReceiptEvent) => {
       updateToolCallMeta('actionReceipt', event);
     },
-    [updateToolCallMeta]
+    [updateToolCallMeta],
   );
 
   const updateSendStatus = useCallback((next: SendStatus) => {
@@ -278,7 +278,7 @@ export function useAgentChat({
     async (convId: string) => {
       if (conversationIdRef.current !== convId) return;
       const { data: result } = await tryCatch(() =>
-        chatApi.getMessages(convId)
+        chatApi.getMessages(convId),
       );
       if (conversationIdRef.current !== convId) return;
       if (result) {
@@ -296,7 +296,7 @@ export function useAgentChat({
       }
       setOptimisticUserMessage(null);
     },
-    [store]
+    [store],
   );
 
   const {
@@ -349,7 +349,7 @@ export function useAgentChat({
 
   const streamingQuickReplies = useMemo(
     () => chatPartUtils.extractQuickRepliesFromParts(streamingMessage),
-    [streamingMessage]
+    [streamingMessage],
   );
 
   useEffect(() => {
@@ -407,7 +407,7 @@ export function useAgentChat({
       setConversationIdState(conv.id);
       return conv;
     },
-    []
+    [],
   );
 
   const sendMessage = useCallback(
@@ -440,7 +440,7 @@ export function useAgentChat({
           return;
         }
         const { data: encodedFiles, error: fileError } = await tryCatch(
-          async () => Promise.all(files.map(fileToBase64))
+          async () => Promise.all(files.map(fileToBase64)),
         );
         if (fileError) {
           setOptimisticUserMessage(null);
@@ -495,7 +495,7 @@ export function useAgentChat({
           conversationId: convId,
           content,
           files: pendingFilesRef.current,
-        })
+        }),
       );
       if (sendError) {
         stopStream();
@@ -511,7 +511,7 @@ export function useAgentChat({
         }
       }
     },
-    [createConversation, startStream, stopStream, updateSendStatus, store]
+    [createConversation, startStream, stopStream, updateSendStatus, store],
   );
 
   const setConversationId = useCallback(
@@ -570,7 +570,7 @@ export function useAgentChat({
       }
       setIsLoadingHistory(false);
     },
-    [stopStream, startStream, updateSendStatus, store]
+    [stopStream, startStream, updateSendStatus, store],
   );
 
   useQuery({
@@ -605,7 +605,7 @@ export function useAgentChat({
         });
         if (!hasBlockingCard) {
           const { data: gate } = await tryCatch(() =>
-            chatApi.getPendingGate(conversationId)
+            chatApi.getPendingGate(conversationId),
           );
           if (gate && conversationIdRef.current === conversationId) {
             store.setState((prev) => ({

--- a/packages/web/src/features/chat/lib/use-streaming-reducer.ts
+++ b/packages/web/src/features/chat/lib/use-streaming-reducer.ts
@@ -15,7 +15,7 @@ import { ChatUIMessage } from './chat-types';
 import { chunkReducer, StreamingState } from './chunk-reducer';
 
 const THROTTLE_MS = 100;
-const STREAM_TIMEOUT_MS = 10 * 60 * 1000;
+const STREAM_TIMEOUT_MS = 2 * 60 * 1000;
 const STALE_CHECK_INTERVAL_MS = 15_000;
 
 export function useStreamingReducer({
@@ -212,6 +212,13 @@ export function useStreamingReducer({
 
       socket.on(WebsocketClientEvent.CHAT_MESSAGE_CHUNK, handler);
 
+      const reconnectHandler = () => {
+        socket.off(WebsocketClientEvent.CHAT_MESSAGE_CHUNK, handler);
+        socket.on(WebsocketClientEvent.CHAT_MESSAGE_CHUNK, handler);
+        lastChunkTimeRef.current = Date.now();
+      };
+      socket.on('connect', reconnectHandler);
+
       streamTimeoutRef.current = setTimeout(() => {
         handleError({ errorMessage: 'Stream timed out' });
       }, STREAM_TIMEOUT_MS);
@@ -224,6 +231,7 @@ export function useStreamingReducer({
 
       cleanupRef.current = () => {
         socket.off(WebsocketClientEvent.CHAT_MESSAGE_CHUNK, handler);
+        socket.off('connect', reconnectHandler);
       };
     },
     [socket, teardown, flush, scheduleFlush, updatePhase],


### PR DESCRIPTION
## Summary
- **Connection scope blindness**: Surface OAuth granted/required scopes so AI avoids building steps on insufficient connections
- **Stream drops/unresponsive**: Reduce staleness timeout to 2min, add heartbeat during tool waits, re-subscribe socket on reconnect, reduce stream timeout to 2min
- **Mode detection**: Add required `mode` field (one_time/recurring) to plan approval, default to one-time when ambiguous
- **Loop nesting**: Extend `ap_build_flow` with `parentStepName` and `stepLocationRelativeToParent` so loops contain their children
- **Large response handling**: Detect >100KB responses and return a preview with item count + instructions instead of broken truncated JSON
- **Stale connection status**: Check OAuth token expiry (with 5-min clock-skew buffer) before returning status to AI
- **Vanishing selection prompts**: Re-fetch pending gate from backend when switching conversations
- **Keyboard navigation**: Replace Radix RadioGroup with listbox pattern so arrow keys move focus without auto-selecting
- **Batch performance**: Parallelize batch execution with concurrency limit of 5 using `chunk()` from shared
- **Connection picker on new chats**: Fall back to `window.location.pathname` when `useParams` returns undefined due to `replaceState`
- **Thinking step ordering**: Flush thinking blocks at `step-start` boundaries so tool pills render chronologically
- **Action receipt cleanup**: Remove redundant "via connectionLabel" text
- **Prompt rules**: Add rules for scope awareness, minimal data fetching, batch actions, field completeness, property discovery

## Test plan
- [ ] Open chat, ask to send Gmail with a read-only connection — AI should warn about insufficient scopes
- [ ] Kill worker mid-stream — conversation should reset within 2 minutes, not 20
- [ ] Send ambiguous prompt ("flag unreplied emails") — AI should default to one-time and ask about recurring
- [ ] Ask to "loop through emails and flag each" via ap_build_flow — loop step should contain children
- [ ] Execute action returning >100KB — AI should get preview with count, not broken JSON
- [ ] Start new chat, trigger connection picker — connections should load (not empty)
- [ ] Switch away from chat with pending picker, switch back — picker should reappear
- [ ] Open multi-question form, press arrow keys — should highlight without selecting
- [ ] Enrich 15 rows — should use batch actions and run faster than serial
- [ ] Expand "Thought for X seconds" — tool pills should appear in chronological order
- [ ] Run `npm run lint-dev`