### PR TITLE
fix(chat): surface stream errors to user and store required-card connections

### DIFF
--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -132,11 +132,12 @@ function createEventEmitter({ sendEvent, userId, conversationId, log }: {
     }
 }
 
-function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectionSelected, onGateOpened }: {
+function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectionSelected, onGateOpened, log }: {
     waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<{ approved: boolean, payload?: Record<string, unknown> }>
     displayToolTimeoutMs: number
     onConnectionSelected?: (params: { pieceName: string, connectionExternalId: string, label: string, projectId: string }) => Promise<void>
     onGateOpened?: (params: { gateId: string, toolName: string, displayName: string, toolInput: Record<string, unknown> }) => Promise<void>
+    log?: { warn: (obj: Record<string, unknown>, msg: string) => void }
 }): ToolSet {
     function blockingExecute({ dismissMessage, successKey, toolName }: {
         dismissMessage: string
@@ -193,6 +194,9 @@ function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectio
                                 label: typeof conn['displayName'] === 'string' ? conn['displayName'] as string : input.displayName,
                                 projectId: typeof conn['projectId'] === 'string' ? conn['projectId'] as string : '',
                             })))
+                    }
+                    else {
+                        log?.warn({ piece: input.piece, payload: decision.payload }, 'ap_show_connection_required approved but payload missing connections array')
                     }
                 }
                 return { connected: true, ...decision.payload }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -79,6 +79,12 @@ function findTopLevelArray(obj: unknown): { array: unknown[], path: string, tota
     return null
 }
 
+function normalizePieceName(piece: string): string {
+    if (piece.startsWith('@')) return piece
+    const stripped = piece.startsWith('piece-') ? piece.slice('piece-'.length) : piece
+    return `@activepieces/piece-${stripped.replace(/_/g, '-')}`
+}
+
 function createEventEmitter({ sendEvent, userId, conversationId, log }: {
     sendEvent: (input: SendChatEventRequest) => Promise<void>
     userId: string
@@ -162,7 +168,35 @@ function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectio
                 displayName: z.string().describe('Human-readable name (e.g. "Gmail", "Slack")'),
                 status: z.enum(['missing', 'error']).optional().describe('Set to "error" when connection exists but needs reconnecting'),
             }),
