### PR TITLE
fix(worker): raise isolate sandbox open-files cap to 4096

### DIFF
--- a/packages/server/worker/src/lib/sandbox/isolate.ts
+++ b/packages/server/worker/src/lib/sandbox/isolate.ts
@@ -107,6 +107,9 @@ export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDire
                 '--share-net',
                 `--box-id=${boxId}`,
                 '--processes',
+                // isolate defaults RLIMIT_NOFILE to 64, too few for Node + heavy piece imports
+                // (e.g. the AI piece). Bounded so a runaway fd leak in untrusted code is still contained.
+                '--open-files=4096',
                 '--chdir=/root',
                 ...envArgs,
                 '--run',


### PR DESCRIPTION
## Problem

Pieces with large dependency trees fail to import in the sandbox with `EMFILE: too many open files`. The AI piece is the canary — its dependency tree (`ai@6` + `@ai-sdk/*` + MCP SDK ≈ 100+ modules, resolved through bun's symlink farm) is the first to cross the limit.

## Root cause

The engine runs inside `isolate`, which defaults `RLIMIT_NOFILE` to **64**. `isolate.ts` builds its args without `--open-files`, so the box inherits that default. Node already holds ~20 fds at startup, leaving only ~44 — too few for a heavy piece import.

## Fix

Add `--open-files=4096` to the isolate args. Bounded (not unlimited) so a runaway fd leak in untrusted piece code is still contained; 4096 is ample for Node + heavy pieces.

Confirmed live on worker-canary: default cap failed at 44 fds; `--open-files=4096` imports cleanly.