### PR TITLE
docs(security): clarify advisory scope and disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,5 @@
 # Security
 
-Contact: security@activepieces.com
-
-Based on [https://supabase.com/.well-known/security.txt](https://supabase.com/.well-known/security.txt)
-
 At Activepieces.com, we consider the security of our systems a top priority. But no matter how much effort we put into system security, there can still be vulnerabilities present.
 
 If you discover a vulnerability, we would like to know about it so we can take steps to address it as quickly as possible. We would like to ask you to help us better protect our clients and our systems.
@@ -19,19 +15,25 @@ If you discover a vulnerability, we would like to know about it so we can take s
 - Missing DNSSEC, CAA, CSP headers
 - Lack of Secure or HTTP only flag on non-sensitive cookies
 - Deadlinks
+- `UNSANDBOXED` execution mode intended for trusted-operator deployments and blocked in EE/Cloud production.
+- Input fields that accept special characters without a demonstrated exploitable sink.
+- Capability-token endpoints (resume URLs, webhook URLs, signed file URLs): the token is the authorization. Reports must demonstrate a disclosure path (logging, `Referer` leakage, weak entropy) to be in scope.
+- Findings whose only attack path is guessing a high-entropy identifier (e.g. nanoid) with no demonstrated disclosure source.
 
 ## Please do the following:
 
-- E-mail your findings to [security@activepieces.com](mailto:security@activepieces.com).
-- Do not run automated scanners on our infrastructure or dashboard. If you wish to do this, contact us and we will set up a sandbox for you.
+- Report your findings privately through the **Security** tab of our GitHub repository using [Report a vulnerability](https://github.com/activepieces/activepieces/security/advisories/new).
+- Do not run automated scanners on our infrastructure or dashboard. If you wish to do this, contact us at security@activepieces.com and we will set up a sandbox for you.
 - Do not take advantage of the vulnerability or problem you have discovered, for example by downloading more data than necessary to demonstrate the vulnerability or deleting or modifying other people's data,
+- Use your own test account and test data when investigating an issue; do not target or access other users' accounts or data,
+- If you encounter personal data belonging to others, stop immediately, do not store or share it, and tell us in your report,
 - Do not reveal the problem to others until it has been resolved,
 - Do not use attacks on physical security, social engineering, distributed denial of service, spam or applications of third parties,
 - Do provide sufficient information to reproduce the problem, so we will be able to resolve it as quickly as possible. Usually, the IP address or the URL of the affected system and a description of the vulnerability will be sufficient, but complex vulnerabilities may require further explanation.
 
 ## What we promise:
 
-- We will respond to your report within 3 business days with our evaluation of the report and an expected resolution date,
+- We will respond to your report within 7 business days with our evaluation of the report and an expected resolution date,
 - If you have followed the instructions above, we will not take any legal action against you in regard to the report,
 - We will handle your report with strict confidentiality, and not pass on your personal details to third parties without your permission,
 - We will keep you informed of the progress towards resolving the problem,
@@ -41,3 +43,7 @@ If you discover a vulnerability, we would like to know about it so we can take s
 ## Disclosure Policy
 
 We follow coordinated disclosure. Every report follows the [Security Advisory Response playbook](https://www.activepieces.com/docs/handbook/engineering/playbooks/security-advisory-response).
+
+> **Note:** Our bug bounty program is currently private and invitation-only. We welcome vulnerability reports from anyone through GitHub's private vulnerability reporting, but reward eligibility is limited to invited researchers at this time.
+
+We only publish advisories for vulnerabilities that affect users and warrant notifying them. Whether or not your report results in a published advisory has no bearing on reward eligibility. Reward ranges, eligibility, and terms are described in our [Vulnerability Disclosure Program](https://trust.activepieces.com).

--- a/docs/handbook/engineering/playbooks/security-advisory-response.mdx
+++ b/docs/handbook/engineering/playbooks/security-advisory-response.mdx
@@ -9,6 +9,11 @@ A security advisory is the public artifact we publish after a vulnerability is r
 ## Triage
 
 <Steps>
+  <Step title="Acknowledge receipt">
+    Reports arrive through GitHub private vulnerability reporting and appear under repo → **Security** → **Advisories**. Reply in the advisory thread on intake confirming the report was received, with a confidentiality reminder. \
+    Do this first, before reproduction and scoring, so the response is never delayed by triage depth.
+  </Step>
+
   <Step title="Reproduce">
     Reproduce locally before scoring. If it doesn't reproduce, ask the reporter for clarification.
   </Step>
@@ -22,18 +27,19 @@ A security advisory is the public artifact we publish after a vulnerability is r
     Buckets: 0.1–3.9 low, 4.0–6.9 medium, 7.0–8.9 high, 9.0–10 critical.
   </Step>
 
-  <Step title="Acknowledge within 3 business days">
-    Reply to the reporter with severity, expected resolution date, and a confidentiality reminder. Clock starts at the report timestamp.
+  <Step title="Send evaluation within 7 business days">
+    Reply to the reporter with the severity and expected resolution date. Clock starts at the report timestamp.
   </Step>
 </Steps>
 
 ## Private fix
 
 <Steps>
-  <Step title="Open a draft advisory">
-    Repo → **Security** → **Advisories** → **New draft security advisory**. \
+  <Step title="Work from the advisory">
+    A report submitted through private vulnerability reporting already appears as a draft advisory under repo → **Security** → **Advisories**; open it. \
+    For an internally discovered issue with no external reporter, create one with **New draft security advisory**. \
     Set affected versions, severity, and a neutral summary. \
-    Save as draft. You'll fill the rest of the metadata in [Draft advisory](#draft-advisory) later.
+    Keep it as a draft. You'll fill the rest of the metadata in [Draft advisory](#draft-advisory) later.
   </Step>
 
   <Step title="Use a temporary private fork">
@@ -124,6 +130,10 @@ Re-confirm the disclosure date with the reporter before sending.
 
   <Step title="Confirm the advisory reaches admins">
     Confirm the new advisory appears on the platform health page (`/platform/infrastructure/health`). Source feeds cache for 15 minutes, so allow that delay before troubleshooting.
+
+    <Note>
+    Pending the security advisories panel reaching production. Until then, skip this step.
+    </Note>
   </Step>
 
   <Step title="Post the changelog">


### PR DESCRIPTION
## Summary
Documentation-only updates to our security policy and internal response playbook.

### SECURITY.md
- Expanded the out-of-scope list (UNSANDBOXED mode, special-char inputs, capability-token endpoints, high-entropy identifier guessing).
- Reworded the capability-token entry to keep real disclosure paths (logging, `Referer` leakage, weak entropy) in scope.

### Security Advisory Response playbook
- Aligned the acknowledgment SLA wording.
- Flagged the platform health-page confirmation step as pending until the security advisories panel reaches production.
