### PR TITLE
fix(json-viewer): add .json extension and sanitize filename on download

### DIFF
--- a/packages/web/src/components/custom/json-viewer.tsx
+++ b/packages/web/src/components/custom/json-viewer.tsx
@@ -100,7 +100,7 @@ const JsonViewer = React.memo(
       const link = document.createElement('a');
       link.href = fileUrl;
       const rawName =
-        typeof title === 'string' && title.trim() ? title : 'data';
+        typeof title === 'string' && title.trim() ? title.trim() : 'data';
       const safeName = rawName.replace(/[/\\:*?"<>|]/g, '_');
       link.download = `${safeName}${ext}`;
       link.click();

--- a/packages/web/src/components/custom/json-viewer.tsx
+++ b/packages/web/src/components/custom/json-viewer.tsx
@@ -93,13 +93,16 @@ const JsonViewer = React.memo(
         type: 'application/json',
       });
       const url = URL.createObjectURL(blob);
-      handleDownloadFile(url);
+      handleDownloadFile(url, '.json');
     };
 
     const handleDownloadFile = (fileUrl: string, ext = '') => {
       const link = document.createElement('a');
       link.href = fileUrl;
-      link.download = `${typeof title === 'string' ? title : 'data'}${ext}`;
+      const rawName =
+        typeof title === 'string' && title.trim() ? title : 'data';
+      const safeName = rawName.replace(/[/\\:*?"<>|]/g, '_');
+      link.download = `${safeName}${ext}`;
       link.click();
       URL.revokeObjectURL(fileUrl);
     };


### PR DESCRIPTION
## Problem

Downloading a run/step JSON output saves the file without an extension,
so browsers name it `.bin`. The contents are valid JSON — renaming to
`.json` opens it fine — but users can't open it directly.

Fixes #13752

## Root cause

`handleDownload()` called `handleDownloadFile(url)` without an `ext`
argument. The function signature already had `ext = ''` as default, so
the filename was assembled without any extension.

## Fix

Pass `'.json'` from `handleDownload()`. Also hardened the filename
assembly in `handleDownloadFile`:

- **Slash in step names** — names like `"GET /api/users"` caused the
  browser to strip everything before the last `/`, silently producing
  `users.json` instead of the full name.
- **Empty title** — `title=""` produced a hidden `.json` file on
  macOS/Linux. Now falls back to `data` for blank/non-string titles.

## Changes

`packages/web/src/components/custom/json-viewer.tsx` — 5 lines changed:

```diff
- handleDownloadFile(url);
+ handleDownloadFile(url, '.json');

- link.download = `${typeof title === 'string' ? title : 'data'}${ext}`;
+ const rawName = typeof title === 'string' && title.trim() ? title : 'data';
+ const safeName = rawName.replace(/[/\\:*?"<>|]/g, '_');
+ link.download = `${safeName}${ext}`;
