### PR TITLE
feat(embedding): embeddable MCP via OAuth

### DIFF
--- a/.agents/features/mcp.md
+++ b/.agents/features/mcp.md
@@ -16,6 +16,10 @@ Exposes an Activepieces project as a Model Context Protocol (MCP) server so that
 - `packages/web/src/app/components/project-settings/mcp-server/mcp-flows.tsx` — list of flows exposed as tools
 - `packages/web/src/app/components/project-settings/mcp-server/mcp-tools.tsx` — controllable tool toggle UI
 - `packages/web/src/app/routes/mcp-authorize/index.tsx` — OAuth authorization page for MCP clients
+- `packages/web/src/app/routes/mcp-authorize/permission-item.tsx` — shared permission-item component used by the MCP OAuth consent screens
+- `packages/web/src/app/routes/embed/embedded-mcp-authorize-dialog.tsx` — in-embed MCP OAuth consent dialog for managed-auth (embedded) users
+- `packages/web/src/app/routes/embed/embedded-mcp-settings-dialog.tsx` — in-embed MCP settings dialog for managed-auth (embedded) users
+- `packages/ee/embed-sdk/src/index.ts` — embed SDK; adds `authorizeMcp()` (in-embed OAuth consent) and `mcpSettings()` (MCP settings dialog) public methods
 - `packages/web/src/features/agents/agent-tools/mcp-tool-dialog/index.tsx` — dialog to add an external MCP server as an agent tool
 - `packages/web/src/features/agents/agent-tools/mcp-tool-dialog/add-mcp-tool-form.tsx` — form inside the dialog
 - `packages/web/src/features/agents/agent-tools/components/mcp-tool.tsx` — inline display of an MCP tool in agent settings
@@ -35,6 +39,7 @@ Exposes an Activepieces project as a Model Context Protocol (MCP) server so that
 - **MCP trigger piece** — `@activepieces/piece-mcp`; a flow with this trigger is exposed as a callable tool via MCP
 - **disabledTools** — JSONB array of controllable tool names currently disabled; `null` or `[]` means all controllable tools are enabled
 - **Flow attribution** — `ap_create_flow`, `ap_build_flow`, and `ap_duplicate_flow` stamp `ownerId` (the OAuth-authenticated user who connected the client) and `createdBy: { type: 'MCP', id: <mcpServerId> }` on every flow they create. `ProjectScopedMcpServer` carries `userId?` so the tools can attribute ownership.
