### PR TITLE
fix(builder): surface internal error cause in run-details step panel

### DIFF
--- a/.agents/features/flow-runs.md
+++ b/.agents/features/flow-runs.md
@@ -103,6 +103,7 @@ The runs table surfaces a Status multi-select and an "Error message" text input 
 ### Failed-Step Surfaces
 
 - **Runs table failed-step column** renders the failed step's display name with a tooltip showing the truncated, JSON-pretty error message; clicking opens `FailedStepDialog` (full error + "Go to run" footer). Legacy runs without a captured message bypass the dialog and navigate straight to the run page.
+- **Run-details step panel** (`flow-step-input-output.tsx`) resolves `INTERNAL_ERROR` runs by output presence, not run status alone (`INTERNAL_ERROR` is non-terminal under `isFlowRunStateTerminal({ ignoreInternalError: true })`, so it is excluded from the skeleton-loader guard to avoid an infinite skeleton). Platform admins see `InternalErrorPanel` (from `run.internalError`, stripped server-side for non-admins) only when the selected step has no output; a step that ran before the crash still shows its captured output. When there is no output, a "no logs captured, contact support" message is shown to everyone.
 - **Builder run-info widget** shows up to two controls during a run:
   - A "Follow run updates" button — visible only while the run is non-terminal and the user has manually selected a different step. Clicking it calls `resumeLiveFollow`, which clears the `userManuallySelectedStepDuringRun` flag and snaps loop indexes to their latest iteration so the canvas resumes following the engine live.
   - On failure, a "See error" button that focuses the failed step on the canvas via `goToFailedStep` in `run-state`.

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -127,7 +127,6 @@
   "Queued": "Queued",
   "Running": "Running",
   "Run exceeded {timeout} seconds, try to optimize your steps.": "Run exceeded {timeout} seconds, try to optimize your steps.",
-  "Run failed for an unknown reason, contact support.": "Run failed for an unknown reason, contact support.",
   "Run failed with an internal error, contact support.": "Run failed with an internal error, contact support.",
   "Run Cancelled": "Run Cancelled",
   "Started": "Started",

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -128,6 +128,7 @@
   "Running": "Running",
   "Run exceeded {timeout} seconds, try to optimize your steps.": "Run exceeded {timeout} seconds, try to optimize your steps.",
   "Run failed for an unknown reason, contact support.": "Run failed for an unknown reason, contact support.",
+  "Run failed with an internal error, contact support.": "Run failed with an internal error, contact support.",
   "Run Cancelled": "Run Cancelled",
   "Started": "Started",
   "Took": "Took",

--- a/packages/web/src/app/builder/flow-canvas/widgets/run-info-widget.tsx
+++ b/packages/web/src/app/builder/flow-canvas/widgets/run-info-widget.tsx
@@ -61,7 +61,7 @@ function getStatusText({
         timeout,
       });
     case FlowRunStatus.INTERNAL_ERROR:
-      return t('Run failed for an unknown reason, contact support.');
+      return t('Run failed with an internal error, contact support.');
     case FlowRunStatus.CANCELED:
       return t('Run Cancelled');
   }

--- a/packages/web/src/app/builder/run-details/flow-step-input-output.tsx
+++ b/packages/web/src/app/builder/run-details/flow-step-input-output.tsx
@@ -133,28 +133,17 @@ export const FlowStepInputOutput = () => {
     return <StepOutputSkeleton className="p-4" />;
   }
 
