### PR TITLE
ci: stop publishing shared/framework/common to npm (pieces are self-contained)

### DIFF
--- a/.github/workflows/release-pieces.yml
+++ b/.github/workflows/release-pieces.yml
@@ -46,20 +46,8 @@ jobs:
       - name: copy project .npmrc to user level
         run: cp .npmrc $HOME/.npmrc
 
-      - name: publish shared package
-        run: npx turbo run build --filter=@activepieces/shared --force && npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/utils/publish-npm-package.ts packages/core/shared 
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: publish pieces-common package
-        run: npx turbo run build --filter=@activepieces/pieces-common --force && npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/utils/publish-npm-package.ts packages/pieces/common
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: publish pieces-framework package
-        run: npx turbo run build --filter=@activepieces/pieces-framework --force && npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/utils/publish-npm-package.ts packages/pieces/framework
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # @activepieces/shared, pieces-common and pieces-framework are no longer published to npm:
+      # pieces are now self-contained bundles that inline these dependencies at build time.
 
       - name: Find changed pieces
         id: changed

--- a/tools/scripts/pieces/publish-pieces-to-npm.ts
+++ b/tools/scripts/pieces/publish-pieces-to-npm.ts
@@ -1,6 +1,6 @@
 import { publishNpmPackage } from '../utils/publish-npm-package'
 import { findAllPiecesDirectoryInSource } from '../utils/piece-script-utils'
-import { chunk } from '../../../packages/core/shared/src/lib/core/common/utils/utils'
+import { chunk } from '@activepieces/core-utils'
 
 function getChangedPiecePaths(): string[] | null {
   const changedPieces = process.env['CHANGED_PIECES']

--- a/tools/scripts/pieces/update-pieces-metadata.ts
+++ b/tools/scripts/pieces/update-pieces-metadata.ts
@@ -3,7 +3,7 @@ import { PieceMetadata } from '../../../packages/pieces/framework/src';
 import { StatusCodes } from 'http-status-codes';
 import { HttpHeader } from '../../../packages/pieces/common/src';
 import { AP_CLOUD_API_BASE, findNewPieces, pieceMetadataExists } from '../utils/piece-script-utils';
-import { chunk } from '../../../packages/core/shared/src/lib/core/common/utils/utils';
+import { chunk } from '@activepieces/core-utils';
 assert(process.env['AP_CLOUD_API_KEY'], 'API Key is not defined');
 
 const { AP_CLOUD_API_KEY } = process.env;

--- a/tools/scripts/validate-publishable-packages.ts
+++ b/tools/scripts/validate-publishable-packages.ts
@@ -13,18 +13,15 @@ async function processBatches<T>(items: T[], batchSize: number, processor: (item
 
 const main = async () => {
   const piecesMetadata = await findAllPiecesDirectoryInSource()
-  const sharedDeps = ['packages/pieces/framework', 'packages/pieces/common']
-  
-  const sharedResults = await Promise.all(sharedDeps.map(packagePrePublishChecks))
-  const validationResults = await processBatches(
-    piecesMetadata.filter(p => !sharedDeps.includes(p)),
+  // pieces-framework, pieces-common and @activepieces/shared are no longer published to npm:
+  // pieces are self-contained bundles that inline these at build time. Exclude them from the
+  // publishable-package validation and only validate the pieces themselves.
+  const notPublished = ['packages/pieces/framework', 'packages/pieces/common']
+  await processBatches(
+    piecesMetadata.filter(p => !notPublished.includes(p)),
     10,
     packagePrePublishChecks
   )
-
-  if (!sharedResults.every(p => p)) {
-    validationResults.push(await packagePrePublishChecks('packages/core/shared'))
-  }
 }
 
 main();


### PR DESCRIPTION
Follow-up to #13822 (merged). Now that pieces are **self-contained bundles** — `preparePieceDistForPublish` bundles each piece and `rewriteManifestForBundle` strips the `@activepieces/shared` / `pieces-framework` / `pieces-common` / `core-*` workspace deps — those packages no longer need to be published to npm.

## Changes
- **`release-pieces.yml`**: removed the `publish shared`, `publish pieces-common`, and `publish pieces-framework` npm steps. Piece publishing (`publish-pieces-to-npm.ts`) is unchanged.
- **`validate-publishable-packages.ts`**: dropped framework/common/shared from the publishable-package validation — only the pieces themselves are validated now.
- **tools scripts** (`publish-pieces-to-npm.ts`, `update-pieces-metadata.ts`): repointed a `chunk` import off the `core/common/utils` shim (removed in #13822's shared consolidation) to `@activepieces/core-utils`.

## Why it's safe
Published pieces no longer declare these as dependencies (verified: the bundled `dist` manifest only keeps genuinely-external deps like `tslib`), so `npm install` of a piece doesn't need them on the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)