### PR TITLE
docs(piece-builder-skill): require AI metadata on every new action and trigger

### DIFF
--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -287,12 +287,12 @@ Full patterns and examples: read `output-quality.md`
 
 ---
 
-## AI-Ready Metadata (Optional)
+## AI-Ready Metadata (Required on New Actions & Triggers)
 
-- **`audience`** (actions only): `'human' | 'ai' | 'both'` — fence an action to one surface. Default is both.
-- **`aiMetadata`**: `{ description?, idempotent? }` — agent-facing description and safe-retry hint.
+- **`audience`** (actions only): `'human' | 'ai' | 'both'` — written explicitly on every action (`'both'` for normal integration actions; `'human'` for LLM-wrappers/utilities). Downstream filters only see it when physically present.
+- **`aiMetadata`**: `{ description, idempotent }` on every action, `{ description }` on every trigger — agent-facing description (what + when-to-pick + key constraint) and safe-retry hint derived from `run()`.
 
-Skip both unless deliberately tuning for agents. Full guidance: read `ai-metadata.md`
+The catalog is fully curated; a new action or trigger without these is a regression. Writing rules, `idempotent` derivation, factory gotchas: read `ai-metadata.md`
 
 ---
 
@@ -304,6 +304,7 @@ Skip both unless deliberately tuning for agents. Full guidance: read `ai-metadat
 4. **Always provide `sampleData`** on triggers — even `{}`.
 5. **Build AND lint must both pass** — lint failures (unused imports, `any`, unused vars) block CI even when build is green.
 6. **Bump version on every existing-piece change** — see Versioning above. Skipping means flows never get your fix.
+7. **AI metadata on every new action & trigger** — explicit `audience` + `aiMetadata { description, idempotent }` on actions, `aiMetadata { description }` on triggers. See `ai-metadata.md`.
 
 ---
 

--- a/.agents/skills/piece-builder/action-patterns.md
+++ b/.agents/skills/piece-builder/action-patterns.md
@@ -14,6 +14,12 @@ export const createRecordAction = createAction({
   name: 'create_record',        // Unique snake_case ID -- never change after publishing
   displayName: 'Create Record',
   description: 'Creates a new record in My App',
+  audience: 'both',             // explicit -- see ai-metadata.md
+  aiMetadata: {
+    description:
+      'Create a new record in My App. Use to add a single entry when you already have its field values. Each call creates a new record, so retries duplicate.',
+    idempotent: false,
+  },
   props: {
     name: Property.ShortText({
       displayName: 'Name',
@@ -49,6 +55,6 @@ The `token` field above assumes a `PieceAuth.SecretText()` auth. For other auth 
 
 For all available property types (`Property.ShortText`, `Property.Dropdown`, `Property.Array`, etc.) read `props-patterns.md`.
 
-## AI-Ready Metadata (optional)
+## AI-Ready Metadata (required on new actions)
 
-Actions accept two optional fields that tune how they appear to AI agents: `audience` (`'human' | 'ai' | 'both'`) and `aiMetadata` (`{ description?, idempotent? }`). They are additive and change nothing for human users. Skip them unless you are deliberately tuning the action for agents — see `ai-metadata.md`.
+Every new action ships with an explicit `audience` (`'both'` for normal integration actions, `'human'` for LLM-wrappers/utilities) and `aiMetadata: { description, idempotent }` — the agent-facing description and safe-retry hint. They are additive and change nothing for human users. Writing rules and the `idempotent` derivation table: `ai-metadata.md`.

--- a/.agents/skills/piece-builder/ai-metadata.md
+++ b/.agents/skills/piece-builder/ai-metadata.md
@@ -1,11 +1,11 @@
 # AI-Ready Metadata
 
-Pieces power both human flow-builders and AI agents (via the MCP server and the agent tooling). Two **optional** fields let an action or trigger declare how it should appear to agents. Both are additive: omit them and the piece behaves exactly as before. Adding them never changes anything for human users.
+Pieces power both human flow-builders and AI agents (via the MCP server and the agent tooling). Two fields declare how an action or trigger appears to agents. They are additive — they change nothing for human users — but the catalog is now fully curated (every existing action carries them), so **new actions and triggers must ship with them**: a piece authored without AI metadata is a regression that has to be backfilled later.
 
-| Field | Where | Shape |
-|---|---|---|
-| `audience` | actions only | `'human' \| 'ai' \| 'both'` |
-| `aiMetadata` | actions **and** triggers | `{ description?: string; idempotent?: boolean }` |
+| Field | Where | Shape | New code |
+|---|---|---|---|
+| `audience` | actions only | `'human' \| 'ai' \| 'both'` | **required, written explicitly** |
+| `aiMetadata` | actions **and** triggers | `{ description?: string; idempotent?: boolean }` | **required** — `{ description, idempotent }` on actions, `{ description }` on triggers |
 
 Both are plain values on the `createAction` / `createTrigger` object — no import is needed. Triggers accept `aiMetadata` but **not** `audience`: a trigger is an event, not an agent-callable operation.
 
@@ -26,12 +26,13 @@ export const createRecordAction = createAction({
 
 | Value | Meaning |
 |---|---|
-| `'human'` | For human flow-builders only; kept off the agent surface. Use for actions that need human judgement or only make sense inside the visual builder. |
+| `'human'` | For human flow-builders only; kept off the agent surface. Use for raw-LLM/ask-AI wrappers (the agent is already an LLM), generic data transforms and flow control the agent does natively, and actions that only make sense inside the visual builder. |
 | `'ai'` | For AI agents only; kept out of the human catalog to reduce clutter. Use for agent-oriented atomics. |
-| `'both'` | Useful to humans and agents alike. |
-| *(omitted)* | Treated as `'both'` — available everywhere. This is the default; most actions need nothing here. |
+| `'both'` | Useful to humans and agents alike — the right value for almost every real integration action. |
 
-Only set `audience` to deliberately fence an action to one surface. Leave it off otherwise.
+**Write the value explicitly — do not omit it.** Piece metadata is serialized from the raw action objects with no default injection, so downstream filters only see `audience` when it is physically present in the file. For a normal integration action, write `audience: 'both'`.
+
+`custom_api_call` is already handled: the shared `createCustomApiCallAction` factory sets `audience: 'human'` internally (a raw HTTP escape hatch is not an agent tool). Only a hand-rolled `createAction({ name: 'custom_api_call', ... })` needs its own `audience` like any other action.
 
 ---
 
@@ -42,9 +43,10 @@ export const createRecordAction = createAction({
   name: 'create_record',
   displayName: 'Create Record',
   description: 'Creates a new record in My App',
+  audience: 'both',
   aiMetadata: {
     description:
-      'Create a new record in My App. Use when the user wants to add an entry. Returns the created record id and fields.',
+      'Create a new record in My App. Use to add a single entry when you already have its field values; for bulk inserts prefer the batch action. Each call creates a new record, so retries duplicate.',
     idempotent: false,
   },
   props: { /* ... */ },
@@ -52,15 +54,36 @@ export const createRecordAction = createAction({
 });
 ```
 
