### PR TITLE
fix(server): require run permission to start a manual flow run over websocket

### DIFF
--- a/.agents/features/flows.md
+++ b/.agents/features/flows.md
@@ -124,6 +124,8 @@ The visual builder (`packages/web/src/app/builder/`) uses XYFlow for the canvas.
 - `notes-state.tsx` — sticky notes overlay
 - `chat-state.ts` — embedded chat drawer state for testing `chat_submission`-trigger flows from the builder
 
+The canvas **Run Flow** / **Test Flow** buttons live in `flow-canvas/widgets/test-flow-widget.tsx`. Starting a manual production run (the "Run Flow" button) requires `WRITE_RUN`: the button is hidden from members without it, mirroring the server-side `WRITE_RUN` check on the `MANUAL_TRIGGER_RUN_STARTED` websocket event (`flow.module.ts`). "Test Flow" runs are membership-only.
+
 ### Canvas Orientation (Horizontal Layout)
 
 The canvas supports two orientations, toggled from the canvas controls (↔ / ↕ button, preference persisted in localStorage): the default top-to-bottom **vertical** layout (unchanged, 232×60 step cards) and a left-to-right **horizontal** layout (compact 80×80 square nodes, step name + piece type below the node, internal step name on hover, branches stacked vertically with labels on the entry lines, loops with a return lane).

--- a/packages/server/api/src/app/core/websockets.service.ts
+++ b/packages/server/api/src/app/core/websockets.service.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, ErrorCode, isNil } from '@activepieces/core-utils'
+import { ActivepiecesError, ErrorCode, isNil, Permission, ProjectRole } from '@activepieces/core-utils'
 import { ApiToWorkerContract, createNotifyClient, Principal, PrincipalForType, PrincipalType, WebsocketServerEvent } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { Socket } from 'socket.io'
@@ -19,6 +19,8 @@ const listener = {
     [PrincipalType.WORKER]: {} as ListenerMap<PrincipalType.WORKER>,
 }
 
