### PR TITLE
fix(ci): await piece bundle rewrite before publishing

### DIFF
--- a/tools/scripts/pieces/prepare-pieces-for-publish.ts
+++ b/tools/scripts/pieces/prepare-pieces-for-publish.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
     console.info(`[preparePieces] processing ${piecePaths.length} pieces${changedPaths ? ' (scoped to changed)' : ' (all)'}`)
 
     for (const piecePath of piecePaths) {
-        preparePieceDistForPublish(piecePath)
+        await preparePieceDistForPublish(piecePath)
     }
 
     console.info(`[preparePieces] done, prepared ${piecePaths.length} pieces`)

--- a/tools/scripts/utils/publish-npm-package.ts
+++ b/tools/scripts/utils/publish-npm-package.ts
@@ -72,10 +72,10 @@ export const publishNpmPackage = async (path: string): Promise<void> => {
   }
   const { version } = await readPackageJson(path)
 
-  // Pins all dependency versions (including transitive) from bun.lock.
-  // For pieces built via CLI or prepare-pieces-for-publish, this already ran during build — calling it
-  // again is idempotent. For shared/common/framework, this is the only place it runs before publish.
-  preparePieceDistForPublish(path)
+  // Bundles the piece and rewrites dist/package.json to drop all workspace:* deps
+  // (every @activepieces/* import is inlined into the bundle). Must be awaited so the
+  // rewrite completes before the manifest is read and validated below.
+  await preparePieceDistForPublish(path)
 
   const json = JSON.parse(readFileSync(`${outputPath}/package.json`).toString())
   json.version = version


### PR DESCRIPTION
## What
  Fixes the Release Pieces workflow failing at the "publish pieces packages" step with:

  > refusing to publish @activepieces/piece-math-helper@0.0.23 — unresolved workspace dependencies: @activepieces/pieces-common: workspace:*, …

  ## Why
  When pieces moved to self-contained bundles, `preparePieceDistForPublish` became **async** — it now awaits esbuild bundling, then rewrites `dist/package.json` to
  inline all `@activepieces/*` code and strip the `workspace:*` deps. Two release scripts still called it **fire-and-forget** (no `await`), so the publish guard read the
  un-rewritten manifest before the rewrite finished and rejected the publish.

  ## Fix
  Add the missing `await` at both call sites so the rewrite completes before the manifest is read/validated:
  - `tools/scripts/utils/publish-npm-package.ts`
  - `tools/scripts/pieces/prepare-pieces-for-publish.ts`

  ## Testing
  Reproduced against `math-helper`: built it (raw `dist/package.json` had the 4 `workspace:*` deps), then ran the fixed prepare + publish path — manifest is rewritten to
  `main: ./src/index.js` with deps reduced to externals only, and both publish guards pass. No actual `npm publish` was run.