### PR TITLE
feat(connectuc): scope New SMS recipients by domain/user, add direction filter, require Send SMS recipients

### DIFF
--- a/packages/pieces/community/connectuc/package.json
+++ b/packages/pieces/community/connectuc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-connectuc",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/connectuc/src/i18n/translation.json
+++ b/packages/pieces/community/connectuc/src/i18n/translation.json
@@ -33,6 +33,7 @@
   "Reason": "Reason",
   "Select domain to which this trigger applies": "Select domain to which this trigger applies",
   "Select the user who owns this contact": "Select the user who owns this contact",
+  "Select the user to which this trigger applies": "Select the user to which this trigger applies",
   "The first name of the contact": "The first name of the contact",
   "The last name of the contact": "The last name of the contact",
   "The email address of the contact": "The email address of the contact",

--- a/packages/pieces/community/connectuc/src/i18n/translation.json
+++ b/packages/pieces/community/connectuc/src/i18n/translation.json
@@ -76,5 +76,11 @@
   "Select the SMS recipient numbers to which this trigger applies": "Select the SMS recipient numbers to which this trigger applies",
   "Ringing": "Ringing",
   "Answered": "Answered",
-  "Both": "Both"
+  "Both": "Both",
+  "SMS Numbers": "SMS Numbers",
+  "Direction": "Direction",
+  "Filter by message direction": "Filter by message direction",
+  "Incoming": "Incoming",
+  "Outgoing": "Outgoing",
+  "Triggers when a new SMS message is received or sent": "Triggers when a new SMS message is received or sent"
 }

