### PR TITLE
feat: add OKX Ticker piece - fetch real-time crypto prices from OKX exchange

### DIFF
--- a/packages/pieces/community/okx-ticker/package.json
+++ b/packages/pieces/community/okx-ticker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@activepieces/piece-okx-ticker",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/okx-ticker/src/index.ts
+++ b/packages/pieces/community/okx-ticker/src/index.ts
@@ -1,0 +1,18 @@
+import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { getTickerAction } from './lib/actions/get-ticker';
+
+export const okxTicker = createPiece({
+  displayName: 'OKX Ticker',
+  description: 'Fetch real-time cryptocurrency prices and ticker data from OKX exchange',
+
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/okx.png',
+  categories: [PieceCategory.CRYPTO],
+  authors: ['lb1192176991-lab'],
+  actions: [
+    getTickerAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/okx-ticker/src/lib/actions/get-ticker.ts
+++ b/packages/pieces/community/okx-ticker/src/lib/actions/get-ticker.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const getTickerAction = createAction({
+  name: 'get_ticker',
+  displayName: 'Get Ticker',
+  description: 'Fetch real-time ticker data for a cryptocurrency from OKX',
+
+  props: {
+    symbol: Property.ShortText({
+      displayName: 'Symbol',
+      description: 'Trading pair symbol e.g. BTC-USDT, ETH-USDT',
+      required: true,
+      defaultValue: 'BTC-USDT',
+    }),
+  },
+
+  async run(context) {
+    const symbol = context.propsValue.symbol;
+
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://www.okx.com/api/v5/market/ticker?instId=${symbol}`,
+    });
+
+    const ticker = response.body;
+
+    if (ticker && ticker['code'] === '0' && ticker['data'] && ticker['data'].length > 0) {
+      const data = ticker['data'][0];
+      return {
+        symbol: symbol,
+        lastPrice: data['last'],
+        high24h: data['high24h'],
+        low24h: data['low24h'],
+        volume24h: data['vol24h'],
+        change24h: data['change24h'],
+        timestamp: data['ts'],
+      };
+    }
+
+    throw new Error(`Failed to fetch ticker for ${symbol}: ${JSON.stringify(ticker)}`);
+  },
+});

--- a/packages/pieces/community/okx-ticker/src/lib/actions/get-ticker.ts
+++ b/packages/pieces/community/okx-ticker/src/lib/actions/get-ticker.ts
@@ -20,20 +20,24 @@ export const getTickerAction = createAction({
 
     const response = await httpClient.sendRequest({
       method: HttpMethod.GET,
-      url: `https://www.okx.com/api/v5/market/ticker?instId=${symbol}`,
+      url: `https://www.okx.com/api/v5/market/ticker?instId=${encodeURIComponent(symbol)}`,
     });
 
     const ticker = response.body;
 
     if (ticker && ticker['code'] === '0' && ticker['data'] && ticker['data'].length > 0) {
       const data = ticker['data'][0];
+      const last = parseFloat(data['last']);
+      const open24h = parseFloat(data['open24h']);
+      const change24h = open24h !== 0 ? ((last - open24h) / open24h) * 100 : 0;
       return {
         symbol: symbol,
         lastPrice: data['last'],
         high24h: data['high24h'],
         low24h: data['low24h'],
         volume24h: data['vol24h'],
-        change24h: data['change24h'],
+        change24hPercent: change24h.toFixed(2),
+        open24h: data['open24h'],
         timestamp: data['ts'],
       };
     }

--- a/packages/pieces/community/okx-ticker/tsconfig.json
+++ b/packages/pieces/community/okx-ticker/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/okx-ticker/tsconfig.lib.json
+++ b/packages/pieces/community/okx-ticker/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,9 @@
       "@activepieces/piece-actualbudget": [
         "packages/pieces/community/actualbudget/src/index.ts"
       ],
+      "@activepieces/piece-okx-ticker": [
+        "packages/pieces/community/okx-ticker/src/index.ts"
+      ],
       "@activepieces/piece-acuity-scheduling": [
         "packages/pieces/community/acuity-scheduling/src/index.ts"
       ],


### PR DESCRIPTION
## Description
Add a new community piece for OKX exchange ticker data. This piece provides a single action to fetch real-time cryptocurrency prices from OKX's public API.

### Features
- Get real-time ticker data for any OKX trading pair (BTC-USDT, ETH-USDT, etc.)
- Returns: last price, 24h high/low, 24h volume, 24h change
- No authentication required (public API)

### Piece Details
- **Name:** 
- **Category:** CRYPTO
- **Actions:** get_ticker - Fetch ticker data for a cryptocurrency symbol

### How to Use
1. Add the OKX Ticker piece to your flow
2. Enter a trading pair symbol (e.g., BTC-USDT)
3. Run to get real-time price data

### Testing
Tested against OKX public API endpoint: https://www.okx.com/api/v5/market/ticker
