### PR TITLE
fix(deps): trust sqlite3 so bun's isolated linker builds it

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "activepieces",
   "version": "0.85.2",
   "packageManager": "bun@1.3.3",
+  "trustedDependencies": [
+    "sqlite3"
+  ],
   "scripts": {
     "prebuild": "node tools/scripts/install-bun.js",
     "serve:frontend": "turbo run serve --filter=web",


### PR DESCRIPTION
## Problem

`bunfig.toml` sets `linker = "isolated"`, and bun only runs a dependency's lifecycle (native build) scripts when the package is on bun's default trusted list or listed in `trustedDependencies`. On bun versions that don't default-trust `sqlite3`, its native binary is never built — so self-hosters running **SQLite mode** (`AP_DB_TYPE=SQLITE3`) fail to install/start. Reported by a self-hoster upgrading to 0.85.

## Fix

Add `"trustedDependencies": ["sqlite3"]` to the root `package.json`. This makes sqlite3's native build deterministic across bun versions; it's a no-op where bun already trusts it. Postgres/PGlite users are unaffected — `sqlite3` is only imported by `sqlite-connection.ts`.

## Notes

- The other half of the original report (root `package.json` "still at 0.83") is already resolved — it's `0.85.2`, matching the latest tag.
- `bun pm untrusted` confirms the only other blocked script is `fastify-socket`'s `preinstall: npx only-allow pnpm`, which is intentionally **not** trusted (it would force pnpm and break bun/npm installs).