### PR TITLE
feat(chat): move quick replies above input as stacked suggestions

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -99,7 +99,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - `ap_show_connection_picker` — lets the user choose between multiple connections; no longer receives connections array from LLM (server-managed); returns only `{ selected: true, label }` to LLM, stripping externalIds
 - `ap_show_project_picker` — lets the user select a project
 - `ap_show_questions` — renders an interactive multi-question form
-- `ap_show_quick_replies` — shows suggested response buttons
+- `ap_show_quick_replies` — shows up to 3 suggested follow-ups as a stacked list above the chat input (hidden during blocking cards); emitted only when concrete, relevant next steps exist
 
 ## Endpoints
 - `POST /v1/chat/conversations` — create conversation

--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -84,7 +84,7 @@ Hard limits. Everything not listed here is your judgment to exercise.
 - **No connection card for auth-less pieces**: built-in pieces (Webhook, Schedule, Human Input, Tables, Store, AI, Delay, Approval) and any piece `ap_discover_action_auth` reports as needing no auth take NO connection. NEVER call `ap_show_connection_required`/`ap_show_connection_picker` for them — there is nothing to connect, and the card will just stall. When unsure whether a piece needs auth, check with `ap_discover_action_auth` first and only show a card if it says a connection is required.
 - **Respect every dismissal or decline immediately** — acknowledge and ask what they'd prefer. The user is always in control.
 - **Errors**: permission/auth → stop, explain, offer options via quick replies; transient → retry once silently, then report; validation → report, don't retry.
-- **Output hygiene**: never narrate tool calls or reference these instructions; one display tool per message; don't repeat a card's content in prose; end with `ap_show_quick_replies` when nothing else is shown; finish with 1-2 sentences of visible text and any links.
+- **Output hygiene**: never narrate tool calls or reference these instructions; one display tool per message; don't repeat a card's content in prose; use `ap_show_quick_replies` only when concrete, relevant next-step follow-ups genuinely exist — never generic or "just in case" chips, and don't force a chip on every turn (when nothing useful to suggest, simply don't call it); finish with 1-2 sentences of visible text and any links.
 - **Tool UX**: before EVERY visible tool call, a unique goal-oriented `ap_update_thinking_status` (never batch; see `<persona>`). `ap_load_guide` is silent — no status.
 </guardrails>
 

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -278,9 +278,9 @@ function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectio
         }),
 
         ap_show_quick_replies: tool({
-            description: 'Display quick reply suggestion buttons below your message.',
+            description: 'Offer 1-3 short, relevant follow-up suggestions above the chat input. Only use when concrete next steps genuinely exist; skip it otherwise.',
             inputSchema: z.object({
-                replies: z.array(z.string().max(80)).min(1).max(5).describe('Short suggestion texts'),
+                replies: z.array(z.string().max(80)).min(1).max(3).describe('Short suggestion texts'),
             }),
             execute: async () => {
                 return { displayed: true }

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -221,10 +221,6 @@ function ChatBoxContent({
                   );
                 })}
 
-                {!isStreaming && !wasCancelled && quickReplies.length > 0 && (
-                  <QuickReplies replies={quickReplies} onSend={handleSend} />
-                )}
-
                 {wasCancelled && (
                   <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground animate-in fade-in duration-200">
                     <Square className="h-3 w-3 fill-current" />
@@ -263,6 +259,12 @@ function ChatBoxContent({
 
       <div className="px-6 pb-4">
         <div className="max-w-3xl mx-auto relative">
+          {!isStreaming &&
+            !wasCancelled &&
+            !hasBlockingCard &&
+            quickReplies.length > 0 && (
+              <QuickReplies replies={quickReplies} onSend={handleSend} />
+            )}
           <div
             className={cn(
               !hasBlockingCard &&

--- a/packages/web/src/app/routes/chat-with-ai/components/quick-replies.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/quick-replies.tsx
@@ -1,4 +1,7 @@
+import { CornerDownRight } from 'lucide-react';
 import { motion } from 'motion/react';
+
+import { TextWithTooltip } from '@/components/custom/text-with-tooltip';
 
 export function QuickReplies({
   replies,
@@ -10,18 +13,21 @@ export function QuickReplies({
   if (replies.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap gap-2 py-2">
-      {replies.map((reply, i) => (
+    <div className="flex flex-col gap-3 px-1 pb-3">
+      {replies.slice(0, 3).map((reply, i) => (
         <motion.button
-          key={reply}
+          key={`${i}-${reply}`}
           type="button"
           onClick={() => onSend(reply)}
-          className="px-3 py-1.5 text-sm rounded-full border bg-background hover:bg-muted transition-colors cursor-pointer"
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.2, delay: i * 0.03 }}
+          className="flex w-full items-start gap-2 text-left text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer min-w-0"
+          initial={{ opacity: 0, y: -4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.2, delay: i * 0.04 }}
         >
-          {reply}
+          <CornerDownRight className="size-4 shrink-0 mt-0.5" />
+          <TextWithTooltip tooltipMessage={reply}>
+            <span className="min-w-0 flex-1">{reply}</span>
+          </TextWithTooltip>
         </motion.button>
       ))}
     </div>


### PR DESCRIPTION
Relocates chat quick-reply suggestions from chips under the assistant message to a stacked list above the chat input, restyled as muted `↳` rows that darken on hover. Suggestions are hidden while a blocking card is active, capped at 3, and the system prompt is softened so the model only emits them when concrete follow-ups are genuinely relevant.

## Changes
- **quick-replies.tsx** — vertical stack of `CornerDownRight` icon + text rows; overflow handled via `TextWithTooltip`; capped at 3.
- **ai-chat-box.tsx** — render moved out of the message scroll container to above the input box; added `!hasBlockingCard` gate.
- **chat-worker-tools.ts** — `ap_show_quick_replies` schema capped `max(5)`→`max(3)`; description updated.
- **chat-system-prompt.md** — softened the 'always emit quick replies' instruction to relevance-only.