### PR TITLE
fix(e2e): make webhook/piece-isolation checks reliable on cloud

### DIFF
--- a/packages/tests-e2e/pages/automations.page.ts
+++ b/packages/tests-e2e/pages/automations.page.ts
@@ -23,10 +23,11 @@ export class AutomationsPage extends BasePage {
 
   async waitFor() {
     await this.page.waitForURL('**/automations**');
-    await Promise.race([
-      this.page.waitForSelector('text="Get started with Activepieces"'),
-      this.page.waitForSelector('button:has-text("Create New")'),
-    ]);
+    await this.page
+      .locator('text="Get started with Activepieces"')
+      .or(this.page.locator('button:has-text("Create New")'))
+      .first()
+      .waitFor();
   }
 
   async newFlowFromScratch() {

--- a/packages/tests-e2e/pages/builder.page.ts
+++ b/packages/tests-e2e/pages/builder.page.ts
@@ -57,4 +57,22 @@ export class BuilderPage extends BasePage {
     await this.page.waitForSelector('.react-flow__nodes', { state: 'visible' });
     await this.page.waitForSelector('.react-flow__node', { state: 'visible' });
   }
-} 
+
+  // A freshly published version may not serve synchronous requests immediately
+  // (the sync URL can briefly 404), so poll until the Return Response reflects
+  // the published flow.
+  async expectSyncWebhookResponse(params: { url: string; key: string; expected: string }) {
+    await expect
+      .poll(
+        async () => {
+          const response = await this.page.context().request.get(params.url);
+          const body: Record<string, unknown> = await response
+            .json()
+            .catch(() => ({}));
+          return body[params.key];
+        },
+        { timeout: 60000, intervals: [2000, 3000, 5000] },
+      )
+      .toBe(params.expected);
+  }
+}

--- a/packages/tests-e2e/scenarios/ce/flows/webhook-should-return-response.spec.ts
+++ b/packages/tests-e2e/scenarios/ce/flows/webhook-should-return-response.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../../fixtures';
+import { test } from '../../../fixtures';
 
 test.describe('Webhooks', () => {
   test('should handle webhook with return response', async ({ page, automationsPage, builderPage }) => {
@@ -40,10 +40,11 @@ test.describe('Webhooks', () => {
     await page.waitForTimeout(1000);
     await builderPage.publishFlow();
 
-    const response = await page.context().request.get(urlWithParams);
-    const body = await response.json();
-
-    expect(body.targetRunVersion).toBe(runVersion.toString());
+    await builderPage.expectSyncWebhookResponse({
+      url: urlWithParams,
+      key: 'targetRunVersion',
+      expected: runVersion.toString(),
+    });
   });
 
 }); 

--- a/packages/tests-e2e/scenarios/ce/pieces/piece-isolation.spec.ts
+++ b/packages/tests-e2e/scenarios/ce/pieces/piece-isolation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../../fixtures';
+import { test } from '../../../fixtures';
 
 /**
  * Warmup resilience smoke test.
@@ -48,9 +48,10 @@ test.describe('Piece isolation — CE', () => {
     await page.waitForTimeout(1000);
     await builderPage.publishFlow();
 
-    const response = await page.context().request.get(`${webhookUrl}/sync?runVersion=${runVersion}`);
-    const body = await response.json();
-
-    expect(body.runVersion).toBe(runVersion.toString());
+    await builderPage.expectSyncWebhookResponse({
+      url: `${webhookUrl}/sync?runVersion=${runVersion}`,
+      key: 'runVersion',
+      expected: runVersion.toString(),
+    });
   });
 });

--- a/packages/tests-e2e/scenarios/ee/pieces/piece-isolation.spec.ts
+++ b/packages/tests-e2e/scenarios/ee/pieces/piece-isolation.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect } from '../../../fixtures';
+import { gzipSync } from 'node:zlib';
+
+import { test } from '../../../fixtures';
 
 /**
  * EE: Bad piece isolation test.
@@ -27,19 +29,7 @@ test.describe('Piece isolation — EE', () => {
       },
     });
 
-    const { Readable } = await import('node:stream');
-    const tar = await import('tar-stream');
-    const zlib = await import('node:zlib');
-
-    const pack = tar.pack();
-    pack.entry({ name: 'package/package.json' }, badPackageJson);
-    pack.finalize();
-
-    const chunks: Buffer[] = [];
-    for await (const chunk of pack.pipe(zlib.createGzip())) {
-      chunks.push(chunk as Buffer);
-    }
-    const tarball = Buffer.concat(chunks);
+    const tarball = createGzippedTarball('package/package.json', badPackageJson);
 
     // POST the broken piece archive to the platform pieces endpoint
     const uploadResponse = await request.post('/api/v1/pieces', {
@@ -88,9 +78,32 @@ test.describe('Piece isolation — EE', () => {
     await page.waitForTimeout(1000);
     await builderPage.publishFlow();
 
-    const response = await page.context().request.get(`${webhookUrl}/sync?runVersion=${runVersion}`);
-    const body = await response.json();
-
-    expect(body.runVersion).toBe(runVersion.toString());
+    await builderPage.expectSyncWebhookResponse({
+      url: `${webhookUrl}/sync?runVersion=${runVersion}`,
+      key: 'runVersion',
+      expected: runVersion.toString(),
+    });
   });
 });
+
+// Build a minimal gzipped ustar archive in memory using only Node built-ins,
+// so the test does not depend on tar-stream (unavailable in the Checkly runtime)
+// or dynamic imports (unsupported in its sandbox). Numeric header fields (uid,
+// gid, mtime) are left as the zero-fill, which tar reads as 0.
+function createGzippedTarball(name: string, content: string): Buffer {
+  const data = Buffer.from(content, 'utf8');
+  const header = Buffer.alloc(512);
+  header.write(name, 0, 100, 'utf8');
+  header.write('0000644\0', 100, 8, 'utf8'); // mode
+  header.write(`${data.length.toString(8).padStart(11, '0')}\0`, 124, 12, 'utf8'); // size
+  header.write('0', 156, 1, 'utf8'); // typeflag: regular file
+  header.write('ustar\0', 257, 6, 'utf8'); // magic
+  header.write('00', 263, 2, 'utf8'); // version
+  header.fill(' ', 148, 156); // checksum field is spaces while summing
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  header.write(`${checksum.toString(8).padStart(6, '0')}\0 `, 148, 8, 'utf8');
+  const padding = (512 - (data.length % 512)) % 512;
+  return gzipSync(
+    Buffer.concat([header, data, Buffer.alloc(padding), Buffer.alloc(1024)]),
+  );
+}


### PR DESCRIPTION
Follow-up to #13799. With login navigation fixed, the Checkly suite now runs to completion and surfaced two real failures:

**1. Empty/undefined sync response (`Received: ""` / `undefined`, /sync 404)**
A single `/sync` request right after publish can hit the pre-publish state on cloud. Replaced it with a shared `BuilderPage.expectSyncWebhookResponse()` that polls until the published flow responds (bounded 60s). Used by the webhook spec and both piece-isolation specs.

**2. `VMError: Dynamic Import not supported` (EE piece-isolation)**
The test dynamically imported `tar-stream`/`node:stream`/`node:zlib`. Dynamic `import()` is unsupported in Checkly's sandbox, and `tar-stream` isn't an available dependency. Now builds the broken-piece tarball with a static `node:zlib` import + `Buffer` only (self-contained, no runtime file or dependency).

Also replaced the `Promise.race` in `AutomationsPage.waitFor()` with `locator.or()` so the losing selector no longer shows as a red timed-out step in traces.