### PR TITLE
chore: remove regenerate button from AI chat

### DIFF
--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -218,7 +218,6 @@ function ChatBoxContent({
                       message={msg}
                       isStreaming={isLastStreamingAssistant}
                       isLastMessage={isLastAssistant}
-                      onRetry={handleRetry}
                     />
                   );
                 })}

--- a/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/assistant-message.tsx
@@ -1,6 +1,6 @@
 import { BatchProgressData } from '@activepieces/shared';
 import { t } from 'i18next';
-import { Check, RefreshCw, Volume2, VolumeOff } from 'lucide-react';
+import { Check, Volume2, VolumeOff } from 'lucide-react';
 import { motion } from 'motion/react';
 import { memo, useMemo, useState } from 'react';
 
@@ -49,12 +49,10 @@ export const AssistantMessage = memo(function AssistantMessage({
   message,
   isStreaming,
   isLastMessage = false,
-  onRetry,
 }: {
   message: ChatUIMessage;
   isStreaming: boolean;
   isLastMessage?: boolean;
-  onRetry: () => void;
 }) {
   const approveGate = useChatStoreContext((s) => s.approveGate);
   const toolCallMeta = useChatStoreContext((s) => s.toolCallMeta);
@@ -403,23 +401,12 @@ export const AssistantMessage = memo(function AssistantMessage({
 
           {!isStreaming && !hasContent && hasRenderedContent && (
             <motion.div
-              className="flex items-center gap-2 py-3 text-sm text-muted-foreground"
+              className="py-3 text-sm text-muted-foreground"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 0.3, delay: 0.2 }}
             >
-              <span>
-                {t(
-                  "The agent completed its work but didn't provide a summary.",
-                )}
-              </span>
-              <button
-                type="button"
-                onClick={onRetry}
-                className={cn(ACTION_BUTTON_CLASS, 'inline-flex')}
-              >
-                <RefreshCw className="h-3.5 w-3.5" />
-              </button>
+              {t("The agent completed its work but didn't provide a summary.")}
             </motion.div>
           )}
 
@@ -456,15 +443,6 @@ export const AssistantMessage = memo(function AssistantMessage({
                     </button>
                   </MessageAction>
                 )}
-                <MessageAction tooltip={t('Regenerate')}>
-                  <button
-                    type="button"
-                    onClick={onRetry}
-                    className={ACTION_BUTTON_CLASS}
-                  >
-                    <RefreshCw className="h-3.5 w-3.5" />
-                  </button>
-                </MessageAction>
               </>
             )}
           </MessageActions>


### PR DESCRIPTION
## What

Temporarily removes the **regenerate** (↻) action from AI chat assistant messages:

- The message-action regenerate button shown next to **Copy** under each completed assistant message.
- The secondary "no summary" fallback regenerate button (shown when *"the agent completed its work but didn't provide a summary"*).

Both were driven by a single `onRetry` prop, so they're removed together along with the now-unused prop and `RefreshCw` import.

## Out of scope (unchanged)

The red **error-banner "Retry"** button is failure-recovery, not regeneration, and stays. It keeps using `handleRetry`, so no dead code is left behind.

## Notes

Implemented as a clean deletion (no commented-out code / feature flag) — restoring later is just re-adding the small button block and prop.