### PR TITLE
fix(engine): pass non-JSON text through JSON property validation

### DIFF
--- a/packages/pieces/core/http/test/send-http-request-action.test.ts
+++ b/packages/pieces/core/http/test/send-http-request-action.test.ts
@@ -1,0 +1,68 @@
+/// <reference types="vitest/globals" />
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { httpSendRequestAction } from '../src/lib/actions/send-http-request-action';
+
+const XML_BODY = '<?xml version="1.0" encoding="UTF-8"?><note><to>Tove</to></note>';
+
+const buildContext = (propsOverrides: Record<string, unknown>) =>
+  ({
+    propsValue: {
+      method: HttpMethod.POST,
+      url: 'https://example.com',
+      headers: { 'Content-Type': 'application/xml' },
+      queryParams: {},
+      authType: 'NONE',
+      ...propsOverrides,
+    },
+  } as unknown as Parameters<typeof httpSendRequestAction.run>[0]);
+
+describe('send_request body handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends a raw text body untouched (body_type raw)', async () => {
+    const sendSpy = vi
+      .spyOn(httpClient, 'sendRequest')
+      .mockResolvedValue({ status: 200, headers: {}, body: 'ok' });
+
+    const result = await httpSendRequestAction.run(
+      buildContext({ body_type: 'raw', body: { data: XML_BODY } }),
+    );
+
+    const request = sendSpy.mock.calls[0][0];
+    expect(request.body).toBe(XML_BODY);
+    expect(request.headers?.['Content-Type']).toBe('application/xml');
+    expect(result).toEqual({ status: 200, headers: {}, body: 'ok' });
+  });
+
+  it('sends non-JSON text untouched when body type is json (issue #13647)', async () => {
+    const sendSpy = vi
+      .spyOn(httpClient, 'sendRequest')
+      .mockResolvedValue({ status: 200, headers: {}, body: 'ok' });
+
+    await httpSendRequestAction.run(
+      buildContext({ body_type: 'json', body: { data: XML_BODY } }),
+    );
+
+    expect(sendSpy.mock.calls[0][0].body).toBe(XML_BODY);
+  });
+
+  it('sends a parsed json object as the body (body_type json)', async () => {
+    const sendSpy = vi
+      .spyOn(httpClient, 'sendRequest')
+      .mockResolvedValue({ status: 200, headers: {}, body: 'ok' });
+
+    await httpSendRequestAction.run(
+      buildContext({
+        headers: { 'Content-Type': 'application/json' },
+        body_type: 'json',
+        body: { data: { key: 'value' } },
+      }),
+    );
+
+    expect(sendSpy.mock.calls[0][0].body).toEqual({ key: 'value' });
+  });
+});

--- a/packages/server/engine/src/lib/variables/processors/json.ts
+++ b/packages/server/engine/src/lib/variables/processors/json.ts
@@ -11,8 +11,8 @@ export const jsonProcessor: ProcessorFn = (_property, value) => {
         }
         return JSON.parse(value)
     }
-    catch (error) {
-        console.error(error)
-        return undefined
+    catch {
+        // non-JSON text (e.g. an XML or plain-text HTTP body) is passed through as-is
+        return value
     }
 }