-  if (
-    run.status === FlowRunStatus.INTERNAL_ERROR &&
-    isNil(selectedStepOutput)
-  ) {
-    return (
-      <div className="flex flex-col justify-center items-center gap-4 w-full pt-8  px-5">
-        <Info size={36} className="text-muted-foreground" />
-        <h4 className="px-6 text-sm text-center text-muted-foreground">
-          {t(
-            'There are no logs captured for this run, because of an internal error, please contact support.',
-          )}
-        </h4>
-      </div>
-    );
-  }
-
-  const message = handleRunFailureOrEmptyLog(run, rententionDays);
+  const message =
+    run.status === FlowRunStatus.INTERNAL_ERROR && isNil(selectedStepOutput)
+      ? t(
+          'There are no logs captured for this run, because of an internal error, please contact support.',
+        )
+      : handleRunFailureOrEmptyLog(run, rententionDays);
   if (message) {
     return (
-      <div className="flex flex-col justify-center items-center gap-4 w-full pt-8  px-5">
+      <div className="flex flex-col justify-center items-center gap-4 w-full pt-8 px-5">
         <Info size={36} className="text-muted-foreground" />
-        <h4 className="px-6 text-sm text-center text-muted-foreground ">
+        <h4 className="px-6 text-sm text-center text-muted-foreground">
           {message}
         </h4>
       </div>

--- a/packages/web/src/app/builder/run-details/flow-step-input-output.tsx
+++ b/packages/web/src/app/builder/run-details/flow-step-input-output.tsx
@@ -118,7 +118,8 @@ export const FlowStepInputOutput = () => {
 
   if (
     run.status === FlowRunStatus.INTERNAL_ERROR &&
-    !isNil(run.internalError)
+    !isNil(run.internalError) &&
+    isNil(selectedStepOutput)
   ) {
     return <InternalErrorPanel internalError={run.internalError} />;
   }
@@ -126,9 +127,26 @@ export const FlowStepInputOutput = () => {
   if (
     !isRunDone &&
     run.status !== FlowRunStatus.PAUSED &&
+    run.status !== FlowRunStatus.INTERNAL_ERROR &&
     isNil(selectedStepOutput)
   ) {
     return <StepOutputSkeleton className="p-4" />;
+  }
+
+  if (
+    run.status === FlowRunStatus.INTERNAL_ERROR &&
+    isNil(selectedStepOutput)
+  ) {
+    return (
+      <div className="flex flex-col justify-center items-center gap-4 w-full pt-8  px-5">
+        <Info size={36} className="text-muted-foreground" />
+        <h4 className="px-6 text-sm text-center text-muted-foreground">
+          {t(
+            'There are no logs captured for this run, because of an internal error, please contact support.',
+          )}
+        </h4>
+      </div>
+    );
   }
 
   const message = handleRunFailureOrEmptyLog(run, rententionDays);
@@ -362,12 +380,6 @@ function handleRunFailureOrEmptyLog(
     !isFlowRunStateTerminal({ status: run.status, ignoreInternalError: true })
   ) {
     return null;
-  }
-
-  if ([FlowRunStatus.INTERNAL_ERROR].includes(run.status)) {
-    return t(
-      'There are no logs captured for this run, because of an internal error, please contact support.',
-    );
   }
 
   if (isNil(run.logsFileId)) {


### PR DESCRIPTION
## Summary

When a flow run ended with `INTERNAL_ERROR`, non-platform-admin users saw an infinite skeleton loader in the run-details step panel if the run produced no step outputs (e.g. the sandbox crashed before any step ran). Platform admins already got a proper `InternalErrorPanel` panel (added in #13452), but that panel was also incorrectly overwriting step outputs for steps that **did** run before the error.

## Problem

Three bugs in `flow-step-input-output.tsx`:

1. **Infinite skeleton for regular users** — the skeleton guard used `isFlowRunStateTerminal({ ignoreInternalError: true })`, which treats `INTERNAL_ERROR` as non-terminal (so `isRunDone = false`). With no step output, the code entered the skeleton branch and never exited.

2. **`InternalErrorPanel` overwrote step outputs** — the platform-admin path checked `run.status === INTERNAL_ERROR && !isNil(run.internalError)` without checking whether the selected step had output. If a step ran successfully before the engine crashed, the admin could not inspect that step's output — the error panel always took over.

3. **Dead INTERNAL_ERROR branch in `handleRunFailureOrEmptyLog`** — the guard used `ignoreInternalError: true`, so the `INTERNAL_ERROR` message case at the bottom was unreachable. It was never shown to anyone.

## Solution

**`packages/web/src/app/builder/run-details/flow-step-input-output.tsx`**

- Add `isNil(selectedStepOutput)` to the `InternalErrorPanel` condition so platform admins can still inspect outputs of steps that ran successfully before the crash.
- Add `run.status !== FlowRunStatus.INTERNAL_ERROR` to the skeleton guard so `INTERNAL_ERROR` runs never show an infinite skeleton.
- Add an explicit `INTERNAL_ERROR + no step output` check that renders the "no logs captured, contact support" message — this is what regular users (who have no `internalError` field) now see instead of the skeleton or the misleading "This step didn't run" message.
- Remove the dead `INTERNAL_ERROR` branch from `handleRunFailureOrEmptyLog` since it can never be reached (the new explicit check above fires first).

**`packages/web/src/app/builder/flow-canvas/widgets/run-info-widget.tsx`**

- Change the canvas-top banner text from "Run failed for an unknown reason, contact support." to "Run failed with an internal error, contact support." — more accurate and less alarming.

**`packages/web/public/locales/en/translation.json`**

- Add translation key for the updated banner message.

## Changed Files

| File | What changed |
|---|---|
| `packages/web/src/app/builder/run-details/flow-step-input-output.tsx` | Fixed skeleton loop, InternalErrorPanel condition, added INTERNAL_ERROR fallback message, removed dead branch |
| `packages/web/src/app/builder/flow-canvas/widgets/run-info-widget.tsx` | Updated INTERNAL_ERROR status text |
| `packages/web/public/locales/en/translation.json` | Added new banner translation key |

## Testing

Steps to verify the fix:

1. **Regular user, INTERNAL_ERROR run with no step outputs** — Open the builder, load such a run, click any step: should see "There are no logs captured for this run…" instead of an infinite skeleton.
2. **Platform admin, INTERNAL_ERROR run with partial step outputs** — Should see `InternalErrorPanel` only when selecting a step with no output; selecting a step that ran and has output should show that output.
3. **Canvas banner** — Top bar should read "Run failed with an internal error, contact support." for INTERNAL_ERROR runs.

- [x] `npm run lint-dev` passes
- [ ] `npm run test-unit` (no unit tests cover this component)
- [ ] `npm run test-api` (not applicable — frontend-only change)

## Edition Impact

Frontend only. Affects all editions (CE / EE / Cloud) since all can produce `INTERNAL_ERROR` runs. Platform-admin path gated by `internalError` field being present (stripped server-side for non-admins, unchanged).

## Breaking Changes

None.

## Related

Closes #13751