### PR TITLE
fix(worker): log errors under pino's `err` key so message and stack are captured

### DIFF
--- a/packages/server/worker/src/lib/cache/code/bun-runner.ts
+++ b/packages/server/worker/src/lib/cache/code/bun-runner.ts
@@ -25,7 +25,7 @@ export const bunRunner = (log: Logger) => ({
             timeoutMs: apDayjsDuration(10, 'minutes').asMilliseconds(),
         }))
         if (error) {
-            log.error({ error }, '[bunRunner#install] Failed to install dependencies')
+            log.error({ err: error }, '[bunRunner#install] Failed to install dependencies')
             throw error
         }
         return data

--- a/packages/server/worker/src/lib/cache/pieces/piece-installer.ts
+++ b/packages/server/worker/src/lib/cache/pieces/piece-installer.ts
@@ -112,7 +112,7 @@ async function installPieces(rootWorkspace: string, pieces: PiecePackage[], incl
                     span.recordException(batchError instanceof Error ? batchError : new Error(String(batchError)))
 
                     if (piecesToInstall.length === 1) {
-                        log.error({ rootWorkspace, error: batchError }, '[pieceInstaller] Piece installation failed, rolling back')
+                        log.error({ rootWorkspace, err: batchError }, '[pieceInstaller] Piece installation failed, rolling back')
                         await rollbackInstallation(rootWorkspace, piecesToInstall)
                         throw batchError
                     }
@@ -120,7 +120,7 @@ async function installPieces(rootWorkspace: string, pieces: PiecePackage[], incl
                     log.warn({
                         rootWorkspace,
                         pieces: piecesToInstall.map(piece => `${piece.pieceName}-${piece.pieceVersion}`),
-                        error: batchError,
+                        err: batchError,
                     }, '[pieceInstaller] Batch install failed, retrying pieces individually')
 
                     const failedPieces = await tryInstallPiecesIndividually(rootWorkspace, piecesToInstall, log)
@@ -166,7 +166,7 @@ async function tryInstallPiecesIndividually(
         if (error) {
             log.error({
                 piece: `${piece.pieceName}@${piece.pieceVersion}`,
-                error,
+                err: error,
             }, '[pieceInstaller] Individual piece installation failed, rolling back')
             await rollbackInstallation(rootWorkspace, [piece])
             failures.push(piece)

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -183,7 +183,7 @@ async function reportFlowStatus(
             code: ErrorCode.ENGINE_OPERATION_FAILURE,
             message: `Flow run ${data.runId} ended with INTERNAL_ERROR`,
             params: { runId: data.runId, flowId: data.flowId, projectId: data.projectId },
-        }).catch((e) => ctx.log.error({ runId: data.runId, error: inspect(e) }, 'Failed to send on-call page for INTERNAL_ERROR'))
+        }).catch((e) => ctx.log.error({ runId: data.runId, err: e }, 'Failed to send on-call page for INTERNAL_ERROR'))
     }
 }
 

--- a/packages/server/worker/src/lib/execute/jobs/execute-polling.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-polling.ts
@@ -69,7 +69,7 @@ export const executePollingJob: JobHandler<PollingJobData, FireAndForgetJobResul
             return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK, logs: result.logs }
         }
         catch (e) {
-            ctx.log.error({ error: String(e) }, 'Polling trigger failed, will retry on next scheduled cycle')
+            ctx.log.error({ err: e }, 'Polling trigger failed, will retry on next scheduled cycle')
             await ctx.sandboxManager.invalidate(ctx.log)
             return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
         }

--- a/packages/server/worker/src/lib/execute/utils/flow-helpers.ts
+++ b/packages/server/worker/src/lib/execute/utils/flow-helpers.ts
@@ -22,12 +22,12 @@ export async function provisionFlowPieces(params: {
         if (!(error instanceof PieceNotFoundError)) {
             throw error
         }
-        log.warn({ error: String(error), flowId }, 'Flow disabled due to missing piece')
+        log.warn({ err: error, flowId }, 'Flow disabled due to missing piece')
         const { error: disableError } = await tryCatch(
             () => apiClient.disableFlow({ flowId, projectId }),
         )
         if (disableError) {
-            log.error({ error: String(disableError), flowId }, 'Failed to disable flow after missing piece')
+            log.error({ err: disableError, flowId }, 'Failed to disable flow after missing piece')
         }
         return false
     }

--- a/packages/server/worker/src/lib/main.ts
+++ b/packages/server/worker/src/lib/main.ts
@@ -22,7 +22,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-    logger.error({ error: err }, 'Worker crashed')
+    logger.error({ err }, 'Worker crashed')
     process.exit(1)
 })
 