--- a/packages/server/engine/src/lib/variables/props-processor.ts
+++ b/packages/server/engine/src/lib/variables/props-processor.ts
@@ -108,16 +108,9 @@ export const propsProcessor = {
 
 const validateProperty = (property: PieceProperty, value: unknown, originalValue: unknown): string[] => {
     if (property.type === PropertyType.JSON) {
-        if (!property.required && originalValue === '') {
-            return []
-        }
-        if (!isNil(originalValue) && isNil(value)) {
-            return [`Expected JSON, received: ${originalValue}`]
-        }
-        if (!property.required && isNil(value)) {
-            return []
-        }
-        if (!isObject(value) && !Array.isArray(value)) {
+        // non-JSON strings are passed through as-is (e.g. XML or plain-text HTTP bodies), so only reject missing required values
+        const isMissing = isNil(value) || value === ''
+        if (property.required && isMissing) {
             return [`Expected JSON, received: ${originalValue}`]
         }
         return []

--- a/packages/server/engine/test/variables/props-validator.test.ts
+++ b/packages/server/engine/test/variables/props-validator.test.ts
@@ -1,4 +1,5 @@
 import { PieceAuth, Property } from '@activepieces/pieces-framework'
+import { PropertyExecutionType } from '@activepieces/shared'
 import { propsProcessor } from '../../src/lib/variables/props-processor'
 describe('Property Validation', () => {
     describe('required properties', () => {
@@ -184,16 +185,25 @@ describe('Property Validation', () => {
             )
             expect(validArrayStringErrors).toEqual({})
 
-            const { errors: invalidJsonErrors } = await propsProcessor.applyProcessorsAndValidators(
+            const { errors: rawTextErrors, processedInput: rawTextProcessedInput } = await propsProcessor.applyProcessorsAndValidators(
                 { json: 'not a json object' },
                 props,
                 PieceAuth.None(),
                 false,
                 {},
             )
-            expect(invalidJsonErrors).toEqual({
-                json: ['Expected JSON, received: not a json object'],
-            })
+            expect(rawTextErrors).toEqual({})
+            expect(rawTextProcessedInput).toEqual({ json: 'not a json object' })
+
+            const { errors: xmlErrors, processedInput: xmlProcessedInput } = await propsProcessor.applyProcessorsAndValidators(
+                { json: '<?xml version="1.0" encoding="UTF-8"?>' },
+                props,
+                PieceAuth.None(),
+                false,
+                {},
+            )
+            expect(xmlErrors).toEqual({})
+            expect(xmlProcessedInput).toEqual({ json: '<?xml version="1.0" encoding="UTF-8"?>' })
 
             const { errors: nullErrors } = await propsProcessor.applyProcessorsAndValidators(
                 { json: null },
@@ -216,20 +226,9 @@ describe('Property Validation', () => {
             expect(emptyStringErrors).toEqual({
                 json: ['Expected JSON, received: '],
             })
-
-            const { errors: invalidTextErrors } = await propsProcessor.applyProcessorsAndValidators(
-                { json: 'asd' },
-                props,
-                PieceAuth.None(),
-                false,
-                {},
-            )
-            expect(invalidTextErrors).toEqual({
-                json: ['Expected JSON, received: asd'],
-            })
         })
 
-        it('should validate optional json property with invalid value', async () => {
+        it('should pass through non-JSON text for optional json property', async () => {
             const props = {
                 json: Property.Json({
                     displayName: 'JSON',
@@ -264,27 +263,47 @@ describe('Property Validation', () => {
             )
             expect(emptyStringErrors).toEqual({})
 
-            const { errors: invalidJsonErrors } = await propsProcessor.applyProcessorsAndValidators(
+            const { errors: rawTextErrors, processedInput: rawTextProcessedInput } = await propsProcessor.applyProcessorsAndValidators(
                 { json: 'not a json object' },
                 props,
                 PieceAuth.None(),
                 false,
                 {},
             )
-            expect(invalidJsonErrors).toEqual({
-                json: ['Expected JSON, received: not a json object'],
-            })
+            expect(rawTextErrors).toEqual({})
+            expect(rawTextProcessedInput).toEqual({ json: 'not a json object' })
+        })
+        it('should pass through non-JSON text for a json property inside dynamic properties', async () => {
+            const xmlBody = '<?xml version="1.0" encoding="UTF-8"?>'
+            const props = {
+                body: Property.DynamicProperties({
+                    displayName: 'Body',
+                    required: false,
+                    refreshers: [],
+                    props: async () => ({}),
+                }),
+            }
+            const propertySettings = {
+                body: {
+                    type: PropertyExecutionType.MANUAL,
+                    schema: {
+                        data: Property.Json({
+                            displayName: 'JSON Body',
+                            required: true,
+                        }),
+                    },
+                },
+            }
 
-            const { errors: invalidTextErrors } = await propsProcessor.applyProcessorsAndValidators(
-                { json: 'asd' },
+            const { errors, processedInput } = await propsProcessor.applyProcessorsAndValidators(
+                { body: { data: xmlBody } },
                 props,
                 PieceAuth.None(),
                 false,
-                {},
+                propertySettings,
             )
-            expect(invalidTextErrors).toEqual({
-                json: ['Expected JSON, received: asd'],
-            })
+            expect(errors).toEqual({})
+            expect(processedInput).toEqual({ body: { data: xmlBody } })
         })
         it('should validate required object property', async () => {
             const props = {


### PR DESCRIPTION
Flows using the HTTP piece could not send arbitrary text bodies (e.g. XML) — the engine's JSON property processor returned undefined when JSON.parse failed, and validation rejected the step with "Expected JSON, received: ...". This also affected flows pinned to piece-http <= 0.3.10, where the published package still types the body prop as Property.Json with no Raw alternative.

The frontend Zod contract already accepts plain strings for JSON props, so the engine now aligns with it: parseable JSON is parsed exactly as before, and anything else is passed through verbatim as a raw string. Validation only rejects required JSON props that are missing or empty. Only previously hard-failing executions change behavior.

Before:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/0d3e966a-edfa-4f7e-b90b-8f7556361c62" />

Now:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/62ce4f46-b15e-4957-b0b4-f0b8ca565696" />


Fixes #13647

