### PR TITLE
feat: add DocX and Sign pieces (LayerOne APIs)

### DIFF
--- a/packages/pieces/community/docx/.eslintrc.json
+++ b/packages/pieces/community/docx/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/docx/README.md
+++ b/packages/pieces/community/docx/README.md
@@ -1,0 +1,35 @@
+# DocX
+
+Génère des documents (PDF / DOCX) et des factures électroniques **Factur-X**
+(conformes à la réforme 2026) à partir de modèles Word, avec gestion de versions.
+
+API : `https://docx.layerone.fr` — authentification par clé API dans l'en-tête `X-API-Key`.
+
+## Authentification
+
+1. Créez un compte gratuit sur [dev.layerone.fr](https://dev.layerone.fr) (20 documents offerts par mois).
+2. Générez une clé DocX dans l'onglet « Clés API ».
+3. Collez la clé dans la connexion.
+
+## Actions
+
+| Action | Description |
+| --- | --- |
+| Générer une facture Factur-X | Facture électronique PDF-A3 conforme 2026 à partir d'un modèle + données JSON |
+| Générer un document | Document PDF ou DOCX à partir d'un modèle + données JSON |
+| Déposer un modèle | Dépose un modèle Word `.docx` (balises `{{ ... }}`) |
+| Mettre à jour un modèle | Remplace un modèle, archive automatiquement l'ancienne version |
+| Restaurer une version de modèle | Restaure une version archivée comme version active |
+| Télécharger un modèle | Récupère le `.docx` d'un modèle |
+| Télécharger une version de modèle | Récupère le `.docx` d'une version archivée |
+| Supprimer un modèle | Supprime un modèle et tout son historique |
+| Trouver un modèle | Liste les modèles, filtre optionnel par nom |
+| Lister les versions d'un modèle | Historique des versions archivées |
+| Consulter le quota et l'usage | Plan, quota et statistiques d'usage de la clé |
+
+## Build
+
+```bash
+turbo run build --filter='@activepieces/piece-docx'
+turbo run lint --filter='@activepieces/piece-docx'
+```

--- a/packages/pieces/community/docx/package.json
+++ b/packages/pieces/community/docx/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@activepieces/piece-docx",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "form-data": "4.0.4",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/docx/src/index.ts
+++ b/packages/pieces/community/docx/src/index.ts
@@ -1,0 +1,39 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { docxAuth } from './lib/common/auth';
+import { renderFacturx } from './lib/actions/render-facturx';
+import { renderDocument } from './lib/actions/render-document';
+import { uploadTemplate } from './lib/actions/upload-template';
+import { updateTemplate } from './lib/actions/update-template';
+import { restoreTemplateVersion } from './lib/actions/restore-template-version';
+import { downloadTemplate } from './lib/actions/download-template';
+import { downloadTemplateVersion } from './lib/actions/download-template-version';
+import { deleteTemplate } from './lib/actions/delete-template';
+import { listTemplates } from './lib/actions/list-templates';
+import { listTemplateVersions } from './lib/actions/list-template-versions';
+import { getUsageStats } from './lib/actions/get-usage-stats';
+
+export const docx = createPiece({
+  displayName: 'DocX',
+  description:
+    'Génère des documents (PDF / DOCX) et des factures Factur-X à partir de modèles Word, avec gestion de versions.',
+  auth: docxAuth,
+  minimumSupportedRelease: '0.36.0',
+  logoUrl: 'https://dev.layerone.fr/logo.png',
+  categories: [PieceCategory.CONTENT_AND_FILES, PieceCategory.PRODUCTIVITY],
+  authors: ['goprotect'],
+  actions: [
+    renderFacturx,
+    renderDocument,
+    uploadTemplate,
+    updateTemplate,
+    restoreTemplateVersion,
+    downloadTemplate,
+    downloadTemplateVersion,
+    deleteTemplate,
+    listTemplates,
+    listTemplateVersions,
+    getUsageStats,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/docx/src/lib/actions/delete-template.ts
+++ b/packages/pieces/community/docx/src/lib/actions/delete-template.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { docxAuth } from '../common/auth';
+import { docxRequest } from '../common/client';
+
+export const deleteTemplate = createAction({
+  auth: docxAuth,
+  name: 'delete_template',
+  displayName: 'Supprimer un modèle',
+  description:
+    'Supprime définitivement un modèle et tout son historique de versions.',
+  props: {
+    template_id: Property.ShortText({
+      displayName: 'ID du modèle',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { template_id } = context.propsValue;
+    return await docxRequest({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.DELETE,
+      path: `/client/templates/${template_id}`,
+    });
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/download-template-version.ts
+++ b/packages/pieces/community/docx/src/lib/actions/download-template-version.ts
@@ -1,0 +1,34 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { docxAuth } from '../common/auth';
+import { docxDownloadToBuffer } from '../common/client';
+
+export const downloadTemplateVersion = createAction({
+  auth: docxAuth,
+  name: 'download_template_version',
+  displayName: 'Télécharger une version de modèle',
+  description:
+    "Télécharge le fichier .docx d'une version archivée d'un modèle.",
+  props: {
+    template_id: Property.ShortText({
+      displayName: 'ID du modèle',
+      required: true,
+    }),
+    version_id: Property.Number({
+      displayName: 'ID de la version',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { template_id, version_id } = context.propsValue;
+    const buffer = await docxDownloadToBuffer({
+      apiKey: context.auth.secret_text,
+      path: `/client/templates/${template_id}/versions/${version_id}`,
+    });
+    const filename = `${template_id}-v${version_id}.docx`;
+    const file = await context.files.write({
+      fileName: filename,
+      data: buffer,
+    });
+    return { filename, file };
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/download-template.ts
+++ b/packages/pieces/community/docx/src/lib/actions/download-template.ts
@@ -1,0 +1,29 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { docxAuth } from '../common/auth';
+import { docxDownloadToBuffer } from '../common/client';
+
+export const downloadTemplate = createAction({
+  auth: docxAuth,
+  name: 'download_template',
+  displayName: 'Télécharger un modèle',
+  description: "Télécharge le fichier .docx d'un modèle déposé.",
+  props: {
+    template_id: Property.ShortText({
+      displayName: 'ID du modèle',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { template_id } = context.propsValue;
+    const buffer = await docxDownloadToBuffer({
+      apiKey: context.auth.secret_text,
+      path: `/client/templates/${template_id}`,
+    });
+    const filename = `${template_id}.docx`;
+    const file = await context.files.write({
+      fileName: filename,
+      data: buffer,
+    });
+    return { template_id, filename, file };
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/get-usage-stats.ts
+++ b/packages/pieces/community/docx/src/lib/actions/get-usage-stats.ts
@@ -1,0 +1,36 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { docxAuth } from '../common/auth';
+import { docxRequest } from '../common/client';
+
+interface DocxUsageStats {
+  plan?: string;
+  quota?: { limit?: number; used?: number; remaining?: number };
+  rate_limit?: number;
+  current_concurrent?: number;
+}
+
+export const getUsageStats = createAction({
+  auth: docxAuth,
+  name: 'get_usage_stats',
+  displayName: "Consulter le quota et l'usage",
+  description:
+    "Retourne le plan, le quota (limite / utilisé / restant) et les statistiques d'usage de la clé API.",
+  props: {},
+  async run(context) {
+    const data = await docxRequest<{ stats?: DocxUsageStats }>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/usage-stats',
+    });
+    const stats = data.stats || {};
+    return {
+      plan: stats.plan,
+      quota_limit: stats.quota?.limit,
+      quota_used: stats.quota?.used,
+      quota_remaining: stats.quota?.remaining,
+      rate_limit: stats.rate_limit,
+      current_concurrent: stats.current_concurrent,
+    };
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/list-template-versions.ts
+++ b/packages/pieces/community/docx/src/lib/actions/list-template-versions.ts
@@ -1,0 +1,42 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { docxAuth } from '../common/auth';
+import { docxRequest } from '../common/client';
+
+interface DocxVersion {
+  version_id: number;
+  version_number: number;
+  content_hash?: string;
+  original_name?: string;
+  size_bytes?: number;
+  archived_at?: string;
+}
+
+export const listTemplateVersions = createAction({
+  auth: docxAuth,
+  name: 'list_template_versions',
+  displayName: "Lister les versions d'un modèle",
+  description: "Liste l'historique des versions archivées d'un modèle.",
+  props: {
+    template_id: Property.ShortText({
+      displayName: 'ID du modèle',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { template_id } = context.propsValue;
+    const data = await docxRequest<{ versions?: DocxVersion[] }>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: `/client/templates/${template_id}/versions`,
+    });
+    return (data.versions || []).map((v) => ({
+      id: v.version_id,
+      version_number: v.version_number,
+      content_hash: v.content_hash,
+      original_name: v.original_name,
+      size_bytes: v.size_bytes,
+      archived_at: v.archived_at,
+    }));
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/list-templates.ts
+++ b/packages/pieces/community/docx/src/lib/actions/list-templates.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { docxAuth } from '../common/auth';
+import { docxRequest } from '../common/client';
+
+interface DocxTemplate {
+  id: string;
+  name?: string;
+  size?: number;
+  client_name?: string;
+}
+
+export const listTemplates = createAction({
+  auth: docxAuth,
+  name: 'list_templates',
+  displayName: 'Trouver un modèle',
+  description:
+    'Liste les modèles déposés pour la clé API, avec un filtre optionnel par nom.',
+  props: {
+    name: Property.ShortText({
+      displayName: 'Filtrer par nom (optionnel)',
+      description:
+        'Laissez vide pour lister tous les modèles, ou saisissez un texte contenu dans le nom du modèle.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { name } = context.propsValue;
+    const data = await docxRequest<{ templates?: DocxTemplate[] }>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: '/client/templates',
+    });
+    const filter = (name || '').toLowerCase();
+    return (data.templates || [])
+      .filter((t) => !filter || (t.name || '').toLowerCase().includes(filter))
+      .map((t) => ({
+        id: t.id,
+        name: t.name,
+        size: t.size,
+        client_name: t.client_name,
+      }));
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/render-document.ts
+++ b/packages/pieces/community/docx/src/lib/actions/render-document.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { docxAuth } from '../common/auth';
+import { docxRenderToBuffer } from '../common/client';
+
+export const renderDocument = createAction({
+  auth: docxAuth,
+  name: 'render_document',
+  displayName: 'Générer un document',
+  description:
+    "Génère un document (PDF ou DOCX) — devis, contrat, attestation — à partir d'un modèle déposé et de données JSON.",
+  props: {
+    template_id: Property.ShortText({
+      displayName: 'ID du modèle',
+      required: true,
+    }),
+    json_data: Property.LongText({
+      displayName: 'Données (JSON)',
+      required: true,
+    }),
+    output_format: Property.StaticDropdown({
+      displayName: 'Format',
+      required: false,
+      defaultValue: 'pdf',
+      options: {
+        options: [
+          { label: 'PDF', value: 'pdf' },
+          { label: 'DOCX', value: 'docx' },
+        ],
+      },
+    }),
+    output_filename: Property.ShortText({
+      displayName: 'Nom du fichier',
+      required: false,
+      defaultValue: 'document.pdf',
+    }),
+  },
+  async run(context) {
+    const { template_id, json_data, output_format, output_filename } =
+      context.propsValue;
+    const filename = output_filename || 'document.pdf';
+    const buffer = await docxRenderToBuffer({
+      apiKey: context.auth.secret_text,
+      path: '/render-document',
+      formBody: {
+        template_id,
+        json_data,
+        output_format: output_format || 'pdf',
+        output_filename: filename,
+      },
+    });
+    const file = await context.files.write({
+      fileName: filename,
+      data: buffer,
+    });
+    return { filename, file };
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/render-facturx.ts
+++ b/packages/pieces/community/docx/src/lib/actions/render-facturx.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { docxAuth } from '../common/auth';
+import { docxRenderToBuffer } from '../common/client';
+
+export const renderFacturx = createAction({
+  auth: docxAuth,
+  name: 'render_facturx',
+  displayName: 'Générer une facture Factur-X',
+  description:
+    "Génère une facture électronique conforme à la réforme 2026 (Factur-X / PDF-A3) à partir d'un modèle déposé et de données JSON.",
+  props: {
+    template_id: Property.ShortText({
+      displayName: 'ID du modèle',
+      description:
+        "Identifiant d'un modèle déjà déposé via l'action « Déposer un modèle ».",
+      required: true,
+    }),
+    json_data: Property.LongText({
+      displayName: 'Données (JSON)',
+      description:
+        'Données de la facture au format JSON, ex : {"Npiece":"F2026-001","client":"ACME","total":1200}.',
+      required: true,
+    }),
+    output_filename: Property.ShortText({
+      displayName: 'Nom du fichier',
+      required: false,
+      defaultValue: 'facture.pdf',
+    }),
+  },
+  async run(context) {
+    const { template_id, json_data, output_filename } = context.propsValue;
+    const filename = output_filename || 'facture.pdf';
+    const buffer = await docxRenderToBuffer({
+      apiKey: context.auth.secret_text,
+      path: '/render-facturx',
+      formBody: {
+        template_id,
+        json_data,
+        output_filename: filename,
+      },
+    });
+    const file = await context.files.write({
+      fileName: filename,
+      data: buffer,
+    });
+    return { filename, file };
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/restore-template-version.ts
+++ b/packages/pieces/community/docx/src/lib/actions/restore-template-version.ts
@@ -1,0 +1,30 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { docxAuth } from '../common/auth';
+import { docxRequest } from '../common/client';
+
+export const restoreTemplateVersion = createAction({
+  auth: docxAuth,
+  name: 'restore_template_version',
+  displayName: 'Restaurer une version de modèle',
+  description:
+    'Restaure une version archivée comme version active du modèle. La version courante est archivée avant écrasement.',
+  props: {
+    template_id: Property.ShortText({
+      displayName: 'ID du modèle',
+      required: true,
+    }),
+    version_id: Property.Number({
+      displayName: 'ID de la version à restaurer',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { template_id, version_id } = context.propsValue;
+    return await docxRequest({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: `/client/templates/${template_id}/restore/${version_id}`,
+    });
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/update-template.ts
+++ b/packages/pieces/community/docx/src/lib/actions/update-template.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import FormData from 'form-data';
+import { docxAuth } from '../common/auth';
+import { DOCX_API_BASE, DOCX_MIME } from '../common/client';
+
+export const updateTemplate = createAction({
+  auth: docxAuth,
+  name: 'update_template',
+  displayName: 'Mettre à jour un modèle',
+  description:
+    "Remplace un modèle existant par une nouvelle version. L'ancienne version est automatiquement archivée (rollback possible).",
+  props: {
+    template_id: Property.ShortText({
+      displayName: 'ID du modèle',
+      required: true,
+    }),
+    template: Property.File({
+      displayName: 'Nouveau fichier (.docx)',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { template_id, template } = context.propsValue;
+    const form = new FormData();
+    form.append('template', template.data, {
+      filename: template.filename || 'template.docx',
+      contentType: DOCX_MIME,
+    });
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.PUT,
+      url: `${DOCX_API_BASE}/client/templates/${template_id}`,
+      headers: {
+        'X-API-Key': context.auth.secret_text,
+        ...form.getHeaders(),
+      },
+      body: form,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/docx/src/lib/actions/upload-template.ts
+++ b/packages/pieces/community/docx/src/lib/actions/upload-template.ts
@@ -1,0 +1,39 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import FormData from 'form-data';
+import { docxAuth } from '../common/auth';
+import { DOCX_API_BASE, DOCX_MIME } from '../common/client';
+
+export const uploadTemplate = createAction({
+  auth: docxAuth,
+  name: 'upload_template',
+  displayName: 'Déposer un modèle',
+  description:
+    "Dépose un modèle Word (.docx) sur le compte pour pouvoir le réutiliser ensuite par son ID. Retourne l'ID du modèle et les balises détectées.",
+  props: {
+    template: Property.File({
+      displayName: 'Fichier modèle (.docx)',
+      description:
+        'Le fichier Word à déposer (contient des balises {{ ... }}).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { template } = context.propsValue;
+    const form = new FormData();
+    form.append('template', template.data, {
+      filename: template.filename || 'template.docx',
+      contentType: DOCX_MIME,
+    });
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${DOCX_API_BASE}/client/templates`,
+      headers: {
+        'X-API-Key': context.auth.secret_text,
+        ...form.getHeaders(),
+      },
+      body: form,
+    });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/docx/src/lib/common/auth.ts
+++ b/packages/pieces/community/docx/src/lib/common/auth.ts
@@ -1,0 +1,45 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { DOCX_API_BASE } from './client';
+
+const AUTH_DESCRIPTION = `
+Il faut d'abord un compte (sans clé, aucun appel ne marche) :
+1. Créez un compte GRATUIT sur https://dev.layerone.fr — 20 documents offerts/mois.
+2. Générez une clé DocX dans l'onglet « Clés API ».
+3. Collez-la ici.
+
+Guide + collection Postman : https://dev.layerone.fr/integrations.html
+`;
+
+export const docxAuth = PieceAuth.SecretText({
+  displayName: 'Clé API DocX',
+  description: AUTH_DESCRIPTION,
+  required: true,
+  validate: async ({ auth }) => {
+    // On poste un /render-document vide : l'API valide la clé
+    // (check_quota_or_raise) AVANT tout traitement. Clé invalide -> 401/403 ;
+    // clé valide -> 400 (aucun modèle fourni), sans consommer de quota.
+    try {
+      const response = await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url: `${DOCX_API_BASE}/render-document`,
+        headers: { 'X-API-Key': auth as string },
+      });
+      // Toute réponse non-401/403 (y compris 400) = clé valide.
+      void response;
+      return { valid: true };
+    } catch (error) {
+      const status = (error as { response?: { status?: number } }).response
+        ?.status;
+      if (status === 401 || status === 403) {
+        return {
+          valid: false,
+          error:
+            'Clé API invalide. Vérifiez votre clé DocX (X-API-Key) sur dev.layerone.fr.',
+        };
+      }
+      // 400 (aucun modèle fourni) ou autre code non-auth = clé valide.
+      return { valid: true };
+    }
+  },
+});

--- a/packages/pieces/community/docx/src/lib/common/client.ts
+++ b/packages/pieces/community/docx/src/lib/common/client.ts
@@ -1,0 +1,101 @@
+import {
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+
+// Base de l'API DocX (identique au connecteur Zapier).
+export const DOCX_API_BASE = 'https://docx.layerone.fr';
+
+// Type MIME d'un document Word (.docx).
+export const DOCX_MIME =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+/**
+ * Sérialise un objet en chaîne application/x-www-form-urlencoded.
+ * Le httpClient d'Activepieces sérialise par défaut en JSON ; pour reproduire
+ * le comportement Zapier (render-* en form-urlencoded), on sérialise nous-mêmes
+ * et on force l'en-tête Content-Type.
+ */
+export function toFormEncoded(body: Record<string, unknown>): string {
+  return Object.entries(body)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${key}=${encodeURIComponent(String(value))}`)
+    .join('&');
+}
+
+/**
+ * Construit les en-têtes communs : la clé API DocX va dans X-API-Key
+ * UNIQUEMENT sur les appels vers docx.layerone.fr (jamais vers une URL externe).
+ */
+export function docxHeaders(
+  apiKey: string,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  return {
+    'X-API-Key': apiKey,
+    ...(extra ?? {}),
+  };
+}
+
+/**
+ * Appel JSON/standard vers l'API DocX. Renvoie le corps de la réponse.
+ */
+export async function docxRequest<T = unknown>(params: {
+  apiKey: string;
+  method: HttpMethod;
+  path: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}): Promise<T> {
+  const { apiKey, method, path, body, headers } = params;
+  const request: HttpRequest = {
+    method,
+    url: `${DOCX_API_BASE}${path}`,
+    headers: docxHeaders(apiKey, headers),
+    body,
+  };
+  const response = await httpClient.sendRequest<T>(request);
+  return response.body;
+}
+
+/**
+ * Appel render-* en form-urlencoded qui renvoie un fichier binaire (PDF/DOCX).
+ * Renvoie le Buffer du fichier généré.
+ */
+export async function docxRenderToBuffer(params: {
+  apiKey: string;
+  path: string;
+  formBody: Record<string, unknown>;
+}): Promise<Buffer> {
+  const { apiKey, path, formBody } = params;
+  const request: HttpRequest<string> = {
+    method: HttpMethod.POST,
+    url: `${DOCX_API_BASE}${path}`,
+    headers: docxHeaders(apiKey, {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    }),
+    body: toFormEncoded(formBody),
+    responseType: 'arraybuffer',
+  };
+  const response = await httpClient.sendRequest<ArrayBuffer>(request);
+  return Buffer.from(response.body);
+}
+
+/**
+ * Téléchargement binaire (GET) qui renvoie un fichier (Buffer).
+ */
+export async function docxDownloadToBuffer(params: {
+  apiKey: string;
+  path: string;
+}): Promise<Buffer> {
+  const { apiKey, path } = params;
+  const request: HttpRequest = {
+    method: HttpMethod.GET,
+    url: `${DOCX_API_BASE}${path}`,
+    headers: docxHeaders(apiKey),
+    responseType: 'arraybuffer',
+  };
+  const response = await httpClient.sendRequest<ArrayBuffer>(request);
+  return Buffer.from(response.body);
+}

--- a/packages/pieces/community/docx/tsconfig.json
+++ b/packages/pieces/community/docx/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/docx/tsconfig.lib.json
+++ b/packages/pieces/community/docx/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/pieces/community/sign/.eslintrc.json
+++ b/packages/pieces/community/sign/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/sign/README.md
+++ b/packages/pieces/community/sign/README.md
@@ -1,0 +1,34 @@
+# Sign
+
+Signature électronique de documents PDF conforme **eIDAS / PAdES** : envoi à la
+signature, vérification d'identité par SMS (OTP), suivi du statut, téléchargement
+du PDF signé et récupération du certificat de preuve juridique.
+
+API : `https://sign.layerone.fr` — authentification par clé API dans l'en-tête `X-API-Key`.
+
+## Authentification
+
+1. Créez un compte gratuit sur [dev.layerone.fr](https://dev.layerone.fr) (10 signatures offertes par mois).
+2. Générez une clé Sign dans l'onglet « Clés API ».
+3. Collez la clé dans la connexion.
+
+## Actions
+
+| Action | Description |
+| --- | --- |
+| Envoyer un document à signer | Envoie un PDF à signer (eIDAS / PAdES) et invite le signataire par email |
+| Détecter les champs de signature | Analyse un PDF et retourne les emplacements balisés `[[...]]` |
+| Télécharger le document signé | Récupère le PDF final signé (PAdES + certificat de preuve) |
+| Annuler une demande de signature | Annule une demande encore en cours |
+| Envoyer un code de vérification (SMS) | Envoie un code OTP par SMS au signataire |
+| Vérifier un code de vérification (SMS) | Valide le code OTP et retourne l'URL de signature |
+| Consulter le statut d'une signature | État d'avancement (en attente, signé, refusé…) |
+| Récupérer le certificat de preuve | Certificat juridique complet (IP, horodatage, chaîne de hachage) |
+| Vérifier l'intégrité de la signature | Vérification cryptographique de la signature PAdES |
+
+## Build
+
+```bash
+turbo run build --filter='@activepieces/piece-sign'
+turbo run lint --filter='@activepieces/piece-sign'
+```

--- a/packages/pieces/community/sign/package.json
+++ b/packages/pieces/community/sign/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-sign",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/shared": "workspace:*",
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/sign/src/index.ts
+++ b/packages/pieces/community/sign/src/index.ts
@@ -1,0 +1,35 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { signAuth } from './lib/common/auth';
+import { sendForSignature } from './lib/actions/send-for-signature';
+import { detectFields } from './lib/actions/detect-fields';
+import { downloadSignedDocument } from './lib/actions/download-signed-document';
+import { cancelDocument } from './lib/actions/cancel-document';
+import { sendOtp } from './lib/actions/send-otp';
+import { verifyOtp } from './lib/actions/verify-otp';
+import { getDocumentStatus } from './lib/actions/get-document-status';
+import { getAuditCertificate } from './lib/actions/get-audit-certificate';
+import { validateSignature } from './lib/actions/validate-signature';
+
+export const sign = createPiece({
+  displayName: 'Sign',
+  description:
+    'Signature électronique de documents PDF (eIDAS / PAdES) : envoi, vérification SMS (OTP), suivi du statut, certificat de preuve juridique.',
+  auth: signAuth,
+  minimumSupportedRelease: '0.36.0',
+  logoUrl: 'https://dev.layerone.fr/logo.png',
+  categories: [PieceCategory.CONTENT_AND_FILES, PieceCategory.SALES_AND_CRM],
+  authors: ['goprotect'],
+  actions: [
+    sendForSignature,
+    detectFields,
+    downloadSignedDocument,
+    cancelDocument,
+    sendOtp,
+    verifyOtp,
+    getDocumentStatus,
+    getAuditCertificate,
+    validateSignature,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/sign/src/lib/actions/cancel-document.ts
+++ b/packages/pieces/community/sign/src/lib/actions/cancel-document.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { signAuth } from '../common/auth';
+import { signRequest } from '../common/client';
+
+export const cancelDocument = createAction({
+  auth: signAuth,
+  name: 'cancel_document',
+  displayName: 'Annuler une demande de signature',
+  description:
+    'Annule une demande de signature encore en cours. Impossible si le document est déjà signé.',
+  props: {
+    document_id: Property.ShortText({
+      displayName: 'ID du document',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { document_id } = context.propsValue;
+    return await signRequest({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.DELETE,
+      path: `/v1/documents/${document_id}`,
+    });
+  },
+});

--- a/packages/pieces/community/sign/src/lib/actions/detect-fields.ts
+++ b/packages/pieces/community/sign/src/lib/actions/detect-fields.ts
@@ -1,0 +1,27 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { signAuth } from '../common/auth';
+import { signRequest } from '../common/client';
+
+export const detectFields = createAction({
+  auth: signAuth,
+  name: 'detect_fields',
+  displayName: 'Détecter les champs de signature',
+  description:
+    "Analyse un PDF et retourne les emplacements de signature balisés ([[...]]) détectés, avant de l'envoyer à la signature.",
+  props: {
+    pdf: Property.File({
+      displayName: 'Fichier PDF',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { pdf } = context.propsValue;
+    return await signRequest({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: '/v1/documents/detect-fields',
+      body: { pdf_base64: pdf.base64 },
+    });
+  },
+});

--- a/packages/pieces/community/sign/src/lib/actions/download-signed-document.ts
+++ b/packages/pieces/community/sign/src/lib/actions/download-signed-document.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { signAuth } from '../common/auth';
+import { signRequest } from '../common/client';
+
+interface SignedDocResponse {
+  pdf_base64?: string;
+  title?: string;
+  size_bytes?: number;
+}
+
+export const downloadSignedDocument = createAction({
+  auth: signAuth,
+  name: 'download_signed_document',
+  displayName: 'Télécharger le document signé',
+  description:
+    'Récupère le PDF final signé (avec signature PAdES qualifiée et certificat de preuve intégré). Disponible une fois le document complété.',
+  props: {
+    document_id: Property.ShortText({
+      displayName: 'ID du document',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { document_id } = context.propsValue;
+    const data = await signRequest<SignedDocResponse>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: `/v1/documents/${document_id}/download`,
+    });
+    const pdfBuffer = Buffer.from(data.pdf_base64 || '', 'base64');
+    const filename = `${data.title || document_id}.pdf`;
+    const file = await context.files.write({
+      fileName: filename,
+      data: pdfBuffer,
+    });
+    return {
+      document_id,
+      title: data.title,
+      size_bytes: data.size_bytes,
+      file,
+    };
+  },
+});

--- a/packages/pieces/community/sign/src/lib/actions/get-audit-certificate.ts
+++ b/packages/pieces/community/sign/src/lib/actions/get-audit-certificate.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { signAuth } from '../common/auth';
+import { signRequest } from '../common/client';
+
+export const getAuditCertificate = createAction({
+  auth: signAuth,
+  name: 'get_audit_certificate',
+  displayName: 'Récupérer le certificat de preuve',
+  description:
+    'Récupère le certificat de preuve juridique complet : qui a signé, depuis quelle IP, à quelle heure, avec la chaîne de hachage cryptographique.',
+  props: {
+    document_id: Property.ShortText({
+      displayName: 'ID du document',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { document_id } = context.propsValue;
+    const data = await signRequest<{ certificate?: Record<string, unknown> }>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: `/v1/documents/${document_id}/audit`,
+    });
+    const cert = data.certificate || {};
+    return { id: document_id, ...cert };
+  },
+});

--- a/packages/pieces/community/sign/src/lib/actions/get-document-status.ts
+++ b/packages/pieces/community/sign/src/lib/actions/get-document-status.ts
@@ -1,0 +1,27 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { signAuth } from '../common/auth';
+import { signRequest } from '../common/client';
+
+export const getDocumentStatus = createAction({
+  auth: signAuth,
+  name: 'get_document_status',
+  displayName: "Consulter le statut d'une signature",
+  description:
+    "Consulte l'état d'avancement d'une demande de signature (en attente, signé, refusé…).",
+  props: {
+    document_id: Property.ShortText({
+      displayName: 'ID du document',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { document_id } = context.propsValue;
+    const data = await signRequest<Record<string, unknown>>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: `/v1/documents/${document_id}`,
+    });
+    return { id: document_id, ...data };
+  },
+});

--- a/packages/pieces/community/sign/src/lib/actions/send-for-signature.ts
+++ b/packages/pieces/community/sign/src/lib/actions/send-for-signature.ts
@@ -1,0 +1,93 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { signAuth } from '../common/auth';
+import { signRequest } from '../common/client';
+
+export const sendForSignature = createAction({
+  auth: signAuth,
+  name: 'send_for_signature',
+  displayName: 'Envoyer un document à signer',
+  description:
+    "Envoie un PDF à signer électroniquement (eIDAS / PAdES). Crée la demande et envoie l'email d'invitation au signataire.",
+  props: {
+    pdf: Property.File({
+      displayName: 'Fichier PDF',
+      description: 'Le document PDF à faire signer.',
+      required: true,
+    }),
+    document_name: Property.ShortText({
+      displayName: 'Nom du document',
+      required: true,
+    }),
+    signer_email: Property.ShortText({
+      displayName: 'Email du signataire',
+      required: true,
+    }),
+    signer_name: Property.ShortText({
+      displayName: 'Nom du signataire',
+      required: true,
+    }),
+    signer_role: Property.ShortText({
+      displayName: 'Rôle du signataire',
+      required: false,
+      defaultValue: 'Client',
+    }),
+    signer_phone: Property.ShortText({
+      displayName: 'Téléphone du signataire (format +33…)',
+      description:
+        'Optionnel — requis seulement si vous utilisez la vérification par SMS (OTP).',
+      required: false,
+    }),
+    note: Property.LongText({
+      displayName: "Message d'accompagnement",
+      required: false,
+    }),
+    expiry_days: Property.Number({
+      displayName: 'Expiration (jours)',
+      required: false,
+      defaultValue: 30,
+    }),
+    company_name: Property.ShortText({
+      displayName: 'Nom de la société affichée',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const {
+      pdf,
+      document_name,
+      signer_email,
+      signer_name,
+      signer_role,
+      signer_phone,
+      note,
+      expiry_days,
+      company_name,
+    } = context.propsValue;
+
+    const signer: Record<string, unknown> = {
+      name: signer_name,
+      email: signer_email,
+      role: signer_role || 'Client',
+    };
+    if (signer_phone) signer['phone'] = signer_phone;
+
+    const body: Record<string, unknown> = {
+      pdf_base64: pdf.base64,
+      document_name,
+      signers: [signer],
+    };
+    if (note) body['note'] = note;
+    if (expiry_days !== undefined && expiry_days !== null) {
+      body['expiry_days'] = expiry_days;
+    }
+    if (company_name) body['company_name'] = company_name;
+
+    return await signRequest({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: '/v1/documents/send',
+      body,
+    });
+  },
+});

--- a/packages/pieces/community/sign/src/lib/actions/send-otp.ts
+++ b/packages/pieces/community/sign/src/lib/actions/send-otp.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { signAuth } from '../common/auth';
+import { signRequest } from '../common/client';
+
+export const sendOtp = createAction({
+  auth: signAuth,
+  name: 'send_otp',
+  displayName: 'Envoyer un code de vérification (SMS)',
+  description:
+    'Envoie un code OTP par SMS au signataire pour vérifier son identité avant la signature.',
+  props: {
+    document_id: Property.ShortText({
+      displayName: 'ID du document',
+      required: true,
+    }),
+    signer_email: Property.ShortText({
+      displayName: 'Email du signataire',
+      required: true,
+    }),
+    signer_phone: Property.ShortText({
+      displayName: 'Téléphone du signataire (format +33…)',
+      required: true,
+    }),
+    document_name: Property.ShortText({
+      displayName: 'Nom du document',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { document_id, signer_email, signer_phone, document_name } =
+      context.propsValue;
+    const body: Record<string, unknown> = {
+      document_id,
+      signer_email,
+      signer_phone,
+    };
+    if (document_name) body['document_name'] = document_name;
+    return await signRequest({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: '/v1/otp/request',
+      body,
+    });
+  },
+});

--- a/packages/pieces/community/sign/src/lib/actions/validate-signature.ts
+++ b/packages/pieces/community/sign/src/lib/actions/validate-signature.ts
@@ -1,0 +1,27 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { signAuth } from '../common/auth';
+import { signRequest } from '../common/client';
+
+export const validateSignature = createAction({
+  auth: signAuth,
+  name: 'validate_signature',
+  displayName: "Vérifier l'intégrité de la signature",
+  description:
+    'Vérifie cryptographiquement que la signature PAdES du document est intègre et valide.',
+  props: {
+    document_id: Property.ShortText({
+      displayName: 'ID du document',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { document_id } = context.propsValue;
+    const data = await signRequest<Record<string, unknown>>({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      path: `/v1/documents/${document_id}/validate`,
+    });
+    return { id: document_id, ...data };
+  },
+});

--- a/packages/pieces/community/sign/src/lib/actions/verify-otp.ts
+++ b/packages/pieces/community/sign/src/lib/actions/verify-otp.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { signAuth } from '../common/auth';
+import { signRequest } from '../common/client';
+
+export const verifyOtp = createAction({
+  auth: signAuth,
+  name: 'verify_otp',
+  displayName: 'Vérifier un code de vérification (SMS)',
+  description:
+    "Valide le code OTP saisi par le signataire et retourne l'URL de signature si le code est correct.",
+  props: {
+    document_id: Property.ShortText({
+      displayName: 'ID du document',
+      required: true,
+    }),
+    signer_email: Property.ShortText({
+      displayName: 'Email du signataire',
+      required: true,
+    }),
+    code: Property.ShortText({
+      displayName: 'Code reçu par SMS',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { document_id, signer_email, code } = context.propsValue;
+    return await signRequest({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.POST,
+      path: '/v1/otp/verify',
+      body: { document_id, signer_email, code },
+    });
+  },
+});

--- a/packages/pieces/community/sign/src/lib/common/auth.ts
+++ b/packages/pieces/community/sign/src/lib/common/auth.ts
@@ -1,0 +1,42 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { SIGN_API_BASE } from './client';
+
+const AUTH_DESCRIPTION = `
+Il faut d'abord un compte (sans clé, aucun appel ne marche) :
+1. Créez un compte GRATUIT sur https://dev.layerone.fr — 10 signatures offertes/mois.
+2. Générez une clé Sign dans l'onglet « Clés API ».
+3. Collez-la ici.
+
+Guide + collection Postman : https://dev.layerone.fr/integrations.html
+`;
+
+export const signAuth = PieceAuth.SecretText({
+  displayName: 'Clé API Sign',
+  description: AUTH_DESCRIPTION,
+  required: true,
+  validate: async ({ auth }) => {
+    // On interroge un document fictif : 401/403 = clé invalide.
+    // Tout autre code (404 « document introuvable »…) = clé valide.
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${SIGN_API_BASE}/v1/documents/activepieces-auth-check`,
+        headers: { 'X-API-Key': auth as string },
+      });
+      return { valid: true };
+    } catch (error) {
+      const status = (error as { response?: { status?: number } }).response
+        ?.status;
+      if (status === 401 || status === 403) {
+        return {
+          valid: false,
+          error:
+            'Clé API invalide. Vérifiez votre clé Sign (X-API-Key) dans dev.layerone.fr.',
+        };
+      }
+      // 404 (document introuvable) ou autre code non-auth = clé valide.
+      return { valid: true };
+    }
+  },
+});

--- a/packages/pieces/community/sign/src/lib/common/client.ts
+++ b/packages/pieces/community/sign/src/lib/common/client.ts
@@ -1,0 +1,45 @@
+import {
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+
+// Base de l'API Sign (identique au connecteur Zapier).
+export const SIGN_API_BASE = 'https://sign.layerone.fr';
+
+/**
+ * Construit les en-têtes communs : la clé API Sign va dans X-API-Key
+ * UNIQUEMENT sur les appels vers sign.layerone.fr (jamais vers une URL externe).
+ */
+export function signHeaders(
+  apiKey: string,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  return {
+    'X-API-Key': apiKey,
+    ...(extra ?? {}),
+  };
+}
+
+/**
+ * Appel JSON/standard vers l'API Sign. Renvoie le corps de la réponse.
+ */
+export async function signRequest<T = unknown>(params: {
+  apiKey: string;
+  method: HttpMethod;
+  path: string;
+  body?: unknown;
+}): Promise<T> {
+  const { apiKey, method, path, body } = params;
+  const request: HttpRequest = {
+    method,
+    url: `${SIGN_API_BASE}${path}`,
+    headers: signHeaders(
+      apiKey,
+      body ? { 'Content-Type': 'application/json' } : undefined,
+    ),
+    body,
+  };
+  const response = await httpClient.sendRequest<T>(request);
+  return response.body;
+}

--- a/packages/pieces/community/sign/tsconfig.json
+++ b/packages/pieces/community/sign/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/sign/tsconfig.lib.json
+++ b/packages/pieces/community/sign/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What

Adds two new community pieces for the **LayerOne** APIs:

- **DocX** (`docx.layerone.fr`) — generate PDF/DOCX documents and **Factur-X** e-invoices from Word templates, with template version management. **11 actions** (render Factur-X, render document, upload/update/download/delete template, list/restore versions, usage stats…).
- **Sign** (`sign.layerone.fr`) — **eIDAS / PAdES** electronic signatures, with SMS OTP verification and legal proof certificates. **9 actions** (send for signature, detect fields, status, download signed, audit certificate, validate, cancel, send/verify OTP).

## Authentication

Both pieces use a per-user API key sent as `X-API-Key`. Users create a free account and generate their key on https://dev.layerone.fr — **no secret is hard-coded** in the pieces.

## Notes

- `build` (tsc) and `eslint` pass with **zero warnings** for both pieces.
- Display labels are in French (the product's primary audience).
- Both pieces mirror the maintained official Zapier connectors for the same APIs (same endpoints, fields and behaviours).