-            execute: blockingExecute({ dismissMessage: 'The user chose not to connect this service. Stop and ask: "Would you like me to continue building with a placeholder you can connect later, or would you prefer to stop here?"', successKey: 'connected', toolName: 'ap_show_connection_required' }),
+            execute: async (input, options) => {
+                if (onGateOpened) {
+                    await tryCatch(() => onGateOpened({
+                        gateId: options.toolCallId,
+                        toolName: 'ap_show_connection_required',
+                        displayName: input.displayName,
+                        toolInput: input as unknown as Record<string, unknown>,
+                    }))
+                }
+                const decision = await waitForApproval({ gateId: options.toolCallId, timeoutMs: displayToolTimeoutMs })
+                if (!decision.approved) {
+                    return { dismissed: true, message: 'The user chose not to connect this service. Stop and ask: "Would you like me to continue building with a placeholder you can connect later, or would you prefer to stop here?"' }
+                }
+                if (onConnectionSelected && decision.payload) {
+                    const connections = decision.payload['connections']
+                    if (Array.isArray(connections)) {
+                        await Promise.all(connections
+                            .filter((conn): conn is Record<string, unknown> =>
+                                isObject(conn) && typeof conn['connectionExternalId'] === 'string' && !!conn['connectionExternalId'])
+                            .map((conn) => onConnectionSelected({
+                                pieceName: normalizePieceName(typeof conn['piece'] === 'string' ? conn['piece'] : input.piece),
+                                connectionExternalId: conn['connectionExternalId'] as string,
+                                label: typeof conn['displayName'] === 'string' ? conn['displayName'] as string : input.displayName,
+                                projectId: typeof conn['projectId'] === 'string' ? conn['projectId'] as string : '',
+                            })))
+                    }
+                }
+                return { connected: true, ...decision.payload }
+            },
         }),
 
         ap_show_connection_picker: tool({
@@ -189,10 +223,8 @@ function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectio
                 const label = payload['label']
                 const projectId = payload['projectId']
                 if (typeof connectionExternalId === 'string' && onConnectionSelected) {
-                    const stripped = input.piece.startsWith('piece-') ? input.piece.slice('piece-'.length) : input.piece
-                    const pieceName = input.piece.startsWith('@') ? input.piece : `@activepieces/piece-${stripped.replace(/_/g, '-')}`
                     await onConnectionSelected({
-                        pieceName,
+                        pieceName: normalizePieceName(input.piece),
                         connectionExternalId,
                         label: typeof label === 'string' ? label : connectionExternalId,
                         projectId: typeof projectId === 'string' ? projectId : '',

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -199,7 +199,7 @@ function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectio
                         log?.warn({ piece: input.piece, payload: decision.payload }, 'ap_show_connection_required approved but payload missing connections array')
                     }
                 }
-                return { connected: true, ...decision.payload }
+                return { connected: true }
             },
         }),
 

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -331,6 +331,7 @@ function buildToolSet({ ctx, eventEmitter, log, planApproved, mcpToolSet, projec
     const displayTools = chatWorkerTools.createDisplayTools({
         waitForApproval,
         displayToolTimeoutMs: DISPLAY_TOOL_TIMEOUT_MS,
+        log,
         onConnectionSelected: async ({ pieceName, connectionExternalId, label, projectId: connProjectId }) => {
             await tryCatch(() => ctx.apiClient.executeChatTool({
                 toolName: '__store_selected_connection',

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -86,6 +86,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             const uiParts: PersistedChatPart[] = []
             const thinkingStartTime = Date.now()
             let abortedStepMessages: ModelMessage[] = []
+            let streamError: Error | null = null
 
             const postApprovalTools = Object.keys(allTools).filter((name) => name !== 'ap_request_plan_approval')
 
@@ -141,12 +142,16 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
                 },
                 onError: ({ error }) => {
                     log.error({ err: error, conversationId }, 'Chat streamText error')
+                    streamError = error instanceof Error ? error : new Error(String(error))
                 },
             })
 
             await streamChunksToClient({ result, ctx, userId, conversationId, runId, log })
 
             if (abortController.signal.aborted) {
+                if (streamError) {
+                    log.warn({ err: streamError, conversationId }, 'Stream error occurred during abort')
+                }
                 log.info({ conversationId, completedSteps: abortedStepMessages.length }, 'Chat agent cancelled by user')
                 const thinkingDurationMs = Date.now() - thinkingStartTime
                 const cancelSavePayload = {
@@ -170,6 +175,10 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
                     event: { type: ChatAgentEventType.FINISHED, data: { conversationId } },
                 })
                 return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
+            }
+
+            if (streamError) {
+                throw streamError
             }
 
             const [response, usage, autoTitle] = await Promise.all([


### PR DESCRIPTION
## Summary
- **Silent dead turn on streamText error**: `onError` callback only logged the error — now captures it and re-throws after streaming completes so the outer catch sends ERROR + FINISHED events to the frontend instead of silently ending the turn.
- **Connection via required card not attached**: `ap_show_connection_required` used `blockingExecute` which never called `onConnectionSelected` — connections created via the required card were not stored in Redis, so `ap_execute_action` ran without auth. Now extracts connection info from the approval payload and stores it.
- Extracted `normalizePieceName` helper to deduplicate inline piece-name normalization across both connection tool handlers.

## Test plan
- [ ] Trigger a model error during streaming (e.g. oversized context) and verify the error appears in the chat UI instead of silently ending the turn
- [ ] Use a piece that requires a new connection, create it via the required card, click Continue, then verify `ap_execute_action` uses the connection
- [ ] Verify the picker path still works (select existing connection, execute action)