### PR TITLE
fix(omnihr): use refresh token to reduce calls to rate-limited

### DIFF
--- a/packages/pieces/community/omnihr/package.json
+++ b/packages/pieces/community/omnihr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-omnihr",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/omnihr/src/lib/actions/get-direct-reports.ts
+++ b/packages/pieces/community/omnihr/src/lib/actions/get-direct-reports.ts
@@ -19,7 +19,7 @@ export const getDirectReports = createAction({
   async run(context) {
     const { system_id } = context.propsValue;
     const auth = context.auth as OmniHrAuth;
-    const headers = await getAuthHeaders(auth);
+    const headers = await getAuthHeaders(auth, context.store);
 
     const directReportsResponse = await httpClient.sendRequest({
       method: HttpMethod.GET,

--- a/packages/pieces/community/omnihr/src/lib/actions/get-employee-info.ts
+++ b/packages/pieces/community/omnihr/src/lib/actions/get-employee-info.ts
@@ -18,7 +18,7 @@ export const getEmployeeInfo = createAction({
   async run(context) {
     const { system_id } = context.propsValue;
     const auth = context.auth as OmniHrAuth;
-    const headers = await getAuthHeaders(auth);
+    const headers = await getAuthHeaders(auth, context.store);
 
     const employeeResponse = await httpClient.sendRequest({
       method: HttpMethod.GET,

--- a/packages/pieces/community/omnihr/src/lib/actions/get-employee-organizational-chart.ts
+++ b/packages/pieces/community/omnihr/src/lib/actions/get-employee-organizational-chart.ts
@@ -19,7 +19,7 @@ export const getEmployeeOrganizationalChart = createAction({
   async run(context) {
     const { system_id } = context.propsValue;
     const auth = context.auth as OmniHrAuth;
-    const headers = await getAuthHeaders(auth);
+    const headers = await getAuthHeaders(auth, context.store);
 
     const snapshotResponse = await httpClient.sendRequest({
       method: HttpMethod.GET,

--- a/packages/pieces/community/omnihr/src/lib/actions/get-employee-system-id.ts
+++ b/packages/pieces/community/omnihr/src/lib/actions/get-employee-system-id.ts
@@ -56,7 +56,7 @@ export const getEmployeeSystemId = createAction({
   async run(context) {
     const { email, employmentStatuses } = context.propsValue;
     const auth = context.auth as OmniHrAuth;
-    const headers = await getAuthHeaders(auth);
+    const headers = await getAuthHeaders(auth, context.store);
 
     const queryParams: Record<string, string> = {
       exclude_self: 'false',

--- a/packages/pieces/community/omnihr/src/lib/common/client.ts
+++ b/packages/pieces/community/omnihr/src/lib/common/client.ts
@@ -1,4 +1,5 @@
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { Store } from '@activepieces/pieces-framework';
 
 export type OmniHrAuth = {
   props: {
@@ -8,33 +9,84 @@ export type OmniHrAuth = {
   };
 };
 
-export async function getAccessToken(auth: OmniHrAuth): Promise<string> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    Origin: auth.props.origin,
-  };
+type TokenPair = { access: string; refresh: string };
 
-  const tokenResponse = await httpClient.sendRequest<{
-    access: string;
-    refresh: string;
-  }>({
+// Scoped per credential so two OmniHR connections in the same flow don't stomp each other.
+function tokenStoreKey(auth: OmniHrAuth): string {
+  return `omnihr_token_pair__${auth.props.username}__${auth.props.origin}`;
+}
+
+async function fetchTokenPair(auth: OmniHrAuth): Promise<TokenPair> {
+  const response = await httpClient.sendRequest<TokenPair>({
     method: HttpMethod.POST,
     url: 'https://api.omnihr.co/api/v1/auth/token/',
-    headers,
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: auth.props.origin,
+    },
     body: {
       username: auth.props.username,
       password: auth.props.password,
     },
   });
+  return response.body;
+}
 
-  return tokenResponse.body.access;
+async function refreshAccessToken(
+  auth: OmniHrAuth,
+  storedPair: TokenPair
+): Promise<TokenPair> {
+  const response = await httpClient.sendRequest<{ access: string; refresh?: string }>({
+    method: HttpMethod.POST,
+    url: 'https://api.omnihr.co/api/v1/auth/token/refresh/',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: auth.props.origin,
+    },
+    body: { refresh: storedPair.refresh },
+  });
+  return {
+    access: response.body.access,
+    // Keep the existing refresh token if the endpoint doesn't rotate it.
+    refresh: response.body.refresh ?? storedPair.refresh,
+  };
+}
+
+async function resolveAccessToken(
+  auth: OmniHrAuth,
+  store?: Store
+): Promise<string> {
+  if (!store) {
+    return (await fetchTokenPair(auth)).access;
+  }
+
+  const storeKey = tokenStoreKey(auth);
+  const stored = await store.get<TokenPair>(storeKey);
+
+  if (stored?.refresh) {
+    try {
+      const newPair = await refreshAccessToken(auth, stored);
+      await store.put(storeKey, newPair);
+      return newPair.access;
+    } catch {
+      // Refresh token expired or invalid — fall through to full credential login.
+    }
+  }
+
+  const newPair = await fetchTokenPair(auth);
+  await store.put(storeKey, newPair);
+  return newPair.access;
+}
+
+export async function getAccessToken(auth: OmniHrAuth): Promise<string> {
+  return (await fetchTokenPair(auth)).access;
 }
 
 export async function getAuthHeaders(
-  auth: OmniHrAuth
+  auth: OmniHrAuth,
+  store?: Store
 ): Promise<Record<string, string>> {
-  const accessToken = await getAccessToken(auth);
-
+  const accessToken = await resolveAccessToken(auth, store);
   return {
     Authorization: `Bearer ${accessToken}`,
     'Content-Type': 'application/json',


### PR DESCRIPTION
  login endpoint

  Store the token pair after the first credential login and exchange the
  refresh token on subsequent runs instead of re-sending username + password
  to /auth/token/ every time. The store key is scoped per credential
  (username + origin) to prevent token cross-contamination when two OmniHR
  connections with different accounts are used in the same flow.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
