### PR TITLE
feat(chat): dock quick replies above input and refine reveal timing

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -31,7 +31,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - `packages/web/src/features/chat/lib/chat-api.ts` — API client for `/v1/chat/*` endpoints
 - `packages/web/src/features/chat/lib/chat-store.ts` — Zustand store for interaction state (approvals, plan progress, display cards, thinking panel)
 - `packages/web/src/features/chat/lib/chat-store-context.tsx` — React context provider and `useChatStoreContext` selector hook
-- `packages/web/src/features/chat/lib/use-chat.ts` — `useAgentChat()` hook managing message state (persisted, optimistic, streaming); stale-check only reconciles when the server reports the conversation is no longer STREAMING
+- `packages/web/src/features/chat/lib/use-chat.ts` — `useAgentChat()` hook managing message state (persisted, optimistic, streaming); stale-check only reconciles when the server reports the conversation is no longer STREAMING; exposes `isAwaitingResponse` (true while `awaiting-stream`/`streaming`/`submitting`, drops the polling/reconcile tail) for quick-reply reveal timing
 - `packages/web/src/features/chat/lib/chunk-reducer.ts` — pure streaming state machine that accumulates `UIMessageChunk` events into a `ChatUIMessage`
 - `packages/web/src/features/chat/lib/use-streaming-reducer.ts` — WebSocket-driven streaming lifecycle hook; buffers chunks and throttles React re-renders
 - `packages/web/src/features/chat/lib/chat-types.ts` — frontend type definitions, tool output parsing, display/hidden tool name sets, `CreditsWarning` type
@@ -100,7 +100,7 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 - `ap_show_connection_picker` — lets the user choose between multiple connections; no longer receives connections array from LLM (server-managed); returns only `{ selected: true, label }` to LLM, stripping externalIds
 - `ap_show_project_picker` — lets the user select a project
 - `ap_show_questions` — renders an interactive multi-question form
-- `ap_show_quick_replies` — shows up to 3 suggested follow-ups as a stacked list above the chat input (hidden during blocking cards); emitted only when concrete, relevant next steps exist
+- `ap_show_quick_replies` — shows up to 3 suggested follow-ups as a stacked list docked above the chat input within the message flow (via `mt-auto`, so they dock above the input when at the bottom and scroll away when scrolling up; hidden during blocking cards and while the answer is streaming); revealed as soon as text streaming completes rather than waiting for the post-stream reconcile tail; emitted only when concrete, relevant next steps exist
 
 ## Endpoints
 - `POST /v1/chat/conversations` — create conversation

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -76,6 +76,7 @@ function ChatBoxContent({
     messages,
     modelName,
     isStreaming,
+    isAwaitingResponse,
     wasCancelled,
     isLoadingHistory,
     error,
@@ -187,12 +188,12 @@ function ChatBoxContent({
               className="flex-1 relative h-full"
               style={{
                 maskImage:
-                  'linear-gradient(to bottom, black 0%, black calc(100% - 40px), transparent 100%)',
+                  'linear-gradient(to bottom, black 0%, black calc(100% - 12px), transparent 100%)',
                 WebkitMaskImage:
-                  'linear-gradient(to bottom, black 0%, black calc(100% - 40px), transparent 100%)',
+                  'linear-gradient(to bottom, black 0%, black calc(100% - 12px), transparent 100%)',
               }}
             >
-              <ChatContainerContent className="max-w-3xl mx-auto px-6 pt-8 pb-16 gap-0">
+              <ChatContainerContent className="max-w-3xl mx-auto px-6 pt-8 pb-4 gap-0 min-h-full">
                 {isLoadingHistory && <MessageSkeletons />}
 
                 {messages.map((msg, idx) => {
@@ -221,6 +222,18 @@ function ChatBoxContent({
                     />
                   );
                 })}
+
+                {!isAwaitingResponse &&
+                  !wasCancelled &&
+                  !hasBlockingCard &&
+                  quickReplies.length > 0 && (
+                    <div className="mt-auto pt-2">
+                      <QuickReplies
+                        replies={quickReplies}
+                        onSend={handleSend}
+                      />
+                    </div>
+                  )}
 
                 {wasCancelled && (
                   <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground animate-in fade-in duration-200">
@@ -260,12 +273,6 @@ function ChatBoxContent({
 
       <div className="px-6 pb-4">
         <div className="max-w-3xl mx-auto relative">
-          {!isStreaming &&
-            !wasCancelled &&
-            !hasBlockingCard &&
-            quickReplies.length > 0 && (
-              <QuickReplies replies={quickReplies} onSend={handleSend} />
-            )}
           <div
             className={cn(
               !hasBlockingCard &&

--- a/packages/web/src/app/routes/chat-with-ai/components/quick-replies.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/quick-replies.tsx
@@ -20,9 +20,9 @@ export function QuickReplies({
           type="button"
           onClick={() => onSend(reply)}
           className="flex w-full items-start gap-2 text-left text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer min-w-0"
-          initial={{ opacity: 0, y: -4 }}
+          initial={{ opacity: 0, y: 6 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.2, delay: i * 0.04 }}
+          transition={{ duration: 0.25, delay: i * 0.06, ease: 'easeOut' }}
         >
           <CornerDownRight className="size-4 shrink-0 mt-0.5" />
           <TextWithTooltip tooltipMessage={reply}>

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -349,6 +349,11 @@ export function useAgentChat({
     sendStatusRef.current.type === 'submitting' ||
     isPollingForAgentReply;
 
+  const isAwaitingResponse =
+    streamPhase === 'awaiting-stream' ||
+    streamPhase === 'streaming' ||
+    sendStatus.type === 'submitting';
+
   const messages: ChatUIMessage[] = useMemo(() => {
     const base = [...persistedMessages];
     if (optimisticUserMessage) base.push(optimisticUserMessage);
@@ -671,6 +676,7 @@ export function useAgentChat({
     modelName,
     messages,
     isStreaming,
+    isAwaitingResponse,
     wasCancelled,
     isLoadingHistory,
     error,


### PR DESCRIPTION
Follow-up to #13785.

## Placement
Quick replies move back into the message flow and use `mt-auto`, so they dock just above the input when the conversation is short or scrolled to the bottom, and scroll away (hidden) when scrolling up — instead of being pinned/overlaying the messages.

## Timing
They now reveal once the answer finishes streaming, via a new `isAwaitingResponse` flag that flips false as soon as the text stream completes (dropping the post-stream polling/reconcile tail that `isStreaming` includes). This fixes both the long delay and the mid-stream "flush" before the result appeared.

## Polish
- Gentle rise-in (`easeOut`, staggered) entrance animation.
- Bottom fade mask reduced (40px → 12px) and column bottom padding tightened (`pb-16` → `pb-4`, `min-h-full`) so the docked rows stay crisp above the input.