### PR TITLE
feat(pieces): add AI-ready metadata to 75 pieces

### DIFF
--- a/packages/pieces/community/activepieces/package.json
+++ b/packages/pieces/community/activepieces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-activepieces",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/activepieces/src/lib/actions/create-project.ts
+++ b/packages/pieces/community/activepieces/src/lib/actions/create-project.ts
@@ -11,6 +11,12 @@ export const createProject = createAction({
   auth: activePieceAuth,
   displayName: 'Create Project',
   description: 'Create a new project',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Create a new project on an Activepieces platform (requires a platform-edition API key). Use when provisioning a fresh project workspace; the only input is its display name. Not idempotent — each call creates a separate project even with the same name.',
+    idempotent: false,
+  },
   props: {
     display_name: Property.ShortText({
       displayName: 'Display Name',

--- a/packages/pieces/community/activepieces/src/lib/actions/list-project.ts
+++ b/packages/pieces/community/activepieces/src/lib/actions/list-project.ts
@@ -11,6 +11,12 @@ export const listProject = createAction({
   auth: activePieceAuth,
   displayName: 'List Projects',
   description: 'List all projects',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'List all projects accessible to the authenticated Activepieces platform API key. Use to discover existing projects or resolve a project id before updating one. Takes no input; read-only and idempotent.',
+    idempotent: true,
+  },
   props: {},
   async run({ auth }) {
     const response = await httpClient.sendRequest<string[]>({

--- a/packages/pieces/community/activepieces/src/lib/actions/update-project.ts
+++ b/packages/pieces/community/activepieces/src/lib/actions/update-project.ts
@@ -11,6 +11,12 @@ export const updateProject = createAction({
   auth: activePieceAuth,
   displayName: 'Update Project',
   description: 'Update a project',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Update an existing project on an Activepieces platform, identified by its project id, setting its display name, notification status, and team-member limit. Use when reconfiguring a known project rather than creating one. Requires the target project id; idempotent — repeating with the same values leaves the project in the same state.',
+    idempotent: true,
+  },
   props: {
     id: Property.ShortText({
       displayName: 'Id',

--- a/packages/pieces/community/actualbudget/package.json
+++ b/packages/pieces/community/actualbudget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-actualbudget",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/actualbudget/src/lib/actions/get-accounts.ts
+++ b/packages/pieces/community/actualbudget/src/lib/actions/get-accounts.ts
@@ -9,6 +9,8 @@ export const getAccounts = createAction({
   name: 'get_accounts',
   displayName: 'Get Accounts',
   description: 'Get your accounts',
+  audience: 'both',
+  aiMetadata: { description: 'Lists all accounts from an Actual Budget server. Use it to discover available accounts and their IDs, typically to resolve the account ID required by the import-transaction actions. Takes no input; read-only and idempotent.', idempotent: true },
   props: {},
   async run(context) {
     await initializeAndDownloadBudget(api, context.auth.props)

--- a/packages/pieces/community/actualbudget/src/lib/actions/get-budget.ts
+++ b/packages/pieces/community/actualbudget/src/lib/actions/get-budget.ts
@@ -9,6 +9,8 @@ export const getBudget = createAction({
   name: 'get_budget',
   displayName: 'Get Budget',
   description: 'Get your monthly budget',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves the budget for a single month from an Actual Budget server, including each category group and category for that month. Use it to read budgeted, spent, and balance figures for a specific period; the month and year must be supplied as separate inputs. Read-only and idempotent.', idempotent: true },
   props: {
     month: Property.StaticDropdown({
       displayName: 'Month',

--- a/packages/pieces/community/actualbudget/src/lib/actions/get-categories.ts
+++ b/packages/pieces/community/actualbudget/src/lib/actions/get-categories.ts
@@ -9,6 +9,8 @@ export const getCategories = createAction({
   name: 'get_categories',
   displayName: 'Get Categories',
   description: 'Get your categories',
+  audience: 'both',
+  aiMetadata: { description: 'Lists all budget categories from an Actual Budget server. Use it to discover available categories and their IDs, typically to resolve a category ID before importing a transaction. Takes no input; read-only and idempotent.', idempotent: true },
   props: {},
   async run(context) {
     await initializeAndDownloadBudget(api, context.auth.props)

--- a/packages/pieces/community/actualbudget/src/lib/actions/import-transaction.ts
+++ b/packages/pieces/community/actualbudget/src/lib/actions/import-transaction.ts
@@ -12,6 +12,8 @@ export const importTransaction = createAction({
   name: 'import_transaction',
   displayName: 'Import Transaction',
   description: 'Add a transaction',
+  audience: 'both',
+  aiMetadata: { description: 'Adds a single transaction to a specified account in Actual Budget. Use it to record one transaction with fields such as date, amount, payee, category, and notes; the target account ID is required. Not idempotent — each call appends another transaction unless an Imported ID is supplied, which Actual uses to deduplicate against prior imports.', idempotent: false },
   props: {
     account_id: Property.ShortText({
       displayName: 'Account ID',

--- a/packages/pieces/community/actualbudget/src/lib/actions/import-transactions.ts
+++ b/packages/pieces/community/actualbudget/src/lib/actions/import-transactions.ts
@@ -8,6 +8,8 @@ export const importTransactions = createAction({
   name: 'import_transactions',
   displayName: 'Import Transactions',
   description: 'Import Transactions',
+  audience: 'both',
+  aiMetadata: { description: 'Bulk-imports an array of transaction objects into a specified account in Actual Budget. Use it to add many transactions at once rather than one at a time; requires the target account ID and a JSON array of transactions (errors if not an array). Not idempotent — each call appends the transactions unless individual entries carry an Imported ID, which Actual uses to deduplicate against prior imports.', idempotent: false },
   props: {
     account_id: Property.ShortText({
       displayName: 'Account ID',

--- a/packages/pieces/community/add-event/package.json
+++ b/packages/pieces/community/add-event/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-add-event",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/add-event/src/lib/actions/create-add-to-calendar-links.ts
+++ b/packages/pieces/community/add-event/src/lib/actions/create-add-to-calendar-links.ts
@@ -11,6 +11,12 @@ export const addEventCreateAddToCalendarLinksAction = createAction({
   displayName: 'Create Dynamic Add to Calendar Links',
   description:
     'Creates an AddEvent event and returns its shareable "Add to Calendar" links. Opening a link lets recipients add the event to Apple, Google, Outlook, and other calendars. Each run produces a unique link, so links can be personalized per recipient.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates an AddEvent event and returns shareable "Add to Calendar" links that let recipients add it to Apple, Google, Outlook, and other calendars. Use when an agent needs distributable per-recipient calendar links rather than a managed calendar entry. Requires a title and start datetime; not idempotent, since each call creates a new event and a unique set of links.',
+    idempotent: false,
+  },
   props: {
     calendar_id: addEventProps.calendarId({ required: false }),
     title: Property.ShortText({

--- a/packages/pieces/community/add-event/src/lib/actions/create-event.ts
+++ b/packages/pieces/community/add-event/src/lib/actions/create-event.ts
@@ -10,6 +10,12 @@ export const addEventCreateEventAction = createAction({
   name: 'create_event',
   displayName: 'Create Event',
   description: 'Creates a new event on your AddEvent calendar.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new event on an AddEvent calendar from the supplied title, schedule, and details. Use when an agent needs to add a brand-new calendar event. Not idempotent: each call creates a separate event, so repeating it produces duplicates; to avoid that, use Find or Create Event instead.',
+    idempotent: false,
+  },
   props: {
     ...addEventProps.eventFields({ mode: 'create' }),
   },

--- a/packages/pieces/community/add-event/src/lib/actions/create-rsvp-attendee.ts
+++ b/packages/pieces/community/add-event/src/lib/actions/create-rsvp-attendee.ts
@@ -10,6 +10,12 @@ export const addEventCreateRsvpAttendeeAction = createAction({
   name: 'create_rsvp_attendee',
   displayName: 'Create RSVP Attendee',
   description: 'Creates a new RSVP attendee on your AddEvent event.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Adds an RSVP attendee (email, name, and response of going/maybe/not-going) to a specific AddEvent event. Use when an agent needs to register someone for an event. Requires a valid event ID; not idempotent, since each call creates another attendee record and, if notifications are enabled, sends a confirmation and organizer email.',
+    idempotent: false,
+  },
   props: {
     event_id: addEventProps.eventId({ required: true }),
     email: Property.ShortText({

--- a/packages/pieces/community/add-event/src/lib/actions/delete-calendar-subscriber.ts
+++ b/packages/pieces/community/add-event/src/lib/actions/delete-calendar-subscriber.ts
@@ -9,6 +9,12 @@ export const addEventDeleteCalendarSubscriberAction = createAction({
   name: 'delete_calendar_subscriber',
   displayName: 'Delete Calendar Subscriber',
   description: 'Deletes a subscriber from your AddEvent calendar.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Removes a subscriber from an AddEvent calendar, identified by subscriber ID. Use when an agent needs to unsubscribe someone from a calendar. Requires a valid subscriber ID; idempotent, since once removed, repeating the call leaves the subscriber absent.',
+    idempotent: true,
+  },
   props: {
     calendar_id: addEventProps.calendarId({ required: false }),
     subscriber_id: addEventProps.subscriberId({ required: true }),

--- a/packages/pieces/community/add-event/src/lib/actions/delete-event.ts
+++ b/packages/pieces/community/add-event/src/lib/actions/delete-event.ts
@@ -9,6 +9,12 @@ export const addEventDeleteEventAction = createAction({
   name: 'delete_event',
   displayName: 'Delete Event',
   description: 'Deletes an event on your AddEvent calendar.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Permanently deletes an AddEvent event identified by its event ID. Use when an agent needs to remove an event entirely. Requires a valid event ID; idempotent, since once the event is deleted, repeating the call leaves it absent.',
+    idempotent: true,
+  },
   props: {
     event_id: addEventProps.eventId({ required: true }),
   },

--- a/packages/pieces/community/add-event/src/lib/actions/find-event.ts
+++ b/packages/pieces/community/add-event/src/lib/actions/find-event.ts
@@ -11,6 +11,12 @@ export const addEventFindEventAction = createAction({
   displayName: 'Find Event',
   description:
     'Finds events matching a search term. Returns up to 20 of the best matches.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Searches AddEvent events by a required search term matched against title, internal name, description, and location, returning up to 20 matches. Use when an agent needs to look up existing events; optionally narrow by calendar and by an earliest/latest start datetime. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     search: Property.ShortText({
       displayName: 'Search Term',

--- a/packages/pieces/community/add-event/src/lib/actions/find-or-create-event.ts
+++ b/packages/pieces/community/add-event/src/lib/actions/find-or-create-event.ts
@@ -11,6 +11,12 @@ export const addEventFindOrCreateEventAction = createAction({
   displayName: 'Find or Create Event',
   description:
     'Searches for an event by a term. If no match is found, creates a new event with the details below.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Searches AddEvent events by a term and returns the first match; if none is found, creates a new event from the supplied details. Use when an agent wants an event to exist without risking a duplicate. Not strictly idempotent: the search term is not a guaranteed unique key, so concurrent or near-duplicate inputs can still create more than one event.',
+    idempotent: false,
+  },
   props: {
     search: Property.ShortText({
       displayName: 'Search Term',

--- a/packages/pieces/community/add-event/src/lib/actions/update-event.ts
+++ b/packages/pieces/community/add-event/src/lib/actions/update-event.ts
@@ -11,6 +11,12 @@ export const addEventUpdateEventAction = createAction({
   displayName: 'Update Event',
   description:
     'Updates an event on your AddEvent calendar. Only the fields you fill in are changed.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Updates an existing AddEvent event identified by its event ID, applying a partial change where only the fields you provide are modified. Use when an agent needs to edit details of an event that already exists. Requires a valid event ID; idempotent, since reapplying the same field values to the same event leaves it in the same state.',
+    idempotent: true,
+  },
   props: {
     event_id: addEventProps.eventId({ required: true }),
     ...addEventProps.eventFields({ mode: 'update' }),

--- a/packages/pieces/community/add-event/src/lib/triggers/new-calendar-subscriber.ts
+++ b/packages/pieces/community/add-event/src/lib/triggers/new-calendar-subscriber.ts
@@ -47,6 +47,10 @@ export const addEventNewCalendarSubscriberTrigger = createTrigger({
   displayName: 'New Calendar Subscriber',
   description:
     'Triggers when a new subscriber is added to your AddEvent calendar. Leave the calendar blank to watch all of them.',
+  aiMetadata: {
+    description:
+      'Fires when a new subscriber is added to an AddEvent calendar, representing a person who has subscribed to receive the calendar. Watches a single calendar when one is specified, or every calendar when left blank.',
+  },
   type: TriggerStrategy.POLLING,
   props,
   sampleData: {

--- a/packages/pieces/community/add-event/src/lib/triggers/new-rsvp-attendee.ts
+++ b/packages/pieces/community/add-event/src/lib/triggers/new-rsvp-attendee.ts
@@ -47,6 +47,10 @@ export const addEventNewRsvpAttendeeTrigger = createTrigger({
   name: 'new_rsvp_attendee',
   displayName: 'New RSVP Attendee',
   description: 'Triggers when a new attendee RSVPs to your AddEvent event.',
+  aiMetadata: {
+    description:
+      'Fires when a new attendee RSVPs to a specific AddEvent event, representing one RSVP response (going, maybe, or not-going) from a person. Scoped to the single event identified by the configured event ID.',
+  },
   type: TriggerStrategy.POLLING,
   props,
   sampleData: {

--- a/packages/pieces/community/afforai/package.json
+++ b/packages/pieces/community/afforai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-afforai",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/afforai/src/lib/actions/ask-chatbot.ts
+++ b/packages/pieces/community/afforai/src/lib/actions/ask-chatbot.ts
@@ -11,6 +11,8 @@ export const askChatbotAction = createAction({
   name: 'afforai_ask_chatbot',
   displayName: 'Ask Chatbot',
   description: 'Gets AI-generated completions for a given chatbot.',
+  audience: 'both',
+  aiMetadata: { description: 'Sends a conversation history to a specific Afforai chatbot (identified by its Chatbot/session ID) and returns an AI-generated reply grounded in that chatbot\'s documents. Choose this to query an existing knowledge base rather than to manage documents. Optionally enable deeper document search and/or live Google search to broaden sources. Not idempotent: each call produces a fresh, potentially different completion.', idempotent: false },
   props: {
     sessionID: Property.ShortText({
       displayName: 'Chatbot ID',

--- a/packages/pieces/community/agentx/package.json
+++ b/packages/pieces/community/agentx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-agentx",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/agentx/src/lib/actions/create-conversation-with-single-agent.ts
+++ b/packages/pieces/community/agentx/src/lib/actions/create-conversation-with-single-agent.ts
@@ -10,6 +10,8 @@ export const createConversationWithSingleAgent = createAction({
   name: 'createConversationWithSingleAgent',
   displayName: 'Create Conversation With Single Agent',
   description: 'Create a new conversation with a specific Agent by ID.',
+  audience: 'both',
+  aiMetadata: { description: 'Opens a new conversation thread with a specific AgentX agent (identified by agent ID), choosing the conversation type (chat, search, or ecommerce). Use this to begin an interaction before sending messages; it does not send any message itself. Each call starts a fresh conversation, so calling it repeatedly creates multiple separate conversations (not idempotent).', idempotent: false },
   props: {
     agentId: AgentIdDropdown,
     type: Property.StaticDropdown({

--- a/packages/pieces/community/agentx/src/lib/actions/find-conversation.ts
+++ b/packages/pieces/community/agentx/src/lib/actions/find-conversation.ts
@@ -10,6 +10,8 @@ export const findConversation = createAction({
   displayName: "Find Conversation",
   description:
     "Looks up an existing conversation by Agent ID (optionally by conversation ID or Name).",
+  audience: 'both',
+  aiMetadata: { description: "Lists conversations belonging to a specific AgentX agent (by agent ID); optionally filter to a single conversation by exact conversation ID, or by name (a partial, case-insensitive match against the name derived from the conversation's first message). Leave both filters blank to return all of the agent's conversations. Use this to resolve a conversation ID before sending or finding messages. Read-only and idempotent.", idempotent: true },
   props: {
     agentId: AgentIdDropdown,
     conversationId: Property.ShortText({

--- a/packages/pieces/community/agentx/src/lib/actions/find-message.ts
+++ b/packages/pieces/community/agentx/src/lib/actions/find-message.ts
@@ -22,6 +22,8 @@ export const findMessage = createAction({
   displayName: "Find Message",
   description:
     "Searches for a specific message by ID (or searches text within messages) inside a conversation.",
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves messages from a specific AgentX conversation (by agent ID and conversation ID): leave the search term blank to return all messages in the conversation, or provide a search term to return only messages whose text contains it (case-insensitive). Use this to inspect or find content within a conversation. Read-only and idempotent.', idempotent: true },
 
   props: {
     agentId: AgentIdDropdown,

--- a/packages/pieces/community/agentx/src/lib/actions/search-agents.ts
+++ b/packages/pieces/community/agentx/src/lib/actions/search-agents.ts
@@ -8,6 +8,8 @@ export const searchAgents = createAction({
   name: "search_agents",
   displayName: "Search Agents",
   description: "Find agents by name or ID using search filters.",
+  audience: 'both',
+  aiMetadata: { description: 'Lists AgentX agents on the account, optionally narrowing the results by partial name match and/or exact agent ID; leave both filters blank to return all agents. Use this to discover available agents or resolve an agent ID before starting a conversation. Read-only and idempotent.', idempotent: true },
   props: {
     name: Property.ShortText({
       displayName: "Agent Name",

--- a/packages/pieces/community/agentx/src/lib/actions/send-message-to-existing-conversation.ts
+++ b/packages/pieces/community/agentx/src/lib/actions/send-message-to-existing-conversation.ts
@@ -10,6 +10,8 @@ export const sendMessageToExistingConversation = createAction({
   name: 'sendMessageToExistingConversation',
   displayName: 'Send Message to Existing Conversation',
   description: 'Send a message to an existing conversation with an agent.',
+  audience: 'both',
+  aiMetadata: { description: 'Posts a message into an existing AgentX conversation (by conversation ID) and gets the agent reply, with a selectable response mode (chat or search) and an optional memory-context window controlling how many prior messages the agent considers. Use this to continue an already-created conversation; create the conversation first to obtain its ID. Each call appends a new message and produces a new reply (not idempotent).', idempotent: false },
   props: {
       agentId: AgentIdDropdown,
     conversationId: ConversationIdDropdown,

--- a/packages/pieces/community/agentx/src/lib/triggers/new-agent.ts
+++ b/packages/pieces/community/agentx/src/lib/triggers/new-agent.ts
@@ -35,6 +35,9 @@ export const newAgent = createTrigger({
   name: "new_agent",
   displayName: "New Agent",
   description: "Triggers when a new AgentX agent is created.",
+  aiMetadata: {
+    description: 'Fires when a new agent is created on the AgentX account, emitting the newly created agent. Polls periodically and only surfaces agents created after the trigger was enabled.',
+  },
   props: {},
   sampleData: {
     _id: "agt_1234567890abcdef",

--- a/packages/pieces/community/agentx/src/lib/triggers/new-conversation.ts
+++ b/packages/pieces/community/agentx/src/lib/triggers/new-conversation.ts
@@ -60,6 +60,9 @@ export const newConversation = createTrigger({
   name: "new_conversation",
   displayName: "New Conversation",
   description: "Triggers when a new conversation begins with a specific Agent. Only detects conversations created after the trigger is enabled.",
+  aiMetadata: {
+    description: 'Fires when a new conversation begins with the configured AgentX agent (selected by agent ID), emitting the new conversation. Polls periodically and only detects conversations created after the trigger was enabled.',
+  },
   type: TriggerStrategy.POLLING,
 
   props: {

--- a/packages/pieces/community/aianswer/package.json
+++ b/packages/pieces/community/aianswer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-aianswer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/aianswer/src/lib/actions/create-phone-call.ts
+++ b/packages/pieces/community/aianswer/src/lib/actions/create-phone-call.ts
@@ -8,6 +8,8 @@ export const createPhoneCall = createAction({
   auth: aiAnswerAuth,
   displayName: 'Create Phone Call',
   description: 'Create a phone call to customer from Agent',
+  audience: 'both',
+  aiMetadata: { description: 'Immediately places an outbound phone call from an AI Answer agent to a destination phone number. Use when an agent should call a customer right now; for a future-dated call use the schedule call action instead. Requires a valid agent ID and an E.164-formatted number with country code (e.g. +919876543210); optional key-value details can be attached. Not idempotent — each call places a new phone call.', idempotent: false },
   props: {
     agentID: Property.ShortText({
       displayName: 'Agent ID',

--- a/packages/pieces/community/aianswer/src/lib/actions/get-call-details.ts
+++ b/packages/pieces/community/aianswer/src/lib/actions/get-call-details.ts
@@ -8,6 +8,8 @@ export const getCallDetails = createAction({
   auth: aiAnswerAuth,
   displayName: 'Get Call Details',
   description: 'Fetch Call details by Call ID',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves the details and status of a single phone call by its call ID. Use to check the outcome or metadata of a call previously created or scheduled. Requires the call ID; read-only and idempotent.', idempotent: true },
   props: {
     callID: Property.ShortText({
       displayName: 'Call ID',

--- a/packages/pieces/community/aianswer/src/lib/actions/get-call-transcript.ts
+++ b/packages/pieces/community/aianswer/src/lib/actions/get-call-transcript.ts
@@ -8,6 +8,8 @@ export const getCallTranscript = createAction({
   auth: aiAnswerAuth,  // Auth configured here
   displayName: 'Get Call Transcript',
   description: 'Fetch the transcript of a call by Call ID',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves the conversation transcript of a completed phone call by its call ID. Use to read what was said on a call after it has finished. Requires the call ID; read-only and idempotent.', idempotent: true },
   props: {
     callID: Property.ShortText({
       displayName: 'Call ID',

--- a/packages/pieces/community/aianswer/src/lib/actions/gmail-get-list-of-agents.ts
+++ b/packages/pieces/community/aianswer/src/lib/actions/gmail-get-list-of-agents.ts
@@ -8,6 +8,8 @@ export const gmailGetListOfAgents = createAction({
   auth: aiAnswerAuth,
   displayName: 'Gmail get list of Agents',
   description: 'get the lists of agents with Gmail',
+  audience: 'both',
+  aiMetadata: { description: 'Lists the available Gmail-connected AI Answer agents on the account, returning their IDs. Use this to discover a valid agent ID before initiating or scheduling a call (those actions require an agent ID). Takes no input; read-only and idempotent.', idempotent: true },
   props: {},
   async run(context) {
     const res = await httpClient.sendRequest<string[]>({

--- a/packages/pieces/community/aianswer/src/lib/actions/schedule-call-agent.ts
+++ b/packages/pieces/community/aianswer/src/lib/actions/schedule-call-agent.ts
@@ -8,6 +8,8 @@ export const scheduleCallAgent = createAction({
   auth: aiAnswerAuth,
   displayName: 'Schedule Call Agent',
   description: 'Schedule a call with an agent',
+  audience: 'both',
+  aiMetadata: { description: 'Schedules an AI Answer agent to place an outbound call at a future date and time. Use when the call should happen later rather than immediately (for an immediate call use the create phone call action). Requires a valid agent ID, destination phone number, an execution time in YYYY-MM-DD HH:MM:SS format, and a timezone (e.g. Asia/Calcutta); optional prospect details can be attached. Not idempotent — each call schedules a new call.', idempotent: false },
   props: {
     agentID: Property.ShortText({
       displayName: 'Agent ID',

--- a/packages/pieces/community/aidbase/package.json
+++ b/packages/pieces/community/aidbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-aidbase",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/aidbase/src/lib/actions/add-faq-item.ts
+++ b/packages/pieces/community/aidbase/src/lib/actions/add-faq-item.ts
@@ -9,6 +9,12 @@ export const addFaqItem = createAction({
   displayName: 'Add FAQ Item',
   description:
     'Adds a new question/answer item to an existing FAQ; supports categories.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Appends a question/answer entry to an existing FAQ knowledge base in Aidbase, optionally tagging it with category names (new categories are created on the fly). Use to populate an FAQ already created via Create FAQ; requires the target FAQ id plus question and answer text. Not idempotent: each call appends a new item even if the question/answer is identical.',
+    idempotent: false,
+  },
 
   props: {
     faq_id: faqDropdown, 

--- a/packages/pieces/community/aidbase/src/lib/actions/add-video.ts
+++ b/packages/pieces/community/aidbase/src/lib/actions/add-video.ts
@@ -8,6 +8,12 @@ export const addVideo = createAction({
   displayName: 'Add Video',
   description:
     'Adds a YouTube video URL as knowledge to the Aidbase knowledge base.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Registers a YouTube video as a new knowledge source in Aidbase so its content can later be trained on and answered from. Use when ingesting video content into the knowledge base; requires a YouTube video URL. Not idempotent: each call creates a new knowledge source even for the same URL.',
+    idempotent: false,
+  },
 
   props: {
     video_url: Property.ShortText({

--- a/packages/pieces/community/aidbase/src/lib/actions/add-website.ts
+++ b/packages/pieces/community/aidbase/src/lib/actions/add-website.ts
@@ -7,6 +7,12 @@ export const addWebsite = createAction({
   name: 'add_website',
   displayName: 'Add Website',
   description: 'Adds a website URL as a knowledge source for Aidbase.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Registers a website URL as a new knowledge source in Aidbase so its content can later be trained on and answered from. Use when ingesting a web page or site into the knowledge base; requires the website URL. Not idempotent: each call creates a new knowledge source even for the same URL.',
+    idempotent: false,
+  },
 
   props: {
     website_url: Property.ShortText({

--- a/packages/pieces/community/aidbase/src/lib/actions/create-chatbot-reply.ts
+++ b/packages/pieces/community/aidbase/src/lib/actions/create-chatbot-reply.ts
@@ -9,6 +9,12 @@ export const createChatbotReply = createAction({
   displayName: 'Create Chatbot Reply',
   description:
     'Generates an AI chatbot reply given a message and optional session context.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Sends a message to a specified Aidbase chatbot and returns its AI-generated reply. Pass a session id to continue an existing conversation, or omit it to start a new one. Use to get an automated support answer for a user message; requires the chatbot id and the message text. Not idempotent: each call generates a fresh reply and advances the conversation.',
+    idempotent: false,
+  },
 
   props: {
     chatbot_id: chatbotDropdown, 

--- a/packages/pieces/community/aidbase/src/lib/actions/create-faq.ts
+++ b/packages/pieces/community/aidbase/src/lib/actions/create-faq.ts
@@ -7,6 +7,12 @@ export const createFaq = createAction({
   name: 'create_faq',
   displayName: 'Create FAQ',
   description: 'Creates a new FAQ entry with title and description.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new, empty FAQ knowledge base in Aidbase identified by a title (description optional). Use this first to obtain an FAQ id before adding entries with Add FAQ Item. Not idempotent: each call creates a separate FAQ even with the same title.',
+    idempotent: false,
+  },
 
   props: {
     title: Property.ShortText({

--- a/packages/pieces/community/aidbase/src/lib/actions/start-training.ts
+++ b/packages/pieces/community/aidbase/src/lib/actions/start-training.ts
@@ -8,7 +8,13 @@ export const startTraining = createAction({
   name: 'start_training',
   displayName: 'Start Training',
   description: 'Starts a training job on an existing knowledge base item (FAQ, website, video, etc.).',
-  
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Triggers a training job for a single existing Aidbase knowledge base item (FAQ, website, video, etc.) so its content becomes answerable by the chatbot. Use after adding a knowledge source; requires the knowledge item id. Not idempotent: each call enqueues another training run.',
+    idempotent: false,
+  },
+
   props: {
     knowledge_id: knowledgeItemDropdown, 
   },

--- a/packages/pieces/community/aidbase/src/lib/triggers/email-priority-changed.ts
+++ b/packages/pieces/community/aidbase/src/lib/triggers/email-priority-changed.ts
@@ -11,6 +11,10 @@ export const emailPriorityChanged = createTrigger({
   name: 'email_priority_changed',
   displayName: 'Email Priority Changed',
   description: 'Fires when an email’s priority is changed.',
+  aiMetadata: {
+    description:
+      'Fires when an Aidbase email’s priority changes (Low, Medium, High), representing a re-prioritization of a support email. Can be filtered to a specific target priority and/or inbox, or left open to fire on any priority change.',
+  },
 
   props: {
     inbox_id: emailInboxDropdown,

--- a/packages/pieces/community/aidbase/src/lib/triggers/email-received.ts
+++ b/packages/pieces/community/aidbase/src/lib/triggers/email-received.ts
@@ -7,6 +7,10 @@ export const emailReceived = createTrigger({
   name: 'email_received',
   displayName: 'Email Received',
   description: 'Fires when a new email is received in an Aidbase inbox.',
+  aiMetadata: {
+    description:
+      'Fires when a customer email arrives in an Aidbase email inbox, representing a new inbound support message. Can be scoped to a specific inbox or left open to fire for any inbox.',
+  },
 
   props: {
     inbox_id: emailInboxDropdown,

--- a/packages/pieces/community/aidbase/src/lib/triggers/email-sent.ts
+++ b/packages/pieces/community/aidbase/src/lib/triggers/email-sent.ts
@@ -7,6 +7,10 @@ export const emailSent = createTrigger({
   name: 'email_sent',
   displayName: 'Email Sent',
   description: 'Fires when an email is sent from Aidbase.',
+  aiMetadata: {
+    description:
+      'Fires when an outbound email is sent from Aidbase (e.g. an agent reply on a support thread), representing a new outgoing message. Can be scoped to a specific inbox or left open to fire for any inbox.',
+  },
 
   props: {
     inbox_id: emailInboxDropdown,

--- a/packages/pieces/community/aidbase/src/lib/triggers/email-status-changed.ts
+++ b/packages/pieces/community/aidbase/src/lib/triggers/email-status-changed.ts
@@ -11,6 +11,10 @@ export const emailStatusChanged = createTrigger({
   name: 'email_status_changed',
   displayName: 'Email Status Changed',
   description: 'Fires when the status of an email changes.',
+  aiMetadata: {
+    description:
+      'Fires when an Aidbase email transitions to a new status (e.g. Opened, Assigned, Need More Info, Resolved, Closed), representing a workflow state change on a support email. Can be filtered to a specific target status and/or inbox, or left open to fire on any status change.',
+  },
 
   props: {
     inbox_id: emailInboxDropdown,

--- a/packages/pieces/community/aidbase/src/lib/triggers/ticket-created.ts
+++ b/packages/pieces/community/aidbase/src/lib/triggers/ticket-created.ts
@@ -7,6 +7,10 @@ export const ticketCreated = createTrigger({
   name: 'ticket_created',
   displayName: 'Ticket Created',
   description: 'Fires when a new ticket is created in Aidbase.',
+  aiMetadata: {
+    description:
+      'Fires when a new support ticket is submitted in Aidbase, representing a fresh customer request. Can be scoped to a specific ticket form or left open to fire for any form.',
+  },
 
   props: {
     ticket_form_id: ticketFormDropdown,

--- a/packages/pieces/community/aidbase/src/lib/triggers/ticket-new-comment.ts
+++ b/packages/pieces/community/aidbase/src/lib/triggers/ticket-new-comment.ts
@@ -11,6 +11,10 @@ export const ticketNewComment = createTrigger({
   name: 'ticket_new_comment',
   displayName: 'Ticket New Comment',
   description: 'Fires when a new comment is added to an existing ticket.',
+  aiMetadata: {
+    description:
+      'Fires when a new comment is posted on an existing Aidbase ticket, representing an added reply or note on a support thread. Can be filtered by commenter type (customer User vs. support Agent) and/or ticket form, or left open to fire for all comments.',
+  },
 
   props: {
     ticket_form_id: ticketFormDropdown,

--- a/packages/pieces/community/aidbase/src/lib/triggers/ticket-priority-changed.ts
+++ b/packages/pieces/community/aidbase/src/lib/triggers/ticket-priority-changed.ts
@@ -11,6 +11,10 @@ export const ticketPriorityChanged = createTrigger({
   name: 'ticket_priority_changed',
   displayName: 'Ticket Priority Changed',
   description: 'Fires when the priority of an existing ticket changes.',
+  aiMetadata: {
+    description:
+      'Fires when an existing Aidbase ticket’s priority changes (Low, Medium, High), representing a re-prioritization of a support ticket. Can be filtered to a specific target priority and/or ticket form, or left open to fire on any priority change.',
+  },
 
   props: {
     ticket_form_id: ticketFormDropdown,

--- a/packages/pieces/community/aidbase/src/lib/triggers/ticket-status-changed.ts
+++ b/packages/pieces/community/aidbase/src/lib/triggers/ticket-status-changed.ts
@@ -11,6 +11,10 @@ export const ticketStatusChanged = createTrigger({
   name: 'ticket_status_changed',
   displayName: 'Ticket Status Changed',
   description: 'Fires when a ticket’s overall status changes.',
+  aiMetadata: {
+    description:
+      'Fires when an Aidbase ticket transitions to a new status (e.g. Open, Assigned, Need More Info, Resolved, Closed), representing a workflow state change on a support ticket. Can be filtered to a specific target status and/or ticket form, or left open to fire on any status change.',
+  },
 
   props: {
     ticket_form_id: ticketFormDropdown,

--- a/packages/pieces/community/aiprise/package.json
+++ b/packages/pieces/community/aiprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-aiprise",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/aiprise/src/lib/actions/create-business-profile.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/create-business-profile.ts
@@ -9,6 +9,12 @@ export const createBusinessProfileAction = createAction({
   displayName: 'Create Business Profile',
   description:
     'Creates a new business profile in AiPrise. The returned profile can then be used to run document checks or other business verifications.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new business (company) profile in AiPrise from supplied details (name, tax ID, addresses, contacts, etc.); the resulting profile is the entity you later run business verifications or document checks against. Use this as the setup step before Start Business Verification or Run Business Document Check. Only the business name is required. Not idempotent — each call creates a separate profile, even with identical input.',
+    idempotent: false,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Business Name',

--- a/packages/pieces/community/aiprise/src/lib/actions/create-user-profile.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/create-user-profile.ts
@@ -9,6 +9,12 @@ export const createUserProfileAction = createAction({
   displayName: 'Create User Profile',
   description:
     'Creates a new user profile in AiPrise. The returned profile can then be used for repeated verifications or ongoing monitoring for the same person.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new person (user) profile in AiPrise from supplied identity details (name, date of birth, contact, address, etc.); the resulting profile is the entity you later run identity verifications or ongoing monitoring against. Use this as the setup step before Start Identity Verification for a profile. All fields are optional. Not idempotent — each call creates a separate profile, even with identical input.',
+    idempotent: false,
+  },
   props: {
     first_name: Property.ShortText({
       displayName: 'First Name',

--- a/packages/pieces/community/aiprise/src/lib/actions/get-additional-user-info.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/get-additional-user-info.ts
@@ -9,6 +9,12 @@ export const getAdditionalUserInfoAction = createAction({
   displayName: "Get Person's Additional Info",
   description:
     "Fetches supplementary information collected from the person during a verification — anything beyond the primary identity fields, such as follow-up answers, extra documents, or custom form data.",
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves supplementary information gathered from a person during an identity verification — anything beyond the core identity fields, such as follow-up answers, extra documents, or custom form data — for a single session. Use when the primary submitted data (Get Person\'s Submitted Verification Data) is not enough. Requires the verification session ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     session_id: Property.ShortText({
       displayName: 'Verification Session ID',

--- a/packages/pieces/community/aiprise/src/lib/actions/get-business-documents.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/get-business-documents.ts
@@ -9,6 +9,12 @@ export const getBusinessDocumentsAction = createAction({
   displayName: 'Get Business Documents',
   description:
     'Lists all documents attached to a business profile — including file UUIDs, names, S3 URLs, timestamps, document sources, and associated verification sessions.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists every document attached to a given business profile, including each file\'s UUID, name, download URL, and the verification session it belongs to. Use this to discover a document\'s file UUID before running a document check, or to inventory what files a business has on file. Requires the business_profile_id. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     business_profile_id: Property.ShortText({
       displayName: 'Business Profile ID',

--- a/packages/pieces/community/aiprise/src/lib/actions/get-business-input-data.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/get-business-input-data.ts
@@ -9,6 +9,12 @@ export const getBusinessInputDataAction = createAction({
   displayName: "Get Business's Submitted Verification Data",
   description:
     'Returns the company information provided during a business verification — such as company name, registration number, directors, and ownership details.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves the company data submitted for a single business verification session — name, registration number, directors, ownership, etc. Use this when you need the business\'s submitted input itself rather than the pass/fail decision (see Get Business Verification Result for the outcome). Requires the verification session ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     session_id: Property.ShortText({
       displayName: 'Verification Session ID',

--- a/packages/pieces/community/aiprise/src/lib/actions/get-business-profile.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/get-business-profile.ts
@@ -9,6 +9,12 @@ export const getBusinessProfileAction = createAction({
   displayName: 'Get Business Profile',
   description:
     'Fetches a business profile from AiPrise by its ID — including the stored company details, addresses, tags, linked verification sessions, and metadata.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches a single business (company) profile by its ID, returning the stored company details, addresses, tags, linked verification sessions, and metadata. Use this to read back a business profile you created or referenced. Requires the business_profile_id. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     business_profile_id: Property.ShortText({
       displayName: 'Business Profile ID',

--- a/packages/pieces/community/aiprise/src/lib/actions/get-business-result.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/get-business-result.ts
@@ -9,6 +9,12 @@ export const getBusinessResultAction = createAction({
   displayName: 'Get Business Verification Result',
   description:
     "Fetches the current status and outcome of a company's background check — whether it is still running, approved, or declined.",
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Looks up the current status and decision (running, approved, or declined) of a single business (KYB) verification by its session ID. Use this to poll or read the outcome of a previously started business verification. Requires the verification session ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     session_id: Property.ShortText({
       displayName: 'Verification Session ID',

--- a/packages/pieces/community/aiprise/src/lib/actions/get-user-input-data.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/get-user-input-data.ts
@@ -9,6 +9,12 @@ export const getUserInputDataAction = createAction({
   displayName: 'Get Person\'s Submitted Verification Data',
   description:
     'Returns the information the person entered and the documents they uploaded during their identity check (e.g. name, date of birth, ID document details).',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves the raw data a person submitted during an identity verification — the details they typed and the documents they uploaded — for a single verification session. Use this when you need the person\'s submitted input itself rather than the pass/fail decision (see Get Identity Verification Result for the outcome). Requires the verification session ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     session_id: Property.ShortText({
       displayName: 'Verification Session ID',

--- a/packages/pieces/community/aiprise/src/lib/actions/get-user-profile.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/get-user-profile.ts
@@ -9,6 +9,12 @@ export const getUserProfileAction = createAction({
   displayName: 'Get User Profile',
   description:
     "Fetches a user profile from AiPrise by its ID — including the person's stored details, tags, linked verification sessions, and metadata.",
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches a single user (person) profile by its ID, returning the stored identity details, tags, linked verification sessions, and metadata. Use this to read back a profile you created or referenced. Requires the user_profile_id. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     user_profile_id: Property.ShortText({
       displayName: 'User Profile ID',

--- a/packages/pieces/community/aiprise/src/lib/actions/get-verification-result.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/get-verification-result.ts
@@ -9,6 +9,12 @@ export const getVerificationResultAction = createAction({
   displayName: 'Get Identity Verification Result',
   description:
     'Fetches the current status and outcome of a person\'s identity check — whether it is still in progress, approved, or declined.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Looks up the current status and decision (in progress, approved, or declined) of a single identity (KYC) verification by its session ID. Use this to poll or read the outcome of a previously started user verification. Requires the verification session ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     session_id: Property.ShortText({
       displayName: 'Verification Session ID',

--- a/packages/pieces/community/aiprise/src/lib/actions/get-verification-url.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/get-verification-url.ts
@@ -9,6 +9,12 @@ export const getVerificationUrlAction = createAction({
   displayName: 'Get Identity Verification Link',
   description:
     'Generates a secure link you can send to a person so they can complete their identity verification on an AiPrise-hosted page — no extra development needed.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a unique hosted-verification URL for a given template that you can send to a person so they complete their identity (KYC) check on an AiPrise-hosted page. Use this for the no-code/self-service flow instead of collecting data yourself. Requires a template ID and a redirect URL the person returns to afterward. Not idempotent — each call mints a new verification link/session.',
+    idempotent: false,
+  },
   props: {
     template_id: Property.ShortText({
       displayName: 'Verification Template',

--- a/packages/pieces/community/aiprise/src/lib/actions/run-business-verification.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/run-business-verification.ts
@@ -9,6 +9,12 @@ export const runBusinessVerificationAction = createAction({
   displayName: 'Start Business Verification',
   description:
     'Kicks off a company background check. AiPrise will run the checks defined in your template — which can include company registry lookup, ownership structure (UBO), sanctions screening, and adverse media.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Starts a business (KYB) verification on an existing business profile by running the checks bundled in a given template (registry lookup, UBO/ownership, sanctions screening, adverse media). Use when you want to begin verifying a company you have already created or looked up a profile for. Requires a template ID and the business_profile_id. Not idempotent — each call launches a new verification session.',
+    idempotent: false,
+  },
   props: {
     template_id: Property.ShortText({
       displayName: 'Verification Template',

--- a/packages/pieces/community/aiprise/src/lib/actions/run-document-check.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/run-document-check.ts
@@ -9,6 +9,12 @@ export const runDocumentCheckAction = createAction({
   displayName: 'Run Business Document Check',
   description:
     'Runs a verification check on a document belonging to an existing business profile. AiPrise will process the uploaded file against the checks defined in the chosen template.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Runs a verification check on a single previously-uploaded document attached to a business profile, processing the file against a chosen template. Use when you need to validate a specific business document (rather than running a full business verification). Requires the business_profile_id, a template ID, and the file UUID of the already-uploaded document. Not idempotent — each call launches a new document check.',
+    idempotent: false,
+  },
   props: {
     business_profile_id: Property.ShortText({
       displayName: 'Business Profile ID',

--- a/packages/pieces/community/aiprise/src/lib/actions/run-user-verification-profile.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/run-user-verification-profile.ts
@@ -9,6 +9,12 @@ export const runUserVerificationProfileAction = createAction({
   displayName: 'Start Identity Verification for profile',
   description:
     'Kicks off a new identity check for a person. AiPrise will run the checks defined in your chosen template (e.g. ID document scan, liveness, address).',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Starts a server-side identity (KYC) verification for an existing user profile by running the checks bundled in a given AiPrise template (ID scan, liveness, address, etc.). Use when you want to programmatically begin verifying a person you have already created a profile for, rather than sending them a hosted link. Requires a template ID and your user_profile_id. Not idempotent — each call launches a new verification session.',
+    idempotent: false,
+  },
   props: {
     template_id: Property.ShortText({
       displayName: 'Verification Template',

--- a/packages/pieces/community/aiprise/src/lib/actions/search-businesses.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/search-businesses.ts
@@ -9,6 +9,12 @@ export const searchBusinessesAction = createAction({
   displayName: 'Search Businesses',
   description:
     'Searches public business registries by name and country, returning a list of matching companies with their entity IDs, types, and addresses. Useful for looking up a business before creating a profile or running a verification.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Searches public business registries by company name and country (optionally narrowed by state/province), returning matching companies with their registry entity IDs, types, and addresses. Use this to look up and identify a real-world business before creating a profile or running a verification. Requires a business name and a 2-letter country code; partial name matches are supported. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Business Name',

--- a/packages/pieces/community/aiprise/src/lib/actions/update-verification-result.ts
+++ b/packages/pieces/community/aiprise/src/lib/actions/update-verification-result.ts
@@ -9,6 +9,12 @@ export const updateVerificationResultAction = createAction({
   displayName: 'Override Identity Verification Decision',
   description:
     'Manually changes the outcome of an identity check — useful when a human reviewer needs to approve or decline a case that AiPrise flagged for manual review.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Manually overrides the decision on an existing identity verification, setting it to Approved, Declined, Review (back to manual review), or Deactivated. Use this to implement a human-review/escalation step on a case AiPrise flagged. Requires the verification session ID and the target decision. Idempotent — it sets the decision to an explicit value, so repeating the same call leaves the case in the same state.',
+    idempotent: true,
+  },
   props: {
     verification_session_id: Property.ShortText({
       displayName: 'Verification Session ID',

--- a/packages/pieces/community/air-ops/package.json
+++ b/packages/pieces/community/air-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-air-ops",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/air-ops/src/lib/actions/get-execution.ts
+++ b/packages/pieces/community/air-ops/src/lib/actions/get-execution.ts
@@ -8,6 +8,8 @@ export const getExecution = createAction({
   name: 'get_execution',
   displayName: 'Get Execution',
   description: 'Get an execution by UUID.',
+  audience: 'both',
+  aiMetadata: { description: "Retrieve a single workflow execution and its status, inputs, and output by looking up its UUID within a selected AirOps workflow. Use to poll or check the result of an execution started by Run Workflow (Async), or to inspect any past run. Requires both the workflow and the execution UUID, and throws if no matching execution exists. Read-only, so repeated calls are idempotent.", idempotent: true },
   props: {
     app: Property.Dropdown({
       displayName: 'Workflow',

--- a/packages/pieces/community/air-ops/src/lib/actions/run-workflow-async.ts
+++ b/packages/pieces/community/air-ops/src/lib/actions/run-workflow-async.ts
@@ -8,6 +8,8 @@ export const runWorkflowAsync = createAction({
   name: 'run_workflow_async',
   displayName: 'Run Workflow (Async)',
   description: 'Queue an AirOps workflow for asynchronous execution.',
+  audience: 'both',
+  aiMetadata: { description: 'Queue a selected AirOps workflow for asynchronous execution and return immediately without waiting for the result. Use for long-running workflows, then retrieve the outcome later with Get Execution; use the synchronous Run Workflow instead when you need the output in the same call. Each call starts a new execution, so it is not idempotent.', idempotent: false },
   props: {
     app: Property.Dropdown({
       displayName: 'Workflow',

--- a/packages/pieces/community/air-ops/src/lib/actions/run-workflow.ts
+++ b/packages/pieces/community/air-ops/src/lib/actions/run-workflow.ts
@@ -8,6 +8,8 @@ export const runWorkflow = createAction({
   name: 'run_workflow',
   displayName: 'Run Workflow',
   description: 'Execute an AirOps workflow synchronously.',
+  audience: 'both',
+  aiMetadata: { description: 'Run a selected AirOps workflow synchronously and wait for its result, passing optional input values. Use when you need the workflow output back in the same call rather than polling; for long-running workflows prefer the async variant. Requires the target workflow (selected from the account) and triggers a new execution each time, so it is not idempotent.', idempotent: false },
   props: {
     app: Property.Dropdown({
       displayName: 'Workflow',

--- a/packages/pieces/community/airparser/package.json
+++ b/packages/pieces/community/airparser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-airparser",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/airparser/src/lib/actions/extract-data-from-document.ts
+++ b/packages/pieces/community/airparser/src/lib/actions/extract-data-from-document.ts
@@ -9,6 +9,8 @@ export const extractDataFromDocumentAction = createAction({
 	name: 'extract_data_from_document',
 	displayName: 'Get Data from Document',
 	description: 'Retrieves parsed JSON data from a specific document.',
+	audience: 'both',
+	aiMetadata: { description: 'Fetches the parsed/extracted structured data and metadata for one already-processed Airparser document, identified by its inbox and document ID. Use after a document has finished parsing to read back the extracted fields. Read-only and idempotent; repeating the call returns the same result.', idempotent: true },
 	props: {
 		inboxId: inboxIdDropdown,
 		documentId: documentIdDropdown,

--- a/packages/pieces/community/airparser/src/lib/actions/upload-document-for-parsing.ts
+++ b/packages/pieces/community/airparser/src/lib/actions/upload-document-for-parsing.ts
@@ -10,6 +10,8 @@ export const uploadDocumentAction = createAction({
 	name: 'upload_document',
 	displayName: 'Upload Document',
 	description: 'Upload a document to an Airparser inbox for parsing.',
+	audience: 'both',
+	aiMetadata: { description: 'Uploads a file to a specified Airparser inbox so it can be parsed into structured data; requires the inbox ID and the file. Use to submit a new document (PDF, email, image, etc.) for extraction. Not idempotent: each call creates a new document, and parsing completes asynchronously, so retrieve the results separately once parsing finishes.', idempotent: false },
 	props: {
 		inboxId: inboxIdDropdown,
 		file: Property.File({

--- a/packages/pieces/community/airparser/src/lib/triggers/document-parsed.ts
+++ b/packages/pieces/community/airparser/src/lib/triggers/document-parsed.ts
@@ -14,6 +14,9 @@ export const documentParsedTrigger = createTrigger({
   name: 'document_parsed',
   displayName: 'Document Parsed',
   description: 'Triggers when a new document is parsed in a specific inbox.',
+  aiMetadata: {
+    description: 'Fires when Airparser finishes parsing a document in the selected inbox (the doc.parsed event), signaling that extracted data is ready to retrieve. Requires a webhook to be configured manually in the Airparser account.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     inboxId: inboxIdDropdown,

--- a/packages/pieces/community/airtop/package.json
+++ b/packages/pieces/community/airtop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-airtop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/airtop/src/lib/actions/click-an-element.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/click-an-element.ts
@@ -11,6 +11,11 @@ export const clickAction = createAction({
 	auth: airtopAuth,
 	displayName: 'Click',
 	description: 'Execute a click interaction in a specific browser window.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Clicks an element in a session window located by a natural-language description, supporting left, double, and right click and optionally waiting for navigation to complete afterward. Use this to drive UI interactions such as pressing buttons or links. Requires session id, window id, and an element description; not idempotent since each click mutates page state and may trigger navigation or submissions.',
+		idempotent: false,
+	},
 	props: {
 		sessionId: sessionId,
 		windowId: windowId,

--- a/packages/pieces/community/airtop/src/lib/actions/create-new-browser-window.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/create-new-browser-window.ts
@@ -10,6 +10,11 @@ export const createNewBrowserWindowAction = createAction({
 	auth: airtopAuth,
 	displayName: 'Create New Browser Window',
 	description: 'Opens a new window within a session, optionally navigating to a URL.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Opens a new browser window inside an existing Airtop session, optionally navigating to a starting URL and setting screen resolution and page-load wait strategy. Requires a session id from Create Session; the returned window id is needed for page interactions like clicking, typing, scraping, and screenshots. Not idempotent: each call creates an additional window.',
+		idempotent: false,
+	},
 	props: {
 		sessionId: sessionId,
 		url: Property.ShortText({

--- a/packages/pieces/community/airtop/src/lib/actions/create-session.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/create-session.ts
@@ -15,6 +15,11 @@ export const createSessionAction = createAction({
 	auth: airtopAuth,
 	displayName: 'Create Session',
 	description: 'Starts a new browser session in Airtop.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Starts a new Airtop cloud browser session, optionally loading a saved profile, Chrome extensions, captcha solving, and either the built-in Airtop proxy or a custom proxy (simple URL, country/sticky, authenticated, or per-domain). Use this as the first step before opening windows or interacting with pages. Not idempotent: each call provisions a new billable session with its own id.',
+		idempotent: false,
+	},
 	props: {
 		profileName: Property.ShortText({
 			displayName: 'Profile Name',

--- a/packages/pieces/community/airtop/src/lib/actions/hover-on-an-element.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/hover-on-an-element.ts
@@ -11,6 +11,11 @@ export const hoverElementAction = createAction({
 	name: 'hover-element',
 	displayName: 'Hover on an Element',
 	description: 'Moves mouse pointer over an element in the browser window.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Moves the mouse pointer over an element in a session window, located by a natural-language description, optionally waiting for navigation afterward. Use this to reveal hover menus, tooltips, or other hover-triggered UI. Requires session id, window id, and an element description; not idempotent since it changes page interaction state and may trigger hover-driven behavior.',
+		idempotent: false,
+	},
 	props: {
 		sessionId: sessionId,
 		windowId: windowId,

--- a/packages/pieces/community/airtop/src/lib/actions/page-query.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/page-query.ts
@@ -11,6 +11,11 @@ export const pageQueryAction = createAction({
 	auth: airtopAuth,
 	displayName: 'Page Query',
 	description: 'Query a page to extract data or ask a question given the data on the page.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Uses AI to answer a natural-language prompt about the content of a session window\'s current page, optionally constrained to a JSON output schema and able to follow pagination/scroll to load more content. Use this to extract structured data or ask a question about what is on the page; requires session id, window id, and a prompt. Read-only and idempotent: it analyzes page content without changing it.',
+		idempotent: true,
+	},
 	props: {
 		sessionId: sessionId,
 		windowId: windowId,

--- a/packages/pieces/community/airtop/src/lib/actions/paginated-extraction.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/paginated-extraction.ts
@@ -11,6 +11,11 @@ export const paginatedExtractionAction = createAction({
 	auth: airtopAuth,
 	displayName: 'Paginated Extraction',
 	description: 'Extract content from paginated or dynamically loaded pages.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Uses AI to extract data across paginated or dynamically loaded pages in a session window, driven by a natural-language prompt and an optional JSON output schema, navigating either by clicking next/previous links or by infinite scroll (auto-detected by default). Use this instead of Page Query when results span multiple pages or require scrolling to load. Requires session id, window id, and a prompt; read-only and idempotent in that it does not mutate the page.',
+		idempotent: true,
+	},
 	props: {
 		sessionId: sessionId,
 		windowId: windowId,

--- a/packages/pieces/community/airtop/src/lib/actions/smart-scrape.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/smart-scrape.ts
@@ -11,6 +11,11 @@ export const smartScrapeAction = createAction({
 	auth: airtopAuth,
 	displayName: 'Smart Scrape',
 	description: 'Scrape a page and return the data as Markdown.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Scrapes the current page in a session window and returns its content as Markdown. Use this when you want the whole page text rather than answering a specific question (use Page Query for targeted extraction). Requires session id and window id; read-only and idempotent since it does not modify the page.',
+		idempotent: true,
+	},
 	props: {
 		sessionId: sessionId,
 		windowId: windowId,

--- a/packages/pieces/community/airtop/src/lib/actions/take-screenshot.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/take-screenshot.ts
@@ -10,6 +10,11 @@ export const takeScreenshotAction = createAction({
 	auth: airtopAuth,
 	displayName: 'Take Screenshot',
 	description: 'Captures a screenshot of the current window.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Captures a screenshot of a given session window, returned as base64 data or a download URL, scoped to the current viewport, the full page, or scan mode for problem pages. Use this to visually inspect what the browser currently shows; requires session id and window id. Read-only and idempotent in that it does not change page state, though each call captures the live view at that moment.',
+		idempotent: true,
+	},
 	props: {
 		sessionId: sessionId,
 		windowId: windowId,

--- a/packages/pieces/community/airtop/src/lib/actions/terminate-session.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/terminate-session.ts
@@ -9,6 +9,11 @@ export const terminateSessionAction = createAction({
 	auth: airtopAuth,
 	displayName: 'Terminate Session',
 	description: 'Ends an existing browser session in Airtop.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Terminates an existing Airtop browser session by its session id, freeing its resources. Use this to clean up when done browsing. Not idempotent in effect since it changes server state, though a missing session is ignored without error.',
+		idempotent: false,
+	},
 	props: {
 		sessionId: sessionId,
 	},

--- a/packages/pieces/community/airtop/src/lib/actions/type.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/type.ts
@@ -10,6 +10,11 @@ export const typeAction = createAction({
 	auth: airtopAuth,
 	displayName: 'Type',
 	description: 'Type into a browser window at the specified field.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Types text into an input in a session window, with options to clear the field first, press Enter and/or Tab afterward, and wait for navigation; the target field can be located by a natural-language element description or left to the active focus. Use this to fill forms or search boxes. Requires session id, window id, and the text; not idempotent since it mutates the page and may submit forms or trigger navigation.',
+		idempotent: false,
+	},
 	props: {
 		sessionId: sessionId,
 		windowId: windowId,

--- a/packages/pieces/community/airtop/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/airtop/src/lib/actions/upload-file.ts
@@ -11,6 +11,11 @@ export const uploadFileToSessionAction = createAction({
 	name: 'upload-file-to-session',
 	displayName: 'Upload File to Sessions',
 	description: 'Push an existing file to one or more sessions, making it available for use in file inputs or downloads.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Pushes an already-uploaded Airtop file (by file id) to specific sessions, or to all active sessions when no session ids are given, making it available for file inputs or downloads in those sessions. Use this after a file exists in Airtop and you need it accessible inside a browsing session. Requires the file id; not idempotent since it performs a push to session state on each call.',
+		idempotent: false,
+	},
 	props: {
 		fileId: fileId,
 		sessionIds: Property.MultiSelectDropdown({

--- a/packages/pieces/community/alai/package.json
+++ b/packages/pieces/community/alai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-alai",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/alai/src/lib/actions/add-slide.ts
+++ b/packages/pieces/community/alai/src/lib/actions/add-slide.ts
@@ -8,6 +8,12 @@ export const addSlide = createAction({
   name: 'addSlide',
   displayName: 'Add Slide',
   description: 'Add a new slide to an existing presentation.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Generate and insert a new AI-authored slide into an existing Alai presentation, given the presentation ID and the slide content/topic; optional slide order controls where it lands (a numeric index, or "end" to append). Use this to extend a deck after it has been generated. Not idempotent: each call appends another slide.',
+    idempotent: false,
+  },
   props: {
     presentationId: presentationId,
     slide_context: Property.LongText({

--- a/packages/pieces/community/alai/src/lib/actions/delete-presentation.ts
+++ b/packages/pieces/community/alai/src/lib/actions/delete-presentation.ts
@@ -7,6 +7,12 @@ export const deletePresentation = createAction({
   name: 'deletePresentation',
   displayName: 'Delete Presentation',
   description: 'Delete a presentation by its ID.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Permanently delete an Alai presentation by its ID. Use this to remove a deck the user no longer needs. Destructive but idempotent: once deleted, repeating the call with the same ID leaves the same end state. Requires the presentation ID.',
+    idempotent: true,
+  },
   props: {
     presentationId: Property.ShortText({
       displayName: 'Presentation ID',

--- a/packages/pieces/community/alai/src/lib/actions/export-presentation.ts
+++ b/packages/pieces/community/alai/src/lib/actions/export-presentation.ts
@@ -7,6 +7,12 @@ export const exportPresentation = createAction({
   name: 'exportPresentation',
   displayName: 'Export Presentation',
   description: 'Export a presentation in the specified formats.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Export an existing Alai presentation into one or more formats (link, PDF, and/or PPTX) by its presentation ID. Use this to render a deck for download or sharing. By default it returns immediately with a generation_id (poll Get Generation for status); set Wait for Completion to block until the export finishes (up to Max Wait Time). Not idempotent: each call kicks off a new export job. Requires the presentation ID and at least one export format.',
+    idempotent: false,
+  },
   props: {
     presentationId: Property.ShortText({
       displayName: 'Presentation ID',

--- a/packages/pieces/community/alai/src/lib/actions/generate-presentation.ts
+++ b/packages/pieces/community/alai/src/lib/actions/generate-presentation.ts
@@ -9,6 +9,12 @@ export const generatePresentation = createAction({
   name: 'generatePresentation',
   displayName: 'Generate Presentation',
   description: 'Create a new AI-generated presentation from text.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Generate a brand-new presentation from input text via the Alai AI API, with optional controls for tone, slide count, text density, theme, and AI images. Use this to turn raw text into slides. By default it returns immediately with a generation_id (poll Get Generation for status); set Wait for Completion to block until the deck finishes (up to Max Wait Time). Not idempotent: each call starts a new generation.',
+    idempotent: false,
+  },
   props: {
     inputText: Property.LongText({
       displayName: 'Input Text',

--- a/packages/pieces/community/alai/src/lib/actions/get-generation.ts
+++ b/packages/pieces/community/alai/src/lib/actions/get-generation.ts
@@ -7,6 +7,12 @@ export const getGeneration = createAction({
   name: 'getGeneration',
   displayName: 'Get Generation',
   description: 'Fetch the status and result of a generation job.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Look up the current status and result of an Alai generation job by its generation_id (returned by Generate Presentation or Export Presentation). Use this to poll for completion or retrieve the finished output and export links. Read-only and idempotent. Requires a valid generation_id.',
+    idempotent: true,
+  },
   props: {
     generationId: Property.ShortText({
       displayName: 'Generation ID',

--- a/packages/pieces/community/algolia/package.json
+++ b/packages/pieces/community/algolia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-algolia",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/algolia/src/lib/actions/browse-records.ts
+++ b/packages/pieces/community/algolia/src/lib/actions/browse-records.ts
@@ -10,6 +10,11 @@ export const browseRecordsAction = createAction({
   name: 'browse-records',
   displayName: 'Browse Records',
   description: 'Retrieves records from an Algolia index.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Retrieves the raw records stored in an Algolia index, paging through them up to an optional limit (default 10,000). Use this to dump or inspect index contents; it is a read-only lookup, not a relevance-ranked query, so it does not accept a search term. Idempotent.',
+    idempotent: true,
+  },
   props: {
     indexName: algoliaProps.index(),
     limit: Property.Number({

--- a/packages/pieces/community/algolia/src/lib/actions/delete-records.ts
+++ b/packages/pieces/community/algolia/src/lib/actions/delete-records.ts
@@ -10,6 +10,11 @@ export const deleteRecordsAction = createAction({
   name: 'delete-records',
   displayName: 'Delete Records',
   description: 'Deletes records from an Algolia index by objectID.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Deletes records from an Algolia index by their objectIDs. Provide an array of the exact objectIDs to remove from the selected index. Idempotent: deleting the same IDs again leaves the index in the same state (already-absent IDs are simply no-ops).',
+    idempotent: true,
+  },
   props: {
     indexName: algoliaProps.index(),
     recordIds: Property.Array({

--- a/packages/pieces/community/algolia/src/lib/actions/save-records.ts
+++ b/packages/pieces/community/algolia/src/lib/actions/save-records.ts
@@ -9,6 +9,11 @@ export const saveRecordsAction = createAction({
   name: 'save-records',
   displayName: 'Save Records',
   description: 'Adds or updates records in an Algolia index.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Adds or updates one or more records in an Algolia search index (creating the index if it does not yet exist). Pass an array of JSON objects; include an `objectID` on a record to overwrite that existing record, or omit it to have Algolia generate a new one. Not idempotent: records without an `objectID` create a fresh record on every call, so repeating the call appends duplicates.',
+    idempotent: false,
+  },
   props: {
     indexName: Property.ShortText({
       displayName: 'Index Name',

--- a/packages/pieces/community/alt-text-ai/package.json
+++ b/packages/pieces/community/alt-text-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-alt-text-ai",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/alt-text-ai/src/lib/actions/generate-alt-text.ts
+++ b/packages/pieces/community/alt-text-ai/src/lib/actions/generate-alt-text.ts
@@ -8,6 +8,8 @@ export const generateAltTextAction = createAction({
     auth: altTextAiAuth,
     displayName: 'Generate Alt Text',
     description: 'Generates a descriptive alt text for a given image.',
+    audience: 'both',
+    aiMetadata: { description: 'Sends an image to AltText.ai and returns AI-generated descriptive alt text for accessibility/SEO. Use when you have an image (uploaded file passed as raw base64) and need a human-readable description; optionally bias the output with keywords, negative keywords, or a keyword-source text. Each call submits the image for fresh generation, so it is not idempotent.', idempotent: false },
     props: {
         image: Property.File({
             displayName: 'Image',

--- a/packages/pieces/community/alttextify/package.json
+++ b/packages/pieces/community/alttextify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-alttextify",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/alttextify/src/lib/actions/generate-alt-text.ts
+++ b/packages/pieces/community/alttextify/src/lib/actions/generate-alt-text.ts
@@ -8,6 +8,8 @@ export const generateAltTextAction = createAction({
     auth: alttextifyAuth,
     displayName: 'Generate Image Alt Text',
     description: 'Generates alt text for specified image.',
+    audience: 'both',
+    aiMetadata: { description: 'Generates descriptive alt text for an image file by sending it to AltTextify. Use when an agent needs accessibility alt text or an SEO caption for an image. Requires the image as a file input; optionally accepts a language code and keyword/negative-keyword lists to steer the output. Idempotent: the same image and options yield the same alt text and create nothing.', idempotent: true },
     props: {
         image: Property.File({
             displayName: 'Image File',

--- a/packages/pieces/community/amazon-s3/package.json
+++ b/packages/pieces/community/amazon-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-s3",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/amazon-s3/src/lib/actions/decrypt-pgp-file.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/actions/decrypt-pgp-file.ts
@@ -9,6 +9,11 @@ export const decryptPgpFile = createAction({
   name: 'decrypt-pgp-file',
   displayName: 'Decrypt PGP File',
   description: 'Decrypt a PGP encrypted file from S3 using a private key stored in AWS Secrets Manager',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Downloads a PGP-encrypted object from the configured S3 bucket and decrypts it using a private key (and optional passphrase) retrieved from AWS Secrets Manager by ARN, returning the decrypted contents as a file. Use when an S3 file is PGP-encrypted and you have the key stored in Secrets Manager. Requires the secret ARN for the private key; idempotent since it only reads and decrypts without modifying anything.',
+    idempotent: true,
+  },
   props: {
     key: Property.ShortText({
       displayName: 'S3 File Key',

--- a/packages/pieces/community/amazon-s3/src/lib/actions/delete-file.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/actions/delete-file.ts
@@ -7,6 +7,11 @@ export const deleteFile = createAction({
   name: 'deleteFile',
   displayName: 'Delete File',
   description: 'Deletes an existing file.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Deletes a single object from the configured S3 bucket by its full key (path). Use to remove a known file. Idempotent: deleting an already-absent key succeeds without error, so repeating the call has no further effect.',
+    idempotent: true,
+  },
   props: {
     key: Property.ShortText({
       displayName: 'File Path',

--- a/packages/pieces/community/amazon-s3/src/lib/actions/generate-signed-upload-url.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/actions/generate-signed-upload-url.ts
@@ -9,6 +9,11 @@ export const generateSignedUploadUrl = createAction({
   displayName: 'Generate Signed Upload URL',
   description:
     'Generate a pre-signed URL that allows anyone with the link to upload a file directly to S3 without needing AWS credentials.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Generates a time-limited pre-signed upload (PUT) URL for a target key in the configured S3 bucket, letting anyone with the link upload a file directly to S3 without AWS credentials until it expires. Use to delegate an upload to an external client. Generating the URL does not itself create or modify any object and is idempotent (each call returns a freshly signed URL).',
+    idempotent: true,
+  },
   props: {
     key: Property.ShortText({
       displayName: 'File Key',

--- a/packages/pieces/community/amazon-s3/src/lib/actions/generate-signed-url.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/actions/generate-signed-url.ts
@@ -8,6 +8,11 @@ export const generateSignedUrl = createAction({
   name: 'generate-signed-url',
   displayName: 'Generate signed URL',
   description: 'Generate a signed URL for a file in a s3 bucket',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Generates a time-limited pre-signed download (GET) URL for an existing object in the configured S3 bucket, letting anyone with the link fetch the file without AWS credentials until it expires. Use when you need to share read access to a stored file. Read-only and idempotent (no object is modified), though each call returns a freshly signed URL.',
+    idempotent: true,
+  },
   props: {
     key: Property.ShortText({
       displayName: 'File Path',

--- a/packages/pieces/community/amazon-s3/src/lib/actions/list-files.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/actions/list-files.ts
@@ -22,6 +22,11 @@ export const listFiles = createAction({
   name: 'list-files',
   displayName: 'List Files',
   description: 'List all files from an S3 bucket folder/prefix.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Lists objects in the configured S3 bucket, optionally filtered to a folder prefix (empty prefix lists the whole bucket), capped at a maximum count (1-1000, default 1000) and sorted newest-first. Use to discover files or look up an object key before reading, moving, or deleting it. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     prefix: Property.ShortText({
       displayName: 'Folder Path (Optional)',

--- a/packages/pieces/community/amazon-s3/src/lib/actions/move-file.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/actions/move-file.ts
@@ -7,6 +7,11 @@ export const moveFile = createAction({
   name: 'moveFile',
   displayName: 'Move File',
   description: 'Move a File to Another Folder',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Moves an object within the configured S3 bucket by copying it to a new key under the destination folder (keeping the same filename) and then deleting the original. Use to relocate or archive a file. Not idempotent — the source object is deleted on the first successful run, so a repeat call errors because the source key no longer exists.',
+    idempotent: false,
+  },
   props: {
     fileKey: Property.ShortText({
       displayName: 'File Path',

--- a/packages/pieces/community/amazon-s3/src/lib/actions/read-file.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/actions/read-file.ts
@@ -8,6 +8,11 @@ export const readFile = createAction({
   name: 'read-file',
   displayName: 'Read File',
   description: 'Read a file from S3 to use it in other steps',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Downloads a single object from the configured S3 bucket by its full key (path) and makes its contents available as a file for later steps. Use to fetch a known file when you have its exact key. Reading the same key repeatedly returns the same content with no side effect (idempotent).',
+    idempotent: true,
+  },
   props: {
     key: Property.ShortText({
       displayName: 'File Path',

--- a/packages/pieces/community/amazon-s3/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/actions/upload-file.ts
@@ -9,6 +9,11 @@ export const amazons3UploadFile = createAction({
   name: 'upload-file',
   displayName: 'Upload File',
   description: 'Upload an File to S3',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Uploads a file to the configured S3 bucket, optionally setting a destination filename, content type, and canned ACL (e.g. private vs. public-read). Use to store new content in S3. Not idempotent: when no filename is given a unique timestamp-based key is generated, so each call writes a new object.',
+    idempotent: false,
+  },
   props: {
     file: Property.File({
       displayName: 'File',

--- a/packages/pieces/community/amazon-s3/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/triggers/new-file.ts
@@ -70,6 +70,9 @@ export const newFile = createTrigger({
 	displayName: 'New or Updated File',
 	description:
 		'Triggers when you add or update a file in your bucket. The bucket/folder you choose must not contain more than 10,000 files.',
+	aiMetadata: {
+		description: 'Fires when an object is added or modified in the configured S3 bucket, optionally scoped to a folder prefix. Polls the bucket and emits each new or updated file based on its last-modified time. The watched bucket/folder must contain no more than 10,000 files.',
+	},
 	props: {
 		markdown:Property.MarkDown({
 			variant:MarkdownVariant.INFO,

--- a/packages/pieces/community/amazon-secrets-manager/package.json
+++ b/packages/pieces/community/amazon-secrets-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-secrets-manager",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/amazon-secrets-manager/src/lib/actions/create-secret.ts
+++ b/packages/pieces/community/amazon-secrets-manager/src/lib/actions/create-secret.ts
@@ -11,6 +11,12 @@ export const createSecret = createAction({
   name: 'createSecret',
   displayName: 'Create Secret',
   description: 'Creates a new secret.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new secret in AWS Secrets Manager in the connection\'s region, storing the supplied text value under a given name with optional description and tags. Use when provisioning a brand-new credential or config value to store. Not idempotent: the name must be unique, and re-running fails (or duplicates) rather than updating — use Update Secret to change an existing secret.',
+    idempotent: false,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Secret Name',

--- a/packages/pieces/community/amazon-secrets-manager/src/lib/actions/delete-secret.ts
+++ b/packages/pieces/community/amazon-secrets-manager/src/lib/actions/delete-secret.ts
@@ -11,6 +11,12 @@ export const deleteSecret = createAction({
   name: 'deleteSecret',
   displayName: 'Delete Secret',
   description: 'Deletes an existing secret.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Deletes an existing AWS Secrets Manager secret (identified by name or ARN, selectable from a list or passed directly). By default schedules deletion after a recovery window (7-30 days, default 30) during which it can be restored; enabling force-delete removes it immediately and irreversibly. Use to decommission a credential. Destructive and not idempotent — a repeat call on an already-deleted secret errors.',
+    idempotent: false,
+  },
   props: {
     secretId: secretIdDropdown,
     recoveryWindowInDays: Property.Number({

--- a/packages/pieces/community/amazon-secrets-manager/src/lib/actions/find-secret.ts
+++ b/packages/pieces/community/amazon-secrets-manager/src/lib/actions/find-secret.ts
@@ -10,6 +10,12 @@ export const findSecret = createAction({
   name: 'findSecret',
   displayName: 'Find Secret',
   description: 'Finds an existing secret using filters.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists/searches secrets in AWS Secrets Manager, filtering by a chosen field (name, description, tag key, tag value, primary region, owning service, or "all") against a search value, with optional max results and sort. Use to discover secrets or resolve a name/ARN before another action. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     filterKey: Property.StaticDropdown({
       displayName: 'Filter Key',

--- a/packages/pieces/community/amazon-secrets-manager/src/lib/actions/get-a-random-password.ts
+++ b/packages/pieces/community/amazon-secrets-manager/src/lib/actions/get-a-random-password.ts
@@ -10,6 +10,12 @@ export const getARandomPassword = createAction({
   name: 'getARandomPassword',
   displayName: 'Generate Random Password',
   description: 'Generates a random password using AWS Secrets Manager.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Generates a random password using the AWS Secrets Manager service, with optional length and character-set controls (exclude specific characters/numbers/punctuation/case, include spaces, require each included type). Use when a flow needs a freshly generated strong password; it does not store anything. Not idempotent — each call returns a different password.',
+    idempotent: false,
+  },
   props: {
     passwordLength: Property.Number({
       displayName: 'Password Length',

--- a/packages/pieces/community/amazon-secrets-manager/src/lib/actions/get-secret-value.ts
+++ b/packages/pieces/community/amazon-secrets-manager/src/lib/actions/get-secret-value.ts
@@ -11,6 +11,12 @@ export const getSecretValue = createAction({
   name: 'getSecretValue',
   displayName: 'Get Secret Value',
   description: 'Retrieves a secret value.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves the stored value of a secret in AWS Secrets Manager, identified by name or ARN (selectable from a list or passed directly). Use when a flow needs the current credential/config held in a secret. Optionally targets a specific version ID or staging label, defaulting to the current (AWSCURRENT) version. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     secretId: secretIdDropdown,
     versionId: Property.ShortText({

--- a/packages/pieces/community/amazon-secrets-manager/src/lib/actions/update-secret.ts
+++ b/packages/pieces/community/amazon-secrets-manager/src/lib/actions/update-secret.ts
@@ -11,6 +11,12 @@ export const updateSecret = createAction({
   name: 'updateSecret',
   displayName: 'Update Secret',
   description: 'Updates an existing secret.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Overwrites an existing AWS Secrets Manager secret (identified by name or ARN, selectable from a list or passed directly) with a new text value and optional description. Use when rotating or changing a credential that already exists; the secret must already exist. Repeating with the same value converges to the same stored value, so it is idempotent, though each call records a new version.',
+    idempotent: true,
+  },
   props: {
     secretId: secretIdDropdown,
     secretValue: Property.LongText({

--- a/packages/pieces/community/amazon-sns/package.json
+++ b/packages/pieces/community/amazon-sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-sns",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/amazon-sns/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/amazon-sns/src/lib/actions/send-message.ts
@@ -8,6 +8,8 @@ export const sendMessageAction = createAction({
   name: 'send-message',
   displayName: 'Send Message',
   description: 'Sends a message to an Amazon SNS topic.',
+  audience: 'both',
+  aiMetadata: { description: 'Publishes a message to an Amazon SNS topic, fanning it out to that topic\'s subscribers (email, SMS, HTTP/S, SQS, Lambda, etc.). Use to send a notification or alert through a pre-existing SNS topic; you must supply the target topic\'s ARN and the message body. Not idempotent — each call publishes a new message and delivers it again.', idempotent: false },
   props: {
     topic: Property.Dropdown({
         auth: amazonSnsAuth,

--- a/packages/pieces/community/amazon-sqs/package.json
+++ b/packages/pieces/community/amazon-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-sqs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/amazon-sqs/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/amazon-sqs/src/lib/actions/send-message.ts
@@ -7,6 +7,8 @@ export const sendMessage = createAction({
   displayName: 'Send Message',
   auth: amazonSqsAuth,
   description: '',
+  audience: 'both',
+  aiMetadata: { description: 'Sends a single message to an Amazon SQS queue identified by its full queue URL, with the message body as plain text. Use to enqueue work or events for downstream consumers polling the queue. Not idempotent: each call enqueues a separate message, so retrying will produce duplicate messages.', idempotent: false },
   props: {
     queueUrl: Property.ShortText({
       displayName: 'Queue URL',

--- a/packages/pieces/community/amazon-textract/package.json
+++ b/packages/pieces/community/amazon-textract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-textract",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document-async.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document-async.ts
@@ -19,6 +19,8 @@ export const analyzeDocumentAsync = createAction({
   displayName: 'Analyze Document from S3 (Multi-Page)',
   description:
     'Extract text, forms, tables, and signatures from a PDF or TIFF stored in S3. Works with both single-page and multi-page documents. This action waits for processing to finish and returns all results automatically — no extra steps needed.',
+  audience: 'both',
+  aiMetadata: { description: 'Analyze a multi-page (or single-page) document stored in S3 with AWS Textract, extracting forms, tables, signatures, and layout structure, optionally answering natural-language queries. Choose it for multi-page PDFs or TIFFs that the synchronous Analyze Document action cannot handle; the document must already be in S3 (no direct upload). It starts an async Textract job and blocks while polling until results are ready (up to a 5-minute timeout), then returns all pages. Effectively idempotent: it is a read-only extraction, and supplying the optional deduplication token makes AWS return the original job result if the same token is reused within 5 minutes.', idempotent: true },
   props: {
     s3Bucket: Property.ShortText({
       displayName: 'S3 Bucket',

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-document.ts
@@ -17,6 +17,8 @@ export const analyzeDocument = createAction({
   displayName: 'Analyze Document',
   description:
     'Extract text, forms (key-value pairs), tables, and signatures from a document. Supports JPEG and PNG via direct upload; PDF and TIFF via S3 only. For multi-page PDFs, use Start Document Analysis instead.',
+  audience: 'both',
+  aiMetadata: { description: 'Synchronously analyze a single-page document with AWS Textract to pull out forms (key-value pairs), tables, and signatures, optionally answering natural-language queries about it. Choose it when you need structured layout extraction rather than just raw text (use Detect Document Text for plain text only) and the document is one page. The source can be an uploaded file (JPEG/PNG only) or an S3 object (also PDF/TIFF, single-page only); for multi-page PDFs use the S3 multi-page action. Idempotent: it is a stateless read-only inference that returns the same result for the same input.', idempotent: true },
   props: {
     source: Property.StaticDropdown({
       displayName: 'Document Source',

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-expense.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-expense.ts
@@ -14,6 +14,8 @@ export const analyzeExpense = createAction({
   displayName: 'Analyze Expense',
   description:
     'Extract structured data from receipts and invoices: vendor name, totals, tax, line items, and more. Works best with clearly formatted receipts and invoices.',
+  audience: 'both',
+  aiMetadata: { description: 'Synchronously analyze a receipt or invoice with AWS Textract to extract structured financial fields such as vendor name, totals, tax, dates, and line items. Choose it specifically for expense documents rather than the general Analyze Document action. The source can be an uploaded file (JPEG/PNG only) or an S3 object (also PDF/TIFF, single-page only). Idempotent: it is a stateless read-only inference that returns the same result for the same input.', idempotent: true },
   props: {
     source: Property.StaticDropdown({
       displayName: 'Document Source',

--- a/packages/pieces/community/amazon-textract/src/lib/actions/analyze-id.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/analyze-id.ts
@@ -14,6 +14,8 @@ export const analyzeId = createAction({
   displayName: 'Analyze ID Document',
   description:
     'Extract structured data from identity documents such as driver\'s licenses and passports. Returns fields like name, date of birth, ID number, and expiry date.',
+  audience: 'both',
+  aiMetadata: { description: 'Synchronously analyze a US identity document (driver\'s license or passport) with AWS Textract to extract fields like name, date of birth, ID number, and expiry date. Choose it specifically for ID documents rather than the general Analyze Document action. The source can be an uploaded file or an S3 object, but only JPEG and PNG are accepted here — PDF and TIFF are not supported. Idempotent: it is a stateless read-only inference that returns the same result for the same input.', idempotent: true },
   props: {
     source: Property.StaticDropdown({
       displayName: 'Document Source',

--- a/packages/pieces/community/amazon-textract/src/lib/actions/detect-document-text.ts
+++ b/packages/pieces/community/amazon-textract/src/lib/actions/detect-document-text.ts
@@ -14,6 +14,8 @@ export const detectDocumentText = createAction({
   displayName: 'Detect Document Text',
   description:
     'Extract plain text from a document. Faster and cheaper than Analyze Document — use this when you only need the text content without forms or tables. Supports JPEG and PNG via direct upload; PDF and TIFF via S3 only.',
+  audience: 'both',
+  aiMetadata: { description: 'Synchronously OCR a single-page document with AWS Textract and return its plain text content (lines and words), without forms, tables, or signatures. Choose it when you only need the raw text — it is faster and cheaper than Analyze Document. The source can be an uploaded file (JPEG/PNG only) or an S3 object (also PDF/TIFF, single-page only). Idempotent: it is a stateless read-only inference that returns the same result for the same input.', idempotent: true },
   props: {
     source: Property.StaticDropdown({
       displayName: 'Document Source',

--- a/packages/pieces/community/aminos/package.json
+++ b/packages/pieces/community/aminos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-aminos",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/aminos/src/lib/actions/createUser.ts
+++ b/packages/pieces/community/aminos/src/lib/actions/createUser.ts
@@ -7,6 +7,8 @@ export const createUser = createAction({
   name: 'createUser',
   displayName: 'Create User on Aminos One',
   description: 'Create a user and plan in Aminos One Panel',
+  audience: 'both',
+  aiMetadata: { description: 'Provisions a new user account on an Aminos One panel by POSTing the user email, display name, and a numeric plan ID to the configured panel base URL. Use to onboard a customer or assign them to a specific pricing plan. Not idempotent: each call attempts a fresh creation and the panel returns an error if the email already exists, so it is not a safe retry.', idempotent: false },
   props: {
    useremail: Property.ShortText({
       displayName: 'Username (e-mail)',

--- a/packages/pieces/community/apitemplate-io/package.json
+++ b/packages/pieces/community/apitemplate-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-apitemplate-io",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/apitemplate-io/src/lib/actions/create-image.ts
+++ b/packages/pieces/community/apitemplate-io/src/lib/actions/create-image.ts
@@ -9,6 +9,8 @@ export const createImage = createAction({
   name: 'createImage',
   displayName: 'Create Image',
   description: 'Creates an image from a template with provided data.',
+  audience: 'both',
+  aiMetadata: { description: 'Renders a new image from a saved APITemplate.io template, merging in the supplied JSON `overrides` array to fill template objects. Requires a template ID (pick from the dropdown). Not idempotent: each call generates and stores a new image with its own transaction reference.', idempotent: false },
   props: {
     templateId: templateIdDropdown,
         data: Property.Json({

--- a/packages/pieces/community/apitemplate-io/src/lib/actions/create-pdf-from-html.ts
+++ b/packages/pieces/community/apitemplate-io/src/lib/actions/create-pdf-from-html.ts
@@ -8,6 +8,8 @@ export const createPdfFromHtml = createAction({
   name: 'createPdfFromHtml',
   displayName: 'Create PDF From HTML',
   description: 'Creates a PDF from HTML.',
+  audience: 'both',
+  aiMetadata: { description: 'Renders a new PDF directly from raw HTML (with optional CSS, templating data, and page settings such as size, orientation, margins, and headers/footers). Use when you have ad-hoc HTML markup rather than a saved template or a live URL. Requires the HTML body. Not idempotent: each call generates and stores a new PDF.', idempotent: false },
   props: {
     html: Property.LongText({
       displayName: 'HTML Content',

--- a/packages/pieces/community/apitemplate-io/src/lib/actions/create-pdf-from-url.ts
+++ b/packages/pieces/community/apitemplate-io/src/lib/actions/create-pdf-from-url.ts
@@ -8,6 +8,8 @@ export const createPdfFromUrl = createAction({
   name: 'createPdfFromUrl',
   displayName: 'Create PDF From URL',
   description: 'Creates a PDF from a webpage URL.',
+  audience: 'both',
+  aiMetadata: { description: 'Renders a new PDF by loading and capturing a live webpage at the given URL, with optional page settings (size, orientation, margins), viewport sizing, full-page capture, and wait-for-selector/timeout controls for dynamic content. Use when the source is a public web page rather than supplied HTML or a saved template. Requires the URL. Not idempotent: each call generates and stores a new PDF.', idempotent: false },
   props: {
     url: Property.ShortText({
       displayName: 'URL',

--- a/packages/pieces/community/apitemplate-io/src/lib/actions/create-pdf.ts
+++ b/packages/pieces/community/apitemplate-io/src/lib/actions/create-pdf.ts
@@ -9,6 +9,8 @@ export const createPdf = createAction({
   name: 'createPdf',
   displayName: 'Create PDF',
   description: 'Creates a PDF from a template with provided data.',
+  audience: 'both',
+  aiMetadata: { description: 'Renders a new PDF from a saved APITemplate.io template, merging in the supplied JSON `overrides` array to fill template objects. Use when the layout is already designed as a template; for ad-hoc HTML or a webpage use the from-HTML or from-URL actions instead. Requires a template ID. Not idempotent: each call generates and stores a new PDF.', idempotent: false },
   props: {
     templateId: templateIdDropdown,
     data: Property.Json({

--- a/packages/pieces/community/apitemplate-io/src/lib/actions/delete-object.ts
+++ b/packages/pieces/community/apitemplate-io/src/lib/actions/delete-object.ts
@@ -9,6 +9,8 @@ export const deleteObject = createAction({
   name: 'deleteObject',
   displayName: 'Delete Object',
   description: 'Deletes a generated PDF or image by its transaction reference or object ID.',
+  audience: 'both',
+  aiMetadata: { description: 'Permanently deletes a previously generated PDF or image, identified by its transaction reference (pick from the dropdown of recent objects). Use to clean up stored output. Idempotent in effect: once the object is gone, repeating the call leaves the same deleted state.', idempotent: true },
   props: {
     transactionRef: transactionRefDropdown,
   },

--- a/packages/pieces/community/apitemplate-io/src/lib/actions/get-account-information.ts
+++ b/packages/pieces/community/apitemplate-io/src/lib/actions/get-account-information.ts
@@ -8,6 +8,8 @@ export const getAccountInformation = createAction({
   name: 'getAccountInformation',
   displayName: 'Get Account Information',
   description: 'Retrieves account information including usage statistics and account details.',
+  audience: 'both',
+  aiMetadata: { description: 'Fetches the APITemplate.io account profile, including plan and generation usage/quota stats. Use to check remaining quota or account status before generating documents. Read-only and idempotent; takes no input.', idempotent: true },
   props: {},
   async run({ auth }) {
     const authConfig = auth.props;

--- a/packages/pieces/community/apitemplate-io/src/lib/actions/list-objects.ts
+++ b/packages/pieces/community/apitemplate-io/src/lib/actions/list-objects.ts
@@ -9,6 +9,8 @@ export const listObjects = createAction({
   displayName: 'List Objects',
   description:
     'Retrieves a list of generated PDFs and images with optional filtering',
+  audience: 'both',
+  aiMetadata: { description: 'Lists previously generated PDFs and images for the account, optionally narrowed by template ID, transaction reference, date range, or external reference (meta); with no filters it returns the full recent set. Supports limit/offset pagination (max 300 per call). Read-only and idempotent.', idempotent: true },
   props: {
     limit: Property.Number({
       displayName: 'Limit',

--- a/packages/pieces/community/appfollow/package.json
+++ b/packages/pieces/community/appfollow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-appfollow",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/appfollow/src/lib/actions/add-user.ts
+++ b/packages/pieces/community/appfollow/src/lib/actions/add-user.ts
@@ -8,6 +8,12 @@ export const addUser = createAction({
   name: 'addUser',
   displayName: 'Add user',
   description: 'Adds a new user to the Appfollow account',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new user in the AppFollow account with a name, email, and role. Use to grant someone access to the account. Not idempotent: each call adds another user, so repeating it may create duplicates.',
+    idempotent: false,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Name',

--- a/packages/pieces/community/appfollow/src/lib/actions/reply-to-review.ts
+++ b/packages/pieces/community/appfollow/src/lib/actions/reply-to-review.ts
@@ -14,6 +14,12 @@ export const replyToReview = createAction({
   displayName: 'Reply to Review',
   description:
     'Reply to a specific review within a date range for a selected application and collection',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Posts a public reply to a specific app store review, identified by its review ID, for the selected application. Use to respond to user feedback in store reviews. Not idempotent: each call submits another reply.',
+    idempotent: false,
+  },
   props: {
     collection_id: collection_idDropdown,
     app_ext_id: application_ext_idDropdown,

--- a/packages/pieces/community/appfollow/src/lib/triggers/new-review.ts
+++ b/packages/pieces/community/appfollow/src/lib/triggers/new-review.ts
@@ -51,6 +51,10 @@ export const newReview = createTrigger({
   name: 'newReview',
   displayName: 'New Review',
   description: 'Triggered when a new review is added',
+  aiMetadata: {
+    description:
+      'Fires when a new app store review is posted for the selected application and collection. Each event represents a single newly created review.',
+  },
   props,
   sampleData: {
     content: '. :)',

--- a/packages/pieces/community/appfollow/src/lib/triggers/new-tag.ts
+++ b/packages/pieces/community/appfollow/src/lib/triggers/new-tag.ts
@@ -41,6 +41,10 @@ export const newTag = createTrigger({
   name: 'newTag',
   displayName: 'New Tag',
   description: 'Triggered when a new tag is added',
+  aiMetadata: {
+    description:
+      'Fires when a new tag is added to the AppFollow account. Each event represents a single newly created tag with its name, category, and color.',
+  },
   props,
   sampleData: {
     tag: 't0021',

--- a/packages/pieces/community/ask-handle/package.json
+++ b/packages/pieces/community/ask-handle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ask-handle",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/ask-handle/src/lib/actions/create-lead.ts
+++ b/packages/pieces/community/ask-handle/src/lib/actions/create-lead.ts
@@ -8,6 +8,8 @@ export const createLead = createAction({
   name: 'create_lead',
   displayName: 'Create Lead',
   description: 'Create a new lead',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new lead record in AskHandle from optional contact and context fields (nickname, email, phone, device, originating page title, referrer). Use to capture a prospect. Not idempotent — each call creates a separate lead, with no de-duplication on email or phone.', idempotent: false },
   props: {
     nickname: Property.ShortText({
       displayName: 'Nickname',

--- a/packages/pieces/community/ask-handle/src/lib/actions/create-message.ts
+++ b/packages/pieces/community/ask-handle/src/lib/actions/create-message.ts
@@ -9,6 +9,8 @@ export const createMessage = createAction({
   name: 'create_message',
   displayName: 'Create Message',
   description: 'Send a message to a room',
+  audience: 'both',
+  aiMetadata: { description: 'Posts a message to a specific AskHandle chat room, identified by its room UUID. Use to send a reply or note into an existing conversation; optionally attach a sender nickname, email, and phone number. Not idempotent — each call appends a new message.', idempotent: false },
   props: {
     room: roomDropdown,
     body: Property.LongText({

--- a/packages/pieces/community/ask-handle/src/lib/actions/list-leads.ts
+++ b/packages/pieces/community/ask-handle/src/lib/actions/list-leads.ts
@@ -8,6 +8,8 @@ export const listLeads = createAction({
   name: 'list_leads',
   displayName: 'List Leads',
   description: 'Get a list of all leads',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves leads from AskHandle, optionally narrowed by a start date, end date, and a maximum result limit; with no filters set it returns all leads. Use to query captured prospects over a time window. Read-only lookup, so it is idempotent.', idempotent: true },
   props: {
     start_date: Property.DateTime({
       displayName: 'Start Date',

--- a/packages/pieces/community/ask-handle/src/lib/actions/list-rooms.ts
+++ b/packages/pieces/community/ask-handle/src/lib/actions/list-rooms.ts
@@ -8,6 +8,8 @@ export const listRooms = createAction({
   name: 'list_rooms',
   displayName: 'List Rooms',
   description: 'Get a list of all rooms',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves all chat rooms in the AskHandle account. Use to discover available rooms or look up a room UUID before sending a message. Takes no input and is a read-only lookup, so it is idempotent.', idempotent: true },
   props: {},
   async run(context) {
     return await askHandleApiCall(

--- a/packages/pieces/community/ask-handle/src/lib/triggers/new-lead.ts
+++ b/packages/pieces/community/ask-handle/src/lib/triggers/new-lead.ts
@@ -12,6 +12,9 @@ export const newLeadTrigger = createTrigger({
   name: 'new_lead',
   displayName: 'New Lead',
   description: 'Triggers when a new lead is created',
+  aiMetadata: {
+    description: 'Fires when a new lead is captured in AskHandle, carrying the contact details and origin context (page, referrer, device). Use to kick off follow-up when a prospect is registered.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {},
   sampleData: {

--- a/packages/pieces/community/ask-handle/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/ask-handle/src/lib/triggers/new-message.ts
@@ -12,6 +12,9 @@ export const newMessageTrigger = createTrigger({
   name: 'new_message',
   displayName: 'New Message',
   description: 'Triggers when a new message is received',
+  aiMetadata: {
+    description: 'Fires when a new message is added to any AskHandle chat room, including who sent it and whether it came from a support agent. Use to react to incoming conversation activity in real time.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {},
   sampleData: {

--- a/packages/pieces/community/ask-handle/src/lib/triggers/new-room.ts
+++ b/packages/pieces/community/ask-handle/src/lib/triggers/new-room.ts
@@ -12,6 +12,9 @@ export const newRoomTrigger = createTrigger({
   name: 'new_room',
   displayName: 'New Room',
   description: 'Triggers when a new room is created',
+  aiMetadata: {
+    description: 'Fires when a new chat room (conversation) is created in AskHandle, including its label, name, and rating. Use to react when a fresh conversation thread begins.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {},
   sampleData: {

--- a/packages/pieces/community/assembled/package.json
+++ b/packages/pieces/community/assembled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-assembled",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/assembled/src/lib/actions/add-shift.ts
+++ b/packages/pieces/community/assembled/src/lib/actions/add-shift.ts
@@ -8,6 +8,8 @@ export const addShift = createAction({
   name: 'add_shift',
   displayName: 'Add Shift on Assembled',
   description: 'Add a new shift to a user\'s schedule in Assembled',
+  audience: 'both',
+  aiMetadata: { description: 'Adds a scheduled shift (activity) to an agent\'s schedule in Assembled over a given start/end time. Requires the agent ID (the agent_id field from the people endpoint, not the person ID) and an activity type ID UUID. Each call creates a new activity, so repeating it produces duplicate shifts.', idempotent: false },
   props: {
     agent_id: Property.ShortText({
       displayName: 'Agent ID',

--- a/packages/pieces/community/assembled/src/lib/actions/custom-graphql.ts
+++ b/packages/pieces/community/assembled/src/lib/actions/custom-graphql.ts
@@ -6,6 +6,8 @@ export const customGraphql = createAction({
   name: 'custom_graphql',
   displayName: 'Custom GraphQL',
   description: 'Perform a custom GraphQL query',
+  audience: 'both',
+  aiMetadata: { description: 'Sends a raw GraphQL request to the Assembled API with an operation string and optional variables. Use as an escape hatch when no dedicated action covers the query or mutation you need. The supplied operation can read or write data, so it is not safe to assume repeating the call has no side effect.', idempotent: false },
   auth: assembledAuth,
   props: {
     query: Property.LongText({ displayName: 'Query', required: true }),

--- a/packages/pieces/community/assembled/src/lib/actions/delete-OOO.ts
+++ b/packages/pieces/community/assembled/src/lib/actions/delete-OOO.ts
@@ -8,6 +8,8 @@ export const deleteOOO = createAction({
   name: 'delete_OOO',
   displayName: 'Delete OOO Request',
   description: 'Cancel/delete a OOO request.',
+  audience: 'both',
+  aiMetadata: { description: 'Cancels (deletes) a time-off request in Assembled, identified by its OOO ID. Use to revoke a previously submitted out-of-office request. Because the cancellation is keyed on the request ID, repeating the call leaves the request cancelled, so it is idempotent.', idempotent: true },
   props: {
     OOO_id: Property.ShortText({
       displayName: 'OOO ID',

--- a/packages/pieces/community/assembled/src/lib/actions/ooo.ts
+++ b/packages/pieces/community/assembled/src/lib/actions/ooo.ts
@@ -8,6 +8,8 @@ export const OOO = createAction({
   name: 'OOO',
   displayName: 'Create OOO Request',
   description: 'Create an Out of Office request in Assembled.',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a time-off (out-of-office) request for a user in Assembled over the given start/end window, requiring the user ID and an activity type ID (a UUID from the activity types endpoint). A mock mode prop can return a fabricated response without hitting the API for testing. Each call submits a new request, so repeating it creates duplicates.', idempotent: false },
   props: {
     mock_mode: Property.Checkbox({
       displayName: 'Mock Mode',

--- a/packages/pieces/community/assembled/src/lib/actions/update-OOO.ts
+++ b/packages/pieces/community/assembled/src/lib/actions/update-OOO.ts
@@ -8,6 +8,8 @@ export const updateOOO = createAction({
   name: 'update_OOO',
   displayName: 'Update OOO Request',
   description: 'Updates an existing OOO request.',
+  audience: 'both',
+  aiMetadata: { description: 'Updates an existing time-off request identified by its OOO ID. Because Assembled has no update endpoint, this cancels the original request and creates a fresh one with the new details, so user ID and activity type ID are required. This mutates state and creates a new request each call, so it is not safe to repeat.', idempotent: false },
   props: {
     OOO_id: Property.ShortText({
       displayName: 'OOO ID',

--- a/packages/pieces/community/assembled/src/lib/triggers/OOO-status-changed.ts
+++ b/packages/pieces/community/assembled/src/lib/triggers/OOO-status-changed.ts
@@ -8,6 +8,9 @@ export const timeOffStatusChanged = createTrigger({
   name: 'OOO_status_changed',
   displayName: 'OOO Status Changed',
   description: 'Triggers on approval/rejection of OOO.',
+  aiMetadata: {
+    description: 'Fires when an existing time-off (out-of-office) request changes status, such as being approved or rejected, polling for time-off updates since the last check. Use to react to decisions on submitted OOO requests.',
+  },
   type: TriggerStrategy.POLLING,
   props: {},
   sampleData: {

--- a/packages/pieces/community/assembled/src/lib/triggers/new-OOO-request.ts
+++ b/packages/pieces/community/assembled/src/lib/triggers/new-OOO-request.ts
@@ -8,6 +8,9 @@ export const newTimeOffRequest = createTrigger({
   name: 'new_OOO_request',
   displayName: 'New OOO Request',
   description: 'Triggers when a new OOO request is created.',
+  aiMetadata: {
+    description: 'Fires when a new time-off (out-of-office) request is created in Assembled, polling for time-off requests updated since the last check. Use to react to newly submitted OOO requests, for example to route them for approval.',
+  },
   type: TriggerStrategy.POLLING,
   props: {},
   sampleData: {

--- a/packages/pieces/community/assembled/src/lib/triggers/schedule-updated.ts
+++ b/packages/pieces/community/assembled/src/lib/triggers/schedule-updated.ts
@@ -8,6 +8,9 @@ export const scheduleUpdated = createTrigger({
   name: 'schedule_updated',
   displayName: 'Schedule Updated',
   description: 'Triggers when user schedule is modified.',
+  aiMetadata: {
+    description: 'Fires when a user\'s schedule changes in Assembled (for example a shift added or modified), polling for schedule-update events since the last check. Use to react to scheduling changes such as added or edited shifts.',
+  },
   type: TriggerStrategy.POLLING,
   props: {},
   sampleData: {

--- a/packages/pieces/community/autocalls/package.json
+++ b/packages/pieces/community/autocalls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-autocalls",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/autocalls/src/lib/actions/add-lead.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/add-lead.ts
@@ -8,6 +8,8 @@ export const addLead = createAction({
   name: 'addLead',
   displayName: 'Add lead to a campaign',
   description: "Add lead to an outbound campaign, to be called by an assistant from our platform.",
+  audience: 'both',
+  aiMetadata: { description: 'Enrolls a lead (phone number plus template variables, optionally with secondary contacts) into an Autocalls outbound campaign so its assistant will dial them. Use to queue contacts for a campaign rather than placing a one-off call. Requires a campaign id and phone number; creates a new lead each call (unless duplicates are disallowed), so it is not idempotent.', idempotent: false },
   props: {
     campaign: Property.Dropdown({
       auth: autocallsAuth,

--- a/packages/pieces/community/autocalls/src/lib/actions/campaign-control.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/campaign-control.ts
@@ -8,6 +8,8 @@ export const campaignControl = createAction({
   name: 'campaignControl',
   displayName: 'Start/Stop Campaign',
   description: "Start or stop an outbound campaign from our platform.",
+  audience: 'both',
+  aiMetadata: { description: 'Sets the run status of an Autocalls outbound campaign, choosing one of two modes via the action input: start (begin dialing leads) or stop (halt dialing). Use to control whether a campaign is actively calling. Requires a campaign id; idempotent since repeating the same start/stop request leaves the campaign in the same state.', idempotent: true },
   props: {
     campaign: Property.Dropdown({
       auth: autocallsAuth,

--- a/packages/pieces/community/autocalls/src/lib/actions/delete-lead.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/delete-lead.ts
@@ -8,6 +8,8 @@ export const deleteLead = createAction({
   name: 'deleteLead',
   displayName: 'Delete Lead',
   description: "Delete a lead from a campaign.",
+  audience: 'both',
+  aiMetadata: { description: 'Permanently removes a single lead from its Autocalls campaign by lead id, identified by phone number and campaign name. Use to drop a contact so it is no longer dialed. Requires the lead id; not idempotent since the lead no longer exists after the first successful delete.', idempotent: false },
   props: {
     lead: Property.Dropdown({
       auth: autocallsAuth,

--- a/packages/pieces/community/autocalls/src/lib/actions/make-phone-call.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/make-phone-call.ts
@@ -8,6 +8,8 @@ export const makePhoneCall = createAction({
   name: 'makePhoneCall',
   displayName: 'Make Phone Call',
   description: "Call a customer by it's phone number using an assistant from our platform.",
+  audience: 'both',
+  aiMetadata: { description: 'Places an outbound AI phone call to a single customer phone number using a selected Autocalls outbound assistant, passing template variables (e.g. customer_name) into the conversation. Use to dial one contact on demand rather than enrolling them in a campaign. Requires a valid outbound assistant id and a phone number; each call dials again, so it is not idempotent.', idempotent: false },
   props: {
     assistant: Property.Dropdown({
       auth: autocallsAuth,

--- a/packages/pieces/community/autocalls/src/lib/actions/send-sms.ts
+++ b/packages/pieces/community/autocalls/src/lib/actions/send-sms.ts
@@ -8,6 +8,8 @@ export const sendSms = createAction({
   name: 'sendSms',
   displayName: 'Send SMS to Customer',
   description: "Send an SMS to a customer using a phone number from our platform.",
+  audience: 'both',
+  aiMetadata: { description: 'Sends a single SMS text message to a customer phone number from a selected SMS-capable Autocalls phone number. Use to deliver an outbound text rather than place a call. Requires a sender phone number id, recipient number, and message body (max 300 characters); each call sends a new message, so it is not idempotent.', idempotent: false },
   props: {
     from: Property.Dropdown({
       auth: autocallsAuth,

--- a/packages/pieces/community/autocalls/src/lib/triggers/get-assistants.ts
+++ b/packages/pieces/community/autocalls/src/lib/triggers/get-assistants.ts
@@ -67,6 +67,9 @@ export const getAssistants = createTrigger({
 name: 'getAssistants',
     displayName: 'Updated Assistant',
     description: 'Triggers when assistants are fetched or updated in your Autocalls account.',
+    aiMetadata: {
+      description: 'Polls the Autocalls account and fires for each assistant created or updated since the last check, optionally bounded by start and end date filters. Represents a new or changed assistant record.',
+    },
 props: {
         start: Property.DateTime({
             displayName: 'Start Date',

--- a/packages/pieces/community/autocalls/src/lib/triggers/inbound-call.ts
+++ b/packages/pieces/community/autocalls/src/lib/triggers/inbound-call.ts
@@ -8,6 +8,9 @@ export const inboundCall = createTrigger({
     name: 'inboundCall',
     displayName: 'Inbound Call',
     description: 'Triggers for variables before connecting an inbound call.',
+    aiMetadata: {
+      description: 'Fires via webhook when an inbound call reaches the selected Autocalls assistant, before the call is connected, providing the caller and assistant phone numbers so the flow can supply variables for the conversation.',
+    },
     props: {
         assistant: Property.Dropdown({
             auth: autocallsAuth,

--- a/packages/pieces/community/autocalls/src/lib/triggers/phone-call-ended.ts
+++ b/packages/pieces/community/autocalls/src/lib/triggers/phone-call-ended.ts
@@ -8,6 +8,9 @@ export const phoneCallEnded = createTrigger({
     name: 'phoneCallEnded',
     displayName: 'Phone Call Ended',
     description: 'Triggers when a phone call ends, with extracted variables.',
+    aiMetadata: {
+      description: 'Fires via webhook when a call handled by the selected Autocalls assistant ends, delivering the call outcome including duration, status, the input and extracted variables, and the full transcript.',
+    },
     props: {
         assistant: Property.Dropdown({
             auth: autocallsAuth,

--- a/packages/pieces/community/avian/package.json
+++ b/packages/pieces/community/avian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-avian",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/avian/src/lib/actions/ask-avian.ts
+++ b/packages/pieces/community/avian/src/lib/actions/ask-avian.ts
@@ -10,6 +10,8 @@ export const askAvian = createAction({
   name: 'ask_avian',
   displayName: 'Ask Avian',
   description: 'Ask Avian anything you want!',
+  audience: 'both',
+  aiMetadata: { description: 'Generate a text (or JSON) completion from an Avian language model for a given prompt, choosing the model and sampling parameters (temperature, top_p, penalties, max tokens). Use it for free-form LLM generation, Q&A, or rewriting against Avian. Optionally pass a memory key to persist and continue a conversation across runs. Not idempotent: each call produces a fresh generation and, when a memory key is set, appends to stored chat history.', idempotent: false },
   props: {
     model: Property.Dropdown({
       auth: avianAuth,

--- a/packages/pieces/community/avoma/package.json
+++ b/packages/pieces/community/avoma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-avoma",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/avoma/src/lib/actions/create-call.ts
+++ b/packages/pieces/community/avoma/src/lib/actions/create-call.ts
@@ -7,6 +7,8 @@ export const createCall = createAction({
   name: 'create_call',
   displayName: 'Create Call',
   description: 'Creates a new call in Avoma',
+  audience: 'both',
+  aiMetadata: { description: 'Imports an external dialer call (Zoom, Twilio, Aircall, HubSpot, etc.) into Avoma for AI recording, transcription, and analysis. Use when ingesting call data captured outside Avoma; requires a publicly accessible recording URL, an Avoma user email, and a unique external_id. Not idempotent — each call creates a new record, and reposting the same external_id and source will fail as a duplicate.', idempotent: false },
   props: {
     external_id: Property.ShortText({
       displayName: 'External ID',

--- a/packages/pieces/community/avoma/src/lib/actions/get-meeting-recording.ts
+++ b/packages/pieces/community/avoma/src/lib/actions/get-meeting-recording.ts
@@ -7,6 +7,8 @@ export const getMeetingRecording = createAction({
   name: 'get_meeting_recording',
   displayName: 'Get Meeting Recording',
   description: 'Returns video and audio recording URLs for a given meeting',
+  audience: 'both',
+  aiMetadata: { description: 'Fetches the audio and video recording URLs for a single Avoma meeting by its meeting UUID. Use to obtain downloadable media links for a recorded meeting; the returned URLs are time-limited (expire in ~5 days) and the recording may still be processing (not yet available). Read-only and idempotent.', idempotent: true },
   props: {
     meeting_uuid: avomaCommon.meetingDropdown
   },

--- a/packages/pieces/community/avoma/src/lib/actions/get-meeting-transcription.ts
+++ b/packages/pieces/community/avoma/src/lib/actions/get-meeting-transcription.ts
@@ -7,6 +7,8 @@ export const getMeetingTranscription = createAction({
   name: 'get_meeting_transcription',
   displayName: 'Get Meeting Transcription',
   description: 'Returns transcription with speakers, timestamps, and VTT file URL',
+  audience: 'both',
+  aiMetadata: { description: 'Fetches the transcription for a single Avoma meeting by its transcription UUID, including speaker-labeled segments and a downloadable VTT subtitle URL. Use to retrieve the text of a recorded meeting or call. Read-only and idempotent.', idempotent: true },
   props: {
     transcription_uuid: avomaCommon.transcriptionDropdown
   },

--- a/packages/pieces/community/avoma/src/lib/triggers/meeting-cancelled.ts
+++ b/packages/pieces/community/avoma/src/lib/triggers/meeting-cancelled.ts
@@ -4,6 +4,9 @@ export const meetingCancelled = createTrigger({
   name: 'meeting_cancelled',
   displayName: 'Meeting Cancelled',
   description: 'Triggers when a meeting booked via the scheduling page is cancelled',
+  aiMetadata: {
+    description: 'Fires when a meeting booked through an Avoma scheduling page is cancelled (the MEETING_BOOKED_VIA_SCHEDULER_CANCELED event), providing the cancellation reason along with the booker and original meeting details. Requires configuring the corresponding webhook in Avoma settings.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     setupInstructions: Property.MarkDown({

--- a/packages/pieces/community/avoma/src/lib/triggers/meeting-rescheduled.ts
+++ b/packages/pieces/community/avoma/src/lib/triggers/meeting-rescheduled.ts
@@ -4,6 +4,9 @@ export const meetingRescheduled = createTrigger({
   name: 'meeting_rescheduled',
   displayName: 'Meeting Rescheduled',
   description: 'Triggers when a scheduled meeting is rescheduled',
+  aiMetadata: {
+    description: 'Fires when a meeting previously booked through an Avoma scheduling page is rescheduled to new times (the MEETING_BOOKED_VIA_SCHEDULER_RESCHEDULED event), providing the updated start/end times along with the booker and meeting details. Requires configuring the corresponding webhook in Avoma settings.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     setupInstructions: Property.MarkDown({

--- a/packages/pieces/community/avoma/src/lib/triggers/new-meeting-scheduled.ts
+++ b/packages/pieces/community/avoma/src/lib/triggers/new-meeting-scheduled.ts
@@ -4,6 +4,9 @@ export const newMeetingScheduled = createTrigger({
   name: 'new_meeting_scheduled',
   displayName: 'New Meeting Scheduled',
   description: 'Triggers when a meeting is booked via one of your Avoma scheduling pages',
+  aiMetadata: {
+    description: 'Fires when an invitee books a new meeting through one of your Avoma scheduling pages (the MEETING_BOOKED_VIA_SCHEDULER event), providing the booker, attendees, start/end times, and scheduling intake responses. Requires configuring the corresponding webhook in Avoma settings.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     setupInstructions: Property.MarkDown({

--- a/packages/pieces/community/avoma/src/lib/triggers/new-note.ts
+++ b/packages/pieces/community/avoma/src/lib/triggers/new-note.ts
@@ -5,6 +5,9 @@ export const newNote = createTrigger({
   displayName: 'New Note',
   description:
     'Triggers when notes are successfully generated for meetings or calls',
+  aiMetadata: {
+    description: 'Fires when Avoma finishes generating AI notes for a recorded meeting or call (the AINOTE event), delivering the summary, action items, transcript and recording references for that conversation. Requires configuring the AINOTE webhook in Avoma settings.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     setupInstructions: Property.MarkDown({

--- a/packages/pieces/community/azure-blob-storage/package.json
+++ b/packages/pieces/community/azure-blob-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-azure-blob-storage",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/azure-blob-storage/src/lib/actions/add-tags-to-blob.ts
+++ b/packages/pieces/community/azure-blob-storage/src/lib/actions/add-tags-to-blob.ts
@@ -8,6 +8,8 @@ export const addTagsToBlob = createAction({
   name: 'addTagsToBlob',
   displayName: 'Add Tags to Blob',
   description: 'Adds Tags to the Blob at the specified location',
+  audience: 'both',
+  aiMetadata: { description: 'Sets key-value tags on the blob at the given container and blob name. Operates in two modes: by default it replaces all existing tags with the supplied set, or with the keep-existing-tags option it merges the new tags onto the current ones. Use to label or categorize a blob for later tag-based search. Idempotent: applying the same tags yields the same final tag set.', idempotent: true },
   props: {
     container: containerProp,
     blobName: Property.ShortText({

--- a/packages/pieces/community/azure-blob-storage/src/lib/actions/create-blob.ts
+++ b/packages/pieces/community/azure-blob-storage/src/lib/actions/create-blob.ts
@@ -8,6 +8,8 @@ export const createBlob = createAction({
   name: 'createBlob',
   displayName: 'Create Blob',
   description: 'Creates a new Blob in the specified location',
+  audience: 'both',
+  aiMetadata: { description: 'Uploads file data as a blob to the given container under the specified blob name, optionally attaching tags. Use to store or update a file in Azure Blob Storage. Idempotent on the blob name: re-uploading to the same name overwrites the existing blob rather than creating duplicates.', idempotent: true },
   props: {
       container: containerProp,
       blobName: Property.ShortText({

--- a/packages/pieces/community/azure-blob-storage/src/lib/actions/create-container.ts
+++ b/packages/pieces/community/azure-blob-storage/src/lib/actions/create-container.ts
@@ -7,6 +7,8 @@ export const createContainer = createAction({
   name: 'createContainer',
   displayName: 'Create Container',
   description: 'Creates a new container',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new container in the Azure Blob Storage account with the given name. Use when you need a fresh container to store blobs. Not idempotent: the container name must not already exist or the call fails.', idempotent: false },
   props: {
     containerName: Property.ShortText({
       displayName: 'Container Name',

--- a/packages/pieces/community/azure-blob-storage/src/lib/actions/delete-blob.ts
+++ b/packages/pieces/community/azure-blob-storage/src/lib/actions/delete-blob.ts
@@ -8,6 +8,8 @@ export const deleteBlob = createAction({
   name: 'deleteBlob',
   displayName: 'Delete Blob',
   description: 'Deletes the Blob at the specified location',
+  audience: 'both',
+  aiMetadata: { description: 'Deletes the blob at the given container and blob name. Use to remove a single blob; this is destructive. Idempotent: it deletes only if the blob exists, so repeating the call against an already-deleted blob succeeds without error.', idempotent: true },
   props: {
       container: containerProp,
       blobName: Property.ShortText({

--- a/packages/pieces/community/azure-blob-storage/src/lib/actions/delete-container.ts
+++ b/packages/pieces/community/azure-blob-storage/src/lib/actions/delete-container.ts
@@ -8,6 +8,8 @@ export const deleteContainer = createAction({
   name: 'deleteContainer',
   displayName: 'Delete Container',
   description: 'Deletes an existing container',
+  audience: 'both',
+  aiMetadata: { description: 'Permanently deletes a container and all blobs it holds from the Azure Blob Storage account. Use only to remove an entire container; this is destructive and cannot be undone. Not idempotent: a second call against an already-deleted container fails.', idempotent: false },
   props: {
     container: containerProp,
   },

--- a/packages/pieces/community/azure-blob-storage/src/lib/actions/find-blobs.ts
+++ b/packages/pieces/community/azure-blob-storage/src/lib/actions/find-blobs.ts
@@ -8,6 +8,8 @@ export const findBlobs = createAction({
   name: 'findBlobs',
   displayName: 'Find Blobs',
   description: 'Finds Blobs based on their tags',
+  audience: 'both',
+  aiMetadata: { description: 'Searches a container for blobs matching the supplied tag key-value pairs, returning the names of blobs whose tags satisfy all conditions (combined with AND). Use to locate blobs by tag rather than by name or prefix. Read-only and idempotent.', idempotent: true },
   props: {
     container: containerProp,
     tags: Property.Object({

--- a/packages/pieces/community/azure-blob-storage/src/lib/actions/list-blobs.ts
+++ b/packages/pieces/community/azure-blob-storage/src/lib/actions/list-blobs.ts
@@ -8,6 +8,8 @@ export const listBlobs = createAction({
   name: 'listBlobs',
   displayName: 'List Blobs',
   description: 'List Blobs in the specified Azure Blob Storage container',
+  audience: 'both',
+  aiMetadata: { description: 'Lists the blobs in a given container, returning each blob name with its properties and metadata. Use to enumerate or discover blobs before reading or processing them; optionally narrow by a name prefix and include snapshots. Read-only and idempotent.', idempotent: true },
   props: {
     container: containerProp,
     includeSnapshots: Property.Checkbox({

--- a/packages/pieces/community/azure-blob-storage/src/lib/actions/list-containers.ts
+++ b/packages/pieces/community/azure-blob-storage/src/lib/actions/list-containers.ts
@@ -7,6 +7,8 @@ export const listContainers = createAction({
   name: 'listContainers',
   displayName: 'List Containers',
   description: 'List Containers in the Azure Blob Storage account',
+  audience: 'both',
+  aiMetadata: { description: 'Lists the containers in an Azure Blob Storage account. Use to discover available containers before reading or writing blobs; optionally narrow results with a name prefix and toggle inclusion of deleted or system containers. Read-only and idempotent.', idempotent: true },
   props: {
     includeDeleted: Property.Checkbox({
       displayName: 'Include Deleted Containers',

--- a/packages/pieces/community/azure-blob-storage/src/lib/actions/read-blob.ts
+++ b/packages/pieces/community/azure-blob-storage/src/lib/actions/read-blob.ts
@@ -21,6 +21,8 @@ export const readBlob = createAction({
   name: 'readBlob',
   displayName: 'Read Blob',
   description: 'Read the Blob at the specified lcoation',
+  audience: 'both',
+  aiMetadata: { description: 'Downloads the blob at the given container and blob name and returns it as a file. Use to fetch the contents of a known blob for downstream processing; the blob name must already exist. Read-only and idempotent.', idempotent: true },
   props: {
     container: containerProp,
     blobName: Property.ShortText({

--- a/packages/pieces/community/azure-communication-services/package.json
+++ b/packages/pieces/community/azure-communication-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-azure-communication-services",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/azure-communication-services/src/lib/actions/send-email.ts
+++ b/packages/pieces/community/azure-communication-services/src/lib/actions/send-email.ts
@@ -7,6 +7,12 @@ export const sendEmail = createAction({
   name: 'send_email',
   displayName: 'Send Email',
   description: 'Send a text or HTML email',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Sends an email through Azure Communication Services from a verified sender address, supporting either plain-text or HTML body via the content type selector. Use to deliver transactional or notification email when the workflow is wired to an Azure Communication Services connection. Requires a sender address provisioned in the Azure resource and at least one recipient; not idempotent — each call dispatches a new message.',
+    idempotent: false,
+  },
   props: {
     from: Property.ShortText({
       displayName: 'Sender Email (From)',

--- a/packages/pieces/community/azure-devops/package.json
+++ b/packages/pieces/community/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-azure-devops",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/azure-devops/src/lib/actions/add-comment.ts
+++ b/packages/pieces/community/azure-devops/src/lib/actions/add-comment.ts
@@ -8,6 +8,8 @@ export const addCommentAction = createAction({
   name: 'add_comment',
   displayName: 'Add Comment',
   description: 'Adds a comment to an existing work item in Azure DevOps',
+  audience: 'both',
+  aiMetadata: { description: 'Posts a new comment (HTML supported) on an existing Azure DevOps work item identified by its numeric ID. Use to add a note or update to a known work item. Requires the project, numeric work item ID, and comment text; not idempotent, as each call appends a separate comment.', idempotent: false },
   props: {
     project: azureDevOpsCommon.projectDropdown,
     work_item_id: Property.Number({

--- a/packages/pieces/community/azure-devops/src/lib/actions/create-work-item.ts
+++ b/packages/pieces/community/azure-devops/src/lib/actions/create-work-item.ts
@@ -12,6 +12,8 @@ export const createWorkItemAction = createAction({
   name: 'create_work_item',
   displayName: 'Create Work Item',
   description: 'Creates a new work item (Bug, Task, User Story, etc.) in Azure DevOps',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new work item of the chosen type (Bug, Task, User Story, etc.) in an Azure DevOps project, optionally setting description, assignee, and priority. Use to file a new tracked item. Requires a project and work item type; not idempotent, as each call creates a separate item with a new ID.', idempotent: false },
   props: {
     project: azureDevOpsCommon.projectDropdown,
     work_item_type: azureDevOpsCommon.workItemTypeDropdown,

--- a/packages/pieces/community/azure-devops/src/lib/actions/get-work-item.ts
+++ b/packages/pieces/community/azure-devops/src/lib/actions/get-work-item.ts
@@ -11,6 +11,8 @@ export const getWorkItemAction = createAction({
   name: 'get_work_item',
   displayName: 'Get Work Item',
   description: 'Retrieves a work item by ID from Azure DevOps',
+  audience: 'both',
+  aiMetadata: { description: 'Fetches a single Azure DevOps work item by its numeric ID, returning its fields (title, state, assignee, etc.). Use to look up details of a known work item; requires the project and the numeric work item ID, not a title. Read-only and idempotent.', idempotent: true },
   props: {
     project: azureDevOpsCommon.projectDropdown,
     work_item_id: Property.Number({

--- a/packages/pieces/community/azure-devops/src/lib/actions/list-work-items.ts
+++ b/packages/pieces/community/azure-devops/src/lib/actions/list-work-items.ts
@@ -13,6 +13,8 @@ export const listWorkItemsAction = createAction({
   name: 'list_work_items',
   displayName: 'List Work Items',
   description: 'Lists work items from Azure DevOps using a WIQL query',
+  audience: 'both',
+  aiMetadata: { description: 'Queries work items in an Azure DevOps project and returns their fields. Leave the WIQL query empty to list all work items ordered by most recently changed, or supply a custom WIQL query to filter (by type, state, assignee, etc.). Use to search or enumerate work items; requires a project, and results are capped by the limit (default 50, max 200). Read-only and idempotent.', idempotent: true },
   props: {
     project: azureDevOpsCommon.projectDropdown,
     wiql_query: Property.LongText({

--- a/packages/pieces/community/azure-devops/src/lib/actions/update-work-item.ts
+++ b/packages/pieces/community/azure-devops/src/lib/actions/update-work-item.ts
@@ -12,6 +12,8 @@ export const updateWorkItemAction = createAction({
   name: 'update_work_item',
   displayName: 'Update Work Item',
   description: 'Updates an existing work item in Azure DevOps',
+  audience: 'both',
+  aiMetadata: { description: 'Updates fields (title, description, state, assignee, priority) on an existing Azure DevOps work item identified by its numeric ID; only the fields you provide are changed. Use to modify a known work item rather than to look it up or create one. Requires the project and numeric work item ID; the work item type prop only loads the matching state list and does not change the item type. Idempotent, since it replaces fields to a fixed target value keyed on a stable ID.', idempotent: true },
   props: {
     project: azureDevOpsCommon.projectDropdown,
     work_item_type: {

--- a/packages/pieces/community/azure-devops/src/lib/triggers/new-updated-work-item-webhook.ts
+++ b/packages/pieces/community/azure-devops/src/lib/triggers/new-updated-work-item-webhook.ts
@@ -44,6 +44,9 @@ export const newUpdatedWorkItemWebhookTrigger = createTrigger({
   displayName: 'New or Updated Work Item (Instant)',
   description:
     'Fires instantly when a work item is created, updated, or commented on in Azure DevOps via a Service Hooks subscription. Requires a public webhook URL reachable from Azure DevOps.',
+  aiMetadata: {
+    description: 'Fires in real time via an Azure DevOps Service Hooks subscription when a work item in the chosen project is created, updated, or commented on, depending on which of those event types are selected. Optionally scope to a single work item type. Requires a publicly reachable webhook URL; use the Polling trigger instead when the instance is not internet-reachable.',
+  },
   props: {
     project: azureDevOpsCommon.projectDropdown,
     work_item_type: azureDevOpsCommon.workItemTypeDropdownOptional,

--- a/packages/pieces/community/azure-devops/src/lib/triggers/new-updated-work-item.ts
+++ b/packages/pieces/community/azure-devops/src/lib/triggers/new-updated-work-item.ts
@@ -115,6 +115,9 @@ export const newUpdatedWorkItemTrigger = createTrigger({
   displayName: 'New or Updated Work Item (Polling)',
   description:
     'Polls Azure DevOps every few minutes and fires when a work item is created or updated. Use this when your Activepieces instance is not reachable from the public internet; otherwise prefer the Instant trigger. Pick a work item type to unlock the state filter.',
+  aiMetadata: {
+    description: 'Fires for each Azure DevOps work item created or changed since the last poll in the chosen project, discovered by periodic polling rather than instantly. Optionally narrow to a single work item type and, once a type is set, to a specific state. Prefer the Instant trigger when the Activepieces instance is publicly reachable.',
+  },
   props,
   sampleData: sampleWorkItem,
   type: TriggerStrategy.POLLING,

--- a/packages/pieces/community/backblaze/package.json
+++ b/packages/pieces/community/backblaze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-backblaze",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/backblaze/src/lib/actions/read-file.ts
+++ b/packages/pieces/community/backblaze/src/lib/actions/read-file.ts
@@ -7,6 +7,8 @@ export const readBackBlazeFileAction = createAction({
   name: 'read-backblaze-file',
   displayName: 'Read File',
   description: 'Read a file from Backblaze bucket to use it in other steps.',
+  audience: 'both',
+  aiMetadata: { description: 'Fetches an object from the configured Backblaze B2 (S3-compatible) bucket by its key and writes it to a downstream file reference for use in later steps. Use to retrieve previously stored file content. Requires the exact object key including any extension. Idempotent: it only reads, leaving the bucket unchanged.', idempotent: true },
   props: {
     key: Property.ShortText({
       displayName: 'Key',

--- a/packages/pieces/community/backblaze/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/backblaze/src/lib/actions/upload-file.ts
@@ -8,6 +8,8 @@ export const backBlazes3UploadFileAction = createAction({
   name: 'upload-backblaze-file',
   displayName: 'Upload File',
   description: 'Upload an File to bucket.',
+  audience: 'both',
+  aiMetadata: { description: 'Uploads a file to the configured Backblaze B2 (S3-compatible) bucket, returning the stored key and a public URL. Use to persist binary or text content to object storage. Requires the file content and a MIME type; an optional file name may include a full path for sub-directories, and when omitted a timestamped name is generated. Not idempotent: it writes an object on every call, and an omitted name produces a new object each time.', idempotent: false },
   props: {
     file: Property.File({
       displayName: 'File',

--- a/packages/pieces/community/backblaze/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/backblaze/src/lib/triggers/new-file.ts
@@ -47,6 +47,9 @@ export const newBackBlazeFileTrigger = createTrigger({
   name: 'new_backblaze_file',
   displayName: 'New File',
   description: 'Trigger when a new file is uploaded.',
+  aiMetadata: {
+    description: 'Fires when a new object appears in the configured Backblaze B2 (S3-compatible) bucket, discovered by polling the bucket listing. An optional folder path restricts watching to objects under that prefix. Each event represents one newly seen object.',
+  },
   props: {
     folderPath: Property.ShortText({
       displayName: 'Folder Path',

--- a/packages/pieces/community/bannerbear/package.json
+++ b/packages/pieces/community/bannerbear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bannerbear",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/bannerbear/src/lib/actions/create-image.ts
+++ b/packages/pieces/community/bannerbear/src/lib/actions/create-image.ts
@@ -16,6 +16,12 @@ export const bannerbearCreateImageAction = createAction({
   name: 'bannerbear_create_image', // Must be a unique across the piece, this shouldn't be changed.
   displayName: 'Create Image',
   description: 'Create image from Bannerbear template',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Renders a new image (or PDF) from a Bannerbear template by applying layer modifications (text, image URLs, ratings, charts, bar codes, colors). Choose this to programmatically generate branded graphics; requires a valid template UID and modifications matching that template\'s available layers. Not idempotent — each call submits a new render and produces a new image.',
+    idempotent: false,
+  },
   props: {
     template: Property.Dropdown({
       auth: bannerbearAuth,

--- a/packages/pieces/community/barcode-lookup/package.json
+++ b/packages/pieces/community/barcode-lookup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-barcode-lookup",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/barcode-lookup/src/lib/actions/search-by-barcode.ts
+++ b/packages/pieces/community/barcode-lookup/src/lib/actions/search-by-barcode.ts
@@ -7,6 +7,12 @@ export const searchByBarcode = createAction({
   name: 'searchByBarcode',
   displayName: 'Search By Barcode',
   description: 'Search for product information by barcode',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Looks up product information from the Barcode Lookup API for a single barcode/UPC/EAN number. Use it to resolve a barcode into product details such as name, brand, and category. Requires the exact barcode number as input; this is a read-only lookup that is safe to repeat.',
+    idempotent: true,
+  },
   props: {
     barcode: Property.ShortText({
       displayName: 'Barcode',

--- a/packages/pieces/community/baremetrics/package.json
+++ b/packages/pieces/community/baremetrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-baremetrics",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/baremetrics/src/lib/actions/create-customer.ts
+++ b/packages/pieces/community/baremetrics/src/lib/actions/create-customer.ts
@@ -10,6 +10,8 @@ export const createCustomer = createAction({
   name: 'create_customer',
   displayName: 'Create Customer',
   description: 'Creates a new customer record',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a customer under a Baremetrics data source, keyed on your own unique customer ID (oid); pick the source from the connected providers. Use to register a customer before attaching subscriptions. Idempotent: the source treats oid as the unique key, so re-running with the same oid updates that customer rather than creating a duplicate.', idempotent: true },
   auth: baremetricsAuth,
   props: {
     source_id: Property.Dropdown({

--- a/packages/pieces/community/baremetrics/src/lib/actions/create-plan.ts
+++ b/packages/pieces/community/baremetrics/src/lib/actions/create-plan.ts
@@ -10,6 +10,8 @@ export const createPlan = createAction({
   name: 'create_plan',
   displayName: 'Create Plan',
   description: 'Creates a new plan for use when creating or updating subscriptions',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a billing plan under a Baremetrics data source, keyed on your own unique plan ID (oid), with currency, amount (in cents), and billing interval. Use to define a plan before creating subscriptions against it. Idempotent: the source treats oid as the unique key, so re-running with the same oid updates that plan rather than creating a duplicate.', idempotent: true },
   auth: baremetricsAuth,
   props: {
     source_id: Property.Dropdown({

--- a/packages/pieces/community/baremetrics/src/lib/actions/create-subscription.ts
+++ b/packages/pieces/community/baremetrics/src/lib/actions/create-subscription.ts
@@ -10,6 +10,8 @@ export const createSubscription = createAction({
   name: 'create_subscription',
   displayName: 'Create Subscription',
   description: 'Creates a new subscription for a customer on a plan',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a subscription linking an existing customer to an existing plan under a Baremetrics data source, keyed on your own unique subscription ID (oid). Requires the customer and plan to already exist in that source. Idempotent: the source treats oid as the unique key, so re-running with the same oid updates that subscription rather than creating a duplicate.', idempotent: true },
   auth: baremetricsAuth,
   props: {
     source_id: Property.Dropdown({

--- a/packages/pieces/community/baremetrics/src/lib/actions/update-customer.ts
+++ b/packages/pieces/community/baremetrics/src/lib/actions/update-customer.ts
@@ -10,6 +10,8 @@ export const updateCustomer = createAction({
   name: 'update_customer',
   displayName: 'Update Customer',
   description: 'Updates the basic information stored on a customer',
+  audience: 'both',
+  aiMetadata: { description: 'Updates an existing customer (name, email, notes, created date) identified by its customer_oid within a Baremetrics data source; only provided fields are changed. Use to amend customer details rather than register a new one. Idempotent: repeating with the same input leaves the customer in the same state.', idempotent: true },
   auth: baremetricsAuth,
   props: {
     source_id: Property.Dropdown({

--- a/packages/pieces/community/base44/package.json
+++ b/packages/pieces/community/base44/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-base44",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/base44/src/lib/actions/create-entity.ts
+++ b/packages/pieces/community/base44/src/lib/actions/create-entity.ts
@@ -7,6 +7,8 @@ export const createEntity = createAction({
   name: 'create_entity',
   displayName: 'Create Entity',
   description: 'Creates an entity (record) in your Base44 app',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new record of a given entity type in a Base44 app, with the field values supplied as a JSON object. Use when you need to add a new item (e.g. a Product, User, or Order) to a Base44 database. Requires the exact entity-type name and matching field data; each call inserts a fresh record, so it is not idempotent. Service access uses the configured token when present, otherwise the user session.', idempotent: false },
   props: {
     entityType: Property.ShortText({
       displayName: 'Entity Type',

--- a/packages/pieces/community/base44/src/lib/actions/find-entity.ts
+++ b/packages/pieces/community/base44/src/lib/actions/find-entity.ts
@@ -7,6 +7,8 @@ export const findEntity = createAction({
   name: 'find_entity',
   displayName: 'Find Entity Record',
   description: 'Find a matching entity record in your Base44 app',
+  audience: 'both',
+  aiMetadata: { description: 'Searches a Base44 app for records of a given entity type that match a JSON filter query, returning all matches. Use when you need to look up existing records by field values (e.g. find a User by email) without modifying anything. Requires the exact entity-type name; this is a read-only lookup and is idempotent.', idempotent: true },
   props: {
     entityType: Property.ShortText({
       displayName: 'Entity Type',

--- a/packages/pieces/community/base44/src/lib/actions/find-or-create-entity.ts
+++ b/packages/pieces/community/base44/src/lib/actions/find-or-create-entity.ts
@@ -7,6 +7,8 @@ export const findOrCreateEntity = createAction({
   name: 'find_or_create_entity',
   displayName: 'Find or Create Entity',
   description: 'Find a matching entity record, or create one if not found',
+  audience: 'both',
+  aiMetadata: { description: 'Searches a Base44 app for an existing record of a given entity type matching a JSON query, and creates one from the supplied data only if no match is found. Use this upsert-style action to avoid duplicates when you want a record to exist but should not create a second copy. Because creation is gated on the search query, it is effectively idempotent so long as the query reliably identifies the same record.', idempotent: true },
   props: {
     entityType: Property.ShortText({
       displayName: 'Entity Type',

--- a/packages/pieces/community/base44/src/lib/triggers/entity-event.ts
+++ b/packages/pieces/community/base44/src/lib/triggers/entity-event.ts
@@ -77,6 +77,9 @@ export const entityEvent = createTrigger({
   name: 'entity_event',
   displayName: 'Entity Event',
   description: 'Triggers when an entity is created or updated',
+  aiMetadata: {
+    description: 'Fires when a record of a chosen entity type is created or updated in a Base44 app, polling on the selected event type (created vs. updated). Each emitted item represents one new or recently changed record of that entity type.',
+  },
   props: {
     entityType: Property.ShortText({
       displayName: 'Entity Type',

--- a/packages/pieces/community/beamer/package.json
+++ b/packages/pieces/community/beamer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-beamer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/beamer/src/lib/actions/create-comment.ts
+++ b/packages/pieces/community/beamer/src/lib/actions/create-comment.ts
@@ -12,6 +12,11 @@ export const createComment = createAction({
   name: 'create_new_comment',
   displayName: 'Create a new comment',
   description: 'Create a new comment for a Feature request',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Posts a comment on an existing Beamer feature request, identified by its numeric feature request ID. Optionally attributes the comment to a user via user ID or email. Use to add discussion or replies to a feedback item. Appends a new comment on each call (not idempotent).',
+    idempotent: false,
+  },
   props: {
     featureRequestId: Property.Number({
       displayName: 'ID',

--- a/packages/pieces/community/beamer/src/lib/actions/create-feature-request.ts
+++ b/packages/pieces/community/beamer/src/lib/actions/create-feature-request.ts
@@ -12,6 +12,11 @@ export const createNewFeatureRequest = createAction({
   name: 'create_new_feature_request',
   displayName: 'Create New Feature Request ',
   description: 'Create New Feature Request',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Creates a feature request on a Beamer feedback board, attributed to a user by email, with a category (bug, feature request, or improvement), a status (under review, planned, in progress, or completed), and public or internal visibility. Use to log product feedback or roadmap items. Creates a new request on each call (not idempotent).',
+    idempotent: false,
+  },
   props: {
     title: Property.ShortText({
       displayName: 'Title',

--- a/packages/pieces/community/beamer/src/lib/actions/create-posts.ts
+++ b/packages/pieces/community/beamer/src/lib/actions/create-posts.ts
@@ -12,6 +12,11 @@ export const createBeamerPost = createAction({
   name: 'create_beamer_post',
   displayName: 'Create Beamer Post ',
   description: 'Create a new post in Beamer',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Publishes a new announcement post to a Beamer account, attributed to a user by email and tagged with a category (new, fix, coming soon, announcement, or improvement). Use to broadcast product news or changelog entries to users. Creates a distinct post on each call (not idempotent).',
+    idempotent: false,
+  },
   props: {
     title: Property.ShortText({
       displayName: 'Title',

--- a/packages/pieces/community/beamer/src/lib/actions/create-vote.ts
+++ b/packages/pieces/community/beamer/src/lib/actions/create-vote.ts
@@ -8,6 +8,11 @@ export const createVote = createAction({
   name: 'create_vote',
   displayName: 'Create a new vote ',
   description: 'Create a new vote on a feature request',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Casts a vote on an existing Beamer feature request, identified by its numeric feature request ID, optionally attributed to a voter by first name and email. Use to register user support for a feedback item. Records a vote on each call (not idempotent).',
+    idempotent: false,
+  },
   props: {
     featureRequestId: Property.Number({
       displayName: 'Feature ID',

--- a/packages/pieces/community/beamer/src/lib/trigger/new-post.ts
+++ b/packages/pieces/community/beamer/src/lib/trigger/new-post.ts
@@ -16,6 +16,9 @@ export const newPost = createTrigger({
   name: 'new_post_on_beamer',
   displayName: 'New Beamer Post',
   description: 'Triggers when new post is found in your beamer account',
+  aiMetadata: {
+    description: 'Fires when a new post is published in the connected Beamer account, delivered via a Beamer webhook integration. Represents a freshly created announcement or changelog entry.',
+  },
   props: {
     md: Property.MarkDown({
       value: markdown,

--- a/packages/pieces/community/beebole/package.json
+++ b/packages/pieces/community/beebole/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-beebole",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/beebole/src/lib/actions/create-company.ts
+++ b/packages/pieces/community/beebole/src/lib/actions/create-company.ts
@@ -18,6 +18,11 @@ export const createCompanyAction = createAction({
   name: 'create_company',
   displayName: 'Create Company',
   description: 'Creates a new company (customer) in Beebole.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Creates a company in Beebole, either an external customer or, when marked internal/corporate, your own organization. Use as the top-level container before creating projects under it. Not idempotent: each call creates a new company even if one with the same name already exists.',
+    idempotent: false,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Company Name',

--- a/packages/pieces/community/beebole/src/lib/actions/create-multiple-time-entries.ts
+++ b/packages/pieces/community/beebole/src/lib/actions/create-multiple-time-entries.ts
@@ -25,6 +25,11 @@ export const createMultipleTimeEntriesAction = createAction({
   displayName: 'Create Multiple Time Entries',
   description:
     'Creates time entries (working time or absence) across multiple days in Beebole.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Logs the same number of hours on each of several dates in Beebole, in one of two modes: working time against a chosen subproject, or an absence of a chosen type (e.g. vacation, sick leave). Use to bulk-log time across a date range; per-date failures are collected rather than aborting unless continue-on-error is disabled. Not idempotent: each call appends new time entries, so repeating it duplicates them.',
+    idempotent: false,
+  },
   props: {
     entryType: Property.StaticDropdown({
       displayName: 'Entry Type',

--- a/packages/pieces/community/beebole/src/lib/actions/create-person.ts
+++ b/packages/pieces/community/beebole/src/lib/actions/create-person.ts
@@ -20,6 +20,11 @@ export const createPersonAction = createAction({
   name: 'create_person',
   displayName: 'Create Person',
   description: 'Creates a new person in Beebole. An available license is required for the person to be active.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Creates a person (employee, project lead, or admin) under a given company in Beebole, optionally emailing them a login invitation when an email is provided. Use to onboard a new team member or contact. Not idempotent: each call creates a new person record and may re-send an invite, with no de-duplication on name or email.',
+    idempotent: false,
+  },
   props: {
     company: beeboleProps.companyDropdown({
       required: true,

--- a/packages/pieces/community/beebole/src/lib/actions/create-project.ts
+++ b/packages/pieces/community/beebole/src/lib/actions/create-project.ts
@@ -20,6 +20,11 @@ export const createProjectAction = createAction({
   name: 'create_project',
   displayName: 'Create Project',
   description: 'Creates a new project under a company in Beebole.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Creates a project owned by an existing company in Beebole, with an optional start date and description. Use after the company exists and before adding subprojects or logging time. Not idempotent: each call creates a new project even with identical details.',
+    idempotent: false,
+  },
   props: {
     company: beeboleProps.companyDropdown({
       required: true,

--- a/packages/pieces/community/beebole/src/lib/actions/create-subproject.ts
+++ b/packages/pieces/community/beebole/src/lib/actions/create-subproject.ts
@@ -18,6 +18,11 @@ export const createSubprojectAction = createAction({
   name: 'create_subproject',
   displayName: 'Create Subproject',
   description: 'Creates a new subproject under an existing project in Beebole.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Creates a subproject inside an existing project (under its company) in Beebole. Use to break a project into work streams that time can be logged against. Not idempotent: each call creates a new subproject even with the same name.',
+    idempotent: false,
+  },
   props: {
     company: beeboleProps.companyDropdown({
       required: true,

--- a/packages/pieces/community/beebole/src/lib/actions/deactivate-subproject.ts
+++ b/packages/pieces/community/beebole/src/lib/actions/deactivate-subproject.ts
@@ -13,6 +13,11 @@ export const deactivateSubprojectAction = createAction({
   name: 'deactivate_subproject',
   displayName: 'Deactivate Subproject',
   description: 'Marks a subproject as inactive in Beebole. Inactive subprojects are hidden from new time entries.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Deactivates a subproject in Beebole so it is hidden from new time entries while existing entries are preserved. Use to retire a completed or unused work stream. Effectively idempotent: a subproject already inactive stays inactive, though the call still hits the API each time.',
+    idempotent: true,
+  },
   props: {
     company: beeboleProps.companyDropdown({
       required: true,

--- a/packages/pieces/community/beebole/src/lib/actions/delete-multiple-time-entries.ts
+++ b/packages/pieces/community/beebole/src/lib/actions/delete-multiple-time-entries.ts
@@ -14,6 +14,11 @@ export const deleteMultipleTimeEntriesAction = createAction({
   name: 'delete_multiple_time_entries',
   displayName: 'Delete Multiple Time Entries',
   description: 'Deletes multiple time entries (working time or absence) by their IDs and dates.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Deletes a batch of time entries in Beebole, each identified by its numeric time-entry ID plus the date it was logged on. Use to remove previously created entries; per-entry failures are collected rather than aborting unless continue-on-error is disabled. Idempotent in effect: once an entry is deleted, re-running with the same IDs has no further effect (already-removed entries simply fail).',
+    idempotent: true,
+  },
   props: {
     entries: Property.Array({
       displayName: 'Time Entries to Delete',

--- a/packages/pieces/community/bettermode/package.json
+++ b/packages/pieces/community/bettermode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bettermode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/bettermode/src/lib/actions/assign-badge.ts
+++ b/packages/pieces/community/bettermode/src/lib/actions/assign-badge.ts
@@ -8,6 +8,8 @@ export const assignBadgeAction = createAction({
   auth: bettermodeAuth,
   displayName: 'Assign Badge to Member',
   description: 'Assign an existing badge to a member by email',
+  audience: 'both',
+  aiMetadata: { description: 'Grants an existing Bettermode badge (by badge ID) to the member resolved from the given email address. The badge must already exist and the email must match a network member, or the call fails. Idempotent: the member ends up holding the badge regardless of how many times it is called.', idempotent: true },
   props: {
     badgeId: Property.Dropdown({
       auth: bettermodeAuth,

--- a/packages/pieces/community/bettermode/src/lib/actions/create-discussion.ts
+++ b/packages/pieces/community/bettermode/src/lib/actions/create-discussion.ts
@@ -8,6 +8,8 @@ export const createDiscussionAction = createAction({
   auth: bettermodeAuth,
   displayName: 'Create Discussion Post',
   description: 'Create a new discussion post in a space',
+  audience: 'both',
+  aiMetadata: { description: 'Publishes a new discussion post (title, HTML content, optional comma-separated tags, optional locked flag) into a Bettermode community space identified by its space ID. Use to start a conversation thread programmatically. Not idempotent: each call publishes a separate post.', idempotent: false },
   props: {
     spaceId: Property.Dropdown({
       auth: bettermodeAuth,

--- a/packages/pieces/community/bettermode/src/lib/actions/create-question.ts
+++ b/packages/pieces/community/bettermode/src/lib/actions/create-question.ts
@@ -8,6 +8,8 @@ export const createQuestionAction = createAction({
   auth: bettermodeAuth,
   displayName: 'Create Question Post',
   description: 'Create a new question post in a space',
+  audience: 'both',
+  aiMetadata: { description: 'Publishes a new question post (title, HTML content, optional comma-separated tags, optional locked flag) into a Bettermode community space identified by its space ID. Use to post a question thread programmatically; the post type is "Question" rather than a discussion. Not idempotent: each call publishes a separate post.', idempotent: false },
   props: {
     spaceId: Property.Dropdown({
       auth: bettermodeAuth,

--- a/packages/pieces/community/bettermode/src/lib/actions/revoke-badge.ts
+++ b/packages/pieces/community/bettermode/src/lib/actions/revoke-badge.ts
@@ -8,6 +8,8 @@ export const revokeBadgeAction = createAction({
   auth: bettermodeAuth,
   displayName: 'Revoke Badge from Member',
   description: 'Revoke a badge from a member by email',
+  audience: 'both',
+  aiMetadata: { description: 'Removes a Bettermode badge (by badge ID) from the member resolved from the given email address. The email must match a network member, or the call fails. Idempotent: the member ends up without the badge regardless of how many times it is called.', idempotent: true },
   props: {
     badgeId: Property.Dropdown({
       auth: bettermodeAuth,

--- a/packages/pieces/community/bigcommerce/package.json
+++ b/packages/pieces/community/bigcommerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bigcommerce",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bigcommerce/src/lib/actions/create-a-product.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/create-a-product.ts
@@ -7,6 +7,12 @@ export const createAProduct = createAction({
   name: 'createAProduct',
   displayName: 'Create a Product',
   description: 'Creates a Product',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new catalog product in a BigCommerce store. Use to add an item to the store. Requires name, type (physical or digital), weight, and price; SKU, description, and brand_id are optional. Not idempotent: each call adds a new product, so search the catalog first if it may already exist.',
+    idempotent: false,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Product Name',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/create-blog-post.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/create-blog-post.ts
@@ -7,6 +7,12 @@ export const createBlogPost = createAction({
   name: 'createBlogPost',
   displayName: 'Create Blog Post',
   description: 'Creates a blog post',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      "Creates a blog post in a BigCommerce store's blog. Requires a title and body (HTML supported); author, URL, published date, meta description/keywords, tags, and a published flag are optional. Use to publish store blog content. Not idempotent: each call creates a new post.",
+    idempotent: false,
+  },
   props: {
     title: Property.ShortText({
       displayName: 'Title',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/create-customer-address.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/create-customer-address.ts
@@ -8,6 +8,12 @@ export const createCustomerAddress = createAction({
   name: 'createCustomerAddress',
   displayName: 'Create Customer Address',
   description: "Creates a customer's address",
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Adds a new address to an existing BigCommerce customer, identified by customer_id (selected from a dropdown of store customers). Requires name, address line 1, city, state/province, postal code, and an ISO 3166-1 alpha-2 country code. Use to attach a shipping or billing address to a customer. Not idempotent: each call appends a new address even if an identical one exists, so use Find or Create Customer’s Address to avoid duplicates.',
+    idempotent: false,
+  },
   props: {
     customer_id: customerDropdown({
       required: true

--- a/packages/pieces/community/bigcommerce/src/lib/actions/create-customer.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/create-customer.ts
@@ -7,6 +7,12 @@ export const createCustomer = createAction({
   name: 'createCustomer',
   displayName: 'Create Customer',
   description: 'Creates a customer',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new customer record in a BigCommerce store from an email plus first/last name (company, phone, and notes optional). Use to register a shopper or contact. Not idempotent: each call adds a new customer, and BigCommerce rejects a duplicate email rather than returning the existing one, so call Search Customer or Find or Create Customer first if the customer may already exist.',
+    idempotent: false,
+  },
   props: {
     email: Property.ShortText({
       displayName: 'Email',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/delete-a-product.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/delete-a-product.ts
@@ -7,6 +7,12 @@ export const deleteAProduct = createAction({
   name: 'deleteAProduct',
   displayName: 'Delete a Product',
   description: 'Deletes an existing Product',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Permanently deletes a catalog product from a BigCommerce store by its productId. Use to remove an item from the store. This is destructive and cannot be undone. Effectively idempotent: deleting an already-removed product has no further effect, though the call may error if the id no longer exists.',
+    idempotent: true,
+  },
   props: {
     productId: Property.ShortText({
       displayName: 'Product ID',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/find-or-create-customer.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/find-or-create-customer.ts
@@ -7,6 +7,12 @@ export const findOrCreateCustomer = createAction({
   name: 'findOrCreateCustomer',
   displayName: 'Find or Create Customer',
   description: 'Finds or creates a customer',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Looks up a BigCommerce customer by email (and phone if given) and returns the match if found, otherwise creates a new customer from the supplied details. Use this instead of Create Customer when the customer may already exist, to avoid duplicate-email errors. Idempotent: repeated calls match the same existing record rather than creating duplicates.',
+    idempotent: true,
+  },
   props: {
     email: Property.ShortText({
       displayName: 'Email',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/find-or-create-customers-address.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/find-or-create-customers-address.ts
@@ -8,6 +8,12 @@ export const findOrCreateCustomersAddress = createAction({
   name: 'findOrCreateCustomersAddress',
   displayName: 'Find or Create Customer’s Address',
   description: 'Finds or creates a customer’s address',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'For a given customer_id, looks up that customer’s addresses and returns the one matching the supplied address line 1, city, and postal code if it exists, otherwise creates a new address from the supplied details. Use instead of Create Customer Address when the address may already be on file, to avoid duplicates. Idempotent: repeated calls reuse the matching address rather than appending duplicates.',
+    idempotent: true,
+  },
   props: {
     customer_id: customerDropdown({
       required: true,

--- a/packages/pieces/community/bigcommerce/src/lib/actions/find-or-create-product.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/find-or-create-product.ts
@@ -7,6 +7,12 @@ export const findOrCreateProduct = createAction({
   name: 'findOrCreateProduct',
   displayName: 'Find or Create Product',
   description: 'Finds or creates a product',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Looks up a catalog product by exact name and returns the match if found, otherwise creates a new product from the supplied details (type, weight, and price required). Use instead of Create a Product when the item may already exist, to avoid duplicates. Idempotent: repeated calls match the same existing product by name rather than creating duplicates.',
+    idempotent: true,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Product Name',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/get-order.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/get-order.ts
@@ -7,6 +7,12 @@ export const getOrder = createAction({
   name: 'getOrder',
   displayName: 'Get Order',
   description: 'Gets details of an order',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves the full details of a single BigCommerce order by its orderId. Use when you already have an order id (e.g. from an order trigger or List Orders) and need its data. Idempotent read-only lookup with no side effects.',
+    idempotent: true,
+  },
   props: {
     orderId: Property.ShortText({
       displayName: 'Order ID',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/list-categories.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/list-categories.ts
@@ -7,6 +7,12 @@ export const listCategories = createAction({
   name: 'listCategories',
   displayName: 'List Categories',
   description: 'Lists all categories',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists product categories from a BigCommerce store. With no name filter it returns all categories; provide a name to filter to matching categories. Use to discover category names or ids before assigning products. Idempotent read-only query with no side effects.',
+    idempotent: true,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Category Name',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/list-orders.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/list-orders.ts
@@ -7,6 +7,12 @@ export const listOrders = createAction({
   name: 'listOrders',
   displayName: 'List Orders',
   description: 'Lists all orders',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists orders from a BigCommerce store. With no filters it returns all orders; optionally narrow by customer_id and/or status_id to a subset. Use to browse or find orders when you do not have a specific order id. Idempotent read-only query with no side effects.',
+    idempotent: true,
+  },
   props: {
     customer_id: Property.Number({
       displayName: 'Customer ID',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/search-customer-address.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/search-customer-address.ts
@@ -8,6 +8,12 @@ export const searchCustomerAddress = createAction({
   name: 'searchCustomerAddress',
   displayName: 'Search Customer Address',
   description: 'Searches for a customer’s address',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Searches customer addresses in a BigCommerce store, optionally filtered by one or more customer ids and/or a name. With no filters it returns all addresses; supplying filters narrows to matches. Use to look up addresses belonging to specific customers. Idempotent read-only query with no side effects.',
+    idempotent: true,
+  },
   props: {
     customer_ids: multiCustomerDropdown({
       required: false,

--- a/packages/pieces/community/bigcommerce/src/lib/actions/search-customer.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/search-customer.ts
@@ -7,6 +7,12 @@ export const searchCustomer = createAction({
   name: 'searchCustomer',
   displayName: 'Search Customer',
   description: 'Searches for a registered customer',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Searches registered customers in a BigCommerce store by email, phone, and/or name. With no filters it returns all customers; supplying any filter narrows to matches. Use to look up a customer or check whether one exists before creating it. Idempotent read-only query with no side effects.',
+    idempotent: true,
+  },
   props: {
     email: Property.ShortText({
       displayName: 'Email',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/search-product.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/search-product.ts
@@ -7,6 +7,12 @@ export const searchProduct = createAction({
   name: 'searchProduct',
   displayName: 'Search Product',
   description: 'Searches for a product in the catalog',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Searches the BigCommerce product catalog by name, SKU, type, brand, weight, and/or price. With no filters it returns all products; supplying any filter narrows to matches. Use to find a product or its id, or to check whether one exists before creating it. Idempotent read-only query with no side effects.',
+    idempotent: true,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Product Name',

--- a/packages/pieces/community/bigcommerce/src/lib/actions/update-a-product.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/actions/update-a-product.ts
@@ -7,6 +7,12 @@ export const updateAProduct = createAction({
   name: 'updateAProduct',
   displayName: 'Update a Product',
   description: 'Updates an existing Product',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Updates an existing catalog product in a BigCommerce store, identified by its productId. Only the fields you supply are sent (null/undefined values are dropped so existing data is preserved), so use it for partial edits to name, type, SKU, description, weight, price, or brand. Idempotent: re-applying the same field values leaves the product in the same state.',
+    idempotent: true,
+  },
   props: {
     productId: Property.ShortText({
       displayName: 'Product ID',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/abandoned-cart.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/abandoned-cart.ts
@@ -11,6 +11,10 @@ export const abandonedCart = createTrigger({
   name: 'abandonedCart',
   displayName: 'Abandoned Cart',
   description: 'Triggers when a cart is abandoned',
+  aiMetadata: {
+    description:
+      'Fires when a shopper abandons a cart in the BigCommerce store (the cart sits inactive without checkout completing). The event identifies the affected cart; use it to drive abandoned-cart recovery flows.',
+  },
   props: {},
   sampleData:{
     producer: 'stores/dxqdddcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/cart-created.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/cart-created.ts
@@ -11,6 +11,10 @@ export const cartCreated = createTrigger({
   name: 'cartCreated',
   displayName: 'Cart Created',
   description: 'Triggers when a new cart is created',
+  aiMetadata: {
+    description:
+      'Fires when a new shopping cart is created in the BigCommerce store (a shopper adds the first item to a fresh cart). The event identifies the new cart.',
+  },
   props: {},
   sampleData: {
     producer: 'stores/dxqdddcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/customer-address-created.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/customer-address-created.ts
@@ -11,6 +11,10 @@ export const customerAddressCreated = createTrigger({
   name: 'customerAddressCreated',
   displayName: 'Customer Address Created',
   description: 'Triggers when a new customer address is created',
+  aiMetadata: {
+    description:
+      'Fires when a new address is added to a customer in the BigCommerce store. The event identifies the affected customer.',
+  },
   props: {},
   sampleData: {
     producer: 'stores/xqcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/customer-address-updated.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/customer-address-updated.ts
@@ -11,6 +11,10 @@ export const customerAddressUpdated = createTrigger({
   name: 'customerAddressUpdated',
   displayName: 'Customer Address Updated',
   description: 'Triggers when a new customer address is updated',
+  aiMetadata: {
+    description:
+      'Fires when an existing customer address is updated in the BigCommerce store. The event identifies the affected customer.',
+  },
   props: {},
   sampleData:{
     producer: 'stores/xqcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/customer-created.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/customer-created.ts
@@ -11,6 +11,10 @@ export const customerCreated = createTrigger({
   name: 'customerCreated',
   displayName: 'Customer Created',
   description: 'Triggers when a new customer is created',
+  aiMetadata: {
+    description:
+      'Fires when a new customer is created in the BigCommerce store. The event identifies the new customer.',
+  },
   props: {},
   sampleData: {
     producer: 'stores/xqcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/customer-updated.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/customer-updated.ts
@@ -11,6 +11,10 @@ export const customerUpdated = createTrigger({
   name: 'customerUpdated',
   displayName: 'Customer Updated',
   description: 'Triggers when a customer is updated',
+  aiMetadata: {
+    description:
+      'Fires when an existing customer record is updated in the BigCommerce store. The event identifies the affected customer.',
+  },
   props: {},
   sampleData: {
     producer: 'stores/xqcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/order-created.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/order-created.ts
@@ -11,6 +11,10 @@ export const orderCreated = createTrigger({
   name: 'orderCreated',
   displayName: 'Order Created',
   description: 'Triggers when a new order is created',
+  aiMetadata: {
+    description:
+      'Fires when a new order is created in the BigCommerce store. The event identifies the new order; pair with Get Order to fetch its full details.',
+  },
   props: {},
   sampleData: {
     producer: 'stores/xqcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/order-status-updated.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/order-status-updated.ts
@@ -11,6 +11,10 @@ export const orderStatusUpdated = createTrigger({
   name: 'orderStatusUpdated',
   displayName: 'Order Status Updated',
   description: 'Triggers when an order status has changed',
+  aiMetadata: {
+    description:
+      'Fires specifically when an order’s status changes in the BigCommerce store (e.g. moves to shipped or completed). Use this instead of Order Updated when you only care about status transitions. The event identifies the affected order.',
+  },
   props: {},
   sampleData: {
     producer: 'stores/xqcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/order-updated.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/order-updated.ts
@@ -11,6 +11,10 @@ export const orderUpdated = createTrigger({
   name: 'orderUpdated',
   displayName: 'Order Updated',
   description: 'Triggers when an order is updated',
+  aiMetadata: {
+    description:
+      'Fires when an existing order is updated in the BigCommerce store (any change to the order, not just its status). The event identifies the affected order; pair with Get Order for full details.',
+  },
   props: {},
   sampleData: {
     producer: 'stores/xqcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/product-created.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/product-created.ts
@@ -11,6 +11,10 @@ export const productCreated = createTrigger({
   name: 'productCreated',
   displayName: 'Product Created',
   description: 'Triggers when a new product is created',
+  aiMetadata: {
+    description:
+      'Fires when a new product is added to the BigCommerce store catalog. The event identifies the new product.',
+  },
   props: {},
   sampleData: {
     producer: 'stores/xqcaklwsso',

--- a/packages/pieces/community/bigcommerce/src/lib/triggers/shipment-created.ts
+++ b/packages/pieces/community/bigcommerce/src/lib/triggers/shipment-created.ts
@@ -11,6 +11,10 @@ export const shipmentCreated = createTrigger({
   name: 'shipmentCreated',
   displayName: 'Shipment Created',
   description: 'Triggers when a new shipment is created',
+  aiMetadata: {
+    description:
+      'Fires when a new shipment is created for an order in the BigCommerce store (items are shipped/fulfilled). The event identifies the new shipment.',
+  },
   props: {},
   sampleData:{
     producer: 'stores/xqcaklwsso',

--- a/packages/pieces/community/bigin-by-zoho/package.json
+++ b/packages/pieces/community/bigin-by-zoho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bigin-by-zoho",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-call.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-call.ts
@@ -9,6 +9,8 @@ export const createCall = createAction({
   name: 'createCall',
   displayName: 'Create Call',
   description: 'Creates a Call Log Entry Record',
+  audience: 'both',
+  aiMetadata: { description: 'Logs a call in Bigin CRM with a required start time, duration in minutes, and type (Outbound, Inbound, or Missed), plus optional subject, description, agenda, reminder, dialed number, owner, contact, and a related Pipeline or Company record. Use to record a phone interaction. Not idempotent: each call creates a new call log entry.', idempotent: false },
   props: {
     callStartTime: Property.DateTime({
       displayName: 'Call Start Time',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-company.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-company.ts
@@ -8,6 +8,8 @@ export const createCompany = createAction({
   name: 'createCompany',
   displayName: 'Create Company',
   description: 'Creates a Company Record',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new company (account) record in Bigin CRM with a name plus optional phone, website, billing address, owner, tags, and description. Use to add an organization the business deals with. Not idempotent: each call creates a new company even if one with the same name already exists, so search first if you need to avoid duplicates.', idempotent: false },
   props: {
     accountName: Property.ShortText({
       displayName: 'Account Name',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-contact.ts
@@ -9,6 +9,8 @@ export const createContact = createAction({
   name: 'createContact',
   displayName: 'Create Contact',
   description: 'Creates a Contact Record',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new contact (person) record in Bigin CRM. Last name is required; optionally set email, mobile, title, owner, associated company, tags, mailing address, and description. Use to add a person to the CRM. Not idempotent: each call creates a new contact even with identical details, so search first to avoid duplicates.', idempotent: false },
   props: {
     firstName: Property.ShortText({
       displayName: 'First Name',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-event.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-event.ts
@@ -10,6 +10,8 @@ export const createEvent = createAction({
   name: 'createEvent',
   displayName: 'Create Event',
   description: 'Creates a new event in Bigin',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a calendar event in Bigin CRM with a title, start and end date/time (end must be after start), plus optional all-day flag, venue, participants, description, and tags. Supports optional recurrence (daily/weekly/monthly/yearly RRULE) and reminders, and can be linked to a related Contact, Pipeline, or Company record. Use to schedule a meeting or appointment. Not idempotent: each call creates a new event.', idempotent: false },
   props: {
     eventTitle: Property.ShortText({
       displayName: 'Event Title',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-pipeline-record.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-pipeline-record.ts
@@ -9,6 +9,8 @@ export const createPipelineRecord = createAction({
   name: 'createPipeline',
   displayName: 'Create Pipeline',
   description: 'Creates a new pipeline record in Bigin',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new pipeline record (deal) in Bigin CRM with a deal name, pipeline, sub-pipeline, stage, and closing date, plus optional amount, owner, company, contact, secondary contacts, associated products, tags, and module-defined fields. Use to open a new sales opportunity. Not idempotent: each call creates a new deal.', idempotent: false },
   props: {
     dealName: Property.ShortText({
       displayName: 'Deal Name',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-task.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/create-task.ts
@@ -10,6 +10,8 @@ export const createTask = createAction({
   name: 'createTask',
   displayName: 'Create Task',
   description: 'Creates a new Task',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new task in Bigin CRM with a subject plus optional due date, owner, priority, status, description, and tags. Supports optional recurrence (daily/weekly/monthly/yearly RRULE) and reminders, and can be linked to a related Contact, Pipeline, or Company record. Use to schedule follow-up work. Not idempotent: each call creates a new task.', idempotent: false },
   props: {
     subject: Property.ShortText({
       displayName: 'Subject',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-company-record.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-company-record.ts
@@ -7,6 +7,8 @@ export const searchCompanyRecord = createAction({
   name: 'searchCompanyRecord',
   displayName: 'Search Company Record',
   description: 'Searches companies by full name (criteria) or word',
+  audience: 'both',
+  aiMetadata: { description: 'Searches company (account) records in Bigin CRM and returns matches. Choose between Criteria mode (matches the Account Name with equals or starts-with) and Word mode (a free-text word search across the module). Use to find a company by name before referencing or updating it. Idempotent: read-only, repeating the search returns the same matches.', idempotent: true },
   props: {
     mode: Property.StaticDropdown({
       displayName: 'Search Mode',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-contact-record.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-contact-record.ts
@@ -7,6 +7,8 @@ export const searchContactRecord = createAction({
   name: 'searchContactRecord',
   displayName: 'Search Contact Record',
   description: 'Searches contacts by criteria, email, phone, or word',
+  audience: 'both',
+  aiMetadata: { description: 'Searches contact (person) records in Bigin CRM and returns matches. The search mode selects what the term is matched against: Criteria (name/email/mobile with equals or starts-with), a dedicated Email lookup, a dedicated Phone lookup, or a free-text Word search. Use to find a person by name, email, or phone before referencing or updating them. Idempotent: read-only, repeating the search returns the same matches.', idempotent: true },
   props: {
     mode: Property.StaticDropdown({
       displayName: 'Search Mode',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-pipeline-records.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-pipeline-records.ts
@@ -7,6 +7,8 @@ export const searchPipelineRecord = createAction({
   name: 'searchPipelineRecord',
   displayName: 'Search Pipeline Record',
   description: 'Searches deals by name via criteria or word',
+  audience: 'both',
+  aiMetadata: { description: 'Searches pipeline records (deals) in Bigin CRM and returns matches. Choose between Criteria mode (matches the Deal Name with equals or starts-with) and Word mode (a free-text word search across the module). Use to find a deal by name before referencing or updating it. Idempotent: read-only, repeating the search returns the same matches.', idempotent: true },
   props: {
     mode: Property.StaticDropdown({
       displayName: 'Search Mode',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-product.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-product.ts
@@ -7,6 +7,8 @@ export const searchProductRecord = createAction({
   name: 'searchProductRecord',
   displayName: 'Search Product Record',
   description: 'Searches products by name/code via criteria or word',
+  audience: 'both',
+  aiMetadata: { description: 'Searches product records in Bigin CRM and returns matches. Choose between Criteria mode (matches Product Name or Product Code with equals or starts-with) and Word mode (a free-text word search across the module). Use to find a product by name or code before associating it with a deal. Idempotent: read-only, repeating the search returns the same matches.', idempotent: true },
   props: {
     mode: Property.StaticDropdown({
       displayName: 'Search Mode',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-user.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/search-user.ts
@@ -7,6 +7,8 @@ export const searchUser = createAction({
   name: 'searchUser',
   displayName: 'Search User',
   description: 'Locate users by email.',
+  audience: 'both',
+  aiMetadata: { description: 'Finds Bigin CRM org users whose email contains the given term (case-insensitive substring match), filtering client-side over the user list; an optional user-type filter (e.g. active, admin, current user) and pagination narrow the fetched set. Use to resolve a user id for assigning records as owner. Idempotent: read-only, repeating the search returns the same matches.', idempotent: true },
   props: {
     email: Property.ShortText({
       displayName: 'Email',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-company.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-company.ts
@@ -14,6 +14,8 @@ export const updateCompany = createAction({
   displayName: 'Update Company',
   description:
     'Updates an existing Company and prepopulates its fields for editing.',
+  audience: 'both',
+  aiMetadata: { description: 'Updates an existing company (account) record in Bigin CRM, identified by selecting the company; its current fields are prepopulated and any you set are overwritten (owner, tags, billing address, and module-defined fields). Use to modify an organization that already exists. Idempotent: re-sending the same field values leaves the record in the same state.', idempotent: true },
   props: {
     companyId: Property.Dropdown({
       auth: biginAuth,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-contact.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-contact.ts
@@ -14,6 +14,8 @@ export const updateContact = createAction({
   name: 'updateContact',
   displayName: 'Update Contact',
   description: 'Select and update an existing Contact record.',
+  audience: 'both',
+  aiMetadata: { description: 'Updates an existing contact (person) record in Bigin CRM, identified by selecting the contact; its current fields are prepopulated and any you set are overwritten (owner, associated company, tags, and module-defined fields). Use to modify a person who already exists. Idempotent: re-sending the same field values leaves the record in the same state.', idempotent: true },
 
   props: {
     contactId: Property.Dropdown({

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-event.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-event.ts
@@ -14,6 +14,8 @@ export const updateEvent = createAction({
   name: 'updateEvent',
   displayName: 'Update Event',
   description: 'Updates an existing event in Bigin',
+  audience: 'both',
+  aiMetadata: { description: 'Updates an existing calendar event in Bigin CRM, identified by selecting the event; its current fields are prepopulated and any you set are overwritten (title, start/end time, all-day, venue, participants, owner, tags), with optional recurrence and reminder settings. Use to modify an event that already exists. Idempotent: re-sending the same field values leaves the record in the same state.', idempotent: true },
   props: {
     eventId: Property.Dropdown({
       auth: biginAuth,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-pipeline-record.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-pipeline-record.ts
@@ -9,6 +9,8 @@ export const updatePipelineRecord = createAction({
   name: 'updatePipeline',
   displayName: 'Update Pipeline',
   description: 'updates a pipeline record in Bigin',
+  audience: 'both',
+  aiMetadata: { description: 'Updates an existing pipeline record (deal) in Bigin CRM, identified by selecting the record; any fields you set are overwritten (deal name, sub-pipeline, stage, amount, closing date, owner, company, contact, secondary contacts, associated products, tags). Use to advance a deal stage or revise its details. Idempotent: re-sending the same field values leaves the record in the same state.', idempotent: true },
   props: {
     pipelineRecordId: pipelineRecordsDropdown,
     pipelineDetails: Property.DynamicProperties({

--- a/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-task.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/actions/update-task.ts
@@ -10,6 +10,8 @@ export const updateTask = createAction({
   name: 'updateTask',
   displayName: 'Update Task',
   description: 'updates a Task',
+  audience: 'both',
+  aiMetadata: { description: 'Updates an existing task in Bigin CRM, identified by selecting the task; its current fields are prepopulated and any you set are overwritten (subject, owner, due date, priority, status, description, tags), with optional recurrence and reminder settings and a related Contact/Pipeline/Company link. Use to modify a task that already exists. Idempotent: re-sending the same field values leaves the record in the same state.', idempotent: true },
   props: {
     taskId: Property.Dropdown({
       displayName: 'Select Task',

--- a/packages/pieces/community/bigin-by-zoho/src/lib/triggers/company-updated.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/triggers/company-updated.ts
@@ -10,6 +10,9 @@ export const companyUpdated = createTrigger({
   name: 'companyUpdated',
   displayName: 'Company Updated',
   description: 'Triggers when a company record is updated',
+  aiMetadata: {
+    description: 'Fires when an existing company (account) record is edited in Bigin CRM, via an Accounts.edit webhook. Represents a change to an organization already in the CRM.',
+  },
   props: {},
   sampleData: {},
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/triggers/contact-updated.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/triggers/contact-updated.ts
@@ -10,6 +10,9 @@ export const contactUpdated = createTrigger({
   name: 'contactUpdated',
   displayName: 'Contact Updated',
   description: 'Triggers when a contact is updated',
+  aiMetadata: {
+    description: 'Fires when an existing contact (person) record is edited in Bigin CRM, via a Contacts.edit webhook. Represents a change to a person already in the CRM.',
+  },
   props: {},
   sampleData: {},
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-call-created.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-call-created.ts
@@ -10,6 +10,9 @@ export const newCallCreated = createTrigger({
   name: 'newCallCreated',
   displayName: 'New Call Created',
   description: 'Triggers when a new call log is created',
+  aiMetadata: {
+    description: 'Fires when a new call log entry is created in Bigin CRM, via a Calls.create webhook. Represents a newly recorded phone interaction.',
+  },
   props: {},
   sampleData: {},
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-company-created.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-company-created.ts
@@ -10,6 +10,9 @@ export const newCompanyCreated = createTrigger({
   name: 'newCompanyCreated',
   displayName: 'New Company Created',
   description: 'Triggers when a new company record is created',
+  aiMetadata: {
+    description: 'Fires when a new company (account) record is created in Bigin CRM, via an Accounts.create webhook. Represents a newly added organization.',
+  },
   props: {},
   sampleData: {},
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-contact-created.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-contact-created.ts
@@ -11,6 +11,9 @@ export const newContactCreated = createTrigger({
   name: 'newContactCreated',
   displayName: 'New Contact Created',
   description: 'Triggers when a new contact is created',
+  aiMetadata: {
+    description: 'Fires when a new contact (person) record is created in Bigin CRM, via a Contacts.create webhook. Represents a newly added person.',
+  },
   props: {},
   sampleData: {
     server_time: 1754252081534,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-event-created.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-event-created.ts
@@ -10,6 +10,9 @@ export const newEventCreated = createTrigger({
   name: 'newEventCreated',
   displayName: 'New Event Created',
   description: 'Triggers when a new event is created',
+  aiMetadata: {
+    description: 'Fires when a new calendar event is created in Bigin CRM, via an Events.create webhook. Represents a newly scheduled meeting or appointment.',
+  },
   props: {},
   sampleData: {},
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-pipeline-record.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-pipeline-record.ts
@@ -10,6 +10,9 @@ export const newPipelineRecordCreated = createTrigger({
   name: 'newPipelineRecordCreated',
   displayName: 'New Pipeline Record Created',
   description: 'Triggers when a new pipeline record is created',
+  aiMetadata: {
+    description: 'Fires when a new pipeline record (deal) is created in Bigin CRM, via a Pipelines.create webhook. Represents a newly opened sales opportunity.',
+  },
   props: {},
   sampleData: {},
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-task-created.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/triggers/new-task-created.ts
@@ -10,6 +10,9 @@ export const newTaskCreated = createTrigger({
   name: 'newTaskCreated',
   displayName: 'New Task Created',
   description: 'Triggers when a new task is created',
+  aiMetadata: {
+    description: 'Fires when a new task is created in Bigin CRM, via a Tasks.create webhook. Represents a newly added piece of follow-up work.',
+  },
   props: {},
   sampleData: {},
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/bigin-by-zoho/src/lib/triggers/pipeline-record-updated.ts
+++ b/packages/pieces/community/bigin-by-zoho/src/lib/triggers/pipeline-record-updated.ts
@@ -10,6 +10,9 @@ export const pipelineRecordUpdated = createTrigger({
   name: 'pipelineRecordUpdated',
   displayName: 'Pipeline Record Updated',
   description: 'Triggers when a pipeline record is updated',
+  aiMetadata: {
+    description: 'Fires when an existing pipeline record (deal) is edited in Bigin CRM, via a Pipelines.edit webhook. Represents a change to a deal already in the CRM, such as a stage or amount update.',
+  },
   props: {},
   sampleData: {},
   type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/bika/package.json
+++ b/packages/pieces/community/bika/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bika",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bika/src/lib/actions/create-record.ts
+++ b/packages/pieces/community/bika/src/lib/actions/create-record.ts
@@ -10,6 +10,8 @@ export const createRecordAction = createAction({
   name: 'bika_create_record',
   displayName: 'Create Record',
   description: 'Creates a new record in database.',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new record in a Bika.ai database table, populating its fields. Requires a space and database (table) to target; field values must match the database schema (read-only field types like formulas and autonumber are ignored). Not idempotent: each call appends a new record.', idempotent: false },
   props: {
     space_id: BikaCommon.space_id,
     database_id: BikaCommon.database_id,

--- a/packages/pieces/community/bika/src/lib/actions/delete-record.ts
+++ b/packages/pieces/community/bika/src/lib/actions/delete-record.ts
@@ -10,6 +10,8 @@ export const deleteRecordAction = createAction({
   name: 'bika_delete_record',
   displayName: 'Delete Record',
   description: 'Deletes a record in database by ID.',
+  audience: 'both',
+  aiMetadata: { description: 'Deletes a single record from a Bika.ai database by its record ID, within a given space and database. Use to permanently remove a known record. Idempotent in effect: once removed, repeating the call leaves the record absent.', idempotent: true },
   props: {
     space_id: BikaCommon.space_id,
     database_id: BikaCommon.database_id,

--- a/packages/pieces/community/bika/src/lib/actions/find-record.ts
+++ b/packages/pieces/community/bika/src/lib/actions/find-record.ts
@@ -11,6 +11,8 @@ export const findRecordAction = createAction({
   name: 'bika_find_record',
   displayName: 'Get Record',
   description: 'Retrieves a record in database by ID.',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves a single record from a Bika.ai database by its record ID. Use when you already know the exact record ID; to search by field values or fetch multiple rows use Find Records instead. Read-only and idempotent.', idempotent: true },
   props: {
     space_id: BikaCommon.space_id,
     database_id: BikaCommon.database_id,

--- a/packages/pieces/community/bika/src/lib/actions/find-records.ts
+++ b/packages/pieces/community/bika/src/lib/actions/find-records.ts
@@ -12,6 +12,8 @@ export const findRecordsAction = createAction({
   name: 'bika_find_records',
   displayName: 'Find Records',
   description: 'Finds records in database.',
+  audience: 'both',
+  aiMetadata: { description: 'Lists records from a Bika.ai database, optionally narrowed by a filter expression (Bika filter-query-language); with no filter it returns all records up to the configured limits. Use to search or page through a table when you need multiple matching rows rather than a single known ID. Read-only and idempotent.', idempotent: true },
   props: {
     space_id: BikaCommon.space_id,
     database_id: BikaCommon.database_id,

--- a/packages/pieces/community/bika/src/lib/actions/update-record.ts
+++ b/packages/pieces/community/bika/src/lib/actions/update-record.ts
@@ -12,6 +12,8 @@ export const updateRecordAction = createAction({
 	name: 'bika_update_record',
 	displayName: 'Update Record',
 	description: 'Updates an existing record in database.',
+	audience: 'both',
+	aiMetadata: { description: 'Updates the fields of an existing Bika.ai record identified by its record ID, within a given space and database. Use when modifying a known record; provide only the fields to change (read-only field types are ignored). Idempotent: repeating with the same input leaves the record in the same state.', idempotent: true },
 	props: {
 		space_id: BikaCommon.space_id,
 		database_id: BikaCommon.database_id,

--- a/packages/pieces/community/billplz/package.json
+++ b/packages/pieces/community/billplz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-billplz",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/billplz/src/lib/actions/create-bill.ts
+++ b/packages/pieces/community/billplz/src/lib/actions/create-bill.ts
@@ -9,6 +9,8 @@ export const createBill = createAction({
   name: 'create_bill',
   displayName: 'Create Bill',
   description: 'Create a new bill within a collection',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new Billplz bill (payment request) inside a given collection, charging a recipient identified by email and/or mobile for an amount in Malaysian Ringgit. Either email or mobile is required, along with a recipient name, description, and callback URL; optionally set a due date, redirect URL, and reference fields. Enabling the deliver option sends the recipient an email/SMS notification. Not idempotent: each call creates a distinct bill and may dispatch a notification.', idempotent: false },
   auth: billplzAuth,
   props: {
     collection_id: Property.Dropdown({

--- a/packages/pieces/community/billplz/src/lib/actions/get-bill.ts
+++ b/packages/pieces/community/billplz/src/lib/actions/get-bill.ts
@@ -9,6 +9,8 @@ export const getBill = createAction({
   name: 'get_bill',
   displayName: 'Get Bill',
   description: 'Retrieve information about a specific bill',
+  audience: 'both',
+  aiMetadata: { description: 'Looks up a single Billplz bill by its bill ID, returning its details and payment status. Use to check whether a bill has been paid or to fetch its current state. Requires a known bill ID. Idempotent: a read-only lookup with no side effects.', idempotent: true },
   auth: billplzAuth,
   props: {
     bill_id: Property.ShortText({

--- a/packages/pieces/community/billplz/src/lib/triggers/get-collections.trigger.ts
+++ b/packages/pieces/community/billplz/src/lib/triggers/get-collections.trigger.ts
@@ -33,6 +33,9 @@ export const getCollectionsTrigger = createTrigger({
   name: 'get_collections',
   displayName: 'Get Collections',
   description: 'Triggers when there are new collections',
+  aiMetadata: {
+    description: 'Fires when a new Billplz collection appears on the authenticated account. Polls the collections list and emits one event per newly detected collection, representing a container into which bills can be created.',
+  },
   auth: billplzAuth,
   props: {},
   type: TriggerStrategy.POLLING,

--- a/packages/pieces/community/binance/package.json
+++ b/packages/pieces/community/binance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-binance",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/binance/src/lib/actions/fetch-pair-price.ts
+++ b/packages/pieces/community/binance/src/lib/actions/fetch-pair-price.ts
@@ -5,6 +5,8 @@ export const fetchCryptoPairPrice = createAction({
   name: 'fetch_crypto_pair_price',
   displayName: 'Fetch Pair Price',
   description: 'Fetch the current price of a pair (e.g. BTC/USDT)',
+  audience: 'both',
+  aiMetadata: { description: 'Fetches the current spot price of a trading pair from the public Binance market data API by combining two coin symbols (e.g. first coin BTC + second coin USDT). Use to look up the live exchange rate of one crypto asset against another. No authentication required; the symbol must be a pair that exists on Binance or the request fails. Read-only lookup, idempotent.', idempotent: true },
   props: {
     first_coin: Property.ShortText({
       displayName: 'First Coin Symbol',

--- a/packages/pieces/community/bland-ai/package.json
+++ b/packages/pieces/community/bland-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bland-ai",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/bland-ai/src/lib/actions/get-call-details.ts
+++ b/packages/pieces/community/bland-ai/src/lib/actions/get-call-details.ts
@@ -8,6 +8,12 @@ export const getCallDetails = createAction({
   name: 'get_call_details',
   displayName: 'Get Call Details',
   description: 'Retrieve details for a specific Bland AI call.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches the full record of one Bland AI call by its call ID (status, transcript, summary, recording URL, and post-call data). Use to inspect or poll the outcome of a call after it has been placed. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     callId: Property.ShortText({
       displayName: 'Call ID',

--- a/packages/pieces/community/bland-ai/src/lib/actions/list-calls.ts
+++ b/packages/pieces/community/bland-ai/src/lib/actions/list-calls.ts
@@ -8,6 +8,12 @@ export const listCalls = createAction({
   name: 'list_calls',
   displayName: 'List Calls',
   description: 'List recent Bland AI calls with optional filters.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists recent Bland AI calls, optionally narrowed by origin (from) and/or destination (to) phone number and capped by a limit (1-100). Leave the number filters empty to retrieve the most recent calls regardless of party. Use to discover call IDs or survey call history. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     limit: Property.Number({
       displayName: 'Limit',

--- a/packages/pieces/community/bland-ai/src/lib/actions/send-call.ts
+++ b/packages/pieces/community/bland-ai/src/lib/actions/send-call.ts
@@ -8,6 +8,12 @@ export const sendCall = createAction({
   name: 'send_call',
   displayName: 'Send Call',
   description: 'Initiate an AI phone call to a recipient.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Places an outbound AI voice call to a phone number (E.164 format, with country code) via Bland AI. Drive the conversation either by supplying free-text Task instructions for the agent or by referencing a pre-built Pathway ID (the Pathway overrides the Task). Use to actually start a call; not idempotent — each call triggers a new outbound dial.',
+    idempotent: false,
+  },
   props: {
     phoneNumber: Property.ShortText({
       displayName: 'Phone Number',

--- a/packages/pieces/community/bokio/package.json
+++ b/packages/pieces/community/bokio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bokio",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bokio/src/lib/actions/add-line-item-to-invoice.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/add-line-item-to-invoice.ts
@@ -9,6 +9,8 @@ export const addLineItemToInvoice = createAction({
   name: 'addLineItemToInvoice',
   displayName: 'Add line item to invoice',
   description: 'Adds a line item to an existing draft invoice',
+  audience: 'both',
+  aiMetadata: { description: 'Appends a single line item to an existing draft invoice in Bokio, identified by invoice ID. Use to add a product, service, or description-only row to an invoice that already exists; pricing fields apply only when item type is a sales item. Not idempotent — each call appends another line item.', idempotent: false },
   props: {
     invoiceId: invoiceIdDropdown,
     itemType: Property.StaticDropdown({

--- a/packages/pieces/community/bokio/src/lib/actions/create-a-journal-entry.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/create-a-journal-entry.ts
@@ -8,6 +8,8 @@ export const createAJournalEntry = createAction({
   name: 'createAJournalEntry',
   displayName: 'Create a journal entry',
   description: 'Creates a new journal entry in Bokio',
+  audience: 'both',
+  aiMetadata: { description: 'Records a new bookkeeping journal entry in a Bokio company, posting debit/credit amounts against account numbers. Use for manual double-entry transactions; the entry date is required and items carry the per-account debit/credit lines. Not idempotent — each call posts a separate journal entry.', idempotent: false },
   props: {
     title: Property.ShortText({
       displayName: 'Title',

--- a/packages/pieces/community/bokio/src/lib/actions/create-an-item.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/create-an-item.ts
@@ -9,6 +9,8 @@ export const createAnItem = createAction({
   name: 'createAnItem',
   displayName: 'Create an item',
   description: 'Creates a new item in Bokio',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new reusable item (a sales item with pricing, or a text item) in a Bokio company catalog. Use to define a product or service that can later be referenced on invoices; item type is required. Not idempotent — each call creates a separate item.', idempotent: false },
   props: {
     itemType: Property.StaticDropdown({
       displayName: 'Item Type',

--- a/packages/pieces/community/bokio/src/lib/actions/create-customer.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/create-customer.ts
@@ -9,6 +9,8 @@ export const createCustomer = createAction({
   name: 'createCustomer',
   displayName: 'Create Customer',
   description: 'Creates a new customer in Bokio',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new customer record in a Bokio accounting company. Use to register a person or company before invoicing them; only customer name and type (individual/company) are required, with optional VAT/org number, contact, and address details. Not idempotent — each call creates a separate customer.', idempotent: false },
   props: {
     customerName: Property.ShortText({
       displayName: 'Customer Name',

--- a/packages/pieces/community/bokio/src/lib/actions/create-invoice.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/create-invoice.ts
@@ -9,6 +9,8 @@ export const createInvoice = createAction({
   name: 'createInvoice',
   displayName: 'Create Invoice',
   description: 'Creates a new draft invoice in Bokio',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new draft invoice in a Bokio company with a single line item. Use to start a new customer invoice; invoice date, due date, and item type are required, and the customer is linked by passing the customer UUID. Not idempotent — each call creates a separate draft invoice.', idempotent: false },
   props: {
     invoiceType: Property.StaticDropdown({
       displayName: 'Invoice Type',

--- a/packages/pieces/community/bokio/src/lib/actions/find-customer.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/find-customer.ts
@@ -8,6 +8,8 @@ export const findCustomer = createAction({
   name: 'findCustomer',
   displayName: 'Find Customer',
   description: 'Find customers in Bokio by filtering and pagination',
+  audience: 'both',
+  aiMetadata: { description: 'Lists customers in a Bokio company with pagination, optionally filtered by name, type, VAT number, or organization number. Leaving the filter empty returns all customers; supplying a filter type and value narrows to matching records. Use to look up a customer or their ID. Idempotent read-only lookup.', idempotent: true },
   props: {
     filterType: Property.StaticDropdown({
       displayName: 'Filter Type',

--- a/packages/pieces/community/bokio/src/lib/actions/get-a-journal-entry.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/get-a-journal-entry.ts
@@ -8,6 +8,8 @@ export const getAJournalEntry = createAction({
   name: 'getAJournalEntry',
   displayName: 'Get a journal entry',
   description: 'Retrieve a specific journal entry by its ID',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves a single journal entry from a Bokio company by its UUID. Use when you already have the journal entry ID and need its full bookkeeping details. Idempotent read-only lookup.', idempotent: true },
   props: {
     journalEntryId: Property.ShortText({
       displayName: 'Journal Entry ID',

--- a/packages/pieces/community/bokio/src/lib/actions/get-an-invoice.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/get-an-invoice.ts
@@ -8,6 +8,8 @@ export const getAnInvoice = createAction({
   name: 'getAnInvoice',
   displayName: 'Get an invoice',
   description: 'Retrieve a specific invoice by its ID',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves a single invoice from a Bokio company by its invoice ID. Use when you already have the invoice ID and need its full details. Idempotent read-only lookup.', idempotent: true },
   props: {
     invoiceId: Property.ShortText({
       displayName: 'Invoice ID',

--- a/packages/pieces/community/bokio/src/lib/actions/get-draft-invoice-by-customer-name.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/get-draft-invoice-by-customer-name.ts
@@ -8,6 +8,8 @@ export const getDraftInvoiceByCustomerName = createAction({
   name: 'getDraftInvoiceByCustomerName',
   displayName: 'Get Draft Invoice by Customer Name',
   description: 'Get all draft invoices for a customer by customer name',
+  audience: 'both',
+  aiMetadata: { description: 'Looks up a Bokio customer by exact name and returns their draft invoices with pagination. Use when you have a customer name (not an ID) and want their pending draft invoices; returns an empty result if no customer matches. Idempotent read-only lookup.', idempotent: true },
   props: {
     customerName: Property.ShortText({
       displayName: 'Customer Name',

--- a/packages/pieces/community/bokio/src/lib/actions/update-an-invoice.ts
+++ b/packages/pieces/community/bokio/src/lib/actions/update-an-invoice.ts
@@ -9,6 +9,8 @@ export const updateAnInvoice = createAction({
   name: 'updateAnInvoice',
   displayName: 'Update an invoice',
   description: 'Updates an existing draft invoice in Bokio',
+  audience: 'both',
+  aiMetadata: { description: 'Updates an existing draft invoice in Bokio, identified by invoice ID, replacing fields such as type, customer, dates, currency, and the full line-items list (passed as a JSON array). Use to modify an invoice that already exists rather than create one. Idempotent — repeating the same update yields the same invoice state.', idempotent: true },
   props: {
     invoiceId: invoiceIdDropdown,
     invoiceType: Property.StaticDropdown({

--- a/packages/pieces/community/bolna/package.json
+++ b/packages/pieces/community/bolna/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bolna",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bolna/src/lib/actions/make-phone-call.ts
+++ b/packages/pieces/community/bolna/src/lib/actions/make-phone-call.ts
@@ -10,6 +10,12 @@ export const makePhoneCall = createAction({
   displayName: 'Make Phone Call',
   description:
     'Initiate an outbound phone call from a Bolna Voice AI agent to a recipient.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Place an outbound voice call to a recipient using a Bolna AI agent. Requires an agent ID and a recipient phone number in E.164 format; optionally set a from-number, schedule the call for a future ISO 8601 time (omit to dial immediately), and pass dynamic user variables referenced in the agent prompt. Each call is not idempotent — repeating it places another call.',
+    idempotent: false,
+  },
   props: {
     agentId: agentId,
     recipientPhoneNumber: Property.ShortText({

--- a/packages/pieces/community/bolna/src/lib/triggers/call-completion-report.ts
+++ b/packages/pieces/community/bolna/src/lib/triggers/call-completion-report.ts
@@ -9,6 +9,10 @@ export const callCompletionReport = createTrigger({
   name: 'callCompletionReport',
   displayName: 'Call Completion Report',
   description: 'Triggers when  Bolna call report  it is completed',
+  aiMetadata: {
+    description:
+      'Fires when a Bolna AI voice call finishes and its execution report is pushed to the configured webhook, emitting only calls with a completed status. Use to act on call outcomes such as transcript, duration, cost, and recording once a conversation has ended. Requires manually configuring the Bolna agent to push execution data to the webhook URL.',
+  },
   props: {
     markdown: Property.MarkDown({
       value: `## Bolna AI Webhook Setup

--- a/packages/pieces/community/bonjoro/package.json
+++ b/packages/pieces/community/bonjoro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bonjoro",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/bonjoro/src/lib/actions/add-greet.ts
+++ b/packages/pieces/community/bonjoro/src/lib/actions/add-greet.ts
@@ -12,6 +12,8 @@ export const addGreetAction = createAction({
   auth: bonjoroAuth,
   displayName: 'Create a Greet',
   description: 'Create a new Greet in Bonjoro',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a personal-video Greet task in Bonjoro for a recipient identified by email (upserting their profile first), with a note and optional assignee, campaign, and message template. Use to queue a new outreach video for a customer. Not idempotent: each call creates a new Greet, so repeating it produces duplicates.', idempotent: false },
   props: {
     note: Property.LongText({
       displayName: 'Note',

--- a/packages/pieces/community/bookedin/package.json
+++ b/packages/pieces/community/bookedin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bookedin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bookedin/src/lib/actions/create-lead.ts
+++ b/packages/pieces/community/bookedin/src/lib/actions/create-lead.ts
@@ -7,6 +7,8 @@ export const createLead = createAction({
   name: 'createLead',
   displayName: 'Create Lead',
   description: 'Creates a new lead in Bookedin AI',
+  audience: 'both',
+  aiMetadata: { description: 'Create a new lead in Bookedin for the authenticated business from a contact first name, last name, email, and phone (all required). Use it to add a prospect into the lead pipeline. Not idempotent — each call creates a separate lead, with no de-duplication on email or phone.', idempotent: false },
   auth: bookedinAuth,
   props: {
     firstName: Property.ShortText({

--- a/packages/pieces/community/bookedin/src/lib/actions/delete-lead.ts
+++ b/packages/pieces/community/bookedin/src/lib/actions/delete-lead.ts
@@ -7,6 +7,8 @@ export const deleteLead = createAction({
   name: 'deleteLead',
   displayName: 'Delete Lead',
   description: 'Delete a lead.',
+  audience: 'both',
+  aiMetadata: { description: 'Permanently delete a lead by its Bookedin lead ID. Use it to remove a known lead from the pipeline; this is destructive and cannot be undone. Idempotent on the end state — once the lead is gone, re-running targets an already-removed record.', idempotent: true },
   auth: bookedinAuth,
   props: {
     lead_id: leadIdDropdown,

--- a/packages/pieces/community/bookedin/src/lib/actions/get-lead-stats.ts
+++ b/packages/pieces/community/bookedin/src/lib/actions/get-lead-stats.ts
@@ -7,6 +7,8 @@ export const getLeadStats = createAction({
   name: 'getLeadStats',
   displayName: 'Get Lead Stats',
   description: 'Get lead statistics (Hot, Warm, Cold, Objectives Met, Total).',
+  audience: 'both',
+  aiMetadata: { description: 'Get aggregate lead statistics for the authenticated Bookedin business, such as counts of Hot, Warm, and Cold leads, objectives met, and the total. Use it for a quick pipeline summary rather than fetching individual leads. Takes no input; read-only and idempotent.', idempotent: true },
   auth: bookedinAuth,
   props: {},
   async run({ auth }) {

--- a/packages/pieces/community/bookedin/src/lib/actions/get-lead.ts
+++ b/packages/pieces/community/bookedin/src/lib/actions/get-lead.ts
@@ -7,6 +7,8 @@ export const getLead = createAction({
   name: 'getLead',
   displayName: 'Get Lead',
   description: 'Get a specific lead by ID.',
+  audience: 'both',
+  aiMetadata: { description: 'Fetch a single lead by its Bookedin lead ID. Use it to read the full record for one known lead; if you only have a name, email, or phone, find the ID first with Get Leads. Read-only and idempotent.', idempotent: true },
   auth: bookedinAuth,
   props: {
     lead_id: leadIdDropdown,

--- a/packages/pieces/community/bookedin/src/lib/actions/get-leads.ts
+++ b/packages/pieces/community/bookedin/src/lib/actions/get-leads.ts
@@ -7,6 +7,8 @@ export const getLeads = createAction({
   name: 'getLeads',
   displayName: 'Get Leads',
   description: 'Get all leads for the current business with pagination metadata.',
+  audience: 'both',
+  aiMetadata: { description: 'List leads for the authenticated Bookedin business, returning a page with pagination metadata. Use it to browse or find leads; leave the filter fields empty to fetch all, or narrow by free-text search (name/email/phone), exact email, phone, or source, and page through results with limit/skip. Read-only and idempotent.', idempotent: true },
   auth: bookedinAuth,
   props: {
     search: Property.ShortText({

--- a/packages/pieces/community/bookedin/src/lib/actions/update-lead.ts
+++ b/packages/pieces/community/bookedin/src/lib/actions/update-lead.ts
@@ -8,6 +8,8 @@ export const updateLead = createAction({
   name: 'updateLead',
   displayName: 'Update Lead',
   description: 'Update a lead.',
+  audience: 'both',
+  aiMetadata: { description: 'Update an existing lead identified by its Bookedin lead ID. Supply any of the individual contact fields (first/last name, email, phone) and handling status, and/or pass a raw JSON payload for complex updates that merges over those fields. Use it to edit a known lead; only the fields you provide are changed. Idempotent — re-applying the same values yields the same lead state.', idempotent: true },
   auth: bookedinAuth,
   props: {
     lead_id: leadIdDropdown,

--- a/packages/pieces/community/brave-search/package.json
+++ b/packages/pieces/community/brave-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-brave-search",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/brave-search/src/lib/actions/web-search.ts
+++ b/packages/pieces/community/brave-search/src/lib/actions/web-search.ts
@@ -7,6 +7,12 @@ export const braveWebSearchAction = createAction({
   name: 'web_search',
   displayName: 'Web Search',
   description: 'Search the web using Brave Search',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Runs a web search query against the Brave Search API and returns the matching web results. Use it to retrieve current information from the public web for a given text query; set the optional count (1-20) to control how many results come back. Read-only lookup that returns the same results for the same query.',
+    idempotent: true,
+  },
   props: {
     query: Property.ShortText({
       displayName: 'Query',

--- a/packages/pieces/community/brilliant-directories/package.json
+++ b/packages/pieces/community/brilliant-directories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-brilliant-directories",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/brilliant-directories/src/lib/actions/create-new-user.ts
+++ b/packages/pieces/community/brilliant-directories/src/lib/actions/create-new-user.ts
@@ -8,6 +8,8 @@ export const createNewUser = createAction({
   auth: brilliantDirectoriesAuth,
   displayName: 'Create new User',
   description: 'Creates a new user in your brilliant directories site',
+  audience: 'both',
+  aiMetadata: { description: 'Registers a new member account on a Brilliant Directories site via the v2 user/create API. Use to onboard a member when you have their email, password, and a subscription ID that maps to a membership plan; extra profile fields can be passed through the Meta object. Not idempotent — each call creates a new account, so calling twice with the same email may produce a duplicate or fail.', idempotent: false },
   props: {
     email: Property.ShortText({
       displayName: 'Email',

--- a/packages/pieces/community/browserless/package.json
+++ b/packages/pieces/community/browserless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-browserless",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/browserless/src/lib/actions/capture-screenshot.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/capture-screenshot.ts
@@ -7,6 +7,8 @@ export const captureScreenshot = createAction({
     name: 'capture_screenshot',
     displayName: 'Capture Screenshot',
     description: 'Take a screenshot of a web page',
+    audience: 'both',
+    aiMetadata: { description: 'Renders a web page in a headless browser and returns a PNG or JPEG screenshot of it. Use to capture the visual state of a public URL; the page URL is required, and options like full-page capture, viewport size, clipping region, and waiting for a CSS selector control what is rendered. Read-only: re-running with the same input re-renders the page and produces an equivalent image without side effects.', idempotent: true },
     auth: browserlessAuth,
     props: {
         url: Property.ShortText({

--- a/packages/pieces/community/browserless/src/lib/actions/generate-pdf.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/generate-pdf.ts
@@ -7,6 +7,8 @@ export const generatePdf = createAction({
     name: 'generate_pdf',
     displayName: 'Generate PDF',
     description: 'Convert a web page to PDF',
+    audience: 'both',
+    aiMetadata: { description: 'Renders content in a headless browser and returns it as a PDF file. Source the content either from a page URL or from a raw HTML string (provide exactly one, not both). Use to produce a printable PDF of a page or supplied markup, with control over paper format, orientation, margins, and headers/footers. Read-only: re-running with the same input re-renders an equivalent PDF without side effects.', idempotent: true },
     auth: browserlessAuth,
     props: {
         url: Property.ShortText({

--- a/packages/pieces/community/browserless/src/lib/actions/get-website-performance.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/get-website-performance.ts
@@ -7,6 +7,8 @@ export const getWebsitePerformance = createAction({
     name: 'get_website_performance',
     displayName: 'Get Website Performance',
     description: 'Analyze website performance metrics using Lighthouse',
+    audience: 'both',
+    aiMetadata: { description: 'Runs a Lighthouse audit on a public URL in a headless browser and returns performance, accessibility, best-practices, SEO, and PWA scores plus key metrics. Use to measure a page\'s quality; the URL is required, and you can scope the audit to specific categories and simulate a desktop or mobile device with network throttling. Read-only analysis: re-running with the same input re-audits the page without side effects (scores may vary slightly run to run).', idempotent: true },
     auth: browserlessAuth,
     props: {
         url: Property.ShortText({

--- a/packages/pieces/community/browserless/src/lib/actions/run-bql-query.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/run-bql-query.ts
@@ -7,6 +7,8 @@ export const runBqlQuery = createAction({
     name: 'run_bql_query',
     displayName: 'Run BQL Query',
     description: 'Execute Browser Query Language (BQL) GraphQL-based queries for advanced browser automation',
+    audience: 'both',
+    aiMetadata: { description: 'Runs a raw Browser Query Language (BQL) GraphQL query against a headless Chromium browser for advanced automation such as navigation, clicking, typing, and multi-step scripted browser flows. Use when the simpler screenshot/scrape/PDF actions cannot express the interaction; requires a valid BQL query string and supports session options like stealth, proxy, and cookies. Not idempotent: the query can perform stateful browser actions and side-effecting navigation, so repeating it may not yield the same result.', idempotent: false },
     auth: browserlessAuth,
     props: {
         query: Property.LongText({

--- a/packages/pieces/community/browserless/src/lib/actions/scrape-url.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/scrape-url.ts
@@ -7,6 +7,8 @@ export const scrapeUrl = createAction({
     name: 'scrape_url',
     displayName: 'Scrape URL',
     description: 'Extract content from a web page',
+    audience: 'both',
+    aiMetadata: { description: 'Loads a web page in a headless browser and extracts the elements matched by the CSS selectors you supply. Use to pull specific text or attributes from a page rather than capturing an image; both the page URL and at least one element selector are required. Read-only: re-running with the same input re-scrapes the page and returns equivalent data without side effects.', idempotent: true },
     auth: browserlessAuth,
     props: {
         url: Property.ShortText({

--- a/packages/pieces/community/bubble/package.json
+++ b/packages/pieces/community/bubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bubble",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/bubble/src/lib/actions/create-thing.ts
+++ b/packages/pieces/community/bubble/src/lib/actions/create-thing.ts
@@ -13,6 +13,8 @@ export const bubbleCreateThingAction = createAction({
   name: 'bubble_create_thing',
   displayName: 'Create Thing',
   description: 'Create a thing',
+  audience: 'both',
+  aiMetadata: { description: 'Create a new record ("thing") of a given data type in a Bubble app via the Bubble Data API. Use to add a new entry; supply the type name and a fields object with the values to set. Not idempotent — each call creates a separate record.', idempotent: false },
   props: {
     typename: bubbleCommon.typename,
     fields: bubbleCommon.fields,

--- a/packages/pieces/community/bubble/src/lib/actions/delete-thing.ts
+++ b/packages/pieces/community/bubble/src/lib/actions/delete-thing.ts
@@ -13,6 +13,8 @@ export const bubbleDeleteThingAction = createAction({
   name: 'bubble_delete_thing',
   displayName: 'Delete Thing',
   description: 'Delete a thing',
+  audience: 'both',
+  aiMetadata: { description: 'Permanently delete a single record ("thing") from a Bubble app by its unique id and data type, via the Bubble Data API. Use when an agent must remove a specific record it already knows the id of. Effectively idempotent (deleting an already-deleted id is a no-op) but destructive — verify the id before calling.', idempotent: true },
   props: {
     typename: bubbleCommon.typename,
     thing_id: bubbleCommon.thing_id,

--- a/packages/pieces/community/bubble/src/lib/actions/get-thing.ts
+++ b/packages/pieces/community/bubble/src/lib/actions/get-thing.ts
@@ -13,6 +13,8 @@ export const bubbleGetThingAction = createAction({
   name: 'bubble_get_thing',
   displayName: 'Get Thing',
   description: 'Get a thing by id',
+  audience: 'both',
+  aiMetadata: { description: 'Fetch a single record ("thing") of a given data type from a Bubble app by its unique id, via the Bubble Data API. Use to read the current values of one known record. Read-only and idempotent.', idempotent: true },
   props: {
     typename: bubbleCommon.typename,
     thing_id: bubbleCommon.thing_id,

--- a/packages/pieces/community/bubble/src/lib/actions/list-things.ts
+++ b/packages/pieces/community/bubble/src/lib/actions/list-things.ts
@@ -13,6 +13,8 @@ export const bubbleListThingsAction = createAction({
   name: 'bubble_list_things',
   displayName: 'List Thing',
   description: 'List things by type',
+  audience: 'both',
+  aiMetadata: { description: 'Search and list records ("things") of a given data type in a Bubble app via the Bubble Data API, filtering by a single constraint (e.g. equals, text contains, greater/less than, in, empty, geographic_search) on a chosen field and value, with cursor and limit for pagination. Use to find records matching a condition or to page through a type. Read-only and idempotent.', idempotent: true },
   props: {
     typename: bubbleCommon.typename,
     constraint: Property.StaticDropdown({

--- a/packages/pieces/community/bubble/src/lib/actions/update-thing.ts
+++ b/packages/pieces/community/bubble/src/lib/actions/update-thing.ts
@@ -13,6 +13,8 @@ export const bubbleUpdateThingAction = createAction({
   name: 'bubble_update_thing',
   displayName: 'Update Thing',
   description: 'Updates a thing',
+  audience: 'both',
+  aiMetadata: { description: 'Update an existing record ("thing") in a Bubble app, identified by its unique id and data type, by patching the supplied fields via the Bubble Data API. Use to modify specific fields of a known record; only the provided fields are changed. Targets one record so repeats with the same input converge, but it mutates server state on each call.', idempotent: false },
   props: {
     typename: bubbleCommon.typename,
     thing_id: bubbleCommon.thing_id,

--- a/packages/pieces/community/buffer/package.json
+++ b/packages/pieces/community/buffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-buffer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/buffer/src/lib/actions/create-idea.ts
+++ b/packages/pieces/community/buffer/src/lib/actions/create-idea.ts
@@ -56,6 +56,12 @@ export const createIdea = createAction({
   name: 'create_idea',
   displayName: 'Create Idea',
   description: "Save a new idea to your Buffer Idea Bank.",
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Saves a new draft idea (title, body text, and/or attached images) to a Buffer organization\'s Idea Bank for later use. Choose it to stash content concepts without scheduling them to a channel. The idea must include at least a title, text, or one image. Not idempotent — each call creates a new idea.',
+    idempotent: false,
+  },
   props: {
     organizationId: bufferProps.organizationId(),
     title: Property.ShortText({

--- a/packages/pieces/community/buffer/src/lib/actions/create-post.ts
+++ b/packages/pieces/community/buffer/src/lib/actions/create-post.ts
@@ -45,6 +45,12 @@ export const createPost = createAction({
   displayName: 'Create Post',
   description:
     'Create a post in Buffer and add it to the queue, share it next, share it now, or schedule it for a custom time.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a social media post in Buffer for one or more channels, where the share mode controls timing: add to the channel queue, share next (skip the queue), share now, or schedule for a custom time. Choose it to draft or publish content to connected social accounts. A custom-scheduled post requires the scheduled time; posting to multiple channels creates a separate post per channel. Not idempotent — each call creates new posts.',
+    idempotent: false,
+  },
   props: {
     organizationId: bufferProps.organizationId(),
     channelIds: bufferProps.channelIds(true),

--- a/packages/pieces/community/buffer/src/lib/triggers/new-channel.ts
+++ b/packages/pieces/community/buffer/src/lib/triggers/new-channel.ts
@@ -35,6 +35,10 @@ export const newChannel = createTrigger({
   name: 'new_channel',
   displayName: 'New Channel',
   description: 'Triggers when a new channel is connected to your Buffer organization.',
+  aiMetadata: {
+    description:
+      'Fires when a new social media channel (e.g. a Facebook page, Instagram or X account) is connected to the selected Buffer organization, representing the newly linked channel.',
+  },
   type: TriggerStrategy.POLLING,
   props: {
     organizationId: bufferProps.organizationId(),

--- a/packages/pieces/community/buffer/src/lib/triggers/new-queue-item.ts
+++ b/packages/pieces/community/buffer/src/lib/triggers/new-queue-item.ts
@@ -45,6 +45,10 @@ export const newQueueItem = createTrigger({
   name: 'new_queue_item',
   displayName: 'New Queue Item',
   description: 'Triggers when a new post is queued in Buffer.',
+  aiMetadata: {
+    description:
+      'Fires when a new not-yet-published post (any status except sent or error, e.g. pending, scheduled, or draft) appears in the selected Buffer organization, optionally limited to specific channels. Represents the queued post.',
+  },
   type: TriggerStrategy.POLLING,
   props: {
     organizationId: bufferProps.organizationId(),

--- a/packages/pieces/community/buffer/src/lib/triggers/new-sent-item.ts
+++ b/packages/pieces/community/buffer/src/lib/triggers/new-sent-item.ts
@@ -44,6 +44,10 @@ export const newSentItem = createTrigger({
   name: 'new_sent_item',
   displayName: 'New Sent Post',
   description: 'Triggers when a Buffer post is successfully published.',
+  aiMetadata: {
+    description:
+      'Fires when a Buffer post is successfully published (status sent) to a connected channel in the selected organization, optionally limited to specific channels. Represents the sent post.',
+  },
   type: TriggerStrategy.POLLING,
   props: {
     organizationId: bufferProps.organizationId(),

--- a/packages/pieces/community/bumpups/package.json
+++ b/packages/pieces/community/bumpups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bumpups",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bumpups/src/lib/actions/generate-creator-description.ts
+++ b/packages/pieces/community/bumpups/src/lib/actions/generate-creator-description.ts
@@ -8,6 +8,8 @@ export const generateCreatorDescription = createAction({
   name: 'generateCreatorDescription',
   displayName: 'Generate Creator Description',
   description: 'Generates a compelling description for a YouTube video based on its content.',
+  audience: 'both',
+  aiMetadata: { description: 'Calls the Bumpups AI model on a public YouTube video URL to generate a ready-to-use video description from the video content. Use when an agent needs a written description for a specific YouTube video; the video URL is required and an optional language code controls the output language. Not idempotent — each call invokes the model and may produce different text.', idempotent: false },
   props: {
     videoUrl: Property.ShortText({
       displayName: 'Video URL',

--- a/packages/pieces/community/bumpups/src/lib/actions/generate-creator-hashtags.ts
+++ b/packages/pieces/community/bumpups/src/lib/actions/generate-creator-hashtags.ts
@@ -9,6 +9,8 @@ export const generateCreatorHashtags = createAction({
   displayName: 'Generate Creator Hashtags',
   description:
     'Generates relevant hashtags for a YouTube video based on its content.',
+  audience: 'both',
+  aiMetadata: { description: 'Calls the Bumpups AI model on a public YouTube video URL to generate social tags from the video content, with an output-format option to return either hashtags or plain keywords. Use when an agent needs discoverability tags for a specific YouTube video; the video URL is required and an optional language code sets the output language. Not idempotent — each call invokes the model and may produce different tags.', idempotent: false },
   props: {
     videoUrl: Property.ShortText({
       displayName: 'Video URL',

--- a/packages/pieces/community/bumpups/src/lib/actions/generate-creator-takeaways.ts
+++ b/packages/pieces/community/bumpups/src/lib/actions/generate-creator-takeaways.ts
@@ -9,6 +9,8 @@ export const generateCreatorTakeaways = createAction({
   displayName: 'Generate Creator Takeaways',
   description:
     'Generates key takeaways for a YouTube video based on its content.',
+  audience: 'both',
+  aiMetadata: { description: 'Calls the Bumpups AI model on a public YouTube video URL to generate key takeaways summarizing the video content, optionally including emojis. Use when an agent needs a bullet-style summary of the main points of a specific YouTube video; the video URL is required and an optional language code sets the output language. Not idempotent — each call invokes the model and may produce different text.', idempotent: false },
   props: {
     videoUrl: Property.ShortText({
       displayName: 'Video URL',

--- a/packages/pieces/community/bumpups/src/lib/actions/generate-creator-titles.ts
+++ b/packages/pieces/community/bumpups/src/lib/actions/generate-creator-titles.ts
@@ -9,6 +9,8 @@ export const generateCreatorTitles = createAction({
   name: 'generateCreatorTitles',
   displayName: 'Generate Creator Titles',
   description: 'Generates engaging titles for a YouTube video based on its content.',
+  audience: 'both',
+  aiMetadata: { description: 'Calls the Bumpups AI model on a public YouTube video URL to generate engaging title suggestions from the video content. Use when an agent needs candidate titles for a specific YouTube video; the video URL is required and an optional language code sets the output language. Not idempotent — each call invokes the model and may produce different titles.', idempotent: false },
   props: {
     videoUrl: Property.ShortText({
       displayName: 'Video URL',

--- a/packages/pieces/community/bumpups/src/lib/actions/generate-timestamps.ts
+++ b/packages/pieces/community/bumpups/src/lib/actions/generate-timestamps.ts
@@ -8,6 +8,8 @@ export const generateTimestamps = createAction({
   name: 'generateTimestamps',
   displayName: 'Generate Timestamps',
   description: 'Generates detailed timestamps for a YouTube video based on its content.',
+  audience: 'both',
+  aiMetadata: { description: 'Calls the Bumpups AI model on a public YouTube video URL to generate chapter timestamps from the video content, with a style option for long or short timestamp segments. Use when an agent needs chaptered timestamps for a specific YouTube video; the video URL is required and an optional language code sets the output language. Not idempotent — each call invokes the model and may produce different timestamps.', idempotent: false },
   props: {
     videoUrl: Property.ShortText({
       displayName: 'Video URL',

--- a/packages/pieces/community/bumpups/src/lib/actions/send-chat.ts
+++ b/packages/pieces/community/bumpups/src/lib/actions/send-chat.ts
@@ -8,6 +8,8 @@ export const sendChat = createAction({
   displayName: 'Send Chat',
   description:
     'Creates an interactive chat response for a given YouTube video using the bump-1.0 model. Provide the video URL and an optional prompt.',
+  audience: 'both',
+  aiMetadata: { description: 'Sends a question or instruction about a public YouTube video to the Bumpups chat model and returns its answer grounded in the video content, with an output-format option for plain text or markdown. Use for free-form queries about a specific video (the general-purpose option versus the fixed description/hashtags/takeaways/titles/timestamps actions); the video URL is required, while the prompt is optional and defaults to a summary if omitted (max 500 chars). Not idempotent — each call invokes the model and may produce different responses.', idempotent: false },
   auth: BumpupsAuth,
   props: {
     videoUrl: Property.ShortText({

--- a/packages/pieces/community/bursty-ai/package.json
+++ b/packages/pieces/community/bursty-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bursty-ai",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bursty-ai/src/lib/actions/run-workflow.ts
+++ b/packages/pieces/community/bursty-ai/src/lib/actions/run-workflow.ts
@@ -8,6 +8,12 @@ export const runWorkflow = createAction({
   displayName: 'Run Workflow',
   description:
     'Run a Bursty AI workflow and optionally wait for and return the results',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Starts (triggers) a BurstyAI no-code AI workflow by its workflow ID, launching a new asynchronous execution. Use to kick off a BurstyAI content/SEO/outreach automation; enable "Wait for Result" to block and poll until the job completes (returns the result, times out after ~10 minutes), or leave it off to fire-and-return the job handle immediately. Not idempotent: each call starts a separate workflow run.',
+    idempotent: false,
+  },
   props: {
     workflow_id: Property.ShortText({
       displayName: 'Workflow ID',

--- a/packages/pieces/community/buttondown/package.json
+++ b/packages/pieces/community/buttondown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-buttondown",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/buttondown/src/lib/actions/create-subscriber.ts
+++ b/packages/pieces/community/buttondown/src/lib/actions/create-subscriber.ts
@@ -14,6 +14,12 @@ export const createSubscriber = createAction({
   name: 'createSubscriber',
   displayName: 'Create Subscriber',
   description: 'Create a new subscriber in Buttondown.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Adds a subscriber to a Buttondown newsletter by email address, with optional tags, metadata, UTM attribution, and referral data. Use "regular" subscriber type to skip double opt-in. Not idempotent: each call creates a subscriber; control duplicate-email handling via collision behavior (default keeps the existing subscriber, or overwrite/merge tags).',
+    idempotent: false,
+  },
   props: {
     email: Property.ShortText({
       displayName: 'Email Address',

--- a/packages/pieces/community/buttondown/src/lib/actions/list-subscribers.ts
+++ b/packages/pieces/community/buttondown/src/lib/actions/list-subscribers.ts
@@ -14,6 +14,12 @@ export const listSubscribers = createAction({
   name: 'listSubscribers',
   displayName: 'List Subscribers',
   description: 'Retrieve subscribers from Buttondown.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists subscribers from a Buttondown newsletter, optionally filtered by type, source, tags, email substring, or referrer URL; with no filters it returns all subscribers. Use to look up or enumerate subscribers. Read-only and idempotent. Returns one page (default 100); pass the returned cursor to page through results.',
+    idempotent: true,
+  },
   props: {
     limit: Property.Number({
       displayName: 'Page Size',

--- a/packages/pieces/community/buttondown/src/lib/actions/send-email.ts
+++ b/packages/pieces/community/buttondown/src/lib/actions/send-email.ts
@@ -15,6 +15,12 @@ export const sendEmail = createAction({
   name: 'sendEmail',
   displayName: 'Send Email',
   description: 'Send an email to your Buttondown subscribers.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates an email in Buttondown from a subject and Markdown/HTML body, then handles it per the chosen delivery status (e.g. send now vs. schedule for a future publish date, or save as draft). Use to broadcast a newsletter or queue one for later. A publish date is required when status is scheduled. Not idempotent: each call creates and may dispatch a new email.',
+    idempotent: false,
+  },
   props: {
     subject: Property.ShortText({
       displayName: 'Subject',

--- a/packages/pieces/community/buttondown/src/lib/common/webhook.ts
+++ b/packages/pieces/community/buttondown/src/lib/common/webhook.ts
@@ -14,6 +14,9 @@ interface CreateButtondownWebhookTriggerParams {
   name: string;
   displayName: string;
   description: string;
+  aiMetadata: {
+    description: string;
+  };
   eventType: ButtondownWebhookEvent;
   sampleData: unknown;
   enrich?: (params: {
@@ -26,6 +29,7 @@ export const createButtondownWebhookTrigger = ({
   name,
   displayName,
   description,
+  aiMetadata,
   eventType,
   sampleData,
   enrich,
@@ -35,6 +39,7 @@ export const createButtondownWebhookTrigger = ({
     name,
     displayName,
     description,
+    aiMetadata,
     type: TriggerStrategy.WEBHOOK,
     props: {
       webhookDescription: Property.ShortText({

--- a/packages/pieces/community/buttondown/src/lib/triggers/email-sent.ts
+++ b/packages/pieces/community/buttondown/src/lib/triggers/email-sent.ts
@@ -7,6 +7,10 @@ export const buttondownEmailSent = createButtondownWebhookTrigger({
   name: 'buttondown_email_sent',
   displayName: 'Email Sent',
   description: 'Triggers when an email is sent from Buttondown.',
+  aiMetadata: {
+    description:
+      'Fires when an email is dispatched to subscribers from Buttondown. Represents a sent newsletter/email; the payload is enriched with the full email details.',
+  },
   eventType: 'email.sent',
   sampleData: {
     event_type: 'email.sent',

--- a/packages/pieces/community/buttondown/src/lib/triggers/new-subscriber.ts
+++ b/packages/pieces/community/buttondown/src/lib/triggers/new-subscriber.ts
@@ -7,6 +7,10 @@ export const buttondownNewSubscriber = createButtondownWebhookTrigger({
   name: 'buttondown_new_subscriber',
   displayName: 'New Subscriber',
   description: 'Triggers when a new subscriber is created.',
+  aiMetadata: {
+    description:
+      'Fires when a subscriber is added to the Buttondown newsletter, regardless of confirmation status. Represents a newly created subscriber record; the payload is enriched with the full subscriber details.',
+  },
   eventType: 'subscriber.created',
   sampleData: {
     event_type: 'subscriber.created',

--- a/packages/pieces/community/buttondown/src/lib/triggers/subscriber-confirmed.ts
+++ b/packages/pieces/community/buttondown/src/lib/triggers/subscriber-confirmed.ts
@@ -7,6 +7,10 @@ export const buttondownSubscriberConfirmed = createButtondownWebhookTrigger({
   name: 'buttondown_subscriber_confirmed',
   displayName: 'Subscriber Confirmed',
   description: 'Triggers when a subscriber confirms their email.',
+  aiMetadata: {
+    description:
+      'Fires when a subscriber completes double opt-in and confirms their email address in Buttondown. Represents a subscriber transitioning to confirmed status; the payload is enriched with the full subscriber details.',
+  },
   eventType: 'subscriber.confirmed',
   sampleData: {
     event_type: 'subscriber.confirmed',

--- a/packages/pieces/community/camb-ai/package.json
+++ b/packages/pieces/community/camb-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-camb-ai",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/camb-ai/src/lib/actions/create-text-to-sound.ts
+++ b/packages/pieces/community/camb-ai/src/lib/actions/create-text-to-sound.ts
@@ -9,6 +9,8 @@ export const createTextToSound = createAction({
     name: 'create_text_to_sound',
     displayName: 'Create Text-to-Sound',
     description: 'Convert input text into “sound effects” using an AI model.',
+    audience: 'both',
+    aiMetadata: { description: 'Generates a sound-effect audio clip from a text prompt describing the desired effect using Camb.AI, polling until the generation task completes and returning the audio. Use to synthesize non-speech sound effects (not spoken voice — use Create Text-to-Speech for that). Duration is capped at 10 seconds (defaults to 8). Not idempotent: each call starts a new generation task and produces fresh audio.', idempotent: false },
     props: {
         prompt: Property.LongText({
             displayName: 'Prompt',

--- a/packages/pieces/community/camb-ai/src/lib/actions/create-text-to-speech.ts
+++ b/packages/pieces/community/camb-ai/src/lib/actions/create-text-to-speech.ts
@@ -9,6 +9,8 @@ export const createTextToSpeech = createAction({
     name: 'create_text_to_speech',
     displayName: 'Create Text-to-Speech',
     description: 'Convert text into speech using a specified voice, language, gender, and age group.',
+    audience: 'both',
+    aiMetadata: { description: 'Synthesizes spoken-voice audio from text via Camb.AI text-to-speech, polling until the task completes and writing the resulting WAV to a file. Requires a language and a voice_id (both selected from Camb.AI dropdowns); optionally tune gender and age. Use for spoken narration/dialogue; for non-speech sound effects use Create Text-to-Sound instead. Not idempotent: each call starts a new synthesis task and produces a new audio file.', idempotent: false },
     props: {
         text: Property.LongText({
             displayName: 'Text',

--- a/packages/pieces/community/camb-ai/src/lib/actions/create-transcription.ts
+++ b/packages/pieces/community/camb-ai/src/lib/actions/create-transcription.ts
@@ -10,6 +10,8 @@ export const createTranscription = createAction({
     name: 'create_transcription',
     displayName: 'Create Transcription',
     description: 'Creates a task to process speech into readable text.',
+    audience: 'both',
+    aiMetadata: { description: 'Transcribes speech from an audio/video source into text via Camb.AI, polling until the transcription task completes. The media can be supplied either as an uploaded file (max 20MB) or as a public file URL, selected via the media source mode; you must specify the spoken language. Use to convert recorded speech to text. Not idempotent: each call starts a new transcription task.', idempotent: false },
     props: {
         language: listSourceLanguagesDropdown,
         source_type: Property.StaticDropdown({

--- a/packages/pieces/community/camb-ai/src/lib/actions/create-translation.ts
+++ b/packages/pieces/community/camb-ai/src/lib/actions/create-translation.ts
@@ -8,6 +8,8 @@ export const createTranslation = createAction({
     name: 'create_translation',
     displayName: 'Create Translation',
     description: 'Translate text from a source language to a target language.',
+    audience: 'both',
+    aiMetadata: { description: 'Translates text from a source language to a target language via Camb.AI, polling until the translation task completes. Each input line is treated as a separate segment to translate, and both languages are chosen from Camb.AI dropdowns; optionally tune formality, gender, and target audience age. Use for text translation only (not audio — use Create Transcription for speech-to-text). Not idempotent: each call starts a new translation task.', idempotent: false },
     props: {
         texts: Property.LongText({
             displayName: 'Text to Translate',

--- a/packages/pieces/community/campaign-monitor/package.json
+++ b/packages/pieces/community/campaign-monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-campaign-monitor",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/campaign-monitor/src/lib/actions/add-subscriber-to-list.ts
+++ b/packages/pieces/community/campaign-monitor/src/lib/actions/add-subscriber-to-list.ts
@@ -10,6 +10,12 @@ export const addSubscriberToListAction = createAction({
   name: 'add_subscriber_to_list',
   displayName: 'Add Subscriber',
   description: 'Adds a new subscriber to a list.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Adds a subscriber (by email) to a specific Campaign Monitor list under a client, optionally setting name, phone, custom fields, and tracking/SMS consent. Choose this to enroll a new contact into an email list; enable Resubscribe to re-add someone who previously unsubscribed. Not idempotent: each call posts a new subscription and may overwrite or re-add the contact, so guard against duplicate runs.',
+    idempotent: false,
+  },
   props: {
     clientId: clientId,
     listId: listId,

--- a/packages/pieces/community/campaign-monitor/src/lib/actions/find-subscriber.ts
+++ b/packages/pieces/community/campaign-monitor/src/lib/actions/find-subscriber.ts
@@ -9,6 +9,12 @@ export const findSubscriberAction = createAction({
   name: 'find_subscriber',
   displayName: 'Find Subscriber',
   description: 'Find a subscriber by email in a specific list.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Looks up a single subscriber by exact email address within a specific Campaign Monitor list under a client, returning their details and tracking preference. Choose this to check whether a contact exists on a list or to read their state before adding/updating; a missing subscriber resolves as not found rather than an error. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     clientId: clientId,
     listId: listId,

--- a/packages/pieces/community/campaign-monitor/src/lib/actions/unsubscribe-subscriber.ts
+++ b/packages/pieces/community/campaign-monitor/src/lib/actions/unsubscribe-subscriber.ts
@@ -10,6 +10,12 @@ export const unsubscribeSubscriberAction = createAction({
   name: 'unsubscribe_subscriber',
   displayName: 'Unsubscribe Subscriber',
   description: 'Remove a subscriber from a list.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Unsubscribes a subscriber, identified by email, from a specific Campaign Monitor list under a client, marking them as opted out. Choose this to suppress a contact from further sends on that list. Idempotent: repeating the call leaves the subscriber in the same unsubscribed state.',
+    idempotent: true,
+  },
   props: {
     clientId: clientId,
     listId: listId,

--- a/packages/pieces/community/campaign-monitor/src/lib/actions/update-subscriber-details.ts
+++ b/packages/pieces/community/campaign-monitor/src/lib/actions/update-subscriber-details.ts
@@ -10,6 +10,12 @@ export const updateSubscriberDetailsAction = createAction({
   name: 'update_subscriber_details',
   displayName: 'Update Subscriber',
   description: 'Update an existing subscriber in a list.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Updates an existing subscriber, identified by their current email address, in a specific Campaign Monitor list under a client — changing name, phone, custom fields, and tracking/SMS consent. Choose this to modify a contact already on a list rather than to add one. Idempotent: it keys on the email and overwrites the same record, so repeating with identical input leaves the subscriber in the same state.',
+    idempotent: true,
+  },
   props: {
     clientId: clientId,
     listId: listId,

--- a/packages/pieces/community/campaign-monitor/src/lib/triggers/new-client.ts
+++ b/packages/pieces/community/campaign-monitor/src/lib/triggers/new-client.ts
@@ -8,6 +8,10 @@ export const newClientTrigger = createTrigger({
   name: 'new_client',
   displayName: 'New Client',
   description: 'Triggered when a new client is added to Campaign Monitor.',
+  aiMetadata: {
+    description:
+      'Fires when a new client account appears in the authenticated Campaign Monitor login, detected by polling the account client list for IDs not previously seen.',
+  },
   props: {},
   type: TriggerStrategy.POLLING,
   sampleData: {

--- a/packages/pieces/community/campaign-monitor/src/lib/triggers/new-subscriber-added.ts
+++ b/packages/pieces/community/campaign-monitor/src/lib/triggers/new-subscriber-added.ts
@@ -10,6 +10,10 @@ export const newSubscriberAddedTrigger = createTrigger({
   name: 'new_subscriber_added',
   displayName: 'New Subscriber Added',
   description: 'Triggered when a new subscriber is added to a list.',
+  aiMetadata: {
+    description:
+      'Fires when a contact subscribes to the specified Campaign Monitor list under a client, via a Subscribe webhook event, and reports the new subscriber together with their details and custom fields.',
+  },
   props: {
     clientId: clientId,
     listId: listId,

--- a/packages/pieces/community/campaign-monitor/src/lib/triggers/subscriber-unsubscribed.ts
+++ b/packages/pieces/community/campaign-monitor/src/lib/triggers/subscriber-unsubscribed.ts
@@ -14,6 +14,10 @@ export const subscriberUnsubscribedTrigger = createTrigger({
   name: 'subscriber_unsubscribed',
   displayName: 'Subscriber Unsubscribed',
   description: 'Triggered when a subscriber unsubscribes from a list',
+  aiMetadata: {
+    description:
+      'Fires when a contact unsubscribes from the specified Campaign Monitor list under a client, via a Deactivate webhook event with an Unsubscribed state, and reports the affected subscriber and their details.',
+  },
   props: {
     clientId: clientId,
     listId: listId,

--- a/packages/pieces/community/canny/package.json
+++ b/packages/pieces/community/canny/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-canny",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/canny/src/lib/actions/create-post.ts
+++ b/packages/pieces/community/canny/src/lib/actions/create-post.ts
@@ -9,6 +9,12 @@ export const createPostAction = createAction({
   name: 'create_post',
   displayName: 'Create Post',
   description: 'Creates a new post on a Canny board.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new feedback post (feature request, bug, etc.) on a Canny board. Use to submit feedback captured elsewhere into Canny. Requires a board ID, an author Canny user ID, a title, and details; creates a distinct post on each call (not idempotent).',
+    idempotent: false,
+  },
   props: {
     boardID: boardIdProp,
     authorID: Property.ShortText({

--- a/packages/pieces/community/canny/src/lib/actions/create-vote.ts
+++ b/packages/pieces/community/canny/src/lib/actions/create-vote.ts
@@ -8,6 +8,12 @@ export const createVoteAction = createAction({
   name: 'create_vote',
   displayName: 'Create Vote',
   description: 'Casts a vote on a post on behalf of a user.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Registers a vote on a Canny post on behalf of a specific user. Use to record support for a feature request when acting as that voter. Requires the post ID and the voter Canny user ID. Effectively idempotent: re-voting the same user on the same post does not add duplicate votes.',
+    idempotent: true,
+  },
   props: {
     postID: Property.ShortText({
       displayName: 'Post ID',

--- a/packages/pieces/community/canny/src/lib/actions/delete-vote.ts
+++ b/packages/pieces/community/canny/src/lib/actions/delete-vote.ts
@@ -8,6 +8,12 @@ export const deleteVoteAction = createAction({
   name: 'delete_vote',
   displayName: 'Delete Vote',
   description: 'Removes a vote from a post for a given user.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      "Removes a specific user's vote from a Canny post. Use to retract support previously registered for a post. Requires the post ID and the voter Canny user ID. Idempotent: removing an already-absent vote leaves the post in the same state.",
+    idempotent: true,
+  },
   props: {
     postID: Property.ShortText({
       displayName: 'Post ID',

--- a/packages/pieces/community/canny/src/lib/actions/list-posts.ts
+++ b/packages/pieces/community/canny/src/lib/actions/list-posts.ts
@@ -8,6 +8,12 @@ export const listPostsAction = createAction({
   name: 'list_posts',
   displayName: 'List Posts',
   description: 'Returns a list of posts for a board, with optional filtering and sorting.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists Canny posts, optionally scoped to one board or queried across all boards when no board is given, with optional search text, status filter, sort order, and pagination (limit/skip). Use to discover or search posts rather than fetch one known post by ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     boardID: Property.Dropdown({
       auth: cannyAuth,

--- a/packages/pieces/community/canny/src/lib/actions/retrieve-post.ts
+++ b/packages/pieces/community/canny/src/lib/actions/retrieve-post.ts
@@ -8,6 +8,12 @@ export const retrievePostAction = createAction({
   name: 'retrieve_post',
   displayName: 'Retrieve Post',
   description: 'Retrieves the details of an existing post by its ID.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Looks up a single Canny post by its unique post ID and returns its full details. Use when you already have a post ID and need its current data (status, score, author, board). Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     id: Property.ShortText({
       displayName: 'Post ID',

--- a/packages/pieces/community/canny/src/lib/triggers/new-comment.ts
+++ b/packages/pieces/community/canny/src/lib/triggers/new-comment.ts
@@ -4,6 +4,10 @@ export const newCommentTrigger = createCannyTrigger({
   name: 'new_comment',
   displayName: 'New Comment',
   description: 'Triggers when a new comment is created on a post.',
+  aiMetadata: {
+    description:
+      'Fires when a new comment is added to any Canny post, delivering the comment along with its author and parent post. Use to react to discussion activity on feedback.',
+  },
   eventType: 'comment.created',
   sampleData: {
     created: '2026-04-06T11:05:00.000Z',

--- a/packages/pieces/community/canny/src/lib/triggers/new-post.ts
+++ b/packages/pieces/community/canny/src/lib/triggers/new-post.ts
@@ -4,6 +4,10 @@ export const newPostTrigger = createCannyTrigger({
   name: 'new_post',
   displayName: 'New Post',
   description: 'Triggers when a new post is created on a Canny board.',
+  aiMetadata: {
+    description:
+      'Fires when a new feedback post is created on any Canny board, delivering the post with its board and author. Use to react to incoming feature requests or feedback as they are submitted.',
+  },
   eventType: 'post.created',
   sampleData: {
     created: '2026-04-06T10:35:59.055Z',

--- a/packages/pieces/community/canny/src/lib/triggers/new-vote.ts
+++ b/packages/pieces/community/canny/src/lib/triggers/new-vote.ts
@@ -4,6 +4,10 @@ export const newVoteTrigger = createCannyTrigger({
   name: 'new_vote',
   displayName: 'New Vote',
   description: 'Triggers when a user votes on a post.',
+  aiMetadata: {
+    description:
+      'Fires when a user casts a vote on a Canny post, delivering the vote with its voter and the parent post. Use to react to changes in demand or support for feedback.',
+  },
   eventType: 'vote.created',
   sampleData: {
     created: '2026-04-06T10:47:47.056Z',

--- a/packages/pieces/community/canny/src/lib/triggers/post-status-changed.ts
+++ b/packages/pieces/community/canny/src/lib/triggers/post-status-changed.ts
@@ -4,6 +4,10 @@ export const postStatusChangedTrigger = createCannyTrigger({
   name: 'post_status_changed',
   displayName: 'Post Status Changed',
   description: "Triggers when a post's status is changed (e.g. open → in progress → complete).",
+  aiMetadata: {
+    description:
+      'Fires when a Canny post moves to a different status (for example open to in progress to complete), delivering the post in its new state. Use to react to changes in how a feature request is progressing.',
+  },
   eventType: 'post.status_changed',
   sampleData: {
     created: '2026-04-06T11:00:00.000Z',

--- a/packages/pieces/community/canny/src/lib/triggers/register-trigger.ts
+++ b/packages/pieces/community/canny/src/lib/triggers/register-trigger.ts
@@ -13,12 +13,14 @@ export function createCannyTrigger({
   name,
   displayName,
   description,
+  aiMetadata,
   eventType,
   sampleData,
 }: {
   name: string;
   displayName: string;
   description: string;
+  aiMetadata: { description: string };
   eventType: CannyEventType;
   sampleData: unknown;
 }) {
@@ -27,6 +29,7 @@ export function createCannyTrigger({
     name,
     displayName,
     description,
+    aiMetadata,
     props: {},
     sampleData,
     type: TriggerStrategy.WEBHOOK,

--- a/packages/pieces/community/capsule-crm/package.json
+++ b/packages/pieces/community/capsule-crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-capsule-crm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/capsule-crm/src/lib/actions/add-note-to-entity.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/add-note-to-entity.ts
@@ -13,6 +13,12 @@ export const addNoteToEntityAction = createAction({
   displayName: 'Add Note to Entity',
   description:
     'Add a comment/note to an entity (e.g., contact, opportunity, project).',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Appends a note entry to one Capsule CRM record, where the entity type selector chooses whether the note attaches to a party (contact), an opportunity, or a project. Use to log a comment or activity against a known record. Not idempotent: each call appends a new note, so repeating it adds duplicate notes.',
+    idempotent: false,
+  },
   props: {
     content: Property.LongText({
       displayName: 'Note Content',

--- a/packages/pieces/community/capsule-crm/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/create-contact.ts
@@ -13,6 +13,12 @@ export const createContactAction = createAction({
   name: 'create_contact',
   displayName: 'Create Contact',
   description: 'Create a new Person or Organisation in Capsule CRM.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new contact record in Capsule CRM. Set the contact type to either a person (requires first and last name, optional linked organisation) or an organisation (requires organisation name); the type selection switches which name fields apply. Use to add a fresh contact you have confirmed does not already exist. Not idempotent: each call creates a separate record, so repeating it produces duplicate contacts.',
+    idempotent: false,
+  },
   props: {
     type: Property.StaticDropdown({
       displayName: 'Contact Type',

--- a/packages/pieces/community/capsule-crm/src/lib/actions/create-opportunity.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/create-opportunity.ts
@@ -16,6 +16,12 @@ export const createOpportunityAction = createAction({
   name: 'create_opportunity',
   displayName: 'Create Opportunity',
   description: 'Create a new Opportunity in Capsule CRM.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new sales opportunity in Capsule CRM linked to a party (contact) and a pipeline milestone, both required. Use to log a new deal once you have the target party and milestone IDs. Not idempotent: each call creates a separate opportunity, so repeating it produces duplicates.',
+    idempotent: false,
+  },
   props: {
     partyId: Property.Dropdown({
       displayName: 'Party',

--- a/packages/pieces/community/capsule-crm/src/lib/actions/create-project.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/create-project.ts
@@ -16,6 +16,12 @@ export const createProjectAction = createAction({
   name: 'create_project',
   displayName: 'Create Project',
   description: 'Create a new Project in Capsule CRM.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new project (case) in Capsule CRM tied to a required party (contact), with optional links to an opportunity, stage, owner, team, tags, and custom fields. Use to open a new piece of work for a contact. Not idempotent: each call creates a separate project, so repeating it produces duplicates.',
+    idempotent: false,
+  },
   props: {
     partyId: Property.Dropdown({
       auth: capsuleCrmAuth,

--- a/packages/pieces/community/capsule-crm/src/lib/actions/create-task.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/create-task.ts
@@ -12,6 +12,12 @@ export const createTaskAction = createAction({
   name: 'create_task',
   displayName: 'Create Task',
   description: 'Create a new Task in Capsule CRM.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new task in Capsule CRM with a description and due date, optionally linked to exactly one entity chosen via the Link To selector (a party/contact, an opportunity, or a project). Use to schedule a to-do or follow-up. Not idempotent: each call creates a separate task, so repeating it produces duplicates.',
+    idempotent: false,
+  },
   props: {
     description: Property.ShortText({
       displayName: 'Description',

--- a/packages/pieces/community/capsule-crm/src/lib/actions/find-contact.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/find-contact.ts
@@ -7,6 +7,12 @@ export const findContactAction = createAction({
   name: 'find_contact',
   displayName: 'Find Contact',
   description: 'Find a Person by search criteria.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Searches Capsule CRM contacts by a free-text term (such as a name or email) and returns only matches of type person, filtering out organisations. Use to look up an existing person before creating or referencing one. Idempotent: it is a read-only search that does not modify any data.',
+    idempotent: true,
+  },
   props: {
     term: Property.ShortText({
       displayName: 'Search Term',

--- a/packages/pieces/community/capsule-crm/src/lib/actions/find-opportunity.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/find-opportunity.ts
@@ -8,6 +8,12 @@ export const findOpportunityAction = createAction({
   name: 'find_opportunity',
   displayName: 'Find Opportunity',
   description: 'Find an Opportunity by search criteria.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      "Finds Capsule CRM opportunities matching a structured filter query (a conditions array of field/operator/value clauses, per Capsule's filter API). Use to locate opportunities by field criteria rather than a free-text term. Idempotent: it is a read-only filter that does not modify any data.",
+    idempotent: true,
+  },
   props: {
     filter: Property.Json({
       displayName: 'Filter',

--- a/packages/pieces/community/capsule-crm/src/lib/actions/find-project.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/find-project.ts
@@ -8,6 +8,12 @@ export const findProjectAction = createAction({
   name: 'find_project',
   displayName: 'Find Project',
   description: 'Find a Project by search criteria.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      "Finds Capsule CRM projects (cases) matching a structured filter query (a conditions array of field/operator/value clauses, per Capsule's filter API). Use to locate projects by field criteria rather than a free-text term. Idempotent: it is a read-only filter that does not modify any data.",
+    idempotent: true,
+  },
   props: {
     filter: Property.Json({
       displayName: 'Filter',

--- a/packages/pieces/community/capsule-crm/src/lib/actions/update-contact.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/update-contact.ts
@@ -13,6 +13,12 @@ export const updateContactAction = createAction({
   name: 'update_contact',
   displayName: 'Update Contact',
   description: 'Update fields on an existing Person or Organisation.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Updates fields on an existing Capsule CRM contact identified by its contact ID. Editable fields depend on whether the contact is a person or an organisation, and nested email, phone, address, and website entries can be added or removed (each supports a delete flag). Use when you already know the target contact ID; only provided fields are changed. Not idempotent because it issues a mutating update on each call.',
+    idempotent: false,
+  },
   props: {
     contact_id: capsuleCrmProps.contact_id(),
     contactFields: Property.DynamicProperties({

--- a/packages/pieces/community/capsule-crm/src/lib/actions/update-opportunity.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/actions/update-opportunity.ts
@@ -16,6 +16,12 @@ export const updateOpportunityAction = createAction({
   name: 'update_opportunity',
   displayName: 'Update Opportunity',
   description: 'Update an existing Opportunity in Capsule CRM.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Updates an existing Capsule CRM opportunity identified by its opportunity ID, changing fields such as name, milestone, value, probability, duration, owner, team, tags, and custom fields. Tags and custom-field entries each support a delete flag for removal. Use when you already know the target opportunity ID; only provided fields are changed. Not idempotent because it issues a mutating update on each call.',
+    idempotent: false,
+  },
   props: {
     opportunityId: Property.Dropdown({
       auth: capsuleCrmAuth,

--- a/packages/pieces/community/capsule-crm/src/lib/common/trigger.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/common/trigger.ts
@@ -9,6 +9,7 @@ type TriggerParams = {
   name: string;
   displayName: string;
   description: string;
+  aiMetadata: { description: string };
   event: string;
   sampleData: unknown;
 };
@@ -17,6 +18,7 @@ export const capsuleCrmCreateTrigger = ({
   name,
   displayName,
   description,
+  aiMetadata,
   event,
   sampleData,
 }: TriggerParams) => {
@@ -25,6 +27,7 @@ export const capsuleCrmCreateTrigger = ({
     name: name,
     displayName: displayName,
     description: description,
+    aiMetadata: aiMetadata,
     props: {},
     type: TriggerStrategy.WEBHOOK,
     sampleData: sampleData,

--- a/packages/pieces/community/capsule-crm/src/lib/triggers/new-case.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/triggers/new-case.ts
@@ -4,6 +4,10 @@ export const newCaseTrigger = capsuleCrmCreateTrigger({
   name: 'new_case',
   displayName: 'New Case',
   description: 'Fires when a new case (project) is created in Capsule CRM.',
+  aiMetadata: {
+    description:
+      'Fires when a new case (project) is created in Capsule CRM, delivering the created case record. Use to react to newly opened cases.',
+  },
   event: 'kase/created',
   sampleData: {
     event: 'kase/created',

--- a/packages/pieces/community/capsule-crm/src/lib/triggers/new-opportunity.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/triggers/new-opportunity.ts
@@ -4,6 +4,10 @@ export const newOpportunityTrigger = capsuleCrmCreateTrigger({
   name: 'new_opportunity',
   displayName: 'New Opportunity',
   description: 'Fires when a new opportunity is created.',
+  aiMetadata: {
+    description:
+      'Fires when a new opportunity (deal) is created in Capsule CRM, delivering the created opportunity record. Use to react to newly added deals entering the pipeline.',
+  },
   event: 'opportunity/created',
   sampleData: {
     event: 'opportunity/created',

--- a/packages/pieces/community/capsule-crm/src/lib/triggers/new-project.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/triggers/new-project.ts
@@ -4,6 +4,10 @@ export const newProjectTrigger = capsuleCrmCreateTrigger({
   name: 'new_project',
   displayName: 'New Project',
   description: 'Fires when a project is created.',
+  aiMetadata: {
+    description:
+      'Fires when a new project (case) is created in Capsule CRM, delivering the created project record. Use to react to newly opened projects.',
+  },
   event: 'kase/created',
   sampleData: {
     event: 'kase/created',

--- a/packages/pieces/community/capsule-crm/src/lib/triggers/new-task.ts
+++ b/packages/pieces/community/capsule-crm/src/lib/triggers/new-task.ts
@@ -4,6 +4,10 @@ export const newTaskTrigger = capsuleCrmCreateTrigger({
   name: 'new_task',
   displayName: 'New Task',
   description: 'Fires when a new task is created.',
+  aiMetadata: {
+    description:
+      'Fires when a new task is created in Capsule CRM, delivering the created task record. Use to react to newly scheduled to-dos or follow-ups.',
+  },
   event: 'task/created',
   sampleData: {
     event: 'task/created',

--- a/packages/pieces/community/captain-data/package.json
+++ b/packages/pieces/community/captain-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-captain-data",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/captain-data/src/lib/actions/get-job-results.ts
+++ b/packages/pieces/community/captain-data/src/lib/actions/get-job-results.ts
@@ -10,6 +10,12 @@ export const getJobResults = createAction({
   name: 'getJobResults',
   displayName: 'Get job results',
   description: 'Get all results for a specific job',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves all output records produced by a specific Captain Data job (a single past run of a workflow), identified by its workflow UID and job UID. Use this to read the data a launched workflow has gathered. Read-only and idempotent; results are not paginated.',
+    idempotent: true,
+  },
   auth: captainDataAuth,
   props: {
     workflow: workflowProp,

--- a/packages/pieces/community/captain-data/src/lib/actions/launch-workflow.ts
+++ b/packages/pieces/community/captain-data/src/lib/actions/launch-workflow.ts
@@ -9,6 +9,12 @@ export const launchWorkflow = createAction({
   name: 'launchWorkflow',
   displayName: 'Launch a workflow',
   description: '',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Schedules a run of an existing Captain Data workflow, identified by its workflow UID, optionally supplying input rows, per-step account/parameter configuration, and a start delay. Use this to kick off a scraping/enrichment automation; it creates a new job on each call, so it is not idempotent. Each step requires the account UIDs and step UID matching the workflow definition.',
+    idempotent: false,
+  },
   auth: captainDataAuth,
   props: {
     workflow: workflowProp,

--- a/packages/pieces/community/carbone/package.json
+++ b/packages/pieces/community/carbone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-carbone",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/carbone/src/lib/actions/delete-template.ts
+++ b/packages/pieces/community/carbone/src/lib/actions/delete-template.ts
@@ -13,6 +13,11 @@ export const deleteTemplateAction = createAction({
   name: 'carbone_delete_template',
   displayName: 'Delete Template',
   description: 'Delete a Carbone template by its ID.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Permanently deletes a stored Carbone template (or specific version) identified by its template/version ID. Use to remove a template that is no longer needed. Not idempotent: the first call removes the template and a repeat call on the same ID fails because it no longer exists.',
+    idempotent: false,
+  },
   props: {
     templateId: carboneProps.templateDropdown({
       displayName: 'Template ID or Version ID',

--- a/packages/pieces/community/carbone/src/lib/actions/list-categories.ts
+++ b/packages/pieces/community/carbone/src/lib/actions/list-categories.ts
@@ -14,6 +14,11 @@ export const listCategoriesAction = createAction({
   name: 'carbone_list_categories',
   displayName: 'List Categories',
   description: 'List all categories used to organize your Carbone templates.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Returns all category names currently used to organize Carbone templates. Use to discover valid category values before filtering, uploading, or updating templates. Idempotent: read-only lookup with no inputs.',
+    idempotent: true,
+  },
   props: {},
   async run(context) {
     const request: HttpRequest = {

--- a/packages/pieces/community/carbone/src/lib/actions/list-tags.ts
+++ b/packages/pieces/community/carbone/src/lib/actions/list-tags.ts
@@ -13,6 +13,11 @@ export const listTagsAction = createAction({
   name: 'carbone_list_tags',
   displayName: 'List Tags',
   description: 'List all tags used to organize your Carbone templates.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Returns all tag names currently used to organize Carbone templates. Use to discover valid tag values before filtering, uploading, or updating templates. Idempotent: read-only lookup with no inputs.',
+    idempotent: true,
+  },
   props: {},
   async run(context) {
     const request: HttpRequest = {

--- a/packages/pieces/community/carbone/src/lib/actions/list-templates.ts
+++ b/packages/pieces/community/carbone/src/lib/actions/list-templates.ts
@@ -15,6 +15,11 @@ export const listTemplatesAction = createAction({
   displayName: 'List Templates',
   description:
     'Retrieve a list of deployed Carbone templates with filtering and pagination.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Lists deployed Carbone templates, optionally narrowed by template ID, version ID, category, or a fuzzy name search, with cursor-based pagination. Leaving all filters empty returns all templates; supplying a filter restricts to matches. Use to discover available templates or look up a template ID before rendering, updating, or deleting. Idempotent: read-only lookup.',
+    idempotent: true,
+  },
   props: {
     id: Property.ShortText({
       displayName: 'Template ID Filter (optional)',

--- a/packages/pieces/community/carbone/src/lib/actions/render-document.ts
+++ b/packages/pieces/community/carbone/src/lib/actions/render-document.ts
@@ -14,6 +14,11 @@ export const renderDocumentAction = createAction({
   name: 'carbone_render_document',
   displayName: 'Render Document',
   description: 'Render a Carbone template with JSON data and download the generated document.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Merges a stored Carbone template (referenced by template ID) with a JSON data object and produces the generated document, optionally converting it to another format such as PDF, XLSX, or DOCX. Use this to produce a finished report or document from a template the agent has already uploaded; the JSON keys must match the `{d.variableName}` placeholders in the template. Not idempotent: each call generates and writes a new output file.',
+    idempotent: false,
+  },
   props: {
     templateId: carboneProps.templateDropdown({
       displayName: 'Template ID',

--- a/packages/pieces/community/carbone/src/lib/actions/update-template.ts
+++ b/packages/pieces/community/carbone/src/lib/actions/update-template.ts
@@ -15,6 +15,11 @@ export const updateTemplateAction = createAction({
   name: 'carbone_update_template',
   displayName: 'Update Template Metadata',
   description: 'Update the metadata of an existing Carbone template.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Updates metadata (name, comment, category, tags, deploy/expire timestamps) on an existing Carbone template or version identified by its ID; only the fields supplied are changed and tags are replaced wholesale. Use to rename, recategorize, or schedule deployment/expiry of a stored template. Idempotent: repeating the call with the same fields leaves the template in the same end state.',
+    idempotent: true,
+  },
   props: {
     templateId: carboneProps.templateDropdown({
       displayName: 'Template ID or Version ID',

--- a/packages/pieces/community/carbone/src/lib/actions/upload-template.ts
+++ b/packages/pieces/community/carbone/src/lib/actions/upload-template.ts
@@ -10,6 +10,11 @@ export const uploadTemplateAction = createAction({
   name: 'carbone_upload_template',
   displayName: 'Upload Template',
   description: 'Upload a template file to Carbone and get a template ID for rendering.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Uploads a template file (DOCX, XLSX, ODS, ODT, PPTX, CSV, or HTML) to Carbone and returns a template ID used later by the render action. Operates in two modes: by default it creates a new versioned template, or when an existing template ID is supplied it adds the file as a new version of that template. Use before rendering when the target template is not yet stored in Carbone. Not idempotent: each call uploads a new template or template version.',
+    idempotent: false,
+  },
   props: {
     file: Property.File({
       displayName: 'Template File',

--- a/packages/pieces/community/cartloom/package.json
+++ b/packages/pieces/community/cartloom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-cartloom",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/cartloom/src/lib/actions/create-discount.ts
+++ b/packages/pieces/community/cartloom/src/lib/actions/create-discount.ts
@@ -8,6 +8,8 @@ export const createDiscountAction = createAction({
   auth: cartloomAuth,
   displayName: 'Create Discount',
   description: 'Create a discount in Cartloom',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new discount in the connected Cartloom store, as either a fixed-amount or percentage discount applied to all products, selected products, or the order total. Use to set up a promotion or coupon; supply a code for a redeemable coupon or leave it blank for an automatic discount, and provide start/stop dates. Not idempotent — each call creates a separate discount.', idempotent: false },
   props: {
     title: Property.ShortText({
       displayName: 'Title',

--- a/packages/pieces/community/cartloom/src/lib/actions/get-discount.ts
+++ b/packages/pieces/community/cartloom/src/lib/actions/get-discount.ts
@@ -7,6 +7,8 @@ export const getDiscountAction = createAction({
   auth: cartloomAuth,
   displayName: 'Get Discount',
   description: 'Get discount info from Cartloom',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves the details of a single Cartloom discount by its discount ID. Use when you have a specific discount ID; to list discounts without an ID, use Get All Discounts. Read-only and idempotent.', idempotent: true },
   props: {
     discountId: Property.ShortText({
       displayName: 'Discount ID',

--- a/packages/pieces/community/cartloom/src/lib/actions/get-discounts.ts
+++ b/packages/pieces/community/cartloom/src/lib/actions/get-discounts.ts
@@ -7,6 +7,8 @@ export const getAllDiscountsAction = createAction({
   auth: cartloomAuth,
   displayName: 'Get All Discounts',
   description: 'Get a list of discounts from Cartloom',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves the full list of discounts configured in the connected Cartloom store. Use to browse existing discounts or find a discount ID before fetching one specific discount. Takes no input and returns all discounts; read-only and idempotent.', idempotent: true },
   props: {},
   async run(context) {
     return await getAllDiscounts(context.auth.props);

--- a/packages/pieces/community/cartloom/src/lib/actions/get-order.ts
+++ b/packages/pieces/community/cartloom/src/lib/actions/get-order.ts
@@ -7,6 +7,8 @@ export const getOrderAction = createAction({
   auth: cartloomAuth,
   displayName: 'Get Order',
   description: 'Get an order from Cartloom',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves a single Cartloom order by its invoice ID. Use when you already know the exact invoice ID and want that one order; to find orders without an invoice ID, use the date- or email-based order search instead. Read-only and idempotent.', idempotent: true },
   props: {
     invoice: Property.ShortText({
       displayName: 'Invoice ID',

--- a/packages/pieces/community/cartloom/src/lib/actions/get-orders-date-email.ts
+++ b/packages/pieces/community/cartloom/src/lib/actions/get-orders-date-email.ts
@@ -7,6 +7,8 @@ export const getOrderEmailAction = createAction({
   auth: cartloomAuth,
   displayName: 'Get Order by Email',
   description: 'Get a list of orders for an email within a date range',
+  audience: 'both',
+  aiMetadata: { description: "Lists Cartloom orders placed by a specific customer email address within a date range. Use to find a customer's order history; use Get Order by Date to list all orders regardless of customer. Requires the email and a start date; the end date defaults to today. Read-only and idempotent.", idempotent: true },
   props: {
     start: Property.DateTime({
       displayName: 'Start Date',

--- a/packages/pieces/community/cartloom/src/lib/actions/get-orders-date.ts
+++ b/packages/pieces/community/cartloom/src/lib/actions/get-orders-date.ts
@@ -7,6 +7,8 @@ export const getOrderDateAction = createAction({
   auth: cartloomAuth,
   displayName: 'Get Order by Date',
   description: 'Get a list of orders from Cartloom within a date range',
+  audience: 'both',
+  aiMetadata: { description: 'Lists all Cartloom orders placed within a date range. Use to retrieve orders for a period when you do not have specific invoice IDs; to narrow results to one customer, use Get Order by Email instead. Requires a start date; the end date defaults to today. Read-only and idempotent.', idempotent: true },
   props: {
     start: Property.DateTime({
       displayName: 'Start Date',

--- a/packages/pieces/community/cartloom/src/lib/actions/get-products.ts
+++ b/packages/pieces/community/cartloom/src/lib/actions/get-products.ts
@@ -7,6 +7,8 @@ export const getProductsAction = createAction({
   auth: cartloomAuth,
   displayName: 'Get Products',
   description: 'Get a list of products from Cartloom',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves the full list of products from the connected Cartloom store. Use to discover available products and their IDs (for example before creating a discount targeting specific products). Takes no input and returns all products; read-only and idempotent.', idempotent: true },
   props: {},
   async run(context) {
     return await getProducts(context.auth.props);

--- a/packages/pieces/community/cashfree-payments/package.json
+++ b/packages/pieces/community/cashfree-payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-cashfree-payments",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/cashfree-payments/src/lib/actions/cancel-payment-link.ts
+++ b/packages/pieces/community/cashfree-payments/src/lib/actions/cancel-payment-link.ts
@@ -7,6 +7,11 @@ export const cancelPaymentLink = createAction({
   name: 'cancel-payment-link',
   displayName: 'Cancel Payment Link',
   description: 'Cancel a payment link in Cashfree Payment Gateway. Only links in ACTIVE status can be cancelled.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Cancels an existing Cashfree payment link, identified by its Link ID, so it can no longer be paid. Use this to revoke a link you previously issued. Only links in ACTIVE status can be cancelled (already-cancelled or paid links return a conflict). Cancelling an already-cancelled link has no further effect, but the operation mutates link state and is not treated as idempotent.',
+    idempotent: false,
+  },
   requireAuth: true,
   props: {
     environment: Property.StaticDropdown({

--- a/packages/pieces/community/cashfree-payments/src/lib/actions/create-cashgram.ts
+++ b/packages/pieces/community/cashfree-payments/src/lib/actions/create-cashgram.ts
@@ -7,6 +7,11 @@ export const createCashgram = createAction({
   name: 'create-cashgram',
   displayName: 'Create Cashgram',
   description: 'Create a Cashgram for instant money transfers using Cashfree',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Creates a Cashfree Payout "Cashgram" — a shareable link that lets a contact claim a money transfer for a given amount — addressed to a name and phone, with an expiry within 30 days. Use this to disburse funds without knowing the recipient bank details. Each call creates a new payout keyed on the caller-supplied Cashgram ID (a duplicate ID returns a conflict), and it moves money, so it is not idempotent.',
+    idempotent: false,
+  },
   requireAuth: true,
   props: {
     environment: Property.StaticDropdown({

--- a/packages/pieces/community/cashfree-payments/src/lib/actions/create-order.ts
+++ b/packages/pieces/community/cashfree-payments/src/lib/actions/create-order.ts
@@ -6,6 +6,11 @@ export const createOrder = createAction({
   name: 'create-order',
   displayName: 'Create Order',
   description: 'Creates an order in Cashfree Payment Gateway',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Creates a payment order in the Cashfree Payment Gateway (PG) given an amount, currency, and customer details, returning the order and its session for collecting payment. Use this to start a checkout/payment flow. Targets sandbox or production via the Environment prop; if no Order ID is supplied a unique one is auto-generated, so each call creates a distinct order and is not idempotent.',
+    idempotent: false,
+  },
   auth: cashfreePaymentsAuth,
   props: {
     environment: Property.StaticDropdown({

--- a/packages/pieces/community/cashfree-payments/src/lib/actions/create-payment-link.ts
+++ b/packages/pieces/community/cashfree-payments/src/lib/actions/create-payment-link.ts
@@ -6,6 +6,11 @@ export const createPaymentLink = createAction({
   name: 'create-payment-link',
   displayName: 'Create Payment Link',
   description: 'Creates a payment link in Cashfree Payment Gateway',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Creates a shareable Cashfree payment link for a given amount, currency, and purpose that a customer can pay through, optionally sending it via SMS/email and supporting partial payments. Use this to collect payment without building a full checkout. Targets sandbox or production via the Environment prop; if no Link ID is supplied a unique one is auto-generated, so each call creates a new link and is not idempotent.',
+    idempotent: false,
+  },
   auth: cashfreePaymentsAuth,
   props: {
     environment: Property.StaticDropdown({

--- a/packages/pieces/community/cashfree-payments/src/lib/actions/create-refund.ts
+++ b/packages/pieces/community/cashfree-payments/src/lib/actions/create-refund.ts
@@ -7,6 +7,11 @@ export const createRefund = createAction({
   name: 'create-refund',
   displayName: 'Create Refund',
   description: 'Initiate a refund for a Cashfree order. Refunds can only be initiated within six months of the original transaction.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Initiates a refund against an existing Cashfree order, identified by its Order ID, for a specified refund amount (must not exceed the original transaction) and a caller-supplied Refund ID. Use this to return money to a customer for a completed payment; refunds are only allowed within six months of the original transaction. Each call moves money so it is not idempotent, though passing the same Refund ID (or the optional Idempotency Key header) lets Cashfree deduplicate retries.',
+    idempotent: false,
+  },
   requireAuth: true,
   props: {
     environment: Property.StaticDropdown({

--- a/packages/pieces/community/cashfree-payments/src/lib/actions/deactivate-cashgram.ts
+++ b/packages/pieces/community/cashfree-payments/src/lib/actions/deactivate-cashgram.ts
@@ -7,6 +7,11 @@ export const deactivateCashgram = createAction({
   name: 'deactivate-cashgram',
   displayName: 'Deactivate Cashgram',
   description: 'Deactivate a Cashgram to prevent further redemptions using Cashfree',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Deactivates an existing Cashfree Payout Cashgram, identified by its Cashgram ID, so the recipient can no longer redeem it. Use this to revoke a money-transfer link you previously created. Deactivating an already-deactivated Cashgram returns a conflict; the operation mutates payout state and is not treated as idempotent.',
+    idempotent: false,
+  },
   requireAuth: true,
   props: {
     environment: Property.StaticDropdown({

--- a/packages/pieces/community/cashfree-payments/src/lib/actions/fetch-payment-link-details.ts
+++ b/packages/pieces/community/cashfree-payments/src/lib/actions/fetch-payment-link-details.ts
@@ -6,6 +6,11 @@ export const fetchPaymentLinkDetails = createAction({
   name: 'fetch-payment-link-details',
   displayName: 'Fetch Payment Link Details',
   description: 'View all details and status of a payment link in Cashfree Payment Gateway',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Retrieves the full details and current status of a single Cashfree payment link identified by its Link ID. Use this to check whether a link is active, expired, or paid, or to read back its configuration. Read-only lookup, so it is idempotent.',
+    idempotent: true,
+  },
   requireAuth: true,
   auth: cashfreePaymentsAuth,
   props: {

--- a/packages/pieces/community/cashfree-payments/src/lib/actions/get-all-refunds-for-order.ts
+++ b/packages/pieces/community/cashfree-payments/src/lib/actions/get-all-refunds-for-order.ts
@@ -7,6 +7,11 @@ export const getAllRefundsForOrder = createAction({
   name: 'get-all-refunds-for-order',
   displayName: 'Get All Refunds for Order',
   description: 'Fetch all refunds processed against an order in Cashfree Payment Gateway',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Lists all refunds processed against a Cashfree order, identified by its Order ID, with summary totals and per-refund status. Use this to check refund progress or reconcile refunds for an order. Read-only listing, so it is idempotent.',
+    idempotent: true,
+  },
   requireAuth: true,
   props: {
     environment: Property.StaticDropdown({

--- a/packages/pieces/community/cashfree-payments/src/lib/actions/get-orders-for-payment-link.ts
+++ b/packages/pieces/community/cashfree-payments/src/lib/actions/get-orders-for-payment-link.ts
@@ -7,6 +7,11 @@ export const getOrdersForPaymentLink = createAction({
   name: 'get-orders-for-payment-link',
   displayName: 'Get Orders for Payment Link',
   description: 'View all order details for a payment link in Cashfree Payment Gateway',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Lists the orders associated with a Cashfree payment link, identified by its Link ID, along with summary totals. Use this to see who paid a link and reconcile collections. The Order Status Filter selects between all orders or paid-only (the default); read-only listing, so it is idempotent.',
+    idempotent: true,
+  },
   requireAuth: true,
   props: {
     environment: Property.StaticDropdown({

--- a/packages/pieces/community/certopus/package.json
+++ b/packages/pieces/community/certopus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-certopus",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/certopus/src/lib/actions/create-credential.ts
+++ b/packages/pieces/community/certopus/src/lib/actions/create-credential.ts
@@ -21,6 +21,11 @@ export const createCredential = createAction({
   name: 'create_credential',
   displayName: 'Create Credential',
   description: 'Create a credential',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Issues a Certopus certificate/credential for a single recipient under a given organisation, event, and category, supplying the recipient email plus the category-specific data fields. Use to grant a certificate to one person; the generate and publish flags control whether Certopus immediately produces and publishes it. Not idempotent — each call creates a new credential, so repeating it issues duplicates.',
+    idempotent: false,
+  },
   props: {
     organisation: Property.Dropdown({
       auth: certopusAuth,

--- a/packages/pieces/community/chain-aware/package.json
+++ b/packages/pieces/community/chain-aware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chain-aware",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/chain-aware/src/lib/actions/audit-wallet-address.ts
+++ b/packages/pieces/community/chain-aware/src/lib/actions/audit-wallet-address.ts
@@ -8,6 +8,11 @@ export const auditWalletAddress = createAction({
   name: 'auditWalletAddress',
   displayName: 'Audit Wallet Address',
   description: 'Audit a wallet address for fraud risk',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Run a ChainAware fraud-risk audit on a single on-chain wallet address for a given network (e.g. ethereum, bsc). Choose this for a broad risk overview of a wallet; use Fraud Check when you specifically need a fraud-probability score. Requires the network name and wallet address. Read-only analysis — idempotent.',
+    idempotent: true,
+  },
   props: {
     network: Property.ShortText({
       displayName: 'Network',

--- a/packages/pieces/community/chain-aware/src/lib/actions/credit-score.ts
+++ b/packages/pieces/community/chain-aware/src/lib/actions/credit-score.ts
@@ -8,6 +8,11 @@ export const creditScore = createAction({
   name: 'creditScore',
   displayName: 'Credit Score',
   description: "Get a user's credit score",
+  audience: 'both',
+  aiMetadata: {
+    description: 'Look up the ChainAware on-chain credit score for a wallet address on a given network. Choose this to assess a wallet\'s creditworthiness or borrowing history rather than fraud risk. Requires the network name and wallet address. Read-only lookup — idempotent.',
+    idempotent: true,
+  },
   props: {
     network: Property.ShortText({
       displayName: 'Network',

--- a/packages/pieces/community/chain-aware/src/lib/actions/fraud-check.ts
+++ b/packages/pieces/community/chain-aware/src/lib/actions/fraud-check.ts
@@ -8,6 +8,11 @@ export const fraudCheck = createAction({
   name: 'fraudCheck',
   displayName: 'Fraud Check',
   description: 'Calculate fraud probability for a wallet address',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Calculate a ChainAware fraud-probability score for a wallet address on a given network. Choose this when you need a quantified fraud likelihood for a wallet; the optional "Only Fraud" flag narrows the result to fraud-related signals only. Requires the network name and wallet address. Read-only analysis — idempotent.',
+    idempotent: true,
+  },
   props: {
     network: Property.ShortText({
       displayName: 'Network',

--- a/packages/pieces/community/chain-aware/src/lib/actions/rug-pull-check.ts
+++ b/packages/pieces/community/chain-aware/src/lib/actions/rug-pull-check.ts
@@ -8,6 +8,11 @@ export const rugPullCheck = createAction({
   name: 'rugPullCheck',
   displayName: 'Rug Pull Check',
   description: 'Calculate fraud probability for a contract address',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Calculate a ChainAware rug-pull / fraud-probability score for a smart-contract address (e.g. a token contract) on a given network. Choose this when assessing a token or contract rather than a user wallet — for wallets use Fraud Check instead. Requires the network name and contract address. Read-only analysis — idempotent.',
+    idempotent: true,
+  },
   props: {
     network: Property.ShortText({
       displayName: 'Network',

--- a/packages/pieces/community/chain-aware/src/lib/actions/wallet-segment.ts
+++ b/packages/pieces/community/chain-aware/src/lib/actions/wallet-segment.ts
@@ -8,6 +8,11 @@ export const walletSegment = createAction({
   name: 'walletSegment',
   displayName: 'Wallet Segment',
   description: 'Get wallet behaviour information',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Retrieve ChainAware behavioural segmentation for a wallet address on a given network — how the wallet is categorized based on its on-chain activity. Choose this to profile or classify a wallet rather than score its fraud risk. Requires the network name and wallet address. Read-only lookup — idempotent.',
+    idempotent: true,
+  },
   props: {
     network: Property.ShortText({
       displayName: 'Network',

--- a/packages/pieces/community/chainalysis-api/package.json
+++ b/packages/pieces/community/chainalysis-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chainalysis-api",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/chainalysis-api/src/lib/actions/check-address-sanction.ts
+++ b/packages/pieces/community/chainalysis-api/src/lib/actions/check-address-sanction.ts
@@ -5,6 +5,8 @@ export const checkAddressSanction = createAction({
   name: 'checkAddressSanction',
   displayName: 'Check Address Sanctions',
   description: 'Check if an address is sanctioned',
+  audience: 'both',
+  aiMetadata: { description: 'Screens a single blockchain address against Chainalysis sanctions data to determine whether it is associated with a sanctioned entity. Use this when you need to verify the sanctions/compliance status of a wallet address before transacting or onboarding. Takes one address string; this is a read-only lookup and is safe to repeat.', idempotent: true },
   auth: chainalysisApiAuth,
   requireAuth: true,
   props: {

--- a/packages/pieces/community/chaindesk/package.json
+++ b/packages/pieces/community/chaindesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chaindesk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/chaindesk/src/lib/actions/query-agent.ts
+++ b/packages/pieces/community/chaindesk/src/lib/actions/query-agent.ts
@@ -13,6 +13,8 @@ export const queryAgentAction = createAction({
   name: 'query-agent',
   auth: chaindeskAuth,
   description: 'Asks question to your Agent.',
+  audience: 'both',
+  aiMetadata: { description: 'Sends a query to a specific Chaindesk agent (selected by agent ID) and returns its generated answer. Use to get a conversational AI response grounded in the agent\'s configured datastores. Pass a conversation ID to continue an existing thread, or omit it to start a new conversation. Not idempotent: each call is a generative request and may create a new conversation.', idempotent: false },
   props: {
     agentId: agentIdDropdown,
     query: Property.LongText({

--- a/packages/pieces/community/chaindesk/src/lib/actions/query-datastore.ts
+++ b/packages/pieces/community/chaindesk/src/lib/actions/query-datastore.ts
@@ -13,6 +13,8 @@ export const queryDatastoretAction = createAction({
   name: 'query-datastore',
   auth: chaindeskAuth,
   description: 'Asks question to your Datastore.',
+  audience: 'both',
+  aiMetadata: { description: 'Runs a semantic search query against a specific Chaindesk datastore (selected by datastore ID) and returns the matching documents/chunks. Use to retrieve relevant knowledge-base content for a question without invoking an agent. Read-only and idempotent: the same query returns the same matches with no side effects.', idempotent: true },
   props: {
     datastoreId: datastoreIdDropdown,
     query: Property.LongText({

--- a/packages/pieces/community/chaindesk/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/chaindesk/src/lib/actions/upload-file.ts
@@ -14,6 +14,8 @@ export const uploadFileAction = createAction({
   name: 'upload-file',
   displayName: 'Upload File',
   description: 'Uploads a new file to provided Datastore.',
+  audience: 'both',
+  aiMetadata: { description: 'Uploads a file as a new datasource into a specific Chaindesk datastore (selected by datastore ID), ingesting its content into the knowledge base. Use to add documents an agent or datastore search can later draw on; requires the binary file input. Not idempotent: each call creates a new datasource, so repeating uploads the same file again.', idempotent: false },
   props: {
     datastoreId: datastoreIdDropdown,
     file: Property.File({

--- a/packages/pieces/community/chargebee/package.json
+++ b/packages/pieces/community/chargebee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chargebee",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/chargebee/src/lib/actions/cancel-subscription.ts
+++ b/packages/pieces/community/chargebee/src/lib/actions/cancel-subscription.ts
@@ -10,6 +10,12 @@ export const cancelSubscription = createAction({
   displayName: 'Cancel Subscription',
   description:
     'Cancel a Chargebee subscription immediately, at end of term, or on a specific date.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Cancel a Chargebee subscription by ID, with control over timing (immediately, end of term, or a specific date) and, for subscriptions with a contract term, a separate contract-term cancel option plus optional termination fee. Use when an agent needs to end a subscription rather than pause or change it. Requires the subscription ID; the timing and credit/refund handling depend on whether the subscription has a contract term. Repeating the call does not re-cancel an already-cancelled subscription, but it is treated as non-idempotent since options like decommission are irreversible.',
+    idempotent: false,
+  },
   props: {
     subscription_id: Property.ShortText({
       displayName: 'Subscription ID',

--- a/packages/pieces/community/chargebee/src/lib/actions/create-customer.ts
+++ b/packages/pieces/community/chargebee/src/lib/actions/create-customer.ts
@@ -9,6 +9,12 @@ export const createCustomer = createAction({
   auth: chargebeeAuth,
   displayName: 'Create Customer',
   description: 'Create a customer in Chargebee.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Create a new customer record in Chargebee, optionally with contact details, billing address, tax/VAT settings, and metadata. Use when an agent needs to register a customer before subscribing or invoicing them. All fields are optional, including the customer ID (auto-generated if omitted). Not idempotent — each call creates a new customer unless a custom ID is supplied that already exists.',
+    idempotent: false,
+  },
   props: {
     id: Property.ShortText({
       displayName: 'Customer ID',

--- a/packages/pieces/community/chargebee/src/lib/actions/create-subscription.ts
+++ b/packages/pieces/community/chargebee/src/lib/actions/create-subscription.ts
@@ -10,6 +10,12 @@ export const createSubscription = createAction({
   displayName: 'Create Subscription',
   description:
     'Create a subscription for an existing customer using a Chargebee item price.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Create a new item-price-based subscription for an existing Chargebee customer. Use when an agent needs to start billing a known customer on a specific item price. Requires a valid customer ID and item price ID; optional fields control trial, billing cycles, coupons, and auto-collection. Not idempotent — each call creates a separate subscription.',
+    idempotent: false,
+  },
   props: {
     customer_id: Property.ShortText({
       displayName: 'Customer ID',

--- a/packages/pieces/community/chargebee/src/lib/actions/get-customer.ts
+++ b/packages/pieces/community/chargebee/src/lib/actions/get-customer.ts
@@ -9,6 +9,12 @@ export const getCustomer = createAction({
   auth: chargebeeAuth,
   displayName: 'Get Customer',
   description: 'Retrieve a customer from Chargebee by ID.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetch a single Chargebee customer record by its customer ID. Use when an agent needs to read a known customer\'s details before acting on them. Requires the exact customer ID; does not search by email or other fields. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     customer_id: Property.ShortText({
       displayName: 'Customer ID',

--- a/packages/pieces/community/chargebee/src/lib/triggers/customer-created.ts
+++ b/packages/pieces/community/chargebee/src/lib/triggers/customer-created.ts
@@ -15,6 +15,10 @@ export const customerCreated = createTrigger({
   name: 'customer_created',
   displayName: 'Customer Created',
   description: 'Triggers when a new customer is created in Chargebee.',
+  aiMetadata: {
+    description:
+      'Fires when Chargebee records a customer_created event — a new customer record has been created. The payload carries the created customer.',
+  },
   props: {},
   type: TriggerStrategy.WEBHOOK,
   sampleData: {

--- a/packages/pieces/community/chargebee/src/lib/triggers/invoice-generated.ts
+++ b/packages/pieces/community/chargebee/src/lib/triggers/invoice-generated.ts
@@ -15,6 +15,10 @@ export const invoiceGenerated = createTrigger({
   name: 'invoice_generated',
   displayName: 'Invoice Generated',
   description: 'Triggers when a new invoice is generated for a subscription.',
+  aiMetadata: {
+    description:
+      'Fires when Chargebee records an invoice_generated event — a new invoice has been created (for a subscription or one-time charge). The payload carries the generated invoice.',
+  },
   props: {},
   type: TriggerStrategy.WEBHOOK,
   sampleData: {

--- a/packages/pieces/community/chargebee/src/lib/triggers/payment-failed.ts
+++ b/packages/pieces/community/chargebee/src/lib/triggers/payment-failed.ts
@@ -16,6 +16,10 @@ export const paymentFailed = createTrigger({
   displayName: 'Payment Failed',
   description:
     'Triggers when a payment attempt fails. Useful for dunning and retry workflows.',
+  aiMetadata: {
+    description:
+      'Fires when Chargebee records a payment_failed event — an attempt to collect a payment failed. Useful for driving dunning and retry workflows. The payload carries the failed transaction with the related invoice, customer, and subscription.',
+  },
   props: {},
   type: TriggerStrategy.WEBHOOK,
   sampleData: {

--- a/packages/pieces/community/chargebee/src/lib/triggers/payment-succeeded.ts
+++ b/packages/pieces/community/chargebee/src/lib/triggers/payment-succeeded.ts
@@ -15,6 +15,10 @@ export const paymentSucceeded = createTrigger({
   name: 'payment_succeeded',
   displayName: 'Payment Succeeded',
   description: 'Triggers when a payment is successfully collected.',
+  aiMetadata: {
+    description:
+      'Fires when Chargebee records a payment_succeeded event — a payment was successfully collected. The payload carries the transaction along with the related invoice, customer, and subscription.',
+  },
   props: {},
   type: TriggerStrategy.WEBHOOK,
   sampleData: {

--- a/packages/pieces/community/chargebee/src/lib/triggers/subscription-cancelled.ts
+++ b/packages/pieces/community/chargebee/src/lib/triggers/subscription-cancelled.ts
@@ -15,6 +15,10 @@ export const subscriptionCancelled = createTrigger({
   name: 'subscription_cancelled',
   displayName: 'Subscription Cancelled',
   description: 'Triggers when a subscription is cancelled.',
+  aiMetadata: {
+    description:
+      'Fires when Chargebee records a subscription_cancelled event — a subscription has been cancelled (immediately or at end of term). The payload carries the cancelled subscription with its customer and invoice.',
+  },
   props: {},
   type: TriggerStrategy.WEBHOOK,
   sampleData: {

--- a/packages/pieces/community/chargebee/src/lib/triggers/subscription-changed.ts
+++ b/packages/pieces/community/chargebee/src/lib/triggers/subscription-changed.ts
@@ -16,6 +16,10 @@ export const subscriptionChanged = createTrigger({
   displayName: 'Subscription Changed',
   description:
     'Triggers when a subscription is updated — plan change, quantity, or add-ons.',
+  aiMetadata: {
+    description:
+      'Fires when Chargebee records a subscription_changed event — an existing subscription was modified (plan/item price change, quantity, or add-ons). The payload carries the updated subscription with its customer and invoice.',
+  },
   props: {},
   type: TriggerStrategy.WEBHOOK,
   sampleData: {

--- a/packages/pieces/community/chargebee/src/lib/triggers/subscription-created.ts
+++ b/packages/pieces/community/chargebee/src/lib/triggers/subscription-created.ts
@@ -15,6 +15,10 @@ export const subscriptionCreated = createTrigger({
   name: 'subscription_created',
   displayName: 'Subscription Created',
   description: 'Triggers when a new subscription is created for a customer.',
+  aiMetadata: {
+    description:
+      'Fires when Chargebee records a subscription_created event — a new subscription has been created for a customer. The payload carries the subscription along with its customer and (if applicable) invoice.',
+  },
   props: {},
   type: TriggerStrategy.WEBHOOK,
   sampleData: {

--- a/packages/pieces/community/chargebee/src/lib/triggers/subscription-renewed.ts
+++ b/packages/pieces/community/chargebee/src/lib/triggers/subscription-renewed.ts
@@ -15,6 +15,10 @@ export const subscriptionRenewed = createTrigger({
   name: 'subscription_renewed',
   displayName: 'Subscription Renewed',
   description: 'Triggers when a subscription is successfully renewed.',
+  aiMetadata: {
+    description:
+      'Fires when Chargebee records a subscription_renewed event — a subscription has advanced into a new billing term. The payload carries the renewed subscription with its customer and invoice.',
+  },
   props: {},
   type: TriggerStrategy.WEBHOOK,
   sampleData: {

--- a/packages/pieces/community/chartly/package.json
+++ b/packages/pieces/community/chartly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chartly",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/chartly/src/lib/actions/create-chart.ts
+++ b/packages/pieces/community/chartly/src/lib/actions/create-chart.ts
@@ -6,6 +6,8 @@ export const createChartAction = createAction({
   name: 'create_chart',
   displayName: 'Create Chart',
   description: 'Generates a chart image based on the provided data, configuration, and chart type',
+  audience: 'both',
+  aiMetadata: { description: 'Renders a Chart.js configuration into a PNG or SVG image via the Chartly API and returns it as a base64 data URL. Build the chart from the simple props (chart type, labels, dataset values, colors, dimensions) or, for full control, pass a complete Chart.js config JSON in the advanced config prop, which overrides the simple settings. Use when an agent needs to produce a chart visualization from numeric data. Each call creates a new cached chart on Chartly, so it is not idempotent.', idempotent: false },
   props: {
     chart_type: Property.StaticDropdown({
       displayName: 'Chart Type',

--- a/packages/pieces/community/chartly/src/lib/actions/get-chart.ts
+++ b/packages/pieces/community/chartly/src/lib/actions/get-chart.ts
@@ -6,6 +6,8 @@ export const getChartAction = createAction({
   name: 'get_chart',
   displayName: 'Get Chart',
   description: 'Retrieve a previously created chart by its ID. Returns cached image data optimized for sharing.',
+  audience: 'both',
+  aiMetadata: { description: 'Fetches a previously created chart from Chartly by its chart ID and returns the cached image as a base64 data URL, auto-detecting PNG vs SVG from the response unless a format is specified. Use when an agent already has a chart ID (e.g. from a prior Create Chart call) and needs to re-fetch the image. Requires a valid chart ID; this is a read-only lookup and is idempotent.', idempotent: true },
   props: {
     chart_id: Property.ShortText({
       displayName: 'Chart ID',

--- a/packages/pieces/community/chat-aid/package.json
+++ b/packages/pieces/community/chat-aid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chat-aid",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/chat-aid/src/lib/actions/add-custom-sources.ts
+++ b/packages/pieces/community/chat-aid/src/lib/actions/add-custom-sources.ts
@@ -13,6 +13,8 @@ export const addCustomSources = createAction({
   name: 'addCustomSources',
   displayName: 'Add Custom Sources',
   description: 'Upload one or more files as custom sources for training',
+  audience: 'both',
+  aiMetadata: { description: 'Upload one or more files (PDF, Word, text, Markdown, HTML, Excel, CSV, PowerPoint, or images) to a Chat Aid knowledge base as custom sources for training, optionally scoped to a specific team (defaults to org-wide). Use this to ingest new documents the assistant should be able to answer from. Not idempotent: each call appends new sources, so repeating it uploads duplicates.', idempotent: false },
   props: {
     files: Property.Array({
       displayName: 'Files',

--- a/packages/pieces/community/chat-aid/src/lib/actions/ask-questions.ts
+++ b/packages/pieces/community/chat-aid/src/lib/actions/ask-questions.ts
@@ -9,6 +9,8 @@ export const askQuestions = createAction({
   displayName: 'Ask Questions',
   description:
     'Query your Chat Aid knowledge base and receive AI-generated answers with source citations',
+  audience: 'both',
+  aiMetadata: { description: 'Ask a natural-language question against the Chat Aid knowledge base and get back an AI-generated answer with source citations; the call submits the prompt then polls until the answer is ready (timing out after ~2 minutes). Optionally pass parent and message timestamps to thread follow-up questions within an ongoing conversation. Use this to retrieve answers grounded in ingested sources. Not idempotent: each call generates a fresh completion and conversation turn.', idempotent: false },
   props: {
     prompt: Property.LongText({
       displayName: 'Question',

--- a/packages/pieces/community/chat-aid/src/lib/actions/get-custom-source-by-id.ts
+++ b/packages/pieces/community/chat-aid/src/lib/actions/get-custom-source-by-id.ts
@@ -8,6 +8,8 @@ export const getCustomSourceById = createAction({
   name: 'getCustomSourceById',
   displayName: 'Get Custom Source by ID',
   description: 'Retrieve single source details by ID',
+  audience: 'both',
+  aiMetadata: { description: 'Fetch the details of a single custom source in the Chat Aid knowledge base by its source ID. Use this to look up or verify a specific source you already have an ID for. Idempotent read-only lookup.', idempotent: true },
   props: {
     sourceId: Property.ShortText({
       displayName: 'Source ID',

--- a/packages/pieces/community/chat-data/package.json
+++ b/packages/pieces/community/chat-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chat-data",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/chat-data/src/lib/actions/createChatbot.ts
+++ b/packages/pieces/community/chat-data/src/lib/actions/createChatbot.ts
@@ -8,6 +8,12 @@ export const createChatbot = createAction({
   displayName: 'Create Chatbot',
   description:
     'Create and train a chatbot using custom data, medical models, or custom models. Training takes 1-2 minutes.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new Chat Data chatbot and kicks off training. The model prop selects the mode: custom-data-upload trains on supplied source text, scraped URLs, products, and Q&As; medical-chat-human / medical-chat-vet use prebuilt medical models; custom-model proxies to your own backend (the data-source props are ignored for the medical and custom-model modes). Use to provision a brand-new bot. Not idempotent — each call creates a separate chatbot.',
+    idempotent: false,
+  },
   props: {
     chatbotName: Property.ShortText({
       displayName: 'Chatbot Name',

--- a/packages/pieces/community/chat-data/src/lib/actions/deleteChatbot.ts
+++ b/packages/pieces/community/chat-data/src/lib/actions/deleteChatbot.ts
@@ -8,6 +8,12 @@ export const deleteChatbot = createAction({
   displayName: 'Delete Chatbot',
   description:
     'Delete a chatbot and all its associated data (training data, conversations, leads, etc.). This action is irreversible.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Permanently deletes a Chat Data chatbot identified by chatbotId, along with all of its training data, conversations, and leads. Use only when the bot should be fully removed; the deletion is irreversible. Not idempotent — a repeat call for an already-deleted chatbot will fail.',
+    idempotent: false,
+  },
   props: {
     chatbotId: Property.Dropdown({
       auth: chatDataAuth,

--- a/packages/pieces/community/chat-data/src/lib/actions/retrainChatbot.ts
+++ b/packages/pieces/community/chat-data/src/lib/actions/retrainChatbot.ts
@@ -8,6 +8,12 @@ export const retrainChatbot = createAction({
   displayName: 'Retrain Chatbot',
   description:
     'Retrain an existing chatbot with new data or remove existing data (custom-data-upload model only)',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrains a custom-data-upload chatbot (selected by chatbotId) by adding source text, scraped URLs, products, and Q&As, and/or removing existing knowledge sources via the deletes list. Use to refresh or extend a bot\'s knowledge base; only works for the custom-data-upload model. Not idempotent — each call mutates the knowledge base (re-crawls URLs, appends/overwrites entries, deletes sources).',
+    idempotent: false,
+  },
   props: {
     chatbotId: Property.Dropdown({
       auth: chatDataAuth,

--- a/packages/pieces/community/chat-data/src/lib/actions/sendMessage.ts
+++ b/packages/pieces/community/chat-data/src/lib/actions/sendMessage.ts
@@ -7,6 +7,12 @@ export const sendMessage = createAction({
   displayName: 'Send Message to Chatbot',
   description:
     'Send messages to a chatbot and receive a response with support for streaming and OpenAI-compatible formats',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Sends a message to a Chat Data chatbot (selected by chatbotId) and returns its generated reply. Leave conversationId empty to start a new conversation or pass one to continue an existing thread. Per-request overrides (base model, base prompt, reasoning, OpenAI-compatible output) are optional. Use to converse with or query a deployed bot. Not idempotent — each call generates a fresh reply and appends to the conversation.',
+    idempotent: false,
+  },
   auth: chatDataAuth,
   props: {
     chatbotId: Property.Dropdown({

--- a/packages/pieces/community/chat-data/src/lib/actions/updateBasePrompt.ts
+++ b/packages/pieces/community/chat-data/src/lib/actions/updateBasePrompt.ts
@@ -7,6 +7,12 @@ export const updateBasePrompt = createAction({
   name: 'update_chatbot_settings',
   displayName: 'Update Chatbot Settings',
   description: 'Update comprehensive settings for a chatbot including name, prompts, behavior, and appearance',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      "Updates configuration of an existing chatbot (selected by chatbotId) — name, base prompt, model, temperature, initial/suggested messages, visibility, rate limits, allowed domains, calendar booking, and other behavior/appearance settings. Only the fields you provide are changed. Use to reconfigure a bot without retraining it. Idempotent: re-applying the same settings leaves the chatbot in the same state.",
+    idempotent: true,
+  },
   props: {
     chatbotId: Property.Dropdown({
       auth: chatDataAuth,

--- a/packages/pieces/community/chat-data/src/lib/actions/uploadFile.ts
+++ b/packages/pieces/community/chat-data/src/lib/actions/uploadFile.ts
@@ -8,6 +8,12 @@ export const uploadFile = createAction({
   displayName: 'Upload File',
   description:
     'Upload a file to be used with a chatbot for training or knowledge base',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Uploads a file to a Chat Data chatbot (selected by chatbotId) to add it to the bot\'s knowledge base / training data. Use when knowledge should come from a document rather than text or URLs. Not idempotent — each call adds another file to the chatbot.',
+    idempotent: false,
+  },
   props: {
     chatbotId: Property.Dropdown({
       auth: chatDataAuth,

--- a/packages/pieces/community/chatbase/package.json
+++ b/packages/pieces/community/chatbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chatbase",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/chatbase/src/lib/actions/create-chatbot.ts
+++ b/packages/pieces/community/chatbase/src/lib/actions/create-chatbot.ts
@@ -8,6 +8,8 @@ export const createChatbotAction = createAction({
 	name: 'create_chatbot',
 	displayName: 'Create Chatbot',
 	description: 'Creates a new chatbot.',
+	audience: 'both',
+	aiMetadata: { description: 'Creates a new Chatbase chatbot, optionally seeding it with inline training text. Use when an agent needs to provision a fresh chatbot before sending prompts to it. Not idempotent: each call creates a separate chatbot even with identical input.', idempotent: false },
 	props: {
 		chatbotName: Property.ShortText({
 			displayName: 'Chatbot Name',

--- a/packages/pieces/community/chatbase/src/lib/actions/list-all-chatbots.ts
+++ b/packages/pieces/community/chatbase/src/lib/actions/list-all-chatbots.ts
@@ -8,6 +8,8 @@ export const listChatbotsAction = createAction({
 	name: 'list_chatbots',
 	displayName: 'List All Chatbots',
 	description: 'Retrieves a list of all chatbots.',
+	audience: 'both',
+	aiMetadata: { description: 'Lists all chatbots in the authenticated Chatbase account. Use when an agent needs to discover available chatbots or resolve a chatbot ID before sending prompts or searching conversations. Takes no input; idempotent read-only listing.', idempotent: true },
 	props: {},
 
 	async run(context) {

--- a/packages/pieces/community/chatbase/src/lib/actions/search-conversations-by-query.ts
+++ b/packages/pieces/community/chatbase/src/lib/actions/search-conversations-by-query.ts
@@ -9,6 +9,8 @@ export const searchConversationsAction = createAction({
 	name: 'search_conversations',
 	displayName: 'Search Conversations by Query',
 	description: 'Searches for conversations from a specific chatbot.',
+	audience: 'both',
+	aiMetadata: { description: 'Retrieves logged conversations for a specific Chatbase chatbot (selected by its ID), with optional filters for source channels (API, WhatsApp, Slack, etc.), a start/end date range, and pagination. Use when an agent needs to review or audit past chatbot conversations; leaving the optional filters empty returns all conversations for the chatbot. Idempotent read-only lookup.', idempotent: true },
 	props: {
 		chatbotId: chatbotIdDropdown,
 		filteredSources: Property.StaticMultiSelectDropdown({

--- a/packages/pieces/community/chatbase/src/lib/actions/send-prompt-to-chatbot.ts
+++ b/packages/pieces/community/chatbase/src/lib/actions/send-prompt-to-chatbot.ts
@@ -9,6 +9,8 @@ export const sendPromptToChatbotAction = createAction({
 	name: 'message_chatbot',
 	displayName: 'Send Prompt to Chatbot',
 	description: 'Sends a prompt to the chatbot to generate a response.',
+	audience: 'both',
+	aiMetadata: { description: 'Sends a user prompt to a specific Chatbase chatbot (selected by its ID) and returns the generated reply, optionally overriding the model and temperature. Use when an agent needs an answer from a trained chatbot; pass a stable conversationId to keep messages threaded in one logged conversation. Not idempotent: each call appends a turn and produces a fresh, possibly different completion.', idempotent: false },
 	props: {
 		chatbotId: chatbotIdDropdown,
 		message: Property.LongText({

--- a/packages/pieces/community/chatfly/package.json
+++ b/packages/pieces/community/chatfly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chatfly",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/chatfly/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/chatfly/src/lib/actions/send-message.ts
@@ -7,6 +7,8 @@ export const sendMessageAction = createAction({
   name: "send_message",
   displayName: "Send Message",
   description: "Send a message to ChatFly bot",
+  audience: 'both',
+  aiMetadata: { description: 'Send a user message to a ChatFly AI chatbot and get back its streaming chat response. Choose this to query or converse with a deployed ChatFly bot. Requires the target bot ID and a session ID that ties the message to a conversation thread; each call posts a new message, so it is not idempotent.', idempotent: false },
   props: {
     bot_id: Property.ShortText({
       displayName: "Bot ID",


### PR DESCRIPTION
## What

Adds optional, additive AI-ready metadata to a fifth batch of **75 pieces** so AI agents (via the MCP server and SDK) can discover and reason about each action and trigger. Additive only — no runtime behavior change.

This batch begins the **alphabetical sweep** (`activepieces` → `chatfly`) toward full-catalog coverage; earlier batches covered the highest-usage integrations.

Per piece:
- `audience: 'both'` + `aiMetadata: { description, idempotent }` on every action (except `custom_api_call`)
- `aiMetadata: { description }` on every trigger
- `package.json` patch bump

## Pieces (75)

activepieces, actualbudget, add-event, afforai, agentx, aianswer, aidbase, aiprise, air-ops, airparser, airtop, alai, algolia, alt-text-ai, alttextify, amazon-s3, amazon-secrets-manager, amazon-sns, amazon-sqs, amazon-textract, aminos, apitemplate-io, appfollow, ask-handle, assembled, autocalls, avian, avoma, azure-blob-storage, azure-communication-services, azure-devops, backblaze, bannerbear, barcode-lookup, baremetrics, base44, beamer, beebole, bettermode, bigcommerce, bigin-by-zoho, bika, billplz, binance, bland-ai, bokio, bolna, bonjoro, bookedin, brave-search, brilliant-directories, browserless, bubble, buffer, bumpups, bursty-ai, buttondown, camb-ai, campaign-monitor, canny, capsule-crm, captain-data, carbone, cartloom, cashfree-payments, certopus, chain-aware, chainalysis-api, chaindesk, chargebee, chartly, chat-aid, chat-data, chatbase, chatfly — 327 actions + 81 triggers.

## Notes

- `aiMetadata.description` is written for agent tool-selection (what it does + when to call + the key constraint + idempotency in prose, naming materially different operation modes where relevant); it does not restate the output shape.
- `idempotent` is derived from each action's `run()` (read/lookup/list → true; create/send/mutate → false).
- `custom_api_call` is intentionally left untouched; its agent-visibility fencing is handled separately.
- `capsule-crm`'s shared webhook-trigger factory type was extended to carry `aiMetadata` so its triggers can declare it.
- Verified: eslint 0 errors, type-check clean for the inserted fields, no `index.ts` changed, diff additive only.
