### PR TITLE
fix(chat): don't gate eval endpoints on platform chatEnabled

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -43,7 +43,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 
 ## Edition Availability
 - Community (CE): not available (module not registered)
-- Enterprise (EE): available when `platform.plan.chatEnabled` is true; the eval/playground endpoints (`/v1/chat/eval/*`) are platformAdmin-only (SERVICE principal)
+- Enterprise (EE): available when `platform.plan.chatEnabled` is true; the eval/playground endpoints (`/v1/chat/eval/*`) are internal global-API-key dry-runs and do **not** require `chatEnabled` (they run as the platform owner with tools disabled)
 - Cloud: available when `platform.plan.chatEnabled` is true
 
 ## Domain Terms
@@ -114,11 +114,11 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - `POST /v1/chat/conversations/:id/cancel` — cancel an in-progress streaming response
 - `GET /v1/chat/conversations/:id/connections?pieceName=` — get available connections for connection picker; falls back to `findConnectionsForPiece` when the Redis cache is empty and stores the result for future calls
 - `GET /v1/chat/conversations/:id/pending-gate` — get pending approval gate for refresh resilience (returns gate info so the frontend can re-show display tool cards)
-- `GET /v1/chat/eval/prompt-sources` — returns the raw prompt template sources (core + project-context + on-demand guides); requires platformAdmin
-- `POST /v1/chat/eval/simulate` — replays one or more user turns (`userMessages[]`, or legacy single `userMessage`) sequentially in one ephemeral conversation with an optional prompt override in dry-run mode (tools are not executed, no MCP, runs as the platform owner — no side effects, no sandbox), polls until each turn settles, and returns the full transcript synchronously (`status` is `IDLE`/`ERROR`/`TIMEOUT`); the `promptOverride.guides` is shallow-merged over the defaults so a partial override keeps the untouched guides; requires platformAdmin
-- `GET /v1/chat/eval/sandbox-platform` — returns `{ platformId }` for the oldest platform on the instance, so a caller replaying a foreign conversation (e.g. the console in dev, whose conversations reference a cloud platform absent locally) can resolve a local platform to sandbox the dry-run in; requires platformAdmin
-- `POST /v1/chat/eval/turn/start` — interactive eval: create-or-continue a stateful eval conversation and enqueue ONE dry-run agent turn, returning immediately (`{ conversationId, runId, priorAssistantTurns }`); the caller polls the state endpoint to stream progress (the worker persists `uiMessages` per step). New conversations are created with a reserved id prefix (see **Eval conversation scoping**); continuation rejects a conversation that is already STREAMING (409, no racing two workers on one row) and any id not created by the eval flow (404); requires platformAdmin
-- `GET /v1/chat/eval/conversations/:id/state` — pure observer that reads the row directly (not `getConversationOrThrow`, which would reset a stale STREAMING row to IDLE) and returns `{ status, uiMessages }`; rejects non-eval conversation ids (404); requires platformAdmin
+- `GET /v1/chat/eval/prompt-sources` — returns the raw prompt template sources (core + project-context + on-demand guides); requires the global eval API key
+- `POST /v1/chat/eval/simulate` — replays one or more user turns (`userMessages[]`, or legacy single `userMessage`) sequentially in one ephemeral conversation with an optional prompt override in dry-run mode (tools are not executed, no MCP, runs as the platform owner — no side effects, no sandbox), polls until each turn settles, and returns the full transcript synchronously (`status` is `IDLE`/`ERROR`/`TIMEOUT`); the `promptOverride.guides` is shallow-merged over the defaults so a partial override keeps the untouched guides; requires the global eval API key
+- `GET /v1/chat/eval/sandbox-platform` — returns `{ platformId }` for the oldest platform on the instance, so a caller replaying a foreign conversation (e.g. the console in dev, whose conversations reference a cloud platform absent locally) can resolve a local platform to sandbox the dry-run in; requires the global eval API key
+- `POST /v1/chat/eval/turn/start` — interactive eval: create-or-continue a stateful eval conversation and enqueue ONE dry-run agent turn, returning immediately (`{ conversationId, runId, priorAssistantTurns }`); the caller polls the state endpoint to stream progress (the worker persists `uiMessages` per step). New conversations are created with a reserved id prefix (see **Eval conversation scoping**); continuation rejects a conversation that is already STREAMING (409, no racing two workers on one row) and any id not created by the eval flow (404); requires the global eval API key
+- `GET /v1/chat/eval/conversations/:id/state` — pure observer that reads the row directly (not `getConversationOrThrow`, which would reset a stale STREAMING row to IDLE) and returns `{ status, uiMessages }`; rejects non-eval conversation ids (404); requires the global eval API key
 
 - `POST /v1/admin/chat/sync-all` — bulk historical sync of all conversations to console analytics (admin API key required)
 

