### PR TITLE
fix(chat): prevent multi-turn conversations from breaking on Anthropic models

### DIFF
--- a/packages/server/utils/src/chat-ai-utils.ts
+++ b/packages/server/utils/src/chat-ai-utils.ts
@@ -87,16 +87,17 @@ function createChatModel({ provider, auth, config, modelId }: {
     }
 }
 
-const THINKING_PROVIDERS = new Set([
-    AIProviderName.ANTHROPIC,
-    AIProviderName.BEDROCK,
-    AIProviderName.OPENROUTER,
-    AIProviderName.ACTIVEPIECES,
-])
-
-function stripThinkingBlocks(messages: ModelMessage[], provider: AIProviderName): ModelMessage[] {
-    if (THINKING_PROVIDERS.has(provider)) return messages
-
+/**
+ * Strip reasoning/thinking blocks from the message history before sending to the
+ * provider. We never need to replay prior-turn thinking: the resulting text, tool
+ * calls, and tool results carry all the context, and re-sending a thinking block
+ * whose cryptographic `signature` didn't survive our DB round-trip (or the
+ * continuation/compaction reshaping) makes Anthropic reject the request with
+ * "Invalid `signature` in `thinking` block". In-flight thinking within a single
+ * streamText tool-loop is managed by the SDK with intact signatures and is
+ * unaffected — this only touches the cross-turn history we assemble.
+ */
+function stripThinkingBlocks(messages: ModelMessage[], _provider: AIProviderName): ModelMessage[] {
     const hasThinking = messages.some(
         (msg) => msg.role === 'assistant' && Array.isArray(msg.content)
             && (msg.content as Array<Record<string, unknown>>).some(

--- a/packages/server/utils/src/chat-ai-utils.ts
+++ b/packages/server/utils/src/chat-ai-utils.ts
@@ -88,14 +88,12 @@ function createChatModel({ provider, auth, config, modelId }: {
 }
 
 /**
- * Strip reasoning/thinking blocks from the message history before sending to the
- * provider. We never need to replay prior-turn thinking: the resulting text, tool
- * calls, and tool results carry all the context, and re-sending a thinking block
- * whose cryptographic `signature` didn't survive our DB round-trip (or the
- * continuation/compaction reshaping) makes Anthropic reject the request with
- * "Invalid `signature` in `thinking` block". In-flight thinking within a single
- * streamText tool-loop is managed by the SDK with intact signatures and is
- * unaffected — this only touches the cross-turn history we assemble.
+ * Strips for ALL providers (not just non-thinking ones) because Anthropic rejects
+ * a re-sent `thinking` block whose `signature` didn't survive our DB round-trip /
+ * compaction / truncation reshaping ("Invalid `signature` in `thinking` block"),
+ * and prior-turn reasoning adds nothing the text + tool results don't already carry.
+ * In-flight thinking within one streamText call keeps its intact signature and is
+ * untouched — this only touches the cross-turn history we assemble.
  */
 function stripThinkingBlocks(messages: ModelMessage[], _provider: AIProviderName): ModelMessage[] {
     const hasThinking = messages.some(


### PR DESCRIPTION
## Problem
Multi-turn chat conversations fail with `messages.N.content.0: Invalid \`signature\` in \`thinking\` block` (Anthropic 400). Anthropic cryptographically signs each thinking block and requires a valid signature whenever you send it back. Our conversation history is persisted to the DB and reshaped (compaction, truncation auto-continuation), so replayed thinking-block signatures go invalid and the whole request is rejected mid-conversation.

## Fix
`stripThinkingBlocks` now strips `reasoning`/`thinking` parts from the cross-turn history for **all** providers (previously kept them for Anthropic/OpenRouter). This is safe: the resulting text, tool calls, and tool results carry all the context the model needs from prior turns, and Anthropic allows omitting thinking entirely — it only rejects *invalid* signatures. In-flight thinking within a single `streamText` tool-loop is managed by the SDK with intact signatures and is untouched, so per-turn reasoning is unchanged.

## Scope
One function in `packages/server/utils/src/chat-ai-utils.ts`. Safe to merge independently — standalone hotfix peeled out of the larger chat refactor (#13676).