### PR TITLE
feat(pieces): add AI-ready metadata to 10 pieces (batch 11)

### DIFF
--- a/packages/pieces/community/azure-ad/package.json
+++ b/packages/pieces/community/azure-ad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-azure-ad",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/azure-ad/src/lib/actions/add-member-to-group.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/add-member-to-group.ts
@@ -8,6 +8,12 @@ export const addMemberToGroupAction = createAction({
     name: 'add_member_to_group',
     displayName: 'Add Member to Group',
     description: 'Adds a user or group as a member of an Azure AD group.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Adds an existing user or group (by directory object ID) as a member of an Azure AD group. Use when granting group-based access or distribution membership; both the group and the member must already exist. Not idempotent — re-adding someone who is already a member fails with a Graph error, so check membership with List Group Members first if unsure.',
+        idempotent: false,
+    },
     props: {
         groupId: groupDropdown,
         memberId: directoryObjectDropdown,

--- a/packages/pieces/community/azure-ad/src/lib/actions/add-or-remove-user-license.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/add-or-remove-user-license.ts
@@ -8,6 +8,12 @@ export const addOrRemoveUserLicenseAction = createAction({
     name: 'add_or_remove_user_license',
     displayName: 'Add or Remove User License',
     description: 'Assigns or removes licenses for a user. Use addLicenses to add (include disabledPlans to disable specific service plans) and removeLicenses to remove by SkuId.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Assigns and/or removes Microsoft 365 license SKUs for an existing user in one call: pass skuId entries to add (optionally with disabledPlans to switch off specific service plans) and SKU ID strings to remove. The user must have a usageLocation set before licenses can be assigned. Not idempotent — removing a license the user does not hold fails, so verify current assignments before retrying.',
+        idempotent: false,
+    },
     props: {
         userId: userDropdown,
         addLicenses: Property.Json({

--- a/packages/pieces/community/azure-ad/src/lib/actions/create-group.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/create-group.ts
@@ -8,6 +8,12 @@ export const createGroupAction = createAction({
     name: 'create_group',
     displayName: 'Create Group',
     description: 'Creates a new group in Azure Active Directory.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Creates a new Azure AD security or Microsoft 365 group with a display name and a unique mail nickname (toggle mailEnabled/securityEnabled for the group type). Use only when provisioning a fresh group, not to modify an existing one. Not idempotent — display names are not unique, so repeating the call can create duplicate groups.',
+        idempotent: false,
+    },
     props: {
         displayName: Property.ShortText({
             displayName: 'Display Name',

--- a/packages/pieces/community/azure-ad/src/lib/actions/create-user.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/create-user.ts
@@ -8,6 +8,12 @@ export const createUserAction = createAction({
     name: 'create_user',
     displayName: 'Create User',
     description: 'Creates a new user in Microsoft Entra ID.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Provisions a new Microsoft Entra ID (Azure AD) user with a unique user principal name, initial password, and optional profile fields; set usageLocation if licenses will be assigned afterwards. Not idempotent — a retry fails on the duplicate UPN rather than updating the account. Use Update User to change an existing user instead.',
+        idempotent: false,
+    },
     props: {
         displayName: Property.ShortText({
             displayName: 'Display Name',

--- a/packages/pieces/community/azure-ad/src/lib/actions/delete-group.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/delete-group.ts
@@ -8,6 +8,12 @@ export const deleteGroupAction = createAction({
     name: 'delete_group',
     displayName: 'Delete Group',
     description: 'Deletes an Azure AD group by ID.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Permanently deletes an Azure AD group by its object ID, removing its memberships with it. Destructive and not idempotent — a repeat call fails with 404 once the group is gone, so confirm the target with Get Group by ID before deleting.',
+        idempotent: false,
+    },
     props: {
         groupId: groupDropdown,
     },

--- a/packages/pieces/community/azure-ad/src/lib/actions/delete-user.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/delete-user.ts
@@ -8,6 +8,12 @@ export const deleteUserAction = createAction({
     name: 'delete_user',
     displayName: 'Delete User',
     description: 'Deletes a user from Azure Active Directory.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Permanently deletes an Azure AD user account by object ID or user principal name. Destructive and not idempotent — repeating the call fails with 404 after the first success. If the removal may need to be reversed, prefer disabling sign-in via Update User (accountEnabled) instead.',
+        idempotent: false,
+    },
     props: {
         userId: userDropdown,
     },

--- a/packages/pieces/community/azure-ad/src/lib/actions/get-enabled-users.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/get-enabled-users.ts
@@ -8,6 +8,12 @@ export const getEnabledUsersAction = createAction({
     name: 'get_enabled_users',
     displayName: 'Get Enabled Users',
     description: 'Retrieves a single page of enabled users (accountEnabled eq true).',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Fetches a single page (up to 999) of directory users whose accounts are enabled. Read-only and idempotent. Pick List Enabled Users instead when you need the complete set across all pages, or List Users for arbitrary OData filters.',
+        idempotent: true,
+    },
     props: {
         top: Property.Number({
             displayName: 'Top',

--- a/packages/pieces/community/azure-ad/src/lib/actions/get-group-by-id.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/get-group-by-id.ts
@@ -8,6 +8,12 @@ export const getGroupByIdAction = createAction({
     name: 'get_group_by_id',
     displayName: 'Get Group by ID',
     description: 'Retrieves an Azure AD group by its object ID.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Retrieves one Azure AD group profile (name, description, mail settings, security flags) by its object ID. Read-only and idempotent; use it to confirm a group exists or inspect it before membership changes or deletion. For extension attributes, use Get Group Custom Attributes instead.',
+        idempotent: true,
+    },
     props: {
         groupId: groupDropdown,
     },

--- a/packages/pieces/community/azure-ad/src/lib/actions/get-group-custom-attributes.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/get-group-custom-attributes.ts
@@ -8,6 +8,12 @@ export const getGroupCustomAttributesAction = createAction({
     name: 'get_group_custom_attributes',
     displayName: 'Get Group Custom Attributes',
     description: 'Gets extension and custom attributes for an Azure AD group. Returns schema extensions and open extensions.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Reads only the extension/custom attributes (extension_* and ext_* properties) of an Azure AD group, along with its ID and display name. Read-only and idempotent. Pick Get Group by ID when you need the standard group profile rather than custom attributes.',
+        idempotent: true,
+    },
     props: {
         groupId: groupDropdown,
     },

--- a/packages/pieces/community/azure-ad/src/lib/actions/get-user-by-id.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/get-user-by-id.ts
@@ -8,6 +8,12 @@ export const getUserByIdAction = createAction({
     name: 'get_user_by_id',
     displayName: 'Get User by ID',
     description: 'Retrieves an Azure AD user by object ID or user principal name.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Retrieves a single Azure AD user profile by object ID or user principal name. Read-only and idempotent; use it to verify a user exists or fetch their details before update, license, or delete operations. Use List Users when you only know a partial name or other attribute.',
+        idempotent: true,
+    },
     props: {
         userId: userDropdown,
     },

--- a/packages/pieces/community/azure-ad/src/lib/actions/list-enabled-users.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/list-enabled-users.ts
@@ -8,6 +8,12 @@ export const listEnabledUsersAction = createAction({
     name: 'list_enabled_users',
     displayName: 'List Enabled Users',
     description: 'Lists all enabled users in the directory, following nextLink for pagination.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Lists every enabled user in the directory, automatically following pagination until all pages are fetched. Read-only and idempotent, but can be slow and return very large results in big tenants — use Get Enabled Users when a single bounded page is enough.',
+        idempotent: true,
+    },
     props: {
         pageSize: Property.Number({
             displayName: 'Page Size',

--- a/packages/pieces/community/azure-ad/src/lib/actions/list-group-members.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/list-group-members.ts
@@ -8,6 +8,12 @@ export const listGroupMembersAction = createAction({
     name: 'list_group_members',
     displayName: 'List Group Members',
     description: 'Lists members of an Azure AD group.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Lists the direct members (users, groups, devices) of an Azure AD group, returning only the first page of up to 999 entries. Read-only and idempotent. Note it does not expand transitive/nested group membership.',
+        idempotent: true,
+    },
     props: {
         groupId: groupDropdown,
         top: Property.Number({

--- a/packages/pieces/community/azure-ad/src/lib/actions/list-users.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/list-users.ts
@@ -8,6 +8,12 @@ export const listUsersAction = createAction({
     name: 'list_users',
     displayName: 'List Users',
     description: 'Lists users in the directory. Supports optional filter and top (page size).',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Lists directory users with an optional OData $filter expression and a page-size cap (max 999), returning only the first page. Read-only and idempotent — the most flexible user search when you need filtering beyond enabled-only; use Get User by ID when you already know the exact user.',
+        idempotent: true,
+    },
     props: {
         top: Property.Number({
             displayName: 'Top',

--- a/packages/pieces/community/azure-ad/src/lib/actions/reset-custom-attributes.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/reset-custom-attributes.ts
@@ -8,6 +8,12 @@ export const resetCustomAttributesAction = createAction({
     name: 'reset_custom_attributes',
     displayName: 'Reset Custom Attributes',
     description: 'Clears extension/custom attributes on a user or group. Provide the resource type and ID, and the extension property names to clear.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Clears extension/custom attribute values on a chosen user or group by setting them to null; pass specific extension property names, or leave empty to clear every detected extension_*/ext_* key (broader blast radius). Destructive to the attribute data but idempotent — re-running finds nothing left to clear and becomes a no-op.',
+        idempotent: true,
+    },
     props: {
         resourceType: Property.StaticDropdown({
             displayName: 'Resource Type',

--- a/packages/pieces/community/azure-ad/src/lib/actions/revoke-sign-in-session.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/revoke-sign-in-session.ts
@@ -8,6 +8,12 @@ export const revokeSignInSessionAction = createAction({
     name: 'revoke_sign_in_session',
     displayName: 'Revoke Sign-in Session',
     description: 'Revokes all refresh tokens for the user, forcing them to sign in again.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Invalidates all of a user\'s refresh and session tokens, forcing re-authentication on every device — use to cut off access after a compromise or during offboarding, typically alongside disabling the account. Safe to repeat: calling it again just renews the revocation. It does not disable the account or reset the password.',
+        idempotent: true,
+    },
     props: {
         userId: userDropdown,
     },

--- a/packages/pieces/community/azure-ad/src/lib/actions/update-user.ts
+++ b/packages/pieces/community/azure-ad/src/lib/actions/update-user.ts
@@ -8,6 +8,12 @@ export const updateUserAction = createAction({
     name: 'update_user',
     displayName: 'Update User',
     description: 'Updates an Azure AD user. Only provide fields you want to change.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Updates profile fields (display name, given name/surname, job title, mail, mobile phone, accountEnabled) on an existing Azure AD user; only the supplied fields change, and at least one is required. Idempotent — re-applying the same values leaves the same state. Also the way to disable or re-enable sign-in via accountEnabled without deleting the account.',
+        idempotent: true,
+    },
     props: {
         userId: userDropdown,
         displayName: Property.ShortText({

--- a/packages/pieces/community/azure-ad/src/lib/triggers/new-deleted-user.ts
+++ b/packages/pieces/community/azure-ad/src/lib/triggers/new-deleted-user.ts
@@ -11,6 +11,9 @@ export const newDeletedUserTrigger = createTrigger({
     name: 'new_deleted_user',
     displayName: 'New Deleted User',
     description: 'Triggers when a user is deleted from Microsoft Entra ID.',
+    aiMetadata: {
+        description: 'Fires when a user account is deleted (soft-deleted) from the Microsoft Entra ID (Azure AD) directory, detected by polling the Microsoft Graph users delta endpoint for removed entries. Each event represents one deleted user, identified by its directory object ID.',
+    },
     type: TriggerStrategy.POLLING,
     props: {},
     sampleData: {

--- a/packages/pieces/community/azure-ad/src/lib/triggers/new-group.ts
+++ b/packages/pieces/community/azure-ad/src/lib/triggers/new-group.ts
@@ -21,6 +21,9 @@ export const newGroupTrigger = createTrigger({
   name: 'new_group',
   displayName: 'New Group',
   description: 'Triggers when a new group is created in Microsoft Entra ID.',
+  aiMetadata: {
+    description: 'Fires when a new group (security or Microsoft 365) is created in the Microsoft Entra ID (Azure AD) directory, detected by polling the Microsoft Graph groups delta endpoint. Each event represents one newly created group with its display name, mail settings, visibility, and creation timestamp; updates to existing groups do not re-fire it.',
+  },
   type: TriggerStrategy.POLLING,
   props: {},
   sampleData: {

--- a/packages/pieces/community/azure-ad/src/lib/triggers/new-user.ts
+++ b/packages/pieces/community/azure-ad/src/lib/triggers/new-user.ts
@@ -17,6 +17,9 @@ export const newUserTrigger = createTrigger({
     name: 'new_user',
     displayName: 'New User',
     description: 'Triggers when a new user is created in Microsoft Entra ID.',
+    aiMetadata: {
+        description: 'Fires when a new user account is created in the Microsoft Entra ID (Azure AD) directory, detected by polling the Microsoft Graph users delta endpoint. Each event represents one newly created user with profile fields such as display name, user principal name, mail, job title, and creation timestamp; updates to existing users do not re-fire it.',
+    },
     type: TriggerStrategy.POLLING,
     props: {},
     sampleData: {

--- a/packages/pieces/community/bocha-search/package.json
+++ b/packages/pieces/community/bocha-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bocha-search",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/bocha-search/src/lib/actions/web-search.ts
+++ b/packages/pieces/community/bocha-search/src/lib/actions/web-search.ts
@@ -8,6 +8,12 @@ export const webSearchAction = createAction({
   name: 'web_search',
   displayName: 'Web Search',
   description: 'Search the web using Bocha.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Runs a Bocha web search for a query and returns matching web pages, optionally with per-result text summaries. Pick this to look up current information on the public web; results can be narrowed by freshness window, capped result count, and include/exclude domain lists (up to 100 domains each, separated by | or ,). Read-only and idempotent — repeating the same query just fetches results again.',
+    idempotent: true,
+  },
   auth: bochaAuth,
   props: {
     query: Property.ShortText({

--- a/packages/pieces/community/canva/package.json
+++ b/packages/pieces/community/canva/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-canva",
-  "version": "0.0.1",
+  "version": "0.0.2",
     "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/canva/src/lib/actions/create-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/create-design.ts
@@ -12,6 +12,12 @@ export const createDesign = createAction({
   name: 'create_design',
   displayName: 'Create Design',
   description: 'Create a new Canva design using preset design types or custom dimensions. Blank designs are automatically deleted if not edited within 7 days.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a brand-new Canva design, either from a preset type (doc, whiteboard, presentation) or with custom pixel dimensions (40-8000px), optionally titled and seeded with an existing image asset. Pick this to start a fresh design; use Import Design instead when converting an existing file like a PDF or PPTX. Not idempotent: every call creates another design, and untouched blank designs are auto-deleted after 7 days.',
+    idempotent: false,
+  },
   props: {
     designTypeOption: Property.StaticDropdown({
       displayName: '🎨 Design Type',

--- a/packages/pieces/community/canva/src/lib/actions/export-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/export-design.ts
@@ -23,6 +23,12 @@ export const exportDesign = createAction({
   name: 'export_design',
   displayName: 'Export Design',
   description: 'Export a Canva design to various formats (PDF, JPG, PNG, GIF, PPTX, MP4). This creates an asynchronous job with download URLs valid for 24 hours.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Starts an asynchronous export job that renders an existing Canva design as PDF, JPG, PNG, GIF, PPTX, or MP4, with format-specific options (quality, page selection, custom image dimensions, PDF paper size). Pick this when you need downloadable output files from a design; download URLs expire after 24 hours and the job may need to be polled for completion. Not idempotent: each call queues a new export job.',
+    idempotent: false,
+  },
   props: {
     designId: Property.Dropdown({
       displayName: 'Design',

--- a/packages/pieces/community/canva/src/lib/actions/find-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/find-design.ts
@@ -16,6 +16,12 @@ export const findDesign = createAction({
   name: 'find_design',
   displayName: 'Find Design',
   description: 'Search and list designs from your Canva library. Use this to find existing designs before creating new ones.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      "Searches the user's Canva design library by keyword, with ownership (owned/shared) and sort filters plus continuation-token pagination; an empty query lists all designs. Pick this to discover or look up design IDs before getting, exporting, or moving a design, rather than creating a duplicate. Read-only and idempotent.",
+    idempotent: true,
+  },
   props: {
     query: Property.ShortText({
       displayName: '🔍 Search Query',

--- a/packages/pieces/community/canva/src/lib/actions/get-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-asset.ts
@@ -11,6 +11,12 @@ export const getAsset = createAction({
   name: 'get_asset',
   displayName: 'Get Asset',
   description: 'Retrieve metadata for a specific asset (image or video), including name, tags, creation date, and thumbnail.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches metadata for a single Canva library asset (image or video) by asset ID, including name, tags, timestamps, thumbnail, and import status. Pick this when you already have an asset ID and need its details or to confirm an upload finished importing; it is about library assets, not designs (use Get Design for those). Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     asset_id: Property.Dropdown({
       displayName: 'Asset',

--- a/packages/pieces/community/canva/src/lib/actions/get-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-design.ts
@@ -12,6 +12,12 @@ export const getDesign = createAction({
   name: 'get_design',
   displayName: 'Get Design',
   description: 'Get the metadata for one of your designs, including owner information, URLs for editing and viewing, and thumbnail information.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches metadata for a single Canva design by design ID, including owner, edit/view URLs, and thumbnail. Pick this when you already know the design ID; use Find Design first if you only have a title or keywords. Read-only and idempotent; fails with 404 if the design does not exist or is inaccessible.',
+    idempotent: true,
+  },
   props: {
     designId: Property.Dropdown({
       displayName: 'Design',

--- a/packages/pieces/community/canva/src/lib/actions/get-folder.ts
+++ b/packages/pieces/community/canva/src/lib/actions/get-folder.ts
@@ -11,6 +11,12 @@ export const getFolder = createAction({
   name: 'get_folder',
   displayName: 'Get Folder',
   description: 'Retrieve metadata for a specific folder, including name, creation date, and thumbnail.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches metadata for a single Canva folder by folder ID, including its name, created/updated timestamps, and thumbnail. Pick this to verify a folder exists or get its details before moving items into it; it returns folder metadata only, not the folder contents. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     folder_id: Property.Dropdown({
       displayName: 'Folder',

--- a/packages/pieces/community/canva/src/lib/actions/import-design.ts
+++ b/packages/pieces/community/canva/src/lib/actions/import-design.ts
@@ -18,6 +18,12 @@ export const importDesign = createAction({
   name: 'import_design',
   displayName: 'Import Design',
   description: 'Import an external file (PDF, PSD, DOCX, PPTX, etc.) into Canva as a new design. This creates an asynchronous job that you can monitor for completion.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Uploads an external document or design file (PDF, DOCX, PPTX, XLSX, PSD, AI, and similar) and converts it into a new Canva design via an asynchronous import job, with a required title of at most 50 characters. Pick this to bring existing files into Canva as editable designs; use Create Design for a blank design and Upload Asset for images/videos meant for the media library. Not idempotent: each call starts a new import and can create duplicate designs.',
+    idempotent: false,
+  },
   props: {
     file: Property.File({
       displayName: 'Design File',

--- a/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
+++ b/packages/pieces/community/canva/src/lib/actions/move-folder-item.ts
@@ -11,6 +11,12 @@ export const moveFolderItem = createAction({
   name: 'move_folder_item',
   displayName: 'Move Folder Item',
   description: 'Move an item from one folder to another in Canva',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Moves a design or image asset into a specified destination folder in Canva, identified by item ID and folder ID. Pick this to reorganize library content; it fails for items that currently live in multiple folders (those must be moved in the Canva UI). Effectively idempotent: repeating the same move leaves the item in the same destination folder.',
+    idempotent: true,
+  },
   props: {
     to_folder_id: Property.Dropdown({
       displayName: 'Destination Folder',

--- a/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
+++ b/packages/pieces/community/canva/src/lib/actions/upload-asset.ts
@@ -21,6 +21,12 @@ export const uploadAsset = createAction({
   name: 'upload_asset',
   displayName: 'Upload Asset',
   description: 'Upload an image or video asset to your Canva library. This creates an asynchronous job that you can monitor for completion.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      "Uploads an image (max 50MB) or video (max 500MB) file into the user's Canva media library via an asynchronous job, with a required asset name of at most 50 characters. Pick this to add media for later use in designs; use Import Design instead when the file should become an editable design itself. Not idempotent: each call starts a new upload and creates a duplicate asset.",
+    idempotent: false,
+  },
   props: {
     file: Property.File({
       displayName: 'Asset File',

--- a/packages/pieces/community/convertkit/package.json
+++ b/packages/pieces/community/convertkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-convertkit",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/convertkit/src/lib/actions/broadcasts.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/broadcasts.ts
@@ -28,6 +28,12 @@ export const listBroadcasts = createAction({
   name: 'broadcasts_list_broadcasts',
   displayName: 'List Broadcasts',
   description: 'List all broadcasts',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves a page of broadcasts (one-off emails) in the ConvertKit account, 50 per page. Use it to find a broadcast ID before getting, updating, or deleting one. Read-only and idempotent; pass a page number to fetch beyond the first 50.',
+    idempotent: true,
+  },
   props: {
     page: broadcastPageNumber,
   },
@@ -42,6 +48,12 @@ export const createBroadcast = createAction({
   name: 'broadcasts_create_broadcast',
   displayName: 'Create Broadcast',
   description: 'Create a new broadcast',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new email broadcast (one-off email), optionally scheduled via the send-at field; without it the broadcast is saved unsent. Not idempotent — every call creates another broadcast, so do not retry blindly.',
+    idempotent: false,
+  },
   props: {
     content: broadcastContent,
     description,
@@ -106,6 +118,12 @@ export const getBroadcastById = createAction({
   name: 'broadcasts_get_broadcast',
   displayName: 'Get Broadcast',
   description: 'Get a broadcast',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches a single broadcast by its ID, returning its content and settings. Use when the broadcast ID is already known (e.g. from List Broadcasts); for delivery metrics use Broadcast Stats instead. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     broadcastId: broadcastId,
   },
@@ -137,6 +155,12 @@ export const updateBroadcast = createAction({
   name: 'broadcasts_update_broadcast',
   displayName: 'Update Broadcast',
   description: 'Update a broadcast',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Updates the content, subject, scheduling, or other fields of an existing broadcast by broadcast ID. Idempotent — repeating the same update leaves the broadcast in the same state. Requires a valid broadcast ID from List Broadcasts.',
+    idempotent: true,
+  },
   props: {
     broadcastId: broadcastId,
     content: broadcastContent,
@@ -205,6 +229,12 @@ export const broadcastStats = createAction({
   name: 'broadcasts_broadcast_stats',
   displayName: 'Broadcast Stats',
   description: 'Get broadcast stats',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves delivery and engagement statistics (recipients, opens, clicks, unsubscribes) for one broadcast by ID. Pick this over Get Broadcast when performance metrics are needed rather than content. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     broadcastId: broadcastId,
   },
@@ -236,6 +266,12 @@ export const deleteBroadcast = createAction({
   name: 'broadcasts_delete_broadcast',
   displayName: 'Delete Broadcast',
   description: 'Delete a broadcast',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Permanently deletes a broadcast by ID. Destructive and not retry-safe — a repeat call fails once the broadcast is gone, so confirm the ID via List Broadcasts first.',
+    idempotent: false,
+  },
   props: {
     broadcastId: broadcastId,
   },

--- a/packages/pieces/community/convertkit/src/lib/actions/custom-fields.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/custom-fields.ts
@@ -15,6 +15,12 @@ export const listFields = createAction({
   name: 'custom_fields_list_fields',
   displayName: 'List Custom Fields',
   description: 'Returns a list of all custom fields',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists every custom field defined on the account, including each field id, key, and label. Use it to discover field keys before setting custom field values on subscribers. Takes no inputs; read-only and idempotent.',
+    idempotent: true,
+  },
   props: {},
   async run(context) {
     return fetchCustomFields(context.auth.secret_text);
@@ -26,6 +32,12 @@ export const createField = createAction({
   name: 'custom_fields_create_field',
   displayName: 'Create Custom Field',
   description: 'Create a new custom field',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates one or more new custom fields from an array of labels (ConvertKit derives each field key from its label). Not idempotent — repeating the call creates duplicate fields, so check List Custom Fields first.',
+    idempotent: false,
+  },
   props: {
     fields: fieldsArray,
   },
@@ -59,6 +71,12 @@ export const updateField = createAction({
   name: 'custom_fields_update_field',
   displayName: 'Custom Fields: Update Field',
   description: 'Update a custom field',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Renames an existing custom field, selected by its current label, to a new label. Not idempotent — once the rename succeeds the old label no longer matches, so a retry with the same inputs fails.',
+    idempotent: false,
+  },
   props: {
     label,
     new_label,
@@ -95,6 +113,12 @@ export const deleteField = createAction({
   name: 'custom_fields_delete_field',
   displayName: 'Custom Fields: Delete Field',
   description: 'Delete a custom field',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Deletes a custom field by label, removing it and its stored values from all subscribers. Destructive and not retry-safe — a repeat call fails once the field is gone.',
+    idempotent: false,
+  },
   props: {
     label,
   },

--- a/packages/pieces/community/convertkit/src/lib/actions/forms.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/forms.ts
@@ -18,6 +18,12 @@ export const listForms = createAction({
   name: 'forms_list_forms',
   displayName: 'List Forms',
   description: 'Returns a list of all forms',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all forms and landing pages in the account with their IDs and names. Use it to find a form ID before adding subscribers to a form or listing form subscriptions. Takes no inputs; read-only and idempotent.',
+    idempotent: true,
+  },
   props: {},
   run(context) {  
     return fetchForms(context.auth.secret_text);
@@ -36,6 +42,12 @@ export const addSubscriberToForm = createAction({
   name: 'forms_add_subscriber_to_form',
   displayName: 'Add Subscriber To Form',
   description: 'Add a subscriber to a form',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Subscribes an email address to a specific form, optionally setting first name, tags, and custom field values. This is the standard way to add a new subscriber in ConvertKit. Effectively idempotent — re-subscribing the same email to the same form upserts rather than creating a duplicate.',
+    idempotent: true,
+  },
   props: {
     formId,
     email: subscriberEmail,
@@ -78,6 +90,12 @@ export const listFormSubscriptions = createAction({
   name: 'forms_list_form_subscriptions',
   displayName: 'List Form Subscriptions',
   description: 'List form subscriptions',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists the subscriptions for one form by form ID, one entry per subscriber who signed up through it. Use it to audit who joined via a given form. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     formId,
   },

--- a/packages/pieces/community/convertkit/src/lib/actions/purchases.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/purchases.ts
@@ -35,6 +35,12 @@ export const listPurchases = createAction({
   name: 'purchases_list_purchases',
   displayName: 'List Purchases',
   description: 'Returns a list of all purchases',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves a paginated list of all purchase records in the account; pass a page number to go beyond the first page. For purchases scoped to one subscriber, product, form, or sequence, prefer the dedicated filtered list actions. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     page: purchasesPageNumber,
   },
@@ -49,6 +55,12 @@ export const getPurchaseById = createAction({
   name: 'purchases_get_purchase_by_id',
   displayName: 'Get Purchase By Id',
   description: 'Returns data for a single purchase',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches one purchase record by its ConvertKit purchase ID (not the external transaction ID). Use List Purchases first if only the transaction details are known. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     purchaseId,
   },
@@ -90,6 +102,12 @@ export const createSinglePurchase = createAction({
   name: 'purchases_create_purchase',
   displayName: 'Create Purchase',
   description: 'Creates a new purchase',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Records a purchase with a single product line item against a subscriber email, including transaction ID, status, currency, and amounts. Use Create Multiple Purchases instead when an order contains several products. Not idempotent — repeat calls create duplicate purchase records.',
+    idempotent: false,
+  },
   props: {
     transactionId,
     transactionTime,
@@ -162,6 +180,12 @@ export const createPurchases = createAction({
   name: 'purchases_create_multiple_purchases',
   displayName: 'Create Multiple Purchases',
   description: 'Creates multiple purchases',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Records one purchase transaction containing multiple product line items for a subscriber email. Pick this over Create Purchase for multi-product orders. Not idempotent — repeat calls create duplicate purchase records.',
+    idempotent: false,
+  },
   props: {
     transactionId,
     transactionTime,
@@ -237,6 +261,12 @@ export const listPurchasesForSubscriber = createAction({
   name: 'purchases_list_purchases_for_subscriber',
   displayName: 'List Purchases For Subscriber',
   description: 'Returns a list of all purchases for a subscriber',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all purchases attributed to one subscriber by numeric subscriber ID. Use Get Subscriber By Email first if only an email address is known. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     subscriberId,
   },
@@ -274,6 +304,12 @@ export const listPurchasesForProduct = createAction({
   name: 'purchases_list_purchases_for_product',
   displayName: 'List Purchases For Product',
   description: 'Returns a list of all purchases for a product',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all purchases of a specific product by product ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     productId,
   },
@@ -300,6 +336,12 @@ export const listPurchasesForForm = createAction({
   name: 'purchases_list_purchases_for_form',
   displayName: 'List Purchases For Form',
   description: 'Returns a list of all purchases for a form',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all purchases associated with a specific form by form ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     formId,
   },
@@ -326,6 +368,12 @@ export const listPurchasesForSequence = createAction({
   name: 'purchases_list_purchases_for_sequence',
   displayName: 'List Purchases For Sequence',
   description: 'Returns a list of all purchases for a sequence',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all purchases associated with a specific sequence by sequence ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     sequenceId,
   },

--- a/packages/pieces/community/convertkit/src/lib/actions/sequences.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/sequences.ts
@@ -18,6 +18,12 @@ export const listSequences = createAction({
   name: 'sequences_list_sequences',
   displayName: 'List Sequences',
   description: 'Returns a list of all sequences',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all sequences (automated email courses) in the account with their IDs and names. Use it to find a sequence ID before enrolling subscribers or listing enrollments. Takes no inputs; read-only and idempotent.',
+    idempotent: true,
+  },
   props: {},
   run(context) {
     return fetchSequences(context.auth.secret_text);
@@ -29,6 +35,12 @@ export const addSubscriberToSequence = createAction({
   name: 'sequences_add_subscriber_to_sequence',
   displayName: 'Add Subscriber To Sequence',
   description: 'Add a subscriber to a sequence',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Enrolls an email address in a sequence so it starts receiving that automated email course, optionally setting first name, tags, and custom field values. Effectively idempotent — re-subscribing the same email to the same sequence upserts instead of duplicating the enrollment.',
+    idempotent: true,
+  },
   props: {
     sequenceId: sequenceIdDropdown,
     email: subscriberEmail,
@@ -72,6 +84,12 @@ export const listSubscriptionsToSequence = createAction({
   name: 'sequences_list_subscriptions_to_sequence',
   displayName: 'List Subscriptions To Sequence',
   description: 'List all subscriptions to a sequence',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all subscriber enrollments for one sequence by sequence ID. Use List Sequences first to find the ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     sequenceId: sequenceIdDropdown,
   },

--- a/packages/pieces/community/convertkit/src/lib/actions/subscribers.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/subscribers.ts
@@ -35,6 +35,12 @@ export const getSubscriberById = createAction({
   name: 'subscribers_get_subscriber_by_id',
   displayName: 'Get Subscriber By Id',
   description: 'Returns data for a single subscriber',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches one subscriber record (email, name, state, custom fields) by numeric subscriber ID. Use Get Subscriber By Email when only an address is known. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     subscriberId,
   },
@@ -49,6 +55,12 @@ export const getSubscriberByEmail = createAction({
   name: 'subscribers_get_subscriber_by_email',
   displayName: 'Get Subscriber By Email',
   description: 'Returns data for a single subscriber',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Looks up a single subscriber by email address and returns the full record including the numeric subscriber ID. Prefer this over Get Subscriber By Id when the ID is unknown. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     email_address: subscriberEmail,
   },
@@ -63,6 +75,12 @@ export const listSubscribers = createAction({
   name: 'subscribers_list_subscribers',
   displayName: 'List Subscribers',
   description: 'Returns a list of all subscribers',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists subscribers with optional filters (created/updated date ranges, email address), paging, and sorting. Use it for bulk audits or fuzzy searches; for one known subscriber prefer the Get Subscriber actions. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     page: subscribersPageNumber,
     sortOrder,
@@ -122,6 +140,12 @@ export const updateSubscriber = createAction({
   name: 'subscribers_update_subscriber',
   displayName: 'Update Subscriber',
   description: 'Update a subscriber',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Updates a subscriber email address, first name, or custom field values by numeric subscriber ID. Idempotent — repeating the same update leaves the subscriber in the same state. It cannot change subscription status; use Unsubscribe Subscriber for that.',
+    idempotent: true,
+  },
   props: {
     subscriberId,
     emailAddress: subscriberEmailOptional,
@@ -163,6 +187,12 @@ export const unsubscribeSubscriber = createAction({
   name: 'subscribers_unsubscribe_subscriber',
   displayName: 'Unsubscribe Subscriber',
   description: 'Unsubscribe a subscriber',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Unsubscribes the given email address from all emails in the account; this is the only removal mechanism, as there is no delete-subscriber action. Treated as non-idempotent — a retry may error once the address is already unsubscribed, though the end state is the same.',
+    idempotent: false,
+  },
   props: {
     email: subscriberEmail,
   },
@@ -195,6 +225,12 @@ export const listTagsBySubscriberId = createAction({
   name: 'subscribers_list_tags_by_subscriber_id',
   displayName: 'List Tags By Subscriber Id',
   description: 'Returns a list of all subscribed tags',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all tags currently applied to a subscriber, looked up by numeric subscriber ID. Use List Tags By Email when only an address is known. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     subscriberId,
   },
@@ -209,6 +245,12 @@ export const listSubscriberTagsByEmail = createAction({
   name: 'subscribers_list_tags_by_email',
   displayName: 'List Tags By Email',
   description: 'Returns a list of all subscribed tags',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all tags applied to a subscriber, looked up by email address (the email is resolved to a subscriber ID internally). Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     email_address: subscriberEmail,
   },

--- a/packages/pieces/community/convertkit/src/lib/actions/tags.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/tags.ts
@@ -30,6 +30,12 @@ export const listTags = createAction({
   name: 'tags_list_tags',
   displayName: 'List Tags',
   description: 'Returns a list of all tags',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists every tag in the account with its ID and name. Use it to find a tag ID before tagging or untagging subscribers, or before listing a tag\'s subscriptions. Takes no inputs; read-only and idempotent.',
+    idempotent: true,
+  },
   props: {},
   run(context) {
     return fetchTags(context.auth.secret_text);
@@ -41,6 +47,12 @@ export const createTag = createAction({
   name: 'tags_create_tag',
   displayName: 'Create Tag',
   description: 'Create a tag',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new tag with the given name. Not idempotent — calling it again can create a duplicate, so check List Tags for an existing tag first.',
+    idempotent: false,
+  },
   props: {
     name,
   },
@@ -76,6 +88,12 @@ export const tagSubscriber = createAction({
   name: 'tags_tag_subscriber',
   displayName: 'Tag Subscriber',
   description: 'Tag a subscriber',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Applies one or more existing tags to a subscriber by email address (subscribing the email to the first tag and attaching the rest), optionally setting first name and custom fields; at least one tag is required. Effectively idempotent — re-applying the same tags converges to the same state.',
+    idempotent: true,
+  },
   props: {
     email: subscriberEmail,
     // tagId: tag,
@@ -123,6 +141,12 @@ export const removeTagFromSubscriberByEmail = createAction({
   name: 'tags_remove_tag_from_subscriber_by_email',
   displayName: 'Remove Tag From Subscriber By Email',
   description: 'Remove a tag from a subscriber by email',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Removes a single tag from a subscriber identified by email address. Use the By Id variant when the numeric subscriber ID is already known. Treated as non-idempotent — a retry may error once the tag is already removed, though the end state is the same.',
+    idempotent: false,
+  },
   props: {
     email: subscriberEmail,
     tagId: tagIdByEmail,
@@ -157,6 +181,12 @@ export const removeTagFromSubscriberById = createAction({
   name: 'tags_remove_tag_from_subscriber_by_id',
   displayName: 'Remove Tag From Subscriber By Id',
   description: 'Remove a tag from a subscriber by id',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Removes a single tag from a subscriber identified by numeric subscriber ID. Use the By Email variant when only an address is known. Treated as non-idempotent — a retry may error once the tag is already removed.',
+    idempotent: false,
+  },
   props: {
     subscriberId,
     tagId: tagIdBySubscriberId,
@@ -191,6 +221,12 @@ export const listSubscriptionsToATag = createAction({
   name: 'tags_list_subscriptions_to_tag',
   displayName: 'List Subscriptions To Tag',
   description: 'List all subscriptions to a tag',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists the subscribers subscribed to a specific tag, with paging, sort order, and subscriber-state filtering. Use List Tags first to find the tag ID. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     tagId: tag,
     page: tagsPageNumber,

--- a/packages/pieces/community/convertkit/src/lib/actions/webhooks.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/webhooks.ts
@@ -16,6 +16,12 @@ export const createWebhook = createAction({
   name: 'create_webhook',
   displayName: 'Add Webhook',
   description: 'Create a webhook automation',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Registers a webhook automation that POSTs to a target URL whenever the chosen ConvertKit event fires (e.g. subscriber activated, tag added); some events also need an event parameter such as a tag or form ID. Not idempotent — each call registers another webhook, so keep the returned rule ID for later deletion.',
+    idempotent: false,
+  },
   props: {
     targetUrl,
     event,
@@ -41,6 +47,12 @@ export const deleteWebhook = createAction({
   name: 'destroy_webhook',
   displayName: 'Delete Webhook',
   description: 'Delete a webhook automation',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Deletes a previously registered webhook automation by its webhook rule ID (returned when the webhook was created). Not retry-safe — a repeat call fails once the webhook is gone.',
+    idempotent: false,
+  },
   props: {
     webhookId,
   },

--- a/packages/pieces/community/convertkit/src/lib/triggers/index.ts
+++ b/packages/pieces/community/convertkit/src/lib/triggers/index.ts
@@ -28,6 +28,10 @@ export const addTag = createTrigger({
   name: 'webhook_subscriber_tag_add',
   displayName: 'Tag added to subscriber',
   description: 'Trigger when a tag is added to a subscriber',
+  aiMetadata: {
+    description:
+      'Fires when the selected tag is added to a subscriber in ConvertKit (Kit), via webhook. Returns the tagged subscriber record; use it to react to segmentation changes such as enrolling the subscriber elsewhere or syncing the tag to another system.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     tagId: tag,
@@ -74,6 +78,10 @@ export const removeTag = createTrigger({
   name: 'webhook_subscriber_tag_remove',
   displayName: 'Tag removed from subscriber',
   description: 'Trigger when a tag is removed from a subscriber',
+  aiMetadata: {
+    description:
+      'Fires when the selected tag is removed from a subscriber in ConvertKit (Kit), via webhook. Returns the affected subscriber record; useful for reversing automations or updating external systems when a subscriber leaves a segment.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     tagId: tag,
@@ -121,6 +129,10 @@ export const subscriberActivated = createTrigger({
   displayName: 'Subscriber activated',
   description:
     'Trigger when a subscriber is activated. This happens when a subscriber confirms their subscription.',
+  aiMetadata: {
+    description:
+      'Fires when a subscriber becomes active in ConvertKit (Kit), i.e. they confirm their subscription (double opt-in), via webhook. Returns the activated subscriber record; use it to welcome new confirmed subscribers or add them to downstream systems.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {},
   sampleData,
@@ -162,6 +174,10 @@ export const subscriberUnsubscribed = createTrigger({
   name: 'webhook_subscriber_unsubscribed',
   displayName: 'Subscriber unsubscribed',
   description: 'Trigger when a subscriber is unsubscribed',
+  aiMetadata: {
+    description:
+      'Fires when a subscriber unsubscribes from the ConvertKit (Kit) account, via webhook. Returns the unsubscribed subscriber record; use it to suppress the contact in other tools or record the opt-out.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {},
   sampleData,
@@ -204,6 +220,10 @@ export const subscriberBounced = createTrigger({
   displayName: 'Subscriber bounced',
   description:
     'Trigger when a subscriber bounced. This happens when an email is sent to a subscriber and the email bounces.',
+  aiMetadata: {
+    description:
+      "Fires when an email sent to a subscriber bounces in ConvertKit (Kit), marking the subscriber as bounced, via webhook. Returns the bounced subscriber record; use it to clean lists or flag invalid email addresses.",
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {},
   sampleData,
@@ -249,6 +269,10 @@ export const subscriberComplained = createTrigger({
   displayName: 'Subscriber complained',
   description:
     'Trigger when a subscriber complained. This happens when a subscriber marks an email as spam.',
+  aiMetadata: {
+    description:
+      'Fires when a subscriber marks an email as spam, putting them in the complained state in ConvertKit (Kit), via webhook. Returns the complaining subscriber record; use it to suppress the contact and protect sender reputation.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {},
   sampleData,
@@ -290,6 +314,10 @@ export const formSubscribed = createTrigger({
   name: 'webhook_form_subscribed',
   displayName: 'Form subscribed',
   description: 'Trigger when a form is subscribed',
+  aiMetadata: {
+    description:
+      'Fires when someone subscribes through the selected ConvertKit (Kit) form, via webhook. Returns the new subscriber record; use it to start onboarding sequences or sync new sign-ups to a CRM.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     formId,
@@ -333,6 +361,10 @@ export const sequenceSubscribed = createTrigger({
   name: 'webhook_sequence_subscribed',
   displayName: 'Sequence subscribed',
   description: 'Trigger when a sequence is subscribed',
+  aiMetadata: {
+    description:
+      'Fires when a subscriber is added to the selected email sequence (course) in ConvertKit (Kit), via webhook. Returns the enrolled subscriber record; use it to track enrollments or mirror them in other systems.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     sequenceIdChoice: sequenceIdDropdown,
@@ -379,6 +411,10 @@ export const sequenceCompleted = createTrigger({
   name: 'webhook_sequence_completed',
   displayName: 'Sequence completed',
   description: 'Trigger when a sequence is completed',
+  aiMetadata: {
+    description:
+      'Fires when a subscriber finishes the last email of the selected sequence (course) in ConvertKit (Kit), via webhook. Returns the subscriber record; use it to follow up after a course ends, e.g. with an offer or a next sequence.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     sequenceIdChoice: sequenceIdDropdown,
@@ -425,6 +461,10 @@ export const linkClicked = createTrigger({
   name: 'webhook_link_clicked',
   displayName: 'Link clicked',
   description: 'Trigger when a link is clicked',
+  aiMetadata: {
+    description:
+      'Fires when a subscriber clicks the specified link URL in a ConvertKit (Kit) email, via webhook. Returns the clicking subscriber record plus the watched link URL; use it to score engagement or trigger interest-based follow-ups.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     initiatorValue,
@@ -470,6 +510,10 @@ export const productPurchased = createTrigger({
   name: 'webhook_product_purchased',
   displayName: 'Product purchased',
   description: 'Trigger when a product is purchased',
+  aiMetadata: {
+    description:
+      'Fires when a subscriber purchases the selected ConvertKit (Kit) Commerce product, via webhook. Returns the purchasing subscriber record plus the product ID; use it to deliver the product, tag buyers, or record the sale elsewhere.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     productId,
@@ -513,6 +557,10 @@ export const purchaseCreated = createTrigger({
   name: 'webhook_purchase_created',
   displayName: 'Purchase created',
   description: 'Trigger when a purchase is created',
+  aiMetadata: {
+    description:
+      'Fires when any new purchase record is created in the ConvertKit (Kit) account (across all products), via webhook. Returns the subscriber associated with the purchase; use it for account-wide sales notifications or bookkeeping.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {},
   sampleData,

--- a/packages/pieces/community/coupa/package.json
+++ b/packages/pieces/community/coupa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-coupa",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/coupa/src/lib/actions/add-file-attachment.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/add-file-attachment.ts
@@ -21,6 +21,12 @@ export const addFileAttachment = createAction({
   displayName: 'Add File Attachment to Object',
   description:
     'Adds an attachment (an uploaded file or a link) to a Purchase Order, Supplier, or Contract in Coupa.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Attach a file or a URL link to an existing Coupa purchase order, supplier, or contract record. Pick the mode via attachmentSource: upload a file directly, or link a URL instead. Not idempotent — each run appends a new attachment to the record, so retries create duplicates.',
+    idempotent: false,
+  },
   props: {
     module: attachmentModuleProperty,
     parentRecord: Property.DynamicProperties({

--- a/packages/pieces/community/coupa/src/lib/actions/cancel-purchase-order.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/cancel-purchase-order.ts
@@ -11,6 +11,12 @@ export const cancelPurchaseOrder = createAction({
   displayName: 'Cancel Purchase Order',
   description:
     'Cancels a purchase order using `PUT /api/purchase_orders/:id/cancel`.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Cancel an existing Coupa purchase order by ID, voiding it rather than completing it — use Close Purchase Order to finalize a fulfilled order instead. This is an irreversible workflow transition and not idempotent: re-running against an already-cancelled order may fail.',
+    idempotent: false,
+  },
   props: {
     purchaseOrderId: purchaseOrderDropdown,
   },

--- a/packages/pieces/community/coupa/src/lib/actions/close-purchase-order.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/close-purchase-order.ts
@@ -11,6 +11,12 @@ export const closePurchaseOrder = createAction({
   displayName: 'Close Purchase Order',
   description:
     'Closes a purchase order using `PUT /api/purchase_orders/:id/close`.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Close an existing Coupa purchase order by ID, marking it complete so no further receiving or invoicing occurs — use Cancel Purchase Order to void an order instead. Not idempotent: closing is a one-way workflow transition and re-running on an already-closed order may fail.',
+    idempotent: false,
+  },
   props: {
     purchaseOrderId: purchaseOrderDropdown,
   },

--- a/packages/pieces/community/coupa/src/lib/actions/create-object.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/create-object.ts
@@ -18,6 +18,12 @@ export const createObject = createAction({
   displayName: 'Create Object',
   description:
     'Creates a record in the selected Coupa module (Purchase Orders, Suppliers, or Contracts).',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Create a new record in a Coupa module — purchase orders, suppliers, contracts, or any other resource via the custom-module option — from a raw JSON body matching the Coupa API schema. Not idempotent: each run POSTs a new record, so retries create duplicates. Use Update Object to modify an existing record instead.',
+    idempotent: false,
+  },
   props: {
     module: moduleProperty,
     customResource: customModuleResourceProperty,

--- a/packages/pieces/community/coupa/src/lib/actions/get-object-by-id.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/get-object-by-id.ts
@@ -19,6 +19,12 @@ export const getObjectById = createAction({
   displayName: 'Get Object by ID',
   description:
     'Retrieves a single record by ID from Purchase Orders, Suppliers, or Contracts.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetch one Coupa record by its ID from purchase orders, suppliers, contracts, or any other resource via the custom-module option, with optional query parameters such as a fields filter. Use this when you already know the record ID; use Search Objects to find records by criteria. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     module: moduleProperty,
     customResource: customModuleResourceProperty,

--- a/packages/pieces/community/coupa/src/lib/actions/get-remit-to-addresses.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/get-remit-to-addresses.ts
@@ -15,6 +15,12 @@ export const getRemitToAddresses = createAction({
   displayName: 'Get Remit-To Addresses by Object ID',
   description:
     'Lists remit-to addresses for a Supplier or resolves the supplier from a Purchase Order.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'List the remit-to (payment) addresses on file for a Coupa supplier. Works in two modes: pass a supplier ID directly, or pass a purchase order ID and it resolves the linked supplier first (failing if the order has no supplier). Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     parentModule: remitToParentTypeProperty,
     parentRecord: Property.DynamicProperties({

--- a/packages/pieces/community/coupa/src/lib/actions/get-supplier-sites.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/get-supplier-sites.ts
@@ -11,6 +11,12 @@ export const getSupplierSites = createAction({
   displayName: 'Get Supplier Sites by Supplier',
   description:
     'Lists supplier sites for a supplier (`GET /api/suppliers/:id/supplier_sites`).',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'List all supplier sites (locations/storefronts) configured under a given Coupa supplier ID. Use this to enumerate a supplier\'s sites; use Get Remit-To Addresses for payment addresses instead. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     supplierId: supplierDropdown,
   },

--- a/packages/pieces/community/coupa/src/lib/actions/grant-approval.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/grant-approval.ts
@@ -11,6 +11,12 @@ export const grantApproval = createAction({
   displayName: 'Grant Approval',
   description:
     'Approves a pending approval in Coupa (e.g. a requisition or purchase order awaiting your decision). Pick the approval from the dropdown.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Approve a pending Coupa approval (e.g. a requisition or purchase order awaiting decision) by its approval ID, advancing the document through its approval chain. Use Reject Approval to decline instead. Not idempotent: the approval must be in a pending state, and re-running after it is decided may fail.',
+    idempotent: false,
+  },
   props: {
     approvalId: pendingApprovalDropdown,
   },

--- a/packages/pieces/community/coupa/src/lib/actions/reject-approval.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/reject-approval.ts
@@ -11,6 +11,12 @@ export const rejectApproval = createAction({
   displayName: 'Reject Approval',
   description:
     'Rejects a pending approval in Coupa (e.g. a requisition or purchase order awaiting your decision). Pick the approval from the dropdown.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Reject a pending Coupa approval (e.g. a requisition or purchase order awaiting decision) by its approval ID, optionally recording a rejection reason. Use Grant Approval to approve instead. Not idempotent: the approval must be in a pending state, and re-running after it is decided may fail.',
+    idempotent: false,
+  },
   props: {
     approvalId: pendingApprovalDropdown,
     reason: Property.LongText({

--- a/packages/pieces/community/coupa/src/lib/actions/search-objects.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/search-objects.ts
@@ -17,6 +17,12 @@ export const searchObjects = createAction({
   displayName: 'Search Objects (Batch)',
   description:
     'Searches records in a Coupa module with pagination (50 per page) and returns standardized fields.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Search and list records in a Coupa module — purchase orders, suppliers, contracts, or any other resource via the custom-module option — using optional Coupa query parameters as filters, auto-paginating through all matching pages. Use this to find records by criteria; use Get Object by ID when you already have an ID. Read-only and idempotent, but unfiltered searches on large modules can be slow.',
+    idempotent: true,
+  },
   props: {
     module: moduleProperty,
     customResource: customModuleResourceProperty,

--- a/packages/pieces/community/coupa/src/lib/actions/set-integration-run-status.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/set-integration-run-status.ts
@@ -11,6 +11,12 @@ export const setIntegrationRunStatus = createAction({
   displayName: 'Set Integration Run Status',
   description:
     'Updates an integration run status (`run`, `success`, `fail`, `pause`, or `pending`).',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Set the status of a Coupa integration run by ID to one of: run, success, fail, pause, or pending — used to report progress of an external integration job back to Coupa. Not idempotent: each call is a status transition, and Coupa may reject transitions that are invalid from the run\'s current state.',
+    idempotent: false,
+  },
   props: {
     integrationRunId: objectIdProperty,
     status: Property.StaticDropdown({

--- a/packages/pieces/community/coupa/src/lib/actions/update-object.ts
+++ b/packages/pieces/community/coupa/src/lib/actions/update-object.ts
@@ -19,6 +19,12 @@ export const updateObject = createAction({
   displayName: 'Update Object',
   description:
     'Updates a record by ID in the selected Coupa module (Purchase Orders, Suppliers, or Contracts).',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Update an existing Coupa record by ID — in purchase orders, suppliers, contracts, or any other resource via the custom-module option — by PUTting a raw JSON body of the fields to change. Requires a known record ID; use Create Object for new records. Effectively idempotent: re-sending the same body to the same ID yields the same record state.',
+    idempotent: true,
+  },
   props: {
     module: moduleProperty,
     customResource: customModuleResourceProperty,

--- a/packages/pieces/community/coupa/src/lib/triggers/new-or-updated-object.ts
+++ b/packages/pieces/community/coupa/src/lib/triggers/new-or-updated-object.ts
@@ -94,6 +94,10 @@ export const newOrUpdatedObject = createTrigger({
   displayName: 'New or Updated Object',
   description:
     'Triggers when a Purchase Order, Supplier, or Contract is created or updated in Coupa.',
+  aiMetadata: {
+    description:
+      'Fires when an object in the selected Coupa module (Purchase Order, Supplier, Contract, or a custom resource) is created or updated, polling on the updated-at timestamp. Each event carries the changed record with standard fields like id, number, status, total, supplier, and updated-at; optional JSON query filters can narrow which records are emitted.',
+  },
   props: {
     module: moduleProperty,
     customResource: customModuleResourceProperty,

--- a/packages/pieces/community/deepgram/package.json
+++ b/packages/pieces/community/deepgram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-deepgram",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/deepgram/src/actions/create-summary.ts
+++ b/packages/pieces/community/deepgram/src/actions/create-summary.ts
@@ -10,6 +10,12 @@ export const createSummaryAction = createAction({
   name: 'create_summary',
   displayName: 'Create Summary',
   description: 'Produces a summary of the content from an audio file.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Uploads an audio file to Deepgram and returns an AI-generated summary of its spoken content (summarize v2), synchronously. Pick this over Create Transcription when you need a condensed overview rather than the full text; by default it falls back to the full transcript if no summary is available. Re-running re-processes the audio and incurs another billed request, though it creates no persistent resource.',
+    idempotent: false,
+  },
   props: {
     audioFile: Property.File({
       displayName: 'Audio File',

--- a/packages/pieces/community/deepgram/src/actions/create-transcription.ts
+++ b/packages/pieces/community/deepgram/src/actions/create-transcription.ts
@@ -10,6 +10,12 @@ export const createTranscriptionCallbackAction = createAction({
   name: 'create_transcription_callback',
   displayName: 'Create Transcription (Callback)',
   description: 'Creates a transcription using a callback URL.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Submits an audio file to Deepgram for asynchronous speech-to-text: the action returns only a request ID immediately, and the finished transcript is delivered later to the callback URL you provide. Pick this for long audio or when a webhook endpoint will consume the result; it does not return the transcript itself. Each run submits a new billed transcription job, so it is not idempotent.',
+    idempotent: false,
+  },
   props: {
     audioFile: Property.File({
       displayName: 'Audio File',

--- a/packages/pieces/community/deepgram/src/actions/list-projects.ts
+++ b/packages/pieces/community/deepgram/src/actions/list-projects.ts
@@ -8,6 +8,12 @@ export const listProjectsAction = createAction({
   name: 'list_projects',
   displayName: 'List Projects',
   description: 'Retrieves a list of all projects associated with the account.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches all Deepgram projects accessible to the authenticated API key, with no inputs or filters. Use it to discover project IDs before project-scoped operations or to verify account access. Read-only and safe to call repeatedly.',
+    idempotent: true,
+  },
   props: {},
   async run(context) {
     const response = await httpClient.sendRequest({

--- a/packages/pieces/community/deepgram/src/actions/text-to-speech.ts
+++ b/packages/pieces/community/deepgram/src/actions/text-to-speech.ts
@@ -9,6 +9,12 @@ export const textToSpeechAction = createAction({
   name: 'text_to_speech',
   displayName: 'Text to Speech',
   description: 'Converts text to audio file.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Synthesizes speech from text using a Deepgram Aura voice and saves the result as an audio file in a chosen encoding (mp3 by default). Pick this only for generating spoken audio from text, the inverse of the transcription actions. Each run produces a newly generated, billed audio file, so it is not idempotent.',
+    idempotent: false,
+  },
   props: {
     text: Property.LongText({
       displayName: 'Text',

--- a/packages/pieces/community/jina-ai/package.json
+++ b/packages/pieces/community/jina-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jina-ai",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/jina-ai/src/lib/actions/classify-content.ts
+++ b/packages/pieces/community/jina-ai/src/lib/actions/classify-content.ts
@@ -9,6 +9,12 @@ export const classifyContentAction = createAction({
   displayName: 'Classify Text or Image',
   description:
     'Assign categories to text or images using the Classifier API (zero-shot/few-shot).',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Classify a single piece of text or an image URL into one of a provided set of labels using Jina AI zero-shot classification; returns the winning label. Pick this to categorize content against your own label set without training; if the input string is a URL it is treated as an image. Stateless inference, so repeat calls are idempotent. To fine-tune a reusable classifier on labeled examples instead, use Train Custom Classifier.',
+    idempotent: true,
+  },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/jina-ai/src/lib/actions/deepsearch-query.ts
+++ b/packages/pieces/community/jina-ai/src/lib/actions/deepsearch-query.ts
@@ -9,6 +9,12 @@ export const deepSearchQueryAction = createAction({
   displayName: 'DeepSearch Query',
   description:
     'Answer complex questions through iterative search, reading, and reasoning with the DeepSearch API.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Answer a complex research question with Jina DeepSearch, which iteratively searches the web, reads pages, and reasons before responding; supports domain include/exclude lists, token budget, and an optional JSON schema for structured output. Pick this for multi-hop research questions rather than a plain keyword search (use Web Search Summarization for that); it is slower and more token-hungry than a single search. Read-only, so safe to retry, though answers may vary between runs.',
+    idempotent: true,
+  },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/jina-ai/src/lib/actions/extract-webpage-content.ts
+++ b/packages/pieces/community/jina-ai/src/lib/actions/extract-webpage-content.ts
@@ -9,6 +9,12 @@ export const extractWebpageContentAction = createAction({
   displayName: 'Extract Webpage Content',
   description:
     'Convert a URL into clean, LLM-friendly Markdown using the Reader API.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetch a single webpage by URL via the Jina Reader API and return its content cleaned for LLM consumption, with optional markdown/HTML/text/screenshot output, CSS-selector targeting or exclusion, and link/image summaries. Pick this when you already have the target URL; to find pages by keyword first, use Web Search Summarization. Read-only fetch, so repeat calls are idempotent (results may be served from cache unless do-not-track is set).',
+    idempotent: true,
+  },
   props: {
     url: Property.ShortText({
       displayName: 'URL',

--- a/packages/pieces/community/jina-ai/src/lib/actions/train-custom-classifier.ts
+++ b/packages/pieces/community/jina-ai/src/lib/actions/train-custom-classifier.ts
@@ -9,6 +9,12 @@ export const trainCustomClassifierAction = createAction({
   displayName: 'Train Custom Classifier',
   description:
     'Fine-tune a classifier with labeled examples for domain-specific tasks.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Train a custom Jina AI classifier from an array of labeled text or image-URL examples, choosing the base embedding model, iteration count, and private/public visibility. Pick this only when zero-shot labeling (Classify Text or Image) is not accurate enough and you have labeled training data. Each call creates a new training job/classifier, so repeated calls are not idempotent.',
+    idempotent: false,
+  },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/jina-ai/src/lib/actions/web-search-summarization.ts
+++ b/packages/pieces/community/jina-ai/src/lib/actions/web-search-summarization.ts
@@ -9,6 +9,12 @@ export const webSearchSummarizationAction = createAction({
   displayName: 'Web Search Summarization',
   description:
     'Perform a web search and retrieve summarized results using the Reader API.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Run a web search through the Jina Reader search API and return the result list, optionally visiting every hit to include full page content; supports country/language/location targeting, in-site (single-domain) search, and pagination. Pick this to discover pages by keyword — use Extract Webpage Content for a known URL or DeepSearch Query for multi-step research questions. Read-only search, so repeat calls are idempotent.',
+    idempotent: true,
+  },
   props: {
     query: Property.ShortText({
       displayName: 'Query',

--- a/packages/pieces/community/jira-cloud/package.json
+++ b/packages/pieces/community/jira-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jira-cloud",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/jira-cloud/src/lib/actions/add-attachment-to-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/add-attachment-to-issue.ts
@@ -10,6 +10,12 @@ export const addAttachmentToIssueAction = createAction({
 	name: 'add_issue_attachment',
 	displayName: 'Add Attachment to Issue',
 	description: 'Adds an attachment to an issue.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Upload a file as an attachment on an existing Jira issue, identified by project and issue. Use when a file (image, log, document) needs to be stored on the issue itself rather than referenced in a comment. Not idempotent: re-running uploads a duplicate copy of the same file.',
+		idempotent: false,
+	},
 	props: {
 		projectId: getProjectIdDropdown(),
 		issueId: getIssueIdDropdown({ refreshers: ['projectId'] }),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/add-comment-to-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/add-comment-to-issue.ts
@@ -9,6 +9,12 @@ export const addCommentToIssueAction = createAction({
 	name: 'add_issue_comment',
 	displayName: 'Add Issue Comment',
 	description: 'Adds a comment to an issue.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Post a new comment on an existing Jira issue. Accepts plain text by default, or raw Atlassian Document Format (ADF) JSON when the ADF flag is set — use the Markdown to Jira Format action to produce ADF from markdown. Not idempotent: each run appends another comment.',
+		idempotent: false,
+	},
 	props: {
 		projectId: getProjectIdDropdown(),
 		issueId: getIssueIdDropdown({ refreshers: ['projectId'] }),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/add-watcher-to-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/add-watcher-to-issue.ts
@@ -10,6 +10,12 @@ export const addWatcherToIssueAction = createAction({
 	name: 'add-watcher-to-issue',
 	displayName: 'Add Watcher to Issue',
 	description: 'Adds a new watcher to an issue.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Subscribe a specific user as a watcher on a Jira issue (by issue ID/key and user account) so they get notifications about its updates. Use to loop someone in without assigning or commenting. Effectively idempotent: adding a user who already watches the issue leaves it unchanged.',
+		idempotent: true,
+	},
 	props: {
 		issueId: issueIdOrKeyProp('Issue ID or Key', true),
 		userId: getUsersDropdown({

--- a/packages/pieces/community/jira-cloud/src/lib/actions/assign-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/assign-issue.ts
@@ -9,6 +9,12 @@ export const assignIssueAction = createAction({
 	name: 'assign_issue',
 	displayName: 'Assign Issue',
 	description: 'Assigns an issue to a user.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Set the assignee of an existing Jira issue to a chosen user, replacing any current assignee. Use to route ownership of an issue; it changes only the assignee field, nothing else. Idempotent: assigning the same user again leaves the issue unchanged.',
+		idempotent: true,
+	},
 	props: {
 		projectId: getProjectIdDropdown(),
 		issueId: getIssueIdDropdown({ refreshers: ['projectId'] }),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/create-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/create-issue.ts
@@ -32,6 +32,12 @@ export const createIssueAction = createAction({
 	name: 'create_issue',
 	displayName: 'Create Issue',
 	description: 'Creates a new issue in a project.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Create a new Jira issue in a given project and issue type, with fields driven by that type\'s create screen (summary, description, custom fields, etc.); selected rich-text fields can be supplied as raw ADF JSON. Use for brand-new work items — to modify an existing one use Update Issue. Not idempotent: every run creates another issue.',
+		idempotent: false,
+	},
 	auth: jiraCloudAuth,
 	props: {
 		projectId: getProjectIdDropdown(),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/delete-issue-comment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/delete-issue-comment.ts
@@ -9,6 +9,12 @@ export const deleteIssueCommentAction = createAction({
 	name: 'delete_issue_comment',
 	displayName: 'Delete Issue Comment',
 	description: 'Deletes a comment on a specific issue.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Permanently remove a specific comment (by comment ID) from a Jira issue. Use to clean up an outdated or incorrect comment; the deletion cannot be undone. Idempotent in effect — the comment ends up gone either way — though a repeat call on an already-deleted comment returns a not-found error.',
+		idempotent: true,
+	},
 	props: {
 		projectId: getProjectIdDropdown(),
 		issueId: getIssueIdDropdown({ refreshers: ['projectId'] }),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/find-user.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/find-user.ts
@@ -8,6 +8,12 @@ export const findUserAction = createAction({
     name:'find-user',
     displayName:'Find User',
     description:'Finds an existing user.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Search Jira users by a keyword matched against display name and email, returning all matches plus a found flag. Use to resolve a person\'s name or email into a Jira accountId before assigning issues or adding watchers. Read-only and idempotent.',
+        idempotent: true,
+    },
     props:{
         keyword:Property.ShortText({
             displayName:'Keyword',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/get-issue-attachment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/get-issue-attachment.ts
@@ -8,6 +8,12 @@ export const getIssueAttachmentAction = createAction({
     name: 'get-issue-attachment',
     displayName: 'Get Issue Attachment',
     description: 'Retrieves an attachment from an issue.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Download a Jira attachment by its attachment ID, fetching both its metadata and the file content itself for use in later steps. Use when you already have the attachment ID (e.g. from Get Issue) and need the actual file, not just a link. Read-only and idempotent.',
+        idempotent: true,
+    },
     props: {
         attachmentId: Property.ShortText({
             displayName: 'Attachment ID',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/get-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/get-issue.ts
@@ -9,6 +9,12 @@ export const getIssueAction = createAction({
   name: 'get_issue',
   displayName: 'Get Issue',
   description: 'Get issue data.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetch a single Jira issue by project and issue, optionally expanding extras like rendered fields, transitions, edit metadata, or changelog, and optionally remapping cryptic field/transition IDs to human-readable names. Use when you know which issue you want; to find issues by criteria use Search Issues instead. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     projectId: getProjectIdDropdown(),
     issueId: getIssueIdDropdown({ refreshers: ['projectId'] }),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/link-issues.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/link-issues.ts
@@ -10,6 +10,12 @@ export const linkIssuesAction = createAction({
   name: 'link-issues',
   displayName: 'Link Issues',
   description: 'Creates a link between two issues.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Create a directional link of a chosen type (e.g. blocks, relates to, duplicates) between two existing Jira issues, given both issue IDs/keys. Use to express dependencies or relationships; direction matters, with the first issue taking the outward role. Not idempotent: re-running can add a duplicate link.',
+    idempotent: false,
+  },
   props: {
     firstIssueId: issueIdOrKeyProp('First Issue', true),
     issueLinkTypeId: issueLinkTypeIdProp('Link Type', true),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/list-issue-comments.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/list-issue-comments.ts
@@ -9,6 +9,12 @@ export const listIssueCommentsAction = createAction({
 	name: 'list_issue_comments',
 	displayName: 'List Issue Comments',
 	description: 'Returns all comments for an issue.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'List comments on a Jira issue, ordered by creation date (ascending or descending) and capped at a configurable limit, including rendered HTML bodies. Use to read an issue\'s discussion before replying or summarizing. Read-only and idempotent.',
+		idempotent: true,
+	},
 	props: {
 		projectId: getProjectIdDropdown(),
 		issueId: getIssueIdDropdown({ refreshers: ['projectId'] }),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/markdown-to-jira-format.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/markdown-to-jira-format.ts
@@ -8,6 +8,12 @@ export const markdownToJiraFormat = createAction({
   displayName: 'Markdown to Jira format',
   description:
     "Convert Markdown-formatted text to Jira's ADF syntax for use in comments and descriptions etc",
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Convert markdown text into an Atlassian Document Format (ADF) JSON document, locally with no API call or auth needed. Use before Add/Update Issue Comment or rich-text issue fields whenever content is authored in markdown, since Jira Cloud rich text requires ADF. Pure transformation, fully idempotent.',
+    idempotent: true,
+  },
   requireAuth: false,
   props: {
     markdown: Property.LongText({

--- a/packages/pieces/community/jira-cloud/src/lib/actions/search-issues.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/search-issues.ts
@@ -9,6 +9,12 @@ export const searchIssues = createAction({
   name: 'search_issues',
   displayName: 'Search Issues',
   description: 'Search for issues with JQL',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Search Jira issues with an arbitrary JQL query, paginating automatically up to a max-results cap (1-5000) and optionally restricting which fields are returned or mapping field IDs to readable names. The go-to tool for finding issues by project, status, assignee, dates, or any JQL-expressible criteria; limit returned fields on large result sets to avoid memory issues. Read-only and idempotent.',
+    idempotent: true,
+  },
   auth: jiraCloudAuth,
   props: {
     memoryWarning: Property.MarkDown({

--- a/packages/pieces/community/jira-cloud/src/lib/actions/transition-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/transition-issue.ts
@@ -15,6 +15,12 @@ export const transitionIssueAction = createAction({
   displayName: 'Transition Issue',
   description:
     'Moves an issue to a new status by executing a workflow transition.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Execute a workflow transition on a Jira issue to move it to a new status (e.g. In Progress to Done), returning the refreshed issue. The transition must be valid from the issue\'s current status under its workflow, so it is not idempotent: re-running after the move succeeds fails because the transition is no longer available.',
+    idempotent: false,
+  },
   props: {
     projectId: getProjectIdDropdown(),
     issueId: getIssueIdDropdown({ refreshers: ['projectId'] }),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/update-issue-comment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/update-issue-comment.ts
@@ -9,6 +9,12 @@ export const updateIssueCommentAction = createAction({
 	name: 'update_issue_comment',
 	displayName: 'Update Issue Comment',
 	description: 'Updates a comment to a specific issue.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Replace the body of an existing comment (by comment ID) on a Jira issue, in plain text or raw ADF JSON when the ADF flag is set. Use to correct or extend an earlier comment instead of posting a new one with Add Issue Comment. Idempotent: re-running with the same body leaves the comment unchanged.',
+		idempotent: true,
+	},
 	props: {
 		projectId: getProjectIdDropdown(),
 		issueId: getIssueIdDropdown({ refreshers: ['projectId'] }),

--- a/packages/pieces/community/jira-cloud/src/lib/actions/update-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/update-issue.ts
@@ -36,6 +36,12 @@ export const updateIssueAction = createAction({
 	name: 'update_issue',
 	displayName: 'Update Issue',
 	description: 'Updates an existing issue.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Update fields on an existing Jira issue (by ID or key) using its edit screen — summary, description, custom fields, etc. — with optional ADF JSON for rich-text fields, and optionally trigger a status transition in the same run; returns the refreshed issue. Use to modify existing items rather than Create Issue. Field updates are idempotent (same values yield the same state), though a repeated status transition may fail once already applied.',
+		idempotent: true,
+	},
 	auth: jiraCloudAuth,
 	props: {
 		issueId: issueIdOrKeyProp('Issue ID or Key', true),

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/issue-assigned.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/issue-assigned.ts
@@ -119,6 +119,10 @@ export const issueAssigned = createTrigger({
   displayName: 'Issue Assigned',
   description:
     'Fires when a Jira issue is assigned to someone. Use it to ping people in Slack/Teams the moment work lands on them, auto-create a to-do when tickets hit your queue, or track hand-offs between teammates.',
+  aiMetadata: {
+    description:
+      'Fires when the assignee of a Jira issue changes, optionally filtered to a specific assignee, the connected user, or a JQL scope. Each event represents one assignment change and includes the issue plus the previous/new assignee, who made the change, and when. Polling-based; events arrive on the next poll, not instantly.',
+  },
   auth: jiraCloudAuth,
   type: TriggerStrategy.POLLING,
   props: {

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-attachment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-attachment.ts
@@ -120,6 +120,10 @@ export const newAttachment = createTrigger({
   displayName: 'New Attachment on Issue',
   description:
     'Fires when a file is attached to a Jira issue. Great for auto-saving screenshots to Google Drive, forwarding customer uploads to support tools, or archiving documents in S3.',
+  aiMetadata: {
+    description:
+      'Fires when a new file attachment is added to a Jira issue, optionally limited to issues matching a JQL filter. Each event represents one attachment and includes its metadata (filename, size, MIME type, author, download URL) plus the parent issue. Polling-based; events arrive on the next poll, not instantly.',
+  },
   auth: jiraCloudAuth,
   type: TriggerStrategy.POLLING,
   props: {

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-comment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-comment.ts
@@ -84,6 +84,10 @@ export const newComment = createTrigger({
 	displayName: 'New Comment',
 	description:
 		'Fires whenever someone adds a new comment to a Jira issue. Great for getting notified in Slack or Teams, syncing customer replies, or reacting to feedback automatically.',
+	aiMetadata: {
+		description:
+			'Fires when a new comment is posted on a Jira issue, optionally limited to issues matching a JQL filter. Each event represents one comment and includes the comment body, author, timestamps, and the parent issue. Polling-based; events arrive on the next poll, not instantly.',
+	},
 	auth: jiraCloudAuth,
 	type: TriggerStrategy.POLLING,
 	props: {

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-issue.ts
@@ -39,6 +39,10 @@ export const newIssue = createTrigger({
   name: 'new_issue',
   displayName: 'New Issue',
   description: 'Triggers when a new issue is created',
+  aiMetadata: {
+    description:
+      'Fires when a new Jira issue is created, optionally limited to issues matching a JQL filter. Each event represents one newly created issue with its full field data (summary, project, type, status, reporter, etc.). Polling-based; events arrive on the next poll, not instantly.',
+  },
   auth: jiraCloudAuth,
   type: TriggerStrategy.POLLING,
   props: {

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/updated-issue-status.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/updated-issue-status.ts
@@ -39,6 +39,10 @@ export const updatedIssueStatus = createTrigger({
   name: 'updated_issue_status',
   displayName: 'Updated Issue Status',
   description: 'Triggers when an issue status is updated',
+  aiMetadata: {
+    description:
+      "Fires when a Jira issue's status changes (e.g. To Do -> In Progress -> Done), optionally limited to issues matching a JQL filter. Each event represents one issue whose status was updated and includes the issue's current field data. Polling-based; events arrive on the next poll, not instantly.",
+  },
   auth: jiraCloudAuth,
   type: TriggerStrategy.POLLING,
   props: {

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/updated-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/updated-issue.ts
@@ -38,6 +38,10 @@ export const updatedIssue = createTrigger({
   name: 'updated_issue',
   displayName: 'Updated Issue',
   description: 'Triggers when an issue is updated',
+  aiMetadata: {
+    description:
+      'Fires when any field of a Jira issue is updated (status, assignee, summary, etc.), optionally limited to issues matching a JQL filter. Each event represents one updated issue with its current field data; it does not include a diff of what changed. Polling-based; events arrive on the next poll, not instantly.',
+  },
   auth: jiraCloudAuth,
   type: TriggerStrategy.POLLING,
   props: {

--- a/packages/pieces/community/jungle-grid/package.json
+++ b/packages/pieces/community/jungle-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jungle-grid",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/jungle-grid/src/lib/actions/cancel-job.ts
+++ b/packages/pieces/community/jungle-grid/src/lib/actions/cancel-job.ts
@@ -8,6 +8,12 @@ export const cancelJob = createAction({
   name: 'cancel_job',
   displayName: 'Cancel Job',
   description: 'Cancel a non-terminal Jungle Grid job. This may stop active execution.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Request cancellation of a running or queued Jungle Grid job by job ID, optionally recording a reason. Pick this to stop a job that is no longer needed; it mutates job state and only applies to jobs that have not already reached a terminal status. Not idempotent: retrying against an already-cancelled or finished job may fail.',
+    idempotent: false,
+  },
   props: {
     job_id: jungleGridCommon.jobId,
     reason: Property.ShortText({

--- a/packages/pieces/community/jungle-grid/src/lib/actions/estimate-job.ts
+++ b/packages/pieces/community/jungle-grid/src/lib/actions/estimate-job.ts
@@ -8,6 +8,12 @@ export const estimateJob = createAction({
   name: 'estimate_job',
   displayName: 'Estimate Job',
   description: 'Estimate the cost, duration, and resources for a Jungle Grid job.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Compute a cost, duration, and resource estimate for a prospective Jungle Grid job from the same specification used by Submit Job, without actually running anything. Pick this to preview or budget-check a job before submission; it is a safe, idempotent calculation with no side effects. Use Submit Job afterwards to actually execute.',
+    idempotent: true,
+  },
   props: {
     instructions: jungleGridCommon.asyncInstructions,
     ...jungleGridCommon.estimateJobProps,

--- a/packages/pieces/community/jungle-grid/src/lib/actions/get-artifact-download-url.ts
+++ b/packages/pieces/community/jungle-grid/src/lib/actions/get-artifact-download-url.ts
@@ -8,6 +8,12 @@ export const getArtifactDownloadUrl = createAction({
   name: 'get_artifact_download_url',
   displayName: 'Get Artifact Download URL',
   description: 'Create a temporary signed download URL for a Jungle Grid artifact. Treat the returned URL as a secret.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Generate a short-lived signed download URL for one artifact of a Jungle Grid job, given the job ID and artifact ID. Pick this after List Job Artifacts when a file actually needs to be downloaded; calling it is safe to repeat (each call just issues a fresh temporary URL), but the URL expires and must be treated as a secret.',
+    idempotent: true,
+  },
   props: {
     job_id: jungleGridCommon.jobId,
     artifact_id: jungleGridCommon.artifactId,

--- a/packages/pieces/community/jungle-grid/src/lib/actions/get-job-logs.ts
+++ b/packages/pieces/community/jungle-grid/src/lib/actions/get-job-logs.ts
@@ -8,6 +8,12 @@ export const getJobLogs = createAction({
   name: 'get_job_logs',
   displayName: 'Get Job Logs',
   description: 'Get recent stdout, stderr, or combined logs for a submitted Jungle Grid job.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetch recent log lines for a Jungle Grid job by job ID, choosing stdout, stderr, or both, with a tail of up to 500 lines and cursor-based paging for more. Pick this to debug a failing job or inspect output text; for structured status or exit-code details use Get Job Status or Get Job Runtime instead. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     job_id: jungleGridCommon.jobId,
     tail_lines: Property.Number({

--- a/packages/pieces/community/jungle-grid/src/lib/actions/get-job-runtime.ts
+++ b/packages/pieces/community/jungle-grid/src/lib/actions/get-job-runtime.ts
@@ -8,6 +8,12 @@ export const getJobRuntime = createAction({
   name: 'get_job_runtime',
   displayName: 'Get Job Runtime',
   description: 'Get runtime tails, exit code, and runtime availability details for a Jungle Grid job.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieve runtime execution details for a Jungle Grid job by job ID, including log tails, exit code, and whether runtime data is available. Pick this to diagnose how a job actually ran; use Get Job Status for lifecycle state only, or Get Job Logs for fuller paginated log output. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     job_id: jungleGridCommon.jobId,
   },

--- a/packages/pieces/community/jungle-grid/src/lib/actions/get-job-status.ts
+++ b/packages/pieces/community/jungle-grid/src/lib/actions/get-job-status.ts
@@ -8,6 +8,12 @@ export const getJobStatus = createAction({
   name: 'get_job_status',
   displayName: 'Get Job Status',
   description: 'Get the current status and metadata for a submitted Jungle Grid job.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Look up the current lifecycle status and metadata of a Jungle Grid job by job ID. Pick this as the standard poll after Submit Job to check whether a job is queued, running, or finished; for exit codes and log tails use Get Job Runtime, and for output files use List Job Artifacts. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     job_id: jungleGridCommon.jobId,
   },

--- a/packages/pieces/community/jungle-grid/src/lib/actions/list-artifacts.ts
+++ b/packages/pieces/community/jungle-grid/src/lib/actions/list-artifacts.ts
@@ -8,6 +8,12 @@ export const listArtifacts = createAction({
   name: 'list_artifacts',
   displayName: 'List Job Artifacts',
   description: 'List files produced by a Jungle Grid job when managed artifact storage is available.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'List the output files (artifacts) produced by a Jungle Grid job, by job ID. Pick this after a job completes to discover what it produced, then use Get Artifact Download URL to fetch a specific file; only works when the workspace has managed artifact storage. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     job_id: jungleGridCommon.jobId,
   },

--- a/packages/pieces/community/jungle-grid/src/lib/actions/list-jobs.ts
+++ b/packages/pieces/community/jungle-grid/src/lib/actions/list-jobs.ts
@@ -8,6 +8,12 @@ export const listJobs = createAction({
   name: 'list_jobs',
   displayName: 'List Jobs',
   description: 'List Jungle Grid jobs for the authenticated workspace, optionally filtered by status.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'List jobs in the authenticated Jungle Grid workspace, optionally filtered by status, with cursor-based pagination up to 100 per page. Pick this to find a job ID when none is known or to survey recent activity; if you already have a job ID, Get Job Status is more direct. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     limit: Property.Number({
       displayName: 'Limit',

--- a/packages/pieces/community/jungle-grid/src/lib/actions/submit-job.ts
+++ b/packages/pieces/community/jungle-grid/src/lib/actions/submit-job.ts
@@ -9,6 +9,12 @@ export const submitJob = createAction({
   displayName: 'Submit Job',
   description:
     'Submit a Jungle Grid job and return immediately with job metadata. This action does not wait for completion.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Submit a new Jungle Grid job for asynchronous execution; it returns immediately with job metadata and does not wait for completion, so poll with Get Job Status afterwards. Pick this to actually run a workload (use Estimate Job first to preview cost). Not idempotent: each call creates a new job, so retries can launch duplicates.',
+    idempotent: false,
+  },
   props: {
     instructions: jungleGridCommon.asyncInstructions,
     ...jungleGridCommon.submitJobProps,

--- a/packages/pieces/community/trust/package.json
+++ b/packages/pieces/community/trust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-trust",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/trust/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/trust/src/lib/actions/create-contact.ts
@@ -8,6 +8,12 @@ export const createContactAction = createAction({
   name: 'create_contact',
   displayName: 'Create Contact',
   description: 'Creates a new contact in the system.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Create a new contact in the Trust workspace, optionally with name, email, phone, and a profile image URL. Pick this to register a person before requesting or attaching testimonials; to modify someone who already exists, use Update Contact instead. All fields are optional, and every call creates a new contact record, so repeated calls produce duplicates (not idempotent).',
+    idempotent: false,
+  },
   props: {
     firstname: Property.ShortText({
       displayName: 'First Name',

--- a/packages/pieces/community/trust/src/lib/actions/create-testimonial.ts
+++ b/packages/pieces/community/trust/src/lib/actions/create-testimonial.ts
@@ -8,6 +8,12 @@ export const createTestimonialAction = createAction({
   name: 'create_testimonial',
   displayName: 'Create Testimonial',
   description: 'Creates a new testimonial in the system.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Create a new testimonial in the Trust workspace with author details (name, email, job title, company), text and/or video content, a 1-5 star rating, plus published and consent flags. Pick this to add a fresh testimonial; media must already be hosted (pass URLs or embed HTML — upload files first via the upload actions). Each call creates a new testimonial, so retries produce duplicates (not idempotent).',
+    idempotent: false,
+  },
   props: {
     firstname: Property.ShortText({
       displayName: 'First Name',

--- a/packages/pieces/community/trust/src/lib/actions/delete-contact.ts
+++ b/packages/pieces/community/trust/src/lib/actions/delete-contact.ts
@@ -8,6 +8,12 @@ export const deleteContactAction = createAction({
   name: 'delete_contact',
   displayName: 'Delete Contact',
   description: 'Deletes a contact by ID.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Permanently delete a Trust contact identified by its contact ID. Pick this only when the contact record should be removed entirely; this is destructive and cannot be undone via the API. Deleting by a fixed ID is idempotent in effect — repeating the call leaves the same end state, though a second attempt may return an error since the contact no longer exists.',
+    idempotent: true,
+  },
   props: {
     contactId: Property.ShortText({
       displayName: 'Contact ID',

--- a/packages/pieces/community/trust/src/lib/actions/delete-testimonial.ts
+++ b/packages/pieces/community/trust/src/lib/actions/delete-testimonial.ts
@@ -8,6 +8,12 @@ export const deleteTestimonialAction = createAction({
   name: 'delete_testimonial',
   displayName: 'Delete Testimonial',
   description: 'Deletes a testimonial by ID.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Permanently delete a Trust testimonial identified by its testimonial ID. Pick this only for outright removal; to merely hide a testimonial from public view, use Update Testimonial and set published to false instead. Deleting by a fixed ID is idempotent in effect — repeats leave the same end state, though a second attempt may error because the testimonial is already gone.',
+    idempotent: true,
+  },
   props: {
     testimonialId: Property.ShortText({
       displayName: 'Testimonial ID',

--- a/packages/pieces/community/trust/src/lib/actions/find-contact.ts
+++ b/packages/pieces/community/trust/src/lib/actions/find-contact.ts
@@ -8,6 +8,12 @@ export const findContactAction = createAction({
   name: 'find_contact',
   displayName: 'Find Contact',
   description: 'Finds a contact by ID or email address.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Look up a Trust contact either by its contact ID (direct fetch) or by email address (search) — provide at least one, and the ID takes priority when both are given. Pick this to resolve a contact ID before an update or delete, or to check whether a person already exists before creating them. Read-only and safe to retry (idempotent).',
+    idempotent: true,
+  },
   props: {
     contactId: Property.ShortText({
       displayName: 'Contact ID',

--- a/packages/pieces/community/trust/src/lib/actions/find-testimonial.ts
+++ b/packages/pieces/community/trust/src/lib/actions/find-testimonial.ts
@@ -8,6 +8,12 @@ export const findTestimonialAction = createAction({
   name: 'find_testimonial',
   displayName: 'Find Testimonial',
   description: 'Finds a testimonial by ID.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetch a single Trust testimonial by its testimonial ID. Pick this to inspect a known testimonial before updating or deleting it; it requires the exact ID and cannot search by author email or text. Read-only and safe to retry (idempotent).',
+    idempotent: true,
+  },
   props: {
     testimonialId: Property.ShortText({
       displayName: 'Testimonial ID',

--- a/packages/pieces/community/trust/src/lib/actions/update-contact.ts
+++ b/packages/pieces/community/trust/src/lib/actions/update-contact.ts
@@ -8,6 +8,12 @@ export const updateContactAction = createAction({
   name: 'update_contact',
   displayName: 'Update Contact',
   description: 'Updates an existing contact in the system.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Update an existing Trust contact identified by its contact ID; both the ID and the email are required by the API, while name, phone, and profile image URL are optional. Pick this to modify a known contact rather than Create Contact, which would add a duplicate. It overwrites via PUT with the supplied fields, so repeating the same call yields the same state (idempotent).',
+    idempotent: true,
+  },
   props: {
     contactId: Property.ShortText({
       displayName: 'Contact ID',

--- a/packages/pieces/community/trust/src/lib/actions/update-testimonial.ts
+++ b/packages/pieces/community/trust/src/lib/actions/update-testimonial.ts
@@ -8,6 +8,12 @@ export const updateTestimonialAction = createAction({
   name: 'update_testimonial',
   displayName: 'Update Testimonial',
   description: 'Updates an existing testimonial in the system.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Update an existing Trust testimonial identified by its testimonial ID; the ID and the author email are required, while content fields (text, rating, media URLs, published and consent flags) are optional. Pick this to edit or publish/unpublish a known testimonial rather than Create Testimonial, which would add a duplicate. It overwrites via PUT with the supplied fields, so repeating the same call yields the same state (idempotent).',
+    idempotent: true,
+  },
   props: {
     testimonialId: Property.ShortText({
       displayName: 'Testimonial ID',

--- a/packages/pieces/community/trust/src/lib/actions/upload-image.ts
+++ b/packages/pieces/community/trust/src/lib/actions/upload-image.ts
@@ -8,6 +8,12 @@ export const uploadImageAction = createAction({
   name: 'upload_image',
   displayName: 'Upload Image',
   description: 'Uploads an image to the Trust media library.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Upload an image file (JPEG, PNG, GIF, etc.) to the Trust media library, typically to use as a profile image for a contact or testimonial. Pick this only when you have raw file data; if the image is already hosted at a URL, pass that URL directly to the contact or testimonial actions instead. Each call uploads a new copy, so retries create duplicate media (not idempotent).',
+    idempotent: false,
+  },
   props: {
     file: Property.File({
       displayName: 'Image File',

--- a/packages/pieces/community/trust/src/lib/actions/upload-small-video.ts
+++ b/packages/pieces/community/trust/src/lib/actions/upload-small-video.ts
@@ -8,6 +8,12 @@ export const uploadSmallVideoAction = createAction({
   name: 'upload_small_video',
   displayName: 'Upload Small Video',
   description: 'Uploads a short video to the Trust media library.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Upload a short video clip (best under 30 seconds) to the Trust media library via the dedicated small-video endpoint. Pick this for brief clips; for longer or larger video files use Upload Video instead, and skip uploading entirely if the video is already hosted at a URL. Each call uploads a new copy, so retries create duplicate media (not idempotent).',
+    idempotent: false,
+  },
   props: {
     file: Property.File({
       displayName: 'Video File',

--- a/packages/pieces/community/trust/src/lib/actions/upload-video.ts
+++ b/packages/pieces/community/trust/src/lib/actions/upload-video.ts
@@ -8,6 +8,12 @@ export const uploadVideoAction = createAction({
   name: 'upload_video',
   displayName: 'Upload Video',
   description: 'Uploads a video to the Trust media library for use in testimonials.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Upload a video file (MP4, MOV, AVI, etc.) to the Trust media library for use in testimonials. Pick this for standard or longer videos; for brief clips under about 30 seconds, Upload Small Video uses a lighter endpoint, and already-hosted videos can be referenced by URL without uploading. Each call uploads a new copy, so retries create duplicate media (not idempotent).',
+    idempotent: false,
+  },
   props: {
     file: Property.File({
       displayName: 'Video File',

--- a/packages/pieces/community/trust/src/lib/triggers/new-testimonial.ts
+++ b/packages/pieces/community/trust/src/lib/triggers/new-testimonial.ts
@@ -45,6 +45,10 @@ export const newTestimonialTrigger = createTrigger({
   displayName: 'New Testimonial Created',
   description:
     'Triggers when a new testimonial is created in your Trust workspace.',
+  aiMetadata: {
+    description:
+      'Fires when a new testimonial is created in the connected Trust workspace, detected by polling for testimonials with a creation timestamp newer than the last poll. Each event represents one customer testimonial, including the author details (name, email, title, company), testimonial text, star rating, and publication/consent status.',
+  },
   props: {},
   sampleData: {
     id: 'testimonial_01abc123',


### PR DESCRIPTION
## What

Batch 11 of the AI-ready metadata rollout — the stragglers left after the full-catalog sweep (#13547–#13682), most of them pieces added to the catalog after the sweep ran.

Pieces (10): azure-ad, canva, convertkit, coupa, jira-cloud, jungle-grid, trust, deepgram, jina-ai, bocha-search.

## Contract (same as batches 1–10)

- Every action: `audience: 'both'` + `aiMetadata: { description, idempotent }`
- Every trigger: `aiMetadata: { description }`
- `package.json`: patch version bump
- Additive only — no logic, import, or formatting changes

145 objects curated: 122 actions + 23 triggers across 103 files (+821/−0 before version bumps).

## Verification

- On-disk audit: `audience: 'both'` count == action count and `aiMetadata` count == actions+triggers in every piece (122 + 145, exact match)
- ESLint on all changed files: 0 errors (21 pre-existing warnings)
- `tsc` (root-paths config over the 10 pieces): 0 `audience`/`aiMetadata` errors; 3 pre-existing errors in untouched files (`expr-eval` local artifact ×2, canva `common/index.ts` imports from `"src"` on main)

Labels (need a maintainer): `skip-changelog`, `area/third-party-pieces`