### PR TITLE
fix: set package.json version before docker build in release workflow

### DIFF
--- a/.github/workflows/release-self-hosted.yml
+++ b/.github/workflows/release-self-hosted.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Set version in package.json
+        run: npm pkg set version="${{ inputs.tag }}"
+
       - name: Fail if tag already exists
         run: '! docker manifest inspect activepieces/activepieces:${{ inputs.tag }}'
 


### PR DESCRIPTION
Without this step, the Docker image tag (e.g. 0.85.2) does not match the version reported inside the container. ap-version.ts reads package.json at runtime via process.cwd(), so bumping it before the build ensures the image and the health UI report the correct version.

Fixes #13702

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->
Sets package.json version to the release tag before the Docker build, so the container reports the correct version at runtime.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
