### PR TITLE
feat(pieces): add Gmail MCP piece

### DIFF
--- a/packages/pieces/community/gmail-mcp/package.json
+++ b/packages/pieces/community/gmail-mcp/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@activepieces/piece-gmail-mcp",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*"
+  }
+}

--- a/packages/pieces/community/gmail-mcp/src/index.ts
+++ b/packages/pieces/community/gmail-mcp/src/index.ts
@@ -1,0 +1,34 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { gmailMcpAuth } from './lib/common/auth';
+import { sendEmail } from './lib/actions/send-email';
+import { readEmail } from './lib/actions/read-email';
+import { searchEmails } from './lib/actions/search-emails';
+import { addLabel } from './lib/actions/add-label';
+import { archiveEmail } from './lib/actions/archive-email';
+import { newEmailTrigger } from './lib/triggers/new-email';
+
+export const gmailMcp = createPiece({
+  displayName: 'Gmail MCP',
+  description: 'Gmail integration via Model Context Protocol - send, read, search, and manage emails',
+  auth: gmailMcpAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/gmail.png',
+  categories: ['COMMUNICATION'],
+  authors: ['pvbang'],
+  actions: [
+    sendEmail,
+    readEmail,
+    searchEmails,
+    addLabel,
+    archiveEmail,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://gmail.googleapis.com/gmail/v1/users/me',
+      auth: gmailMcpAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${(auth as { access_token: string }).access_token}`,
+      }),
+    }),
+  ],
+  triggers: [newEmailTrigger],
+});

--- a/packages/pieces/community/gmail-mcp/src/lib/actions/add-label.ts
+++ b/packages/pieces/community/gmail-mcp/src/lib/actions/add-label.ts
@@ -1,0 +1,19 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gmailMcpAuth } from '../common/auth';
+import { gmailRequest } from '../common/gmail-api';
+
+export const addLabel = createAction({
+  auth: gmailMcpAuth,
+  name: 'gmail_mcp_add_label',
+  displayName: 'Add Label to Email',
+  description: 'Add a label to a Gmail message',
+  props: {
+    messageId: Property.ShortText({ displayName: 'Message ID', required: true }),
+    labelId: Property.ShortText({ displayName: 'Label ID', required: true }),
+  },
+  async run(context) {
+    const { messageId, labelId } = context.propsValue;
+    return await gmailRequest(context.auth.access_token, HttpMethod.POST, `/messages/${messageId}/modify`, { addLabelIds: [labelId] });
+  },
+});

--- a/packages/pieces/community/gmail-mcp/src/lib/actions/archive-email.ts
+++ b/packages/pieces/community/gmail-mcp/src/lib/actions/archive-email.ts
@@ -1,0 +1,17 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gmailMcpAuth } from '../common/auth';
+import { gmailRequest } from '../common/gmail-api';
+
+export const archiveEmail = createAction({
+  auth: gmailMcpAuth,
+  name: 'gmail_mcp_archive_email',
+  displayName: 'Archive Email',
+  description: 'Archive an email by removing the INBOX label',
+  props: {
+    messageId: Property.ShortText({ displayName: 'Message ID', required: true }),
+  },
+  async run(context) {
+    return await gmailRequest(context.auth.access_token, HttpMethod.POST, `/messages/${context.propsValue.messageId}/modify`, { removeLabelIds: ['INBOX'] });
+  },
+});

--- a/packages/pieces/community/gmail-mcp/src/lib/actions/read-email.ts
+++ b/packages/pieces/community/gmail-mcp/src/lib/actions/read-email.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gmailMcpAuth } from '../common/auth';
+import { gmailRequest } from '../common/gmail-api';
+
+export const readEmail = createAction({
+  auth: gmailMcpAuth,
+  name: 'gmail_mcp_read_email',
+  displayName: 'Read Email',
+  description: 'Read a specific email by message ID',
+  props: {
+    messageId: Property.ShortText({ displayName: 'Message ID', required: true }),
+    format: Property.StaticDropdown({
+      displayName: 'Format',
+      required: false,
+      defaultValue: 'full',
+      options: {
+        options: [
+          { label: 'Full', value: 'full' },
+          { label: 'Metadata', value: 'metadata' },
+          { label: 'Minimal', value: 'minimal' },
+          { label: 'Raw', value: 'raw' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { messageId, format } = context.propsValue;
+    return await gmailRequest(context.auth.access_token, HttpMethod.GET, `/messages/${messageId}?format=${format ?? 'full'}`);
+  },
+});

--- a/packages/pieces/community/gmail-mcp/src/lib/actions/search-emails.ts
+++ b/packages/pieces/community/gmail-mcp/src/lib/actions/search-emails.ts
@@ -1,0 +1,19 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gmailMcpAuth } from '../common/auth';
+import { gmailRequest } from '../common/gmail-api';
+
+export const searchEmails = createAction({
+  auth: gmailMcpAuth,
+  name: 'gmail_mcp_search_emails',
+  displayName: 'Search Emails',
+  description: 'Search emails using Gmail query syntax',
+  props: {
+    query: Property.ShortText({ displayName: 'Search Query', description: 'Gmail search query (e.g., "from:user@example.com subject:hello")', required: true }),
+    maxResults: Property.Number({ displayName: 'Max Results', required: false, defaultValue: 10 }),
+  },
+  async run(context) {
+    const { query, maxResults } = context.propsValue;
+    return await gmailRequest(context.auth.access_token, HttpMethod.GET, `/messages?q=${encodeURIComponent(query)}&maxResults=${maxResults ?? 10}`);
+  },
+});

--- a/packages/pieces/community/gmail-mcp/src/lib/actions/send-email.ts
+++ b/packages/pieces/community/gmail-mcp/src/lib/actions/send-email.ts
@@ -1,0 +1,24 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gmailMcpAuth } from '../common/auth';
+import { gmailRequest, encodeEmail } from '../common/gmail-api';
+
+export const sendEmail = createAction({
+  auth: gmailMcpAuth,
+  name: 'gmail_mcp_send_email',
+  displayName: 'Send Email',
+  description: 'Send an email via Gmail MCP',
+  props: {
+    to: Property.ShortText({ displayName: 'To', required: true }),
+    subject: Property.ShortText({ displayName: 'Subject', required: true }),
+    body: Property.LongText({ displayName: 'Body', required: true }),
+    cc: Property.ShortText({ displayName: 'CC', required: false }),
+    bcc: Property.ShortText({ displayName: 'BCC', required: false }),
+    isHtml: Property.Checkbox({ displayName: 'Send as HTML', required: false, defaultValue: false }),
+  },
+  async run(context) {
+    const { to, subject, body, cc, bcc, isHtml } = context.propsValue;
+    const raw = encodeEmail({ to, subject, body, cc: cc ?? undefined, bcc: bcc ?? undefined, isHtml: isHtml ?? false });
+    return await gmailRequest(context.auth.access_token, HttpMethod.POST, '/messages/send', { raw });
+  },
+});

--- a/packages/pieces/community/gmail-mcp/src/lib/common/auth.ts
+++ b/packages/pieces/community/gmail-mcp/src/lib/common/auth.ts
@@ -1,0 +1,19 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const gmailMcpAuth = PieceAuth.OAuth2({
+  description: 'Gmail OAuth2 authentication for MCP',
+  authUrl: 'https://accounts.google.com/o/oauth2/auth',
+  tokenUrl: 'https://oauth2.googleapis.com/token',
+  required: true,
+  scope: [
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.labels',
+  ],
+});
+
+export type GmailMcpAuthValue = {
+  access_token: string;
+  refresh_token: string;
+};

--- a/packages/pieces/community/gmail-mcp/src/lib/common/gmail-api.ts
+++ b/packages/pieces/community/gmail-mcp/src/lib/common/gmail-api.ts
@@ -1,0 +1,42 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
+export async function gmailRequest(
+  accessToken: string,
+  method: HttpMethod,
+  path: string,
+  body?: unknown
+) {
+  const response = await httpClient.sendRequest({
+    method,
+    url: `${GMAIL_API_BASE}${path}`,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body,
+  });
+  return response.body;
+}
+
+export function encodeEmail(options: {
+  to: string;
+  subject: string;
+  body: string;
+  cc?: string;
+  bcc?: string;
+  isHtml?: boolean;
+}): string {
+  const contentType = options.isHtml ? 'text/html' : 'text/plain';
+  const lines = [
+    `To: ${options.to}`,
+    options.cc ? `Cc: ${options.cc}` : '',
+    options.bcc ? `Bcc: ${options.bcc}` : '',
+    `Subject: ${options.subject}`,
+    `Content-Type: ${contentType}; charset=utf-8`,
+    '',
+    options.body,
+  ].filter(Boolean);
+  return Buffer.from(lines.join('\r\n')).toString('base64url');
+}

--- a/packages/pieces/community/gmail-mcp/src/lib/triggers/new-email.ts
+++ b/packages/pieces/community/gmail-mcp/src/lib/triggers/new-email.ts
@@ -1,0 +1,57 @@
+import { createTrigger, TriggerStrategy, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { gmailMcpAuth } from '../common/auth';
+import { gmailRequest } from '../common/gmail-api';
+
+export const newEmailTrigger = createTrigger({
+  auth: gmailMcpAuth,
+  name: 'gmail_mcp_new_email',
+  displayName: 'New Email Received',
+  description: 'Triggers when a new email is received in Gmail',
+  props: {
+    label: Property.ShortText({ displayName: 'Label Filter', required: false }),
+  },
+  type: TriggerStrategy.POLLING,
+  sampleData: {
+    id: '18f1234abcd',
+    threadId: '18f1234abcd',
+    snippet: 'Hello, this is a sample email...',
+    from: 'sender@example.com',
+    subject: 'Sample Email',
+    date: '2025-01-01T00:00:00Z',
+  },
+  async onEnable(context) {
+    const messages: any = await gmailRequest(context.auth.access_token, HttpMethod.GET, '/messages?maxResults=1');
+    if (messages?.messages?.[0]) {
+      await context.store.put('lastMessageId', messages.messages[0].id);
+    }
+  },
+  async onDisable(context) {
+    await context.store.delete('lastMessageId');
+  },
+  async run(context) {
+    const lastId = await context.store.get<string>('lastMessageId');
+    let query = 'is:unread';
+    if (context.propsValue.label) query += ` label:${context.propsValue.label}`;
+    const messages: any = await gmailRequest(context.auth.access_token, HttpMethod.GET, `/messages?q=${encodeURIComponent(query)}&maxResults=20`);
+    if (!messages?.messages) return [];
+    const newMessages = [];
+    for (const msg of messages.messages) {
+      if (msg.id === lastId) break;
+      const full: any = await gmailRequest(context.auth.access_token, HttpMethod.GET, `/messages/${msg.id}?format=full`);
+      newMessages.push(full);
+    }
+    if (messages.messages.length > 0) await context.store.put('lastMessageId', messages.messages[0].id);
+    return newMessages.map((m: any) => ({ data: m, epochMilliSeconds: Date.now() }));
+  },
+  async test(context) {
+    const messages: any = await gmailRequest(context.auth.access_token, HttpMethod.GET, '/messages?maxResults=3');
+    if (!messages?.messages) return [];
+    const results = [];
+    for (const msg of messages.messages) {
+      const full: any = await gmailRequest(context.auth.access_token, HttpMethod.GET, `/messages/${msg.id}?format=full`);
+      results.push(full);
+    }
+    return results.map((m: any) => ({ data: m, epochMilliSeconds: Date.now() }));
+  },
+});

--- a/packages/pieces/community/gmail-mcp/tsconfig.json
+++ b/packages/pieces/community/gmail-mcp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new Gmail MCP piece implementing email management actions and triggers via the Model Context Protocol.

### Actions
- **Send Email** - Send emails with HTML/plain text support, CC, BCC
- **Read Email** - Read specific email by message ID with format options
- **Search Emails** - Search using Gmail query syntax
- **Add Label** - Add labels to messages
- **Archive Email** - Archive by removing INBOX label
- **Custom API Call** - Direct Gmail API access

### Triggers
- **New Email Received** - Polling trigger for new unread emails with optional label filter

### Technical Details
- OAuth2 authentication with gmail.modify, gmail.compose, gmail.readonly, gmail.labels scopes
- Follows ActivePieces piece conventions (createPiece, createAction, createTrigger)
- TypeScript with strict mode
- Uses @activepieces/pieces-common httpClient

Closes #8072