### PR TITLE
feat(pieces): add Asqav piece to sign AI agent actions and verify tamper-evident receipts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -868,6 +868,16 @@
         "tslib": "^2.3.0",
       },
     },
+    "packages/pieces/community/asqav": {
+      "name": "@activepieces/piece-asqav",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/assembled": {
       "name": "@activepieces/piece-assembled",
       "version": "0.1.4",
@@ -9029,6 +9039,8 @@
     "@activepieces/piece-ask-handle": ["@activepieces/piece-ask-handle@workspace:packages/pieces/community/ask-handle"],
 
     "@activepieces/piece-asknews": ["@activepieces/piece-asknews@workspace:packages/pieces/community/asknews"],
+
+    "@activepieces/piece-asqav": ["@activepieces/piece-asqav@workspace:packages/pieces/community/asqav"],
 
     "@activepieces/piece-assembled": ["@activepieces/piece-assembled@workspace:packages/pieces/community/assembled"],
 

--- a/packages/pieces/community/asqav/.eslintrc.json
+++ b/packages/pieces/community/asqav/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/asqav/package.json
+++ b/packages/pieces/community/asqav/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-asqav",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/asqav/src/index.ts
+++ b/packages/pieces/community/asqav/src/index.ts
@@ -1,0 +1,30 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/shared';
+import { asqavAuth } from './lib/auth';
+import { signAction } from './lib/actions/sign-action';
+import { verifySignature } from './lib/actions/verify-signature';
+import { ASQAV_BASE_URL } from './lib/common';
+
+export const asqav = createPiece({
+  displayName: 'Asqav',
+  description:
+    'Sign AI agent actions and verify the tamper-evident receipts that prove what each agent did.',
+  auth: asqavAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/asqav.png',
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  authors: ['jagmarques'],
+  actions: [
+    signAction,
+    verifySignature,
+    createCustomApiCallAction({
+      baseUrl: () => ASQAV_BASE_URL,
+      auth: asqavAuth,
+      authMapping: async (auth) => ({
+        'X-API-Key': auth.secret_text,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/asqav/src/lib/actions/sign-action.ts
+++ b/packages/pieces/community/asqav/src/lib/actions/sign-action.ts
@@ -1,0 +1,68 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { asqavApiCall, getOrCreateAgent } from '../common';
+import { asqavAuth } from '../auth';
+
+export const signAction = createAction({
+  name: 'sign_action',
+  auth: asqavAuth,
+  displayName: 'Sign Action',
+  description:
+    'Sign an agent action with Asqav and get back a tamper-evident receipt with a verification URL.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Sign an action with a named Asqav agent and return a tamper-evident receipt with a verification URL. Use after a consequential step to record proof of what was done; to check an existing receipt use Verify Signature instead. Each call issues a new receipt, so retries create duplicate signatures.',
+    idempotent: false,
+  },
+  props: {
+    agentName: Property.ShortText({
+      displayName: 'Agent Name',
+      description:
+        'The Asqav agent that signs this action. Reused when it already exists, created on first run.',
+      required: true,
+      defaultValue: 'activepieces',
+    }),
+    actionType: Property.ShortText({
+      displayName: 'Action Type',
+      description:
+        'Namespaced identifier for the action being signed, in namespace:verb format, for example "payments:charge" or "email:send".',
+      required: true,
+    }),
+    context: Property.Json({
+      displayName: 'Context',
+      description:
+        'Optional JSON object of non-sensitive metadata bound into the signed receipt.',
+      required: false,
+    }),
+    complianceMode: Property.Checkbox({
+      displayName: 'Compliance Mode',
+      description:
+        'Request a policy-evaluated compliance receipt. Needs an active policy matching the action type in your Asqav organization.',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const apiKey = context.auth.secret_text;
+    const { agentName, actionType, complianceMode } = context.propsValue;
+
+    const agent = await getOrCreateAgent(apiKey, agentName);
+
+    const body: Record<string, unknown> = {
+      action_type: actionType,
+      context: context.propsValue.context ?? {},
+      session_id: null,
+    };
+    if (complianceMode) {
+      body['compliance_mode'] = true;
+    }
+
+    return asqavApiCall<Record<string, unknown>>({
+      apiKey,
+      method: HttpMethod.POST,
+      resourceUri: `/agents/${agent.agent_id}/sign`,
+      body,
+    });
+  },
+});

--- a/packages/pieces/community/asqav/src/lib/actions/verify-signature.ts
+++ b/packages/pieces/community/asqav/src/lib/actions/verify-signature.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { asqavApiCall } from '../common';
+import { asqavAuth } from '../auth';
+
+export const verifySignature = createAction({
+  name: 'verify_signature',
+  auth: asqavAuth,
+  displayName: 'Verify Signature',
+  description:
+    'Verify a signed Asqav receipt by its signature ID and return the verification result.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Look up an Asqav receipt by its signature ID and return whether it verifies. Use to check a receipt produced earlier by Sign Action. Read-only and safe to retry.',
+    idempotent: true,
+  },
+  props: {
+    signatureId: Property.ShortText({
+      displayName: 'Signature ID',
+      description:
+        'The signature ID returned by the Sign Action step, for example "sig_...".',
+      required: true,
+    }),
+  },
+  async run(context) {
+    return asqavApiCall<Record<string, unknown>>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      resourceUri: `/verify/${context.propsValue.signatureId}`,
+    });
+  },
+});

--- a/packages/pieces/community/asqav/src/lib/auth.ts
+++ b/packages/pieces/community/asqav/src/lib/auth.ts
@@ -1,0 +1,29 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { asqavApiCall } from './common';
+
+export const asqavAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: `To get your Asqav API key:
+1. Sign in at [asqav.com](https://asqav.com).
+2. Open **Dashboard → API Keys**.
+3. Create a key and copy it (it starts with \`sk_\`).`,
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await asqavApiCall({
+        apiKey: auth,
+        method: HttpMethod.GET,
+        resourceUri: '/agents',
+        queryParams: { limit: '1' },
+      });
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error:
+          'Invalid API key. Copy a current key from your Asqav dashboard under API Keys.',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/asqav/src/lib/auth.ts
+++ b/packages/pieces/community/asqav/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { PieceAuth } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { asqavApiCall } from './common';
+import { asqavApiCall, AsqavApiError } from './common';
 
 export const asqavAuth = PieceAuth.SecretText({
   displayName: 'API Key',
@@ -18,11 +18,21 @@ export const asqavAuth = PieceAuth.SecretText({
         queryParams: { limit: '1' },
       });
       return { valid: true };
-    } catch {
+    } catch (error) {
+      if (error instanceof AsqavApiError && error.status === 401) {
+        return {
+          valid: false,
+          error:
+            'Invalid API key. Copy a current key from your Asqav dashboard under API Keys.',
+        };
+      }
+      if (error instanceof AsqavApiError && error.status !== undefined) {
+        return { valid: false, error: error.message };
+      }
       return {
         valid: false,
         error:
-          'Invalid API key. Copy a current key from your Asqav dashboard under API Keys.',
+          'Could not reach the Asqav API. Check your network connection and try again.',
       };
     }
   },

--- a/packages/pieces/community/asqav/src/lib/common.ts
+++ b/packages/pieces/community/asqav/src/lib/common.ts
@@ -7,6 +7,13 @@ import {
 
 export const ASQAV_BASE_URL = 'https://api.asqav.com/api/v1';
 
+export class AsqavApiError extends Error {
+  constructor(message: string, public readonly status?: number) {
+    super(message);
+    this.name = 'AsqavApiError';
+  }
+}
+
 interface AsqavApiCallParams {
   apiKey: string;
   method: HttpMethod;
@@ -75,40 +82,47 @@ function mapAsqavError(error: unknown): Error {
 
   switch (status) {
     case 401:
-      return new Error(
-        'Asqav rejected the API key (401). Reconnect with a valid key from your Asqav dashboard at https://asqav.com.'
+      return new AsqavApiError(
+        'Asqav rejected the API key (401). Reconnect with a valid key from your Asqav dashboard at https://asqav.com.',
+        status
       );
     case 403:
       if (reason === 'content_scan_blocked') {
-        return new Error(
-          `Asqav's content scanner blocked signing (403): ${text} Remove sensitive data such as PII from the Context and retry.`
+        return new AsqavApiError(
+          `Asqav's content scanner blocked signing (403): ${text} Remove sensitive data such as PII from the Context and retry.`,
+          status
         );
       }
-      return new Error(
-        `Asqav refused the request (403): ${text} The key may lack the required scope, or the agent may be suspended or owned by another organization.`
+      return new AsqavApiError(
+        `Asqav refused the request (403): ${text} The key may lack the required scope, or the agent may be suspended or owned by another organization.`,
+        status
       );
     case 412:
       if (reason === 'no_policy_evaluated_for_action_type') {
-        return new Error(
-          `Asqav precondition failed (412): ${text} Compliance mode needs an active policy matching this action type. Create one in your Asqav dashboard, or turn off Compliance Mode on this step.`
+        return new AsqavApiError(
+          `Asqav precondition failed (412): ${text} Compliance mode needs an active policy matching this action type. Create one in your Asqav dashboard, or turn off Compliance Mode on this step.`,
+          status
         );
       }
       if (reason === 'compliance_mode_strict_unsigned_action') {
-        return new Error(
-          `Asqav precondition failed (412): ${text} Your organization requires compliance mode, so enable Compliance Mode on this step.`
+        return new AsqavApiError(
+          `Asqav precondition failed (412): ${text} Your organization requires compliance mode, so enable Compliance Mode on this step.`,
+          status
         );
       }
-      return new Error(`Asqav precondition failed (412): ${text}`);
+      return new AsqavApiError(`Asqav precondition failed (412): ${text}`, status);
     case 422:
-      return new Error(
-        `Asqav rejected the request payload (422): ${text}. Check the step inputs, for example Context must be a JSON object.`
+      return new AsqavApiError(
+        `Asqav rejected the request payload (422): ${text}. Check the step inputs, for example Context must be a JSON object.`,
+        status
       );
     case 429:
-      return new Error(
-        `Asqav rate limit reached (429): ${text} Wait and retry, or raise the plan limit in your Asqav dashboard.`
+      return new AsqavApiError(
+        `Asqav rate limit reached (429): ${text} Wait and retry, or raise the plan limit in your Asqav dashboard.`,
+        status
       );
     default:
-      return new Error(`Asqav API error (${status}): ${text}`);
+      return new AsqavApiError(`Asqav API error (${status}): ${text}`, status);
   }
 }
 
@@ -116,23 +130,51 @@ interface AsqavAgent {
   agent_id: string;
   name: string;
   algorithm: string;
+  created_at: string;
+}
+
+// The Asqav API does not enforce unique agent names, so two concurrent
+// first runs can each create an agent with the same name. To keep every
+// run converging on one canonical agent, always pick the oldest exact
+// match (created_at ascending, agent_id as tiebreaker) instead of relying
+// on API listing order.
+function pickCanonicalAgent(
+  agents: AsqavAgent[],
+  name: string
+): AsqavAgent | undefined {
+  return agents
+    .filter((agent) => agent.name === name)
+    .sort(
+      (a, b) =>
+        a.created_at.localeCompare(b.created_at) ||
+        a.agent_id.localeCompare(b.agent_id)
+    )[0];
+}
+
+async function listAgentsByName(
+  apiKey: string,
+  name: string
+): Promise<AsqavAgent[]> {
+  return asqavApiCall<AsqavAgent[]>({
+    apiKey,
+    method: HttpMethod.GET,
+    resourceUri: '/agents',
+    queryParams: { name, revoked: 'false', limit: '50' },
+  });
 }
 
 export async function getOrCreateAgent(
   apiKey: string,
   name: string
 ): Promise<AsqavAgent> {
-  const existing = await asqavApiCall<AsqavAgent[]>({
-    apiKey,
-    method: HttpMethod.GET,
-    resourceUri: '/agents',
-    queryParams: { name, revoked: 'false', limit: '50' },
-  });
-  const match = existing.find((agent) => agent.name === name);
-  if (match) {
-    return match;
+  const existing = pickCanonicalAgent(
+    await listAgentsByName(apiKey, name),
+    name
+  );
+  if (existing) {
+    return existing;
   }
-  return asqavApiCall<AsqavAgent>({
+  const created = await asqavApiCall<AsqavAgent>({
     apiKey,
     method: HttpMethod.POST,
     resourceUri: '/agents/create',
@@ -142,4 +184,11 @@ export async function getOrCreateAgent(
       capabilities: [],
     },
   });
+  // Re-list after creating: if a concurrent run created the same name in
+  // the GET-to-POST window, both runs settle on the same canonical agent.
+  const canonical = pickCanonicalAgent(
+    await listAgentsByName(apiKey, name),
+    name
+  );
+  return canonical ?? created;
 }

--- a/packages/pieces/community/asqav/src/lib/common.ts
+++ b/packages/pieces/community/asqav/src/lib/common.ts
@@ -1,0 +1,145 @@
+import {
+  httpClient,
+  HttpError,
+  HttpMethod,
+  QueryParams,
+} from '@activepieces/pieces-common';
+
+export const ASQAV_BASE_URL = 'https://api.asqav.com/api/v1';
+
+interface AsqavApiCallParams {
+  apiKey: string;
+  method: HttpMethod;
+  resourceUri: string;
+  queryParams?: QueryParams;
+  body?: unknown;
+}
+
+export async function asqavApiCall<T>({
+  apiKey,
+  method,
+  resourceUri,
+  queryParams,
+  body,
+}: AsqavApiCallParams): Promise<T> {
+  try {
+    const response = await httpClient.sendRequest<T>({
+      method,
+      url: `${ASQAV_BASE_URL}${resourceUri}`,
+      headers: {
+        'X-API-Key': apiKey,
+      },
+      queryParams,
+      body,
+    });
+    return response.body;
+  } catch (error) {
+    throw mapAsqavError(error);
+  }
+}
+
+function extractDetail(body: unknown): { reason?: string; text: string } {
+  if (typeof body === 'object' && body !== null && 'detail' in body) {
+    const detail = (body as { detail: unknown }).detail;
+    if (typeof detail === 'string') {
+      return { text: detail };
+    }
+    if (Array.isArray(detail)) {
+      // FastAPI validation errors: [{ loc, msg, type, input }, ...]
+      const text = detail
+        .map((item: { loc?: unknown[]; msg?: string }) => {
+          const field = Array.isArray(item.loc) ? item.loc.join('.') : '';
+          return field ? `${field}: ${item.msg ?? ''}` : item.msg ?? JSON.stringify(item);
+        })
+        .join('; ');
+      return { text };
+    }
+    if (typeof detail === 'object' && detail !== null) {
+      const obj = detail as { reason?: string; error?: string; detail?: string; message?: string };
+      return {
+        reason: obj.reason ?? obj.error,
+        text: obj.detail ?? obj.message ?? JSON.stringify(detail),
+      };
+    }
+    return { text: JSON.stringify(detail) };
+  }
+  return { text: typeof body === 'string' ? body : JSON.stringify(body) };
+}
+
+function mapAsqavError(error: unknown): Error {
+  if (!(error instanceof HttpError)) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  const status = error.response.status;
+  const { reason, text } = extractDetail(error.response.body);
+
+  switch (status) {
+    case 401:
+      return new Error(
+        'Asqav rejected the API key (401). Reconnect with a valid key from your Asqav dashboard at https://asqav.com.'
+      );
+    case 403:
+      if (reason === 'content_scan_blocked') {
+        return new Error(
+          `Asqav's content scanner blocked signing (403): ${text} Remove sensitive data such as PII from the Context and retry.`
+        );
+      }
+      return new Error(
+        `Asqav refused the request (403): ${text} The key may lack the required scope, or the agent may be suspended or owned by another organization.`
+      );
+    case 412:
+      if (reason === 'no_policy_evaluated_for_action_type') {
+        return new Error(
+          `Asqav precondition failed (412): ${text} Compliance mode needs an active policy matching this action type. Create one in your Asqav dashboard, or turn off Compliance Mode on this step.`
+        );
+      }
+      if (reason === 'compliance_mode_strict_unsigned_action') {
+        return new Error(
+          `Asqav precondition failed (412): ${text} Your organization requires compliance mode, so enable Compliance Mode on this step.`
+        );
+      }
+      return new Error(`Asqav precondition failed (412): ${text}`);
+    case 422:
+      return new Error(
+        `Asqav rejected the request payload (422): ${text}. Check the step inputs, for example Context must be a JSON object.`
+      );
+    case 429:
+      return new Error(
+        `Asqav rate limit reached (429): ${text} Wait and retry, or raise the plan limit in your Asqav dashboard.`
+      );
+    default:
+      return new Error(`Asqav API error (${status}): ${text}`);
+  }
+}
+
+interface AsqavAgent {
+  agent_id: string;
+  name: string;
+  algorithm: string;
+}
+
+export async function getOrCreateAgent(
+  apiKey: string,
+  name: string
+): Promise<AsqavAgent> {
+  const existing = await asqavApiCall<AsqavAgent[]>({
+    apiKey,
+    method: HttpMethod.GET,
+    resourceUri: '/agents',
+    queryParams: { name, revoked: 'false', limit: '50' },
+  });
+  const match = existing.find((agent) => agent.name === name);
+  if (match) {
+    return match;
+  }
+  return asqavApiCall<AsqavAgent>({
+    apiKey,
+    method: HttpMethod.POST,
+    resourceUri: '/agents/create',
+    body: {
+      name,
+      algorithm: 'ml-dsa-65',
+      capabilities: [],
+    },
+  });
+}

--- a/packages/pieces/community/asqav/tsconfig.json
+++ b/packages/pieces/community/asqav/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/asqav/tsconfig.lib.json
+++ b/packages/pieces/community/asqav/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -110,6 +110,9 @@
       "@activepieces/piece-ashby": [
         "packages/pieces/community/ashby/src/index.ts"
       ],
+      "@activepieces/piece-asqav": [
+        "packages/pieces/community/asqav/src/index.ts"
+      ],
       "@activepieces/piece-assembled": [
         "packages/pieces/community/assembled/src/index.ts"
       ],


### PR DESCRIPTION
### What this adds

A community piece for Asqav (https://asqav.com). Disclosure: I work on Asqav.

Asqav signs AI agent actions server side and returns tamper-evident receipts, so a team can prove afterwards what an agent did and when. This piece lets a flow sign an action and verify a receipt without leaving Activepieces.

Actions:

- **Sign Action**: signs an action with a named Asqav agent and returns the receipt with a verification URL. The agent is reused when it already exists and created on the first run. A Compliance Mode checkbox requests a policy-evaluated receipt for orgs that use policies.
- **Verify Signature**: looks up a receipt by signature ID and returns the verification result.
- **Custom API Call** for everything else.

The connection validates the API key with a real request at setup time and shows a readable error when the key is wrong. API errors map to messages that say what to fix. A 401 points at the connection, a 412 explains which compliance precondition failed, and a 422 names the offending field.

All HTTP goes through `httpClient` from `@activepieces/pieces-common`, and the piece adds no external dependencies.

### Testing

I ran the piece actions against the live Asqav API with a real key:

- Connection validate returns valid for a good key and "Invalid API key. Copy a current key from your Asqav dashboard under API Keys." for a bad one.
- Sign Action created the agent on its first run, signed an action, and returned `signature_id` plus a working verification URL. A second run reused the same agent instead of creating a duplicate.
- Verify Signature returned `verified: true` for that signature.
- A wrong-typed Context input surfaces as "Asqav rejected the request payload (422): body.context: Input should be a valid dictionary. Check the step inputs, for example Context must be a JSON object."

In this repo, `npx turbo run lint build --filter=@activepieces/piece-asqav` passes, and `validate-publishable-packages` passes with the new package.

One note for review: the piece points at `https://cdn.activepieces.com/pieces/asqav.png` for the logo, matching the other pieces. Tell me the preferred way to get the logo file to you and I will sort it.