--- a/packages/server/api/src/app/ee/chat/chat-eval-controller.ts
+++ b/packages/server/api/src/app/ee/chat/chat-eval-controller.ts
@@ -1,9 +1,7 @@
 import {
-    ActivepiecesError,
     apId,
     ChatConversationStatus,
     ChatPromptOverride,
-    ErrorCode,
     isNil,
     LATEST_JOB_DATA_SCHEMA_VERSION,
     PersistedChatRole,
@@ -66,16 +64,8 @@ const chatEvalController: FastifyPluginAsyncZod = async (app) => {
         const { platformId, userMessage, userMessages, promptOverride } = request.body
         const turns = userMessages ?? [userMessage as string]
 
-        // dryRun runs as the platform owner with tools disabled — no side effects. Gate it behind
-        // the same chatEnabled plan flag the production chat path requires, so the eval can't run the
-        // chat loop for a platform that isn't entitled to it.
-        const platform = await platformService(log).getOneWithPlanOrThrow(platformId)
-        if (!platform.plan.chatEnabled) {
-            throw new ActivepiecesError({
-                code: ErrorCode.FEATURE_DISABLED,
-                params: { message: 'Chat is disabled for this platform' },
-            })
-        }
+        // Eval is an internal api-key dry-run, so it doesn't require the platform's chatEnabled entitlement.
+        const platform = await platformService(log).getOneOrThrow(platformId)
         const evalUserId = platform.ownerId
 
         const conversation = await chatService(log).createConversation({
@@ -158,13 +148,7 @@ const chatEvalController: FastifyPluginAsyncZod = async (app) => {
             if (isNil(platformId)) {
                 return reply.status(StatusCodes.BAD_REQUEST).send({ message: 'platformId is required to start a new conversation' })
             }
-            const platform = await platformService(log).getOneWithPlanOrThrow(platformId)
-            if (!platform.plan.chatEnabled) {
-                throw new ActivepiecesError({
-                    code: ErrorCode.FEATURE_DISABLED,
-                    params: { message: 'Chat is disabled for this platform' },
-                })
-            }
+            const platform = await platformService(log).getOneOrThrow(platformId)
             evalPlatformId = platformId
             evalUserId = platform.ownerId
             const conversation = await chatService(log).createConversation({ platformId, userId: evalUserId, request: {}, id: (EVAL_CONVERSATION_ID_PREFIX + apId()).slice(0, 21) })


### PR DESCRIPTION
## What

The chat eval/playground endpoints (`/v1/chat/eval/simulate`, `/v1/chat/eval/turn/start`) are **internal, api-key-authenticated dry-runs** (tools disabled, no side effects) used by the console to improve the global chat prompt. They were gating on the target platform's `chatEnabled` *entitlement* flag, which is a customer-facing feature gate that doesn't apply here.

On cloud this 402'd: the eval runs on the sandbox platform (oldest platform on the instance), which has chat disabled → `FEATURE_DISABLED`.

## Change

- Drop the `chatEnabled` gate from both eval endpoints.
- Use `getOneOrThrow` instead of `getOneWithPlanOrThrow` (we only need the platform to run the dry-run as its owner — no plan/entitlement lookup), and remove the now-unused `ActivepiecesError`/`ErrorCode` imports.

## Note

This clears the entitlement 402. The dry-run still resolves an AI provider for the platform (`resolveChatProvider`); on cloud that resolves the managed Activepieces provider, so no per-platform chat config is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)