-**`description`** — written **for an agent**, not for the builder UI. The human `description` answers "what does this do" for someone reading a dropdown; `aiMetadata.description` answers "when should I call this tool, and what do I get back" for an agent choosing between hundreds of tools. Be explicit about intent, inputs, and the return shape. When the human `description` already reads well for an agent, omit this and the agent falls back to it.
+### Writing `aiMetadata.description`
 
-**`idempotent`** — `true` when calling the action repeatedly with the same input is safe and yields the same result without extra side effects (a GET/lookup, or an upsert keyed on a stable id). `false` (or omitted) for actions that create or mutate on every call (`Send Message`, `Create Record`). Agents use this to reason about safe retries; it maps to the MCP `idempotentHint`.
+It is written **for an agent choosing between hundreds of tools**, not for the builder UI. The human `description` answers "what does this do" in a dropdown; the agent description answers "when should I pick this one". 1–3 sentences:
+
+1. **What it does** — without echoing the human description verbatim.
+2. **When to pick it** over neighboring actions — name the materially different sibling or mode if one exists ("for bulk inserts prefer X", "use Y to search by email instead").
+3. **The key constraint** — required pairings, limits, side effects — and the retry behavior in prose ("safe to retry", "each call creates a new record").
+
+Do **not** describe the return shape (output contracts are a separate feature), do not embed worked examples, and do not pad — shorter wins for agent context.
+
+### Deriving `idempotent`
+
+Read the `run()` body and decide from what the API call actually does — not from the action's name:
+
+| `run()` does | `idempotent` |
+|---|---|
+| GET / list / search / lookup | `true` |
+| Upsert keyed on a caller-supplied stable id | `true` |
+| Update of a specific record to a given state (PATCH/PUT by id) | `true` |
+| Create / send / append / enqueue (new entity per call) | `false` |
+| Delete (a retry typically 404s or errors) | `false` |
+| Multi-step mutations (e.g. copy-then-delete "move") | `false` — a partial retry duplicates or errors |
+
+Agents use this to reason about safe retries; it maps to the MCP `idempotentHint`.
 
 ---
 
 ## Triggers
 
-Triggers take `aiMetadata` only — no `audience`:
+Triggers take `aiMetadata` with `description` only — no `audience`, no `idempotent`:
 
 ```typescript
 export const newRecordTrigger = createTrigger({
@@ -68,19 +91,24 @@ export const newRecordTrigger = createTrigger({
   displayName: 'New Record',
   description: 'Triggers when a new record is created',
   aiMetadata: {
-    description: 'Fires when a new record is created in My App.',
+    description: 'Fires when a new record is created in My App, once per record.',
   },
   // ... type, props, sampleData, run, onEnable, onDisable
 });
 ```
 
-`idempotent` is accepted for shape consistency but rarely meaningful on a trigger — leave it off.
+Describe **when the event fires and what one payload represents** (per record? per batch? on update too?).
+
+---
+
+## Factory-built actions and triggers
+
+If actions/triggers are produced by a shared factory (a helper that wraps `createAction`/`createTrigger`), the factory's params type must declare `audience`/`aiMetadata` and forward them into the wrapped call — otherwise the fields in your config objects silently fail to compile or never reach the framework. Add the fields to the factory's param type and pass them through.
 
 ---
 
 ## When to add this
 
