### PR TITLE
fix(e2e): land on automations after login when chat is the default

### DIFF
--- a/packages/tests-e2e/fixtures/index.ts
+++ b/packages/tests-e2e/fixtures/index.ts
@@ -18,10 +18,10 @@ type CustomFixtures = {
 };
 
 export const test = base.extend<CustomFixtures>({
-  // Override page fixture to automatically authenticate before each test
+  // Authenticate before each test, then land on the automations dashboard.
   page: async ({ page }, use) => {
     const authPage = new AuthenticationPage(page);
-    
+
     if (process.env.E2E_EMAIL && process.env.E2E_PASSWORD) {
       await authPage.signIn({
         email: process.env.E2E_EMAIL,
@@ -33,7 +33,9 @@ export const test = base.extend<CustomFixtures>({
         password: DEFAULT_PASSWORD,
       });
     }
-    
+
+    await new AutomationsPage(page).open();
+
     await use(page);
   },
 

--- a/packages/tests-e2e/global-setup.ts
+++ b/packages/tests-e2e/global-setup.ts
@@ -1,5 +1,6 @@
 import { chromium } from '@playwright/test';
 import { AuthenticationPage } from './pages/authentication.page';
+import { AutomationsPage } from './pages/automations.page';
 
 export const DEFAULT_EMAIL = 'test@activepieces.com';
 export const DEFAULT_PASSWORD = 'TestPassword123!@#';
@@ -32,8 +33,7 @@ async function globalSetup() {
       });
     }
 
-    // Wait for successful authentication (redirect to automations page)
-    await page.waitForURL('**/automations', { timeout: 15000 });
+    await new AutomationsPage(page).open();
 
     console.log('✓ Global setup completed successfully');
   } catch (error) {

--- a/packages/tests-e2e/pages/automations.page.ts
+++ b/packages/tests-e2e/pages/automations.page.ts
@@ -8,6 +8,19 @@ export class AutomationsPage extends BasePage {
     await this.waitFor();
   }
 
+  // Login may land on the chat page when chat is enabled, so navigate to
+  // automations explicitly instead of relying on the landing page.
+  async open() {
+    await this.page.waitForURL(
+      (url) =>
+        !url.pathname.includes('/sign-in') &&
+        !url.pathname.includes('/sign-up'),
+      { timeout: 15000 },
+    );
+    await this.visit();
+    await this.waitFor();
+  }
+
   async waitFor() {
     await this.page.waitForURL('**/automations**');
     await Promise.race([


### PR DESCRIPTION
PR #13786 makes login land on the chat page when chat is enabled, so the Checkly/Playwright e2e tests that assumed the automations dashboard as the landing page timed out.

This centralizes post-login navigation in the `page` fixture (and global setup) via a reusable `AutomationsPage.open()` that waits for auth to settle, then navigates to automations explicitly — instead of relying on the landing page.

The 3 spec files are left untouched; the fix moved up to the shared fixture seam.

Add the `ready-for-e2e` label to run the CI Playwright e2e on this PR.