+- **Embedded MCP OAuth** — in-embed consent flow where a managed-auth (embedded) user approves an MCP OAuth request inside the host app via the SDK's `authorizeMcp()`, instead of being redirected to a standalone Activepieces login they don't have. Backed by the `/embed/mcp-authorize` route and the existing `POST /v1/mcp-oauth/approve` (which accepts the embed USER session). `mcpSettings()` similarly renders the MCP settings page inside the embed.
 
 ## Entity
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -233,6 +233,7 @@
                   "pages": [
                      "embedding/customize-pieces",
                      "embedding/embed-connections",
+                     "embedding/embeddable-mcp",
                      "embedding/navigation",
                      "embedding/predefined-connection",
                      "embedding/sdk-changelog",

--- a/docs/embedding/embeddable-mcp.mdx
+++ b/docs/embedding/embeddable-mcp.mdx
@@ -1,0 +1,181 @@
+---
+title: "Embeddable MCP"
+description: "Let your embedded users connect their automations to AI with one click"
+icon: "plug"
+---
+
+<Snippet file="enterprise-feature.mdx" />
+
+## What it does
+
+Every Activepieces project can act as an [MCP](/mcp/overview) server — a place an AI can connect to in order to run that project's flows.
+
+When you embed Activepieces, your users log in through **your** app, not Activepieces. So they can't use the normal "connect your AI" screen (it would ask them to log in to Activepieces, which they can't).
+
+Embeddable MCP fixes that. Your user clicks one **Authorize** button inside your app, and your backend gets a token it can use to run that user's automations through AI.
+
+**Who does what:**
+- **Your backend** runs the connect steps and keeps the token.
+- **Your user** just clicks Authorize in a small popup inside your app.
+- **Activepieces** checks everything and gives back a token for that one user's project.
+
+<Info>
+It's normal OAuth. The only Activepieces-specific part is one SDK call (`authorizeMcp`) that shows the Authorize popup inside your app.
+</Info>
+
+## Before you start
+
+Embedding should already work for you:
+1. You created a **signing key**.
+2. Your backend **signs a user token (JWT)**.
+3. Your frontend called `activepieces.configure({ jwtToken, instanceUrl, … })`.
+
+Below, `INSTANCE_URL` is your Activepieces address (like `https://app.your-company.com`).
+
+## The whole idea in 6 steps
+
+1. **Register your app once** → you get a `client_id`.
+2. **Make two random codes** (a "verifier" and a "challenge").
+3. **Ask Activepieces to start a connection** → you get an `authRequestId`.
+4. **Show the Authorize popup** in your app → the user clicks Authorize → you get a `code`.
+5. **Trade the `code` for a token.**
+6. **Use the token** to run the user's flows.
+
+## Steps
+
+<Steps>
+  <Step title="1. Register your app (only once)">
+    This tells Activepieces who your app is. Save the `client_id` — it's the same for all users.
+
+    ```bash
+    curl -X POST "$INSTANCE_URL/register" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "client_name": "My App AI Assistant",
+        "redirect_uris": ["https://app.your-company.com/mcp/callback"]
+      }'
+    ```
+
+    You get back a `client_id`.
+
+    <Tip>
+    `client_name` is the name your user sees in the popup ("**My App AI Assistant** wants to connect"). Skip it and it says "Unknown app".
+    </Tip>
+  </Step>
+
+  <Step title="2. Make two random codes">
+    Make a random `codeVerifier`, then turn it into a `codeChallenge`. Keep the verifier for step 5.
+
+    ```ts
+    import crypto from 'crypto';
+
+    const base64url = (b: Buffer) =>
+      b.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+
+    const codeVerifier = base64url(crypto.randomBytes(45));
+    const codeChallenge = base64url(crypto.createHash('sha256').update(codeVerifier).digest());
+    ```
+  </Step>
+
+  <Step title="3. Get an authRequestId">
+    Call `/authorize`. It doesn't reply with data — it **redirects**. Don't follow the redirect; just read the `authRequestId` from the redirect address.
+
+    ```ts
+    const params = new URLSearchParams({
+      client_id: CLIENT_ID,
+      redirect_uri: 'https://app.your-company.com/mcp/callback',
+      response_type: 'code',
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    });
+
+    const res = await fetch(`${INSTANCE_URL}/authorize?${params}`, { redirect: 'manual' });
+    const location = res.headers.get('location'); // .../mcp-authorize?authRequestId=eyJ...
+    const authRequestId = new URL(location).searchParams.get('authRequestId');
+    ```
+
+    <Warning>The `authRequestId` only lasts 10 minutes. Get it right before showing the popup.</Warning>
+  </Step>
+
+  <Step title="4. Show the Authorize popup">
+    Send the `authRequestId` to your frontend and pass it to the SDK. A popup shows up inside your app and the user clicks Authorize.
+
+    ```ts
+    const result = await activepieces.authorizeMcp({ authRequestId });
+
+    if (result.denied) {
+      // user clicked Deny
+    } else {
+      // result.redirectUrl looks like: .../mcp/callback?code=THE_CODE
+      const code = new URL(result.redirectUrl).searchParams.get('code');
+      // send `code` to your backend for step 5
+    }
+    ```
+  </Step>
+
+  <Step title="5. Trade the code for a token">
+    On your backend, swap the `code` (plus the `codeVerifier` from step 2) for a token.
+
+    ```ts
+    const res = await fetch(`${INSTANCE_URL}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: codeVerifier,
+        redirect_uri: 'https://app.your-company.com/mcp/callback',
+        client_id: CLIENT_ID,
+      }),
+    });
+    const { access_token, refresh_token } = await res.json();
+    ```
+
+    Save the `refresh_token` for this user. The `access_token` works for 15 minutes; the `refresh_token` gets you new ones and can be turned off anytime.
+  </Step>
+
+  <Step title="6. Use the token">
+    Point your AI at `INSTANCE_URL/mcp` with the token. It only works for that user's project. Quick check:
+
+    ```bash
+    curl -X POST "$INSTANCE_URL/mcp" \
+      -H "Authorization: Bearer $ACCESS_TOKEN" \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json, text/event-stream" \
+      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+    ```
+
+    You'll see the user's tools and flows come back.
+  </Step>
+</Steps>
+
+## Get a new token / disconnect
+
+Get a fresh token when the 15-minute one expires:
+
+```bash
+curl -X POST "$INSTANCE_URL/token" -H "Content-Type: application/json" \
+  -d '{"grant_type":"refresh_token","refresh_token":"<REFRESH_TOKEN>","client_id":"<CLIENT_ID>"}'
+```
+
+Disconnect (turn the AI off):
+
+```bash
+curl -X POST "$INSTANCE_URL/revoke" -H "Content-Type: application/json" \
+  -d '{"token":"<REFRESH_TOKEN>","client_id":"<CLIENT_ID>"}'
+```
+
+## Optional: let users manage their MCP
+
+Add a button so users can see their connection and turn tools on or off — inside your app:
+
+```ts
+await activepieces.mcpSettings();
+```
+
+## Good to know
+
+- **Use the same `redirect_uri` everywhere** (register, `/authorize`, `/token`). If it differs, it's rejected.
+- **`authRequestId` lasts 10 minutes** — make it right before the popup.
+- **The token is only for that one user's project** — that's how users stay separate.
+- **Cursor and Claude Desktop are different.** Those are tools a user installs and connects themselves, so they don't use this popup. Embeddable MCP is for the AI **your app** runs for the user.