+const eventPermissions: Partial<Record<WebsocketServerEvent, Permission>> = {}
+
 export const websocketService = {
     to: (workerId: string) => app!.io.to(workerId),
     notifyWorkers: () => createNotifyClient<ApiToWorkerContract>(app!.io.to(WORKERS_ROOM)),
@@ -31,9 +33,10 @@ export const websocketService = {
 
         const castedType = type as keyof typeof listener
         const projectId = socket.handshake.auth.projectId
+        let projectRole: ProjectRole | undefined
         switch (type) {
             case PrincipalType.USER: {
-                await validateProjectId({ userId: principal.id, projectId, log })
+                projectRole = await validateProjectId({ userId: principal.id, projectId, log })
                 log.info({
                     message: 'User connected',
                     user: { id: principal.id },
@@ -66,17 +69,30 @@ export const websocketService = {
             // Socket.IO emits the reserved lowercase 'disconnect' per-socket; map our DISCONNECT enum
             // onto it or the handler never fires (it never did — worker cleanup relied on the 60s sweep).
             const socketEvent = event === WebsocketServerEvent.DISCONNECT ? 'disconnect' : event
-            socket.on(socketEvent, async (data, callback) => rejectedPromiseHandler(handler(socket)(data, principal, projectId, callback), log))
+            socket.on(socketEvent, async (data, callback) => {
+                // Permissions are a project-role concept, so they only apply to USER principals.
+                const requiredPermission = castedType === PrincipalType.USER
+                    ? eventPermissions[event as WebsocketServerEvent]
+                    : undefined
+                if (!isNil(requiredPermission) && !hasPermission(projectRole, requiredPermission)) {
+                    log.warn({ event, userId: principal.id, projectId, requiredPermission }, 'Websocket event blocked: missing permission')
+                    return
+                }
+                return rejectedPromiseHandler(handler(socket)(data, principal, projectId, callback), log)
+            })
         }
     },
     async verifyPrincipal(socket: Socket): Promise<Principal> {
         return accessTokenManager(app!.log).verifyPrincipal(socket.handshake.auth.token)
     },
-    addListener<T, PR extends PrincipalType.WORKER | PrincipalType.USER>(principalType: PR, event: WebsocketServerEvent, handler: WebsocketListener<T, PR>): void {
+    addListener<T, PR extends PrincipalType.WORKER | PrincipalType.USER>(principalType: PR, event: WebsocketServerEvent, handler: WebsocketListener<T, PR>, permission?: Permission): void {
         switch (principalType) {
             case PrincipalType.USER: {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 listener[PrincipalType.USER][event] = handler as unknown as WebsocketListener<any, PrincipalType.USER>
+                if (!isNil(permission)) {
+                    eventPermissions[event] = permission
+                }
                 break
             }
             case PrincipalType.WORKER: {
@@ -91,7 +107,7 @@ export const websocketService = {
     },
 }
 
-const validateProjectId = async ({ userId, projectId, log }: ValidateProjectIdArgs): Promise<void> => {
+const validateProjectId = async ({ userId, projectId, log }: ValidateProjectIdArgs): Promise<ProjectRole> => {
     if (isNil(projectId)) {
         throw new ActivepiecesError({
             code: ErrorCode.AUTHENTICATION,
@@ -113,6 +129,11 @@ const validateProjectId = async ({ userId, projectId, log }: ValidateProjectIdAr
             },
         })
     }
+    return role
+}
+
+function hasPermission(role: ProjectRole | undefined, permission: Permission): boolean {
+    return !isNil(role) && (role.permissions ?? []).includes(permission)
 }
 
 type ValidateProjectIdArgs = {

--- a/packages/server/api/src/app/flows/flow.module.ts
+++ b/packages/server/api/src/app/flows/flow.module.ts
@@ -1,4 +1,4 @@
-import { PrincipalType, TestFlowRunRequestBody, WebsocketClientEvent, WebsocketServerEvent } from '@activepieces/shared'
+import { Permission, PrincipalType, TestFlowRunRequestBody, WebsocketClientEvent, WebsocketServerEvent } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { websocketService } from '../core/websockets.service'
 import { flowVersionController } from './flow/flow-version.controller'
@@ -10,6 +10,8 @@ export const flowModule: FastifyPluginAsyncZod = async (app) => {
     await app.register(flowVersionController, { prefix: '/v1/flows' })
     await app.register(flowController, { prefix: '/v1/flows' })
     await app.register(sampleDataController, { prefix: '/v1/sample-data' })
+    // Membership-only by design: a test run mirrors the membership-only
+    // /v1/sample-data/test-step route. Only production manual runs require WRITE_RUN.
     websocketService.addListener(PrincipalType.USER, WebsocketServerEvent.TEST_FLOW_RUN, (socket) => {
         return async (data: TestFlowRunRequestBody, principal, projectId) => {
             const flowRun = await flowRunService(app.log).test({
@@ -29,5 +31,5 @@ export const flowModule: FastifyPluginAsyncZod = async (app) => {
             })
             socket.emit(WebsocketClientEvent.MANUAL_TRIGGER_RUN_STARTED, flowRun)
         }
-    })
+    }, Permission.WRITE_RUN)
 }

--- a/packages/server/api/test/integration/cloud/websockets/manual-trigger-rbac.test.ts
+++ b/packages/server/api/test/integration/cloud/websockets/manual-trigger-rbac.test.ts
@@ -1,0 +1,76 @@
+import { apId, DefaultProjectRole, WebsocketServerEvent } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { Socket } from 'socket.io'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { websocketService } from '../../../../src/app/core/websockets.service'
+import * as flowRunServiceModule from '../../../../src/app/flows/flow-run/flow-run-service'
+import { createMemberContext, createTestContext, TestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    // `fresh` is required because this suite uses vi.spyOn on flowRunService (a server-internal module).
+    app = await setupTestEnvironment({ fresh: true })
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+type CapturedHandlers = Record<string, (data: unknown, callback?: (d: unknown) => void) => unknown>
+
+// A socket.io Socket stand-in that records the handlers init() registers, so a single
+// event can be invoked directly (the real transport is irrelevant to this RBAC check).
+function buildFakeSocket(token: string, projectId: string): { socket: Socket, handlers: CapturedHandlers } {
+    const handlers: CapturedHandlers = {}
+    const fake = {
+        handshake: { auth: { token, projectId } },
+        join: async (): Promise<void> => undefined,
+        on: (event: string, cb: (data: unknown, callback?: (d: unknown) => void) => unknown): void => {
+            handlers[event] = cb
+        },
+        emit: (): boolean => true,
+    }
+    return { socket: fake as unknown as Socket, handlers }
+}
+
+// Connects the given context's socket and fires MANUAL_TRIGGER_RUN_STARTED.
+// Returns whether the handler reached flowRunService.startManualTrigger.
+async function didStartManualRun(ctx: TestContext): Promise<boolean> {
+    const startManualTrigger = vi.fn().mockResolvedValue({ id: apId() })
+    vi.spyOn(flowRunServiceModule, 'flowRunService').mockReturnValue(
+        { startManualTrigger } as unknown as ReturnType<typeof flowRunServiceModule.flowRunService>,
+    )
+
+    const { socket, handlers } = buildFakeSocket(ctx.token, ctx.project.id)
+    await websocketService.init(socket, app.log)
+
+    const handler = handlers[WebsocketServerEvent.MANUAL_TRIGGER_RUN_STARTED]
+    await handler({ flowVersionId: apId() })
+
+    return startManualTrigger.mock.calls.length > 0
+}
+
+describe('Websocket MANUAL_TRIGGER_RUN_STARTED RBAC', () => {
+    async function setup(): Promise<{ viewer: TestContext, editor: TestContext }> {
+        const admin = await createTestContext(app)
+        const viewer = await createMemberContext(app, admin, { projectRole: DefaultProjectRole.VIEWER })
+        const editor = await createMemberContext(app, admin, { projectRole: DefaultProjectRole.EDITOR })
+        return { viewer, editor }
+    }
+
+    it('blocks a Viewer (no WRITE_RUN) from starting a manual production run', async () => {
+        const { viewer } = await setup()
+        expect(await didStartManualRun(viewer)).toBe(false)
+    })
+
+    it('allows an Editor (has WRITE_RUN) to start a manual production run', async () => {
+        const { editor } = await setup()
+        expect(await didStartManualRun(editor)).toBe(true)
+    })
+})

--- a/packages/web/src/app/builder/flow-canvas/widgets/test-flow-widget.tsx
+++ b/packages/web/src/app/builder/flow-canvas/widgets/test-flow-widget.tsx
@@ -1,6 +1,7 @@
 import { isNil, assertNotNullOrUndefined } from '@activepieces/core-utils';
 import {
   FlowTriggerType,
+  Permission,
   UpdateRunProgressRequest,
 } from '@activepieces/shared';
 import { t } from 'i18next';
@@ -12,6 +13,7 @@ import { ChatDrawerSource } from '@/app/builder/types';
 import { flowRunUtils } from '@/features/flow-runs';
 import { flowHooks } from '@/features/flows';
 import { pieceSelectorUtils } from '@/features/pieces';
+import { useAuthorization } from '@/hooks/authorization-hooks';
 
 import { AboveTriggerButton } from './above-trigger-button';
 
@@ -35,6 +37,9 @@ const TestFlowWidget = () => {
   ]);
   const runRef = useRef(run);
   runRef.current = run;
+
+  const { checkAccess } = useAuthorization();
+  const userHasPermissionToRun = checkAccess(Permission.WRITE_RUN);
 
   const triggerHasSampleData =
     flowVersion.trigger.type === FlowTriggerType.PIECE &&
@@ -104,6 +109,12 @@ const TestFlowWidget = () => {
         loading={isTestingFlow}
       />
     );
+  }
+
+  // Starting a manual run requires WRITE_RUN (enforced server-side). Hide the action
+  // from users who lack it so they cannot fire a run the server would reject.
+  if (isManualTrigger && !userHasPermissionToRun) {
+    return null;
   }
 
   return (


### PR DESCRIPTION
## Summary
- Read-only members could start real flow runs through the live (websocket) connection, even though they can't do it anywhere else. This locks that down.
- Starting a manual run now requires the same "run" permission already required to retry or cancel runs.
- Editors and admins are unaffected; only read-only members lose this ability (which they were never supposed to have).
- Adds a test covering both cases.

## Test plan
- [ ] As a Viewer, try to start a flow run (should be blocked)
- [ ] As an Editor or Admin, run a flow from the builder (should still work)
