### PR TITLE
chore(observability): group structured-log fields by entity (evlog nested schema)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -529,6 +529,7 @@
                      "handbook/engineering/playbooks/canary-deployment",
                      "handbook/engineering/playbooks/infrastructure",
                      "handbook/engineering/playbooks/database-migration",
+                     "handbook/engineering/playbooks/structured-logging",
                      "handbook/engineering/playbooks/security-advisory-response",
                      "handbook/engineering/playbooks/product-announcement",
                      "handbook/engineering/playbooks/frontend-best-practices",

--- a/docs/handbook/engineering/playbooks/structured-logging.mdx
+++ b/docs/handbook/engineering/playbooks/structured-logging.mdx
@@ -1,0 +1,65 @@
+---
+title: "Structured Logging"
+description: "Field-naming conventions for evlog wide events across the Activepieces server"
+icon: "list-tree"
+---
+
+All structured logging on the server goes through [evlog](https://www.evlog.dev) — `logger.{info,warn,error,debug}({ fields }, msg)` and `wideEvent.set/error/timed` from `@activepieces/server-utils`.
+
+The **field keys** (not the message string) are the real schema — they are what dashboards, alerts, and the OTLP drain query against. If the same thing is logged under different keys (`runId` here, `flowRunId` there, a bare `id` elsewhere), every query becomes a guessing game and correlation silently breaks.
+
+One rule above all: **one concept = one field name, everywhere.**
+
+## Rules
+
+<Steps>
+<Step title="Every entity id is a flat <entity>Id key">
+Never an alias, never a bare `id`. A flow run id is always `flowRunId` (never `runId` or `id`); a flow is `flowId`, a flow version is `flowVersionId`. The prefix names the entity, so the key is unambiguous on its own.
+
+```ts
+// ✅ Correct
+logger.info({ flowRunId, flowId, projectId }, 'Flow run started')
+
+// ❌ Wrong — alias + ambiguous bare id
+logger.info({ runId: flowRun.id }, 'Flow run started')
+logger.info({ id: flowRun.id }, 'Flow run started')
+```
+</Step>
+
+<Step title="Names/labels are <entity>Name, never bare name">
+`pieceName`, `stepName`, `triggerName`, `flowName`. Bare `name` is reserved for evlog's `wideEvent.timed({ name })` operation label.
+</Step>
+
+<Step title="Errors use error">
+Pass the error to evlog — `logger.error(err)` or `logger.error({ err }, 'msg')` — and it is emitted under the canonical `error` key. Don't invent an `err` field.
+</Step>
+
+<Step title="Units go in the suffix">
+Durations end in `Ms` (`durationMs`, `timings.{op}Ms`), bytes in `Bytes`, counts in `Count` or a plural.
+</Step>
+
+<Step title="Don't set reserved fields">
+These are added automatically — never set them yourself: `service`, `version`, `level`, `msg`, `timestamp`, `error`, `requestId`, `method`, `path`.
+</Step>
+</Steps>
+
+## Canonical keys
+
+| Concept | Key |
+| --- | --- |
+| Flow run id | `flowRunId` |
+| Flow id | `flowId` |
+| Flow version id | `flowVersionId` |
+| Project / Platform / User | `projectId` / `platformId` / `userId` |
+| Job id | `jobId` |
+| App connection id | `connectionId` |
+| Piece | `pieceName`, `pieceVersion` |
+| Step / Trigger | `stepName`, `triggerName` |
+| Sandbox / Worker / Webhook | `sandboxId` / `workerId` / `webhookId` |
+| Conversation / Waitpoint | `conversationId` / `waitpointId` |
+| Migration | `migrationName` |
+| Error | `error` |
+
+<Warning>
+This convention governs the keys **emitted to logs**, not entity or DTO field names. Data-model fields such as `JobData.runId` stay as-is — the value is simply logged under `flowRunId`.
+</Warning>

--- a/docs/handbook/engineering/playbooks/structured-logging.mdx
+++ b/docs/handbook/engineering/playbooks/structured-logging.mdx
@@ -8,58 +8,72 @@ All structured logging on the server goes through [evlog](https://www.evlog.dev)
 
 The **field keys** (not the message string) are the real schema — they are what dashboards, alerts, and the OTLP drain query against. If the same thing is logged under different keys (`runId` here, `flowRunId` there, a bare `id` elsewhere), every query becomes a guessing game and correlation silently breaks.
 
-One rule above all: **one concept = one field name, everywhere.**
+One rule above all: **one concept = one field, everywhere.**
+
+## Group fields by entity
+
+Following [evlog's guidance](https://www.evlog.dev/learn/wide-events), group related fields under the entity they belong to instead of flat, prefixed keys. An entity's own id is just `id` inside its group.
+
+```ts
+// ✅ Grouped — clear, and flattens to flowRun.id / flow.id
+logger.info({
+  flowRun: { id: run.id, status: run.status },
+  flow: { id: run.flowId },
+  project: { id: run.projectId },
+}, 'Flow run started')
+
+// ❌ Flat prefixes, alias, and a bare id
+logger.info({ runId: run.id, flowRunId: run.id, id: run.id }, 'Flow run started')
+```
+
+The group name is the camelCase singular entity from the domain model. The id lives at `entity.id`, and the entity's attributes sit beside it in the same group.
 
 ## Rules
 
 <Steps>
-<Step title="Every entity id is a flat <entity>Id key">
-Never an alias, never a bare `id`. A flow run id is always `flowRunId` (never `runId` or `id`); a flow is `flowId`, a flow version is `flowVersionId`. The prefix names the entity, so the key is unambiguous on its own.
-
-```ts
-// ✅ Correct
-logger.info({ flowRunId, flowId, projectId }, 'Flow run started')
-
-// ❌ Wrong — alias + ambiguous bare id
-logger.info({ runId: flowRun.id }, 'Flow run started')
-logger.info({ id: flowRun.id }, 'Flow run started')
-```
+<Step title="The id is `id`, inside its entity group">
+Never a top-level `flowRunId`, `runId`, or bare `id`. A flow run is `flowRun: { id }`, a flow is `flow: { id }`. This gives exactly one queryable path per entity.
 </Step>
 
-<Step title="Names/labels are <entity>Name, never bare name">
-`pieceName`, `stepName`, `triggerName`, `flowName`. Bare `name` is reserved for evlog's `wideEvent.timed({ name })` operation label.
+<Step title="Attributes live beside the id, merged into one group">
+`{ jobId, jobType }` becomes `job: { id, type }`; `{ pieceName, pieceVersion }` becomes `piece: { name, version }`. Never a bare `name` / `version` / `status` / `type` at the top level — they're meaningless without their entity.
 </Step>
 
-<Step title="Errors use error">
-Pass the error to evlog — `logger.error(err)` or `logger.error({ err }, 'msg')` — and it is emitted under the canonical `error` key. Don't invent an `err` field.
+<Step title="Errors use `error`">
+Pass the error straight to evlog — `logger.error(err)` or `logger.error({ err }, 'msg')` — and it lands under the canonical `error` key. Descriptive error fields like `migrationError` are fine.
 </Step>
 
 <Step title="Units go in the suffix">
 Durations end in `Ms` (`durationMs`, `timings.{op}Ms`), bytes in `Bytes`, counts in `Count` or a plural.
 </Step>
 
-<Step title="Don't set reserved fields">
-These are added automatically — never set them yourself: `service`, `version`, `level`, `msg`, `timestamp`, `error`, `requestId`, `method`, `path`.
+<Step title="Keep it shallow, and leave reserved fields flat">
+One level of grouping (two max). `requestId`, `service`, `version`, `level`, `msg`, `timestamp`, `error`, `method`, `path` are added automatically — never set them, and never fold `requestId` into a group.
 </Step>
 </Steps>
 
-## Canonical keys
+## Groups
 
-| Concept | Key |
-| --- | --- |
-| Flow run id | `flowRunId` |
-| Flow id | `flowId` |
-| Flow version id | `flowVersionId` |
-| Project / Platform / User | `projectId` / `platformId` / `userId` |
-| Job id | `jobId` |
-| App connection id | `connectionId` |
-| Piece | `pieceName`, `pieceVersion` |
-| Step / Trigger | `stepName`, `triggerName` |
-| Sandbox / Worker / Webhook | `sandboxId` / `workerId` / `webhookId` |
-| Conversation / Waitpoint | `conversationId` / `waitpointId` |
-| Migration | `migrationName` |
-| Error | `error` |
+| Group | Fields | Entity |
+| --- | --- | --- |
+| `flowRun` | `id`, `status`, `environment` | A flow execution |
+| `flow` | `id`, `version` | A flow definition |
+| `flowVersion` | `id` | A flow version |
+| `project` | `id` | A project |
+| `platform` | `id` | A platform / workspace |
+| `user` | `id` | A user |
+| `job` | `id`, `type` | A queue job |
+| `piece` | `name`, `version` | An integration piece |
+| `connection` | `id` | An app connection |
+| `sandbox` | `id` | An execution sandbox |
+| `worker` | `id` | A worker process |
+| `webhook` | `id`, `requestId`, `mode`, `flowFound`, `responseStatus` | A webhook request |
+| `conversation` | `id` | A chat conversation |
+| `waitpoint` | `id` | A pause / resume point |
+| `step` | `name` | A flow step |
+| `trigger` | `name` | A flow trigger |
+| `migration` | `name` | A database migration |
 
 <Warning>
-This convention governs the keys **emitted to logs**, not entity or DTO field names. Data-model fields such as `JobData.runId` stay as-is — the value is simply logged under `flowRunId`.
+This convention governs the keys in **logging calls** only, not entity or DTO field names. Data-model fields such as `JobData.runId`, DB query arguments, and service-call arguments stay as-is — the value is simply logged under `flowRun: { id }`.
 </Warning>

--- a/docs/install/configuration/breaking-changes.mdx
+++ b/docs/install/configuration/breaking-changes.mdx
@@ -9,11 +9,11 @@ icon: "hammer"
 
 ### What has changed?
 
-#### Log field names are now consistent
-A flow run id is now always logged as `flowRunId` — it used to appear as `runId`, `flowRunId`, or a bare `id` depending on the code path. Errors are now logged under `error`. This only changes how logs look — nothing about the API, database, or flows changes.
+#### Log fields are now grouped by entity
+Log fields are now grouped under the entity they belong to, so each thing has one name. A flow run id is `flowRun.id` (it used to appear as `runId`, `flowRunId`, or a bare `id`), and other ids follow the same shape (`flow.id`, `project.id`, `job.id`, …). Errors are logged under `error`. This only changes how logs look — nothing about the API, database, or flows changes.
 
 ### Do you need to take action?
-- Only if you build dashboards or alerts on Activepieces logs. Update them to the consistent names, e.g. `runId` → `flowRunId` and `err` → `error`.
+- Only if you build dashboards or alerts on Activepieces logs. Update them to the new grouped names, e.g. `runId` → `flowRun.id` and `err` → `error`.
 
 ## 0.85.4
 ### What has changed?

--- a/docs/install/configuration/breaking-changes.mdx
+++ b/docs/install/configuration/breaking-changes.mdx
@@ -5,8 +5,28 @@ icon: "hammer"
 ---
 
 
+## 0.86.0
+
+### What has changed?
+
+#### Log field names are now consistent
+A flow run id is now always logged as `flowRunId` — it used to appear as `runId`, `flowRunId`, or a bare `id` depending on the code path. Errors are now logged under `error`. This only changes how logs look — nothing about the API, database, or flows changes.
+
+### Do you need to take action?
+- Only if you build dashboards or alerts on Activepieces logs. Update them to the consistent names, e.g. `runId` → `flowRunId` and `err` → `error`.
+
 ## 0.85.4
 ### What has changed?
+
+#### Observability: OpenTelemetry replaced with evlog
+Logging moved from pino + OpenTelemetry to [evlog](https://evlog.dev). Logs are now one rich event per request/job instead of many small lines, so the JSON shape changed.
+
+**Traces and metrics are no longer exported.** OpenTelemetry tracing produced a huge volume of low-value spans — far more data (and cost) than it was worth — so we dropped it in favour of these wide events, which carry the same context in one place. `AP_OTEL_ENABLED=true` now sends **logs** only, over OTLP.
+
+New optional env vars: `AP_LOG_SAMPLE_RATE_INFO` (percent of info logs to keep, default `100`) and `AP_LOG_KEEP_SLOW_MS` (always keep requests slower than this, default `2000`). Drain settings (`AP_AXIOM_*`, `AP_BETTERSTACK_*`, `AP_LOKI_*`, `AP_HYPERDX_TOKEN`) are unchanged.
+
+**Action:** only if you ingest Activepieces telemetry — update log dashboards to the new shape, and move any trace- or metric-based monitoring to logs.
+
 #### Referencing step outputs
 Previously if you had a step called step_1 you would had to reference it "step_1['the_property_you_want']" but now you must reference it as "step_1['output']['the_property_you_want']", there is already a migration that will take care of this for you, but if you must abide by this new syntax if you are writing/editing step references manually not through the builder.
 You can now also reference the step error via "step_1['error']", these changes come with the error handling feature.

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -65,19 +65,19 @@ Email templates live in `src/assets/emails/`. When creating or modifying email t
 
 ## Structured Logging Field Schema (evlog)
 
-All structured logging goes through evlog — `logger.{info,warn,error,debug}({ fields }, msg)` and `wideEvent.set/error/timed` from `@activepieces/server-utils`. The **field keys** (not message strings) are the queryable schema behind dashboards, alerts, and the OTLP drain. They MUST be consistent: **one concept = one key name, everywhere.**
+All structured logging goes through evlog — `logger.{info,warn,error,debug}({ fields }, msg)` and `wideEvent.set/error/timed` from `@activepieces/server-utils`. The **field keys** (not message strings) are the queryable schema behind dashboards, alerts, and the OTLP drain. They MUST be consistent: **one concept = one path, everywhere.** Following [evlog's guidance](https://www.evlog.dev/learn/wide-events), fields are **grouped by entity** (which flattens to the dotted `entity.id` paths OpenTelemetry recommends), not flat prefixed keys.
 
 **Rules:**
 
-1. **Every entity id is a flat `<entity>Id` key — never an alias, never a bare `id`.** A flow run id is always `flowRunId`, never `runId` or `id`. The prefix mirrors the domain entity (`FlowRun` → `flowRunId`, `FlowVersion` → `flowVersionId`). This is the rule that matters most: the codebase previously logged the same flow-run id as `runId`, `flowRunId`, *and* `id`, which broke every correlation query.
-2. **Names/labels are `<entity>Name`, never a bare `name`.** `pieceName`, `stepName`, `triggerName`, `flowName`. Bare `name` is reserved (evlog `wideEvent.timed({ name })` op-label, migration class names).
-3. **Errors use `error`, not `err`.** `ap-logger.ts` normalizes `obj.err ?? obj.error` and emits the canonical `error` key, so writing either works — but prefer `error`.
-4. **Units as a suffix:** durations end in `Ms` (`durationMs`, `timings.{op}Ms`), bytes `Bytes`, counts `Count`/plural.
-5. **Do not set reserved / auto-populated keys manually:** `service`, `version`, `level`, `msg`, `timestamp`, `error`, `timings`, `requestId`, `method`, `path`, and `audit.context.{traceId,ip,userAgent}` (attached by `evlog-setup.ts` / `ap-logger.ts` / `wide-event.ts` and the evlog request middleware).
+1. **Group fields by entity; the entity's own id is `id` inside its group — never a top-level `<entity>Id`, `runId`, or bare `id`.** A flow run is `flowRun: { id }` (flattens to `flowRun.id`), not `flowRunId`/`runId`/`id`. The group is the camelCase singular entity from the domain model. This is the rule that matters most: the codebase previously logged the same flow-run id as `runId`, `flowRunId`, *and* `id`, which broke every correlation query.
+2. **An entity's attributes live beside `id` in the same group, merged into one object.** `{ jobId, jobType }` → `job: { id, type }`; `{ pieceName, pieceVersion }` → `piece: { name, version }`; `flowRun: { id, status, environment }`. Never bare `name`/`version`/`status`/`type` at the top level.
+3. **Errors use `error`, not `err`.** `ap-logger.ts` normalizes `obj.err ?? obj.error` and emits the canonical `error` key. Descriptively-named error fields (`migrationError`, `pageError`) are fine and stay as-is.
+4. **Units as a suffix on leaf keys:** durations end in `Ms` (`durationMs`, `timings.{op}Ms`), bytes `Bytes`, counts `Count`/plural.
+5. **Do not nest, and never set, reserved / auto-populated keys:** `service`, `version`, `level`, `msg`, `timestamp`, `error`, `timings`, `requestId`, `traceId`, `method`, `path` (attached by `evlog-setup.ts` / `ap-logger.ts` / `wide-event.ts` and the evlog request middleware). `requestId` stays flat — do not fold it into a group.
 
-**Canonical keys:** `flowRunId`, `flowId`, `flowVersionId`, `projectId`, `platformId`, `userId`, `jobId`, `connectionId` (grandfathered for `AppConnection`), `pieceName`, `pieceVersion`, `stepName`, `triggerName`, `sandboxId`, `workerId`, `webhookId`, `conversationId`, `waitpointId`, `migrationName`.
+**Canonical groups:** `flowRun: { id, status, environment }`, `flow: { id, version }`, `flowVersion: { id }`, `project: { id }`, `platform: { id }`, `user: { id }`, `job: { id, type }`, `piece: { name, version }`, `connection: { id }` (`AppConnection`), `sandbox: { id }`, `worker: { id }`, `webhook: { id, requestId, mode, flowFound, responseStatus }`, `conversation: { id }`, `waitpoint: { id }`, `step: { name }`, `trigger: { name }`, `migration: { name }`.
 
-Note: `JobData.runId` and other **data-model / wire fields stay as-is** — this convention governs the keys *emitted to logs* (the value is read into a `flowRunId` log key), not entity/DTO field names.
+Only the metadata object of a logging call (`logger.*`, `log.child`, `createLogger`, `wideEvent.set`) is grouped. **Data-model / wire fields stay flat** — `JobData.runId`, DB query args (`findOneBy({ id })`), service-call arguments (`resumeFromWaitpoint({ flowRunId })`), DTOs, return objects, and client event payloads are NOT logs and keep their original keys.
 
 ## Release Version Detection (`apVersionUtil`)
 

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -63,6 +63,22 @@ Email templates live in `src/assets/emails/`. When creating or modifying email t
 - Write database migrations for schema changes, never modify entities directly without a migration . use db-migration skill
 - Keep enterprise features isolated in `src/app/ee/`
 
+## Structured Logging Field Schema (evlog)
+
+All structured logging goes through evlog — `logger.{info,warn,error,debug}({ fields }, msg)` and `wideEvent.set/error/timed` from `@activepieces/server-utils`. The **field keys** (not message strings) are the queryable schema behind dashboards, alerts, and the OTLP drain. They MUST be consistent: **one concept = one key name, everywhere.**
+
+**Rules:**
+
+1. **Every entity id is a flat `<entity>Id` key — never an alias, never a bare `id`.** A flow run id is always `flowRunId`, never `runId` or `id`. The prefix mirrors the domain entity (`FlowRun` → `flowRunId`, `FlowVersion` → `flowVersionId`). This is the rule that matters most: the codebase previously logged the same flow-run id as `runId`, `flowRunId`, *and* `id`, which broke every correlation query.
+2. **Names/labels are `<entity>Name`, never a bare `name`.** `pieceName`, `stepName`, `triggerName`, `flowName`. Bare `name` is reserved (evlog `wideEvent.timed({ name })` op-label, migration class names).
+3. **Errors use `error`, not `err`.** `ap-logger.ts` normalizes `obj.err ?? obj.error` and emits the canonical `error` key, so writing either works — but prefer `error`.
+4. **Units as a suffix:** durations end in `Ms` (`durationMs`, `timings.{op}Ms`), bytes `Bytes`, counts `Count`/plural.
+5. **Do not set reserved / auto-populated keys manually:** `service`, `version`, `level`, `msg`, `timestamp`, `error`, `timings`, `requestId`, `method`, `path`, and `audit.context.{traceId,ip,userAgent}` (attached by `evlog-setup.ts` / `ap-logger.ts` / `wide-event.ts` and the evlog request middleware).
+
+**Canonical keys:** `flowRunId`, `flowId`, `flowVersionId`, `projectId`, `platformId`, `userId`, `jobId`, `connectionId` (grandfathered for `AppConnection`), `pieceName`, `pieceVersion`, `stepName`, `triggerName`, `sandboxId`, `workerId`, `webhookId`, `conversationId`, `waitpointId`, `migrationName`.
+
+Note: `JobData.runId` and other **data-model / wire fields stay as-is** — this convention governs the keys *emitted to logs* (the value is read into a `flowRunId` log key), not entity/DTO field names.
+
 ## Release Version Detection (`apVersionUtil`)
 
 `apVersionUtil.getCurrentRelease()` (in `@activepieces/server-utils`, `ap-version.ts`) reads the running release from `<process.cwd()>/package.json`. **It is `cwd`-relative, not module-relative** — `__dirname` was tried and does not work in the bundled output, so do not "fix" it that way. On any failure (missing file, bad JSON, missing/non-string `version`) it logs a `warn` and returns the sentinel `UNKNOWN_VERSION` (`'0.0.0'`).

--- a/packages/server/api/src/app/ai/ai-provider-service.ts
+++ b/packages/server/api/src/app/ai/ai-provider-service.ts
@@ -181,7 +181,7 @@ export const aiProviderService = (log: FastifyBaseLogger) => ({
         catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error'
             const includeHttpErrorInMessage = provider === AIProviderName.CLOUDFLARE_GATEWAY
-            log.error({ err: error }, '[aiProviderService#validateProviderCredentials] Failed to validate provider credentials')
+            log.error({ error }, '[aiProviderService#validateProviderCredentials] Failed to validate provider credentials')
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_AI_PROVIDER_CREDENTIALS,
                 params: {

--- a/packages/server/api/src/app/ai/providers/cloudflare-gateway-provider.ts
+++ b/packages/server/api/src/app/ai/providers/cloudflare-gateway-provider.ts
@@ -50,7 +50,7 @@ export const cloudflareGatewayProvider: AIProviderStrategy<CloudflareGatewayProv
                 }
             }
             catch (error: unknown) {
-                log.error({ err: error }, '[cloudflareGatewayProvider#validateConnection] Failed to validate model')
+                log.error({ error }, '[cloudflareGatewayProvider#validateConnection] Failed to validate model')
                 invalidModels.push(model.modelId)
             }
         }

--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -84,7 +84,7 @@ export const appConnectionService = (log: FastifyBaseLogger) => ({
                 ...(projectIds ? { projectIds: ArrayContains(projectIds) } : {}),
             })
             if (!isNil(existingForPlaceholder) && existingForPlaceholder.status !== AppConnectionStatus.MISSING) {
-                log.info({ connectionId: existingForPlaceholder.id, pieceName, platformId, existingStatus: existingForPlaceholder.status }, 'Placeholder upsert skipped — non-missing connection already exists')
+                log.info({ connection: { id: existingForPlaceholder.id }, piece: { name: pieceName }, platform: { id: platformId }, existingStatus: existingForPlaceholder.status }, 'Placeholder upsert skipped — non-missing connection already exists')
                 return this.removeSensitiveData(existingForPlaceholder)
             }
         }
@@ -135,7 +135,7 @@ export const appConnectionService = (log: FastifyBaseLogger) => ({
             ...(projectIds ? { projectIds: ArrayContains(projectIds) } : {}),
             scope,
         })
-        log.info({ connectionId: newId, pieceName, platformId, isNew: isNil(existingConnection) }, 'App connection upserted')
+        log.info({ connection: { id: newId }, piece: { name: pieceName }, platform: { id: platformId }, isNew: isNil(existingConnection) }, 'App connection upserted')
         return this.removeSensitiveData(updatedConnection)
     },
     async update(params: UpdateParams): Promise<AppConnectionWithoutSensitiveData> {
@@ -299,7 +299,7 @@ export const appConnectionService = (log: FastifyBaseLogger) => ({
             scope: params.scope,
             ...(params.projectId ? { projectIds: ArrayContains([params.projectId]) } : {}),
         })
-        log.info({ connectionId: params.id, platformId: params.platformId }, 'App connection deleted')
+        log.info({ connection: { id: params.id }, platform: { id: params.platformId } }, 'App connection deleted')
     },
 
     async list({

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -180,9 +180,11 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     app.addHook('preHandler', (request, _reply, done) => {
         try {
             const principal = request.principal
+            const projectId = extractProjectId(principal)
+            const platformId = extractPlatformId(principal)
             wideEvent.set({
-                ...spreadIfDefined('projectId', extractProjectId(principal)),
-                ...spreadIfDefined('platformId', extractPlatformId(principal)),
+                ...spreadIfDefined('project', isNil(projectId) ? undefined : { id: projectId }),
+                ...spreadIfDefined('platform', isNil(platformId) ? undefined : { id: platformId }),
                 ...spreadIfDefined('principalType', principal?.type),
             })
         }

--- a/packages/server/api/src/app/authentication/authentication-utils.ts
+++ b/packages/server/api/src/app/authentication/authentication-utils.ts
@@ -209,7 +209,7 @@ export const authenticationUtils = (log: FastifyBaseLogger) => ({
             })
         }
         catch (e) {
-            log.warn({ err: e }, '[authenticationUtils#sendTelemetry] Failed to send telemetry')
+            log.warn({ error: e }, '[authenticationUtils#sendTelemetry] Failed to send telemetry')
         }
     },
 
@@ -232,7 +232,7 @@ export const authenticationUtils = (log: FastifyBaseLogger) => ({
             await response.json()
         }
         catch (error) {
-            log.warn({ err: error }, '[authenticationUtils#saveNewsLetterSubscriber] Failed to save newsletter subscriber')
+            log.warn({ error }, '[authenticationUtils#saveNewsLetterSubscriber] Failed to save newsletter subscriber')
         }
     },
     async extractUserIdFromRequest(request: FastifyRequest): Promise<string> {

--- a/packages/server/api/src/app/authentication/authentication.service.ts
+++ b/packages/server/api/src/app/authentication/authentication.service.ts
@@ -37,7 +37,7 @@ export const authenticationService = (log: FastifyBaseLogger) => ({
             })
             await userInvitationsService(log).provisionUserInvitation({ email: params.email })
 
-            log.info({ email: params.email, platformId }, 'User signed up to existing platform')
+            log.info({ email: params.email, platform: { id: platformId } }, 'User signed up to existing platform')
             return authenticationUtils(log).getProjectAndToken({
                 userId: user.id,
                 platformId,
@@ -97,7 +97,7 @@ export const authenticationService = (log: FastifyBaseLogger) => ({
             platformId,
         })
         assertNotNullOrUndefined(user, 'User not found')
-        log.info({ email: params.email, platformId }, 'User signed in with password')
+        log.info({ email: params.email, platform: { id: platformId } }, 'User signed in with password')
         return authenticationUtils(log).getProjectAndToken({
             userId: user.id,
             platformId,
@@ -163,7 +163,7 @@ export const authenticationService = (log: FastifyBaseLogger) => ({
 
         assertNotNullOrUndefined(platform, 'Platform not found')
         const user = await getUserForPlatform(params.identityId, platform, log)
-        log.info({ userId: user.id, platformId: platform.id }, 'User switched platform')
+        log.info({ user: { id: user.id }, platform: { id: platform.id } }, 'User switched platform')
         return authenticationUtils(log).getProjectAndToken({
             userId: user.id,
             platformId: platform.id,

--- a/packages/server/api/src/app/core/canary/canary-routing.middleware.ts
+++ b/packages/server/api/src/app/core/canary/canary-routing.middleware.ts
@@ -19,12 +19,12 @@ export const canaryRoutingMiddleware = async (request: FastifyRequest, reply: Fa
         workerGroupService(request.log).isCanaryPlatform({ platformId }),
     )
     if (canaryLookupError) {
-        request.log.error({ err: canaryLookupError }, '[canaryRoutingMiddleware] failed to fetch canary platform IDs, falling through')
+        request.log.error({ error: canaryLookupError }, '[canaryRoutingMiddleware] failed to fetch canary platform IDs, falling through')
         return
     }
     if (!shouldForward) return
 
-    request.log.info({ platformId }, '[canaryRoutingMiddleware] proxying to canary')
+    request.log.info({ platform: { id: platformId } }, '[canaryRoutingMiddleware] proxying to canary')
 
     await awaitProxy(request, reply)
 }
@@ -34,7 +34,7 @@ async function awaitProxy(request: FastifyRequest, reply: FastifyReply): Promise
         reply.raw.once('finish', resolve)
         void reply.from(request.url, {
             onError: (reply, { error: proxyError }) => {
-                request.log.error({ err: proxyError }, '[canaryRoutingMiddleware] proxy failed')
+                request.log.error({ error: proxyError }, '[canaryRoutingMiddleware] proxy failed')
                 void reply.send(proxyError)
             },
         })

--- a/packages/server/api/src/app/core/collaborative/lock/lock.module.ts
+++ b/packages/server/api/src/app/core/collaborative/lock/lock.module.ts
@@ -36,7 +36,7 @@ export const lockModule: FastifyPluginAsyncZod = async (app) => {
                 callback?.(result)
             }
             catch (error) {
-                app.log.error({ err: error }, '[LOCK_RESOURCE] Failed to acquire lock')
+                app.log.error({ error }, '[LOCK_RESOURCE] Failed to acquire lock')
                 callback?.({ acquired: false, lock: null })
             }
         }
@@ -56,7 +56,7 @@ export const lockModule: FastifyPluginAsyncZod = async (app) => {
                 }
             }
             catch (error) {
-                app.log.error({ err: error }, '[UNLOCK_RESOURCE] Failed to release lock')
+                app.log.error({ error }, '[UNLOCK_RESOURCE] Failed to release lock')
             }
         }
     })

--- a/packages/server/api/src/app/core/collaborative/lock/lock.service.ts
+++ b/packages/server/api/src/app/core/collaborative/lock/lock.service.ts
@@ -6,20 +6,20 @@ const KEY_PREFIX = 'lock:'
 
 export const lockService = (log: FastifyBaseLogger) => ({
     async acquire({ resourceId, userId, userDisplayName, force }: AcquireParams): Promise<AcquireResult> {
-        log.debug({ resourceId, userId, force }, '[Lock] Attempting to acquire lock')
+        log.debug({ resourceId, user: { id: userId }, force }, '[Lock] Attempting to acquire lock')
         const redis = await redisConnections.useExisting()
         const key = KEY_PREFIX + resourceId
         const value = JSON.stringify({ userId, userDisplayName })
 
         if (force) {
             await redis.set(key, value, 'EX', LOCK_TTL_SECONDS)
-            log.debug({ resourceId, userId }, '[Lock] Lock force-acquired')
+            log.debug({ resourceId, user: { id: userId } }, '[Lock] Lock force-acquired')
             return { acquired: true, lock: null }
         }
 
         const setResult = await redis.set(key, value, 'EX', LOCK_TTL_SECONDS, 'NX')
         if (setResult !== null) {
-            log.debug({ resourceId, userId }, '[Lock] Lock acquired')
+            log.debug({ resourceId, user: { id: userId } }, '[Lock] Lock acquired')
             return { acquired: true, lock: null }
         }
 
@@ -28,16 +28,16 @@ export const lockService = (log: FastifyBaseLogger) => ({
 
         if (lock && lock.userId === userId) {
             await redis.set(key, value, 'EX', LOCK_TTL_SECONDS)
-            log.debug({ resourceId, userId }, '[Lock] Lock renewed (same user)')
+            log.debug({ resourceId, user: { id: userId } }, '[Lock] Lock renewed (same user)')
             return { acquired: true, lock: null }
         }
 
-        log.debug({ resourceId, userId, lockedByUserId: lock?.userId }, '[Lock] Lock already held by another user')
+        log.debug({ resourceId, user: { id: userId }, lockedByUserId: lock?.userId }, '[Lock] Lock already held by another user')
         return { acquired: false, lock }
     },
 
     async release({ resourceId, userId }: ReleaseParams): Promise<boolean> {
-        log.debug({ resourceId, userId }, '[Lock] Attempting to release lock')
+        log.debug({ resourceId, user: { id: userId } }, '[Lock] Attempting to release lock')
         const redis = await redisConnections.useExisting()
         const key = KEY_PREFIX + resourceId
         const existing = await redis.get(key)
@@ -45,13 +45,13 @@ export const lockService = (log: FastifyBaseLogger) => ({
             const lock: LockValue = JSON.parse(existing)
             if (lock.userId === userId) {
                 await redis.del(key)
-                log.debug({ resourceId, userId }, '[Lock] Lock released')
+                log.debug({ resourceId, user: { id: userId } }, '[Lock] Lock released')
                 return true
             }
-            log.debug({ resourceId, userId, lockedByUserId: lock.userId }, '[Lock] Cannot release lock held by another user')
+            log.debug({ resourceId, user: { id: userId }, lockedByUserId: lock.userId }, '[Lock] Cannot release lock held by another user')
         }
         else {
-            log.debug({ resourceId, userId }, '[Lock] No lock found to release')
+            log.debug({ resourceId, user: { id: userId } }, '[Lock] No lock found to release')
         }
         return false
     },

--- a/packages/server/api/src/app/core/collaborative/presence/presence.module.ts
+++ b/packages/server/api/src/app/core/collaborative/presence/presence.module.ts
@@ -32,7 +32,7 @@ export const presenceModule: FastifyPluginAsyncZod = async (app) => {
                 callback?.({ users })
             }
             catch (error) {
-                app.log.error({ err: error }, '[JOIN_PRESENCE] Failed to join presence')
+                app.log.error({ error }, '[JOIN_PRESENCE] Failed to join presence')
                 callback?.({ users: [] })
             }
         }
@@ -53,7 +53,7 @@ export const presenceModule: FastifyPluginAsyncZod = async (app) => {
                 })
             }
             catch (error) {
-                app.log.error({ err: error }, '[LEAVE_PRESENCE] Failed to leave presence')
+                app.log.error({ error }, '[LEAVE_PRESENCE] Failed to leave presence')
             }
         }
     })

--- a/packages/server/api/src/app/core/websockets.service.ts
+++ b/packages/server/api/src/app/core/websockets.service.ts
@@ -32,8 +32,8 @@ export const websocketService = {
                 await validateProjectId({ userId: principal.id, projectId, log })
                 log.info({
                     message: 'User connected',
-                    userId: principal.id,
-                    projectId,
+                    user: { id: principal.id },
+                    project: { id: projectId },
                 })
                 await socket.join(projectId)
                 await socket.join(principal.id)
@@ -43,7 +43,7 @@ export const websocketService = {
                 const workerId = socket.handshake.auth.workerId
                 log.info({
                     message: 'Worker connected',
-                    workerId,
+                    worker: { id: workerId },
                 })
                 await socket.join(workerId)
                 break

--- a/packages/server/api/src/app/ee/chat/chat-eval-controller.ts
+++ b/packages/server/api/src/app/ee/chat/chat-eval-controller.ts
@@ -134,7 +134,7 @@ async function waitForSimulationResult({ conversationId, platformId, userId, pri
             return settled
         }
     }
-    log.warn({ conversationId }, 'Chat simulation timed out before completing')
+    log.warn({ conversation: { id: conversationId } }, 'Chat simulation timed out before completing')
     return { status: SIMULATION_TIMEOUT_STATUS, uiMessages: null }
 }
 

--- a/packages/server/api/src/app/ee/chat/chat-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/chat/chat-rpc-handlers.ts
@@ -162,7 +162,7 @@ export const chatRpcHandlers = (log: FastifyBaseLogger) => ({
 
         const saveResult = await chatHelpers.conversationRepo().update(input.conversationId, updates)
         if (saveResult.affected === 0) {
-            log.warn({ conversationId: input.conversationId }, 'saveChatMessages: conversation not found, may have been deleted')
+            log.warn({ conversation: { id: input.conversationId } }, 'saveChatMessages: conversation not found, may have been deleted')
         }
 
         if (input.messages.length > 0) {

--- a/packages/server/api/src/app/ee/chat/chat-service.ts
+++ b/packages/server/api/src/app/ee/chat/chat-service.ts
@@ -30,7 +30,7 @@ export const chatService = (log: FastifyBaseLogger) => ({
             modelName: request.modelName ?? null,
             messages: [],
         })
-        log.info({ conversationId: conversation.id, platformId, userId }, '[chatService] Conversation created')
+        log.info({ conversation: { id: conversation.id }, platform: { id: platformId }, user: { id: userId } }, '[chatService] Conversation created')
         return conversation
     },
 
@@ -94,7 +94,7 @@ export const chatService = (log: FastifyBaseLogger) => ({
             })
         }
         await chatHelpers.conversationRepo().delete(conversation.id)
-        log.info({ conversationId: id, platformId, userId }, '[chatService] Conversation deleted')
+        log.info({ conversation: { id }, platform: { id: platformId }, user: { id: userId } }, '[chatService] Conversation deleted')
     },
 
     async getMessages({ id, platformId, userId }: ConversationIdentifier): Promise<{ data: PersistedChatMessage[] | ChatHistoryMessage[] }> {

--- a/packages/server/api/src/app/ee/chat/chat-sync-job.ts
+++ b/packages/server/api/src/app/ee/chat/chat-sync-job.ts
@@ -145,7 +145,7 @@ async function pushBatch({ conversations, licenseKey, log, userCache, platformCa
     for (const conversation of conversations) {
         const payloadResult = await tryCatch(() => toSyncPayload({ conversation, log, userCache, platformCache, providerCache }))
         if (payloadResult.error) {
-            log.error({ conversationId: conversation.id, error: String(payloadResult.error) }, 'Failed to build sync payload for conversation, skipping')
+            log.error({ conversation: { id: conversation.id }, error: String(payloadResult.error) }, 'Failed to build sync payload for conversation, skipping')
             continue
         }
         payloads.push(payloadResult.data)

--- a/packages/server/api/src/app/ee/chat/mcp/chat-mcp.ts
+++ b/packages/server/api/src/app/ee/chat/mcp/chat-mcp.ts
@@ -15,7 +15,7 @@ async function getMcpCredentials({ platformId, userId, log }: {
         mcpOAuthTokenService.issueInternalAccessToken({ userId, platformId, projectId: null }),
     )
     if (error) {
-        log.warn({ err: error, platformId }, 'Failed to get MCP credentials — chat will work without MCP tools')
+        log.warn({ error, platform: { id: platformId } }, 'Failed to get MCP credentials — chat will work without MCP tools')
         return { mcpServerUrl: null, mcpToken: null }
     }
     const frontendUrl = system.getOrThrow(AppSystemProp.FRONTEND_URL)

--- a/packages/server/api/src/app/ee/embed-subdomain/embed-subdomain.service.ts
+++ b/packages/server/api/src/app/ee/embed-subdomain/embed-subdomain.service.ts
@@ -58,7 +58,7 @@ export const embedSubdomainService = (log: FastifyBaseLogger) => ({
 
         const deleteResult = await tryCatch(() => cloudflareService(log).deleteCustomHostname({ cloudflareId: oldCloudflareId }))
         if (deleteResult.error) {
-            log.warn({ platformId, oldCloudflareId, error: deleteResult.error }, 'Failed to delete previous Cloudflare custom hostname; manual cleanup may be required')
+            log.warn({ platform: { id: platformId }, oldCloudflareId, error: deleteResult.error }, 'Failed to delete previous Cloudflare custom hostname; manual cleanup may be required')
         }
 
         return updated
@@ -76,7 +76,7 @@ export const embedSubdomainService = (log: FastifyBaseLogger) => ({
 
         const statusResult = await tryCatch(() => cloudflareService(log).getCustomHostname({ cloudflareId: record.cloudflareId }))
         if (statusResult.error) {
-            log.warn({ platformId, cloudflareId: record.cloudflareId, error: statusResult.error }, 'Failed to refresh hostname status from Cloudflare; returning cached record')
+            log.warn({ platform: { id: platformId }, cloudflareId: record.cloudflareId, error: statusResult.error }, 'Failed to refresh hostname status from Cloudflare; returning cached record')
             return record
         }
         const cloudflareStatus = statusResult.data
@@ -84,7 +84,7 @@ export const embedSubdomainService = (log: FastifyBaseLogger) => ({
 
         const recordsChanged = JSON.stringify(record.verificationRecords) !== JSON.stringify(cloudflareStatus.verificationRecords)
         if (newStatus !== record.status || recordsChanged) {
-            log.info({ platformId, oldStatus: record.status, newStatus, cloudflareStatus: cloudflareStatus.status, sslStatus: cloudflareStatus.sslStatus }, 'Embed hostname status refreshed')
+            log.info({ platform: { id: platformId }, oldStatus: record.status, newStatus, cloudflareStatus: cloudflareStatus.status, sslStatus: cloudflareStatus.sslStatus }, 'Embed hostname status refreshed')
             return repo().save({
                 ...record,
                 status: newStatus,

--- a/packages/server/api/src/app/ee/helper/email/email-sender/log-email-sender.ts
+++ b/packages/server/api/src/app/ee/helper/email/email-sender/log-email-sender.ts
@@ -10,7 +10,7 @@ export const logEmailSender = (log: FastifyBaseLogger): EmailSender => {
             log.debug({
                 name: 'LogEmailSender#send',
                 emails,
-                platformId,
+                platform: { id: platformId },
                 templateData,
             })
         },

--- a/packages/server/api/src/app/ee/helper/email/email-sender/smtp-email-sender.ts
+++ b/packages/server/api/src/app/ee/helper/email/email-sender/smtp-email-sender.ts
@@ -51,7 +51,7 @@ export const smtpEmailSender = (log: FastifyBaseLogger): SMTPEmailSender => {
                 const smtpClient = initSmtpClient()
                 log.info({
                     emails,
-                    platformId,
+                    platform: { id: platformId },
                     templateData,
                 }, '[smtpEmailSender#send] sending email')
                 await smtpClient.sendMail({
@@ -65,7 +65,7 @@ export const smtpEmailSender = (log: FastifyBaseLogger): SMTPEmailSender => {
                 log.error({
                     error: e,
                     emails,
-                    platformId,
+                    platform: { id: platformId },
                     title: templateData.name,
                 }, '[smtpEmailSender#send] error sending email')
                 throw e

--- a/packages/server/api/src/app/ee/helper/email/email-service.ts
+++ b/packages/server/api/src/app/ee/helper/email/email-service.ts
@@ -19,8 +19,8 @@ export const emailService = (log: FastifyBaseLogger) => ({
         log.info({
             message: '[emailService#sendInvitation] sending invitation email',
             email: userInvitation.email,
-            platformId: userInvitation.platformId,
-            projectId: userInvitation.projectId,
+            platform: { id: userInvitation.platformId },
+            project: { id: userInvitation.projectId },
             type: userInvitation.type,
             projectRole: userInvitation.projectRole,
             platformRole: userInvitation.platformRole,
@@ -44,8 +44,8 @@ export const emailService = (log: FastifyBaseLogger) => ({
         log.info({
             message: '[emailService#sendProjectMemberAdded] sending project member added email',
             email: userInvitation.email,
-            platformId: userInvitation.platformId,
-            projectId: userInvitation.projectId,
+            platform: { id: userInvitation.platformId },
+            project: { id: userInvitation.projectId },
             type: userInvitation.type,
             projectRole: userInvitation.projectRole,
             platformRole: userInvitation.platformRole,
@@ -78,7 +78,7 @@ export const emailService = (log: FastifyBaseLogger) => ({
         log.info({
             message: '[emailService#sendScimUserWelcome] sending welcome email',
             email,
-            platformId,
+            platform: { id: platformId },
         })
 
         const loginLink = await domainHelper.getPublicUrl({
@@ -114,7 +114,7 @@ export const emailService = (log: FastifyBaseLogger) => ({
 
         log.info({
             name: '[emailService#sendIssueCreatedNotification]',
-            projectId,
+            project: { id: projectId },
             flowName,
             createdAt,
         })
@@ -195,7 +195,7 @@ export const emailService = (log: FastifyBaseLogger) => ({
         const user = await userService(log).getMetaInformation({ id: userId })
 
         if (isNil(user) || !isValidEmail(user.email)) {
-            log.info({ userId, email: user?.email }, '[emailService#sendBadgeAwardedEmail] Skipping: external user has no valid email')
+            log.info({ user: { id: userId }, email: user?.email }, '[emailService#sendBadgeAwardedEmail] Skipping: external user has no valid email')
             return
         }
         const badge = BADGES[badgeName as keyof typeof BADGES]

--- a/packages/server/api/src/app/ee/managed-authn/lib/external-token-extractor.ts
+++ b/packages/server/api/src/app/ee/managed-authn/lib/external-token-extractor.ts
@@ -54,7 +54,7 @@ export const externalTokenExtractor = (log: FastifyBaseLogger) => {
                 }
             }
             catch (error) {
-                log.error({ err: error }, '[externalTokenExtractor#extract] Failed to extract external token')
+                log.error({ error }, '[externalTokenExtractor#extract] Failed to extract external token')
 
                 throw new ActivepiecesError({
                     code: ErrorCode.INVALID_BEARER_TOKEN,

--- a/packages/server/api/src/app/ee/platform/platform-plan/platform-ai-credits.service.ts
+++ b/packages/server/api/src/app/ee/platform/platform-plan/platform-ai-credits.service.ts
@@ -232,7 +232,7 @@ async function tryAutoTopUpPlan(plan: PlatformPlan, apiKeyHash: string, log: Fas
 
         if (autoTopUpCreditsThisMonthAfterThisTopUp > plan.maxAutoTopUpCreditsMonthly) {
             log.info({
-                platformId: plan.platformId,
+                platform: { id: plan.platformId },
                 totalCreditsThisMonth,
                 creditsToAdd: plan.aiCreditsAutoTopUpCreditsToAdd,
                 maxMonthlyLimit: plan.maxAutoTopUpCreditsMonthly,

--- a/packages/server/api/src/app/ee/platform/platform-plan/platform-plan.service.ts
+++ b/packages/server/api/src/app/ee/platform/platform-plan/platform-plan.service.ts
@@ -53,7 +53,7 @@ export const platformPlanService = (log: FastifyBaseLogger) => ({
 
     async update(params: UpdatePlatformBillingParams): Promise<PlatformPlan> {
         const { platformId, ...update } = params
-        log.info({ platformId }, 'updating platform billing')
+        log.info({ platform: { id: platformId } }, 'updating platform billing')
 
         const platformPlan = await platformPlanRepo().findOneByOrFail({
             platformId,

--- a/packages/server/api/src/app/ee/platform/platform-plan/stripe-billing.controller.ts
+++ b/packages/server/api/src/app/ee/platform/platform-plan/stripe-billing.controller.ts
@@ -122,7 +122,7 @@ export const stripeBillingController: FastifyPluginAsyncZod = async (fastify) =>
                 return await reply.status(StatusCodes.OK).send({ received: true })
             }
             catch (err) {
-                request.log.error({ err }, 'Stripe webhook processing failed')
+                request.log.error({ error: err }, 'Stripe webhook processing failed')
                 exceptionHandler.handle(err, request.log)
                 return reply
                     .status(StatusCodes.BAD_REQUEST)

--- a/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
@@ -30,7 +30,7 @@ export const platformProjectBackgroundJobs = (log: FastifyBaseLogger) => ({
             }
             const flowExists = await flowRepo().existsBy({ id: flow.id })
             if (!flowExists) {
-                log.info({ flowId: flow.id }, '[hardDeleteProjectHandler] Flow already deleted, skipping preDelete')
+                log.info({ flow: { id: flow.id } }, '[hardDeleteProjectHandler] Flow already deleted, skipping preDelete')
                 continue
             }
             await flowSideEffects(log).preDelete({ flowToDelete: flow })

--- a/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-helper.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/git-sync/git-sync-helper.ts
@@ -19,7 +19,7 @@ export const gitSyncHelper = (log: FastifyBaseLogger) => ({
             return { flows, connections, tables }
         }
         catch (error) {
-            log.error({ err: error }, '[gitSyncHelper#getStateFromGit] Failed to read flow files')
+            log.error({ error }, '[gitSyncHelper#getStateFromGit] Failed to read flow files')
             throw error
         }
     },
@@ -33,7 +33,7 @@ export const gitSyncHelper = (log: FastifyBaseLogger) => ({
             await fs.writeFile(flowJsonPath, JSON.stringify(flowState, null, 2))
         }
         catch (error) {
-            log.error({ err: error, fileName }, '[gitSyncHelper#upsertFlowToGit] Failed to write flow file')
+            log.error({ error, fileName }, '[gitSyncHelper#upsertFlowToGit] Failed to write flow file')
             throw error
         }
     },

--- a/packages/server/api/src/app/event-destinations/event-destinations.service.ts
+++ b/packages/server/api/src/app/event-destinations/event-destinations.service.ts
@@ -185,7 +185,7 @@ const skipInternalDestinationsOnFlowCycle = async ({
         return destinations
     }
     log.warn({
-        flowId: eventFlowId,
+        flow: { id: eventFlowId },
         action: event.action,
     }, '[eventDestinationService#trigger] Source flow is wired as an internal webhook target; dropping internal destinations to break the cycle, external destinations will still fire')
     return destinationsWithFlowIds

--- a/packages/server/api/src/app/flows/flow-run/flow-run-hooks.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-hooks.ts
@@ -46,7 +46,7 @@ export const flowRunHooks = (log: FastifyBaseLogger) => ({
         }
         const { error } = await tryCatch(() => aiUsageTracker(log).track({ flowRun, flowVersion }))
         if (error) {
-            log.warn({ err: error, flowRunId: flowRun.id }, 'Failed to capture AI usage event')
+            log.warn({ error, flowRun: { id: flowRun.id } }, 'Failed to capture AI usage event')
         }
     },
 })

--- a/packages/server/api/src/app/flows/flow-run/flow-run-module.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-module.ts
@@ -39,8 +39,8 @@ export const flowRunModule: FastifyPluginAsync = async (app) => {
             .getRawMany()
         for (const { projectId, flowId, environment, count } of projectFlowCounts) {
             app.log.info({
-                projectId,
-                flowId,
+                project: { id: projectId },
+                flow: { id: flowId },
                 environment,
                 count: parseInt(count, 10),
             }, 'Tracking flow run created')
@@ -72,11 +72,11 @@ export const flowRunModule: FastifyPluginAsync = async (app) => {
     systemJobHandlers.registerJobHandler(SystemJobName.RESUME_DELAY_WAITPOINT, async (data: SystemJobData<SystemJobName.RESUME_DELAY_WAITPOINT>) => {
         const flowRun = await flowRunService(app.log).getOneOrThrow({ id: data.flowRunId, projectId: data.projectId })
         if (flowRun.status !== FlowRunStatus.PAUSED) {
-            app.log.info({ flowRunId: data.flowRunId, waitpointId: data.waitpointId, status: flowRun.status },
+            app.log.info({ flowRun: { id: data.flowRunId }, waitpoint: { id: data.waitpointId }, status: flowRun.status },
                 '[RESUME_DELAY_WAITPOINT] Flow not PAUSED, skipping')
             return
         }
-        app.log.info({ flowRunId: data.flowRunId, waitpointId: data.waitpointId },
+        app.log.info({ flowRun: { id: data.flowRunId }, waitpoint: { id: data.waitpointId } },
             '[RESUME_DELAY_WAITPOINT] Resuming flow')
         await resumeService(app.log).resumeFromWaitpoint({
             flowRunId: data.flowRunId,

--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -146,7 +146,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
             id: flowRunId,
             projectId,
         })
-        log.info({ flowRunId, flowId: oldFlowRun.flowId, strategy }, 'Flow run retry initiated')
+        log.info({ flowRun: { id: flowRunId }, flow: { id: oldFlowRun.flowId }, strategy }, 'Flow run retry initiated')
 
         const retentionDays = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
         if (
@@ -318,10 +318,10 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
         wideEvent.set({
             flowRun: {
                 id: newFlowRun.id,
-                flowId,
                 environment,
                 executionType,
             },
+            flow: { id: flowId },
         })
 
         await addToQueue({
@@ -336,7 +336,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
         }, log)
 
         await flowRunSideEffects(log).onStart(newFlowRun)
-        log.info({ flowRunId: newFlowRun.id, flowId, projectId, executionType }, 'Flow run started')
+        log.info({ flowRun: { id: newFlowRun.id }, flow: { id: flowId }, project: { id: projectId }, executionType }, 'Flow run started')
         return newFlowRun
     },
 
@@ -481,8 +481,8 @@ async function cancelSingleRun(log: FastifyBaseLogger, flowRun: FlowRun, platfor
         status: FlowRunStatus.CANCELED,
     })
     log.info({
-        runId: flowRun.id,
-        flowId: flowRun.flowId,
+        flowRun: { id: flowRun.id },
+        flow: { id: flowRun.flowId },
     }, 'Flow run cancelled')
 }
 

--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -146,7 +146,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
             id: flowRunId,
             projectId,
         })
-        log.info({ runId: flowRunId, flowId: oldFlowRun.flowId, strategy }, 'Flow run retry initiated')
+        log.info({ flowRunId, flowId: oldFlowRun.flowId, strategy }, 'Flow run retry initiated')
 
         const retentionDays = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
         if (
@@ -336,7 +336,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
         }, log)
 
         await flowRunSideEffects(log).onStart(newFlowRun)
-        log.info({ runId: newFlowRun.id, flowId, projectId, executionType }, 'Flow run started')
+        log.info({ flowRunId: newFlowRun.id, flowId, projectId, executionType }, 'Flow run started')
         return newFlowRun
     },
 

--- a/packages/server/api/src/app/flows/flow-run/flow-runs-queue.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-runs-queue.ts
@@ -32,7 +32,7 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
             async (job) => {
                 log.info({
                     jobId: job.id,
-                    runId: job.data.runId,
+                    flowRunId: job.data.runId,
                 }, '[runsMetadataQueue#worker] Saving runs metadata')
                 const key = redisMetadataKey(job.data.runId)
                 await distributedLock(log).runExclusive({
@@ -45,7 +45,7 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
                             if (isNil(runMetadata) || Object.keys(runMetadata).length === 0) {
                                 log.info({
                                     jobId: job.id,
-                                    runId: job.data.runId,
+                                    flowRunId: job.data.runId,
                                 }, '[runsMetadataQueue#worker] Runs metadata not found, skipping job')
                                 return
                             }
@@ -74,7 +74,7 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
                                 if (isNil(updatedFlowRun)) {
                                     log.info({
                                         jobId: job.id,
-                                        runId: job.data.runId,
+                                        flowRunId: job.data.runId,
                                     }, '[runsMetadataQueue#worker] Flow run was deleted during update, skipping job')
                                     return
                                 }
@@ -86,7 +86,7 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
                                 if (!flowExists) {
                                     log.info({
                                         jobId: job.id,
-                                        runId: job.data.runId,
+                                        flowRunId: job.data.runId,
                                     }, '[runsMetadataQueue#worker] Flow does not exist (deleted), skipping job')
                                     return
                                 }
@@ -148,7 +148,7 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
 
     async add(params: RunsMetadataUpsertData): Promise<void> {
         log.info({
-            runId: params.id,
+            flowRunId: params.id,
             projectId: params.projectId,
         }, '[runsMetadataQueue#add] Adding runs metadata to queue')
         await queue.add(params)

--- a/packages/server/api/src/app/flows/flow-run/flow-runs-queue.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-runs-queue.ts
@@ -31,8 +31,8 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
             queueName,
             async (job) => {
                 log.info({
-                    jobId: job.id,
-                    flowRunId: job.data.runId,
+                    job: { id: job.id },
+                    flowRun: { id: job.data.runId },
                 }, '[runsMetadataQueue#worker] Saving runs metadata')
                 const key = redisMetadataKey(job.data.runId)
                 await distributedLock(log).runExclusive({
@@ -44,8 +44,8 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
                             const runMetadata = await distributedStore.hgetJson<RunsMetadataUpsertData>(key)
                             if (isNil(runMetadata) || Object.keys(runMetadata).length === 0) {
                                 log.info({
-                                    jobId: job.id,
-                                    flowRunId: job.data.runId,
+                                    job: { id: job.id },
+                                    flowRun: { id: job.data.runId },
                                 }, '[runsMetadataQueue#worker] Runs metadata not found, skipping job')
                                 return
                             }
@@ -73,8 +73,8 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
                                 const updatedFlowRun = await flowRunRepo().findOneBy({ id: job.data.runId })
                                 if (isNil(updatedFlowRun)) {
                                     log.info({
-                                        jobId: job.id,
-                                        flowRunId: job.data.runId,
+                                        job: { id: job.id },
+                                        flowRun: { id: job.data.runId },
                                     }, '[runsMetadataQueue#worker] Flow run was deleted during update, skipping job')
                                     return
                                 }
@@ -85,8 +85,8 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
                                 const flowExists = !isNil(flowId) && await flowService(log).exists(flowId)
                                 if (!flowExists) {
                                     log.info({
-                                        jobId: job.id,
-                                        flowRunId: job.data.runId,
+                                        job: { id: job.id },
+                                        flowRun: { id: job.data.runId },
                                     }, '[runsMetadataQueue#worker] Flow does not exist (deleted), skipping job')
                                     return
                                 }
@@ -148,8 +148,8 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
 
     async add(params: RunsMetadataUpsertData): Promise<void> {
         log.info({
-            flowRunId: params.id,
-            projectId: params.projectId,
+            flowRun: { id: params.id },
+            project: { id: params.projectId },
         }, '[runsMetadataQueue#add] Adding runs metadata to queue')
         await queue.add(params)
     },

--- a/packages/server/api/src/app/flows/flow-run/waitpoint/waitpoint-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/waitpoint/waitpoint-service.ts
@@ -18,7 +18,7 @@ export const waitpointService = (log: FastifyBaseLogger) => ({
             status: WaitpointStatus.COMPLETED,
         })
         if (!isNil(preCompleted)) {
-            log.info({ flowRunId: params.flowRunId, stepName: params.stepName, existingStatus: preCompleted.status }, '[waitpointService#createForPause] Waitpoint already pre-completed for this step')
+            log.info({ flowRun: { id: params.flowRunId }, step: { name: params.stepName }, existingStatus: preCompleted.status }, '[waitpointService#createForPause] Waitpoint already pre-completed for this step')
             return { inserted: false, waitpoint: preCompleted }
         }
 
@@ -47,7 +47,7 @@ export const waitpointService = (log: FastifyBaseLogger) => ({
         const waitpoint = await waitpointRepo().findOneByOrFail({ flowRunId: params.flowRunId, stepName: params.stepName })
         const inserted = waitpoint.id === id
         if (inserted) {
-            log.info({ flowRunId: params.flowRunId, waitpointId: id }, '[waitpointService#createForPause] Waitpoint created')
+            log.info({ flowRun: { id: params.flowRunId }, waitpoint: { id } }, '[waitpointService#createForPause] Waitpoint created')
             if (params.type === PauseType.DELAY && !isNil(params.resumeDateTime)) {
                 await systemJobsSchedule(log).upsertJob({
                     job: {
@@ -63,7 +63,7 @@ export const waitpointService = (log: FastifyBaseLogger) => ({
             }
         }
         else {
-            log.info({ flowRunId: params.flowRunId, existingStatus: waitpoint.status }, '[waitpointService#createForPause] Waitpoint already exists')
+            log.info({ flowRun: { id: params.flowRunId }, existingStatus: waitpoint.status }, '[waitpointService#createForPause] Waitpoint already exists')
         }
         return { inserted, waitpoint }
     },
@@ -79,7 +79,7 @@ export const waitpointService = (log: FastifyBaseLogger) => ({
                 .getOne()
 
             if (isNil(pending)) {
-                log.info({ flowRunId: params.flowRunId, waitpointId: params.waitpointId }, '[waitpointService#complete] No pending waitpoint matches; dropping stale resume signal')
+                log.info({ flowRun: { id: params.flowRunId }, waitpoint: { id: params.waitpointId } }, '[waitpointService#complete] No pending waitpoint matches; dropping stale resume signal')
                 return { completedExisting: false, waitpoint: null }
             }
 
@@ -90,7 +90,7 @@ export const waitpointService = (log: FastifyBaseLogger) => ({
                 workerHandlerId: params.workerHandlerId ?? pending.workerHandlerId,
             }
             await repo.save(updated)
-            log.info({ flowRunId: params.flowRunId }, '[waitpointService#complete] Completed existing PENDING waitpoint')
+            log.info({ flowRun: { id: params.flowRunId } }, '[waitpointService#complete] Completed existing PENDING waitpoint')
             return { completedExisting: true, waitpoint: updated }
         })
     },
@@ -114,24 +114,24 @@ export const waitpointService = (log: FastifyBaseLogger) => ({
                 return found
             })
             if (isNil(waitpoint)) {
-                log.info({ flowRunId, waitpointId }, '[waitpointService#handleResumeSignal] Stale waitpointId, ignoring')
+                log.info({ flowRun: { id: flowRunId }, waitpoint: { id: waitpointId } }, '[waitpointService#handleResumeSignal] Stale waitpointId, ignoring')
                 return false
             }
-            log.info({ flowRunId, waitpointId }, '[waitpointService#handleResumeSignal] Resume triggered')
+            log.info({ flowRun: { id: flowRunId }, waitpoint: { id: waitpointId } }, '[waitpointService#handleResumeSignal] Resume triggered')
             return true
         }
 
         if (flowRunStatus === FlowRunStatus.RUNNING || flowRunStatus === FlowRunStatus.QUEUED) {
             const { completedExisting } = await this.complete({ flowRunId, projectId, waitpointId, resumePayload, workerHandlerId })
             if (!completedExisting) {
-                log.info({ flowRunId, waitpointId }, '[waitpointService#handleResumeSignal] Stale resume signal during RUNNING/QUEUED, ignoring')
+                log.info({ flowRun: { id: flowRunId }, waitpoint: { id: waitpointId } }, '[waitpointService#handleResumeSignal] Stale resume signal during RUNNING/QUEUED, ignoring')
                 return false
             }
-            log.info({ flowRunId }, '[waitpointService#handleResumeSignal] Marked PENDING waitpoint COMPLETED while flow still RUNNING/QUEUED; runsMetadataQueue will trigger resume on PAUSED upload')
+            log.info({ flowRun: { id: flowRunId } }, '[waitpointService#handleResumeSignal] Marked PENDING waitpoint COMPLETED while flow still RUNNING/QUEUED; runsMetadataQueue will trigger resume on PAUSED upload')
             return true
         }
 
-        log.info({ flowRunId, flowRunStatus }, '[waitpointService#handleResumeSignal] Flow run not in resumable state, ignoring')
+        log.info({ flowRun: { id: flowRunId }, flowRunStatus }, '[waitpointService#handleResumeSignal] Flow run not in resumable state, ignoring')
         return false
     },
 
@@ -148,6 +148,6 @@ export const waitpointService = (log: FastifyBaseLogger) => ({
 
     async deleteByFlowRunId(flowRunId: string): Promise<void> {
         await waitpointRepo().delete({ flowRunId })
-        log.info({ flowRunId }, '[waitpointService#deleteByFlowRunId] Waitpoint deleted')
+        log.info({ flowRun: { id: flowRunId } }, '[waitpointService#deleteByFlowRunId] Waitpoint deleted')
     },
 })

--- a/packages/server/api/src/app/flows/flow-version/flow-version-backup.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/flow-version-backup.service.ts
@@ -22,7 +22,7 @@ export const flowVersionBackupService = (log: FastifyBaseLogger) => ({
         })
 
         log.info({
-            flowVersionId: flowVersion.id,
+            flowVersion: { id: flowVersion.id },
             schemaVersion: flowVersion.schemaVersion,
         }, 'Stored backup version for flow version')
 
@@ -44,7 +44,7 @@ export const flowVersionBackupService = (log: FastifyBaseLogger) => ({
         const backupFlowVersion: FlowVersion = JSON.parse(fileData.data.toString('utf-8'))
 
         log.info({
-            flowVersionId: flowVersion.id,
+            flowVersion: { id: flowVersion.id },
             schemaVersion,
         }, 'Backup version retrieved for flow version')
         return backupFlowVersion

--- a/packages/server/api/src/app/flows/flow/flow.jobs.ts
+++ b/packages/server/api/src/app/flows/flow/flow.jobs.ts
@@ -52,7 +52,7 @@ export const flowBackgroundJobs = (log: FastifyBaseLogger) => ({
 
         const flowExists = await flowRepo().existsBy({ id: flow.id })
         if (!flowExists) {
-            log.info({ flowId: flow.id }, '[deleteFlowHandler] Flow already deleted, skipping')
+            log.info({ flow: { id: flow.id } }, '[deleteFlowHandler] Flow already deleted, skipping')
             return
         }
 

--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -96,7 +96,7 @@ export const flowService = (log: FastifyBaseLogger) => ({
             log,
         )
 
-        log.info({ flowId: savedFlow.id, projectId, displayName: request.displayName }, 'Flow created')
+        log.info({ flow: { id: savedFlow.id }, project: { id: projectId }, displayName: request.displayName }, 'Flow created')
         return {
             ...savedFlow,
             version: savedFlowVersion,
@@ -385,7 +385,7 @@ export const flowService = (log: FastifyBaseLogger) => ({
                 await flowRepo().update(id, {
                     folderId: operation.request.folderId,
                 })
-                log.info({ flowId: id, folderId: operation.request.folderId }, 'Flow moved to folder')
+                log.info({ flow: { id }, folderId: operation.request.folderId }, 'Flow moved to folder')
                 break
             }
 
@@ -512,7 +512,7 @@ export const flowService = (log: FastifyBaseLogger) => ({
         await flowRepo().update(id, {
             operationStatus: FlowOperationStatus.DELETING,
         })
-        log.info({ flowId: id, projectId }, 'Flow deletion requested')
+        log.info({ flow: { id }, project: { id: projectId } }, 'Flow deletion requested')
     },
 
     async deleteAllByPlatformId(platformId: PlatformId): Promise<void> {

--- a/packages/server/api/src/app/helper/application-events.ts
+++ b/packages/server/api/src/app/helper/application-events.ts
@@ -63,7 +63,7 @@ export const applicationEvents = (log: FastifyBaseLogger) => ({
                 listener(projectId, event)
             }
         }).catch((error) => {
-            log.error({ err: error }, '[applicationEvents#sendWorkerEvent] Failed to send worker event')
+            log.error({ error }, '[applicationEvents#sendWorkerEvent] Failed to send worker event')
         })
     },
 })

--- a/packages/server/api/src/app/helper/exception-handler.ts
+++ b/packages/server/api/src/app/helper/exception-handler.ts
@@ -24,7 +24,7 @@ export const exceptionHandler = {
         })
     },
     handle: (e: unknown, log: FastifyBaseLogger): void => {
-        log.error({ err: e }, 'Unhandled exception')
+        log.error({ error: e }, 'Unhandled exception')
         if (sentryInitialized) {
             Sentry.captureException(e)
         }

--- a/packages/server/api/src/app/helper/logger/index.ts
+++ b/packages/server/api/src/app/helper/logger/index.ts
@@ -44,7 +44,7 @@ export const pinoLogging = {
         return globalFacade
     },
     createRunContextLog({ log, runId, webhookId, flowId, flowVersionId }: { log: FastifyBaseLogger, runId: string, webhookId: string | undefined, flowId: string, flowVersionId: string }): FastifyBaseLogger {
-        return log.child({ runId, webhookId, flowId, flowVersionId })
+        return log.child({ flowRunId: runId, webhookId, flowId, flowVersionId })
     },
     createWebhookContextLog({ log, webhookId, flowId }: { log: FastifyBaseLogger, webhookId: string, flowId: string }): FastifyBaseLogger {
         return log.child({ webhookId, flowId })

--- a/packages/server/api/src/app/helper/promise-handler.ts
+++ b/packages/server/api/src/app/helper/promise-handler.ts
@@ -2,6 +2,6 @@ import { FastifyBaseLogger } from 'fastify'
 
 export function rejectedPromiseHandler(promise: Promise<unknown>, log: FastifyBaseLogger) {
     promise.catch((error) => {
-        log.error({ err: error }, '[rejectedPromiseHandler#catch] Unhandled promise rejection')
+        log.error({ error }, '[rejectedPromiseHandler#catch] Unhandled promise rejection')
     })
 }

--- a/packages/server/api/src/app/helper/system-jobs/system-job.ts
+++ b/packages/server/api/src/app/helper/system-jobs/system-job.ts
@@ -36,7 +36,7 @@ export const systemJobsSchedule = (log: FastifyBaseLogger): SystemJobSchedule =>
 
         const { error } = await tryCatch(async () => removeDeprecatedJobs())
         if (!isNil(error)) {
-            log.error({ err: error }, '[systemJob#init] Error removing deprecated jobs')
+            log.error({ error }, '[systemJob#init] Error removing deprecated jobs')
         }
     },
 

--- a/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
@@ -111,7 +111,7 @@ function unauthorized({ req, reply, scope, message, invalidToken }: {
 async function resolveIdentity({ token, scope, log }: { token: string, scope: McpServerType, log: FastifyBaseLogger }): Promise<ResolvedIdentity | null> {
     const { data: payload, error } = await tryCatch(() => mcpOAuthTokenService.verifyAccessToken(token))
     if (error) {
-        log.debug({ err: error }, 'OAuth token verification failed')
+        log.debug({ error }, 'OAuth token verification failed')
         return null
     }
     const { projectId } = payload
@@ -149,7 +149,7 @@ async function resolveMcpAndUser({ identity, log }: { identity: ResolvedIdentity
         return { mcp, userId: identity.userId }
     }
     catch (err) {
-        log.debug({ err }, 'Failed to resolve MCP server')
+        log.debug({ error: err }, 'Failed to resolve MCP server')
         return { mcp: null }
     }
 }
@@ -169,11 +169,11 @@ async function resolveConversationProjectId({ conversationId, userId, log }: {
         chatConversationRepo().findOne({ where: { id: conversationId, userId }, select: ['projectId'] }),
     )
     if (error) {
-        log.warn({ err: error, conversationId }, 'DB error resolving conversation project')
+        log.warn({ error, conversation: { id: conversationId } }, 'DB error resolving conversation project')
         return null
     }
     if (!conversation) {
-        log.debug({ conversationId }, 'Conversation not found for project resolution')
+        log.debug({ conversation: { id: conversationId } }, 'Conversation not found for project resolution')
         return null
     }
     return conversation.projectId ?? null

--- a/packages/server/api/src/app/mcp/oauth/token/mcp-oauth-token.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/token/mcp-oauth-token.controller.ts
@@ -28,7 +28,7 @@ export const mcpOAuthTokenController: FastifyPluginAsyncZod = async (app) => {
                     error_description: e.errorDescription,
                 })
             }
-            req.log.error({ err: e, clientId: client_id }, 'OAuth token error')
+            req.log.error({ error: e, clientId: client_id }, 'OAuth token error')
             return reply.status(500).send({ error: 'server_error' })
         }
     })

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -96,7 +96,7 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
                 const triggerVersionResult = await mcpUtils.resolveLatestPieceVersion({ pieceName: trigger.pieceName, projectId, platformId, log })
                 if (triggerVersionResult.error) {
                     await flowService(log).delete({ id: flowId, projectId }).catch((deleteErr) => {
-                        log.warn({ err: deleteErr, flowId }, 'Failed to clean up orphaned flow after trigger version resolution error')
+                        log.warn({ error: deleteErr, flow: { id: flowId } }, 'Failed to clean up orphaned flow after trigger version resolution error')
                     })
                     return triggerVersionResult.error
                 }

--- a/packages/server/api/src/app/mcp/tools/ap-create-table.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-create-table.ts
@@ -70,7 +70,7 @@ export const apCreateTableTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_create_table failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_create_table failed')
                 return mcpUtils.mcpToolError('Failed to create table', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-delete-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-records.ts
@@ -37,7 +37,7 @@ export const apDeleteRecordsTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_delete_records failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_delete_records failed')
                 return mcpUtils.mcpToolError('Failed to delete records', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-delete-table.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-delete-table.ts
@@ -38,7 +38,7 @@ export const apDeleteTableTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_delete_table failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_delete_table failed')
                 return mcpUtils.mcpToolError('Failed to delete table', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-find-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-find-records.ts
@@ -107,7 +107,7 @@ export const apFindRecordsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseL
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_find_records failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_find_records failed')
                 return mcpUtils.mcpToolError('Failed to find records', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-piece-props.ts
@@ -170,7 +170,7 @@ async function resolvePropertyOptions({ props, componentProps, pieceName, pieceV
             }
         }
         catch (err) {
-            log.warn({ err, propertyName: prop.name }, 'Failed to resolve property options — dropdown will be empty. Try calling ap_get_piece_props again with auth.')
+            log.warn({ error: err, propertyName: prop.name }, 'Failed to resolve property options — dropdown will be empty. Try calling ap_get_piece_props again with auth.')
         }
     }))
 }
@@ -201,7 +201,7 @@ async function discoverAvailableConnections({ pieceName, projectId, platformId, 
         return { message: 'No connections found. Set up in UI or use ap_setup_guide.', connections: [] }
     }
     catch (err) {
-        log.debug({ err, pieceName }, 'Failed to discover connections')
+        log.debug({ error: err, piece: { name: pieceName } }, 'Failed to discover connections')
         return { message: 'Use ap_list_connections to find connections.', connections: [] }
     }
 }

--- a/packages/server/api/src/app/mcp/tools/ap-get-run.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-get-run.ts
@@ -57,7 +57,7 @@ export const apGetRunTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_get_run failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_get_run failed')
                 return mcpUtils.mcpToolError('Failed to get run', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-insert-records.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-insert-records.ts
@@ -54,7 +54,7 @@ export const apInsertRecordsTool = (mcp: ProjectScopedMcpServer, log: FastifyBas
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_insert_records failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_insert_records failed')
                 return mcpUtils.mcpToolError('Failed to insert records', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-list-ai-models.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-ai-models.ts
@@ -65,7 +65,7 @@ export const apListAiModelsTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                             return `- ${p.provider} (${p.name}) — ${textModels.length} text model(s)\n  Models:\n${modelLines}${overflow}`
                         }
                         catch (err) {
-                            log.warn({ err, provider: p.provider }, 'ap_list_ai_models: failed to fetch models for provider')
+                            log.warn({ error: err, provider: p.provider }, 'ap_list_ai_models: failed to fetch models for provider')
                             structuredProviders.push({ provider: p.provider, displayName: p.name, models: [] })
                             return `- ${p.provider} (${p.name})\n  (failed to fetch models)`
                         }
@@ -81,7 +81,7 @@ export const apListAiModelsTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_list_ai_models failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_list_ai_models failed')
                 return mcpUtils.mcpToolError('Failed to list AI models', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-runs.ts
@@ -71,7 +71,7 @@ export const apListRunsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_list_runs failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_list_runs failed')
                 return mcpUtils.mcpToolError('Failed to list runs', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-list-tables.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-list-tables.ts
@@ -72,7 +72,7 @@ export const apListTablesTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_list_tables failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_list_tables failed')
                 return mcpUtils.mcpToolError('Failed to list tables', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-manage-fields.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-manage-fields.ts
@@ -87,7 +87,7 @@ export const apManageFieldsTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_manage_fields failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_manage_fields failed')
                 return mcpUtils.mcpToolError('Field operation failed', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-retry-run.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-retry-run.ts
@@ -61,7 +61,7 @@ export const apRetryRunTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
                 return { content: [{ type: 'text', text: formatRunResult(completedRun) }] }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_retry_run failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_retry_run failed')
                 return mcpUtils.mcpToolError('Failed to retry run', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-run-action.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-run-action.ts
@@ -31,7 +31,7 @@ export const apRunActionTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLog
                 })
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_run_action failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_run_action failed')
                 return mcpUtils.mcpToolError('Failed to run action', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
@@ -28,7 +28,7 @@ export const apSetupGuideTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLo
                 return await aiProviderGuide(mcp, log)
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_setup_guide failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_setup_guide failed')
                 return mcpUtils.mcpToolError('Failed to generate setup guide', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-test-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-test-flow.ts
@@ -23,7 +23,7 @@ export const apTestFlowTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
                 return await executeFlowTest({ flowId, projectId: mcp.projectId, triggerTestData, log })
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_test_flow failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_test_flow failed')
                 return mcpUtils.mcpToolError('Failed to test flow', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-test-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-test-step.ts
@@ -24,7 +24,7 @@ export const apTestStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
                 return await executeFlowTest({ flowId, projectId: mcp.projectId, stepName, triggerTestData, log })
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_test_step failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_test_step failed')
                 return mcpUtils.mcpToolError('Failed to test step', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-update-record.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-record.ts
@@ -56,7 +56,7 @@ export const apUpdateRecordTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
                 }
             }
             catch (err) {
-                log.error({ err, projectId: mcp.projectId }, 'ap_update_record failed')
+                log.error({ error: err, project: { id: mcp.projectId } }, 'ap_update_record failed')
                 return mcpUtils.mcpToolError('Failed to update record', err)
             }
         },

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -230,7 +230,7 @@ async function diagnoseMissingInputs({ settings, platformId, log }: {
         return parts.join(' ')
     }
     catch (err) {
-        log.warn({ err, pieceName, actionName }, 'diagnoseMissingInputs: failed to fetch piece metadata')
+        log.warn({ error: err, piece: { name: pieceName }, actionName }, 'diagnoseMissingInputs: failed to fetch piece metadata')
         return null
     }
 }

--- a/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-trigger.ts
@@ -163,7 +163,7 @@ async function diagnoseMissingTriggerInputs({ pieceName, pieceVersion, triggerNa
         return parts.join(' ')
     }
     catch (err) {
-        log.warn({ err, pieceName, triggerName }, 'diagnoseMissingTriggerInputs: failed to fetch piece metadata')
+        log.warn({ error: err, piece: { name: pieceName }, trigger: { name: triggerName } }, 'diagnoseMissingTriggerInputs: failed to fetch piece metadata')
         return null
     }
 }

--- a/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/flow-run-utils.ts
@@ -268,12 +268,12 @@ export async function executeAdhocAction({
         return { content: [{ type: 'text', text: formatAdhocActionResult(completedRun, stepName, action.displayName) }] }
     }
     catch (err) {
-        log.error({ err, projectId, flowId: flow.id }, 'executeAdhocAction failed')
+        log.error({ error: err, project: { id: projectId }, flow: { id: flow.id } }, 'executeAdhocAction failed')
         return mcpUtils.mcpToolError('Failed to run action', err)
     }
     finally {
         flowService(log).delete({ id: flow.id, projectId }).catch(err => {
-            log.warn({ err, flowId: flow.id }, 'adhoc flow cleanup failed')
+            log.warn({ error: err, flow: { id: flow.id } }, 'adhoc flow cleanup failed')
         })
     }
 }

--- a/packages/server/api/src/app/mcp/tools/mcp-utils.ts
+++ b/packages/server/api/src/app/mcp/tools/mcp-utils.ts
@@ -187,7 +187,7 @@ async function detectUnknownInputProps({ pieceName, pieceVersion, componentName,
         return { unknownKeys, message: unknownMessage }
     }
     catch (err) {
-        log.warn({ err, pieceName, componentName }, 'detectUnknownInputProps: failed to fetch piece metadata')
+        log.warn({ error: err, piece: { name: pieceName }, componentName }, 'detectUnknownInputProps: failed to fetch piece metadata')
         return { unknownKeys: [], message: '' }
     }
 }
@@ -391,7 +391,7 @@ async function fillDefaultsForMissingOptionalProps({ settings, platformId, log }
         settings.input = { ...defaults, ...(typeof settings.input === 'object' && settings.input !== null ? settings.input : {}) }
     }
     catch (err) {
-        log.warn({ err, pieceName, actionName }, 'fillDefaultsForMissingOptionalProps: failed, skipping defaults')
+        log.warn({ error: err, piece: { name: pieceName }, actionName }, 'fillDefaultsForMissingOptionalProps: failed, skipping defaults')
     }
 }
 

--- a/packages/server/api/src/app/pieces/dev-piece-watcher.ts
+++ b/packages/server/api/src/app/pieces/dev-piece-watcher.ts
@@ -54,7 +54,7 @@ async function buildPieces(app: FastifyInstance, piecesInfo: PieceInfo[]): Promi
         app.log.info('Changes are ready! Please refresh the frontend to see the new updates.')
     }
     catch (error) {
-        app.log.error({ err: error }, 'Failed to run build process...')
+        app.log.error({ error }, 'Failed to run build process...')
     }
     finally {
         await lock.release()
@@ -122,7 +122,7 @@ export async function startDevPieceWatcher(app: FastifyInstance): Promise<void> 
     })
 
     watcher.on('error', (error) => {
-        app.log.error({ err: error }, 'File watcher error')
+        app.log.error({ error }, 'File watcher error')
     })
 
     for (const pieceInfo of pieceInfos) {

--- a/packages/server/api/src/app/pieces/metadata/utils/file-pieces-utils.ts
+++ b/packages/server/api/src/app/pieces/metadata/utils/file-pieces-utils.ts
@@ -64,7 +64,7 @@ export const filePiecesUtils = (log: FastifyBaseLogger) => ({
         }
         catch (e) {
             const err = e as Error
-            log.warn({ err }, '[filePieceMetadataService#loadDistPiecesMetadata] Failed to load pieces from folder')
+            log.warn({ error: err }, '[filePieceMetadataService#loadDistPiecesMetadata] Failed to load pieces from folder')
             return []
         }
     },

--- a/packages/server/api/src/app/pieces/piece-install-service.ts
+++ b/packages/server/api/src/app/pieces/piece-install-service.ts
@@ -53,7 +53,7 @@ export const pieceInstallService = (log: FastifyBaseLogger) => ({
             return savedPiece
         }
         catch (error) {
-            log.error({ err: error }, '[pieceInstallService#add] Failed to add piece')
+            log.error({ error }, '[pieceInstallService#add] Failed to add piece')
 
             if (error instanceof ActivepiecesError && error.error.code === ErrorCode.VALIDATION) {
                 throw error

--- a/packages/server/api/src/app/pieces/piece-sync-service.ts
+++ b/packages/server/api/src/app/pieces/piece-sync-service.ts
@@ -81,7 +81,7 @@ async function installNewPieces(cloudPieces: PieceRegistryResponse[], dbPieces: 
             const url = `${CLOUD_API_URL}/${piece.name}${piece.version ? '?version=' + piece.version : ''}`
             const response = await fetch(url)
             if (!response.ok) {
-                log.warn({ pieceName: piece.name, version: piece.version, status: response.status }, '[pieceSyncService#installNewPieces] Error reading piece metadata')
+                log.warn({ piece: { name: piece.name, version: piece.version }, status: response.status }, '[pieceSyncService#installNewPieces] Error reading piece metadata')
                 return
             }
             const pieceMetadata = await response.json()
@@ -92,7 +92,7 @@ async function installNewPieces(cloudPieces: PieceRegistryResponse[], dbPieces: 
                 publishCacheRefresh: false,
             }))
             if (error) {
-                log.debug({ pieceName: piece.name, version: piece.version }, '[pieceSyncService#installNewPieces] Piece already exists, skipping')
+                log.debug({ piece: { name: piece.name, version: piece.version } }, '[pieceSyncService#installNewPieces] Piece already exists, skipping')
             }
         }))
     }

--- a/packages/server/api/src/app/platform/platform-jobs.ts
+++ b/packages/server/api/src/app/platform/platform-jobs.ts
@@ -21,7 +21,7 @@ export const platformBackgroundJobs = (log: FastifyBaseLogger) => ({
             .getCount()
 
         if (remainingProjects > 0) {
-            log.info({ platformId, remainingProjects }, '[hardDeletePlatformHandler] Projects still exist, retrying later')
+            log.info({ platform: { id: platformId }, remainingProjects }, '[hardDeletePlatformHandler] Projects still exist, retrying later')
             throw new Error(`Platform ${platformId} still has ${remainingProjects} projects, will retry`)
         }
 
@@ -44,6 +44,6 @@ export const platformBackgroundJobs = (log: FastifyBaseLogger) => ({
             }
         })
 
-        log.info({ platformId }, '[hardDeletePlatformHandler] Platform deleted')
+        log.info({ platform: { id: platformId } }, '[hardDeletePlatformHandler] Platform deleted')
     },
 })

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -93,7 +93,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
             platformId: savedPlatform.id,
         })
 
-        log.info({ platformId: savedPlatform.id, ownerId }, 'Platform created')
+        log.info({ platform: { id: savedPlatform.id }, ownerId }, 'Platform created')
         return stripFederatedAuth(savedPlatform)
     },
     async createPlatformWithProject({ identityId, name, invalidatePreviousTokens }: CreatePlatformWithProjectParams): Promise<AuthenticationResponse> {
@@ -201,7 +201,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
         if (!isNil(params.federatedAuthProviders?.saml)) {
             invalidateSamlClientCache(params.id)
         }
-        log.info({ platformId: params.id }, 'Platform updated')
+        log.info({ platform: { id: params.id } }, 'Platform updated')
         const saved = await platformRepo().save(updatedPlatform)
         return stripFederatedAuth(saved)
     },

--- a/packages/server/api/src/app/trigger/test-trigger/test-trigger-controller.ts
+++ b/packages/server/api/src/app/trigger/test-trigger/test-trigger-controller.ts
@@ -9,9 +9,9 @@ export const testTriggerController: FastifyPluginAsyncZod = async (app) => {
         const { flowId, flowVersionId, testStrategy } = req.body
 
         const logWithContext = req.log.child({
-            flowId,
-            flowVersionId,
-            projectId: req.projectId,
+            flow: { id: flowId },
+            flowVersion: { id: flowVersionId },
+            project: { id: req.projectId },
             testStrategy,
         })
         return testTriggerService(logWithContext).test({

--- a/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
@@ -104,7 +104,7 @@ export const flowTriggerSideEffect = (log: FastifyBaseLogger) => {
                 if (!params.ignoreError) {
                     throw error
                 }
-                log.warn({ flowId, error: error.message }, '[flowTriggerSideEffect#disable] Ignored error during trigger disable')
+                log.warn({ flow: { id: flowId }, error: error.message }, '[flowTriggerSideEffect#disable] Ignored error during trigger disable')
             }
             else if (!params.ignoreError) {
                 assertEngineResponseIsOk(engineHelperResponse!, flowId, flowVersionId)

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
@@ -16,9 +16,9 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
         async enable(params: EnableTriggerParams): Promise<TriggerSource> {
             const { flowVersion, projectId, simulate, templateId } = params
             log.info({
-                flowId: flowVersion.flowId,
-                flowVersionId: flowVersion.id,
-                projectId,
+                flow: { id: flowVersion.flowId },
+                flowVersion: { id: flowVersion.id },
+                project: { id: projectId },
                 simulate,
             }, '[triggerSourceService#enable] Enabling trigger source')
             const pieceTrigger = await triggerUtils(log).getPieceTriggerOrThrow({ flowVersion, projectId })
@@ -150,8 +150,8 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
         async disable(params: DisableTriggerParams): Promise<void> {
             const { projectId, flowId, simulate, templateId } = params
             log.info({
-                flowId,
-                projectId,
+                flow: { id: flowId },
+                project: { id: projectId },
                 simulate,
             }, '[triggerSourceService#disable] Disabling trigger source')
             const triggerSource = await triggerSourceRepo().findOneBy({

--- a/packages/server/api/src/app/user/badges/badge-service.ts
+++ b/packages/server/api/src/app/user/badges/badge-service.ts
@@ -59,7 +59,7 @@ async function processBadgeChecks(
             log.info({
                 message: 'Awarding badge',
                 badgeName,
-                userId,
+                user: { id: userId },
             })
 
             await emailService(log).sendBadgeAwardedEmail(userId, badgeName)

--- a/packages/server/api/src/app/variable/variable.service.ts
+++ b/packages/server/api/src/app/variable/variable.service.ts
@@ -52,7 +52,7 @@ export const variableService = (log: FastifyBaseLogger) => ({
             }
             throw error
         }
-        log.info({ id, projectId, name }, 'Variable created')
+        log.info({ id, project: { id: projectId }, name }, 'Variable created')
         return getOneOrThrowWithoutValue({ id, projectId, platformId })
     },
 
@@ -63,7 +63,7 @@ export const variableService = (log: FastifyBaseLogger) => ({
             ...(isNil(value) ? {} : { value: await encryptUtils.encryptObject({ secret_text: value }) }),
             ...spreadIfDefined('metadata', metadata),
         })
-        log.info({ id, projectId }, 'Variable updated')
+        log.info({ id, project: { id: projectId } }, 'Variable updated')
         return getOneOrThrowWithoutValue({ id, projectId, platformId })
     },
 
@@ -150,7 +150,7 @@ export const variableService = (log: FastifyBaseLogger) => ({
     async delete(params: GetOneParams): Promise<VariableWithoutSensitiveData> {
         const target = await getOneOrThrowWithoutValue(params)
         await variableRepo().delete({ id: params.id, projectId: params.projectId, platformId: params.platformId })
-        log.info({ id: params.id, projectId: params.projectId }, 'Variable deleted')
+        log.info({ id: params.id, project: { id: params.projectId } }, 'Variable deleted')
         return target
     },
 })

--- a/packages/server/api/src/app/webhooks/webhook-controller.ts
+++ b/packages/server/api/src/app/webhooks/webhook-controller.ts
@@ -19,8 +19,8 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
         WEBHOOK_PARAMS,
         async (request: FastifyRequest<{ Params: WebhookUrlParams }>, reply) => {
             wideEvent.set({
+                flow: { id: request.params.flowId },
                 webhook: {
-                    flowId: request.params.flowId,
                     method: request.method,
                     async: false,
                 },
@@ -52,8 +52,8 @@ export const webhookController: FastifyPluginAsyncZod = async (app) => {
         WEBHOOK_PARAMS,
         async (request: FastifyRequest<{ Params: WebhookUrlParams }>, reply) => {
             wideEvent.set({
+                flow: { id: request.params.flowId },
                 webhook: {
-                    flowId: request.params.flowId,
                     method: request.method,
                     async: true,
                 },

--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -103,7 +103,7 @@ export const webhookService = {
             },
         })
         const flowVersionIdToRun = await webhookService.getFlowVersionIdToRun(flowVersionToRun, flow)
-        wideEvent.set({ webhook: { flowVersionId: flowVersionIdToRun } })
+        wideEvent.set({ flowVersionId: flowVersionIdToRun })
 
         const response = await webhookHandshake.handleHandshakeRequest({
             payload: (payload ?? await data(flow.projectId)) as TriggerPayload,
@@ -273,7 +273,7 @@ async function handleSync(params: SyncWebhookParams): Promise<EngineHttpResponse
         failParentOnFailure,
     })
 
-    wideEvent.set({ webhook: { runId: createdRun.id } })
+    wideEvent.set({ flowRunId: createdRun.id })
     params.onRunCreated?.(createdRun)
 
     const listenerResult = await engineResponseWatcher(logger).oneTimeListener<EngineHttpResponse>(webhookRequestId, true, timeoutMs ?? WEBHOOK_TIMEOUT_MS, {

--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -57,9 +57,9 @@ export const webhookService = {
         const webhookHeader = 'x-webhook-id'
         const webhookRequestId = apId()
         wideEvent.set({
+            flow: { id: flowId },
             webhook: {
                 requestId: webhookRequestId,
-                flowId,
                 async,
                 saveSampleData,
                 execute,
@@ -84,7 +84,7 @@ export const webhookService = {
         }
         const { flow } = flowExecutionResult
         if (flow.status === FlowStatus.DISABLED && !saveSampleData) {
-            pinoLogger.warn({ flowId }, 'Webhook received for disabled flow')
+            pinoLogger.warn({ flow: { id: flowId } }, 'Webhook received for disabled flow')
             wideEvent.set({ webhook: { flowFound: false } })
             return {
                 status: StatusCodes.NOT_FOUND,
@@ -98,12 +98,12 @@ export const webhookService = {
         wideEvent.set({
             webhook: {
                 flowFound: true,
-                projectId: flow.projectId,
-                platformId: flowExecutionResult.platformId,
             },
+            project: { id: flow.projectId },
+            platform: { id: flowExecutionResult.platformId },
         })
         const flowVersionIdToRun = await webhookService.getFlowVersionIdToRun(flowVersionToRun, flow)
-        wideEvent.set({ flowVersionId: flowVersionIdToRun })
+        wideEvent.set({ flowVersion: { id: flowVersionIdToRun } })
 
         const response = await webhookHandshake.handleHandshakeRequest({
             payload: (payload ?? await data(flow.projectId)) as TriggerPayload,
@@ -115,8 +115,8 @@ export const webhookService = {
         })
         if (!isNil(response)) {
             logger.info({
-                flowId: flow.id,
-                flowVersionId: flowVersionIdToRun,
+                flow: { id: flow.id },
+                flowVersion: { id: flowVersionIdToRun },
                 webhookRequestId,
             }, 'Handshake request completed')
             wideEvent.set({ webhook: { handshake: true } })
@@ -273,7 +273,7 @@ async function handleSync(params: SyncWebhookParams): Promise<EngineHttpResponse
         failParentOnFailure,
     })
 
-    wideEvent.set({ flowRunId: createdRun.id })
+    wideEvent.set({ flowRun: { id: createdRun.id } })
     params.onRunCreated?.(createdRun)
 
     const listenerResult = await engineResponseWatcher(logger).oneTimeListener<EngineHttpResponse>(webhookRequestId, true, timeoutMs ?? WEBHOOK_TIMEOUT_MS, {

--- a/packages/server/api/src/app/workers/job-queue/interceptors/rate-limiter-interceptor.ts
+++ b/packages/server/api/src/app/workers/job-queue/interceptors/rate-limiter-interceptor.ts
@@ -135,12 +135,12 @@ export const rateLimiterInterceptor: JobInterceptor = {
 
         const allowed = await tryAcquireSlot({ jobId, jobData, log })
         if (allowed) {
-            log.debug({ jobId, projectId: jobData.projectId }, '[rateLimiterInterceptor] Job allowed')
+            log.debug({ job: { id: jobId }, project: { id: jobData.projectId } }, '[rateLimiterInterceptor] Job allowed')
             return { verdict: InterceptorVerdict.ALLOW }
         }
 
         const delayInMs = Math.min(600_000, 20_000 * Math.pow(2, job.attemptsMade))
-        log.info({ jobId, projectId: jobData.projectId, delayInMs }, '[rateLimiterInterceptor] Job rate limited')
+        log.info({ job: { id: jobId }, project: { id: jobData.projectId }, delayInMs }, '[rateLimiterInterceptor] Job rate limited')
         return {
             verdict: InterceptorVerdict.REJECT,
             delayInMs,
@@ -153,6 +153,6 @@ export const rateLimiterInterceptor: JobInterceptor = {
             return
         }
         await releaseSlot({ jobId, jobData, log })
-        log.debug({ jobId, projectId: jobData.projectId }, '[rateLimiterInterceptor] Slot released')
+        log.debug({ job: { id: jobId }, project: { id: jobData.projectId } }, '[rateLimiterInterceptor] Slot released')
     },
 }

--- a/packages/server/api/src/app/workers/job-queue/interceptors/zombie-polling-interceptor.ts
+++ b/packages/server/api/src/app/workers/job-queue/interceptors/zombie-polling-interceptor.ts
@@ -18,7 +18,7 @@ export const zombiePollingInterceptor: JobInterceptor = {
         if (!isNil(activeTriggerSource)) {
             return { verdict: InterceptorVerdict.ALLOW }
         }
-        log.warn({ flowVersionId }, '[zombiePollingInterceptor] No active trigger source — discarding repeat job (flow disabled, re-published, or deleted)')
+        log.warn({ flowVersion: { id: flowVersionId } }, '[zombiePollingInterceptor] No active trigger source — discarding repeat job (flow disabled, re-published, or deleted)')
         await jobQueue(log).removeRepeatingJob({ flowVersionId })
         return { verdict: InterceptorVerdict.DISCARD }
     },

--- a/packages/server/api/src/app/workers/job-queue/job-broker.ts
+++ b/packages/server/api/src/app/workers/job-queue/job-broker.ts
@@ -46,7 +46,7 @@ async function createBullMQWorker(queueName: string, log: FastifyBaseLogger): Pr
     await worker.startStalledCheckTimer()
 
     worker.on('stalled', (jobId: string) => {
-        log.warn({ queueName, jobId }, '[jobBroker] Job stalled — BullMQ will retry automatically')
+        log.warn({ queueName, job: { id: jobId } }, '[jobBroker] Job stalled — BullMQ will retry automatically')
     })
 
     log.info({ queueName }, '[jobBroker] BullMQ worker initialized')
@@ -57,7 +57,7 @@ async function fetchJobFromRedis(queueName: string, jobId: string, log: FastifyB
     const worker = await ensureBullMQWorker(queueName, log)
     const job = await Job.fromId(worker, jobId)
     if (isNil(job)) {
-        log.warn({ jobId, queueName }, '[jobBroker] Job not found in Redis')
+        log.warn({ job: { id: jobId }, queueName }, '[jobBroker] Job not found in Redis')
         return null
     }
     return job
@@ -87,20 +87,20 @@ async function tryDequeue(worker: BullMQWorker, queueName: string, log: FastifyB
 
     if (job.deferredFailure) {
         log.warn(
-            { queueName, jobId: job.id, jobName: job.name, deferredFailure: job.deferredFailure },
+            { queueName, job: { id: job.id }, jobName: job.name, deferredFailure: job.deferredFailure },
             '[jobBroker#tryDequeue] Failing job with deferred failure (BullMQ stalled limit exceeded)',
         )
         const { error: failError } = await tryCatch(() => job.moveToFailed(new UnrecoverableError(job.deferredFailure), token, false))
         if (failError) {
             log.error(
-                { queueName, jobId: job.id, error: String(failError) },
+                { queueName, job: { id: job.id }, error: String(failError) },
                 '[jobBroker#tryDequeue] Failed to fail deferred-failure job',
             )
         }
         return tryDequeue(worker, queueName, log)
     }
 
-    log.info({ queueName, jobId: job.id, jobName: job.name }, '[jobBroker#tryDequeue] Dequeued job')
+    log.info({ queueName, job: { id: job.id }, jobName: job.name }, '[jobBroker#tryDequeue] Dequeued job')
 
     const originalSchemaVersion = (job.data as Record<string, unknown>).schemaVersion
     const migratedData = await jobMigrations(log).apply(job.data)
@@ -115,12 +115,12 @@ async function tryDequeue(worker: BullMQWorker, queueName: string, log: FastifyB
         const issues = parseResult.error.issues.map(issue => `${issue.path.join('.') || '<root>'}: ${issue.message}`).join('; ')
         const reason = `Job data failed schema validation after migration: ${issues}`
         log.error(
-            { queueName, jobId, schemaVersion: migratedData.schemaVersion, jobType: migratedData.jobType, issues: parseResult.error.issues },
+            { queueName, job: { id: jobId, type: migratedData.jobType }, schemaVersion: migratedData.schemaVersion, issues: parseResult.error.issues },
             '[jobBroker#tryDequeue] Failing job with invalid schema as unrecoverable',
         )
         const { error: failError } = await tryCatch(() => job.moveToFailed(new UnrecoverableError(reason), token, false))
         if (failError) {
-            log.error({ queueName, jobId, error: String(failError) }, '[jobBroker#tryDequeue] Failed to fail invalid-schema job')
+            log.error({ queueName, job: { id: jobId }, error: String(failError) }, '[jobBroker#tryDequeue] Failed to fail invalid-schema job')
         }
         return tryDequeue(worker, queueName, log)
     }
@@ -164,10 +164,10 @@ async function returnJobToQueue(jobId: string, token: string, queueName: string,
     for (const interceptor of interceptors) {
         const { error } = await tryCatch(() => interceptor.onJobFinished({ jobId, jobData, failed: false, log }))
         if (error) {
-            log.error({ jobId, error: String(error) }, '[jobBroker#returnJobToQueue] interceptor cleanup failed')
+            log.error({ job: { id: jobId }, error: String(error) }, '[jobBroker#returnJobToQueue] interceptor cleanup failed')
         }
     }
-    log.info({ jobId }, '[jobBroker#returnJobToQueue] orphaned job returned to queue')
+    log.info({ job: { id: jobId } }, '[jobBroker#returnJobToQueue] orphaned job returned to queue')
 }
 
 async function runInterceptors({ jobId, jobData, job, log }: { jobId: string, jobData: JobData, job: Job, log: FastifyBaseLogger }): Promise<{ delayInMs: number, priority?: number } | 'DISCARD' | null> {
@@ -178,7 +178,7 @@ async function runInterceptors({ jobId, jobData, job, log }: { jobId: string, jo
             for (const passedInterceptor of passed) {
                 const { error } = await tryCatch(() => passedInterceptor.onJobFinished({ jobId, jobData, failed: false, log }))
                 if (error) {
-                    log.error({ jobId, error: String(error) }, '[jobBroker] Failed to clean up interceptor on discard')
+                    log.error({ job: { id: jobId }, error: String(error) }, '[jobBroker] Failed to clean up interceptor on discard')
                 }
             }
             return 'DISCARD'
@@ -187,7 +187,7 @@ async function runInterceptors({ jobId, jobData, job, log }: { jobId: string, jo
             for (const passedInterceptor of passed) {
                 const { error } = await tryCatch(() => passedInterceptor.onJobFinished({ jobId, jobData, failed: false, log }))
                 if (error) {
-                    log.error({ jobId, error: String(error) }, '[jobBroker] Failed to clean up interceptor on reject')
+                    log.error({ job: { id: jobId }, error: String(error) }, '[jobBroker] Failed to clean up interceptor on reject')
                 }
             }
             return { delayInMs: result.delayInMs, priority: result.priority }
@@ -250,7 +250,7 @@ export const jobBroker = (log: FastifyBaseLogger) => ({
             }
         })
         if (error) {
-            log.error({ jobId: input.jobId, error: String(error), originalError: input.errorMessage }, '[jobBroker] Failed to move job to final state — leaving for stalled-scan recovery')
+            log.error({ job: { id: input.jobId }, error: String(error), originalError: input.errorMessage }, '[jobBroker] Failed to move job to final state — leaving for stalled-scan recovery')
             if (userJobData) {
                 await engineResponseWatcher(log).publish(userJobData.webserverId, userJobData.requestId, {
                     status: EngineResponseStatus.INTERNAL_ERROR,
@@ -264,7 +264,7 @@ export const jobBroker = (log: FastifyBaseLogger) => ({
         for (const interceptor of interceptors) {
             const { error: interceptorError } = await tryCatch(() => interceptor.onJobFinished({ jobId: input.jobId, jobData, failed, log }))
             if (interceptorError) {
-                log.error({ jobId: input.jobId, error: String(interceptorError) }, '[jobBroker] Interceptor onJobFinished failed')
+                log.error({ job: { id: input.jobId }, error: String(interceptorError) }, '[jobBroker] Interceptor onJobFinished failed')
             }
         }
     },
@@ -275,7 +275,7 @@ export const jobBroker = (log: FastifyBaseLogger) => ({
             return
         }
         await job.extendLock(input.token, LOCK_DURATION_MS)
-        log.debug({ jobId: input.jobId }, '[jobBroker] Lock extended')
+        log.debug({ job: { id: input.jobId } }, '[jobBroker] Lock extended')
     },
 
     async close(): Promise<void> {

--- a/packages/server/api/src/app/workers/job-queue/job-queue.ts
+++ b/packages/server/api/src/app/workers/job-queue/job-queue.ts
@@ -63,7 +63,7 @@ export const jobQueue = (log: FastifyBaseLogger) => ({
         )
 
         log.info({
-            flowVersionId,
+            flowVersion: { id: flowVersionId },
         }, '[jobQueue#removeRepeatingJob] removed jobs from all queues')
     },
 
@@ -74,13 +74,13 @@ export const jobQueue = (log: FastifyBaseLogger) => ({
         if (!isNil(job)) {
             await job.remove()
             log.info({
-                jobId,
+                job: { id: jobId },
                 queueName,
             }, '[jobQueue#removeOneTimeJob] removed job from queue')
             return
         }
         log.info({
-            jobId,
+            job: { id: jobId },
             queueName,
         }, '[jobQueue#removeOneTimeJob] job not found in queue')
     },

--- a/packages/server/api/src/app/workers/job-queue/queue-dispatcher.ts
+++ b/packages/server/api/src/app/workers/job-queue/queue-dispatcher.ts
@@ -54,10 +54,10 @@ function createQueueDispatcher(params: {
 
             const waiter = waiters.shift()
             if (isNil(waiter)) {
-                log.warn({ queueName, jobId: job.jobId }, '[QueueDispatcher] job dequeued but no waiter available, returning to queue')
+                log.warn({ queueName, job: { id: job.jobId } }, '[QueueDispatcher] job dequeued but no waiter available, returning to queue')
                 const { error: orphanError } = await tryCatch(() => onOrphanedJob(job.jobId, job.token, job.queueName, log))
                 if (orphanError) {
-                    log.error({ queueName, jobId: job.jobId, error: String(orphanError) }, '[QueueDispatcher] failed to return orphaned job to queue')
+                    log.error({ queueName, job: { id: job.jobId }, error: String(orphanError) }, '[QueueDispatcher] failed to return orphaned job to queue')
                 }
                 continue
             }

--- a/packages/server/api/src/app/workers/machine/machine-service.ts
+++ b/packages/server/api/src/app/workers/machine/machine-service.ts
@@ -73,7 +73,7 @@ export const machineService = (log: FastifyBaseLogger) => {
         async onDisconnect(request: OnDisconnectParams): Promise<void> {
             log.info({
                 message: 'Worker disconnected',
-                workerId: request.workerId,
+                worker: { id: request.workerId },
             })
             await workerMachineCache().delete([request.workerId])
         },

--- a/packages/server/api/src/app/workers/migrations/job-data-migrations.ts
+++ b/packages/server/api/src/app/workers/migrations/job-data-migrations.ts
@@ -125,8 +125,8 @@ export const jobMigrations = (log: FastifyBaseLogger) => ({
         let jobData = job as JobData
         log.info({
             schemaVersion: jobData.schemaVersion,
-            jobType: jobData.jobType,
-            projectId: jobData.projectId,
+            job: { type: jobData.jobType },
+            project: { id: jobData.projectId },
         }, '[jobMigrations] Apply migration for job')
         const migrations = createMigrations(log)
         for (const migration of migrations) {

--- a/packages/server/api/src/app/workers/platform-queue-migration.service.ts
+++ b/packages/server/api/src/app/workers/platform-queue-migration.service.ts
@@ -84,7 +84,7 @@ async function migrateSchedulers({ sourceQueue, targetQueue, platformId, batchSi
             ).then(async (data) => {
                 if (!isNil(data)) { // to make sure job is not removed unless it is upserted in target queue
                     log.info({
-                        platformId,
+                        platform: { id: platformId },
                         schedulerId,
                         batch: `${offset}-${offset + batchSize - 1}`,
                     }, '[platformQueueMigrationService#migrateSchedulers] Migrated scheduler to new queue')
@@ -93,7 +93,7 @@ async function migrateSchedulers({ sourceQueue, targetQueue, platformId, batchSi
                 }
                 else {
                     log.error({
-                        platformId,
+                        platform: { id: platformId },
                         schedulerId,
                         batch: `${offset}-${offset + batchSize - 1}`,
                     }, '[platformQueueMigrationService#migrateSchedulers] Failed to migrate scheduler to new queue')
@@ -112,14 +112,14 @@ async function migrateSchedulers({ sourceQueue, targetQueue, platformId, batchSi
     if (!migrationFailed) {
         await removeOrphanedDelayedJobs({ sourceQueue, schedulerIds: migratedSchedulerIds, batchSize })
         log.info({
-            platformId,
+            platform: { id: platformId },
             migratedSchedulers: migratedSchedulerIds.length,
         }, '[platformQueueMigrationService#migrateSchedulers] Migrated schedulers to new queue')
         return
     }
 
     log.error({
-        platformId,
+        platform: { id: platformId },
         migratedSchedulers: migratedSchedulerIds.length,
     }, '[platformQueueMigrationService#migrateSchedulers] Some batches failed to migrate schedulers, delayed orphaned jobs not deleted')
 }

--- a/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
+++ b/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
@@ -65,17 +65,17 @@ function pageOnceForUnreadableAppVersion(log: FastifyBaseLogger, appVersion: str
 export function createHandlers(log: FastifyBaseLogger, workerGroupId?: string): WorkerToApiContract {
     return {
         async poll(input) {
-            log.info({ workerId: input.workerId, workerGroupId }, '[workerRpc#poll] Poll request received')
+            log.info({ worker: { id: input.workerId }, workerGroupId }, '[workerRpc#poll] Poll request received')
             await machineService(log).onConnection(input, workerGroupId)
             const workerVersion = input.workerProps.version
             const appVersion = apVersionUtil.getCurrentRelease()
             if (!apVersionUtil.versionsAreCompatible({ versionA: workerVersion, versionB: appVersion })) {
                 const versionUnreadable = workerVersion === UNKNOWN_VERSION || appVersion === UNKNOWN_VERSION
                 if (versionUnreadable) {
-                    log.error({ workerId: input.workerId, workerVersion, appVersion }, '[workerRpc#poll] Withholding job — a release version could not be read from package.json (reported as 0.0.0); this will NOT self-heal on deploy completion, check the worker/app deployment (cwd/packaging)')
+                    log.error({ worker: { id: input.workerId }, workerVersion, appVersion }, '[workerRpc#poll] Withholding job — a release version could not be read from package.json (reported as 0.0.0); this will NOT self-heal on deploy completion, check the worker/app deployment (cwd/packaging)')
                 }
                 else {
-                    log.warn({ workerId: input.workerId, workerVersion, appVersion }, '[workerRpc#poll] Withholding job — worker version does not match app; worker will idle until upgraded')
+                    log.warn({ worker: { id: input.workerId }, workerVersion, appVersion }, '[workerRpc#poll] Withholding job — worker version does not match app; worker will idle until upgraded')
                 }
                 if (appVersion === UNKNOWN_VERSION) {
                     pageOnceForUnreadableAppVersion(log, appVersion)
@@ -85,16 +85,16 @@ export function createHandlers(log: FastifyBaseLogger, workerGroupId?: string): 
             const pollQueueName = getPollQueueName(workerGroupId)
             const job = await jobBroker(log).poll(pollQueueName)
             if (job) {
-                log.info({ workerId: input.workerId, jobId: job.jobId, jobType: job.jobData.jobType }, '[workerRpc#poll] Returning job to worker')
+                log.info({ worker: { id: input.workerId }, job: { id: job.jobId, type: job.jobData.jobType } }, '[workerRpc#poll] Returning job to worker')
             }
             else {
-                log.debug({ workerId: input.workerId }, '[workerRpc#poll] No job available, returning null')
+                log.debug({ worker: { id: input.workerId } }, '[workerRpc#poll] No job available, returning null')
             }
             return job
         },
 
         async completeJob(input) {
-            log.info({ jobId: input.jobId, status: input.status }, '[workerRpc#completeJob] Job completed by worker')
+            log.info({ job: { id: input.jobId }, status: input.status }, '[workerRpc#completeJob] Job completed by worker')
             await jobBroker(log).completeJob(input)
         },
 
@@ -271,7 +271,7 @@ export function createHandlers(log: FastifyBaseLogger, workerGroupId?: string): 
                     request: { status: FlowStatus.DISABLED },
                 },
             })
-            log.info({ flowId, projectId }, '[workerRpc#disableFlow] Flow disabled by worker request')
+            log.info({ flow: { id: flowId }, project: { id: projectId } }, '[workerRpc#disableFlow] Flow disabled by worker request')
         },
 
         async sendChatEvent(input) {
@@ -334,7 +334,7 @@ async function persistInternalErrorToLogs({ log, projectId, logsFileId, internal
     })
 
     if (error) {
-        log.error({ error, logsFileId, projectId }, '[workerRpc#uploadRunLog] Failed to persist internal error to logs file')
+        log.error({ error, logsFileId, project: { id: projectId } }, '[workerRpc#uploadRunLog] Failed to persist internal error to logs file')
     }
 }
 

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/server-utils",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/server/utils/src/ap-logger.ts
+++ b/packages/server/utils/src/ap-logger.ts
@@ -68,7 +68,7 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
                 }
                 else {
                     if (err) {
-                        log.error({ msg: message ?? err.message, err: `${err.message}\n${err.stack ?? ''}`, ...bindings, ...fields })
+                        log.error({ msg: message ?? err.message, error: `${err.message}\n${err.stack ?? ''}`, ...bindings, ...fields })
                     }
                     else {
                         log.error({ msg: message, ...bindings, ...fields })
@@ -88,7 +88,7 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
                 }
                 else {
                     if (err) {
-                        log.error({ msg: message ?? err.message, err: `${err.message}\n${err.stack ?? ''}`, ...bindings, ...fields })
+                        log.error({ msg: message ?? err.message, error: `${err.message}\n${err.stack ?? ''}`, ...bindings, ...fields })
                     }
                     else {
                         log.error({ msg: message, ...bindings, ...fields })

--- a/packages/server/utils/src/ap-version.ts
+++ b/packages/server/utils/src/ap-version.ts
@@ -24,7 +24,7 @@ function readCurrentRelease(): string {
         }
     }
     catch (e) {
-        logger.warn({ err: e, packageJsonPath, cwd: process.cwd() }, 'failed to read package.json, defaulting current release to 0.0.0')
+        logger.warn({ error: e, packageJsonPath, cwd: process.cwd() }, 'failed to read package.json, defaulting current release to 0.0.0')
         cachedCurrentRelease = UNKNOWN_VERSION
     }
     return cachedCurrentRelease

--- a/packages/server/utils/test/ap-logger.test.ts
+++ b/packages/server/utils/test/ap-logger.test.ts
@@ -79,22 +79,22 @@ describe('apLogger', () => {
             expect(arg.msg).toBeUndefined()
         })
 
-        it('error(Error) logs to log.error with err details', () => {
+        it('error(Error) logs to log.error with error details', () => {
             const logger = apLogger.create({})
             const err = new Error('boom')
             logger.error(err)
             expect(spies.logErrorSpy).toHaveBeenCalledOnce()
             const arg = spies.logErrorSpy.mock.calls[0][0]
-            expect(arg.err).toContain('boom')
+            expect(arg.error).toContain('boom')
         })
 
-        it('error(obj with .err Error) extracts the error', () => {
+        it('error(obj with .err Error) extracts the error under the error key', () => {
             const logger = apLogger.create({})
             const err = new Error('nested')
             logger.error({ err, requestId: 'r1' }, 'context msg')
             expect(spies.logErrorSpy).toHaveBeenCalledOnce()
             const arg = spies.logErrorSpy.mock.calls[0][0]
-            expect(arg.err).toContain('nested')
+            expect(arg.error).toContain('nested')
             expect(arg.requestId).toBe('r1')
         })
 

--- a/packages/server/worker/src/lib/cache/cache-paths.ts
+++ b/packages/server/worker/src/lib/cache/cache-paths.ts
@@ -47,6 +47,6 @@ export async function deleteStaleCache(): Promise<void> {
         }
     }
     catch (error) {
-        logger.error({ err: error }, 'Failed to delete stale cache')
+        logger.error({ error }, 'Failed to delete stale cache')
     }
 }

--- a/packages/server/worker/src/lib/cache/flow/flow-cache.ts
+++ b/packages/server/worker/src/lib/cache/flow/flow-cache.ts
@@ -29,7 +29,7 @@ export const flowCache = (log: ApLogger, apiClient: WorkerToApiContract) => ({
                                 versionId: flowVersionId,
                             })
                             log.info({
-                                flowVersionId,
+                                flowVersion: { id: flowVersionId },
                                 state: flowVersion?.state,
                                 found: !isNil(flowVersion),
                             }, 'Fetched flow version')

--- a/packages/server/worker/src/lib/cache/pieces/piece-cache.ts
+++ b/packages/server/worker/src/lib/cache/pieces/piece-cache.ts
@@ -34,7 +34,7 @@ export const pieceCache = (log: ApLogger, apiClient: WorkerToApiContract) => ({
                     name: 'pieceFetch',
                     fn: async () => {
                         const piecePackage = await getPiecePackage({ pieceName, pieceVersion, platformId }, apiClient)
-                        log.info({ pieceName, pieceVersion, platformId }, 'Cached piece')
+                        log.info({ piece: { name: pieceName, version: pieceVersion }, platform: { id: platformId } }, 'Cached piece')
                         return JSON.stringify(piecePackage)
                     },
                 })

--- a/packages/server/worker/src/lib/egress/iptables-lockdown.ts
+++ b/packages/server/worker/src/lib/egress/iptables-lockdown.ts
@@ -20,7 +20,7 @@ export const iptablesLockdown = {
             for (const args of buildApplyCommandsForFamily({ params, rejectWith: family.rejectWith, family: family.ipFamily })) {
                 const { error } = await tryCatch(() => runRule({ binary: family.binary, args }))
                 if (error) {
-                    log.error({ err: error, binary: family.binary, args }, 'iptables rule failed; rolling back')
+                    log.error({ error, binary: family.binary, args }, 'iptables rule failed; rolling back')
                     await removeLockdown({ log, params })
                     throw new IptablesLockdownError(
                         `Failed to apply ${family.binary} rule "${args.join(' ')}" — ` +
@@ -84,7 +84,7 @@ async function preflightCleanup({ log, params }: { log: ApLogger, params: ApplyP
     for (const family of FAMILIES) {
         for (const args of iptablesLockdown.buildRemoveCommands(params)) {
             const { error } = await tryCatch(() => runRule({ binary: family.binary, args }))
-            if (error) log.debug({ err: error, binary: family.binary, args }, 'preflight cleanup step had no prior state (expected on fresh start)')
+            if (error) log.debug({ error, binary: family.binary, args }, 'preflight cleanup step had no prior state (expected on fresh start)')
         }
     }
 }
@@ -93,7 +93,7 @@ async function removeLockdown({ log, params }: { log: ApLogger, params: ApplyPar
     for (const family of FAMILIES) {
         for (const args of iptablesLockdown.buildRemoveCommands(params)) {
             const { error } = await tryCatch(() => runRule({ binary: family.binary, args }))
-            if (error) log.warn({ err: error, binary: family.binary, args }, 'iptables cleanup command failed (best-effort)')
+            if (error) log.warn({ error, binary: family.binary, args }, 'iptables cleanup command failed (best-effort)')
         }
     }
 }

--- a/packages/server/worker/src/lib/egress/lifecycle.ts
+++ b/packages/server/worker/src/lib/egress/lifecycle.ts
@@ -61,7 +61,7 @@ async function maybeApplyIptablesLockdown({ log, proxy, settings }: ApplyLockdow
     const { nameservers: sandboxNameservers, readError: sandboxResolvConfReadError } = await readSandboxResolvConfNameservers()
     if (sandboxResolvConfReadError !== undefined) {
         log.warn(
-            { sandboxResolvConf: SANDBOX_RESOLV_CONF_PATH, err: sandboxResolvConfReadError },
+            { sandboxResolvConf: SANDBOX_RESOLV_CONF_PATH, error: sandboxResolvConfReadError },
             'Could not read sandbox resolv.conf — DNS allowlist will only include host nameservers, which may not match what the sandbox queries. This is the exact condition that caused the 2026-05-06 EAI_AGAIN outage.',
         )
     }

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-mcp-client.ts
@@ -29,7 +29,7 @@ async function connectMcpClient({ mcpCredentials, conversationId, log }: {
     }))
 
     if (!client) {
-        log.warn({ err: error }, 'Failed to create MCP client — chat will work without MCP tools')
+        log.warn({ error }, 'Failed to create MCP client — chat will work without MCP tools')
         return { mcpClient: null, mcpToolSet: {} }
     }
 

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/chat-worker-tools.ts
@@ -125,7 +125,7 @@ function createEventEmitter({ sendEvent, userId, conversationId, log }: {
             const { error } = await tryCatch(() => sendEvent({ userId, conversationId, event }))
             if (!error) return
             if (attempt === maxAttempts) {
-                log?.warn({ err: error, attempt, eventType: event.type }, 'Event delivery failed after retries')
+                log?.warn({ error, attempt, eventType: event.type }, 'Event delivery failed after retries')
                 return
             }
             const delayMs = attempt === 1 ? 200 : 1_000
@@ -618,7 +618,7 @@ function wrapTestFlowGate({ mcpTools, checkFlowWrites, waitForApproval, storePen
             if (flowId && gateId) {
                 const { data: check, error } = await tryCatch(() => checkFlowWrites(flowId))
                 if (error) {
-                    log?.warn({ err: error, flowId }, 'ap_test_flow write-check failed, running test without confirmation gate')
+                    log?.warn({ error, flow: { id: flowId } }, 'ap_test_flow write-check failed, running test without confirmation gate')
                 }
                 else if (isObject(check) && check['hasWrites'] === true) {
                     const writeSteps = Array.isArray(check['writeSteps']) ? check['writeSteps'].filter((s): s is string => typeof s === 'string') : []

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/execute-chat-agent.ts
@@ -33,7 +33,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
     jobType: WorkerJobType.EXECUTE_CHAT_AGENT,
     async execute(ctx: JobContext, data: ExecuteChatAgentJobData): Promise<FireAndForgetJobResult> {
         const { conversationId, runId, platformId, userId, userMessage, modelName, files, promptOverride, dryRun } = data
-        const log = ctx.log.child({ conversationId })
+        const log = ctx.log.child({ conversation: { id: conversationId } })
 
         const config = await ctx.apiClient.getChatConfig({
             conversationId, runId, platformId, userId, userMessage, modelName, files,
@@ -127,9 +127,9 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
 
             if (abortController.signal.aborted) {
                 if (streamError) {
-                    log.warn({ err: streamError, conversationId }, 'Stream error occurred during abort')
+                    log.warn({ error: streamError, conversation: { id: conversationId } }, 'Stream error occurred during abort')
                 }
-                log.info({ conversationId, completedSteps: abortedStepMessages.length }, 'Chat agent cancelled by user')
+                log.info({ conversation: { id: conversationId }, completedSteps: abortedStepMessages.length }, 'Chat agent cancelled by user')
                 const thinkingDurationMs = Date.now() - thinkingStartTime
                 const cancelSavePayload = {
                     conversationId,
@@ -141,11 +141,11 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
                 }
                 const { error: cancelSaveError } = await tryCatch(() => ctx.apiClient.saveChatMessages(cancelSavePayload))
                 if (cancelSaveError) {
-                    log.warn({ err: cancelSaveError, conversationId }, 'Cancel save failed, retrying')
+                    log.warn({ error: cancelSaveError, conversation: { id: conversationId } }, 'Cancel save failed, retrying')
                     await new Promise((resolve) => setTimeout(resolve, 1_000))
                     const { error: retryError } = await tryCatch(() => ctx.apiClient.saveChatMessages(cancelSavePayload))
                     if (retryError) {
-                        log.error({ err: retryError, conversationId }, 'Cancel save retry also failed')
+                        log.error({ error: retryError, conversation: { id: conversationId } }, 'Cancel save retry also failed')
                     }
                 }
                 await sendEventWithRetry({
@@ -161,7 +161,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             const autoTitle = await autoTitlePromise
 
             log.info({
-                conversationId,
+                conversation: { id: conversationId },
                 continuations,
                 inputTokens: totalInputTokens,
                 outputTokens: totalOutputTokens,
@@ -183,11 +183,11 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             }
             const { error: saveError } = await tryCatch(() => ctx.apiClient.saveChatMessages(savePayload))
             if (saveError) {
-                log.warn({ err: saveError, conversationId }, 'First saveChatMessages attempt failed, retrying')
+                log.warn({ error: saveError, conversation: { id: conversationId } }, 'First saveChatMessages attempt failed, retrying')
                 await new Promise((resolve) => setTimeout(resolve, 1_000))
                 const { error: retryError } = await tryCatch(() => ctx.apiClient.saveChatMessages(savePayload))
                 if (retryError) {
-                    log.error({ err: retryError, conversationId }, 'saveChatMessages retry also failed')
+                    log.error({ error: retryError, conversation: { id: conversationId } }, 'saveChatMessages retry also failed')
                     throw retryError
                 }
             }
@@ -209,7 +209,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             })
         }
         catch (err) {
-            log.error({ err, conversationId }, '[executeChatAgent] Agent job failed')
+            log.error({ error: err, conversation: { id: conversationId } }, '[executeChatAgent] Agent job failed')
             const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
             const errorCode = isCreditExhaustedError(errorMessage) ? ErrorCode.AI_CREDIT_LIMIT_EXCEEDED : undefined
             await ctx.apiClient.saveChatMessages({
@@ -227,7 +227,7 @@ export const executeChatAgentJob: JobHandler<ExecuteChatAgentJobData, FireAndFor
             clearInterval(cancelCheckInterval)
             if (mcpClient) {
                 await mcpClient.close().catch((closeErr: unknown) => {
-                    log.warn({ err: closeErr }, 'Failed to close MCP client')
+                    log.warn({ error: closeErr }, 'Failed to close MCP client')
                 })
             }
         }
@@ -279,7 +279,7 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, mcpToolSet, projects
                 toolName: '__approval_wait', toolInput: { gateId, timeoutMs: blockMs }, platformId, userId,
             }))
             if (error) {
-                log.warn({ err: error, gateId }, 'Approval wait RPC failed, retrying')
+                log.warn({ error, gateId }, 'Approval wait RPC failed, retrying')
                 await new Promise((resolve) => setTimeout(resolve, 1_000))
                 continue
             }
@@ -395,7 +395,7 @@ async function streamChunksToClient({ result, ctx, userId, conversationId, runId
                 flushTimer = setTimeout(() => {
                     flushTimer = null
                     flushChunks().catch((err: unknown) => {
-                        log.error({ err, conversationId }, 'Failed to flush chat chunk batch')
+                        log.error({ error: err, conversation: { id: conversationId } }, 'Failed to flush chat chunk batch')
                     })
                 }, BATCH_FLUSH_MS)
             }
@@ -430,7 +430,7 @@ async function generateTitleIfFirstTurn({ model, userMessage, previousUiMessages
     })
 
     if (!generatedTitle) {
-        log.warn({ conversationId }, 'Failed to auto-generate title')
+        log.warn({ conversation: { id: conversationId } }, 'Failed to auto-generate title')
     }
     return generatedTitle ?? undefined
 }
@@ -450,7 +450,7 @@ async function retryWithBackoff({ fn, maxAttempts = RETRY_MAX_ATTEMPTS, log }: {
         const { error } = await tryCatch(fn)
         if (!error) return
         if (attempt === maxAttempts) {
-            log?.warn({ err: error, attempt }, 'All retry attempts exhausted')
+            log?.warn({ error, attempt }, 'All retry attempts exhausted')
             return
         }
         await delayWithJitter(RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1))

--- a/packages/server/worker/src/lib/execute/jobs/ee/chat/run-chat-turn.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/chat/run-chat-turn.ts
@@ -73,7 +73,7 @@ export async function runChatTurn({ model, provider, systemPrompt, messages, too
             return { activeTools: chatToolPhases.activeToolsForPhase({ phase: phaseState.phase, allToolNames }) }
         },
         experimental_repairToolCall: async ({ toolCall, error }) => {
-            log.warn({ toolName: toolCall.toolName, err: error }, 'Repairing malformed tool call')
+            log.warn({ toolName: toolCall.toolName, error }, 'Repairing malformed tool call')
             const { data: repaired } = await tryCatch(async () => {
                 const { text } = await generateText({
                     model,
@@ -96,7 +96,7 @@ export async function runChatTurn({ model, provider, systemPrompt, messages, too
                 log.info({ toolName: result.toolCall.toolName, durationMs: result.durationMs }, 'Tool call completed')
             }
             else {
-                log.warn({ toolName: result.toolCall.toolName, durationMs: result.durationMs, err: result.error }, 'Tool call failed')
+                log.warn({ toolName: result.toolCall.toolName, durationMs: result.durationMs, error: result.error }, 'Tool call failed')
             }
         },
         onAbort: ({ steps }) => {
@@ -107,7 +107,7 @@ export async function runChatTurn({ model, provider, systemPrompt, messages, too
             onProgress([...uiParts])
         },
         onError: ({ error }) => {
-            log.error({ err: error }, 'Chat streamText error')
+            log.error({ error }, 'Chat streamText error')
             streamError = error instanceof Error ? error : new Error(String(error))
         },
     })
@@ -121,7 +121,7 @@ export async function runChatTurn({ model, provider, systemPrompt, messages, too
         if (streamError) {
             if (shouldRetryStream({ producedVisibleOutput, streamRetries })) {
                 streamRetries++
-                log.warn({ streamRetries, err: streamError }, 'Chat stream failed before any visible output — retrying the turn')
+                log.warn({ streamRetries, error: streamError }, 'Chat stream failed before any visible output — retrying the turn')
                 streamError = null
                 await delayWithJitter(STREAM_RETRY_BASE_DELAY_MS)
                 continue

--- a/packages/server/worker/src/lib/execute/jobs/event-destination.ts
+++ b/packages/server/worker/src/lib/execute/jobs/event-destination.ts
@@ -25,7 +25,7 @@ export const eventDestinationJob: JobHandler<EventDestinationJobData, FireAndFor
         if (error) {
             ctx.log.warn({
                 webhookUrl: data.webhookUrl,
-                webhookId: data.webhookId,
+                webhook: { id: data.webhookId },
                 error: error.message,
             }, 'Event destination request failed before reaching the server')
         }

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -30,7 +30,7 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResu
 
         const flowVersion = await flowCache(ctx.log, ctx.apiClient).getVersion({ flowVersionId: data.flowVersionId })
         if (isNil(flowVersion)) {
-            ctx.log.info({ flowVersionId: data.flowVersionId }, 'Flow version not found, skipping')
+            ctx.log.info({ flowVersion: { id: data.flowVersionId } }, 'Flow version not found, skipping')
             await reportFlowStatus(ctx, data, FlowRunStatus.FAILED)
             return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.INTERNAL_ERROR }
         }
@@ -183,7 +183,7 @@ async function reportFlowStatus(
             code: ErrorCode.ENGINE_OPERATION_FAILURE,
             message: `Flow run ${data.runId} ended with INTERNAL_ERROR`,
             params: { runId: data.runId, flowId: data.flowId, projectId: data.projectId },
-        }).catch((e) => ctx.log.error({ flowRunId: data.runId, error: inspect(e) }, 'Failed to send on-call page for INTERNAL_ERROR'))
+        }).catch((e) => ctx.log.error({ flowRun: { id: data.runId }, error: inspect(e) }, 'Failed to send on-call page for INTERNAL_ERROR'))
     }
 }
 

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -183,7 +183,7 @@ async function reportFlowStatus(
             code: ErrorCode.ENGINE_OPERATION_FAILURE,
             message: `Flow run ${data.runId} ended with INTERNAL_ERROR`,
             params: { runId: data.runId, flowId: data.flowId, projectId: data.projectId },
-        }).catch((e) => ctx.log.error({ runId: data.runId, error: inspect(e) }, 'Failed to send on-call page for INTERNAL_ERROR'))
+        }).catch((e) => ctx.log.error({ flowRunId: data.runId, error: inspect(e) }, 'Failed to send on-call page for INTERNAL_ERROR'))
     }
 }
 

--- a/packages/server/worker/src/lib/execute/jobs/execute-trigger-hook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-trigger-hook.ts
@@ -20,13 +20,13 @@ export const executeTriggerHookJob: JobHandler<ExecuteTriggerHookJobData, Synchr
 
         const flowVersion = await flowCache(ctx.log, ctx.apiClient).getVersion({ flowVersionId: data.flowVersionId })
         if (!flowVersion) {
-            ctx.log.info({ flowVersionId: data.flowVersionId }, 'Flow version not found for trigger hook, skipping')
+            ctx.log.info({ flowVersion: { id: data.flowVersionId } }, 'Flow version not found for trigger hook, skipping')
             return { kind: JobResultKind.SYNCHRONOUS, status: EngineResponseStatus.OK, response: undefined }
         }
 
         const provisioned = await provisionFlowPieces({ flowVersion, platformId: data.platformId, flowId: data.flowId, projectId: data.projectId, log: ctx.log, apiClient: ctx.apiClient })
         if (!provisioned) {
-            ctx.log.info({ flowId: data.flowId }, 'Failed to provision pieces for trigger hook, skipping')
+            ctx.log.info({ flow: { id: data.flowId } }, 'Failed to provision pieces for trigger hook, skipping')
             return { kind: JobResultKind.SYNCHRONOUS, status: EngineResponseStatus.OK, response: undefined }
         }
 

--- a/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
@@ -42,7 +42,7 @@ export const executeWebhookJob: JobHandler<WebhookJobData, FireAndForgetJobResul
 
         const flowVersion = await flowCache(ctx.log, ctx.apiClient).getVersion({ flowVersionId: data.flowVersionIdToRun })
         if (isNil(flowVersion)) {
-            ctx.log.info({ flowVersionId: data.flowVersionIdToRun }, 'Flow version not found for webhook, skipping')
+            ctx.log.info({ flowVersion: { id: data.flowVersionIdToRun } }, 'Flow version not found for webhook, skipping')
             return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
         }
 
@@ -126,7 +126,7 @@ export const executeWebhookJob: JobHandler<WebhookJobData, FireAndForgetJobResul
         if (error) {
             await ctx.sandboxManager.invalidate(ctx.log)
             if (isSandboxTimeout(error)) {
-                ctx.log.warn({ flowVersionId: data.flowVersionIdToRun }, 'Webhook execution timed out in sandbox')
+                ctx.log.warn({ flowVersion: { id: data.flowVersionIdToRun } }, 'Webhook execution timed out in sandbox')
                 return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
             }
             throw error

--- a/packages/server/worker/src/lib/execute/jobs/renew-webhook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/renew-webhook.ts
@@ -19,7 +19,7 @@ export const renewWebhookJob: JobHandler<RenewWebhookJobData, FireAndForgetJobRe
 
         const flowVersion = await flowCache(ctx.log, ctx.apiClient).getVersion({ flowVersionId: data.flowVersionId })
         if (isNil(flowVersion)) {
-            ctx.log.info({ flowVersionId: data.flowVersionId }, 'Flow version not found for renew webhook, skipping')
+            ctx.log.info({ flowVersion: { id: data.flowVersionId } }, 'Flow version not found for renew webhook, skipping')
             return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
         }
 

--- a/packages/server/worker/src/lib/execute/sandbox-manager.ts
+++ b/packages/server/worker/src/lib/execute/sandbox-manager.ts
@@ -16,7 +16,7 @@ export function createSandboxManager({ boxId, proxyPort }: { boxId: number, prox
             if (currentSandbox) {
                 params.log.info('Sandbox not ready or not reusable, creating fresh one')
                 currentSandbox.shutdown().catch((err) =>
-                    params.log.error({ err }, 'Error shutting down previous sandbox'),
+                    params.log.error({ error: err }, 'Error shutting down previous sandbox'),
                 )
             }
             currentSandbox = createSandboxForJob({ ...params, boxId, reusable: canReuseSandbox(), proxyPort })

--- a/packages/server/worker/src/lib/execute/utils/flow-helpers.ts
+++ b/packages/server/worker/src/lib/execute/utils/flow-helpers.ts
@@ -22,12 +22,12 @@ export async function provisionFlowPieces(params: {
         if (!(error instanceof PieceNotFoundError)) {
             throw error
         }
-        log.warn({ error: String(error), flowId }, 'Flow disabled due to missing piece')
+        log.warn({ error: String(error), flow: { id: flowId } }, 'Flow disabled due to missing piece')
         const { error: disableError } = await tryCatch(
             () => apiClient.disableFlow({ flowId, projectId }),
         )
         if (disableError) {
-            log.error({ error: String(disableError), flowId }, 'Failed to disable flow after missing piece')
+            log.error({ error: String(disableError), flow: { id: flowId } }, 'Failed to disable flow after missing piece')
         }
         return false
     }

--- a/packages/server/worker/src/lib/sandbox/isolate.ts
+++ b/packages/server/worker/src/lib/sandbox/isolate.ts
@@ -115,7 +115,7 @@ export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDire
                 engineSandboxPath,
             ]
 
-            log.debug({ sandboxId, command: `${isolateBinaryPath} ${args.join(' ')}` }, 'Spawning isolate process')
+            log.debug({ sandbox: { id: sandboxId }, command: `${isolateBinaryPath} ${args.join(' ')}` }, 'Spawning isolate process')
 
             const child = spawn(isolateBinaryPath, args, {
                 shell: false,

--- a/packages/server/worker/src/lib/sandbox/sandbox.ts
+++ b/packages/server/worker/src/lib/sandbox/sandbox.ts
@@ -82,17 +82,17 @@ export function createSandbox(
 
         io.on('connection', (socket) => {
             if (!isNil(connectedSocket) && connectedSocket.connected) {
-                log.warn({ sandboxId, socketId: socket.id }, '[WebSocket] Rejecting extra connection — sandbox already has an active socket')
+                log.warn({ sandbox: { id: sandboxId }, socketId: socket.id }, '[WebSocket] Rejecting extra connection — sandbox already has an active socket')
                 socket.disconnect(true)
                 return
             }
             connectedSocket = socket
-            log.info({ sandboxId, socketId: socket.id }, '[WebSocket] Sandbox connected')
+            log.info({ sandbox: { id: sandboxId }, socketId: socket.id }, '[WebSocket] Sandbox connected')
 
             createRpcServer<WorkerContract>(socket, workerHandlers)
 
             socket.on('disconnect', (reason) => {
-                log.info({ sandboxId, reason, socketId: socket.id }, '[WebSocket] Sandbox disconnected')
+                log.info({ sandbox: { id: sandboxId }, reason, socketId: socket.id }, '[WebSocket] Sandbox disconnected')
                 if (connectedSocket === socket) {
                     connectedSocket = null
                 }
@@ -141,9 +141,9 @@ export function createSandbox(
                 return
             }
             log.debug({
-                sandboxId,
-                flowVersionId: flowVersionId ?? 'undefined',
-                platformId,
+                sandbox: { id: sandboxId },
+                flowVersion: { id: flowVersionId ?? 'undefined' },
+                platform: { id: platformId },
             }, 'Starting sandbox')
 
             wsRpcToken = randomBytes(32).toString('hex')
@@ -200,9 +200,9 @@ export function createSandbox(
             childProcess!.removeAllListeners('exit')
 
             log.debug({
-                sandboxId,
-                flowVersionId: flowVersionId ?? 'undefined',
-                platformId,
+                sandbox: { id: sandboxId },
+                flowVersion: { id: flowVersionId ?? 'undefined' },
+                platform: { id: platformId },
             }, 'Sandbox started')
         },
         execute: async (operationType: EngineOperationType, operation: EngineOperation, executeOptions: SandboxOptions) => {
@@ -229,14 +229,14 @@ export function createSandbox(
 
                 timeout = setTimeout(async () => {
                     killedByTimeout = true
-                    log.debug({ sandboxId }, 'Killing sandbox by timeout')
+                    log.debug({ sandbox: { id: sandboxId } }, 'Killing sandbox by timeout')
                     if (!isNil(executeProcess)) {
                         await killProcess(executeProcess, log)
                     }
                 }, executeOptions.timeoutInSeconds * 1000)
 
                 executeProcess.on('error', (error) => {
-                    log.error({ sandboxId, error: String(error) }, 'Sandbox process error')
+                    log.error({ sandbox: { id: sandboxId }, error: String(error) }, 'Sandbox process error')
                 })
 
                 executeProcess.on('exit', (code, signal) => {
@@ -253,13 +253,13 @@ export function createSandbox(
                     })
                 })
 
-                log.debug({ sandboxId, operationType }, '[Sandbox] Executing operation via RPC')
+                log.debug({ sandbox: { id: sandboxId }, operationType }, '[Sandbox] Executing operation via RPC')
                 const operationTimeoutMs = (executeOptions.timeoutInSeconds + 5) * 1000
                 const client = createRpcClient<EngineContract>(executeSocket, operationTimeoutMs)
                 client.executeOperation({ operationType, operation }).then((engineResponse: EngineResponse<unknown>) => {
                     resolve({ ...engineResponse, logs: buildLogs(stdOut, stdError) })
                 }).catch((error: unknown) => {
-                    log.error({ sandboxId, error: String(error) }, '[Sandbox] RPC call failed')
+                    log.error({ sandbox: { id: sandboxId }, error: String(error) }, '[Sandbox] RPC call failed')
                     reject(error)
                 })
             })
@@ -270,7 +270,7 @@ export function createSandbox(
             finally {
                 busy = false
                 log.debug({
-                    sandboxId,
+                    sandbox: { id: sandboxId },
                     operationType,
                     killedByTimeout: String(killedByTimeout),
                 }, '[Sandbox] Execute completed (finally block)')
@@ -288,7 +288,7 @@ export function createSandbox(
         shutdown: async () => {
             if (!isNil(childProcess)) {
                 killedByShutdown = true
-                log.debug({ sandboxId }, 'Shutting down sandbox')
+                log.debug({ sandbox: { id: sandboxId } }, 'Shutting down sandbox')
                 await killProcess(childProcess, log)
                 childProcess = null
             }
@@ -308,7 +308,7 @@ export function createSandbox(
 function handleProcessExit(log: SandboxLogger, params: ProcessExitParams): void {
     const { sandboxId, operationType, code, signal, killedByTimeout, killedByShutdown, stdOut, stdError, reject } = params
     log.info({
-        sandboxId,
+        sandbox: { id: sandboxId },
         operationType,
         code: String(code),
         signal: signal ?? 'null',
@@ -383,13 +383,13 @@ function authenticateHandshake({ getExpectedToken, log, sandboxId }: {
         const provided = socket.handshake.auth?.['connectionToken']
         const expected = getExpectedToken()
         if (typeof provided !== 'string' || expected === null) {
-            log.warn({ sandboxId, socketId: socket.id }, '[WebSocket] Rejecting handshake: missing connection token')
+            log.warn({ sandbox: { id: sandboxId }, socketId: socket.id }, '[WebSocket] Rejecting handshake: missing connection token')
             return next(new Error('unauthorized'))
         }
         const a = Buffer.from(provided)
         const b = Buffer.from(expected)
         if (a.length !== b.length || !timingSafeEqual(a, b)) {
-            log.warn({ sandboxId, socketId: socket.id }, '[WebSocket] Rejecting handshake: invalid connection token')
+            log.warn({ sandbox: { id: sandboxId }, socketId: socket.id }, '[WebSocket] Rejecting handshake: invalid connection token')
             return next(new Error('unauthorized'))
         }
         next()

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -86,7 +86,7 @@ export const worker = {
                     // Kill switch: if SSRF hardening can't be applied, refuse to accept any job.
                     // Running without egress protection in a configured-hardened worker is
                     // more dangerous than crash-looping — the orchestrator will restart us.
-                    logger.fatal({ err: error }, 'Egress stack failed to start; aborting worker to avoid running unprotected')
+                    logger.fatal({ error }, 'Egress stack failed to start; aborting worker to avoid running unprotected')
                     process.exit(1)
                 }
                 egressStack = data
@@ -197,12 +197,12 @@ async function pollAndExecute(apiClient: WorkerToApiContract, sbManager: Sandbox
             continue
         }
 
-        workerLog.debug({ jobId: job.jobId, jobType: job.jobData.jobType }, 'Job received from poll')
+        workerLog.debug({ job: { id: job.jobId, type: job.jobData.jobType } }, 'Job received from poll')
 
         const lockExtensionInterval = setInterval(() => {
             void tryCatch(() => apiClient.extendLock({ jobId: job.jobId, token: job.token, queueName: job.queueName })).then(({ error }) => {
                 if (error) {
-                    workerLog.warn({ error, jobId: job.jobId }, 'Failed to extend lock')
+                    workerLog.warn({ error, job: { id: job.jobId } }, 'Failed to extend lock')
                 }
             })
         }, 30_000)
@@ -229,7 +229,7 @@ async function pollAndExecute(apiClient: WorkerToApiContract, sbManager: Sandbox
         clearInterval(lockExtensionInterval)
 
         if (completeError) {
-            workerLog.error({ error: completeError, jobId: job.jobId }, 'Failed to complete job')
+            workerLog.error({ error: completeError, job: { id: job.jobId } }, 'Failed to complete job')
         }
     }
 }
@@ -239,19 +239,18 @@ async function executeJob(apiClient: WorkerToApiContract, job: ConsumeJobRequest
     const jobData = JobData.parse(rawData)
     const jobLogger = createLogger({
         event: 'job.execute',
-        jobId: job.jobId,
-        jobType: jobData.jobType,
+        job: { id: job.jobId, type: jobData.jobType },
         ...spreadIfDefined('requestId', 'requestId' in jobData ? jobData.requestId : 'httpRequestId' in jobData ? jobData.httpRequestId : undefined),
-        ...spreadIfDefined('projectId', 'projectId' in jobData && jobData.projectId != null ? jobData.projectId : undefined),
-        ...spreadIfDefined('platformId', 'platformId' in jobData ? jobData.platformId : undefined),
-        ...spreadIfDefined('flowId', 'flowId' in jobData ? jobData.flowId : undefined),
-        ...spreadIfDefined('flowRunId', 'runId' in jobData ? jobData.runId : undefined),
-        ...spreadIfDefined('flowVersionId', 'flowVersionId' in jobData ? jobData.flowVersionId : undefined),
+        ...spreadIfDefined('project', 'projectId' in jobData && jobData.projectId != null ? { id: jobData.projectId } : undefined),
+        ...spreadIfDefined('platform', 'platformId' in jobData ? { id: jobData.platformId } : undefined),
+        ...spreadIfDefined('flow', 'flowId' in jobData ? { id: jobData.flowId } : undefined),
+        ...spreadIfDefined('flowRun', 'runId' in jobData ? { id: jobData.runId } : undefined),
+        ...spreadIfDefined('flowVersion', 'flowVersionId' in jobData ? { id: jobData.flowVersionId } : undefined),
     })
     return wideEvent.run({
         logger: jobLogger,
         fn: async () => {
-            const log = logger.child({ jobId: job.jobId, jobType: jobData.jobType })
+            const log = logger.child({ job: { id: job.jobId, type: jobData.jobType } })
             const apiUrl = getApiUrl()
             const { PUBLIC_URL: publicUrl } = await workerSettings.waitForSettings()
             log.debug({ apiUrl, publicUrl }, 'Worker settings resolved')
@@ -269,7 +268,7 @@ async function executeJob(apiClient: WorkerToApiContract, job: ConsumeJobRequest
                 log.debug({ handlerType: handler.jobType }, 'Executing job with handler')
                 const { data: result, error } = await tryCatch(() => handler.execute(ctx, jobData))
                 if (error) {
-                    log.error({ err: error }, 'Job execution failed')
+                    log.error({ error }, 'Job execution failed')
                     wideEvent.error(error)
                     wideEvent.set({ outcome: 'failed' })
                     throw error

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -245,7 +245,7 @@ async function executeJob(apiClient: WorkerToApiContract, job: ConsumeJobRequest
         ...spreadIfDefined('projectId', 'projectId' in jobData && jobData.projectId != null ? jobData.projectId : undefined),
         ...spreadIfDefined('platformId', 'platformId' in jobData ? jobData.platformId : undefined),
         ...spreadIfDefined('flowId', 'flowId' in jobData ? jobData.flowId : undefined),
-        ...spreadIfDefined('runId', 'runId' in jobData ? jobData.runId : undefined),
+        ...spreadIfDefined('flowRunId', 'runId' in jobData ? jobData.runId : undefined),
         ...spreadIfDefined('flowVersionId', 'flowVersionId' in jobData ? jobData.flowVersionId : undefined),
     })
     return wideEvent.run({


### PR DESCRIPTION
## What
Logs referred to the same concept under inconsistent keys — the FlowRun id appeared as `runId`, `flowRunId`, **and** a bare `id`; errors split between `err` and `error`; entity ids were flat and ungrouped. This breaks correlation queries and dashboards.

This migrates **every** structured-log call across the server to evlog's grouped schema: fields are nested under the entity they belong to, so each concept has exactly one queryable path.

## How
Following [evlog's guidance](https://www.evlog.dev/learn/wide-events) (grouped > flat-prefixed; flattens to OpenTelemetry-style `entity.id`), the metadata object of every logging call (`logger.*`, `log.child`, `createLogger`, `wideEvent.set`) now uses groups:

- `runId`/`flowRunId`/bare run id → `flowRun: { id }`
- `flowId` → `flow: { id }`, `flowVersionId` → `flowVersion: { id }`
- `projectId`/`platformId`/`userId` → `project|platform|user: { id }`
- `{ jobId, jobType }` → `job: { id, type }`, `{ pieceName, pieceVersion }` → `piece: { name, version }`
- `sandboxId`/`workerId`/`webhookId`/`connectionId`/`conversationId`/`waitpointId` → their groups
- `stepName`/`triggerName` → `step|trigger: { name }`
- generic `err` → `error` (also normalized in `ap-logger`)

**Only logging metadata objects were touched.** Data-model/wire fields (`JobData.runId`), DB query args, service-call arguments, DTOs, return values, on-call `params`, and client event payloads keep their flat keys. `requestId`/`traceId` stay flat (reserved). Done via a fan-out of subagents over api / worker / engine / utils / migrations.

## Scope
108 files, ~210 logging sites grouped. `api` + `worker` + `engine` + `server-utils` lint clean (0 errors); all 112 server-utils tests pass.

## Docs
- `packages/server/AGENTS.md` → Structured Logging Field Schema (grouped convention + canonical groups)
- `docs/handbook/engineering/playbooks/structured-logging.mdx` (external playbook)
- `docs/install/configuration/breaking-changes.mdx` (`runId`/`id` → `flowRun.id`, `err` → `error`; plus the earlier evlog migration)

## Breaking change
The **shape of emitted logs** changes (e.g. `runId` → `flowRun.id`). Dashboards/alerts keyed on the old field names must update. No API/DB/flow behavior changes.