### PR TITLE
fix: coerce serialized string booleans for checkbox properties

### DIFF
--- a/packages/server/engine/src/lib/variables/processors/checkbox.ts
+++ b/packages/server/engine/src/lib/variables/processors/checkbox.ts
@@ -1,0 +1,14 @@
+import { ProcessorFn } from './types'
+
+export const checkboxProcessor: ProcessorFn = (_property, value) => {
+    if (typeof value === 'boolean') {
+        return value
+    }
+    if (value === 'true') {
+        return true
+    }
+    if (value === 'false') {
+        return false
+    }
+    return value
+}

--- a/packages/server/engine/src/lib/variables/processors/index.ts
+++ b/packages/server/engine/src/lib/variables/processors/index.ts
@@ -1,4 +1,5 @@
 import { PropertyType } from '@activepieces/pieces-framework'
+import { checkboxProcessor } from './checkbox'
 import { dateTimeProcessor } from './date-time'
 import { fileProcessor } from './file'
 import { jsonProcessor } from './json'
@@ -11,6 +12,7 @@ export const processors: Partial<Record<PropertyType, ProcessorFn>> = {
     JSON: jsonProcessor,
     OBJECT: objectProcessor,
     NUMBER: numberProcessor,
+    CHECKBOX: checkboxProcessor,
     LONG_TEXT: textProcessor,
     SHORT_TEXT: textProcessor,
     SECRET_TEXT: textProcessor,

--- a/packages/server/engine/test/variables/props-validator.test.ts
+++ b/packages/server/engine/test/variables/props-validator.test.ts
@@ -418,5 +418,34 @@ describe('Property Validation', () => {
                 object: ['Expected object, received: not an object'],
             })
         })
+
+        it('should coerce serialized string booleans for checkbox properties', async () => {
+            const props = {
+                flag: Property.Checkbox({
+                    displayName: 'Checkbox',
+                    required: true,
+                }),
+            }
+
+            const { processedInput: falseInput, errors: falseErrors } = await propsProcessor.applyProcessorsAndValidators(
+                { flag: 'false' },
+                props,
+                PieceAuth.None(),
+                false,
+                {},
+            )
+            expect(falseErrors).toEqual({})
+            expect(falseInput.flag).toBe(false)
+
+            const { processedInput: trueInput, errors: trueErrors } = await propsProcessor.applyProcessorsAndValidators(
+                { flag: 'true' },
+                props,
+                PieceAuth.None(),
+                false,
+                {},
+            )
+            expect(trueErrors).toEqual({})
+            expect(trueInput.flag).toBe(true)
+        })
     })
 })


### PR DESCRIPTION
**Fixes #13711**

### Problem
Checkbox properties fail validation with `Expected boolean, received: false` whenever the value reaches the engine as a serialized string (e.g. from flow input serialization) instead of a native boolean. This makes any affected action unusable — the linked report hits it on Pinterest's *Create Pin* (`is_removable`), but it applies to **every piece with a `Checkbox` prop**.

### Root cause
`packages/server/engine/src/lib/variables/processors/index.ts` registers processors for `JSON`, `OBJECT`, `NUMBER`, text types, `DATE_TIME` and `FILE` — but **none for `CHECKBOX`**. So a string like `"false"` is never coerced before `validateProperty`'s `CHECKBOX` branch (`typeof value === 'boolean'`) rejects it.

### Fix
Add `checkboxProcessor` (mirroring `numberProcessor`) and register it under `CHECKBOX`:
- native booleans pass through unchanged,
- `"true"` / `"false"` map to real booleans,
- any other value is left untouched, so genuinely invalid input still fails validation (the existing `'not a boolean'` negative test continues to pass).

### Tests
Added a regression test in `props-validator.test.ts` asserting that a checkbox receiving `"false"` / `"true"` coerces to `false` / `true` and validates clean. Verified failing before the fix and passing after, against the engine unit suite.
