### PR TITLE
fix(engine): handle piece-not-found gracefully instead of INTERNAL_ERROR

### DIFF
--- a/packages/server/engine/src/lib/helper/piece-loader.ts
+++ b/packages/server/engine/src/lib/helper/piece-loader.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import path from 'path'
 import { Action, Piece, PiecePropertyMap, Trigger } from '@activepieces/pieces-framework'
-import { ActivepiecesError, EngineGenericError, ErrorCode, extractPieceFromModule, getPackageAliasForPiece, getPieceNameFromAlias, isNil, trimVersionFromAlias } from '@activepieces/shared'
+import { ActivepiecesError, EngineGenericError, ErrorCode, extractPieceFromModule, getPackageAliasForPiece, getPieceNameFromAlias, isNil, PieceNotFoundError, trimVersionFromAlias } from '@activepieces/shared'
 import { utils } from '../utils'
 
 export const pieceLoader = {
@@ -24,7 +24,7 @@ export const pieceLoader = {
             })
 
             if (isNil(piece)) {
-                throw new EngineGenericError('PieceNotFoundError', `Piece not found for piece: ${pieceName}, pieceVersion: ${pieceVersion}`)
+                throw new PieceNotFoundError(`Piece not found for piece: ${pieceName}, pieceVersion: ${pieceVersion}`)
             }
             return piece
         })
@@ -123,7 +123,7 @@ export const pieceLoader = {
             ? await findInDistFolder(packageName)
             : await traverseAllParentFoldersToFindPiece(packageName)
         if (isNil(piecePath)) {
-            throw new EngineGenericError('PieceNotFoundError', `Piece not found for package: ${packageName}`)
+            throw new PieceNotFoundError(`Piece not found for package: ${packageName}`)
         }
         return piecePath
     },

--- a/packages/server/engine/test/utils.test.ts
+++ b/packages/server/engine/test/utils.test.ts
@@ -1,4 +1,28 @@
+import { EngineGenericError, ExecutionErrorType, PieceNotFoundError } from '@activepieces/shared'
 import { utils } from '../src/lib/utils'
+
+describe('utils.tryCatchAndThrowOnEngineError', () => {
+    it('rethrows ENGINE-level errors so they surface as INTERNAL_ERROR', async () => {
+        await expect(
+            utils.tryCatchAndThrowOnEngineError(async () => {
+                throw new EngineGenericError('SomeEngineBug', 'boom')
+            }),
+        ).rejects.toThrow(EngineGenericError)
+    })
+
+    it('does not rethrow PieceNotFoundError so a missing piece fails the step instead of the job', async () => {
+        const error = new PieceNotFoundError('Piece not found for package: @activepieces/piece-store-0.6.15')
+
+        expect(error.type).toBe(ExecutionErrorType.USER)
+
+        const result = await utils.tryCatchAndThrowOnEngineError(async () => {
+            throw error
+        })
+
+        expect(result.error).toBe(error)
+        expect(result.data).toBeNull()
+    })
+})
 
 describe('utils.sizeof', () => {
     it('should return correct size for a simple string', () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.95.1",
+  "version": "0.96.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/shared/src/lib/automation/engine/execution-errors.ts
+++ b/packages/shared/src/lib/automation/engine/execution-errors.ts
@@ -109,6 +109,12 @@ export class EngineGenericError extends ExecutionError {
     }
 }
 
+export class PieceNotFoundError extends ExecutionError {
+    constructor(message: string, cause?: unknown) {
+        super('PieceNotFoundError', formatMessage(message), ExecutionErrorType.USER, cause)
+    }
+}
+
 export class SSRFBlockedError extends ExecutionError {
     constructor({ host, ip, cause }: { host: string, ip: string, cause?: unknown }) {
         super(


### PR DESCRIPTION
## Problem

BullMQ jobs were failing (and paging oncall) with:

```
PieceNotFoundError: Piece not found for package: @activepieces/piece-store-0.6.15
```

When a flow pins a piece version that isn't bundled in the running worker, provisioning still passes (the metadata exists in the DB), but the engine's on-disk `import` fails. That was thrown as an `EngineGenericError` (`ExecutionErrorType.ENGINE`), which `tryCatchAndThrowOnEngineError` **rethrows**, so it propagated to `INTERNAL_ERROR` → failed BullMQ job + oncall page.

A missing / version-skewed piece is a user/config condition, not a genuine engine bug — the engine's own error philosophy reserves `INTERNAL_ERROR` for the latter.

## Fix

- Add a USER-level `PieceNotFoundError` to `@activepieces/shared`.
- Throw it from the engine `piece-loader` (messages unchanged).

Being a `USER` error, it now flows through the existing FAILED-step path: the run ends as **FAILED** with the same message, with no failed infra job and no page. The already-graceful worker-side path (missing *metadata* → flow disabled) is unaffected.

## Tests

- New `utils.test.ts` cases pin the contract: `PieceNotFoundError` is **not** rethrown by `tryCatchAndThrowOnEngineError`, while `EngineGenericError` still is.
- Engine suite (349) + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)