### PR TITLE
fix(web): keep json download extension

### DIFF
--- a/packages/web/src/components/custom/json-viewer.tsx
+++ b/packages/web/src/components/custom/json-viewer.tsx
@@ -93,7 +93,7 @@ const JsonViewer = React.memo(
         type: 'application/json',
       });
       const url = URL.createObjectURL(blob);
-      handleDownloadFile(url);
+      handleDownloadFile(url, ".json");
     };
 
     const handleDownloadFile = (fileUrl: string, ext = '') => {


### PR DESCRIPTION
## Summary
- preserve the `.json` filename extension when downloading run/step JSON payloads
- keep the existing JSON blob MIME type while fixing the browser download name

## Testing
- `git diff --check`