--- a/docs/embedding/sdk-changelog.mdx
+++ b/docs/embedding/sdk-changelog.mdx
@@ -18,6 +18,11 @@ Change log format: MM/DD/YYYY (version)
 
 
 
+### 06/18/2026 (0.10.0)
+- SDK URL: https://cdn.activepieces.com/sdk/embed/0.10.0.js
+- Added `authorizeMcp({ authRequestId })` — opens an in-embed MCP OAuth consent dialog so embedded (managed-auth) users can approve connecting an AI client to their project **without a standalone Activepieces login**. Resolves with `{ redirectUrl }` on approval or `{ denied: true }`. See [Embeddable MCP](./embeddable-mcp).
+- Added `mcpSettings()` — opens the MCP settings dialog (connection URL, tools, exposed flows) for the embedded user's project, inside the host app.
+
 ### 04/21/2026 (0.9.0)
 - SDK URL: https://cdn.activepieces.com/sdk/embed/0.9.0.js
 - This version requires you to **upgrade Activepieces to [0.82.0](https://github.com/activepieces/activepieces/releases/tag/0.82.0)**.

--- a/packages/ee/embed-sdk/package.json
+++ b/packages/ee/embed-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ee-embed-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "commonjs",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/ee/embed-sdk/src/index.ts
+++ b/packages/ee/embed-sdk/src/index.ts
@@ -11,6 +11,10 @@ export enum ActivepiecesClientEventName {
   CLIENT_CONFIGURATION_FINISHED = 'CLIENT_CONFIGURATION_FINISHED',
   CLIENT_CONNECTION_PIECE_NOT_FOUND = 'CLIENT_CONNECTION_PIECE_NOT_FOUND',
   CLIENT_BUILDER_HOME_BUTTON_CLICKED = 'CLIENT_BUILDER_HOME_BUTTON_CLICKED',
+  CLIENT_SHOW_MCP_IFRAME = 'CLIENT_SHOW_MCP_IFRAME',
+  CLIENT_MCP_SETTINGS_DIALOG_CLOSED = 'CLIENT_MCP_SETTINGS_DIALOG_CLOSED',
+  CLIENT_MCP_OAUTH_APPROVED = 'CLIENT_MCP_OAUTH_APPROVED',
+  CLIENT_MCP_OAUTH_DENIED = 'CLIENT_MCP_OAUTH_DENIED',
 }
 export interface ActivepiecesClientInit {
   type: ActivepiecesClientEventName.CLIENT_INIT;
@@ -62,6 +66,22 @@ export interface ActivepiecesBuilderHomeButtonClicked {
   data: {
     route: string;
   };
+}
+export interface ActivepiecesClientShowMcpIframe {
+  type: ActivepiecesClientEventName.CLIENT_SHOW_MCP_IFRAME;
+  data: Record<string, never>;
+}
+export interface ActivepiecesClientMcpSettingsDialogClosed {
+  type: ActivepiecesClientEventName.CLIENT_MCP_SETTINGS_DIALOG_CLOSED;
+  data: Record<string, never>;
+}
+export interface ActivepiecesClientMcpOAuthApproved {
+  type: ActivepiecesClientEventName.CLIENT_MCP_OAUTH_APPROVED;
+  data: { redirectUrl: string };
+}
+export interface ActivepiecesClientMcpOAuthDenied {
+  type: ActivepiecesClientEventName.CLIENT_MCP_OAUTH_DENIED;
+  data: Record<string, never>;
 }
 
 type IframeWithWindow = HTMLIFrameElement & { contentWindow: Window };
@@ -162,9 +182,13 @@ type ConfigureParams = {
   embedding?: EmbeddingParam;
 }
 
+export type McpOAuthDialogResult =
+  | { redirectUrl: string }
+  | { denied: true };
+
 type RequestMethod = Required<Parameters<typeof fetch>>[1]['method'];
 class ActivepiecesEmbedded {
-  readonly _sdkVersion = "0.9.0";
+  readonly _sdkVersion = "0.10.0";
   //used for  Automatically Sync URL feature i.e /org/1234
   _prefix = '/';
   _instanceUrl = '';
@@ -173,6 +197,10 @@ class ActivepiecesEmbedded {
   _resolveNewConnectionDialogClosed?: (result: ActivepiecesNewConnectionDialogClosed['data']) => void;
   _dashboardAndBuilderIframeWindow?: Window;
   _rejectNewConnectionDialogClosed?: (error: unknown) => void;
+  _resolveMcpSettingsDialogClosed?: () => void;
+  _resolveMcpOAuthDialogClosed?: (result: McpOAuthDialogResult) => void;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  _cleanMcpIframe: () => void = () => { };
   _resolveStepSettingsDialogClosed?: () => void;
   _rejectStepSettingsDialogClosed?: (error: unknown) => void;
   _handleVendorNavigation?: (data: { route: string }) => void;
@@ -180,6 +208,7 @@ class ActivepiecesEmbedded {
   _parentOrigin = window.location.origin;
   readonly _MAX_CONTAINER_CHECK_COUNT = 100;
   readonly _HUNDRED_MILLISECONDS = 100;
+  readonly _OVERLAY_IFRAME_CSS = ['display:none', 'position:fixed', 'top:0', 'left:0', 'width:100%', 'height:100%', 'border:none'].join(';');
   _embeddingAuth?: {
     //this is used to do authentication with the backend
     userJwtToken:string,
@@ -354,12 +383,7 @@ class ActivepiecesEmbedded {
   }
     
   private _addConnectionIframe({pieceName, connectionName}:{pieceName:string, connectionName?:string}) {
-    const connectionsIframe = this.connectToEmbed({
-      iframeContainer: document.body,
-      initialRoute: `/embed/connections?${NEW_CONNECTION_QUERY_PARAMS.name}=${pieceName}&randomId=${Date.now()}&${NEW_CONNECTION_QUERY_PARAMS.connectionName}=${connectionName || ''}`
-    });
-    connectionsIframe.style.cssText = ['display:none', 'position:fixed', 'top:0', 'left:0', 'width:100%', 'height:100%', 'border:none'].join(';');
-    return connectionsIframe;
+    return this._addOverlayIframe(`/embed/connections?${NEW_CONNECTION_QUERY_PARAMS.name}=${pieceName}&randomId=${Date.now()}&${NEW_CONNECTION_QUERY_PARAMS.connectionName}=${connectionName || ''}`);
   }
 
   private _openNewWindowForConnections({pieceName, connectionName,newWindow}:{pieceName:string, connectionName?:string, newWindow:newWindowFeatures}) {
@@ -416,6 +440,94 @@ class ActivepiecesEmbedded {
       },
     };
     this._dashboardAndBuilderIframeWindow.postMessage(event, '*');
+  }
+
+  /**
+   * Opens the MCP settings (connection URL, tools, exposed flows) for the
+   * embedded user's project in an overlay dialog. Resolves when the dialog is
+   * closed.
+   */
+  async mcpSettings() {
+    this._cleanMcpIframe();
+    return this._addGracePeriodBeforeMethod({
+      condition: () => !!document.body,
+      method: async () => {
+        const target = this._addOverlayIframe('/embed/mcp');
+        return new Promise<void>((resolve) => {
+          this._resolveMcpSettingsDialogClosed = resolve;
+          this._setMcpIframeEventsListener(target);
+        });
+      },
+      errorMessage: 'unable to add mcp settings embedding',
+    });
+  }
+
+  /**
+   * Opens an MCP OAuth consent dialog for the given authRequestId (obtained by
+   * your backend from the /authorize redirect). The embedded user approves
+   * using their embed session. Resolves with `{ redirectUrl }` on approval (the
+   * client's redirect URI carrying the auth code), or `{ denied: true }`.
+   */
+  async authorizeMcp({ authRequestId }: { authRequestId: string }): Promise<McpOAuthDialogResult> {
+    this._cleanMcpIframe();
+    return this._addGracePeriodBeforeMethod({
+      condition: () => !!document.body,
+      method: async () => {
+        const target = this._addOverlayIframe(
+          `/embed/mcp-authorize?authRequestId=${encodeURIComponent(authRequestId)}&randomId=${Date.now()}`,
+        );
+        return new Promise<McpOAuthDialogResult>((resolve) => {
+          this._resolveMcpOAuthDialogClosed = resolve;
+          this._setMcpIframeEventsListener(target);
+        });
+      },
+      errorMessage: 'unable to add mcp oauth embedding',
+    });
+  }
+
+  private _addOverlayIframe(initialRoute: string): IframeWithWindow {
+    const iframe = this.connectToEmbed({
+      iframeContainer: document.body,
+      initialRoute,
+    });
+    iframe.style.cssText = this._OVERLAY_IFRAME_CSS;
+    return iframe;
+  }
+
+  private _setMcpIframeEventsListener(target: IframeWithWindow) {
+    const mcpMessageHandler = (event: MessageEvent<ActivepiecesClientShowMcpIframe | ActivepiecesClientMcpSettingsDialogClosed | ActivepiecesClientMcpOAuthApproved | ActivepiecesClientMcpOAuthDenied>) => {
+      if (event.source !== target.contentWindow) {
+        return;
+      }
+      switch (event.data.type) {
+        case ActivepiecesClientEventName.CLIENT_SHOW_MCP_IFRAME: {
+          target.style.display = 'block';
+          break;
+        }
+        case ActivepiecesClientEventName.CLIENT_MCP_SETTINGS_DIALOG_CLOSED: {
+          this._resolveMcpSettingsDialogClosed?.();
+          this._cleanMcpIframe();
+          break;
+        }
+        case ActivepiecesClientEventName.CLIENT_MCP_OAUTH_APPROVED: {
+          this._resolveMcpOAuthDialogClosed?.({ redirectUrl: event.data.data.redirectUrl });
+          this._cleanMcpIframe();
+          break;
+        }
+        case ActivepiecesClientEventName.CLIENT_MCP_OAUTH_DENIED: {
+          this._resolveMcpOAuthDialogClosed?.({ denied: true });
+          this._cleanMcpIframe();
+          break;
+        }
+      }
+    };
+    window.addEventListener('message', mcpMessageHandler);
+    this._cleanMcpIframe = () => {
+      window.removeEventListener('message', mcpMessageHandler);
+      this._resolveMcpSettingsDialogClosed = undefined;
+      this._resolveMcpOAuthDialogClosed = undefined;
+      this._removeEmbedding(target);
+    };
   }
 
   private _prependForwardSlashToRoute(route: string) {
@@ -515,17 +627,17 @@ class ActivepiecesEmbedded {
     return str.startsWith('/') ? str.slice(1) : str;
   }
   /**Adds a grace period before executing the method depending on the condition */
-  private _addGracePeriodBeforeMethod({
+  private _addGracePeriodBeforeMethod<T>({
     method,
     condition,
     errorMessage,
   }: {
-    method: () => Promise<any> | void;
+    method: () => Promise<T> | T;
     condition: () => boolean;
     /**Error message to show when grace period passes */
     errorMessage: string;
-  }) {
-    return new Promise((resolve, reject) => {
+  }): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
       let checkCounter = 0;
       if (condition()) {
         resolve(method());

--- a/packages/ee/embed-sdk/src/index.ts
+++ b/packages/ee/embed-sdk/src/index.ts
@@ -505,17 +505,23 @@ class ActivepiecesEmbedded {
           break;
         }
         case ActivepiecesClientEventName.CLIENT_MCP_SETTINGS_DIALOG_CLOSED: {
-          this._resolveMcpSettingsDialogClosed?.();
+          const resolve = this._resolveMcpSettingsDialogClosed;
+          this._resolveMcpSettingsDialogClosed = undefined;
+          resolve?.();
           this._cleanMcpIframe();
           break;
         }
         case ActivepiecesClientEventName.CLIENT_MCP_OAUTH_APPROVED: {
-          this._resolveMcpOAuthDialogClosed?.({ redirectUrl: event.data.data.redirectUrl });
+          const resolve = this._resolveMcpOAuthDialogClosed;
+          this._resolveMcpOAuthDialogClosed = undefined;
+          resolve?.({ redirectUrl: event.data.data.redirectUrl });
           this._cleanMcpIframe();
           break;
         }
         case ActivepiecesClientEventName.CLIENT_MCP_OAUTH_DENIED: {
-          this._resolveMcpOAuthDialogClosed?.({ denied: true });
+          const resolve = this._resolveMcpOAuthDialogClosed;
+          this._resolveMcpOAuthDialogClosed = undefined;
+          resolve?.({ denied: true });
           this._cleanMcpIframe();
           break;
         }
@@ -524,6 +530,9 @@ class ActivepiecesEmbedded {
     window.addEventListener('message', mcpMessageHandler);
     this._cleanMcpIframe = () => {
       window.removeEventListener('message', mcpMessageHandler);
+      // Resolve any dialog still pending (e.g. superseded by a new open) so its caller never hangs.
+      this._resolveMcpSettingsDialogClosed?.();
+      this._resolveMcpOAuthDialogClosed?.({ denied: true });
       this._resolveMcpSettingsDialogClosed = undefined;
       this._resolveMcpOAuthDialogClosed = undefined;
       this._removeEmbedding(target);

--- a/packages/web/src/app/routes/embed/embedded-mcp-authorize-dialog.tsx
+++ b/packages/web/src/app/routes/embed/embedded-mcp-authorize-dialog.tsx
@@ -1,0 +1,158 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+  ActivepiecesClientEventName,
+  ActivepiecesClientMcpOAuthApproved,
+  ActivepiecesClientMcpOAuthDenied,
+  ActivepiecesClientShowMcpIframe,
+} from 'ee-embed-sdk';
+import { t } from 'i18next';
+import { jwtDecode } from 'jwt-decode';
+import { Lock, Plug, Workflow } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { memoryRouter } from '@/app/guards';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Separator } from '@/components/ui/separator';
+import { api } from '@/lib/api';
+import { authenticationSession } from '@/lib/authentication-session';
+import { parentWindow } from '@/lib/dom-utils';
+
+import { PermissionItem } from '../mcp-authorize/permission-item';
+
+const postMessageToParent = (
+  event:
+    | ActivepiecesClientShowMcpIframe
+    | ActivepiecesClientMcpOAuthApproved
+    | ActivepiecesClientMcpOAuthDenied,
+) => {
+  parentWindow.postMessage(event, '*');
+};
+
+export const EmbeddedMcpAuthorizeDialog = () => {
+  const authRequestId = new URLSearchParams(
+    memoryRouter.state.location.search,
+  ).get('authRequestId');
+  const clientName = decodeClientName(authRequestId);
+  const [isDialogOpen, setIsDialogOpen] = useState(true);
+
+  useEffect(() => {
+    postMessageToParent({
+      type: ActivepiecesClientEventName.CLIENT_SHOW_MCP_IFRAME,
+      data: {},
+    });
+    document.body.style.background = 'transparent';
+  }, []);
+
+  const approveMutation = useMutation({
+    mutationFn: () => {
+      const projectId = authenticationSession.getProjectId();
+      return api.post<{ redirectUrl: string }>('/v1/mcp-oauth/approve', {
+        authRequestId,
+        ...(projectId && { projectId }),
+      });
+    },
+    onSuccess: (data) => {
+      setIsDialogOpen(false);
+      postMessageToParent({
+        type: ActivepiecesClientEventName.CLIENT_MCP_OAUTH_APPROVED,
+        data: { redirectUrl: data.redirectUrl },
+      });
+    },
+  });
+
+  const deny = () => {
+    setIsDialogOpen(false);
+    postMessageToParent({
+      type: ActivepiecesClientEventName.CLIENT_MCP_OAUTH_DENIED,
+      data: {},
+    });
+  };
+
+  return (
+    <Dialog
+      open={isDialogOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          deny();
+        }
+      }}
+    >
+      <DialogContent
+        showOverlay={false}
+        onInteractOutside={(e) => e.preventDefault()}
+        showCloseButton={false}
+        className="min-w-[400px] max-w-[440px]"
+      >
+        <DialogHeader>
+          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+            <Plug className="h-5 w-5 text-primary" />
+          </div>
+          <DialogTitle className="text-center text-xl">
+            {t('Authorize Application')}
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            <span className="font-semibold text-foreground">{clientName}</span>{' '}
+            {t('wants to connect to your Activepieces account')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <PermissionItem
+            icon={<Workflow className="h-4 w-4 text-primary" />}
+            text={t('Build, test, and manage automations')}
+          />
+          <PermissionItem
+            icon={<Lock className="h-4 w-4 text-primary" />}
+            text={t('Use connections and execute flows')}
+          />
+        </div>
+
+        <Separator />
+
+        {approveMutation.isError && (
+          <div className="rounded-md border border-destructive/50 bg-destructive-100 p-3 text-sm text-destructive">
+            {t('Authorization failed. Please try again.')}
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            className="flex-1"
+            onClick={deny}
+          >
+            {t('Deny')}
+          </Button>
+          <Button
+            type="button"
+            className="flex-1"
+            loading={approveMutation.isPending}
+            disabled={!authRequestId}
+            onClick={() => approveMutation.mutate()}
+          >
+            {t('Authorize')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+function decodeClientName(token: string | null): string {
+  try {
+    if (!token) return t('Unknown app');
+    return (
+      jwtDecode<{ clientName?: string }>(token).clientName ?? t('Unknown app')
+    );
+  } catch {
+    return t('Unknown app');
+  }
+}

--- a/packages/web/src/app/routes/embed/embedded-mcp-settings-dialog.tsx
+++ b/packages/web/src/app/routes/embed/embedded-mcp-settings-dialog.tsx
@@ -1,0 +1,58 @@
+import {
+  ActivepiecesClientEventName,
+  ActivepiecesClientMcpSettingsDialogClosed,
+  ActivepiecesClientShowMcpIframe,
+} from 'ee-embed-sdk';
+import { useEffect, useState } from 'react';
+
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { parentWindow } from '@/lib/dom-utils';
+
+import { McpServerSettings } from '../../components/project-settings/mcp-server';
+
+const postMessageToParent = (
+  event:
+    | ActivepiecesClientShowMcpIframe
+    | ActivepiecesClientMcpSettingsDialogClosed,
+) => {
+  parentWindow.postMessage(event, '*');
+};
+
+export const EmbeddedMcpSettingsDialog = () => {
+  const [isDialogOpen, setIsDialogOpen] = useState(true);
+
+  useEffect(() => {
+    postMessageToParent({
+      type: ActivepiecesClientEventName.CLIENT_SHOW_MCP_IFRAME,
+      data: {},
+    });
+    document.body.style.background = 'transparent';
+  }, []);
+
+  const closeDialog = () => {
+    setIsDialogOpen(false);
+    postMessageToParent({
+      type: ActivepiecesClientEventName.CLIENT_MCP_SETTINGS_DIALOG_CLOSED,
+      data: {},
+    });
+  };
+
+  return (
+    <Dialog
+      open={isDialogOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          closeDialog();
+        }
+      }}
+    >
+      <DialogContent
+        showOverlay={false}
+        onInteractOutside={(e) => e.preventDefault()}
+        className="max-h-[80vh] min-w-[450px] max-w-[450px] lg:min-w-[700px] lg:max-w-[700px] overflow-y-auto"
+      >
+        <McpServerSettings />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/web/src/app/routes/mcp-authorize/index.tsx
+++ b/packages/web/src/app/routes/mcp-authorize/index.tsx
@@ -23,6 +23,8 @@ import { MultiSelectFilter } from '@/features/automations/components/multi-selec
 import { api } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
 
+import { PermissionItem } from './permission-item';
+
 function McpAuthorizePage() {
   const [searchParams] = useSearchParams();
   const authRequestId = searchParams.get('authRequestId');
@@ -214,23 +216,6 @@ function McpAuthorizePage() {
           </div>
         </CardContent>
       </Card>
-    </div>
-  );
-}
-
-function PermissionItem({
-  icon,
-  text,
-}: {
-  icon: React.ReactNode;
-  text: string;
-}) {
-  return (
-    <div className="flex items-center gap-3 rounded-md border bg-accent/50 px-3 py-2.5 text-sm">
-      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10">
-        {icon}
-      </div>
-      <span>{text}</span>
     </div>
   );
 }

--- a/packages/web/src/app/routes/mcp-authorize/permission-item.tsx
+++ b/packages/web/src/app/routes/mcp-authorize/permission-item.tsx
@@ -1,0 +1,16 @@
+export function PermissionItem({
+  icon,
+  text,
+}: {
+  icon: React.ReactNode;
+  text: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border bg-accent/50 px-3 py-2.5 text-sm">
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10">
+        {icon}
+      </div>
+      <span>{text}</span>
+    </div>
+  );
+}

--- a/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
+++ b/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
@@ -54,6 +54,9 @@ export const useEventLabels = (): EventLabelsMap => {
     [ApplicationEventName.PROJECT_RELEASE_CREATED]: {
       label: t('Project release created'),
     },
+    [ApplicationEventName.PROJECT_REPLACED]: {
+      label: t('Project replaced'),
+    },
     [ApplicationEventName.FLOW_PUBLISHED]: {
       label: t('Flow published'),
     },

--- a/packages/web/src/app/routes/public-routes.tsx
+++ b/packages/web/src/app/routes/public-routes.tsx
@@ -11,6 +11,8 @@ import NotFoundPage from './404-page';
 import AuthenticatePage from './authenticate';
 import { EmbedPage } from './embed';
 import { EmbeddedConnectionDialog } from './embed/embedded-connection-dialog';
+import { EmbeddedMcpAuthorizeDialog } from './embed/embedded-mcp-authorize-dialog';
+import { EmbeddedMcpSettingsDialog } from './embed/embedded-mcp-settings-dialog';
 import { McpAuthorizePage } from './mcp-authorize';
 import { RedirectPage } from './redirect';
 
@@ -39,6 +41,14 @@ export const publicRoutes = [
   {
     path: '/embed/connections',
     element: <EmbeddedConnectionDialog></EmbeddedConnectionDialog>,
+  },
+  {
+    path: '/embed/mcp',
+    element: <EmbeddedMcpSettingsDialog></EmbeddedMcpSettingsDialog>,
+  },
+  {
+    path: '/embed/mcp-authorize',
+    element: <EmbeddedMcpAuthorizeDialog></EmbeddedMcpAuthorizeDialog>,
   },
   {
     path: '/authenticate',


### PR DESCRIPTION
## What
Let embedded (managed-auth) users connect AI to their project's MCP server with one-click approval **inside the host app**, using OAuth — no standalone Activepieces login required.

## Why
Embedded users log in through the host app, not Activepieces, so they can't use the standalone OAuth consent screen (it asks for an Activepieces login they don't have). This adds an in-embed consent path.

## Changes
- **embed SDK**: `authorizeMcp()` (in-embed OAuth consent dialog) + `mcpSettings()` (MCP settings dialog). Reuses the overlay-iframe helper and adds the cleanup/entry-guard the connection dialog already has.
- **web**: `/embed/mcp` and `/embed/mcp-authorize` dialog routes; extracted shared `PermissionItem` from the MCP consent page.
- **docs**: `embedding/embeddable-mcp` implementation guide.
- **fix**: add missing `PROJECT_REPLACED` event label (unblocks web build).

## Testing
Verified end-to-end on a local instance: register → authorize → in-embed approve → token exchange → `tools/list` against `/mcp` returns the user's tools (token is project-scoped).