-- **Always fine to skip.** These fields are optional; an untagged piece keeps working exactly as before.
-- Add `aiMetadata.description` to your most-used actions when the human description is terse or builder-specific — it is the single highest-value thing for agent usability.
-- Set `idempotent: true` on read-only / lookup / upsert actions so agents can retry them safely.
-- Reach for `audience` only when an action should be restricted to humans or to agents.
+- **New actions and triggers: always.** `audience: 'both'` + `aiMetadata { description, idempotent }` on every action, `aiMetadata { description }` on every trigger.
+- Set `audience: 'human'` instead when the action is an ask-an-LLM wrapper, a generic transform, or otherwise meaningless as an agent tool.
+- Touching an existing untagged action anyway? Tag it while you're there.

--- a/.agents/skills/piece-builder/props-patterns.md
+++ b/.agents/skills/piece-builder/props-patterns.md
@@ -2,6 +2,15 @@
 
 Used in both `createAction({ props: {...} })` and `createTrigger({ props: {...} })`.
 
+## Property descriptions are the agent's only signal
+
+The `description` on a property is what an LLM/MCP agent (and the human in the builder) reads to decide how to fill it — write it as a one-or-two-sentence spec, not a label:
+
+- **State the format, not just the concept.** `"Issue title. Max 255 characters."` beats `"The title"`.
+- **Bake a realistic sample into the prose** when format matters — actual ID shapes (`'cus_abc123xyz'`), ISO 8601 dates (`'2026-04-17T10:30:00Z'`), full URLs with protocol. There is no separate example field; the description carries the whole signal. E.g. `"Current status of the record. One of: 'open', 'in_progress', 'closed'."`
+- **Skip samples** when the prop is self-explanatory (a boolean checkbox), or when values come from the API at runtime (`Property.Dropdown`, `Property.DynamicProperties`).
+- **Never use placeholder-only samples** — `'string'`, `'value'`, `'<your API key>'`, empty `{}`/`[]`.
+
 ---
 
 ## Text

--- a/.agents/skills/piece-builder/trigger-patterns.md
+++ b/.agents/skills/piece-builder/trigger-patterns.md
@@ -274,6 +274,6 @@ export const myTrigger = createTrigger({
 
 ---
 
-## AI-Ready Metadata (optional)
+## AI-Ready Metadata (required on new triggers)
 
-Triggers accept an optional `aiMetadata` field (`{ description?, idempotent? }`) to describe the event for AI agents. They do **not** take `audience` — that field is actions-only, since a trigger is an event rather than an agent-callable operation. The field is additive and changes nothing for human users. See `ai-metadata.md`.
+Every new trigger ships with `aiMetadata: { description }` — one or two sentences on when the event fires and what one payload represents. Triggers do **not** take `audience` (actions-only — a trigger is an event, not an agent-callable operation) and don't need `idempotent`. The field is additive and changes nothing for human users. See `ai-metadata.md`.


### PR DESCRIPTION
## What

Updates the shared piece-builder skill docs at `.agents/skills/piece-builder/` so every **new** action and trigger ships with the AI-ready metadata fields that are now live across the whole catalog.

Replaces #12670, which was drafted against the retired `infoForLLM`/`ActionResult` proposal (#12669, closed). This version is written against the shipped contract (framework 0.29.1: `audience` + `aiMetadata { description, idempotent }`) and bakes in what we learned curating ~6,150 actions/triggers in the metadata rollout (#13547–#13701).

## Why now

The catalog is fully curated — every existing action carries an explicit `audience` and `aiMetadata`. But the authoring skill still calls these fields "optional / skip unless tuning", so every newly authored piece lands untagged and has to be found and backfilled later (the rollout already picked up 10 such stragglers). This flips the default at the source.

## Changes

| File | Change |
|---|---|
| `ai-metadata.md` | Required-by-default stance; explicit `audience` (piece metadata is serialized raw — no default injection, the value must be physically present); agent-description rubric (what + when-to-pick + key constraint, retry behavior in prose, **no return shape** — output contracts are a separate feature); `idempotent` derivation table from `run()` semantics (reads/upserts-by-stable-id = true; creates/sends = false; deletes = false since retries 404; multi-step mutations = false); factory-forwarding gotcha; note that `createCustomApiCallAction` sets `audience: 'human'` internally |
| `SKILL.md` | Section renamed to "Required on New Actions & Triggers"; new critical reminder |
| `action-patterns.md` | Canonical action template now carries `audience` + `aiMetadata` |
| `trigger-patterns.md` | Triggers ship `aiMetadata { description }` only (no `audience`, no `idempotent`) |
| `props-patterns.md` | Property descriptions written as the agent's only signal: format spec + realistic sample baked into the prose; never placeholder samples |

Docs-only — no code changes.

Label (needs a maintainer): `skip-changelog`