### PR TITLE
fix(migration): correct AddExternalIdToFolder release to 0.85.4

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1795000000000-AddExternalIdToFolder.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1795000000000-AddExternalIdToFolder.ts
@@ -9,7 +9,7 @@ const isPGlite = system.get(AppSystemProp.DB_TYPE) === DatabaseType.PGLITE
 export class AddExternalIdToFolder1795000000000 implements Migration {
     name = 'AddExternalIdToFolder1795000000000'
     breaking = false
-    release = '0.96.0'
+    release = '0.85.4'
     transaction = false
 
     public async up(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
## What

The \`AddExternalIdToFolder1795000000000\` migration's \`release\` field was set to \`0.96.0\` during the conflict resolution of #13113. That value is the \`@activepieces/shared\` package version — not the app release line.

The \`release\` field tracks the **app** release (root \`package.json\`), which is \`0.85.4\` on main. This corrects it.

\`\`\`diff
- release = '0.96.0'
+ release = '0.85.4'
\`\`\`

## Why

\`@activepieces/shared\` (0.9x line) and the root \`activepieces\` app (0.8x line) version independently. \`0.96.0\` was a wrong value derived from the shared package; it has no relation to a real app release.

No behavior change — \`release\` is informational migration metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)