### PR TITLE
feat(taskade): add task update/move, project creation, and AI agent actions

### DIFF
--- a/packages/pieces/community/taskade/package.json
+++ b/packages/pieces/community/taskade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-taskade",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/taskade/src/index.ts
+++ b/packages/pieces/community/taskade/src/index.ts
@@ -3,6 +3,12 @@ import { createTaskAction } from './lib/actions/create-task.action';
 import { PieceCategory } from '@activepieces/shared';
 import { completeTaskAction } from './lib/actions/complete-task.action';
 import { deleteTaskAction } from './lib/actions/delete-task.action';
+import { updateTaskAction } from './lib/actions/update-task.action';
+import { uncompleteTaskAction } from './lib/actions/uncomplete-task.action';
+import { moveTaskAction } from './lib/actions/move-task.action';
+import { createProjectAction } from './lib/actions/create-project.action';
+import { createProjectFromTemplateAction } from './lib/actions/create-project-from-template.action';
+import { runAgentAction } from './lib/actions/run-agent.action';
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
 import { taskadeAuth } from './lib/auth';
 
@@ -13,11 +19,17 @@ export const taskade = createPiece({
 	categories: [PieceCategory.PRODUCTIVITY],
 	description: 'collaboration platform for remote teams to organize and manage projects',
 	logoUrl: 'https://cdn.activepieces.com/pieces/taskade.png',
-	authors: ['kishanprmr'],
+	authors: ['kishanprmr', 'johnxie'],
 	actions: [
 		createTaskAction,
 		completeTaskAction,
 		deleteTaskAction,
+		updateTaskAction,
+		uncompleteTaskAction,
+		moveTaskAction,
+		createProjectAction,
+		createProjectFromTemplateAction,
+		runAgentAction,
 		createCustomApiCallAction({
 			baseUrl: () => 'https://www.taskade.com/api/v1',
 			auth: taskadeAuth,

--- a/packages/pieces/community/taskade/src/lib/actions/create-project-from-template.action.ts
+++ b/packages/pieces/community/taskade/src/lib/actions/create-project-from-template.action.ts
@@ -1,0 +1,26 @@
+import { taskadeAuth } from '../auth';
+import { createAction } from '@activepieces/pieces-framework';
+import { taskadeProps } from '../common/props';
+import { TaskadeAPIClient } from '../common/client';
+
+export const createProjectFromTemplateAction = createAction({
+	auth: taskadeAuth,
+	name: 'taskade-create-project-from-template',
+	displayName: 'Create Project From Template',
+	description: 'Creates a new project from a template.',
+	props: {
+		workspace_id: taskadeProps.workspace_id,
+		folder_id: taskadeProps.folder_id,
+		template_id: taskadeProps.template_id,
+	},
+	async run(context) {
+		const { workspace_id, folder_id, template_id } = context.propsValue;
+
+		const client = new TaskadeAPIClient(context.auth.secret_text);
+
+		return await client.createProjectFromTemplate({
+			folderId: folder_id ?? workspace_id,
+			templateId: template_id,
+		});
+	},
+});

--- a/packages/pieces/community/taskade/src/lib/actions/create-project.action.ts
+++ b/packages/pieces/community/taskade/src/lib/actions/create-project.action.ts
@@ -1,0 +1,31 @@
+import { taskadeAuth } from '../auth';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { taskadeProps } from '../common/props';
+import { TaskadeAPIClient } from '../common/client';
+
+export const createProjectAction = createAction({
+	auth: taskadeAuth,
+	name: 'taskade-create-project',
+	displayName: 'Create Project',
+	description: 'Creates a new project in a folder.',
+	props: {
+		workspace_id: taskadeProps.workspace_id,
+		folder_id: taskadeProps.folder_id,
+		content: Property.LongText({
+			displayName: 'Project Content',
+			description: 'Content of the new project in markdown format.',
+			required: true,
+		}),
+	},
+	async run(context) {
+		const { workspace_id, folder_id, content } = context.propsValue;
+
+		const client = new TaskadeAPIClient(context.auth.secret_text);
+
+		return await client.createProject({
+			folderId: folder_id ?? workspace_id,
+			contentType: 'text/markdown',
+			content,
+		});
+	},
+});

--- a/packages/pieces/community/taskade/src/lib/actions/move-task.action.ts
+++ b/packages/pieces/community/taskade/src/lib/actions/move-task.action.ts
@@ -1,0 +1,57 @@
+import { taskadeAuth } from '../auth';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { taskadeProps } from '../common/props';
+import { TaskadeAPIClient } from '../common/client';
+
+export const moveTaskAction = createAction({
+	auth: taskadeAuth,
+	name: 'taskade-move-task',
+	displayName: 'Move Task',
+	description: 'Moves a task relative to another task in a project.',
+	props: {
+		workspace_id: taskadeProps.workspace_id,
+		folder_id: taskadeProps.folder_id,
+		project_id: taskadeProps.project_id,
+		task_id: taskadeProps.task_id,
+		target_task_id: taskadeProps.target_task_id,
+		position: Property.StaticDropdown({
+			displayName: 'Position',
+			description: 'Position of the task relative to the target task',
+			required: true,
+			defaultValue: 'afterend',
+			options: {
+				disabled: false,
+				options: [
+					{
+						label: 'beforebegin',
+						value: 'beforebegin',
+					},
+					{
+						label: 'afterbegin',
+						value: 'afterbegin',
+					},
+					{
+						label: 'beforeend',
+						value: 'beforeend',
+					},
+					{
+						label: 'afterend',
+						value: 'afterend',
+					},
+				],
+			},
+		}),
+	},
+	async run(context) {
+		const { project_id, task_id, target_task_id, position } = context.propsValue;
+
+		const client = new TaskadeAPIClient(context.auth.secret_text);
+
+		return await client.moveTask(project_id, task_id, {
+			target: {
+				taskId: target_task_id,
+				position,
+			},
+		});
+	},
+});

--- a/packages/pieces/community/taskade/src/lib/actions/run-agent.action.ts
+++ b/packages/pieces/community/taskade/src/lib/actions/run-agent.action.ts
@@ -1,0 +1,30 @@
+import { taskadeAuth } from '../auth';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { taskadeProps } from '../common/props';
+import { TaskadeAPIClient } from '../common/client';
+
+export const runAgentAction = createAction({
+	auth: taskadeAuth,
+	name: 'taskade-run-agent',
+	displayName: 'Run AI Agent',
+	description: 'Sends a prompt to a Taskade AI agent and returns its response.',
+	props: {
+		space_id: taskadeProps.space_id,
+		agent_id: taskadeProps.agent_id,
+		prompt: Property.LongText({
+			displayName: 'Prompt',
+			required: true,
+		}),
+	},
+	async run(context) {
+		const { space_id, agent_id, prompt } = context.propsValue;
+
+		const client = new TaskadeAPIClient(context.auth.secret_text);
+
+		return await client.runAgent({
+			spaceId: space_id,
+			agentId: agent_id,
+			prompt,
+		});
+	},
+});

--- a/packages/pieces/community/taskade/src/lib/actions/uncomplete-task.action.ts
+++ b/packages/pieces/community/taskade/src/lib/actions/uncomplete-task.action.ts
@@ -1,0 +1,24 @@
+import { taskadeAuth } from '../auth';
+import { createAction } from '@activepieces/pieces-framework';
+import { taskadeProps } from '../common/props';
+import { TaskadeAPIClient } from '../common/client';
+
+export const uncompleteTaskAction = createAction({
+	auth: taskadeAuth,
+	name: 'taskade-uncomplete-task',
+	displayName: 'Uncomplete Task',
+	description: 'Marks a task as incomplete in a project.',
+	props: {
+		workspace_id: taskadeProps.workspace_id,
+		folder_id: taskadeProps.folder_id,
+		project_id: taskadeProps.project_id,
+		task_id: taskadeProps.task_id,
+	},
+	async run(context) {
+		const { project_id, task_id } = context.propsValue;
+
+		const client = new TaskadeAPIClient(context.auth.secret_text);
+
+		return await client.uncompleteTask(project_id, task_id);
+	},
+});

--- a/packages/pieces/community/taskade/src/lib/actions/update-task.action.ts
+++ b/packages/pieces/community/taskade/src/lib/actions/update-task.action.ts
@@ -1,0 +1,50 @@
+import { taskadeAuth } from '../auth';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { taskadeProps } from '../common/props';
+import { TaskadeAPIClient } from '../common/client';
+
+export const updateTaskAction = createAction({
+	auth: taskadeAuth,
+	name: 'taskade-update-task',
+	displayName: 'Update Task',
+	description: 'Updates the content of an existing task.',
+	props: {
+		workspace_id: taskadeProps.workspace_id,
+		folder_id: taskadeProps.folder_id,
+		project_id: taskadeProps.project_id,
+		task_id: taskadeProps.task_id,
+		content_type: Property.StaticDropdown({
+			displayName: 'Content Type',
+			required: true,
+			defaultValue: 'text/markdown',
+			options: {
+				disabled: false,
+				options: [
+					{
+						label: 'text/markdown',
+						value: 'text/markdown',
+					},
+					{
+						label: 'text/plain',
+						value: 'text/plain',
+					},
+				],
+			},
+		}),
+		content: Property.ShortText({
+			displayName: 'Task Content',
+			description: 'New task content. Must be a single line with a maximum of 2000 characters.',
+			required: true,
+		}),
+	},
+	async run(context) {
+		const { project_id, task_id, content_type, content } = context.propsValue;
+
+		const client = new TaskadeAPIClient(context.auth.secret_text);
+
+		return await client.updateTask(project_id, task_id, {
+			contentType: content_type,
+			content,
+		});
+	},
+});

--- a/packages/pieces/community/taskade/src/lib/common/client.ts
+++ b/packages/pieces/community/taskade/src/lib/common/client.ts
@@ -7,11 +7,22 @@ import {
 	AuthenticationType,
 } from '@activepieces/pieces-common';
 import {
+	AgentResponse,
+	AgentSpaceResponse,
+	CreateProjectFromTemplateParams,
+	CreateProjectParams,
+	CreateProjectResponse,
 	CreateTaskDateParams,
 	CreateTaskParams,
 	ListAPIResponse,
+	MoveTaskParams,
 	ProjectResponse,
+	ProjectTemplateResponse,
 	CreateTaskResponse,
+	RunAgentParams,
+	RunAgentResponse,
+	TaskActionResponse,
+	UpdateTaskParams,
 	WorkspaceFolderResponse,
 	WorkspaceResponse,
 	TaskResponse,
@@ -28,7 +39,25 @@ export class TaskadeAPIClient {
 		query?: RequestParams,
 		body: any | undefined = undefined,
 	): Promise<T> {
-		const baseUrl = 'https://www.taskade.com/api/v1';
+		return await this.sendRequest<T>('https://www.taskade.com/api/v1', method, resourceUri, query, body);
+	}
+
+	async makeV2Request<T extends HttpMessageBody>(
+		method: HttpMethod,
+		resourceUri: string,
+		query?: RequestParams,
+		body: any | undefined = undefined,
+	): Promise<T> {
+		return await this.sendRequest<T>('https://www.taskade.com/api/v2', method, resourceUri, query, body);
+	}
+
+	private async sendRequest<T extends HttpMessageBody>(
+		baseUrl: string,
+		method: HttpMethod,
+		resourceUri: string,
+		query?: RequestParams,
+		body: any | undefined = undefined,
+	): Promise<T> {
 		const qs: QueryParams = {};
 
 		if (query) {
@@ -101,5 +130,68 @@ export class TaskadeAPIClient {
 
 	async deleteTask(projectId: string, taskId: string) {
 		return await this.makeRequest(HttpMethod.DELETE, `/projects/${projectId}/tasks/${taskId}`);
+	}
+
+	async updateTask(
+		projectId: string,
+		taskId: string,
+		params: UpdateTaskParams,
+	): Promise<TaskActionResponse> {
+		return await this.makeRequest(
+			HttpMethod.PUT,
+			`/projects/${projectId}/tasks/${taskId}`,
+			undefined,
+			params,
+		);
+	}
+
+	async uncompleteTask(projectId: string, taskId: string) {
+		return await this.makeRequest(
+			HttpMethod.POST,
+			`/projects/${projectId}/tasks/${taskId}/uncomplete`,
+			undefined,
+			{},
+		);
+	}
+
+	async moveTask(
+		projectId: string,
+		taskId: string,
+		params: MoveTaskParams,
+	): Promise<TaskActionResponse> {
+		return await this.makeRequest(
+			HttpMethod.PUT,
+			`/projects/${projectId}/tasks/${taskId}/move`,
+			undefined,
+			params,
+		);
+	}
+
+	async createProject(params: CreateProjectParams): Promise<CreateProjectResponse> {
+		return await this.makeRequest(HttpMethod.POST, '/projects', undefined, params);
+	}
+
+	async createProjectFromTemplate(
+		params: CreateProjectFromTemplateParams,
+	): Promise<CreateProjectResponse> {
+		return await this.makeRequest(HttpMethod.POST, '/projects/from-template', undefined, params);
+	}
+
+	async listProjectTemplates(
+		folderId: string,
+	): Promise<ListAPIResponse<ProjectTemplateResponse>> {
+		return await this.makeRequest(HttpMethod.GET, `/folders/${folderId}/project-templates`);
+	}
+
+	async listAgentSpaces(): Promise<ListAPIResponse<AgentSpaceResponse>> {
+		return await this.makeV2Request(HttpMethod.POST, '/listSpaces', undefined, {});
+	}
+
+	async listAgents(spaceId: string): Promise<ListAPIResponse<AgentResponse>> {
+		return await this.makeV2Request(HttpMethod.POST, '/listAgents', undefined, { spaceId });
+	}
+
+	async runAgent(params: RunAgentParams): Promise<RunAgentResponse> {
+		return await this.makeV2Request(HttpMethod.POST, '/promptAgent', undefined, params);
 	}
 }

--- a/packages/pieces/community/taskade/src/lib/common/props.ts
+++ b/packages/pieces/community/taskade/src/lib/common/props.ts
@@ -130,4 +130,123 @@ export const taskadeProps = {
 			};
 		},
 	}),
+	target_task_id: Property.Dropdown({
+		auth: taskadeAuth,
+		displayName: 'Target Task',
+		refreshers: ['project_id'],
+		required: true,
+		options: async ({ auth, project_id }) => {
+			if (!auth) {
+				return createEmptyOptions('Please connect account first.');
+			}
+			if (!project_id) {
+				return createEmptyOptions('Please select project.');
+			}
+
+			const client = new TaskadeAPIClient(auth.secret_text);
+			const options: DropdownOption<string>[] = [];
+
+			let after;
+			let moreTasks = true;
+			while (moreTasks) {
+				const response = await client.listTasks(project_id as string, { limit: 100, after });
+				if (response.items.length === 0) {
+					moreTasks = false;
+				} else {
+					after = response.items[response.items.length - 1].id;
+					for (const task of response.items) {
+						options.push({ label: task.text, value: task.id });
+					}
+				}
+			}
+			return {
+				disabled: false,
+				options,
+			};
+		},
+	}),
+	template_id: Property.Dropdown({
+		auth: taskadeAuth,
+		displayName: 'Template',
+		refreshers: ['workspace_id', 'folder_id'],
+		required: true,
+		options: async ({ auth, workspace_id, folder_id }) => {
+			if (!auth) {
+				return createEmptyOptions('Please connect account first.');
+			}
+			if (!workspace_id) {
+				return createEmptyOptions('Please select workspace.');
+			}
+
+			const workspaceId = workspace_id as string;
+			const folderId = (folder_id as string) ?? workspaceId;
+
+			const client = new TaskadeAPIClient(auth.secret_text);
+			const response = await client.listProjectTemplates(folderId);
+
+			const options: DropdownOption<string>[] = [];
+
+			for (const template of response.items) {
+				options.push({ label: template.name, value: template.id });
+			}
+
+			return {
+				disabled: false,
+				options,
+			};
+		},
+	}),
+	space_id: Property.Dropdown({
+		auth: taskadeAuth,
+		displayName: 'Workspace',
+		refreshers: [],
+		required: true,
+		options: async ({ auth }) => {
+			if (!auth) {
+				return createEmptyOptions('Please connect account first.');
+			}
+
+			const client = new TaskadeAPIClient(auth.secret_text);
+			const response = await client.listAgentSpaces();
+
+			const options: DropdownOption<string>[] = [];
+
+			for (const space of response.items) {
+				options.push({ label: space.name, value: space.id });
+			}
+
+			return {
+				disabled: false,
+				options,
+			};
+		},
+	}),
+	agent_id: Property.Dropdown({
+		auth: taskadeAuth,
+		displayName: 'Agent',
+		refreshers: ['space_id'],
+		required: true,
+		options: async ({ auth, space_id }) => {
+			if (!auth) {
+				return createEmptyOptions('Please connect account first.');
+			}
+			if (!space_id) {
+				return createEmptyOptions('Please select workspace.');
+			}
+
+			const client = new TaskadeAPIClient(auth.secret_text);
+			const response = await client.listAgents(space_id as string);
+
+			const options: DropdownOption<string>[] = [];
+
+			for (const agent of response.items) {
+				options.push({ label: agent.name, value: agent.id });
+			}
+
+			return {
+				disabled: false,
+				options,
+			};
+		},
+	}),
 };

--- a/packages/pieces/community/taskade/src/lib/common/types.ts
+++ b/packages/pieces/community/taskade/src/lib/common/types.ts
@@ -11,6 +11,8 @@ export interface BaseResponse {
 export type WorkspaceResponse = BaseResponse;
 export type WorkspaceFolderResponse = BaseResponse;
 export type ProjectResponse = BaseResponse;
+export type ProjectTemplateResponse = BaseResponse;
+export type AgentSpaceResponse = BaseResponse;
 
 export interface CreateTaskParams {
 	contentType: string;
@@ -39,4 +41,54 @@ export interface CreateTaskDateParams {
 		date: string;
 		time: string;
 	};
+}
+
+export interface UpdateTaskParams {
+	contentType: string;
+	content: string;
+}
+
+export interface MoveTaskParams {
+	target: {
+		taskId: string;
+		position: string;
+	};
+}
+
+export interface TaskActionResponse {
+	ok: boolean;
+	item: TaskResponse;
+}
+
+export interface CreateProjectParams {
+	folderId: string;
+	contentType: string;
+	content: string;
+}
+
+export interface CreateProjectFromTemplateParams {
+	folderId: string;
+	templateId: string;
+}
+
+export interface CreateProjectResponse {
+	ok: boolean;
+	item: ProjectResponse;
+}
+
+export interface AgentResponse {
+	id: string;
+	name: string;
+	description: string;
+}
+
+export interface RunAgentParams {
+	spaceId: string;
+	agentId: string;
+	prompt: string;
+}
+
+export interface RunAgentResponse {
+	ok: boolean;
+	summary: string;
 }


### PR DESCRIPTION
## What does this PR do?

Deepens the existing **Taskade** piece (`@activepieces/piece-taskade`) from 3 actions to 9, covering task editing, project creation, and Taskade AI agents. Submitted officially by Taskade (the vendor).

All endpoints are taken from Taskade's live OpenAPI specs: [v1](https://www.taskade.com/api/documentation/v1/json) and [v2](https://www.taskade.com/api/documentation/v2/json).

### New actions

| Action | Endpoint |
|---|---|
| Update Task | `PUT /v1/projects/{projectId}/tasks/{taskId}` |
| Uncomplete Task | `POST /v1/projects/{projectId}/tasks/{taskId}/uncomplete` |
| Move Task | `PUT /v1/projects/{projectId}/tasks/{taskId}/move` |
| Create Project | `POST /v1/projects` |
| Create Project From Template | `POST /v1/projects/from-template` (templates listed via `GET /v1/folders/{folderId}/project-templates`) |
| Run AI Agent | `POST /v2/promptAgent` (agents/spaces listed via `POST /v2/listAgents`, `POST /v2/listSpaces`) |

### Explain How the Feature Works

- Each action lives in its own file under `src/lib/actions/`, mirroring the existing action style (cascading Workspace → Folder → Project → Task dropdowns from `common/props.ts`, `TaskadeAPIClient` from `common/client.ts`).
- `TaskadeAPIClient` gains a `makeV2Request` method (the AI agent endpoints live under `https://www.taskade.com/api/v2`); the existing `makeRequest` (v1) behavior is unchanged — both delegate to a shared private `sendRequest`.
- New dropdowns: project templates (per folder), agent workspaces (v2 `listSpaces`), agents (v2 `listAgents`), and a target-task dropdown for Move Task.
- Move Task positions follow the API enum: `beforebegin`, `afterbegin`, `beforeend`, `afterend`.
- Update Task enforces the API contract in its description (single line, max 2000 chars).

### Existing behavior untouched

Create Task, Complete Task, Delete Task, and the Custom API Call passthrough are unchanged. Auth (Personal Access Token, Bearer) is unchanged. Piece version bumped `0.1.5` → `0.2.0`.

### Notes for reviewers

- i18n files under `src/i18n/` were intentionally left untouched — they appear to be regenerated by the scheduled `generate-translations` workflow.
- Verified locally: all files type-check cleanly (`strict`, `noPropertyAccessFromIndexSignature`, etc.) against the published framework packages; full `turbo run build --filter='@activepieces/piece-*'` and `lint-pieces` left to CI.

### Relevant User Scenarios

- Keep tasks in sync with external systems (update content, re-open tasks, reorder within a project).
- Spin up projects (blank or from team templates) from any flow.
- Pipe flow data into a Taskade AI agent and use its response downstream.