--- a/packages/server/worker/src/lib/sandbox/sandbox.ts
+++ b/packages/server/worker/src/lib/sandbox/sandbox.ts
@@ -236,7 +236,7 @@ export function createSandbox(
                 }, executeOptions.timeoutInSeconds * 1000)
 
                 executeProcess.on('error', (error) => {
-                    log.error({ sandboxId, error: String(error) }, 'Sandbox process error')
+                    log.error({ sandboxId, err: error }, 'Sandbox process error')
                 })
 
                 executeProcess.on('exit', (code, signal) => {
@@ -259,7 +259,7 @@ export function createSandbox(
                 client.executeOperation({ operationType, operation }).then((engineResponse: EngineResponse<unknown>) => {
                     resolve({ ...engineResponse, logs: buildLogs(stdOut, stdError) })
                 }).catch((error: unknown) => {
-                    log.error({ sandboxId, error: String(error) }, '[Sandbox] RPC call failed')
+                    log.error({ sandboxId, err: error }, '[Sandbox] RPC call failed')
                     reject(error)
                 })
             })
@@ -357,7 +357,7 @@ function killProcess(child: ChildProcess, log: SandboxLogger): Promise<void> {
     return new Promise<void>((resolve) => {
         treeKill(pid, 'SIGKILL', (err) => {
             if (err) {
-                log.error({ pid: String(pid), error: String(err) }, 'Failed to kill child process tree')
+                log.error({ pid: String(pid), err }, 'Failed to kill child process tree')
             }
             else {
                 log.debug({ pid: String(pid) }, 'Killed child process tree')

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -78,7 +78,7 @@ export const worker = {
             }
             void warmupPiecesOnStartup(apiClient)
             void startPollingWorkers(apiClient).catch((err) => {
-                logger.error({ error: err }, 'Polling workers crashed unexpectedly')
+                logger.error({ err }, 'Polling workers crashed unexpectedly')
             })
         })
 
@@ -89,7 +89,7 @@ export const worker = {
         })
 
         socket.on('connect_error', (error) => {
-            logger.error({ error: error.message }, 'Socket.IO connection error')
+            logger.error({ err: error }, 'Socket.IO connection error')
         })
 
         if (withHealthServer) {
@@ -156,14 +156,14 @@ async function pollAndExecute(apiClient: WorkerToApiContract, sbManager: Sandbox
 
         const { data: machineInfo, error: machineError } = await tryCatch(buildMachineInfo)
         if (machineError) {
-            workerLog.error({ error: machineError }, 'Failed to build machine info')
+            workerLog.error({ err: machineError }, 'Failed to build machine info')
             await sleep(20000)
             continue
         }
 
         const { data: job, error: pollError } = await tryCatch(() => apiClient.poll(machineInfo))
         if (pollError) {
-            workerLog.error({ error: pollError }, 'Poll failed')
+            workerLog.error({ err: pollError }, 'Poll failed')
             await sleep(25000)
             continue
         }
@@ -178,7 +178,7 @@ async function pollAndExecute(apiClient: WorkerToApiContract, sbManager: Sandbox
         const lockExtensionInterval = setInterval(() => {
             void tryCatch(() => apiClient.extendLock({ jobId: job.jobId, token: job.token, queueName: job.queueName })).then(({ error }) => {
                 if (error) {
-                    workerLog.warn({ error, jobId: job.jobId }, 'Failed to extend lock')
+                    workerLog.warn({ err: error, jobId: job.jobId }, 'Failed to extend lock')
                 }
             })
         }, 30_000)
@@ -205,7 +205,7 @@ async function pollAndExecute(apiClient: WorkerToApiContract, sbManager: Sandbox
         clearInterval(lockExtensionInterval)
 
         if (completeError) {
-            workerLog.error({ error: completeError, jobId: job.jobId }, 'Failed to complete job')
+            workerLog.error({ err: completeError, jobId: job.jobId }, 'Failed to complete job')
         }
     }
 }
@@ -260,7 +260,7 @@ export function ensurePublicApiUrl(publicUrl: string): string {
 async function fetchAndStoreSettings(sock: Socket): Promise<void> {
     const { data: request, error } = await tryCatch(buildMachineInfo)
     if (error) {
-        logger.error({ error }, 'Failed to build machine info for settings fetch')
+        logger.error({ err: error }, 'Failed to build machine info for settings fetch')
         return
     }
     return new Promise<void>((resolve) => {
@@ -336,7 +336,7 @@ async function buildSandboxInfo(): Promise<SandboxInformation[]> {
 async function warmupPiecesOnStartup(apiClient: WorkerToApiContract): Promise<void> {
     const { data: pieces, error } = await tryCatch(() => apiClient.getUsedPieces({}))
     if (error) {
-        logger.error({ error }, 'Failed to fetch used pieces for warmup')
+        logger.error({ err: error }, 'Failed to fetch used pieces for warmup')
         return
     }
     if (!pieces || pieces.length === 0) {
@@ -348,7 +348,7 @@ async function warmupPiecesOnStartup(apiClient: WorkerToApiContract): Promise<vo
         pieceInstaller(logger, apiClient).install({ pieces, includeFilters: false }),
     )
     if (installError) {
-        logger.error({ error: installError }, 'Failed to install pieces during startup warmup')
+        logger.error({ err: installError }, 'Failed to install pieces during startup warmup')
     }
     else {
         void tryCatch(() => apiClient.markPieceAsUsed({ pieces }))


### PR DESCRIPTION
## What does this PR do?

Fixes lost error details in worker logs. Pino only runs its Error serializer on the `err` key (`serializers` default: `{err: pino.stdSerializers.err}`, `errorKey` default: `'err'`), and the worker logger configures neither. So today:

- `log.error({ error: e })` emits `"error":{}` — Error's `message`/`stack` are non-enumerable
- `log.error({ error: String(e) })` keeps the message but drops the stack

This PR switches every error-carrying log call in the worker to `{ err: <raw Error> }`, so logs get structured `err.message` and `err.stack`. Covers poll/socket/warmup, piece-installer, sandbox, flow execution, polling, and the startup crash handler.

Before/after:
```
log.error({ error: e })  → {"level":50,"error":{},"msg":"..."}
log.error({ err: e })    → {"level":50,"err":{"type":"Error","message":"boom","stack":"Error: boom\n  at ..."}}
```

Considered setting `errorKey: 'error'` globally instead, but the `String(e)` call sites need edits regardless, and Fastify's request-error logging already emits under `err` — converging on pino's default keeps one key across the stream.

### Relevant User Scenarios

Self-hosters debugging worker crashes, failed piece installs, or sandbox errors currently see `"error":{}` or a one-line string in their logs; with this change they get the full stack trace.