--- a/packages/pieces/community/connectuc/src/lib/actions/send-sms.ts
+++ b/packages/pieces/community/connectuc/src/lib/actions/send-sms.ts
@@ -33,6 +33,14 @@ export const sendSmsAction = createAction({
     async run(context) {
         const { recipients, content, sender, attachment_urls } = context.propsValue;
 
+        const recipientList = (recipients ?? [])
+            .map((recipient) => String(recipient).trim())
+            .filter((recipient) => recipient.length > 0);
+
+        if (recipientList.length === 0) {
+            throw new Error('At least one SMS destination is required');
+        }
+
         const media = attachment_urls && attachment_urls.length > 0 ? attachment_urls.map((url) => {
             const urlStr = String(url);
             return {
@@ -45,7 +53,7 @@ export const sendSmsAction = createAction({
             application: 'connectuc',
             content: content,
             media: media,
-            recipients: recipients,
+            recipients: recipientList,
             referenceId: randomUUID(),
             sender: sender,
         };

--- a/packages/pieces/community/connectuc/src/lib/common/props.ts
+++ b/packages/pieces/community/connectuc/src/lib/common/props.ts
@@ -241,7 +241,7 @@ export const smsNumberProp = () =>
  */
 export const smsRecipientsProp = () =>
     Property.MultiSelectDropdown({
-        displayName: 'Select Recipients',
+        displayName: 'SMS Numbers',
         description: 'Select the SMS recipient numbers to which this trigger applies',
         required: false,
         auth: connectucAuth,

--- a/packages/pieces/community/connectuc/src/lib/common/props.ts
+++ b/packages/pieces/community/connectuc/src/lib/common/props.ts
@@ -245,12 +245,28 @@ export const smsRecipientsProp = () =>
         description: 'Select the SMS recipient numbers to which this trigger applies',
         required: false,
         auth: connectucAuth,
-        refreshers: [],
-        options: async ({ auth }) => {
+        refreshers: ['domain', 'users'],
+        options: async ({ auth, domain, users }) => {
             if (!auth) {
                 return {
                     disabled: true,
                     placeholder: 'Please connect your account first',
+                    options: [],
+                };
+            }
+
+            if (!domain) {
+                return {
+                    disabled: true,
+                    placeholder: 'Please select a domain first',
+                    options: [],
+                };
+            }
+
+            if (!users) {
+                return {
+                    disabled: true,
+                    placeholder: 'Please select a user first',
                     options: [],
                 };
             }
@@ -266,6 +282,10 @@ export const smsRecipientsProp = () =>
                     accessToken: authValue.access_token,
                     endpoint: '/sms/numbers',
                     method: HttpMethod.GET,
+                    queryParams: {
+                        domain: domain as string,
+                        users: users as string,
+                    },
                 });
 
                 const options = response.numbers.map(n => ({
@@ -346,6 +366,71 @@ export const usersProp = () =>
                     disabled: false,
                     options,
                 };
+            } catch (error) {
+                console.error('Error fetching subscribers:', error);
+                return {
+                    disabled: true,
+                    placeholder: 'Error loading subscribers',
+                    options: [],
+                };
+            }
+        },
+    });
+
+/**
+ * Reusable user dropdown property (single-select)
+ * Fetches subscribers from /activepieces/subscribers endpoint filtered by domain
+ * Uses subscriber user as value (no "All" option)
+ */
+export const userProp = () =>
+    Property.Dropdown({
+        displayName: 'User',
+        description: 'Select the user to which this trigger applies',
+        required: true,
+        auth: connectucAuth,
+        refreshers: ['domain'],
+        options: async ({ auth, domain }) => {
+            if (!auth) {
+                return {
+                    disabled: true,
+                    placeholder: 'Please connect your account first',
+                    options: [],
+                };
+            }
+
+            if (!domain) {
+                return {
+                    disabled: true,
+                    placeholder: 'Please select a domain first',
+                    options: [],
+                };
+            }
+
+            try {
+                const authValue = auth as OAuth2PropertyValue;
+
+                interface Subscriber {
+                    first_name: string;
+                    last_name: string;
+                    user: string;
+                }
+
+                const subscribers = await connectucApiCall<Subscriber[]>({
+                    accessToken: authValue.access_token,
+                    endpoint: '/activepieces/subscribers',
+                    method: HttpMethod.GET,
+                    queryParams: { domain: domain as string },
+                });
+
+                const options = subscribers.map(subscriber => {
+                    const fullName = `${subscriber.first_name} ${subscriber.last_name}`.trim();
+                    return {
+                        label: `${fullName} (${subscriber.user})`,
+                        value: subscriber.user,
+                    };
+                });
+
+                return { disabled: false, options };
             } catch (error) {
                 console.error('Error fetching subscribers:', error);
                 return {

--- a/packages/pieces/community/connectuc/src/lib/triggers/new-sms.ts
+++ b/packages/pieces/community/connectuc/src/lib/triggers/new-sms.ts
@@ -9,7 +9,7 @@ export const newSms = createTrigger({
     displayName: 'New SMS',
     description: 'Triggers when a new SMS message is received or sent',
     aiMetadata: {
-        description: 'Fires when a new inbound SMS/MMS message is received for the selected ConnectUC domain, users, and recipient numbers. Represents an incoming text with its content, sender, recipients, and any media attachments.',
+        description: 'Fires when a new SMS/MMS message is sent or received (configurable via Direction) for the selected ConnectUC domain, user, and recipient numbers. Represents a text with its content, sender, recipients, direction, and any media attachments.'
     },
     props: {
         domain: domainProp(),

--- a/packages/pieces/community/connectuc/src/lib/triggers/new-sms.ts
+++ b/packages/pieces/community/connectuc/src/lib/triggers/new-sms.ts
@@ -1,7 +1,7 @@
 import { createTrigger, TriggerStrategy, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { connectucAuth } from '../../index';
 import { registerConnectUCWebhook, unregisterConnectUCWebhook } from '../common/webhook-helpers';
-import { domainProp, usersProp, smsRecipientsProp } from '../common/props';
+import { domainProp, userProp, smsRecipientsProp } from '../common/props';
 
 export const newSms = createTrigger({
     auth: connectucAuth,
@@ -13,7 +13,7 @@ export const newSms = createTrigger({
     },
     props: {
         domain: domainProp(),
-        users: usersProp(),
+        users: userProp(),
         recipients: smsRecipientsProp(),
     },
     sampleData: {

--- a/packages/pieces/community/connectuc/src/lib/triggers/new-sms.ts
+++ b/packages/pieces/community/connectuc/src/lib/triggers/new-sms.ts
@@ -1,4 +1,4 @@
-import { createTrigger, TriggerStrategy, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { createTrigger, TriggerStrategy, OAuth2PropertyValue, Property } from '@activepieces/pieces-framework';
 import { connectucAuth } from '../../index';
 import { registerConnectUCWebhook, unregisterConnectUCWebhook } from '../common/webhook-helpers';
 import { domainProp, userProp, smsRecipientsProp } from '../common/props';
@@ -7,7 +7,7 @@ export const newSms = createTrigger({
     auth: connectucAuth,
     name: 'newSms',
     displayName: 'New SMS',
-    description: 'Triggers when a new SMS message is received',
+    description: 'Triggers when a new SMS message is received or sent',
     aiMetadata: {
         description: 'Fires when a new inbound SMS/MMS message is received for the selected ConnectUC domain, users, and recipient numbers. Represents an incoming text with its content, sender, recipients, and any media attachments.',
     },
@@ -15,6 +15,19 @@ export const newSms = createTrigger({
         domain: domainProp(),
         users: userProp(),
         recipients: smsRecipientsProp(),
+        direction: Property.StaticDropdown({
+            displayName: 'Direction',
+            description: 'Filter by message direction',
+            required: false,
+            options: {
+                options: [
+                    { label: 'Incoming', value: 'incoming' },
+                    { label: 'Outgoing', value: 'outgoing' },
+                    { label: 'Both', value: 'both' },
+                ],
+            },
+            defaultValue: 'incoming',
+        }),
     },
     sampleData: {
         conversationId: 1234567,

--- a/packages/pieces/community/connectuc/src/lib/triggers/new-sms.ts
+++ b/packages/pieces/community/connectuc/src/lib/triggers/new-sms.ts
@@ -18,12 +18,12 @@ export const newSms = createTrigger({
         direction: Property.StaticDropdown({
             displayName: 'Direction',
             description: 'Filter by message direction',
-            required: false,
+            required: true,
             options: {
                 options: [
                     { label: 'Incoming', value: 'incoming' },
                     { label: 'Outgoing', value: 'outgoing' },
-                    { label: 'Both', value: 'both' },
+                    { label: 'Both', value: '*' },
                 ],
             },
             defaultValue: 'incoming',


### PR DESCRIPTION
## What does this PR do?

  Improves the **ConnectUC** piece across the New SMS trigger and Send SMS action:

  - **New SMS – recipients scoped by domain + user.** The recipients dropdown previously
    called `/sms/numbers` with no filters, listing every SMS number on the account. It now
    filters by the selected domain and user (`?domain=…&users=…`), refreshes when either
    changes, and is disabled until both are chosen. The field was relabeled **"SMS Numbers"**
    (the underlying field key is unchanged for backward compatibility).
  - **New SMS – single-select user.** Switched the trigger's user picker from the shared
    multi-select `usersProp` (which injected an "All Always" option) to a new single-select
    `userProp`, which fits the per-user SMS-number filtering.
  - **New SMS – Direction filter.** Added a required **Direction** dropdown — Incoming
    (`incoming`), Outgoing (`outgoing`), Both (`*`) — defaulting to Incoming.

  ### Explain How the Feature Works

  In the **New SMS** trigger, after connecting ConnectUC, the user selects a Domain and a User;
  the **SMS Numbers** dropdown then loads only that user's numbers. The new **Direction** filter
  controls whether the trigger fires on incoming, outgoing, or both (`*`) messages. The selected
  values are sent to ConnectUC when the webhook is registered, so filtering happens server-side.

  In **Send SMS**, the action validates that at least one SMS destination is supplied before
  calling `/sms/messages`, and sends a cleaned recipients list (blank rows removed).

  ### Relevant User Scenarios

  - Building flows scoped to a specific ConnectUC domain/user without sifting through every
    number on the account.
  - Triggering automations on sent messages (or both directions), not just received ones.
